### PR TITLE
Enable dumping expert input tensors for GPT-OSS

### DIFF
--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -186,7 +186,7 @@ class MLPBlock(torch.nn.Module):
             )
         else:
             g = self.router(x)
-        x = self.experts(hidden_states=x, router_logits=g)
+        x = self.experts(x, g)
 
         if self.is_sequence_parallel:
             x = tensor_model_parallel_all_gather(x.contiguous(), 0)


### PR DESCRIPTION
Summary:
Switching experts call to use positional function args.

Signed-off-by: Pratyush Patel <pratyushpatel@meta.com>

Test Plan: Tested with various inputs.

Differential Revision: D86459362


