### PR TITLE
[Core] Replace LogprobsLists with multiple numpy arrays in EngineCoreOutput

### DIFF
--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import msgspec
+import numpy as np
 import torch
 
 from vllm.lora.request import LoRARequest
@@ -14,7 +15,7 @@ from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.v1.metrics.stats import SchedulerStats
-from vllm.v1.outputs import LogprobsLists, LogprobsTensors
+from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.serial_utils import UtilityResult
 
 # These are possible values of RequestOutput.finish_reason,
@@ -109,7 +110,11 @@ class EngineCoreOutput(
     request_id: str
     new_token_ids: list[int]
 
-    new_logprobs: LogprobsLists | None = None
+    new_logprob_token_ids: np.ndarray | None = None
+    new_logprobs: np.ndarray | None = None
+    new_sampled_token_ranks: np.ndarray | None = None
+    new_cu_num_generated_tokens: np.ndarray | None = None
+
     new_prompt_logprobs_tensors: LogprobsTensors | None = None
 
     pooling_output: torch.Tensor | None = None


### PR DESCRIPTION
## Purpose
Similar to quite a few other GC optimizations, each batch would create <batch_size> of EngineCoreOutputs. For large batch size scenarios which means it would guarantee to invoke GC0 which is less ideal.

In this PR, we only replace LogprobsLists with a few numpy arrays in EngineCoreOutput, which would get rid of the GC0 invocations. For large batch size cases, it turned out to improve throughput a lot.

## Test Plan & Test Result
CI Signals

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

