### PR TITLE
Add Multimodal Processor Benchmark 

### DIFF
--- a/docs/cli/bench/mm_processor.md
+++ b/docs/cli/bench/mm_processor.md
@@ -1,0 +1,9 @@
+# vllm bench mm-processor
+
+## JSON CLI Arguments
+
+--8<-- "docs/cli/json_tip.inc.md"
+
+## Arguments
+
+--8<-- "docs/argparse/bench_mm_processor.inc.md"

--- a/docs/mkdocs/hooks/generate_argparse.py
+++ b/docs/mkdocs/hooks/generate_argparse.py
@@ -92,6 +92,7 @@ def auto_mock(module_name: str, attr: str, max_mocks: int = 100):
 
 
 bench_latency = auto_mock("vllm.benchmarks", "latency")
+bench_mm_processor = auto_mock("vllm.benchmarks", "mm_processor")
 bench_serve = auto_mock("vllm.benchmarks", "serve")
 bench_sweep_plot = auto_mock("vllm.benchmarks.sweep.plot", "SweepPlotArgs")
 bench_sweep_plot_pareto = auto_mock(
@@ -222,6 +223,7 @@ def on_startup(command: Literal["build", "gh-deploy", "serve"], dirty: bool):
         "run-batch": create_parser(openai_run_batch.make_arg_parser),
         # Benchmark CLI
         "bench_latency": create_parser(bench_latency.add_cli_args),
+        "bench_mm_processor": create_parser(bench_mm_processor.add_cli_args),
         "bench_serve": create_parser(bench_serve.add_cli_args),
         "bench_sweep_plot": create_parser(bench_sweep_plot.add_cli_args),
         "bench_sweep_plot_pareto": create_parser(bench_sweep_plot_pareto.add_cli_args),

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -1437,148 +1437,12 @@ def add_dataset_parser(parser: FlexibleArgumentParser):
     )
 
     random_group = parser.add_argument_group("random dataset options")
-    random_group.add_argument(
-        "--random-input-len",
-        type=int,
-        default=1024,
-        help="Number of input tokens per request, used only for random sampling.",
-    )
-    random_group.add_argument(
-        "--random-output-len",
-        type=int,
-        default=128,
-        help="Number of output tokens per request, used only for random sampling.",
-    )
-    random_group.add_argument(
-        "--random-range-ratio",
-        type=float,
-        default=0.0,
-        help="Range ratio for sampling input/output length, "
-        "used only for random sampling. Must be in the range [0, 1) to define "
-        "a symmetric sampling range"
-        "[length * (1 - range_ratio), length * (1 + range_ratio)].",
-    )
-    random_group.add_argument(
-        "--random-prefix-len",
-        type=int,
-        default=0,
-        help=(
-            "Number of fixed prefix tokens before the random context "
-            "in a request. "
-            "The total input length is the sum of `random-prefix-len` and "
-            "a random "
-            "context length sampled from [input_len * (1 - range_ratio), "
-            "input_len * (1 + range_ratio)]."
-        ),
-    )
-    random_group.add_argument(
-        "--random-batch-size",
-        type=int,
-        default=1,
-        help=("Batch size for random sampling. Only used for embeddings benchmark."),
-    )
-    random_group.add_argument(
-        "--no-reranker",
-        action="store_true",
-        help=(
-            "Whether the model supports reranking natively."
-            " Only used for reranker benchmark."
-        ),
-    )
+    add_random_dataset_base_args(random_group)
 
-    # random multimodal dataset options
     random_mm_group = parser.add_argument_group(
         "random multimodal dataset options extended from random dataset"
     )
-    random_mm_group.add_argument(
-        "--random-mm-base-items-per-request",
-        type=int,
-        default=RandomMultiModalDataset.DEFAULT_BASE_ITEMS_PER_REQUEST,
-        help=(
-            "Base number of multimodal items per request for random-mm. "
-            "Actual per-request count is sampled around this base using "
-            "--random-mm-num-mm-items-range-ratio."
-        ),
-    )
-    random_mm_group.add_argument(
-        "--random-mm-num-mm-items-range-ratio",
-        type=float,
-        default=RandomMultiModalDataset.DEFAULT_NUM_MM_ITEMS_RANGE_RATIO,
-        help=(
-            "Range ratio r in [0, 1] for sampling items per request. "
-            "We sample uniformly from the closed integer range "
-            "[floor(n*(1-r)), ceil(n*(1+r))] "
-            "where n is the base items per request. "
-            "r=0 keeps it fixed; r=1 allows 0 items. The maximum is clamped "
-            "to the sum of per-modality limits from "
-            "--random-mm-limit-mm-per-prompt. "
-            "An error is raised if the computed min exceeds the max."
-        ),
-    )
-    random_mm_group.add_argument(
-        "--random-mm-limit-mm-per-prompt",
-        type=json.loads,
-        default=RandomMultiModalDataset.DEFAULT_LIMIT_MM_PER_PROMPT,
-        help=(
-            "Per-modality hard caps for items attached per request, e.g. "
-            '\'{"image": 3, "video": 0}\'. The sampled per-request item '
-            "count is clamped to the sum of these limits. When a modality "
-            "reaches its cap, its buckets are excluded and probabilities are "
-            "renormalized."
-            "OBS.: Only image sampling is supported for now."
-        ),
-    )
-
-    def _parse_mm_bucket_config(v: object) -> dict[tuple[int, int, int], float]:
-        # If already a dict (e.g., programmatic call), normalize keys
-        def normalize(d: dict) -> dict[tuple[int, int, int], float]:
-            out: dict[tuple[int, int, int], float] = {}
-            for k, val in d.items():
-                key = k
-                if isinstance(key, str):
-                    with suppress(Exception):
-                        key = ast.literal_eval(key)
-                if not (
-                    isinstance(key, tuple)
-                    and len(key) == 3
-                    and all(isinstance(x, int) for x in key)
-                ):
-                    raise ValueError(
-                        f"Invalid bucket key {k!r}. Expected tuple (H, W, T)."
-                    )
-                out[(int(key[0]), int(key[1]), int(key[2]))] = float(val)
-            return out
-
-        if isinstance(v, dict):
-            return normalize(v)
-        if isinstance(v, str):
-            # Python literal (supports tuple keys)
-            parsed = ast.literal_eval(v)
-            if not isinstance(parsed, dict):
-                raise ValueError("Bucket config must parse to a dict.")
-            return normalize(parsed)
-        raise ValueError("Unsupported value for --random-mm-bucket-config.")
-
-    random_mm_group.add_argument(
-        "--random-mm-bucket-config",
-        type=_parse_mm_bucket_config,
-        default=RandomMultiModalDataset.DEFAULT_MM_ITEM_BUCKET_CONFIG,
-        help=(
-            "The bucket config is a dictionary mapping a multimodal item"
-            "sampling configuration to a probability."
-            "Currently allows for 2 modalities: images and videos. "
-            "An bucket key is a tuple of (height, width, num_frames)"
-            "The value is the probability of sampling that specific item. "
-            "Example: "
-            "--random-mm-bucket-config "
-            "{(256, 256, 1): 0.5, (720, 1280, 1): 0.4, (720, 1280, 16): 0.10} "
-            "First item: images with resolution 256x256 w.p. 0.5"
-            "Second item: images with resolution 720x1280 w.p. 0.4 "
-            "Third item: videos with resolution 720x1280 and 16 frames w.p. 0.1"
-            "OBS.: If the probabilities do not sum to 1, they are normalized."
-            "OBS bis.: Only image sampling is supported for now."
-        ),
-    )
+    add_random_multimodal_dataset_args(random_mm_group)
 
     hf_group = parser.add_argument_group("hf dataset options")
     hf_group.add_argument(
@@ -1635,6 +1499,170 @@ def add_dataset_parser(parser: FlexibleArgumentParser):
         default=128,
         help="Number of output tokens per request, used only for prefix "
         "repetition dataset.",
+    )
+
+def add_random_dataset_base_args(
+    parser_or_group: FlexibleArgumentParser | argparse._ArgumentGroup,
+) -> None:
+    """Add CLI arguments for base random dataset options.
+    
+    This function adds arguments needed for:
+    - random (random dataset)
+    - random-mm (random multimodal dataset)
+    - random-rerank (random dataset for reranking)
+    
+    Args:
+        parser_or_group: Either a parser or an argument group to add arguments to.
+    """
+    parser_or_group.add_argument(
+        "--random-input-len",
+        type=int,
+        default=1024,
+        help="Number of input tokens per request, used only for random sampling.",
+    )
+    parser_or_group.add_argument(
+        "--random-output-len",
+        type=int,
+        default=128,
+        help="Number of output tokens per request, used only for random sampling.",
+    )
+    parser_or_group.add_argument(
+        "--random-range-ratio",
+        type=float,
+        default=0.0,
+        help="Range ratio for sampling input/output length, "
+        "used only for random sampling. Must be in the range [0, 1) to define "
+        "a symmetric sampling range"
+        "[length * (1 - range_ratio), length * (1 + range_ratio)].",
+    )
+    parser_or_group.add_argument(
+        "--random-prefix-len",
+        type=int,
+        default=0,
+        help=(
+            "Number of fixed prefix tokens before the random context "
+            "in a request. "
+            "The total input length is the sum of `random-prefix-len` and "
+            "a random "
+            "context length sampled from [input_len * (1 - range_ratio), "
+            "input_len * (1 + range_ratio)]."
+        ),
+    )
+    parser_or_group.add_argument(
+        "--random-batch-size",
+        type=int,
+        default=1,
+        help=("Batch size for random sampling. Only used for embeddings benchmark."),
+    )
+    parser_or_group.add_argument(
+        "--no-reranker",
+        action="store_true",
+        help=(
+            "Whether the model supports reranking natively."
+            " Only used for reranker benchmark."
+        ),
+    )
+
+
+def add_random_multimodal_dataset_args(
+    parser_or_group: FlexibleArgumentParser | argparse._ArgumentGroup,
+) -> None:
+    """Add CLI arguments for random multimodal dataset options.
+    
+    This function adds arguments needed for:
+    - random-mm (random multimodal dataset)
+    
+    Args:
+        parser_or_group: Either a parser or an argument group to add arguments to.
+    """
+    parser_or_group.add_argument(
+        "--random-mm-base-items-per-request",
+        type=int,
+        default=RandomMultiModalDataset.DEFAULT_BASE_ITEMS_PER_REQUEST,
+        help=(
+            "Base number of multimodal items per request for random-mm. "
+            "Actual per-request count is sampled around this base using "
+            "--random-mm-num-mm-items-range-ratio."
+        ),
+    )
+    parser_or_group.add_argument(
+        "--random-mm-num-mm-items-range-ratio",
+        type=float,
+        default=RandomMultiModalDataset.DEFAULT_NUM_MM_ITEMS_RANGE_RATIO,
+        help=(
+            "Range ratio r in [0, 1] for sampling items per request. "
+            "We sample uniformly from the closed integer range "
+            "[floor(n*(1-r)), ceil(n*(1+r))] "
+            "where n is the base items per request. "
+            "r=0 keeps it fixed; r=1 allows 0 items. The maximum is clamped "
+            "to the sum of per-modality limits from "
+            "--random-mm-limit-mm-per-prompt. "
+            "An error is raised if the computed min exceeds the max."
+        ),
+    )
+    parser_or_group.add_argument(
+        "--random-mm-limit-mm-per-prompt",
+        type=json.loads,
+        default=RandomMultiModalDataset.DEFAULT_LIMIT_MM_PER_PROMPT,
+        help=(
+            "Per-modality hard caps for items attached per request, e.g. "
+            '\'{"image": 3, "video": 0}\'. The sampled per-request item '
+            "count is clamped to the sum of these limits. When a modality "
+            "reaches its cap, its buckets are excluded and probabilities are "
+            "renormalized."
+            "OBS.: Only image sampling is supported for now."
+        ),
+    )
+
+    def _parse_mm_bucket_config(v: object) -> dict[tuple[int, int, int], float]:
+        # If already a dict (e.g., programmatic call), normalize keys
+        def normalize(d: dict) -> dict[tuple[int, int, int], float]:
+            out: dict[tuple[int, int, int], float] = {}
+            for k, val in d.items():
+                key = k
+                if isinstance(key, str):
+                    with suppress(Exception):
+                        key = ast.literal_eval(key)
+                if not (
+                    isinstance(key, tuple)
+                    and len(key) == 3
+                    and all(isinstance(x, int) for x in key)
+                ):
+                    raise ValueError(
+                        f"Invalid bucket key {k!r}. Expected tuple (H, W, T)."
+                    )
+                out[(int(key[0]), int(key[1]), int(key[2]))] = float(val)
+            return out
+
+        if isinstance(v, dict):
+            return normalize(v)
+        if isinstance(v, str):
+            # Python literal (supports tuple keys)
+            parsed = ast.literal_eval(v)
+            if not isinstance(parsed, dict):
+                raise ValueError("Bucket config must parse to a dict.")
+            return normalize(parsed)
+        raise ValueError("Unsupported value for --random-mm-bucket-config.")
+
+    parser_or_group.add_argument(
+        "--random-mm-bucket-config",
+        type=_parse_mm_bucket_config,
+        default=RandomMultiModalDataset.DEFAULT_MM_ITEM_BUCKET_CONFIG,
+        help=(
+            "The bucket config is a dictionary mapping a multimodal item"
+            "sampling configuration to a probability."
+            "Currently allows for 2 modalities: images and videos. "
+            "An bucket key is a tuple of (height, width, num_frames)"
+            "The value is the probability of sampling that specific item. "
+            "Example: "
+            "--random-mm-bucket-config "
+            "{(256, 256, 1): 0.5, (720, 1280, 1): 0.4, (720, 1280, 16): 0.10} "
+            "First item: images with resolution 256x256 w.p. 0.5"
+            "Second item: images with resolution 720x1280 w.p. 0.4 "
+            "Third item: videos with resolution 720x1280 and 16 frames w.p. 0.1"
+            "OBS.: If the probabilities do not sum to 1, they are normalized."
+            "OBS bis.: Only image sampling is supported for now."
+        ),
     )
 
 

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -1501,16 +1501,17 @@ def add_dataset_parser(parser: FlexibleArgumentParser):
         "repetition dataset.",
     )
 
+
 def add_random_dataset_base_args(
     parser_or_group: FlexibleArgumentParser | argparse._ArgumentGroup,
 ) -> None:
     """Add CLI arguments for base random dataset options.
-    
+
     This function adds arguments needed for:
     - random (random dataset)
     - random-mm (random multimodal dataset)
     - random-rerank (random dataset for reranking)
-    
+
     Args:
         parser_or_group: Either a parser or an argument group to add arguments to.
     """
@@ -1568,10 +1569,10 @@ def add_random_multimodal_dataset_args(
     parser_or_group: FlexibleArgumentParser | argparse._ArgumentGroup,
 ) -> None:
     """Add CLI arguments for random multimodal dataset options.
-    
+
     This function adds arguments needed for:
     - random-mm (random multimodal dataset)
-    
+
     Args:
         parser_or_group: Either a parser or an argument group to add arguments to.
     """

--- a/vllm/benchmarks/mm_processor.py
+++ b/vllm/benchmarks/mm_processor.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+r"""Benchmark multimodal processor latency.
+
+This benchmark measures the latency of the mm processor module
+using multimodal prompts from datasets.
+MM processor stats are automatically enabled.
+
+Run:
+    vllm bench mm-processor \
+        --model <your_model> \
+        --dataset-name random-mm \
+        --num-prompts 10 \
+"""
+
+import argparse
+import dataclasses
+import json
+import time
+from datetime import datetime
+from typing import Any
+
+import numpy as np
+
+from vllm.benchmarks.throughput import get_requests
+from vllm.engine.arg_utils import EngineArgs
+from vllm.multimodal.processing import (
+    get_timing_stats_from_engine_client,
+)
+from vllm.utils.gc_utils import freeze_gc_heap
+from vllm.utils.import_utils import PlaceholderModule
+
+try:
+    import pandas as pd
+except ImportError:
+    pd = PlaceholderModule("pandas")
+
+def collect_mm_processor_stats(
+    llm_engine: Any,
+) -> dict[str, list[float]]:
+    """
+    Collect multimodal processor timing stats.
+    Returns a dictionary mapping stage names to lists of timing values (in seconds).
+    """
+    all_stats = get_timing_stats_from_engine_client(llm_engine)
+
+    stats_by_stage = {
+        "hf_processor_time": [],
+        "hashing_time": [],
+        "cache_lookup_time": [],
+        "prompt_update_time": [],
+        "total_time": [],
+    }
+
+    for stats_dict in all_stats.values():
+        stats_by_stage["hf_processor_time"].append(
+            stats_dict.get("hf_processor_time", 0.0)
+        )
+        stats_by_stage["hashing_time"].append(stats_dict.get("hashing_time", 0.0))
+        stats_by_stage["cache_lookup_time"].append(
+            stats_dict.get("cache_lookup_time", 0.0)
+        )
+        stats_by_stage["prompt_update_time"].append(
+            stats_dict.get("prompt_update_time", 0.0)
+        )
+        stats_by_stage["total_time"].append(stats_dict.get("total_time", 0.0))
+
+    return stats_by_stage
+
+
+def calculate_mm_processor_metrics(
+    stats_by_stage: dict[str, list[float]],
+    selected_percentiles: list[float],
+) -> dict[str, dict[str, float]]:
+    """
+    Calculate aggregate metrics from stats by stage.
+    """
+    metrics = {}
+
+    for stage_name, times in stats_by_stage.items():
+        if not times:
+            metrics[stage_name] = {
+                "mean": 0.0,
+                "median": 0.0,
+                "std": 0.0,
+                **{f"p{p}": 0.0 for p in selected_percentiles},
+            }
+            continue
+
+        times_ms = [t * 1000 for t in times]
+        metrics[stage_name] = {
+            "mean": float(np.mean(times_ms)),
+            "median": float(np.median(times_ms)),
+            "std": float(np.std(times_ms)),
+            **{
+                f"p{p}": float(np.percentile(times_ms, p)) for p in selected_percentiles
+            },
+        }
+
+    return metrics
+
+
+def validate_args(args):
+    """
+    Validate command-line arguments for mm_processor benchmark.
+    """
+    if not getattr(args, "tokenizer", None):
+        args.tokenizer = args.model
+    if not hasattr(args, "dataset_path"):
+        args.dataset_path = None
+    if not hasattr(args, "lora_path"):
+        args.lora_path = None
+    if not hasattr(args, "max_loras"):
+        args.max_loras = None
+
+def benchmark_multimodal_processor(
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    """
+    Run the multimodal processor benchmark.
+    """
+    from vllm import LLM, SamplingParams
+
+    validate_args(args)
+    
+    if args.seed is None:
+        args.seed = 0
+
+    engine_args = EngineArgs.from_cli_args(args)
+    llm = LLM(**dataclasses.asdict(engine_args))
+    
+    tokenizer = llm.get_tokenizer()
+    requests = get_requests(args, tokenizer)
+
+    assert all(
+        llm.llm_engine.model_config.max_model_len
+        >= (request.prompt_len + request.expected_output_len)
+        for request in requests
+    ), (
+        "Please ensure that max_model_len is greater than the sum of "
+        "prompt_len and expected_output_len for all requests."
+    )
+
+    prompts = [request.prompt for request in requests]
+    expected_output_lens = [request.expected_output_len for request in requests]
+
+    sampling_params = [
+        SamplingParams(
+            n=1,
+            temperature=0.0,
+            max_tokens=output_len,
+            detokenize=True,
+        )
+        for output_len in expected_output_lens
+    ]
+
+    selected_percentiles = [
+        float(p) for p in getattr(args, "metric_percentiles", "99").split(",")
+    ]
+
+    freeze_gc_heap()
+
+    print(f"Processing {len(prompts)} requests...")
+    start_time = time.perf_counter()
+
+    outputs = llm.chat(
+        prompts, sampling_params, use_tqdm=not getattr(args, "disable_tqdm", False)
+    )
+
+    end_time = time.perf_counter()
+    total_time = end_time - start_time
+
+    mm_stats_by_stage = collect_mm_processor_stats(
+        llm.llm_engine,
+    )
+
+    if not any(mm_stats_by_stage.values()):
+        print(
+            "\n⚠️  Warning: No MM processor stats found in registry.\n"
+            "   This may indicate that:\n"
+            "   - No multimodal requests were processed\n"
+            "   - Stats were already retrieved (registry is cleared after retrieval)\n"
+        )
+
+    mm_processor_metrics = calculate_mm_processor_metrics(
+        mm_stats_by_stage, selected_percentiles
+    )
+
+    completed = len([o for o in outputs if o.finished])
+    failed = len(outputs) - completed
+
+    e2el_times = []
+    for output in outputs:
+        if not output.finished or output.metrics is None:
+            continue
+        metrics = output.metrics
+        for attr in ("finished_time", "last_token_time"):
+            if (
+                getattr(metrics, attr, None) is not None
+                and getattr(metrics, "arrival_time", None) is not None
+            ):
+                e2el_times.append(
+                    (getattr(metrics, attr) - metrics.arrival_time) * 1000
+                )
+                break
+
+    if not e2el_times and completed > 0:
+        avg_time_per_request = total_time / completed
+        e2el_times = [avg_time_per_request * 1000] * completed
+
+    if e2el_times:
+        mean_e2el_ms = float(np.mean(e2el_times))
+        median_e2el_ms = float(np.median(e2el_times))
+        std_e2el_ms = float(np.std(e2el_times))
+        percentiles_e2el_ms = [
+            (p, float(np.percentile(e2el_times, p))) for p in selected_percentiles
+        ]
+    else:
+        mean_e2el_ms = 0.0
+        median_e2el_ms = 0.0
+        std_e2el_ms = 0.0
+        percentiles_e2el_ms = [(p, 0.0) for p in selected_percentiles]
+
+    benchmark_result = {
+        "completed": completed,
+        "failed": failed,
+        "mean_e2el_ms": mean_e2el_ms,
+        "median_e2el_ms": median_e2el_ms,
+        "std_e2el_ms": std_e2el_ms,
+        "percentiles_e2el_ms": percentiles_e2el_ms,
+        "mm_processor_stats": mm_processor_metrics,
+    }
+
+    return benchmark_result
+
+
+def add_cli_args(parser: argparse.ArgumentParser) -> None:
+    """Add CLI arguments for the multimodal processor benchmark."""
+    from vllm.engine.arg_utils import EngineArgs
+
+    EngineArgs.add_cli_args(parser)
+
+    parser.set_defaults(enable_mm_processor_stats=True)
+
+    parser.add_argument(
+        "--dataset-name",
+        type=str,
+        default="random-mm",
+        choices=["random-mm", "random-rerank"],
+        help="Name of the dataset to benchmark on. Defaults to 'random-mm'.",
+    )
+    parser.add_argument(
+        "--num-prompts",
+        type=int,
+        default=10,
+        help="Number of prompts to process.",
+    )
+
+    from vllm.benchmarks.datasets import (
+        add_random_dataset_base_args,
+        add_random_multimodal_dataset_args,
+    )
+
+    add_random_dataset_base_args(parser)
+    add_random_multimodal_dataset_args(parser)
+
+    parser.add_argument(
+        "--output-json",
+        type=str,
+        default=None,
+        help="Path to save the benchmark results in JSON format.",
+    )
+    parser.add_argument(
+        "--metric-percentiles",
+        type=str,
+        default="99",
+        help="Comma-separated list of percentiles to calculate (e.g., '50,90,99').",
+    )
+    parser.add_argument(
+        "--disable-tqdm",
+        action="store_true",
+        help="Disable tqdm progress bar.",
+    )
+
+
+def main(args: argparse.Namespace) -> None:
+    """Main entry point for the multimodal processor benchmark."""
+
+    print("Starting multimodal processor benchmark...")
+    result = benchmark_multimodal_processor(args)
+
+    print("\n" + "=" * 80)
+    print("Multimodal Processor Benchmark Results")
+    print("=" * 80)
+
+    if "mm_processor_stats" in result:
+        print("\nMM Processor Timing (ms):")
+        selected_percentiles = [
+            float(p) for p in getattr(args, "metric_percentiles", "99").split(",")
+        ]
+        mm_data = []
+        for stage, metrics in result["mm_processor_stats"].items():
+            row = {
+                "Stage": stage,
+                "Mean": f"{metrics['mean']:.2f}",
+                "Median": f"{metrics['median']:.2f}",
+                "Std": f"{metrics['std']:.2f}",
+            }
+            for p in selected_percentiles:
+                row[f"P{p}"] = f"{metrics.get(f'p{p}', 0.0):.2f}"
+            mm_data.append(row)
+
+        mm_df = pd.DataFrame(mm_data)
+        print(mm_df.to_string(index=False))
+
+    if "mean_e2el_ms" in result:
+        print("\nEnd-to-End Latency (ms):")
+        selected_percentiles = [
+            float(p) for p in getattr(args, "metric_percentiles", "99").split(",")
+        ]
+
+        e2el_data = [
+            {"Metric": "Mean", "Value (ms)": f"{result['mean_e2el_ms']:.2f}"},
+            {"Metric": "Median", "Value (ms)": f"{result['median_e2el_ms']:.2f}"},
+            {"Metric": "Std", "Value (ms)": f"{result['std_e2el_ms']:.2f}"},
+        ]
+
+        for p in selected_percentiles:
+            percentile_value = next(
+                (val for pct, val in result["percentiles_e2el_ms"] if pct == p),
+                0.0,
+            )
+            e2el_data.append(
+                {
+                    "Metric": f"P{p}",
+                    "Value (ms)": f"{percentile_value:.2f}",
+                }
+            )
+
+        e2el_df = pd.DataFrame(e2el_data)
+        print(e2el_df.to_string(index=False))
+
+    if args.output_json:
+        result["config"] = {
+            "model": args.model,
+            "num_prompts": args.num_prompts,
+            "input_len": getattr(args, "random_input_len", None),
+            "output_len": getattr(args, "random_output_len", None),
+        }
+        result["timestamp"] = datetime.now().isoformat()
+
+        with open(args.output_json, "w") as f:
+            json.dump(result, f, indent=2)
+        print(f"\nResults saved to {args.output_json}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Benchmark mm processor latency"
+    )
+    add_cli_args(parser)
+    args = parser.parse_args()
+    main(args)

--- a/vllm/benchmarks/mm_processor.py
+++ b/vllm/benchmarks/mm_processor.py
@@ -35,6 +35,7 @@ try:
 except ImportError:
     pd = PlaceholderModule("pandas")
 
+
 def collect_mm_processor_stats(
     llm_engine: Any,
 ) -> dict[str, list[float]]:
@@ -113,6 +114,7 @@ def validate_args(args):
     if not hasattr(args, "max_loras"):
         args.max_loras = None
 
+
 def benchmark_multimodal_processor(
     args: argparse.Namespace,
 ) -> dict[str, Any]:
@@ -122,13 +124,13 @@ def benchmark_multimodal_processor(
     from vllm import LLM, SamplingParams
 
     validate_args(args)
-    
+
     if args.seed is None:
         args.seed = 0
 
     engine_args = EngineArgs.from_cli_args(args)
     llm = LLM(**dataclasses.asdict(engine_args))
-    
+
     tokenizer = llm.get_tokenizer()
     requests = get_requests(args, tokenizer)
 
@@ -355,9 +357,7 @@ def main(args: argparse.Namespace) -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Benchmark mm processor latency"
-    )
+    parser = argparse.ArgumentParser(description="Benchmark mm processor latency")
     add_cli_args(parser)
     args = parser.parse_args()
     main(args)

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -355,11 +355,17 @@ def get_requests(args, tokenizer):
         sample_kwargs["range_ratio"] = args.random_range_ratio
         # prefer random_* arguments, fall back to regular arguments
         random_prefix_len = getattr(args, "random_prefix_len", None)
-        sample_kwargs["prefix_len"] = random_prefix_len if random_prefix_len is not None else args.prefix_len
+        sample_kwargs["prefix_len"] = (
+            random_prefix_len if random_prefix_len is not None else args.prefix_len
+        )
         random_input_len = getattr(args, "random_input_len", None)
-        sample_kwargs["input_len"] = random_input_len if random_input_len is not None else args.input_len
+        sample_kwargs["input_len"] = (
+            random_input_len if random_input_len is not None else args.input_len
+        )
         random_output_len = getattr(args, "random_output_len", None)
-        sample_kwargs["output_len"] = random_output_len if random_output_len is not None else args.output_len
+        sample_kwargs["output_len"] = (
+            random_output_len if random_output_len is not None else args.output_len
+        )
         dataset_cls = RandomDataset
     elif args.dataset_name == "sharegpt":
         dataset_cls = ShareGPTDataset
@@ -415,9 +421,17 @@ def get_requests(args, tokenizer):
         dataset_cls = RandomMultiModalDataset
         # prefer random_* arguments, fall back to regular arguments
         random_input_len = getattr(args, "random_input_len", None)
-        sample_kwargs["input_len"] = random_input_len if random_input_len is not None else getattr(args, "input_len", None)
+        sample_kwargs["input_len"] = (
+            random_input_len
+            if random_input_len is not None
+            else getattr(args, "input_len", None)
+        )
         random_output_len = getattr(args, "random_output_len", None)
-        sample_kwargs["output_len"] = random_output_len if random_output_len is not None else getattr(args, "output_len", None)
+        sample_kwargs["output_len"] = (
+            random_output_len
+            if random_output_len is not None
+            else getattr(args, "output_len", None)
+        )
         sample_kwargs["base_items_per_request"] = getattr(
             args, "random_mm_base_items_per_request", None
         )
@@ -427,21 +441,29 @@ def get_requests(args, tokenizer):
         sample_kwargs["limit_mm_per_prompt"] = getattr(
             args, "random_mm_limit_mm_per_prompt", None
         )
-        sample_kwargs["bucket_config"] = getattr(
-            args, "random_mm_bucket_config", None
-        )
+        sample_kwargs["bucket_config"] = getattr(args, "random_mm_bucket_config", None)
         sample_kwargs["enable_multimodal_chat"] = True
         random_prefix_len = getattr(args, "random_prefix_len", None)
         prefix_len = getattr(args, "prefix_len", None)
-        sample_kwargs["prefix_len"] = random_prefix_len if random_prefix_len is not None else prefix_len
+        sample_kwargs["prefix_len"] = (
+            random_prefix_len if random_prefix_len is not None else prefix_len
+        )
         sample_kwargs["range_ratio"] = args.random_range_ratio
     elif args.dataset_name == "random-rerank":
         dataset_cls = RandomDatasetForReranking
         # prefer random_* arguments, fall back to regular arguments
         random_input_len = getattr(args, "random_input_len", None)
-        sample_kwargs["input_len"] = random_input_len if random_input_len is not None else getattr(args, "input_len", None)
+        sample_kwargs["input_len"] = (
+            random_input_len
+            if random_input_len is not None
+            else getattr(args, "input_len", None)
+        )
         random_output_len = getattr(args, "random_output_len", None)
-        sample_kwargs["output_len"] = random_output_len if random_output_len is not None else getattr(args, "output_len", None)
+        sample_kwargs["output_len"] = (
+            random_output_len
+            if random_output_len is not None
+            else getattr(args, "output_len", None)
+        )
         sample_kwargs["batchsize"] = getattr(args, "random_batch_size", 1)
         sample_kwargs["is_reranker"] = not getattr(args, "no_reranker", False)
         sample_kwargs["range_ratio"] = args.random_range_ratio
@@ -504,7 +526,8 @@ def validate_args(args):
         random_input_len = getattr(args, "random_input_len", None)
         if args.input_len is None and random_input_len is None:
             raise ValueError(
-                "Either --input-len or --random-input-len must be provided for a random dataset"
+                "Either --input-len or --random-input-len must be provided "
+                "for a random dataset"
             )
 
     # === Dataset Name Specific Checks ===
@@ -538,8 +561,12 @@ def validate_args(args):
         else:
             raise ValueError(f"{args.dataset_path} is not supported by hf dataset.")
 
-    # --random-range-ratio: only used when dataset_name is 'random', 'random-mm', or 'random-rerank'
-    if args.dataset_name not in {"random", "random-mm", "random-rerank"} and args.random_range_ratio is not None:
+    # --random-range-ratio: only used when dataset_name is 'random',
+    # 'random-mm', or 'random-rerank'
+    if (
+        args.dataset_name not in {"random", "random-mm", "random-rerank"}
+        and args.random_range_ratio is not None
+    ):
         warnings.warn(
             "--random-range-ratio will be ignored since \
                 --dataset-name is not 'random', 'random-mm', or 'random-rerank'.",
@@ -547,13 +574,15 @@ def validate_args(args):
         )
 
     # --random-batch-size: only used when dataset_name is 'random-rerank'
-    if args.dataset_name != "random-rerank" and getattr(args, "random_batch_size", None) is not None:
-        if args.random_batch_size != 1:
-            warnings.warn(
-                "--random-batch-size will be ignored since \
+    if (
+        args.dataset_name != "random-rerank"
+        and getattr(args, "random_batch_size", None) is not None
+    ) and args.random_batch_size != 1:
+        warnings.warn(
+            "--random-batch-size will be ignored since \
                     --dataset-name is not 'random-rerank'.",
-                stacklevel=2,
-            )
+            stacklevel=2,
+        )
 
     # --no-reranker: only used when dataset_name is 'random-rerank'
     if args.dataset_name != "random-rerank" and getattr(args, "no_reranker", False):
@@ -563,8 +592,8 @@ def validate_args(args):
             stacklevel=2,
         )
 
-    # --prefix-len: only used when dataset_name is 'random', 'random-mm', 'sonnet', or not
-    # set.
+    # --prefix-len: only used when dataset_name is 'random', 'random-mm',
+    # 'sonnet', or not set.
     if (
         args.dataset_name not in {"random", "random-mm", "sonnet", None}
         and args.prefix_len is not None
@@ -576,7 +605,8 @@ def validate_args(args):
         )
 
     # === Random Dataset Argument Conflict Detection ===
-    # Check for conflicts between regular and random arguments when using random datasets
+    # Check for conflicts between regular and random arguments when using
+    # random datasets
     if args.dataset_name in {"random", "random-mm", "random-rerank"}:
         random_input_len = getattr(args, "random_input_len", None)
         random_output_len = getattr(args, "random_output_len", None)
@@ -585,19 +615,22 @@ def validate_args(args):
         if args.input_len is not None and random_input_len is not None:
             warnings.warn(
                 "Both --input-len and --random-input-len are specified. "
-                "The random version (--random-input-len) will be preferred in this run.",
+                "The random version (--random-input-len) will be preferred "
+                "in this run.",
                 stacklevel=2,
             )
         if args.output_len is not None and random_output_len is not None:
             warnings.warn(
                 "Both --output-len and --random-output-len are specified. "
-                "The random version (--random-output-len) will be preferred in this run.",
+                "The random version (--random-output-len) will be preferred "
+                "in this run.",
                 stacklevel=2,
             )
         if args.prefix_len is not None and random_prefix_len is not None:
             warnings.warn(
                 "Both --prefix-len and --random-prefix-len are specified. "
-                "The random version (--random-prefix-len) will be preferred in this run.",
+                "The random version (--random-prefix-len) will be preferred "
+                "in this run.",
                 stacklevel=2,
             )
 
@@ -650,7 +683,16 @@ def add_cli_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--dataset-name",
         type=str,
-        choices=["sharegpt", "random", "sonnet", "burstgpt", "hf", "prefix_repetition", "random-mm", "random-rerank"],
+        choices=[
+            "sharegpt",
+            "random",
+            "sonnet",
+            "burstgpt",
+            "hf",
+            "prefix_repetition",
+            "random-mm",
+            "random-rerank",
+        ],
         help="Name of the dataset to benchmark on.",
         default="sharegpt",
     )
@@ -735,10 +777,16 @@ def add_cli_args(parser: argparse.ArgumentParser):
 
     # hf dtaset
     parser.add_argument(
-        "--hf-subset", type=str, default=None, help="Subset of the HF dataset.",
+        "--hf-subset",
+        type=str,
+        default=None,
+        help="Subset of the HF dataset.",
     )
     parser.add_argument(
-        "--hf-split", type=str, default=None, help="Split of the HF dataset.",
+        "--hf-split",
+        type=str,
+        default=None,
+        help="Split of the HF dataset.",
     )
     parser.add_argument(
         "--profile",

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -24,10 +24,14 @@ from vllm.benchmarks.datasets import (
     MultiModalConversationDataset,
     PrefixRepetitionRandomDataset,
     RandomDataset,
+    RandomDatasetForReranking,
+    RandomMultiModalDataset,
     SampleRequest,
     ShareGPTDataset,
     SonnetDataset,
     VisionArenaDataset,
+    add_random_dataset_base_args,
+    add_random_multimodal_dataset_args,
 )
 from vllm.benchmarks.lib.utils import convert_to_pytorch_benchmark_format, write_to_json
 from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
@@ -342,8 +346,6 @@ def get_requests(args, tokenizer):
         "lora_path": args.lora_path,
         "max_loras": args.max_loras,
         "num_requests": args.num_prompts,
-        "input_len": args.input_len,
-        "output_len": args.output_len,
     }
 
     if args.dataset_name == "random" or (
@@ -351,12 +353,20 @@ def get_requests(args, tokenizer):
         and args.dataset_name not in {"prefix_repetition", "random-mm", "random-rerank"}
     ):
         sample_kwargs["range_ratio"] = args.random_range_ratio
-        sample_kwargs["prefix_len"] = args.prefix_len
+        # prefer random_* arguments, fall back to regular arguments
+        random_prefix_len = getattr(args, "random_prefix_len", None)
+        sample_kwargs["prefix_len"] = random_prefix_len if random_prefix_len is not None else args.prefix_len
+        random_input_len = getattr(args, "random_input_len", None)
+        sample_kwargs["input_len"] = random_input_len if random_input_len is not None else args.input_len
+        random_output_len = getattr(args, "random_output_len", None)
+        sample_kwargs["output_len"] = random_output_len if random_output_len is not None else args.output_len
         dataset_cls = RandomDataset
     elif args.dataset_name == "sharegpt":
         dataset_cls = ShareGPTDataset
         if args.backend == "vllm-chat":
             sample_kwargs["enable_multimodal_chat"] = True
+        if args.output_len is not None:
+            sample_kwargs["output_len"] = args.output_len
     elif args.dataset_name == "sonnet":
         assert tokenizer.chat_template or tokenizer.default_chat_template, (
             "Tokenizer/model must have chat template for sonnet dataset."
@@ -364,9 +374,15 @@ def get_requests(args, tokenizer):
         dataset_cls = SonnetDataset
         sample_kwargs["prefix_len"] = args.prefix_len
         sample_kwargs["return_prompt_formatted"] = True
+        if args.input_len is not None:
+            sample_kwargs["input_len"] = args.input_len
+        if args.output_len is not None:
+            sample_kwargs["output_len"] = args.output_len
     elif args.dataset_name == "burstgpt":
         dataset_cls = BurstGPTDataset
     elif args.dataset_name == "hf":
+        if args.output_len is not None:
+            sample_kwargs["output_len"] = args.output_len
         if args.dataset_path in VisionArenaDataset.SUPPORTED_DATASET_PATHS:
             dataset_cls = VisionArenaDataset
             common_kwargs["dataset_subset"] = None
@@ -395,6 +411,40 @@ def get_requests(args, tokenizer):
         sample_kwargs["suffix_len"] = args.prefix_repetition_suffix_len
         sample_kwargs["num_prefixes"] = args.prefix_repetition_num_prefixes
         sample_kwargs["output_len"] = args.prefix_repetition_output_len
+    elif args.dataset_name == "random-mm":
+        dataset_cls = RandomMultiModalDataset
+        # prefer random_* arguments, fall back to regular arguments
+        random_input_len = getattr(args, "random_input_len", None)
+        sample_kwargs["input_len"] = random_input_len if random_input_len is not None else getattr(args, "input_len", None)
+        random_output_len = getattr(args, "random_output_len", None)
+        sample_kwargs["output_len"] = random_output_len if random_output_len is not None else getattr(args, "output_len", None)
+        sample_kwargs["base_items_per_request"] = getattr(
+            args, "random_mm_base_items_per_request", None
+        )
+        sample_kwargs["num_mm_items_range_ratio"] = getattr(
+            args, "random_mm_num_mm_items_range_ratio", None
+        )
+        sample_kwargs["limit_mm_per_prompt"] = getattr(
+            args, "random_mm_limit_mm_per_prompt", None
+        )
+        sample_kwargs["bucket_config"] = getattr(
+            args, "random_mm_bucket_config", None
+        )
+        sample_kwargs["enable_multimodal_chat"] = True
+        random_prefix_len = getattr(args, "random_prefix_len", None)
+        prefix_len = getattr(args, "prefix_len", None)
+        sample_kwargs["prefix_len"] = random_prefix_len if random_prefix_len is not None else prefix_len
+        sample_kwargs["range_ratio"] = args.random_range_ratio
+    elif args.dataset_name == "random-rerank":
+        dataset_cls = RandomDatasetForReranking
+        # prefer random_* arguments, fall back to regular arguments
+        random_input_len = getattr(args, "random_input_len", None)
+        sample_kwargs["input_len"] = random_input_len if random_input_len is not None else getattr(args, "input_len", None)
+        random_output_len = getattr(args, "random_output_len", None)
+        sample_kwargs["output_len"] = random_output_len if random_output_len is not None else getattr(args, "output_len", None)
+        sample_kwargs["batchsize"] = getattr(args, "random_batch_size", 1)
+        sample_kwargs["is_reranker"] = not getattr(args, "no_reranker", False)
+        sample_kwargs["range_ratio"] = args.random_range_ratio
     else:
         raise ValueError(f"Unknown dataset name: {args.dataset_name}")
     # Remove None values
@@ -451,8 +501,11 @@ def validate_args(args):
     ):
         print("When dataset path is not set, it will default to random dataset")
         args.dataset_name = "random"
-        if args.input_len is None:
-            raise ValueError("input_len must be provided for a random dataset")
+        random_input_len = getattr(args, "random_input_len", None)
+        if args.input_len is None and random_input_len is None:
+            raise ValueError(
+                "Either --input-len or --random-input-len must be provided for a random dataset"
+            )
 
     # === Dataset Name Specific Checks ===
     # --hf-subset and --hf-split: only used
@@ -485,25 +538,68 @@ def validate_args(args):
         else:
             raise ValueError(f"{args.dataset_path} is not supported by hf dataset.")
 
-    # --random-range-ratio: only used when dataset_name is 'random'
-    if args.dataset_name != "random" and args.random_range_ratio is not None:
+    # --random-range-ratio: only used when dataset_name is 'random', 'random-mm', or 'random-rerank'
+    if args.dataset_name not in {"random", "random-mm", "random-rerank"} and args.random_range_ratio is not None:
         warnings.warn(
             "--random-range-ratio will be ignored since \
-                --dataset-name is not 'random'.",
+                --dataset-name is not 'random', 'random-mm', or 'random-rerank'.",
             stacklevel=2,
         )
 
-    # --prefix-len: only used when dataset_name is 'random', 'sonnet', or not
+    # --random-batch-size: only used when dataset_name is 'random-rerank'
+    if args.dataset_name != "random-rerank" and getattr(args, "random_batch_size", None) is not None:
+        if args.random_batch_size != 1:
+            warnings.warn(
+                "--random-batch-size will be ignored since \
+                    --dataset-name is not 'random-rerank'.",
+                stacklevel=2,
+            )
+
+    # --no-reranker: only used when dataset_name is 'random-rerank'
+    if args.dataset_name != "random-rerank" and getattr(args, "no_reranker", False):
+        warnings.warn(
+            "--no-reranker will be ignored since \
+                --dataset-name is not 'random-rerank'.",
+            stacklevel=2,
+        )
+
+    # --prefix-len: only used when dataset_name is 'random', 'random-mm', 'sonnet', or not
     # set.
     if (
-        args.dataset_name not in {"random", "sonnet", None}
+        args.dataset_name not in {"random", "random-mm", "sonnet", None}
         and args.prefix_len is not None
     ):
         warnings.warn(
             "--prefix-len will be ignored since --dataset-name\
-                 is not 'random', 'sonnet', or not set.",
+                 is not 'random', 'random-mm', 'sonnet', or not set.",
             stacklevel=2,
         )
+
+    # === Random Dataset Argument Conflict Detection ===
+    # Check for conflicts between regular and random arguments when using random datasets
+    if args.dataset_name in {"random", "random-mm", "random-rerank"}:
+        random_input_len = getattr(args, "random_input_len", None)
+        random_output_len = getattr(args, "random_output_len", None)
+        random_prefix_len = getattr(args, "random_prefix_len", None)
+
+        if args.input_len is not None and random_input_len is not None:
+            warnings.warn(
+                "Both --input-len and --random-input-len are specified. "
+                "The random version (--random-input-len) will be preferred in this run.",
+                stacklevel=2,
+            )
+        if args.output_len is not None and random_output_len is not None:
+            warnings.warn(
+                "Both --output-len and --random-output-len are specified. "
+                "The random version (--random-output-len) will be preferred in this run.",
+                stacklevel=2,
+            )
+        if args.prefix_len is not None and random_prefix_len is not None:
+            warnings.warn(
+                "Both --prefix-len and --random-prefix-len are specified. "
+                "The random version (--random-prefix-len) will be preferred in this run.",
+                stacklevel=2,
+            )
 
     # === LoRA Settings ===
     if getattr(args, "enable_lora", False) and args.backend != "vllm":
@@ -554,7 +650,7 @@ def add_cli_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--dataset-name",
         type=str,
-        choices=["sharegpt", "random", "sonnet", "burstgpt", "hf", "prefix_repetition"],
+        choices=["sharegpt", "random", "sonnet", "burstgpt", "hf", "prefix_repetition", "random-mm", "random-rerank"],
         help="Name of the dataset to benchmark on.",
         default="sharegpt",
     )
@@ -636,23 +732,13 @@ def add_cli_args(parser: argparse.ArgumentParser):
         help="Number of fixed prefix tokens before the random "
         "context in a request (default: 0).",
     )
-    # random dataset
-    parser.add_argument(
-        "--random-range-ratio",
-        type=float,
-        default=0.0,
-        help="Range ratio for sampling input/output length, "
-        "used only for RandomDataset. Must be in the range [0, 1) to define "
-        "a symmetric sampling range "
-        "[length * (1 - range_ratio), length * (1 + range_ratio)].",
-    )
 
     # hf dtaset
     parser.add_argument(
-        "--hf-subset", type=str, default=None, help="Subset of the HF dataset."
+        "--hf-subset", type=str, default=None, help="Subset of the HF dataset.",
     )
     parser.add_argument(
-        "--hf-split", type=str, default=None, help="Split of the HF dataset."
+        "--hf-split", type=str, default=None, help="Split of the HF dataset.",
     )
     parser.add_argument(
         "--profile",
@@ -662,37 +748,38 @@ def add_cli_args(parser: argparse.ArgumentParser):
     )
 
     # prefix repetition dataset
-    prefix_repetition_group = parser.add_argument_group(
-        "prefix repetition dataset options"
-    )
-    prefix_repetition_group.add_argument(
+    parser.add_argument(
         "--prefix-repetition-prefix-len",
         type=int,
         default=None,
         help="Number of prefix tokens per request, used only for prefix "
         "repetition dataset.",
     )
-    prefix_repetition_group.add_argument(
+    parser.add_argument(
         "--prefix-repetition-suffix-len",
         type=int,
         default=None,
         help="Number of suffix tokens per request, used only for prefix "
         "repetition dataset. Total input length is prefix_len + suffix_len.",
     )
-    prefix_repetition_group.add_argument(
+    parser.add_argument(
         "--prefix-repetition-num-prefixes",
         type=int,
         default=None,
         help="Number of prefixes to generate, used only for prefix repetition "
         "dataset. Prompts per prefix is num_requests // num_prefixes.",
     )
-    prefix_repetition_group.add_argument(
+    parser.add_argument(
         "--prefix-repetition-output-len",
         type=int,
         default=None,
         help="Number of output tokens per request, used only for prefix "
         "repetition dataset.",
     )
+
+    # (random, random-mm, random-rerank)
+    add_random_dataset_base_args(parser)
+    add_random_multimodal_dataset_args(parser)
 
     parser = AsyncEngineArgs.add_cli_args(parser)
 

--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -72,10 +72,8 @@ class ObservabilityConfig:
     This is for internal use only (e.g., benchmarks) and is not exposed as a CLI
     argument."""
 
-
     enable_mfu_metrics: bool = False
     """Enable Model FLOPs Utilization (MFU) metrics."""
-    
 
     @cached_property
     def collect_model_forward_time(self) -> bool:

--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -67,6 +67,16 @@ class ObservabilityConfig:
     enable_mfu_metrics: bool = False
     """Enable Model FLOPs Utilization (MFU) metrics."""
 
+    enable_mm_processor_stats: bool = False
+    """Enable collection of timing statistics for multimodal processor operations.
+    This is for internal use only (e.g., benchmarks) and is not exposed as a CLI
+    argument."""
+
+
+    enable_mfu_metrics: bool = False
+    """Enable Model FLOPs Utilization (MFU) metrics."""
+    
+
     @cached_property
     def collect_model_forward_time(self) -> bool:
         """Whether to collect model forward time for the request."""

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -523,6 +523,7 @@ class EngineArgs:
         ObservabilityConfig.enable_layerwise_nvtx_tracing
     )
     enable_mfu_metrics: bool = ObservabilityConfig.enable_mfu_metrics
+    enable_mm_processor_stats: bool = ObservabilityConfig.enable_mm_processor_stats
     scheduling_policy: SchedulerPolicy = SchedulerConfig.policy
     scheduler_cls: str | type[object] | None = SchedulerConfig.scheduler_cls
 
@@ -1712,6 +1713,7 @@ class EngineArgs:
             cudagraph_metrics=self.cudagraph_metrics,
             enable_layerwise_nvtx_tracing=self.enable_layerwise_nvtx_tracing,
             enable_mfu_metrics=self.enable_mfu_metrics,
+            enable_mm_processor_stats=self.enable_mm_processor_stats,
         )
 
         # Compilation config overrides

--- a/vllm/entrypoints/cli/__init__.py
+++ b/vllm/entrypoints/cli/__init__.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from vllm.entrypoints.cli.benchmark.latency import BenchmarkLatencySubcommand
+from vllm.entrypoints.cli.benchmark.mm_processor import (
+    BenchmarkMMProcessorSubcommand,
+)
 from vllm.entrypoints.cli.benchmark.serve import BenchmarkServingSubcommand
 from vllm.entrypoints.cli.benchmark.startup import BenchmarkStartupSubcommand
 from vllm.entrypoints.cli.benchmark.sweep import BenchmarkSweepSubcommand
@@ -8,6 +11,7 @@ from vllm.entrypoints.cli.benchmark.throughput import BenchmarkThroughputSubcomm
 
 __all__: list[str] = [
     "BenchmarkLatencySubcommand",
+    "BenchmarkMMProcessorSubcommand",
     "BenchmarkServingSubcommand",
     "BenchmarkStartupSubcommand",
     "BenchmarkSweepSubcommand",

--- a/vllm/entrypoints/cli/benchmark/mm_processor.py
+++ b/vllm/entrypoints/cli/benchmark/mm_processor.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import argparse
+
+from vllm.benchmarks.mm_processor import add_cli_args, main
+from vllm.entrypoints.cli.benchmark.base import BenchmarkSubcommandBase
+
+
+class BenchmarkMMProcessorSubcommand(BenchmarkSubcommandBase):
+    """The `mm-processor` subcommand for `vllm bench`."""
+
+    name = "mm-processor"
+    help = "Benchmark multimodal processor latency across different configurations."
+
+    @classmethod
+    def add_cli_args(cls, parser: argparse.ArgumentParser) -> None:
+        add_cli_args(parser)
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        main(args)

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 from typing_extensions import assert_never
 
-from vllm.config import ModelConfig
+from vllm.config import ModelConfig, ObservabilityConfig
 from vllm.logger import init_logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.multimodal.cache import BaseMultiModalProcessorCache
@@ -47,6 +47,7 @@ class InputPreprocessor:
         self,
         model_config: ModelConfig,
         tokenizer: TokenizerLike | None,
+        observability_config: ObservabilityConfig | None = None,
         mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
         mm_processor_cache: BaseMultiModalProcessorCache | None = None,
     ) -> None:
@@ -54,6 +55,7 @@ class InputPreprocessor:
 
         self.model_config = model_config
         self.tokenizer = tokenizer
+        self.observability_config = observability_config
         self.mm_registry = mm_registry
         self.mm_processor_cache = mm_processor_cache
 
@@ -232,6 +234,7 @@ class InputPreprocessor:
         if not hasattr(self, "_mm_processor"):
             self._mm_processor = self.mm_registry.create_processor(
                 self.model_config,
+                self.observability_config,
                 tokenizer=self.tokenizer,
                 cache=self.mm_processor_cache,
             )


### PR DESCRIPTION
Resolves #24171. 

## Purpose

This PR adds in a benchmark for the multimodal processor. This tests for the MM processor on a single vllm instance on a single GPU. 

Originally, I planned to additionally test for 1. DP on multiple GPUs and 2. multiple instances on a single GPU. On second thought, testing 1. DP seems equivalent to just running the benchmark multiple times. For 2. multiple instances on single GPU, I would like direction on which type of load balancing should be done on the #2 point. I could use a nginx round robin, or is the request router from the [production_stack repo](https://github.com/vllm-project/production-stack/tree/main/src/vllm_router) recommended? This also seems to be a good stopping place since the PR is just around 800 lines.

## Test Plan
```
# Using just HuggingFaceTB/SmolVLM-Instruct to save on compute during development, and random-mm dataset for simplicity
~vllm bench mm-processor     --model HuggingFaceTB/SmolVLM-Instruct     --dataset-name random-mm     --num-prompts 100     --max-concurrency 10~

# concurrency
~vllm bench mm-processor     --model HuggingFaceTB/SmolVLM-Instruct     --dataset-name random-mm     --num-prompts 100     --max-concurrency 50~

vllm bench mm-processor \
        --model HuggingFaceTB/SmolVLM-Instruct \
        --num-prompts 10 \
        --input-len 1024 \
        --output-len 128 \
        --num-images 1
```

## Test Result

```
# Example result
# vllm bench mm-processor \
        --model HuggingFaceTB/SmolVLM-Instruct \
        --num-prompts 10 \
        --input-len 1024 \
        --output-len 128 \
        --num-images 1
================================================================================                                                                                
Multimodal Processor Benchmark Results                                                                                                                          
================================================================================                                                                                
                                                                                                                                                                
MM Processor Timing (ms):                                                                                                                                       
             Stage   Mean Median    Std  P99.0                                                                                                                  
 hf_processor_time 228.01 156.81 204.41 780.97                                                                                                                  
      hashing_time   0.06   0.06   0.01   0.08
 cache_lookup_time   0.09   0.08   0.01   0.12
prompt_update_time   5.00   4.93   0.52   6.20
        total_time   0.00   0.00   0.00   0.00

End-to-End Latency (ms):
Metric Value (ms)
  Mean     430.99
Median     430.99
   Std       0.00
 P99.0     430.99
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

