### PR TITLE
[Frontend] Support for direct url passing to opencv for video

### DIFF
--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -627,8 +627,8 @@ You can configure video processing behavior using `--media-io-kwargs`. The follo
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `num_frames` | int | 32 | Number of frames to sample from video |
-| `fps` | int | -1 | Target FPS for frame sampling (opencv backend) |
-| `max_duration` | int | 300 | Maximum video duration in seconds (opencv_dynamic backend) |
+| `fps` | int | -1 (opencv)<br>2 (opencv_dynamic) | Target FPS for frame sampling. Used differently by each backend: `opencv` uses it to limit total frames, `opencv_dynamic` uses it as sampling rate |
+| `max_duration` | int | 300 | Maximum video duration in seconds (opencv_dynamic backend only) |
 | `direct_url_loading` | bool | false | Pass HTTP/HTTPS URLs directly to OpenCV instead of downloading first |
 
 ##### Direct URL Loading

--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -304,7 +304,6 @@ class MediaConnector:
         )
         video_io = VideoMediaIO(image_io, **self.media_io_kwargs.get("video", {}))
 
-        # Check if direct URL loading is enabled
         direct_url_loading = self.media_io_kwargs.get("video", {}).get(
             "direct_url_loading", False
         )
@@ -324,7 +323,6 @@ class MediaConnector:
                         f"{envs.VLLM_VIDEO_FETCH_TIMEOUT} seconds"
                     ) from e
 
-        # Default: download to bytes
         return self.load_from_url(
             video_url,
             video_io,
@@ -347,7 +345,6 @@ class MediaConnector:
         )
         video_io = VideoMediaIO(image_io, **self.media_io_kwargs.get("video", {}))
 
-        # Check if direct URL loading is enabled
         direct_url_loading = self.media_io_kwargs.get("video", {}).get(
             "direct_url_loading", False
         )
@@ -371,7 +368,6 @@ class MediaConnector:
                     f"{envs.VLLM_VIDEO_FETCH_TIMEOUT} seconds"
                 ) from e
 
-        # Default: download to bytes
         return await self.load_from_url_async(
             video_url,
             video_io,

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -140,7 +140,6 @@ class OpenCVVideoBackend(VideoLoader):
                     frames[i] = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
                     i += 1
 
-        # Replace assertion with warning for partial frame loading
         if i < num_frames_to_sample:
             logger.warning(
                 "Expected reading %d frames, but only loaded %d frames from video. "
@@ -260,7 +259,6 @@ class OpenCVDynamicVideoBackend(OpenCVVideoBackend):
                     frames[i] = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
                     i += 1
 
-        # Replace assertion with warning for partial frame loading
         if i < len(frame_indices):
             logger.warning(
                 "Expected reading %d frames, but only loaded %d frames from video. "


### PR DESCRIPTION
## Purpose

Fix video frame loading reliability issues when loading from HTTP/HTTPS URLs by adding an opt-in `direct_url_loading` parameter.

**Problem:** 
- Some video formats fail to load properly when downloaded to `BytesIO` before OpenCV processing, resulting in "Expected X frames, but loaded Y frames" errors or complete failures
- Hard assertion failures prevented graceful handling of partial frame loading

**Solution:**
- Add opt-in `direct_url_loading` parameter (default: `false`) that passes URLs directly to OpenCV for native HTTP streaming
- Replace assertions with warnings for graceful partial frame handling
- Maintain all security controls (domain restrictions, timeouts) and backward compatibility

**Changes:**
- `vllm/multimodal/video.py`: Added `load_url()` methods to VideoLoader backends, replaced assertions with warnings
- `vllm/multimodal/utils.py`: Added direct URL loading logic with timeout enforcement in `fetch_video()` and `fetch_video_async()`
- `tests/multimodal/test_utils.py`: Added comprehensive tests for direct URL loading, backend compatibility, and security
- `docs/features/multimodal_inputs.md`: Added usage documentation and examples


## Test Plan

### Set up environment
cd /path/to/vllm
source .venv/bin/activate

### Run new direct URL loading tests
pytest tests/multimodal/test_utils.py::test_fetch_video_direct_url_loading -v
pytest tests/multimodal/test_utils.py::test_fetch_video_direct_url_with_dynamic_backend -v
pytest tests/multimodal/test_utils.py::test_fetch_video_direct_url_respects_domain_restrictions -v

### Run all multimodal tests to verify no regressions
pytest tests/multimodal/test_utils.py -v

### Run linting
pre-commit run --files vllm/multimodal/video.py vllm/multimodal/utils.py tests/multimodal/test_utils.py## Test Result

## Test Result
New Tests (6/6 passed)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

