### PR TITLE
[Feature][Attention][PCP] Support PCP (Prefill Context Parallel) with MLA

### DIFF
--- a/tests/distributed/test_context_parallel.py
+++ b/tests/distributed/test_context_parallel.py
@@ -50,6 +50,7 @@ class ParallelSetup(NamedTuple):
     tp_size: int
     pp_size: int
     dcp_size: int
+    pcp_size: int
     cp_kv_cache_interleave_size: int
     eager_mode: bool
     chunked_prefill: bool
@@ -73,6 +74,7 @@ class CPTestSettings:
         tp_base: int = 4,
         pp_base: int = 1,
         dcp_multipliers: list[float] | None = None,
+        pcp_base: int = 1,
         cp_kv_cache_interleave_size: int = 1,
         multi_node_only: bool = False,
         runner: RunnerOption = "auto",
@@ -91,7 +93,8 @@ class CPTestSettings:
                             ParallelSetup(
                                 tp_size=tp_base,
                                 pp_size=pp_multiplier * pp_base,
-                                dcp_size=int(dcp_multiplier * tp_base),
+                                dcp_size=max(1, int(dcp_multiplier * tp_base)),
+                                pcp_size=pcp_base,
                                 cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
                                 eager_mode=eager_mode_val,
                                 chunked_prefill=chunked_prefill_val,
@@ -129,6 +132,9 @@ CP_TEXT_GENERATION_MODELS = {
             cp_kv_cache_interleave_size=64,
             attn_backend="FLASHMLA",
         ),
+        CPTestSettings.detailed(
+            tp_base=1, pcp_base=2, cp_kv_cache_interleave_size=64,
+        ),
     ],
     "Qwen/Qwen2.5-1.5B-Instruct": [
         CPTestSettings.detailed(
@@ -156,6 +162,7 @@ def _test_cp_gsm8k(
         tp_size,
         pp_size,
         dcp_size,
+        pcp_size,
         cp_kv_cache_interleave_size,
         eager_mode,
         chunked_prefill,
@@ -212,7 +219,9 @@ def _test_cp_gsm8k(
             str(pp_size),
             "--decode-context-parallel-size",
             str(dcp_size),
-            "--dcp-kv-cache-interleave-size",
+            "--prefill-context-parallel-size",
+            str(pcp_size),
+            "--cp-kv-cache-interleave-size",
             str(cp_kv_cache_interleave_size),
             "--distributed-executor-backend",
             distributed_backend,

--- a/tests/distributed/test_context_parallel.py
+++ b/tests/distributed/test_context_parallel.py
@@ -132,9 +132,8 @@ CP_TEXT_GENERATION_MODELS = {
             cp_kv_cache_interleave_size=64,
             attn_backend="FLASHMLA",
         ),
-        CPTestSettings.detailed(
-            tp_base=1, pcp_base=2, cp_kv_cache_interleave_size=64,
-        ),
+        CPTestSettings.detailed(tp_base=1, pcp_base=4, cp_kv_cache_interleave_size=64),
+        CPTestSettings.detailed(tp_base=2, pcp_base=2, cp_kv_cache_interleave_size=64),
     ],
     "Qwen/Qwen2.5-1.5B-Instruct": [
         CPTestSettings.detailed(

--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -320,8 +320,8 @@ class AttentionImpl(ABC, Generic[T]):
     pcp_world_size: int
     pcp_rank: int
 
-    total_cp_world_size: int
-    total_cp_rank: int
+    cp_world_size: int
+    cp_rank: int
 
     def __new__(cls, *args, **kwargs):
         # use __new__ so that all subclasses will call this
@@ -343,11 +343,11 @@ class AttentionImpl(ABC, Generic[T]):
         except AssertionError:
             self.pcp_world_size = 1
             self.pcp_rank = 0
-        self.total_cp_world_size = self.pcp_world_size * self.dcp_world_size
-        self.total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
+        self.cp_world_size = self.pcp_world_size * self.dcp_world_size
+        self.cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
 
         self.need_to_return_lse_for_decode = (
-            self.dcp_world_size > 1 and self.can_return_lse_for_decode
+            self.cp_world_size > 1 and self.can_return_lse_for_decode
         )
         return self
 

--- a/vllm/attention/ops/common.py
+++ b/vllm/attention/ops/common.py
@@ -467,3 +467,220 @@ def unpack_seq_triton(
         out = out.reshape(output_shape)
 
     return out
+
+
+@triton.jit
+def _fused_pcp_qkv_select_kernel(
+    q_ptr,
+    q_stride_B,
+    q_stride_H,
+    k_ptr,
+    k_stride_B,
+    k_stride_H,
+    v_ptr,
+    v_stride_B,
+    v_stride_H,
+    query_start_ptr,
+    out_q_head_ptr,
+    out_q_tail_ptr,
+    out_k_head_ptr,
+    out_k_tail_ptr,
+    out_v_head_ptr,
+    out_v_tail_ptr,
+    pcp_world_size: tl.constexpr,
+    pcp_rank: tl.constexpr,
+    n_head: tl.constexpr,
+    q_head_dim: tl.constexpr,
+    k_head_dim: tl.constexpr,
+    v_head_dim: tl.constexpr,
+    SEQ_BLOCK_SIZE: tl.constexpr,
+    DIM_BLOCK_SIZE: tl.constexpr,
+):
+    req_id = tl.program_id(0) // (2 * pcp_world_size)
+    seq_block_id = tl.program_id(0) % (2 * pcp_world_size)
+    head_id = tl.program_id(1)
+    dim_block_id = tl.program_id(2)
+    dim_off = tl.arange(0, DIM_BLOCK_SIZE) + dim_block_id * DIM_BLOCK_SIZE
+
+    q_start_loc = tl.load(query_start_ptr + req_id)
+    q_end_loc = tl.load(query_start_ptr + req_id + 1)
+    q_select_len = (q_end_loc - q_start_loc) // 2
+
+    # Select Q
+    if seq_block_id < 2:
+        block_q_start_loc = q_start_loc + seq_block_id * q_select_len
+        out_ptr = out_q_head_ptr if seq_block_id == 0 else out_q_tail_ptr
+        for qi in range(tl.cdiv(q_select_len, SEQ_BLOCK_SIZE)):
+            q_offset = tl.arange(0, SEQ_BLOCK_SIZE) + qi * SEQ_BLOCK_SIZE
+            mask = (dim_off[None, :] < q_head_dim) & (q_offset[:, None] < q_select_len)
+            q_src_idx = block_q_start_loc + q_offset[:, None]
+            q_dst_idx = q_start_loc // 2 + q_offset[:, None]
+            q_val = tl.load(
+                q_ptr
+                + q_src_idx * q_stride_B
+                + head_id * q_stride_H
+                + dim_off[None, :],
+                mask=mask,
+            )
+            tl.store(
+                out_ptr
+                + q_dst_idx * n_head * q_head_dim
+                + head_id * q_head_dim
+                + dim_off[None, :],
+                q_val,
+                mask=mask,
+            )
+
+    # Select KV
+    kv_start_loc = q_start_loc * pcp_world_size
+    kv_select_len = q_select_len
+    k_d_mask = dim_off[None, :] < k_head_dim
+    v_d_mask = dim_off[None, :] < v_head_dim
+    block_src_kv_start_loc = kv_start_loc + seq_block_id * kv_select_len
+    block_dst_kv_head_start_loc = (
+        kv_start_loc // 2 // pcp_world_size * (pcp_rank + 1)
+        + seq_block_id * kv_select_len
+    )
+    block_dst_kv_tail_start_loc = (
+        kv_start_loc // 2 // pcp_world_size * (2 * pcp_world_size - pcp_rank)
+        + seq_block_id * kv_select_len
+    )
+    for ki in range(tl.cdiv(kv_select_len, SEQ_BLOCK_SIZE)):
+        kv_offset = tl.arange(0, SEQ_BLOCK_SIZE) + ki * SEQ_BLOCK_SIZE
+        kv_block_mask = kv_offset[:, None] < kv_select_len
+        kv_src_idx = block_src_kv_start_loc + kv_offset[:, None]
+        kv_dst_idx_head = block_dst_kv_head_start_loc + kv_offset[:, None]
+        kv_dst_idx_tail = block_dst_kv_tail_start_loc + kv_offset[:, None]
+        k_val = tl.load(
+            k_ptr + kv_src_idx * k_stride_B + head_id * k_stride_H + dim_off[None, :],
+            mask=k_d_mask & kv_block_mask,
+        )
+        v_val = tl.load(
+            v_ptr + kv_src_idx * v_stride_B + head_id * v_stride_H + dim_off[None, :],
+            mask=v_d_mask & kv_block_mask,
+        )
+        if seq_block_id < pcp_rank + 1:
+            tl.store(
+                out_k_head_ptr
+                + kv_dst_idx_head * n_head * k_head_dim
+                + head_id * k_head_dim
+                + dim_off[None, :],
+                k_val,
+                mask=k_d_mask & kv_block_mask,
+            )
+            tl.store(
+                out_v_head_ptr
+                + kv_dst_idx_head * n_head * v_head_dim
+                + head_id * v_head_dim
+                + dim_off[None, :],
+                v_val,
+                mask=v_d_mask & kv_block_mask,
+            )
+        if seq_block_id < 2 * pcp_world_size - pcp_rank:
+            tl.store(
+                out_k_tail_ptr
+                + kv_dst_idx_tail * n_head * k_head_dim
+                + head_id * k_head_dim
+                + dim_off[None, :],
+                k_val,
+                mask=k_d_mask & kv_block_mask,
+            )
+            tl.store(
+                out_v_tail_ptr
+                + kv_dst_idx_tail * n_head * v_head_dim
+                + head_id * v_head_dim
+                + dim_off[None, :],
+                v_val,
+                mask=v_d_mask & kv_block_mask,
+            )
+
+
+def fused_pcp_qkv_select(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    pcp_world_size: int,
+    pcp_rank: int,
+):
+    """
+    Select the query and kv tensors for PCP. Instead of calling
+    `torch.index_select` multiple times, this function fuses the
+    selection for Q, K, and V into a single kernel to reduce
+    kernel launch overhead.
+    Args:
+        q: query tensor on the current PCP rank.
+        k: key tensor across PCP ranks.
+        v: value tensor across PCP ranks.
+        query_start_loc: start location of each query.
+        pcp_world_size: number of PCP ranks.
+        pcp_rank: rank of the current PCP rank.
+    Returns:
+        q_head: selected query tensor for pcp head.
+        k_head: selected key tensor for pcp head.
+        v_head: selected value tensor for pcp head.
+        q_tail: selected query tensor for pcp tail.
+        k_tail: selected key tensor for pcp tail.
+        v_tail: selected value tensor for pcp tail.
+
+    """
+    q_head = torch.empty(
+        (q.size(0) // 2,) + q.shape[1:], device=q.device, dtype=q.dtype
+    )
+    q_tail = torch.empty_like(q_head)
+    k_head = torch.empty(
+        (q.size(0) // 2 * (pcp_rank + 1),) + k.shape[1:], device=k.device, dtype=k.dtype
+    )
+    v_head = torch.empty(
+        (q.size(0) // 2 * (pcp_rank + 1),) + v.shape[1:], device=v.device, dtype=v.dtype
+    )
+    k_tail = torch.empty(
+        (q.size(0) // 2 * (2 * pcp_world_size - pcp_rank),) + k.shape[1:],
+        device=k.device,
+        dtype=k.dtype,
+    )
+    v_tail = torch.empty(
+        (q.size(0) // 2 * (2 * pcp_world_size - pcp_rank),) + v.shape[1:],
+        device=v.device,
+        dtype=v.dtype,
+    )
+    BS = len(query_start_loc) - 1
+    DIM_BLOCK_SIZE: int = 64
+    SEQ_BLOCK_SIZE: int = 256
+    assert q.shape[1] == k.shape[1] == v.shape[1]
+    n_head = q.shape[1]
+    n_dim_block = (
+        max(q.shape[2], k.shape[2], v.shape[2]) + DIM_BLOCK_SIZE
+    ) // DIM_BLOCK_SIZE
+    grid = (
+        2 * pcp_world_size * BS,
+        n_head,
+        n_dim_block,
+    )
+    _fused_pcp_qkv_select_kernel[grid](
+        q,
+        q.stride(0),
+        q.stride(1),
+        k,
+        k.stride(0),
+        k.stride(1),
+        v,
+        v.stride(0),
+        v.stride(1),
+        query_start_loc,
+        q_head,
+        q_tail,
+        k_head,
+        k_tail,
+        v_head,
+        v_tail,
+        pcp_world_size,
+        pcp_rank,
+        n_head,
+        q.shape[2],
+        k.shape[2],
+        v.shape[2],
+        SEQ_BLOCK_SIZE,
+        DIM_BLOCK_SIZE,
+    )
+    return q_head, k_head, v_head, q_tail, k_tail, v_tail

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -242,12 +242,12 @@ class ParallelConfig:
     """
     cp_kv_cache_interleave_size: int = 1
     """Interleave size of kv_cache storage while using DCP or PCP.
-    For `total_cp_rank = pcp_rank * dcp_world_size + dcp_rank`,
-        and `total_cp_world_size = pcp_world_size * dcp_world_size`.
-    store interleave_size tokens on total_cp_rank i,
-    then store next interleave_size tokens on total_cp_rank i+1.
+    For `cp_rank = pcp_rank * dcp_world_size + dcp_rank`,
+        and `cp_world_size = pcp_world_size * dcp_world_size`.
+    store interleave_size tokens on cp_rank i,
+    then store next interleave_size tokens on cp_rank i+1.
     Interleave_size=1: token-level alignment, where token `i` is stored on
-        total_cp_rank `i % total_cp_world_size`.
+        cp_rank `i % cp_world_size`.
     Interleave_size=block_size: block-level alignment, where tokens are
         first populated to the preceding ranks. Tokens are then stored
         in (rank i+1, block j) only after (rank i, block j) is fully occupied.

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1092,9 +1092,6 @@ def get_dcp_group() -> GroupCoordinator:
     return _DCP
 
 
-# kept for backward compatibility
-get_context_model_parallel_group = get_dcp_group
-
 _PP: GroupCoordinator | None = None
 
 

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1028,6 +1028,10 @@ class FusedMoEConfig:
         return self.moe_parallel_config.dp_size
 
     @property
+    def pcp_size(self):
+        return self.moe_parallel_config.pcp_size
+
+    @property
     def ep_size(self):
         return self.moe_parallel_config.ep_size
 
@@ -1038,6 +1042,10 @@ class FusedMoEConfig:
     @property
     def dp_rank(self):
         return self.moe_parallel_config.dp_rank
+
+    @property
+    def pcp_rank(self):
+        return self.moe_parallel_config.pcp_rank
 
     @property
     def ep_rank(self):

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -233,6 +233,20 @@ class CudaPlatformBase(Platform):
                     "Forcing kv cache block size to 64 for FlashMLASparse backend."
                 )
 
+        # lazy import to avoid circular import
+        from vllm.config import CUDAGraphMode
+
+        compilation_config = vllm_config.compilation_config
+        if (
+            compilation_config.cudagraph_mode.has_full_cudagraphs()
+            and parallel_config.prefill_context_parallel_size > 1
+        ):
+            logger.warning_once(
+                "Prefill context parallel (PCP) is enabled, which is "
+                "incompatible with full CUDA graphs. "
+                "Overriding cudagraph_mode to PIECEWISE."
+            )
+            compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
         scheduler_config = vllm_config.scheduler_config
         # Note: model_config may be None during testing
         if (

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -45,7 +45,7 @@ from vllm.v1.attention.backends.utils import (
     AttentionCGSupport,
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
-    get_dcp_local_seq_lens,
+    get_cp_local_seq_lens,
     get_kv_cache_layout,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
@@ -405,7 +405,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             query_kv_lens = query_start_loc[1:] - query_start_loc[:-1]
             dcp_context_kv_lens = seq_lens - query_kv_lens
 
-            dcp_context_kv_lens = get_dcp_local_seq_lens(
+            dcp_context_kv_lens = get_cp_local_seq_lens(
                 dcp_context_kv_lens,
                 self.dcp_world_size,
                 self.dcp_rank,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -53,7 +53,7 @@ from vllm.v1.attention.backends.utils import (
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
     KVCacheLayoutType,
-    get_dcp_local_seq_lens,
+    get_cp_local_seq_lens,
     get_kv_cache_layout,
     get_per_layer_parameters,
     infer_global_hyperparameters,
@@ -892,7 +892,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     seq_lens_cpu[num_decodes:] - query_lens_prefill_cpu
                 )
 
-            seq_lens_cpu = get_dcp_local_seq_lens(
+            seq_lens_cpu = get_cp_local_seq_lens(
                 seq_lens_cpu,
                 self.dcp_world_size,
                 self.dcp_rank,

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -1455,19 +1455,23 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             # part and once for the tail part), then concatenate the results and
             # restore the original ordering.
             #
-            # Example pcp_world_size=2 & full sequence: [0,1,2,3]
+            # Considering pcp_world_size=2 and sequence is [0,1,2,3,4,5,6,7]
             #
-            #   pcp_rank0: Q [0,3] KV [0,1,2,3]
-            #    Q\KV  0 1 2 3
-            # head 0   1 0 0 0
-            #      -----------
-            # tail 3   1 1 1 1
+            #   pcp_rank0: Q [0,1,6,7] KV [0,1,2,3,4,5,6,7]
+            #    Q\KV  0 1 2 3 4 5 6 7
+            # head 0   1 0 0 0 0 0 0 0
+            #      1   1 1 0 0 0 0 0 0
+            #      -------------------
+            # tail 6   1 1 1 1 1 1 1 0
+            #      7   1 1 1 1 1 1 1 1
             #
-            #   pcp_rank1: Q[1,3] KV[0,1,2,3]
-            #    Q\KV  0 1 2 3
-            # head 1   1 1 0 0
-            #      -----------
-            # tail 2   1 1 1 0
+            #   pcp_rank1: Q[2,3,4,5] KV [0,1,2,3,4,5,6,7]
+            #    Q\KV  0 1 2 3 4 5 6 7
+            # head 2   1 1 1 0 0 0 0 0
+            #      3   1 1 1 1 0 0 0 0
+            #      -------------------
+            # tail 4   1 1 1 1 1 0 0 0
+            #      5   1 1 1 1 1 1 0 0
 
             q_head, k_head, v_head, q_tail, k_tail, v_tail = fused_pcp_qkv_select(
                 q=q,

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -231,6 +231,7 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
 
 class FlashAttnMLAImpl(MLACommonImpl[FlashAttnMLAMetadata]):
     can_return_lse_for_decode: bool = True
+    supports_pcp: bool = True
 
     def __init__(
         self,

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -112,7 +112,7 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
             vllm_config,
             device,
             FlashAttnMLAMetadata,
-            supports_dcp_with_varlen=(interleave_size == 1),
+            supports_cp_with_varlen=(interleave_size == 1),
         )
         self.max_num_splits = 0  # No upper bound on the number of splits.
         self.fa_aot_schedule = get_flash_attn_version() == 3
@@ -174,7 +174,7 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
         query_start_loc_cpu: torch.Tensor,
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
-        dcp_tot_seq_lens_device: torch.Tensor | None,
+        cp_tot_seq_lens_device: torch.Tensor | None,
     ) -> FlashAttnMLADecodeMetadata:
         query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         max_query_len = query_lens_cpu.max().item()
@@ -224,7 +224,7 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
             max_seq_len=max_seq_len,
             scheduler_metadata=scheduler_metadata,
             max_num_splits=max_num_splits,
-            dcp_tot_seq_lens=dcp_tot_seq_lens_device,
+            cp_tot_seq_lens=cp_tot_seq_lens_device,
         )
         return metadata
 
@@ -311,6 +311,10 @@ class FlashAttnMLAImpl(MLACommonImpl[FlashAttnMLAMetadata]):
         # to prevent invalid grid configuration during graph capture.
         max_seqlen_q = max(attn_metadata.decode.max_query_len, 1)
 
+        assert self.pcp_world_size is not None
+        assert self.dcp_world_size is not None
+        assert self.pcp_rank is not None
+        assert self.dcp_rank is not None
         attn_out = flash_attn_varlen_func(
             q=q_pe,
             k=k_pe_cache.unsqueeze(-2),  # Add head dim of 1
@@ -327,14 +331,14 @@ class FlashAttnMLAImpl(MLACommonImpl[FlashAttnMLAMetadata]):
             fa_version=3,  # only version 3 is supported
             scheduler_metadata=attn_metadata.decode.scheduler_metadata,
             num_splits=attn_metadata.decode.max_num_splits,
-            cp_world_size=self.dcp_world_size,
-            cp_rank=self.dcp_rank,
-            cp_tot_seqused_k=attn_metadata.decode.dcp_tot_seq_lens,
+            cp_world_size=self.pcp_world_size * self.dcp_world_size,
+            cp_rank=self.pcp_rank * self.dcp_world_size + self.dcp_rank,
+            cp_tot_seqused_k=attn_metadata.decode.cp_tot_seq_lens,
         )
 
         if self.need_to_return_lse_for_decode:
             o, lse = attn_out
-            # FA returns LSE in shape [ H, B ] but DCP wants [ B, H ]
+            # FA returns LSE in shape [ H, B ] but CP wants [ B, H ]
             return o, lse.transpose(0, 1)  # [ H, B ] -> [ B, H ]
         else:
             o = attn_out

--- a/vllm/v1/attention/backends/mla/flashmla.py
+++ b/vllm/v1/attention/backends/mla/flashmla.py
@@ -148,7 +148,7 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
         query_start_loc_cpu: torch.Tensor,
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
-        dcp_tot_seq_lens_device: torch.Tensor | None,
+        cp_tot_seq_lens_device: torch.Tensor | None,
     ) -> FlashMLADecodeMetadata:
         query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         # we use the max but all should be the same due to uniform length requirement
@@ -194,7 +194,7 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
             seq_lens=seq_lens_device,
             tile_scheduler_metadata=tile_scheduler_metadata,
             num_splits=num_splits,
-            dcp_tot_seq_lens=dcp_tot_seq_lens_device,
+            cp_tot_seq_lens=cp_tot_seq_lens_device,
         )
 
 

--- a/vllm/v1/attention/backends/mla/flashmla.py
+++ b/vllm/v1/attention/backends/mla/flashmla.py
@@ -200,6 +200,7 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
 
 class FlashMLAImpl(MLACommonImpl[FlashMLAMetadata]):
     can_return_lse_for_decode: bool = True
+    supports_pcp: bool = True
 
     def __init__(
         self,

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -111,7 +111,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
         query_start_loc_cpu: torch.Tensor,
         query_start_loc_device: torch.Tensor,
         num_decode_tokens: int,
-        dcp_tot_seq_lens_device: torch.Tensor | None,
+        cp_tot_seq_lens_device: torch.Tensor | None,
     ) -> AiterMLADecodeMetadata:
         # kernel block size is always 1, although the kv block size is not 1.
         device = self.device
@@ -172,7 +172,7 @@ class AiterMLAMetadataBuilder(MLACommonMetadataBuilder[AiterMLAMetadata]):
             paged_kv_indices=paged_kv_indices,
             paged_kv_last_page_len=paged_kv_last_page_len,
             qo_indptr=qo_indptr,
-            dcp_tot_seq_lens=dcp_tot_seq_lens_device,
+            cp_tot_seq_lens=cp_tot_seq_lens_device,
             max_qo_len=max_qo_len,
             attn_out_dtype=self.decode_attn_out_dtype,
         )

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -1333,23 +1333,3 @@ def get_pcp_query_indices(cu_num_tokens: torch.Tensor):
         return_tail=True,
     )
     return torch.from_numpy(head_indices), torch.from_numpy(tail_indices)
-
-
-def get_pcp_kv_indices(
-    cu_num_tokens: torch.Tensor,
-    pcp_rank: int,
-    pcp_size: int,
-):
-    kv_head_indices, _ = get_pcp_part_indices(
-        cu_num_tokens,
-        pcp_rank + 1,
-        2 * pcp_size,
-        return_head=True,
-    )
-    kv_tail_indices, _ = get_pcp_part_indices(
-        cu_num_tokens,
-        2 * pcp_size - pcp_rank,
-        2 * pcp_size,
-        return_head=True,
-    )
-    return torch.from_numpy(kv_head_indices), torch.from_numpy(kv_tail_indices)

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -687,7 +687,9 @@ class EagleProposer:
             block_table_tensor=common_attn_metadata.block_table_tensor,
             slot_mapping=common_attn_metadata.slot_mapping[:total_num_tokens],
             causal=True,
-            dcp_local_seq_lens=common_attn_metadata.dcp_local_seq_lens,
+            cp_local_seq_lens=common_attn_metadata.cp_local_seq_lens,
+            cp_local_seq_lens_cpu=common_attn_metadata.cp_local_seq_lens_cpu,
+            pcp_allgather_restore_idx=common_attn_metadata.pcp_allgather_restore_idx,
         )
 
         return (
@@ -967,7 +969,9 @@ class EagleProposer:
             block_table_tensor=common_attn_metadata.block_table_tensor,
             slot_mapping=common_attn_metadata.slot_mapping[token_indices],
             causal=True,
-            dcp_local_seq_lens=common_attn_metadata.dcp_local_seq_lens,
+            cp_local_seq_lens=common_attn_metadata.cp_local_seq_lens,
+            cp_local_seq_lens_cpu=common_attn_metadata.cp_local_seq_lens_cpu,
+            pcp_allgather_restore_idx=common_attn_metadata.pcp_allgather_restore_idx,
         )
 
         return spec_common_attn_metadata, token_indices

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -138,16 +138,16 @@ class BlockTable:
         # NOTE(woosuk): We can't simply use `token_indices // block_size`
         # here because M (max_model_len) is not necessarily divisible by
         # block_size.
-        total_cp_world_size = self.pcp_world_size * self.dcp_world_size
-        total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
-        if total_cp_world_size > 1:
+        cp_world_size = self.pcp_world_size * self.dcp_world_size
+        cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
+        if cp_world_size > 1:
             # Note(hc): The DCP implement store kvcache with an interleave
             # style, the kvcache for the token whose token_idx is i is
             # always stored on the GPU whose dcp_rank equals i % cp_world_size:
 
             # Use a "virtual block" which equals to world_size * block_size
             # for block_table_indices calculation.
-            virtual_block_size = self.block_size * total_cp_world_size
+            virtual_block_size = self.block_size * cp_world_size
             block_table_indices = (
                 req_indices * self.max_num_blocks_per_req
                 + positions // virtual_block_size
@@ -160,13 +160,13 @@ class BlockTable:
             mask = (
                 virtual_block_offsets
                 // self.cp_kv_cache_interleave_size
-                % total_cp_world_size
-                == total_cp_rank
+                % cp_world_size
+                == cp_rank
             )
             # Calculate local block_offsets
             block_offsets = (
                 virtual_block_offsets
-                // (total_cp_world_size * self.cp_kv_cache_interleave_size)
+                // (cp_world_size * self.cp_kv_cache_interleave_size)
                 * self.cp_kv_cache_interleave_size
                 + virtual_block_offsets % self.cp_kv_cache_interleave_size
             )

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -17,7 +17,7 @@ class PCPManager:
     Manager for Prefill Context Parallelism (PCP) metadata and buffers.
 
     This manager encapsulates all PCP-related buffers and logic so that the
-    ModelRunner can access them via `self.pcp_manager`..
+    ModelRunner can access them via `self.pcp_manager`.
     """
 
     def __init__(
@@ -28,11 +28,9 @@ class PCPManager:
         max_num_reqs: int,
         device: torch.device,
         pin_memory: bool = False,
-        arange_np: np.ndarray | None = None,
     ) -> None:
         self.pcp_world_size = pcp_world_size
         self.pcp_rank = pcp_rank
-        self.arange_np = arange_np
 
         self.pcp_allgather_restore_idx = CpuGpuBuffer(
             max_buffer_num_tokens,

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from typing import TYPE_CHECKING, Any, cast
-import torch
+
 import numpy as np
+import torch
+
 from vllm.config import VllmConfig, get_layers_from_vllm_config
-from vllm.v1.utils import CpuGpuBuffer
 from vllm.distributed.parallel_state import get_pcp_group
+from vllm.v1.utils import CpuGpuBuffer
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -1,13 +1,249 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from typing import TYPE_CHECKING, Any, cast
-
+import torch
+import numpy as np
 from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.v1.utils import CpuGpuBuffer
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 else:
     AttentionLayerBase = object
+
+
+class PCPManager:
+    """
+    Manager for Prefill Context Parallelism (PCP) metadata and buffers.
+
+    This manager encapsulates all PCP-related buffers and logic so that the
+    ModelRunner can access them via `self.pcp_manager`..
+    """
+
+    def __init__(
+        self,
+        pcp_world_size: int,
+        pcp_rank: int,
+        max_buffer_num_tokens: int,
+        max_num_reqs: int,
+        device: torch.device,
+        pin_memory: bool = False,
+        arange_np: np.ndarray | None = None,
+    ) -> None:
+        self.pcp_world_size = pcp_world_size
+        self.pcp_rank = pcp_rank
+        self.arange_np = arange_np
+
+        self.pcp_allgather_restore_idx = CpuGpuBuffer(
+            max_buffer_num_tokens,
+            dtype=torch.int64,
+            device=device,
+            pin_memory=pin_memory,
+        )
+        self.pcp_padded_slot_mapping = torch.empty(
+            (max_buffer_num_tokens,),
+            dtype=torch.int64,
+            device=device,
+        )
+        self.num_pcp_pads_cpu_tensor = torch.zeros(
+            (max_num_reqs,), device="cpu", dtype=torch.int64
+        )
+        self.num_pcp_pads_cpu = self.num_pcp_pads_cpu_tensor.numpy()
+        self.pcp_unpad_mask_cpu_tensor = torch.zeros(
+            (max_buffer_num_tokens,),
+            device="cpu",
+            dtype=torch.bool,
+        )
+        self.pcp_unpad_mask_cpu = self.pcp_unpad_mask_cpu_tensor.numpy()
+
+    def _get_cumsum_and_arange(
+        self,
+        num_scheduled_tokens: np.ndarray,
+        arange_np: np.ndarray,
+        cumsum_dtype: np.dtype | None = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Get the cumulative sum and batched arange of the given array.
+        # E.g., [2, 5, 3] -> ([2, 7, 10], [0, 1, 0, 1, 2, 3, 4, 0, 1, 2])
+        # Equivalent to but faster than:
+        # np.concatenate([np.arange(n) for n in num_scheduled_tokens])
+        """
+        # Step 1. [2, 5, 3] -> [2, 7, 10]
+        cu_num_tokens = np.cumsum(num_scheduled_tokens, dtype=cumsum_dtype)
+        total_num_tokens = cu_num_tokens[-1]
+        # Step 2. [2, 7, 10] -> [0, 0, 2, 2, 2, 2, 2, 7, 7, 7]
+        cumsums_offsets = np.repeat(
+            cu_num_tokens - num_scheduled_tokens, num_scheduled_tokens
+        )
+        # Step 3. [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
+        arange = arange_np[:total_num_tokens] - cumsums_offsets
+
+        return cu_num_tokens, arange
+
+    def update_tokens_for_pcp(
+        self,
+        tokens: np.ndarray,
+        arange_np: np.ndarray,
+        num_reqs: int,
+        reorder_batch_threshold: int | None = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Update token counts and positions for Prefill Context Parallelism (PCP).
+
+        When using Prefill Context Parallelism, each request's prefill sequence is
+        split across multiple PCP ranks. The splitting strategy used here is the
+        "DualChunkSwap" style: each request's (padded) sequence is split into
+        2 * pcp_world_size chunks and ranks are assigned chunks in an interleaved
+        head/tail pattern to balance load.
+
+        This function:
+        - Computes how many tokens each request should be processed by the current
+          PCP rank (pcp_tokens).
+        - Computes the flattened positions of those tokens within the local
+          padded buffer (pcp_positions).
+        - Updates runner state arrays used to restore original order and mask out
+          padded tokens after allgather:
+            - self.num_pcp_pads_cpu: number of pads added per request
+            - self.pcp_unpad_mask_cpu: boolean mask marking real tokens in the
+              padded allgather buffer
+            - self.pcp_allgather_restore_idx: index array used to restore original
+              ordering after per-rank allgather and interleaving.
+
+        Args:
+            tokens: 1D numpy array of length num_reqs containing the number of new
+                    tokens scheduled for each request (before PCP splitting).
+            arange_np: 1D numpy array of length max_buffer_num_tokens used for
+                       efficient batched arange operations.
+            num_reqs: Total number of requests in the batch.
+            reorder_batch_threshold: Threshold for decode vs prefill requests.
+
+        Returns:
+            Tuple (pcp_tokens, pcp_positions):
+            - pcp_tokens: number of tokens per request that this PCP rank will
+                          actually process (after splitting / replication).
+            - pcp_positions: flattened positions for those tokens on this rank,
+                             used to build the positions buffer for the model.
+
+        Example:
+        >>> Assume tokens = [1, 5, 8], pcp_world_size = 2. After _update_tokens_for_pcp.
+        >>> pcp_rank = 0 get ([1, 4, 4], [0, 0, 1, 6, 7, 0, 1, 6, 7])
+        >>> pcp_rank = 1 get ([1, 4, 4], [0, 2, 3, 4, 5, 2, 3, 4, 5])
+        >>> Meanwhile, the following results are same for each pcp rank
+        >>> self.num_pcp_pads_cpu
+        [1, 3, 0]
+        >>> self.pcp_unpad_mask_cpu
+        [True, False, True, True, True, True, True, False, False,
+        False, True, True, True, True, True, True, True, True]
+        >>> self.pcp_allgather_resotre_idx
+        [0, 9, 1, 2, 10, 11, 12, 13, 3, 4, 5, 6, 14, 15, 16, 17, 7, 8]
+        """
+
+        assert reorder_batch_threshold is not None, (
+            "PCP depends on reorder batch to split decode and prefill requests."
+        )
+        num_decode_reqs = sum(tokens <= reorder_batch_threshold)
+        num_decode_tokens = sum(tokens[:num_decode_reqs])
+
+        # DualChunkSwap requires alignment to a multiple of (2 * pcp_world_size).
+        # We first pad each request's token count up to that multiple.
+        num_padded_scheduled_tokens = np.ceil(
+            tokens / (2 * self.pcp_world_size)
+        ).astype(np.int32) * (2 * self.pcp_world_size)
+
+        # PCP does not split decode requests. For decode requests, we instead
+        # duplicate the scheduled tokens across the pcp_world_size ranks.
+        num_padded_scheduled_tokens[:num_decode_reqs] = (
+            tokens[:num_decode_reqs] * self.pcp_world_size
+        )
+
+        # Record how many pads were added per request (padded - original).
+        self.num_pcp_pads_cpu[:num_reqs] = num_padded_scheduled_tokens - tokens
+
+        # cu_padded_tokens: cumulative sum of padded token counts,
+        # pcp_padded_arange: per-request arange flattened for padded tokens.
+        cu_padded_tokens, pcp_padded_arange = self._get_cumsum_and_arange(
+            num_padded_scheduled_tokens, arange_np
+        )
+        # Build the mask that marks which positions in the padded allgather buffer
+        # correspond to real (unpadded) tokens.
+        self.pcp_unpad_mask_cpu[: pcp_padded_arange.shape[0]] = (
+            pcp_padded_arange < np.repeat(tokens, num_padded_scheduled_tokens)
+        )
+
+        pcp_tokens = num_padded_scheduled_tokens // self.pcp_world_size
+
+        # Compute per-request "chunk sizes" for the head/tail splitting.
+        # For prefill requests, we further split the pcp_tokens into two chunks
+        # (head and tail). For decode requests, the chunk equals pcp_tokens.
+        pcp_chunk_sizes = (pcp_tokens // 2).clip(min=1)
+        pcp_chunk_sizes[:num_decode_reqs] = pcp_tokens[:num_decode_reqs]
+
+        # Build arange-style helpers for pcp tokens and chunk sizes:
+        # - pcp_arange gives indices repeated for each token in pcp_tokens
+        # - pcp_chunk_arange gives indices repeated for each position inside chunks
+        _, pcp_arange = self._get_cumsum_and_arange(pcp_tokens, arange_np)
+        _, pcp_chunk_arange = self._get_cumsum_and_arange(pcp_chunk_sizes, arange_np)
+
+        # Mask that marks whether a position belongs to the head chunk (True)
+        # or the tail chunk (False). For decode requests, tail chunk won't exist
+        # and is handled specially below.
+        pcp_head_chunk_mask = pcp_arange < np.repeat(pcp_chunk_sizes, pcp_tokens)
+
+        def get_current_rank_positions(
+            positions_start_loc: int | np.ndarray, rank: int
+        ):
+            """
+            Compute flattened positions for the given rank with a given start
+            offset for each request (positions_start_loc).
+
+            - For head chunks: start at positions_start_loc + rank * chunk_size.
+            - For tail chunks: start at positions_start_loc + (2*pcp_world_size- rank -
+            1) * chunk_size.
+            - For decode requests: no tail chunks; their positions are filled from the
+              contiguous (unpadded) `tokens` arange instead (handled after).
+            """
+            positions = np.zeros(len(pcp_head_chunk_mask), dtype=np.int32)
+            head_start_loc = positions_start_loc + rank * pcp_chunk_sizes
+            tail_start_loc = (
+                positions_start_loc
+                + (2 * self.pcp_world_size - rank - 1) * pcp_chunk_sizes
+            )
+            # Fill head positions using chunk arange offset by head_start_loc.
+            positions[pcp_head_chunk_mask] = pcp_chunk_arange + np.repeat(
+                head_start_loc, pcp_chunk_sizes
+            )
+            # Fill tail positions. Note decode requests do not have tail chunks,
+            # so the tail filling is only for prefill positions.
+            positions[~pcp_head_chunk_mask] = (
+                pcp_chunk_arange[num_decode_tokens:]
+                + np.repeat(tail_start_loc, pcp_chunk_sizes)[num_decode_tokens:]
+            )
+            return positions
+
+        positions = get_current_rank_positions(0, self.pcp_rank)
+        # Decode tokens are duplicated only after AG. But their positions are
+        # same without prefill context parallel.
+        if num_decode_reqs > 0:
+            positions[:num_decode_tokens] = self._get_cumsum_and_arange(
+                tokens[:num_decode_reqs], arange_np
+            )[1]
+
+        # Build the restore index used after allgather.
+        padded_pos_start_loc = np.roll(cu_padded_tokens, 1)
+        padded_pos_start_loc[0] = 0
+        all_positions_lst = [
+            get_current_rank_positions(padded_pos_start_loc, rank_i)
+            for rank_i in range(self.pcp_world_size)
+        ]
+        all_positions = np.concatenate(all_positions_lst)
+        self.pcp_allgather_restore_idx.np[: all_positions.shape[0]] = (
+            all_positions.argsort()
+        )
+        self.pcp_allgather_restore_idx.copy_to_gpu(all_positions.shape[0])
+
+        return (
+            pcp_tokens[:num_reqs],
+            positions,
+        )
 
 
 def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -43,6 +43,7 @@ from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_
 from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
 from vllm.distributed.parallel_state import (
     get_dcp_group,
+    get_pcp_group,
     get_pp_group,
     get_tp_group,
     graph_capture,
@@ -108,7 +109,7 @@ from vllm.v1.attention.backends.utils import (
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
     create_fast_prefill_custom_backend,
-    get_dcp_local_seq_lens,
+    get_cp_local_seq_lens,
     reorder_batch_to_split_decodes_and_prefills,
     split_attn_metadata,
 )
@@ -152,7 +153,7 @@ from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 from vllm.v1.spec_decode.suffix_decoding import SuffixDecodingProposer
 from vllm.v1.structured_output.utils import apply_grammar_bitmask
 from vllm.v1.utils import CpuGpuBuffer, record_function_or_nullcontext
-from vllm.v1.worker.cp_utils import check_attention_cp_compatibility
+from vllm.v1.worker.cp_utils import PCPManager, check_attention_cp_compatibility
 from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
 from vllm.v1.worker.ec_connector_model_runner_mixin import ECConnectorModelRunnerMixin
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
@@ -316,7 +317,11 @@ class GPUModelRunner(
         # Always set to false after the first forward pass
         self.calculate_kv_scales = self.cache_config.calculate_kv_scales
         self.dcp_world_size = self.parallel_config.decode_context_parallel_size
+        self.pcp_world_size = self.parallel_config.prefill_context_parallel_size
+        self.cp_world_size = self.dcp_world_size * self.pcp_world_size
         self.dcp_rank = 0 if self.dcp_world_size <= 1 else get_dcp_group().rank_in_group
+        self.pcp_rank = 0 if self.pcp_world_size <= 1 else get_pcp_group().rank_in_group
+        self.cp_rank = self.dcp_world_size * self.pcp_rank + self.dcp_rank
         self.max_num_tokens = scheduler_config.max_num_batched_tokens
         self.max_num_reqs = scheduler_config.max_num_seqs
 
@@ -481,25 +486,38 @@ class GPUModelRunner(
         # Cache the device properties.
         self._init_device_properties()
 
+        if self.pcp_world_size > 1:
+            # NOTE For PCP, we will pad the tokens of each request
+            # to a multiple of 2 * pcp_size that is possible greater
+            # than the max_num_batched_tokens.
+            max_buffer_num_tokens = (
+                self.max_num_tokens + self.max_num_reqs * 2 * self.pcp_world_size
+            )
+        else:
+            max_buffer_num_tokens = self.max_num_tokens
+
         # Persistent buffers for CUDA graphs.
-        self.input_ids = self._make_buffer(self.max_num_tokens, dtype=torch.int32)
-        self.positions = self._make_buffer(self.max_num_tokens, dtype=torch.int64)
+        self.input_ids = self._make_buffer(max_buffer_num_tokens, dtype=torch.int32)
+        self.positions = self._make_buffer(max_buffer_num_tokens, dtype=torch.int64)
         self.query_start_loc = self._make_buffer(
             self.max_num_reqs + 1, dtype=torch.int32
         )
         self.seq_lens = self._make_buffer(self.max_num_reqs, dtype=torch.int32)
         self.encoder_seq_lens = self._make_buffer(self.max_num_reqs, dtype=torch.int32)
-        if self.dcp_world_size > 1:
-            self.dcp_local_seq_lens = self._make_buffer(
+        if self.cp_world_size > 1:
+            self.cp_local_seq_lens = self._make_buffer(
                 self.max_num_reqs, dtype=torch.int32
             )
         # Because inputs_embeds may be bfloat16 and we don't need a numpy
         # version of this tensor, avoid a RuntimeError by not creating a
         # numpy buffer.
         self.inputs_embeds = self._make_buffer(
-            self.max_num_tokens, self.inputs_embeds_size, dtype=self.dtype, numpy=False
+            max_buffer_num_tokens,
+            self.inputs_embeds_size,
+            dtype=self.dtype,
+            numpy=False,
         )
-        self.is_token_ids = self._make_buffer(self.max_num_tokens, dtype=torch.bool)
+        self.is_token_ids = self._make_buffer(max_buffer_num_tokens, dtype=torch.bool)
         self.discard_request_mask = self._make_buffer(
             self.max_num_reqs, dtype=torch.bool
         )
@@ -512,7 +530,20 @@ class GPUModelRunner(
 
         # Only relevant for multimodal models
         if self.supports_mm_inputs:
-            self.is_mm_embed = self._make_buffer(self.max_num_tokens, dtype=torch.bool)
+            self.is_mm_embed = self._make_buffer(
+                max_buffer_num_tokens, dtype=torch.bool
+            )
+
+        # Manager for Prefill Context Parallism
+        if self.pcp_world_size > 1:
+            self.pcp_manager = PCPManager(
+                self.pcp_world_size,
+                self.pcp_rank,
+                max_buffer_num_tokens,
+                self.max_num_reqs,
+                self.device,
+                self.pin_memory,
+            )
 
         # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
         if self.uses_mrope:
@@ -527,7 +558,7 @@ class GPUModelRunner(
             # 1D-RoPE.
             # See page 5 of https://arxiv.org/abs/2409.12191
             self.mrope_positions = self._make_buffer(
-                (3, self.max_num_tokens + 1), dtype=torch.int64
+                (3, max_buffer_num_tokens + 1), dtype=torch.int64
             )
 
         # Only relevant for models using XD-RoPE (e.g, HunYuan-VL)
@@ -543,7 +574,7 @@ class GPUModelRunner(
         # OPTIMIZATION: Cache the tensors rather than creating them every step.
         # Keep in int64 to avoid overflow with long context
         self.arange_np = np.arange(
-            max(self.max_num_reqs + 1, self.max_model_len, self.max_num_tokens),
+            max(self.max_num_reqs + 1, self.max_model_len, max_buffer_num_tokens),
             dtype=np.int64,
         )
 
@@ -557,7 +588,7 @@ class GPUModelRunner(
         self.kv_sharing_fast_prefill_logits_indices = None
         if self.cache_config.kv_sharing_fast_prefill:
             self.kv_sharing_fast_prefill_logits_indices = torch.zeros(
-                self.max_num_tokens, dtype=torch.int32, device=self.device
+                max_buffer_num_tokens, dtype=torch.int32, device=self.device
             )
 
         self.uniform_decode_query_len = 1 + self.num_spec_tokens
@@ -1329,6 +1360,32 @@ class GPUModelRunner(
             out=positions_np,
         )
 
+        self.input_batch.block_table.compute_slot_mapping(req_indices, positions_np)
+        self.input_batch.block_table.commit_slot_mapping(total_num_scheduled_tokens)
+
+        if self.pcp_world_size > 1:
+            num_scheduled_tokens[:num_reqs], pcp_positions = (
+                self.pcp_manager.update_tokens_for_pcp(
+                    num_scheduled_tokens[:num_reqs],
+                    self.arange_np,
+                    self.input_batch.num_reqs,
+                    self.reorder_batch_threshold,
+                )
+            )
+
+            # Re-update after PCP split sequences.
+            total_num_scheduled_tokens = sum(num_scheduled_tokens)
+            scheduler_output.total_num_scheduled_tokens = total_num_scheduled_tokens
+
+            req_indices = np.repeat(self.arange_np[:num_reqs], num_scheduled_tokens)
+            cu_num_tokens, _ = self._get_cumsum_and_arange(num_scheduled_tokens)
+            positions_np = self.positions.np[:total_num_scheduled_tokens]
+            np.add(
+                self.input_batch.num_computed_tokens_cpu[req_indices],
+                pcp_positions[:total_num_scheduled_tokens],
+                out=positions_np,
+            )
+
         # Calculate M-RoPE positions.
         # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
         if self.uses_mrope:
@@ -1404,9 +1461,6 @@ class GPUModelRunner(
 
                 output_idx += num_sched
 
-        self.input_batch.block_table.compute_slot_mapping(req_indices, positions_np)
-        self.input_batch.block_table.commit_slot_mapping(total_num_scheduled_tokens)
-
         # Prepare the attention metadata.
         self.query_start_loc.np[0] = 0
         self.query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
@@ -1428,9 +1482,16 @@ class GPUModelRunner(
 
         # Record which requests should not be sampled,
         # so that we could clear the sampled tokens before returning
-        self.discard_request_mask.np[:num_reqs] = (
-            self.seq_lens.np[:num_reqs] < num_tokens_np
-        )
+        if self.pcp_world_size > 1:
+            self.discard_request_mask.np[:num_reqs] = (
+                self.input_batch.num_computed_tokens_cpu[:num_reqs]
+                + num_scheduled_tokens * self.pcp_world_size
+                - self.pcp_manager.num_pcp_pads_cpu[:num_reqs]
+            ) < num_tokens_np
+        else:
+            self.discard_request_mask.np[:num_reqs] = (
+                self.seq_lens.np[:num_reqs] < num_tokens_np
+            )
         self.discard_request_mask.copy_to_gpu(num_reqs)
 
         # Copy the tensors to the GPU.
@@ -1464,10 +1525,19 @@ class GPUModelRunner(
             # We will ignore the sampled tokens from the partial requests.
             # TODO: Support prompt logprobs.
             logits_indices = query_start_loc[1:] - 1
+            if self.pcp_world_size > 1:
+                logits_indices = (
+                    torch.from_numpy(cu_num_tokens) * self.pcp_world_size
+                    - self.pcp_manager.num_pcp_pads_cpu_tensor[:num_reqs]
+                    - 1
+                )
+            else:
+                logits_indices = query_start_loc[1:] - 1
             num_draft_tokens = None
             spec_decode_metadata = None
             num_sampled_tokens = np.ones(num_reqs, dtype=np.int32)
         else:
+            assert self.pcp_world_size == 1, "PCP not support spec decode now"
             # Get the number of draft tokens for each request.
             # Iterate over the dictionary rather than all requests since not all
             # requests have draft tokens.
@@ -1535,6 +1605,10 @@ class GPUModelRunner(
         if len(self.kv_cache_config.kv_cache_groups) == 0:
             return {}, None
 
+        assert num_tokens_padded is None or self.pcp_world_size == 1, (
+            "PCP not support pad attn now"
+        )
+
         num_tokens_padded = num_tokens_padded or num_tokens
         num_reqs_padded = num_reqs_padded or num_reqs
         assert num_reqs_padded is not None and num_tokens_padded is not None
@@ -1563,9 +1637,16 @@ class GPUModelRunner(
         def _get_block_table_and_slot_mapping(kv_cache_gid: int):
             assert num_reqs_padded is not None and num_tokens_padded is not None
             kv_cache_spec = kv_cache_groups[kv_cache_gid].kv_cache_spec
+            
+            maybe_pcp_full_tokens = (
+                num_tokens_padded
+                if self.pcp_world_size == 1
+                else num_tokens * self.pcp_world_size
+                - sum(self.pcp_manager.num_pcp_pads_cpu[:num_reqs])
+            )
             if isinstance(kv_cache_spec, EncoderOnlyAttentionSpec):
                 blk_table_tensor = torch.zeros(
-                    (num_reqs_padded, 1),
+                    (num_tokens_padded, 1),
                     dtype=torch.int32,
                     device=self.device,
                 )
@@ -1577,12 +1658,25 @@ class GPUModelRunner(
             else:
                 blk_table = self.input_batch.block_table[kv_cache_gid]
                 blk_table_tensor = blk_table.get_device_tensor(num_reqs_padded)
-                slot_mapping = blk_table.slot_mapping.gpu[:num_tokens_padded]
+                slot_mapping = blk_table.slot_mapping.gpu[:maybe_pcp_full_tokens]
 
-            # Fill unused with -1. Needed for reshape_and_cache in full cuda
-            # graph mode. `blk_table_tensor` -1 to match mamba PAD_SLOT_ID
-            slot_mapping[num_tokens:num_tokens_padded].fill_(-1)
-            blk_table_tensor[num_reqs:num_reqs_padded].fill_(-1)
+                # Fill unused with -1. Needed for reshape_and_cache in full cuda
+                # graph mode. `blk_table_tensor` -1 to match mamba PAD_SLOT_ID
+                if self.pcp_world_size == 1:
+                    slot_mapping[num_tokens:num_tokens_padded].fill_(-1)
+                    blk_table_tensor[num_reqs:num_reqs_padded].fill_(-1)
+            if self.pcp_world_size > 1:
+                # After pcp allgather and restore, there are padded tokens in
+                # kv, so we need pad slotmapping for alignment.
+                pcp_padded_slot_mapping = self.pcp_manager.pcp_padded_slot_mapping[
+                    : num_tokens * self.pcp_world_size
+                ]
+                cp_unpad_mask = self.pcp_manager.pcp_unpad_mask_cpu_tensor[
+                    : num_tokens * self.pcp_world_size
+                ]
+                pcp_padded_slot_mapping.fill_(-1)
+                pcp_padded_slot_mapping[cp_unpad_mask] = slot_mapping
+                slot_mapping = pcp_padded_slot_mapping
 
             return blk_table_tensor, slot_mapping
 
@@ -1604,20 +1698,25 @@ class GPUModelRunner(
             causal=True,
         )
 
-        if self.dcp_world_size > 1:
-            self.dcp_local_seq_lens.cpu[:num_reqs] = get_dcp_local_seq_lens(
+        if self.cp_world_size > 1:
+            self.cp_local_seq_lens.cpu[:num_reqs] = get_cp_local_seq_lens(
                 self.seq_lens.cpu[:num_reqs],
-                self.dcp_world_size,
-                self.dcp_rank,
+                self.cp_world_size,
+                self.cp_rank,
                 self.parallel_config.cp_kv_cache_interleave_size,
             )
-            self.dcp_local_seq_lens.cpu[num_reqs:].fill_(0)
-            self.dcp_local_seq_lens.copy_to_gpu(num_reqs_padded)
+            self.cp_local_seq_lens.cpu[num_reqs:].fill_(0)
+            self.cp_local_seq_lens.copy_to_gpu(num_reqs_padded)
 
-            cm_base.dcp_local_seq_lens = self.dcp_local_seq_lens.gpu[:num_reqs_padded]
-            cm_base.dcp_local_seq_lens_cpu = self.dcp_local_seq_lens.cpu[
+            cm_base.cp_local_seq_lens = self.cp_local_seq_lens.gpu[:num_reqs_padded]
+            cm_base.cp_local_seq_lens_cpu = self.cp_local_seq_lens.cpu[
                 :num_reqs_padded
             ]
+
+        if self.pcp_world_size > 1:
+            cm_base.pcp_allgather_restore_idx=self.pcp_manager.pcp_allgather_restore_idx.gpu[
+                    : num_tokens * self.pcp_world_size
+                ]
 
         if logits_indices is not None and self.cache_config.kv_sharing_fast_prefill:
             cm_base.num_logits_indices = logits_indices.size(0)
@@ -3111,6 +3210,9 @@ class GPUModelRunner(
                     scheduler_output,
                     num_scheduled_tokens_np,
                 )
+                if self.pcp_world_size > 1:
+                    max_num_scheduled_tokens = int(num_scheduled_tokens_np.max())
+                    num_tokens_unpadded = scheduler_output.total_num_scheduled_tokens
 
                 cascade_attn_prefix_lens = None
                 # Disable cascade attention when using microbatching (DBO)
@@ -3235,6 +3337,23 @@ class GPUModelRunner(
                 hidden_states = model_output
                 aux_hidden_states = None
 
+            if self.pcp_world_size > 1:
+                # NOTE we must `slice` hidden_states because pcp_allgather_restore_idx
+                # ignores the padding from CUDA Graph.
+                hidden_states = get_pcp_group().all_gather(
+                    hidden_states[:num_tokens_unpadded],
+                    0,
+                )
+                restore_idx = self.pcp_manager.pcp_allgather_restore_idx.gpu[
+                    : hidden_states.shape[0]
+                ]
+                hidden_states = torch.index_select(
+                    hidden_states,
+                    0,
+                    restore_idx,
+                )
+                # Restore total_num_scheduled_tokens.
+                scheduler_output.total_num_scheduled_tokens = num_scheduled_tokens
             if not self.broadcast_pp_output:
                 # Common case.
                 if not get_pp_group().is_last_rank:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1636,7 +1636,7 @@ class GPUModelRunner(
         def _get_block_table_and_slot_mapping(kv_cache_gid: int):
             assert num_reqs_padded is not None and num_tokens_padded is not None
             kv_cache_spec = kv_cache_groups[kv_cache_gid].kv_cache_spec
-            
+
             maybe_pcp_full_tokens = (
                 num_tokens_padded
                 if self.pcp_world_size == 1
@@ -1701,14 +1701,14 @@ class GPUModelRunner(
             self.cp_local_seq_lens.copy_to_gpu(num_reqs_padded)
 
             cm_base.cp_local_seq_lens = self.cp_local_seq_lens.gpu[:num_reqs_padded]
-            cm_base.cp_local_seq_lens_cpu = self.cp_local_seq_lens.cpu[
-                :num_reqs_padded
-            ]
+            cm_base.cp_local_seq_lens_cpu = self.cp_local_seq_lens.cpu[:num_reqs_padded]
 
         if self.pcp_world_size > 1:
-            cm_base.pcp_allgather_restore_idx=self.pcp_manager.pcp_allgather_restore_idx.gpu[
+            cm_base.pcp_allgather_restore_idx = (
+                self.pcp_manager.pcp_allgather_restore_idx.gpu[
                     : num_tokens * self.pcp_world_size
                 ]
+            )
 
         if logits_indices is not None and self.cache_config.kv_sharing_fast_prefill:
             cm_base.num_logits_indices = logits_indices.size(0)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4743,7 +4743,7 @@ class GPUModelRunner(
 
         # Add `is_profile` here to pre-allocate communication buffers
         hidden_states, last_hidden_states = self._dummy_run(
-            self.max_num_tokens, is_profile=True
+            self.max_num_tokens // self.pcp_world_size, is_profile=True
         )
         if get_pp_group().is_last_rank:
             if self.is_pooling_model:


### PR DESCRIPTION
## Purpose
Ref to issue https://github.com/vllm-project/vllm/issues/25749. Enable PCP for MLA models.
This PR mainly includes the following changes:

- Add PCP Manager to `vllm/v1/worker/cp_utils.py` for model runner.
- Modified `vllm/v1/worker/gpu_model_runner.py` for PCP splitting logic for tokens
- Modified `vllm/v1/attention/backends/mla/common.py` to adapt the MLA backend to PCP
- Add utility functions required by PCP to `vllm/v1/attention/backends/utils.py` and `vllm/attention/ops/common.py`
- Renamed variables and functions shared by both PCP and DCP

## Test Plan
```shell
vllm serve deepseek-ai/DeepSeek-V2-Lite-Chat --gpu-memory-utilization 0.9 --tensor-parallel-size 1 --prefill-context-parallel-size 2
```

## Test Result
- PCP1TP8 (Baseline)
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6277|±  |0.0094|
|     |       |strict-match    |     5|exact_match|↑  |0.6179|±  |0.0095|
```
- PCP2TP4
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6259|±  |0.0094|
|     |       |strict-match    |     5|exact_match|↑  |0.6164|±  |0.0095|
```
- PCP4TP2
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6308|±  |0.0094|
|     |       |strict-match    |     5|exact_match|↑  |0.6236|±  |0.0094|
```
- PCP8TP1
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6240|±  |0.0094|
|     |       |strict-match    |     5|exact_match|↑  |0.6168|±  |0.0095|
```

## Benchmark
In addition to reducing GPU memory redundancy and **increasing KV cache capacity**, PCP can also reduce the all-reduce communication overhead of `o_proj` and **lower TTFT**. We evaluated the performance of PCP and TP on DeepSeek-R1 and Kimi-K2 using 4K-length inputs on the H20-3e.

### DeepSeek-R1

```shell
vllm bench serve --backend vllm  --model deepseek-ai/DeepSeek-R1/  --endpoint /v1/completions   --dataset-name random   --random-input 4096   --random-output 1   --max-concurrency 1  --num-prompt 10 --ignore-eos --metric-percentiles "50,90,99"
```

| Parallel Config |P50 TTFT (ms)  |     P90 TTFT (ms)    |  P99 TTFT (ms)   |   Performance gain  |
|:-----:|:------:|:------:|:-----:|:----:|
| PCP1TP8 |    414  | 417 |  418   | --- |
|   PCP2TP4  |   400  |  403  |   404   |  3.2%  |
|   PCP4TP2  |   392    |  394   |   395  |  5.3%  |

### Kimi-K2

```shell
vllm bench serve --backend vllm  --model moonshotai/Kimi-K2-Instruct/  --endpoint /v1/completions   --dataset-name random   --random-input 4096   --random-output 1   --max-concurrency 1  --num-prompt 10 --ignore-eos --metric-percentiles "50,90,99"  --trust-remote-code
```

| Parallel Config |P50 TTFT (ms)  |     P90 TTFT (ms)    |  P99 TTFT (ms)   |   Performance gain  |
|:-----:|:------:|:------:|:-----:|:----:|
| PCP1TP8 |    394  |  396  |  396  | --- |
|   PCP2TP4  |  371   |  373  |   373   |  5.9%  |
|   PCP4TP2  |   351    |  353   |  354   |  10.9%  |


Of course, PCP additionally introduces communication overhead from KV all-gather and index select kernel launch overhead for restoring KV. Further tuning is still needed to improve performance.

- [x] Support piecewise graph
- [x] Support chunk prefill and prefix caching
- [x] Add ci test
- [x] Accuracy test
- [x] Benchmark

## Limitations
Although the current PCP logic is fully compatible with decoding, the lack of splitting of decode tokens means that every PCP rank holds the full set of decode tokens, leading to significant redundant communication and computation (include attention and MoE). We therefore recommend enabling PCP on P instances in a P/D-disaggregation case.

## Future work
These items will be tackled in follow-up PRs; community contributions are warmly welcomed.
- [ ] PCP support decode length > 1
- [ ] PCP support fullgraph
- [ ] PCP support others MLA prefill attention backends (currently only FlashAttention prefill is supported)
- [ ] Ring-CP style attention backend algorithm, ref RFC https://github.com/vllm-project/vllm/issues/26133.
- [ ] PCP support GQA
- [ ] PCP support P/D Disaggregation
- [ ] PCP suppots DSA
- [ ] PCP support distributed PCP (multi-machine)
- [ ] dynamic PCP？(https://arxiv.org/pdf/2510.10620)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

