### PR TITLE
[CI][ROCm] Fix multiprocessing launch for the test on ROCm

### DIFF
--- a/tests/v1/e2e/test_kv_sharing_fast_prefill.py
+++ b/tests/v1/e2e/test_kv_sharing_fast_prefill.py
@@ -17,7 +17,7 @@ from vllm.model_executor.models.registry import ModelRegistry
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.sequence import IntermediateTensors
 
-from ...utils import fork_new_process_for_each_test
+from ...utils import spawn_new_process_for_each_test
 
 # global seed
 SEED = 42
@@ -117,7 +117,7 @@ def cleanup(llm: LLM, compilation_config: CompilationConfig):
     cleanup_dist_env_and_memory()
 
 
-@fork_new_process_for_each_test
+@spawn_new_process_for_each_test
 @pytest.mark.parametrize("enforce_eager", [True])
 def test_kv_sharing_fast_prefill(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Tested using: `pytest -s -v test_kv_sharing_fast_prefill.py`

This PR resolves the following error on AMD GPUs:

```
>   raise RuntimeError(
    ^^^^^^^^^^^^^^^^^
        "Cannot re-initialize CUDA in forked subprocess. To use CUDA with "
        "multiprocessing, you must use the 'spawn' start method"
    )
E   RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method

```

<img width="1145" height="476" alt="image" src="https://github.com/user-attachments/assets/3861aad5-ec10-4a31-9e1b-a5ad50236fe5" />
