### PR TITLE
[compile] Add utility for hashing the entire vllm codebase.

### DIFF
--- a/tests/compile/test_source_checksum.py
+++ b/tests/compile/test_source_checksum.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from pathlib import Path
+
+import pytest
+
+from vllm.compilation.source_checksum import (
+    calculate_vllm_source_checksum,
+    calculate_vllm_source_factors,
+    should_exclude_dir,
+)
+
+
+def test_should_exclude_dir():
+    assert should_exclude_dir(".git")
+    assert should_exclude_dir(".github")
+    assert should_exclude_dir(".pytest_cache")
+
+    assert should_exclude_dir("__pycache__")
+    assert should_exclude_dir(".mypy_cache")
+    assert should_exclude_dir(".ruff_cache")
+
+    assert not should_exclude_dir("vllm")
+    assert not should_exclude_dir("csrc")
+    assert not should_exclude_dir("tests")
+    assert not should_exclude_dir("benchmarks")
+
+
+def test_calculate_vllm_source_checksum_consistency():
+    """Test that checksum calculation is consistent across multiple runs."""
+    factors1 = calculate_vllm_source_factors()
+    checksum1 = calculate_vllm_source_checksum(factors1)
+
+    factors2 = calculate_vllm_source_factors()
+    checksum2 = calculate_vllm_source_checksum(factors2)
+
+    assert checksum1 == checksum2
+    # Checksum should be a SHA256 hex string (64 characters)
+    assert len(checksum1) == 64
+
+    assert factors1 == factors2
+
+
+def test_calculate_vllm_source_factors_structure():
+    factors = calculate_vllm_source_factors()
+
+    assert isinstance(factors, dict)
+    assert len(factors) > 0
+
+    for path in factors:
+        assert isinstance(path, str)
+        assert not path.startswith("/")
+
+    for checksum in factors.values():
+        assert isinstance(checksum, str)
+        assert len(checksum) == 64
+
+
+def test_includes_main_source_directories():
+    factors = calculate_vllm_source_factors()
+
+    vllm_files = [p for p in factors if p.startswith("vllm/")]
+    assert len(vllm_files) > 0
+
+    csrc_files = [p for p in factors if p.startswith("csrc/")]
+    assert len(csrc_files) > 0
+
+
+def test_checksum_changes_with_factors():
+    factors1 = {"file1.py": "a" * 64}
+    factors2 = {"file1.py": "b" * 64}
+
+    checksum1 = calculate_vllm_source_checksum(factors1)
+    checksum2 = calculate_vllm_source_checksum(factors2)
+
+    assert checksum1 != checksum2
+
+
+def test_excludes_dot_directories():
+    factors = calculate_vllm_source_factors()
+
+    # No file should be in a dot directory
+    for path in factors:
+        parts = path.split("/")
+        for part in parts:
+            if part:  # Skip empty parts
+                assert not part.startswith("."), f"Found file in dot directory: {path}"
+
+
+def test_factors_change_when_file_added():
+    current = Path(__file__).resolve()
+    root_path = None
+    for parent in current.parents:
+        if (parent / "setup.py").is_file() and (parent / "vllm").is_dir():
+            root_path = parent
+            break
+
+    assert root_path is not None
+
+    factors_before = calculate_vllm_source_factors()
+    checksum_before = calculate_vllm_source_checksum(factors_before)
+
+    test_file = root_path / "vllm" / "_test_checksum_temporary.py"
+    assert not test_file.exists(), "Temporary test file already exists"
+
+    try:
+        test_file.write_text("# Temporary test file for checksum testing\n")
+
+        factors_after = calculate_vllm_source_factors()
+        checksum_after = calculate_vllm_source_checksum(factors_after)
+
+        assert factors_before != factors_after
+        assert "vllm/_test_checksum_temporary.py" in factors_after
+        assert "vllm/_test_checksum_temporary.py" not in factors_before
+        assert checksum_before != checksum_after
+
+        test_file.write_text("# Modified temporary test file\n")
+
+        factors_modified = calculate_vllm_source_factors()
+        checksum_modified = calculate_vllm_source_checksum(factors_modified)
+
+        assert (
+            factors_after["vllm/_test_checksum_temporary.py"]
+            != factors_modified["vllm/_test_checksum_temporary.py"]
+        )
+        assert checksum_after != checksum_modified
+
+    finally:
+        if test_file.exists():
+            test_file.unlink()
+
+    factors_final = calculate_vllm_source_factors()
+    checksum_final = calculate_vllm_source_checksum(factors_final)
+
+    assert factors_final == factors_before
+    assert checksum_final == checksum_before
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/vllm/compilation/source_checksum.py
+++ b/vllm/compilation/source_checksum.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Utility to calculate checksum of vLLM source code for detecting changes.
+"""
+
+import hashlib
+import os
+from pathlib import Path
+
+INCLUDE_EXTENSIONS: set[str] = {
+    ".py",
+    ".pyx",
+    ".pxd",
+    ".cpp",
+    ".cc",
+    ".cxx",
+    ".c",
+    ".cu",
+    ".cuh",
+    ".h",
+    ".hpp",
+    ".hxx",
+    ".cmake",
+    ".txt",
+    ".toml",
+}
+
+
+TOP_LEVEL_INCLUDE_DIRS: set[str] = {
+    "cmake",
+    "csrc",
+    "requirements",
+    "tools",
+    "vllm",
+}
+
+EXCLUDE_DIRS: set[str] = {
+    "__pycache__",
+}
+
+
+def should_exclude_dir(dir_name: str) -> bool:
+    if dir_name.startswith("."):
+        return True
+    return dir_name in EXCLUDE_DIRS
+
+
+def calculate_file_checksum(file_path: Path) -> str:
+    with open(file_path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def calculate_vllm_source_factors() -> dict[str, str]:
+    current = Path(__file__).resolve()
+    root_path = None
+    for parent in current.parents:
+        if (parent / "setup.py").is_file() and (parent / "vllm").is_dir():
+            root_path = parent
+            break
+
+    if root_path is None:
+        raise RuntimeError("Could not find vLLM root directory")
+
+    checksums: dict[str, str] = {}
+
+    root_str = str(root_path) + os.sep
+    root_str_len = len(root_str)
+
+    for file_path in root_path.rglob("*"):
+        if not file_path.is_file():
+            continue
+
+        file_str = str(file_path)
+        assert file_str.startswith(root_str)
+        relative_str = file_str[root_str_len:]
+        relative_str = relative_str.replace(os.sep, "/")
+
+        _, ext = os.path.splitext(relative_str)
+        if ext not in INCLUDE_EXTENSIONS:
+            continue
+
+        parts = relative_str.split(os.sep)
+
+        if len(parts) > 0:
+            top_level_dir = parts[0]
+            if top_level_dir not in TOP_LEVEL_INCLUDE_DIRS:
+                continue
+
+        if any(should_exclude_dir(part) for part in parts):
+            continue
+
+        checksums[relative_str] = calculate_file_checksum(file_path)
+
+    return dict(sorted(checksums.items()))
+
+
+def calculate_vllm_source_checksum(factors: dict[str, str]) -> str:
+    factors_str = "".join(f"{path}:{checksum}" for path, checksum in factors.items())
+    return hashlib.sha256(factors_str.encode()).hexdigest()
+
+
+def print_vllm_source_checksum() -> None:
+    factors = calculate_vllm_source_factors()
+    checksum = calculate_vllm_source_checksum(factors)
+    print(f"vLLM source checksum: {checksum}")
+
+
+if __name__ == "__main__":
+    print_vllm_source_checksum()


### PR DESCRIPTION
Summary:
Following up on the recent refactoring on compile hashing, instead of hashing only the dynamo traced files, we should be more conservative and able to hash the entire vllm codebase to address corner cases that are not guarded by traced files.

This PR adds the basic functionality to hash over the entire codebase (with some heuristics on what are the meaningful source files to be included). It doesn't change the current caching behavior (yet) and we can figure out how to refactor the caching code in discussion.

Test Plan:
time python vllm/compilation/source_checksum.py (measured <1sec on my local machine) pytest tests/compile/test_source_checksum.py

Reviewers:

Subscribers:

Tasks:

Tags:

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

