### PR TITLE
[CI][ROCm][v1/e2e][1/n] Fix multiprocessing for AMD gpu

### DIFF
--- a/tests/v1/e2e/test_kv_sharing_fast_prefill.py
+++ b/tests/v1/e2e/test_kv_sharing_fast_prefill.py
@@ -8,7 +8,7 @@ import pytest
 from vllm import LLM, SamplingParams
 from vllm.config import CompilationConfig, CompilationMode
 
-from ...utils import check_answers, fork_new_process_for_each_test, prep_prompts
+from ...utils import check_answers, spawn_new_process_for_each_test, prep_prompts
 
 # global seed
 SEED = 42
@@ -43,7 +43,7 @@ def test_prompts():
     return prompts
 
 
-@fork_new_process_for_each_test
+@spawn_new_process_for_each_test
 @pytest.mark.parametrize("kv_sharing_fast_prefill", [False, True])
 @pytest.mark.parametrize("enforce_eager", [True, False])
 def test_kv_sharing_fast_prefill(

--- a/tests/v1/e2e/test_kv_sharing_fast_prefill.py
+++ b/tests/v1/e2e/test_kv_sharing_fast_prefill.py
@@ -8,7 +8,7 @@ import pytest
 from vllm import LLM, SamplingParams
 from vllm.config import CompilationConfig, CompilationMode
 
-from ...utils import check_answers, spawn_new_process_for_each_test, prep_prompts
+from ...utils import check_answers, prep_prompts, spawn_new_process_for_each_test
 
 # global seed
 SEED = 42


### PR DESCRIPTION
Tested using: `pytest -s -v test_kv_sharing_fast_prefill.py`

This PR resolves the following error on AMD GPUs:

```
>   raise RuntimeError(
    ^^^^^^^^^^^^^^^^^
        "Cannot re-initialize CUDA in forked subprocess. To use CUDA with "
        "multiprocessing, you must use the 'spawn' start method"
    )
E   RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method

```

<img width="1145" height="476" alt="image" src="https://github.com/user-attachments/assets/3861aad5-ec10-4a31-9e1b-a5ad50236fe5" />
