### PR TITLE
Revert back to torch.equal over torch.allclose from #28819 

### DIFF
--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1028,8 +1028,8 @@ class EagleProposer:
                 elif (
                     isinstance(target_embed_tokens.weight, torch.Tensor)
                     and isinstance(self.model.model.embed_tokens.weight, torch.Tensor)
-                    # Offload to CPU for comparison to avoid extra GPU memory usage
-                    # in CI testing environments with limited GPU memory
+                    # TODO: Offload to CPU for comparison to avoid extra GPU memory
+                    # usage in CI testing environments with limited GPU memory
                     and torch.equal(
                         target_embed_tokens.weight.cpu(),
                         self.model.model.embed_tokens.weight.cpu(),
@@ -1078,8 +1078,8 @@ class EagleProposer:
                 hasattr(target_language_model, "lm_head")
                 and isinstance(target_language_model.lm_head.weight, torch.Tensor)
                 and isinstance(self.model.lm_head.weight, torch.Tensor)
-                # Offload to CPU for comparison to avoid extra GPU memory usage
-                # in CI testing environments with limited GPU memory
+                # TODO: Offload to CPU for comparison to avoid extra GPU memory
+                # usage in CI testing environments with limited GPU memory
                 and torch.equal(
                     target_language_model.lm_head.weight.cpu(),
                     self.model.lm_head.weight.cpu(),

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1077,7 +1077,8 @@ class EagleProposer:
                 and isinstance(target_language_model.lm_head.weight, torch.Tensor)
                 and isinstance(self.model.lm_head.weight, torch.Tensor)
                 and torch.equal(
-                    target_language_model.lm_head.weight, self.model.lm_head.weight
+                    target_language_model.lm_head.weight.cpu(),
+                    self.model.lm_head.weight.cpu(),
                 )
             ):
                 share_lm_head = True

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1028,6 +1028,8 @@ class EagleProposer:
                 elif (
                     isinstance(target_embed_tokens.weight, torch.Tensor)
                     and isinstance(self.model.model.embed_tokens.weight, torch.Tensor)
+                    # Offload to CPU for comparison to avoid extra GPU memory usage
+                    # in CI testing environments with limited GPU memory
                     and torch.equal(
                         target_embed_tokens.weight.cpu(),
                         self.model.model.embed_tokens.weight.cpu(),
@@ -1076,6 +1078,8 @@ class EagleProposer:
                 hasattr(target_language_model, "lm_head")
                 and isinstance(target_language_model.lm_head.weight, torch.Tensor)
                 and isinstance(self.model.lm_head.weight, torch.Tensor)
+                # Offload to CPU for comparison to avoid extra GPU memory usage
+                # in CI testing environments with limited GPU memory
                 and torch.equal(
                     target_language_model.lm_head.weight.cpu(),
                     self.model.lm_head.weight.cpu(),

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1028,11 +1028,9 @@ class EagleProposer:
                 elif (
                     isinstance(target_embed_tokens.weight, torch.Tensor)
                     and isinstance(self.model.model.embed_tokens.weight, torch.Tensor)
-                    and torch.allclose(
+                    and torch.equal(
                         target_embed_tokens.weight.cpu(),
                         self.model.model.embed_tokens.weight.cpu(),
-                        rtol=1e-5,
-                        atol=1e-7,
                     )
                 ):
                     share_embeddings = True


### PR DESCRIPTION
As pointed out in https://github.com/vllm-project/vllm/pull/28819 , we already had some offline discussions (cc @benchislett) on whether `torch.equal` or `torch.allclose` should be used here to detect whether draft model has exactly the same layers as the target model to enable weight-sharing. 
I have two major concerns with `torch.allclose` approach:
1. `embed_tokens` tend to have very small magnitudes of updates during speculators training, making them look very close **but not equal** to the verifier model. `torch.allclose` opens up a pathway of overriding those weights due to their similarity, which is not something that a user who trained a speculator model with distinct embed_tokens expects.
2. `torch.allclose` also opens up an additional set of questions for how to tune `atol/rtol`, especially for different dtypes (which will become even more problematic ones people start using quantized models)

I would advocate here to go back to `torch.equal` until someone demonstrates a use case where `torch.equal` fails to identify equal layers due to issues with FP precision. If that happens, we can update the logic to check for bitwise equality like this:
```python
a_bits = a.view(torch.int32)
b_bits = b.view(torch.int32)

bitwise_equal = torch.equal(a_bits, b_bits)
```

The PR also adds CPU offloading to prevent GPU OOM issues reported in #28819 