### PR TITLE
[CI/Build] Make test_attention_selector.py run tests on correct platform

### DIFF
--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -50,13 +50,9 @@ DEVICE_MLA_BLOCK_SIZES = {
 def generate_params():
     is_rocm = current_platform.is_rocm()
     params = []
+    device_list = ["cuda", "cpu"] if not is_rocm else ["hip", "cpu"]
     for use_mla in [True, False]:
-        for device in ["cuda", "hip", "cpu"]:
-            if device == "cuda" and is_rocm:
-                continue
-            if device == "hip" and not is_rocm:
-                continue
-
+        for device in device_list:
             backends = (
                 DEVICE_MLA_BACKENDS[device]
                 if use_mla

--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 from vllm.attention.selector import _cached_get_attn_backend, get_attn_backend
+from vllm.platforms import current_platform
 from vllm.platforms.cpu import CpuPlatform
 from vllm.platforms.cuda import CudaPlatform
 from vllm.platforms.rocm import RocmPlatform
@@ -78,6 +79,9 @@ def test_env(
     block_size: int,
     monkeypatch: pytest.MonkeyPatch,
 ):
+    is_rocm = current_platform.is_rocm()
+    if (device == "hip" and not is_rocm) or (device == "cuda" and is_rocm):
+        pytest.skip("Test only on correct platform")
     """Test attention backend selection with valid device-backend pairs."""
     with monkeypatch.context() as m:
         m.setenv(STR_BACKEND_ENV_VAR, name)

--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -48,9 +48,15 @@ DEVICE_MLA_BLOCK_SIZES = {
 
 
 def generate_params():
+    is_rocm = current_platform.is_rocm()
     params = []
     for use_mla in [True, False]:
         for device in ["cuda", "hip", "cpu"]:
+            if device == "cuda" and is_rocm:
+                continue
+            if device == "hip" and not is_rocm:
+                continue
+
             backends = (
                 DEVICE_MLA_BACKENDS[device]
                 if use_mla
@@ -79,10 +85,6 @@ def test_env(
     block_size: int,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    if device == "hip" and not current_platform.is_rocm():
-        pytest.skip("HIP tests require a ROCm platform to run.")
-    elif device == "cuda" and not current_platform.is_cuda():
-        pytest.skip("CUDA tests require a CUDA platform to run.")
     """Test attention backend selection with valid device-backend pairs."""
     with monkeypatch.context() as m:
         m.setenv(STR_BACKEND_ENV_VAR, name)

--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -79,9 +79,10 @@ def test_env(
     block_size: int,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    is_rocm = current_platform.is_rocm()
-    if (device == "hip" and not is_rocm) or (device == "cuda" and is_rocm):
-        pytest.skip("Test only on correct platform")
+    if device == "hip" and not current_platform.is_rocm():
+        pytest.skip("HIP tests require a ROCm platform to run.")
+    elif device == "cuda" and not current_platform.is_cuda():
+        pytest.skip("CUDA tests require a CUDA platform to run.")
     """Test attention backend selection with valid device-backend pairs."""
     with monkeypatch.context() as m:
         m.setenv(STR_BACKEND_ENV_VAR, name)


### PR DESCRIPTION
This PR fixes test_attention_selector.py to make sure that tests run only correct platform, so if `hip `or `cuda` is selected, the test will only run on the corresponding platform, since the `get_attn_backend`  needs to be on the correct platform to work correctly.
