### PR TITLE
[CI/Build] Remove skip global cleanup in test_struct_output_generate.py

### DIFF
--- a/tests/v1/entrypoints/llm/test_struct_output_generate.py
+++ b/tests/v1/entrypoints/llm/test_struct_output_generate.py
@@ -97,7 +97,6 @@ def test_guided_decoding_deprecated():
     assert sp1.structured_outputs == guided_decoding
 
 
-@pytest.mark.skip_global_cleanup
 @pytest.mark.parametrize(
     "model_name, backend, tokenizer_mode, speculative_config",
     PARAMS_MODELS_BACKENDS_TOKENIZER_MODE,
@@ -602,7 +601,6 @@ Make the response as short as possible.
                 )
 
 
-@pytest.mark.skip_global_cleanup
 @pytest.mark.parametrize(
     "model_name, backend, tokenizer_mode, reasoning_parser, speculative_config",  # noqa: E501
     [
@@ -687,7 +685,6 @@ def test_structured_output_with_reasoning_matrices(
         jsonschema.validate(instance=output_json, schema=reasoning_schema)
 
 
-@pytest.mark.skip_global_cleanup
 @pytest.mark.parametrize("model_name, tokenizer_mode", PARAMS_MODELS_TOKENIZER_MODE)
 def test_structured_output_auto_mode(
     unsupported_json_schema: dict[str, Any],
@@ -734,7 +731,6 @@ def test_structured_output_auto_mode(
         assert isinstance(parsed_json, dict)
 
 
-@pytest.mark.skip_global_cleanup
 def test_guidance_no_additional_properties():
     llm = LLM(
         model="Qwen/Qwen2.5-1.5B-Instruct",


### PR DESCRIPTION
This PR removes the @pytest.mark.skip_global_cleanup decorators for the tests that use the GPU.  The decorator was created for tests that do not need GPU cleanup in order to improve CI performance.  However, these tests do use the GPU and when one of the tests in this file fails, this causes the GPU to OOM when subsequent tests run, preventing the rest of the test suite to complete. 

This has been observed by others as well: https://github.com/vllm-project/vllm/issues/27844#issuecomment-3476922148