### PR TITLE
[CI Failure] Add working_dir to Kernels DeepGEMM Test (H100)

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -551,6 +551,7 @@ steps:
     - pytest -v -s kernels/mamba
 
 - label: Kernels DeepGEMM Test (H100)
+  working_dir: "/vllm-workspace/"
   timeout_in_minutes: 45
   gpu: h100
   num_gpus: 1


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

From nightly https://buildkite.com/vllm/ci/builds/39860/steps/canvas?sid=019aa011-0c6b-41b7-a847-2a74913e51b1 , this test is failing due to `ERROR: file or directory not found: tests/kernels/quantization/test_block_fp8.py`. According to https://github.com/vllm-project/vllm/blob/main/.buildkite/test-pipeline.yaml#L26 , we can override `working_dir`

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

