### PR TITLE
Handle triton kernel import exception 

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -28,7 +28,7 @@ logger = init_logger(__name__)
 if has_triton_kernels():
     try:
         from triton_kernels.matmul_ogs import PrecisionConfig
-    except ImportError:
+    except (ImportError, AttributeError) as e:
         logger.error(
             "Failed to import Triton kernels. Please make sure your triton "
             "version is compatible."

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -31,7 +31,8 @@ if has_triton_kernels():
     except (ImportError, AttributeError) as e:
         logger.error(
             "Failed to import Triton kernels. Please make sure your triton "
-            "version is compatible."
+            "version is compatible. Error: %s",
+            e,
         )
 
 


### PR DESCRIPTION
The PR at https://github.com/vllm-project/vllm/pull/25319 introduced an `ImportError` catch to prevent failures when importing `triton`. However, after upgrading vLLM from 0.11.0 to 0.11.1 via:

```bash
pip install -U vllm
```

Running vllm serve Qwen/Qwen3-8B results in the following error:
```
AttributeError: module 'triton.language' has no attribute 'constexpr_function'
  File "/usr/local/lib/python3.11/site-packages/triton_kernels/numerics_details/flexpoint.py", line 55, in <module>
    @tl.constexpr_function
     ^^^^^^^^^^^^^^^^^^^^^
```

This suggests a compatibility issue between the upgraded triton version and triton-kernels, where constexpr_function was either removed or renamed.

While the original PR handled ImportError, this case involves an AttributeError due to API changes in triton.language. Adding a guard for AttributeError (in addition to ImportError) could help gracefully handle such mismatches and improve robustness during dependency upgrades.

This change proposes catching AttributeError when accessing tl.constexpr_function to prevent breakage in environments where triton and triton-kernels are mismatched.