### PR TITLE
[CI/Build] Skip lm-format-enforcer tests in test_struct_output_generate.py for now

### DIFF
--- a/tests/v1/entrypoints/llm/test_struct_output_generate.py
+++ b/tests/v1/entrypoints/llm/test_struct_output_generate.py
@@ -47,10 +47,14 @@ EAGLE_SPEC_CONFIG = {
 PARAMS_MODELS_BACKENDS_TOKENIZER_MODE = [
     ("mistralai/Ministral-8B-Instruct-2410", "xgrammar", "auto", None),
     ("mistralai/Ministral-8B-Instruct-2410", "guidance", "auto", None),
-    ("mistralai/Ministral-8B-Instruct-2410", "lm-format-enforcer", "auto", None),
+    # FIXME: The lm-format-enforcer tests are flaky and should be disabled for,
+    # now because lm-format-enforcer is returning incomplete JSON.
+    # Created an issue for this here:
+    # https://github.com/noamgat/lm-format-enforcer/issues/169
+    # ("mistralai/Ministral-8B-Instruct-2410", "lm-format-enforcer", "auto", None),
     ("mistralai/Ministral-8B-Instruct-2410", "xgrammar", "mistral", None),
     ("Qwen/Qwen2.5-1.5B-Instruct", "xgrammar", "auto", None),
-    ("Qwen/Qwen2.5-1.5B-Instruct", "lm-format-enforcer", "auto", None),
+    # ("Qwen/Qwen2.5-1.5B-Instruct", "lm-format-enforcer", "auto", None),
     # FIXME: This tests are flaky on CI thus disabled. Tracking in Issue #24402
     # ("mistralai/Ministral-8B-Instruct-2410", "outlines", "auto", None),
     # ("mistralai/Ministral-8B-Instruct-2410", "outlines", "mistral", None),

--- a/tests/v1/entrypoints/llm/test_struct_output_generate.py
+++ b/tests/v1/entrypoints/llm/test_struct_output_generate.py
@@ -47,14 +47,34 @@ EAGLE_SPEC_CONFIG = {
 PARAMS_MODELS_BACKENDS_TOKENIZER_MODE = [
     ("mistralai/Ministral-8B-Instruct-2410", "xgrammar", "auto", None),
     ("mistralai/Ministral-8B-Instruct-2410", "guidance", "auto", None),
-    # FIXME: The lm-format-enforcer tests are flaky and should be disabled for,
-    # now because lm-format-enforcer is returning incomplete JSON.
-    # Created an issue for this here:
-    # https://github.com/noamgat/lm-format-enforcer/issues/169
-    # ("mistralai/Ministral-8B-Instruct-2410", "lm-format-enforcer", "auto", None),
+    pytest.param(
+        "mistralai/Ministral-8B-Instruct-2410",
+        "lm-format-enforcer",
+        "auto",
+        None,
+        marks=pytest.mark.skip(
+            reason=(
+                "Flaky: lm-format-enforcer intermittently returns"
+                "incomplete JSON."
+                "See https://github.com/noamgat/lm-format-enforcer/issues/169"
+            )
+        ),
+    ),
     ("mistralai/Ministral-8B-Instruct-2410", "xgrammar", "mistral", None),
     ("Qwen/Qwen2.5-1.5B-Instruct", "xgrammar", "auto", None),
-    # ("Qwen/Qwen2.5-1.5B-Instruct", "lm-format-enforcer", "auto", None),
+    pytest.param(
+        "Qwen/Qwen2.5-1.5B-Instruct",
+        "lm-format-enforcer",
+        "auto",
+        None,
+        marks=pytest.mark.skip(
+            reason=(
+                "Flaky: lm-format-enforcer intermittently returns"
+                "incomplete JSON."
+                "See https://github.com/noamgat/lm-format-enforcer/issues/169"
+            )
+        ),
+    ),
     # FIXME: This tests are flaky on CI thus disabled. Tracking in Issue #24402
     # ("mistralai/Ministral-8B-Instruct-2410", "outlines", "auto", None),
     # ("mistralai/Ministral-8B-Instruct-2410", "outlines", "mistral", None),


### PR DESCRIPTION
This PR disables lm-format-enforcer because lm-format-enforcer sometimes produces incomplete JSON in an unpredictable manner. I have created an issue here,[ https://github.com/noamgat/lm-format-enforcer/issues/169]( https://github.com/noamgat/lm-format-enforcer/issues/169).  Here is an example of a failure in upstream vLLM CI: [https://buildkite.com/vllm/ci/builds/33063/steps/canvas?jid=01999fef-a6e4-4cde-9392-6bb44de16099](https://buildkite.com/vllm/ci/builds/33063/steps/canvas?jid=01999fef-a6e4-4cde-9392-6bb44de16099).  We are trying to get our CI green at AMD, so this it is a priority for us to resolve this failure.

There is another [PR](https://github.com/vllm-project/vllm/pull/26031) up for this, but since this is so urgent for us, I need to put this one up.  Whichever one gets merged first is fine for me.

