### PR TITLE
[DeepSeek + LMCache Multiprocess] handle MLA for deepseek model + LMCache Multiprocess connector

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -65,7 +65,7 @@ def maybe_exclude_tp_rank_for_mla_models(
     world_size: int,
     rank: int,
     vllm_config: VllmConfig,
-) -> int:
+) -> tuple[int, int]:
     """
     Convert the rank for the MLA.
     """

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -61,7 +61,7 @@ def reformat_block_ids(block_ids: tuple[list[int], ...] | None) -> list[int]:
     return block_ids[0]
 
 
-def maybe_exclude_tp_rank_for_mla_models(
+def extract_world_size_and_kv_rank(
     world_size: int,
     rank: int,
     vllm_config: VllmConfig,
@@ -88,7 +88,7 @@ def maybe_exclude_tp_rank_for_mla_models(
 def create_scheduler_adapter(
     server_url: str, zmq_context: zmq.Context, vllm_config: VllmConfig
 ) -> LMCacheMPSchedulerAdapter:
-    world_size, rank = maybe_exclude_tp_rank_for_mla_models(
+    world_size, rank = extract_world_size_and_kv_rank(
         vllm_config.parallel_config.world_size,
         vllm_config.parallel_config.rank,
         vllm_config,
@@ -106,7 +106,7 @@ def create_scheduler_adapter(
 def create_worker_adapter(
     server_url: str, zmq_context: zmq.Context, vllm_config: VllmConfig
 ) -> LMCacheMPWorkerAdapter:
-    world_size, rank = maybe_exclude_tp_rank_for_mla_models(
+    world_size, rank = extract_world_size_and_kv_rank(
         vllm_config.parallel_config.world_size,
         vllm_config.parallel_config.rank,
         vllm_config,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 import torch
 import zmq
-from lmcache.utils import init_logger as lmcache_init_logger
 from lmcache.integration.vllm.utils import mla_enabled
+from lmcache.utils import init_logger as lmcache_init_logger
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -88,7 +88,7 @@ def extract_world_size_and_kv_rank(
 def create_scheduler_adapter(
     server_url: str, zmq_context: zmq.Context, vllm_config: VllmConfig
 ) -> LMCacheMPSchedulerAdapter:
-    world_size, rank = extract_world_size_and_kv_rank(
+    world_size, kv_rank = extract_world_size_and_kv_rank(
         vllm_config.parallel_config.world_size,
         vllm_config.parallel_config.rank,
         vllm_config,
@@ -98,7 +98,7 @@ def create_scheduler_adapter(
         zmq_context,
         vllm_config.model_config.model,
         world_size,
-        rank,
+        kv_rank,
         vllm_config.cache_config.block_size,
     )
 
@@ -106,7 +106,7 @@ def create_scheduler_adapter(
 def create_worker_adapter(
     server_url: str, zmq_context: zmq.Context, vllm_config: VllmConfig
 ) -> LMCacheMPWorkerAdapter:
-    world_size, rank = extract_world_size_and_kv_rank(
+    world_size, kv_rank = extract_world_size_and_kv_rank(
         vllm_config.parallel_config.world_size,
         vllm_config.parallel_config.rank,
         vllm_config,
@@ -116,7 +116,7 @@ def create_worker_adapter(
         zmq_context,
         vllm_config.model_config.model,
         world_size,
-        rank,
+        kv_rank,
         vllm_config.cache_config.block_size,
     )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 import torch
 import zmq
 from lmcache.utils import init_logger as lmcache_init_logger
+from lmcache.integration.vllm.utils import mla_enabled
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
@@ -60,17 +61,44 @@ def reformat_block_ids(block_ids: tuple[list[int], ...] | None) -> list[int]:
     return block_ids[0]
 
 
+def maybe_exclude_tp_rank_for_mla_models(
+    world_size: int,
+    rank: int,
+    vllm_config: VllmConfig,
+) -> int:
+    """
+    Convert the rank for the MLA.
+    """
+    use_mla = mla_enabled(vllm_config.model_config)
+    if not use_mla:
+        return world_size, rank
+    else:
+        # Tensor parallel does not change the KV caches for MLA models.
+        # So we need to "exclude" the effect of TP on rank and world size
+        tp_size = vllm_config.parallel_config.tensor_parallel_size
+        # vLLM constructs TP groups first, and then construct other
+        # parallel groups on top of TP groups.
+        # for example, TP=4, PP=2,
+        # TP group: [0, 1, 2, 3], [4, 5, 6, 7]
+        # PP group: [0, 4], [1, 5], [2, 6], [3, 7]
+        # So we can "exclude" the effect of TP by rank // tp_size.
+        return world_size // tp_size, rank // tp_size
+
+
 def create_scheduler_adapter(
     server_url: str, zmq_context: zmq.Context, vllm_config: VllmConfig
 ) -> LMCacheMPSchedulerAdapter:
-    # TODO: have a helper function to calculate the correct rank and
-    # world size for the MLA and other models
+    world_size, rank = maybe_exclude_tp_rank_for_mla_models(
+        vllm_config.parallel_config.world_size,
+        vllm_config.parallel_config.rank,
+        vllm_config,
+    )
     return LMCacheMPSchedulerAdapter(
         server_url,
         zmq_context,
         vllm_config.model_config.model,
-        vllm_config.parallel_config.world_size,
-        vllm_config.parallel_config.rank,
+        world_size,
+        rank,
         vllm_config.cache_config.block_size,
     )
 
@@ -78,14 +106,17 @@ def create_scheduler_adapter(
 def create_worker_adapter(
     server_url: str, zmq_context: zmq.Context, vllm_config: VllmConfig
 ) -> LMCacheMPWorkerAdapter:
-    # TODO: have a helper function to calculate the correct rank and
-    # world size for the MLA and other models
+    world_size, rank = maybe_exclude_tp_rank_for_mla_models(
+        vllm_config.parallel_config.world_size,
+        vllm_config.parallel_config.rank,
+        vllm_config,
+    )
     return LMCacheMPWorkerAdapter(
         server_url,
         zmq_context,
         vllm_config.model_config.model,
-        vllm_config.parallel_config.world_size,
-        vllm_config.parallel_config.rank,
+        world_size,
+        rank,
         vllm_config.cache_config.block_size,
     )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR handles MLA for deepseek models

## Test Plan

Run 
```
MODEL="deepseek-ai/DeepSeek-V2-Lite"
PORT=8000
NUM_CONCURRENT=50

lm_eval --model local-completions --tasks gsm8k \
    --model_args model=${MODEL},base_url=http://127.0.0.1:${PORT}/v1/completions,num_concurrent=${NUM_CONCURRENT},max_retries=3,tokenized_requests=False \
    --limit 300 \
    --seed 0 \
    --gen_kwargs '{"temperature": 0.0}'
```

## Test Result

### Baseline: vanilla vLLM:

```
PYTHONHASHSEED=0 vllm serve deepseek-ai/DeepSeek-V2-Lite --gpu-memory-utilization 0.9
```

Results:
<img width="542" height="69" alt="image" src="https://github.com/user-attachments/assets/49de0e25-1d34-4c7a-b66c-dffeefe1673d" />


### Test: on vLLM + LMCache offloading:

```
PYTHONHASHSEED=0 vllm serve deepseek-ai/DeepSeek-V2-Lite --kv-transfer-config '{"kv_connector":"LMCacheMPConnector", "kv_role":"kv_both"}' --gpu-memory-utilization 0.7 --no-enable-prefix-caching -tp 2
```

We run `lm_eval` two times, first time is vLLM result without caching, second time is based on LMCache's KV caches.

First time:
<img width="523" height="69" alt="image" src="https://github.com/user-attachments/assets/21394e3f-72a1-4385-ac55-96ba605d9d56" />

Second time:
<img width="537" height="66" alt="image" src="https://github.com/user-attachments/assets/f43f4c7e-7304-4a0d-91fb-a395f133a693" />




---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

