### PR TITLE
[CI/Build][AMD] Skip if flash_attn_varlen_func not available in test_aiter_flash_attn.py

### DIFF
--- a/tests/kernels/attention/test_aiter_flash_attn.py
+++ b/tests/kernels/attention/test_aiter_flash_attn.py
@@ -10,9 +10,6 @@ from vllm.platforms import current_platform
 
 from vllm.attention.utils.fa_utils import is_flash_attn_varlen_func_available
 
-if not is_flash_attn_varlen_func_available():
-    pytest.skip("flash_attn_varlen_func required to run this test.",
-            allow_module_level=True)
 
 NUM_HEADS = [(4, 4), (8, 2)]
 HEAD_SIZES = [128, 256]
@@ -106,6 +103,8 @@ def test_varlen_with_paged_kv(
     num_blocks: int,
     q_dtype: torch.dtype | None,
 ) -> None:
+    if not is_flash_attn_varlen_func_available():
+        pytest.skip("flash_attn_varlen_func required to run this test.")
     torch.set_default_device("cuda")
     current_platform.seed_everything(0)
     num_seqs = len(seq_lens)

--- a/tests/kernels/attention/test_aiter_flash_attn.py
+++ b/tests/kernels/attention/test_aiter_flash_attn.py
@@ -8,6 +8,12 @@ import torch
 import vllm.v1.attention.backends.rocm_aiter_fa  # noqa: F401
 from vllm.platforms import current_platform
 
+from vllm.attention.utils.fa_utils import is_flash_attn_varlen_func_available
+
+if not is_flash_attn_varlen_func_available():
+    pytest.skip("flash_attn_varlen_func required to run this test.",
+            allow_module_level=True)
+
 NUM_HEADS = [(4, 4), (8, 2)]
 HEAD_SIZES = [128, 256]
 BLOCK_SIZES = [16]

--- a/tests/kernels/attention/test_aiter_flash_attn.py
+++ b/tests/kernels/attention/test_aiter_flash_attn.py
@@ -6,10 +6,8 @@ import pytest
 import torch
 
 import vllm.v1.attention.backends.rocm_aiter_fa  # noqa: F401
-from vllm.platforms import current_platform
-
 from vllm.attention.utils.fa_utils import is_flash_attn_varlen_func_available
-
+from vllm.platforms import current_platform
 
 NUM_HEADS = [(4, 4), (8, 2)]
 HEAD_SIZES = [128, 256]


### PR DESCRIPTION
This PR skips the tests in `test_aiter_flash_attn.py` if `flash_attn_varlen_func `is not available.  The function isn't currently available, but could be in the future, or the test might get updated.  

This is similar to how `test_flash_attn.py` works.