### PR TITLE
[BugFix] Fix false assertion with spec-decode=[2,4,..] and TP>2

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -921,7 +921,7 @@ class CompilationConfig:
         self, uniform_decode_query_len: int, tensor_parallel_size: int
     ):
         multiple_of = uniform_decode_query_len
-        if tensor_parallel_size > 1:
+        if tensor_parallel_size > 1 and self.pass_config.enable_sequence_parallelism:
             multiple_of = max(uniform_decode_query_len, tensor_parallel_size)
             if (
                 multiple_of % uniform_decode_query_len != 0


### PR DESCRIPTION
Fix `vllm serve deepseek-ai/DeepSeek-R1 --speculative-config '{"method": "mtp", "num_speculative_tokens": 2}' -tp 8` falsely asserting; should only assert when sequence parallelism is enabled. (Introduced in https://github.com/vllm-project/vllm/pull/28315)

### Main
```
vllm serve meta-llama/Meta-Llama-3-8B-Instruct -tp 4 --port 3333 --speculative-config '{"method": "eagle", "model": "yuhuili/EAGLE-LLaMA3-Instruct-8B", "num_speculative_tokens": 2}'
...
RuntimeError: Worker failed with error 'Can't determine cudagraph shapes that are both a multiple of 3 (num_speculative_tokens + 1) required by spec-decode and 4 (tensor_parallel_size) required by sequence parallelism please adjust num_speculative_tokens or disable sequence parallelism'
```

### PR

Boots fine