### PR TITLE
[CI/Build] Add max_jobs docker build arg to rocm_base to prevent oom

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -22,6 +22,10 @@ ENV AITER_ROCM_ARCH=gfx942;gfx950
 # Required for RCCL in ROCm7.1
 ENV HSA_NO_SCRATCH_RECLAIM=1
 
+# max jobs used by Ninja to build extensions
+ARG max_jobs=2
+ENV MAX_JOBS=${max_jobs}
+
 ARG PYTHON_VERSION=3.12
 
 RUN mkdir -p /app


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Building the rocm_base docker image uses a a lot of memory on machines with large numbers of CPU cores, consistently going OOM on a 32-core / 64GB machine. 

This adds a build arg to set the `MAX_JOBS` env variable to limit the number of processes Ninja will spin up while building. The default is set to `2` to mirror the values in the main `Dockerfile`.

## Test Plan
N/A

## Test Result
N/A
