### PR TITLE
[CI] Fix precommit `rope_theta` issue

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -991,8 +991,7 @@ class DeepseekV2MLAAttention(nn.Module):
                 qk_rope_head_dim,
                 rotary_dim=qk_rope_head_dim,
                 max_position=max_position_embeddings,
-                base=rope_theta,
-                rope_scaling=rope_scaling,
+                rope_parameters=config.rope_parameters,
                 is_neox_style=True,
             )
             self.indexer = Indexer(


### PR DESCRIPTION
## Purpose

Fix precommit issue introduced by  https://github.com/vllm-project/vllm/pull/28968

```bash
Error: vllm/model_executor/models/deepseek_v2.py:994:22: F821 Undefined name `rope_theta`
Error: vllm/model_executor/models/deepseek_v2.py:995:30: F821 Undefined name `rope_scaling`
```
