### PR TITLE
[Bugfix] Fix logprobs to support rank sequences and empty slices

### DIFF
--- a/tests/test_logprobs.py
+++ b/tests/test_logprobs.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import pytest
+
 from vllm.logprobs import (
     FlatLogprobs,
     Logprob,
@@ -267,7 +269,7 @@ def test_flat_logprobs_empty_slice() -> None:
 def test_append_logprobs_rank_length_mismatch() -> None:
     """Test that ValueError is raised when rank length doesn't match token_ids"""
     logprobs = create_sample_logprobs(flat_logprobs=True)
-    try:
+    with pytest.raises(ValueError, match=r"Expected 2 ranks.*got 1"):
         append_logprobs_for_next_position(
             logprobs,
             token_ids=[10, 11],
@@ -276,7 +278,17 @@ def test_append_logprobs_rank_length_mismatch() -> None:
             rank=[7],
             num_logprobs=2,
         )
-        assert False, "Expected ValueError but no exception was raised"
-    except ValueError as e:
-        assert "Expected 2 ranks" in str(e)
-        assert "got 1" in str(e)
+
+
+def test_append_logprobs_rank_string_rejected() -> None:
+    """Test that TypeError is raised when rank is a string"""
+    logprobs = create_sample_logprobs(flat_logprobs=True)
+    with pytest.raises(TypeError, match="rank cannot be a string"):
+        append_logprobs_for_next_position(
+            logprobs,
+            token_ids=[10, 11],
+            logprobs=[0.5, 0.6],
+            decoded_tokens=["10", "11"],
+            rank="12",
+            num_logprobs=2,
+        )

--- a/vllm/logprobs.py
+++ b/vllm/logprobs.py
@@ -193,7 +193,9 @@ def append_logprobs_for_next_position(
     # Accept either a single sampled-token rank (legacy path) or
     # a full sequence of ranks (e.g., prompt logprobs already provide
     # per-token ranks). When provided, enforce 1:1 with token_ids.
-    if isinstance(rank, (list, tuple)):
+    if not isinstance(rank, int):
+        if isinstance(rank, str):
+            raise TypeError("rank cannot be a string")
         ranks = list(rank)
         if len(ranks) != len(token_ids):
             raise ValueError(


### PR DESCRIPTION
## Purpose

This PR fixes two critical issues in the logprobs module:

1. **Support rank sequences**: The `append_logprobs_for_next_position()` function now accepts either a single rank (int) or a sequence of ranks (list/tuple). This is required for V1 engine's spec decoding and prompt logprobs features, which pass rank arrays from numpy tensors.

2. **Fix empty slice bug**: `FlatLogprobs.__getitem__()` now correctly handles empty slices (e.g., `logprobs[1:1]`) without raising `IndexError`.

**Additional improvements:**
- Improved type checking to use `isinstance(rank, (list, tuple))` instead of the less precise `Iterable` check, avoiding issues with strings
- Updated `append_fast()` type signature to accept `Iterable[int | None]`
- Added comprehensive test coverage including error case validation

## Test Plan

```bash
pytest tests/test_logprobs.py -v
```

