### PR TITLE
[ROCm] Fix for import when building with upstream triton for gfx1100 for gpt-oss serving

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -44,6 +44,7 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
         value_layout = StridedLayout
         if on_gfx950():
             from triton_kernels.tensor_details.layout import GFX950MXScaleLayout
+            
             scale_layout = GFX950MXScaleLayout
         else:
             scale_layout = StridedLayout

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -44,7 +44,7 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
         value_layout = StridedLayout
         if on_gfx950():
             from triton_kernels.tensor_details.layout import GFX950MXScaleLayout
-            
+
             scale_layout = GFX950MXScaleLayout
         else:
             scale_layout = StridedLayout

--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -39,15 +39,14 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
         value_layout = StridedLayout
         scale_layout = StridedLayout
     elif current_platform.is_rocm():
-        from triton_kernels.tensor_details.layout import (
-            GFX950MXScaleLayout,
-            StridedLayout,
-        )
-
         from vllm.platforms.rocm import on_gfx950
 
         value_layout = StridedLayout
-        scale_layout = GFX950MXScaleLayout if on_gfx950() else StridedLayout
+        if on_gfx950():
+            from triton_kernels.tensor_details.layout import GFX950MXScaleLayout
+            scale_layout = GFX950MXScaleLayout
+        else:
+            scale_layout = StridedLayout
     else:
         value_layout, value_layout_opts = layout.make_default_matmul_mxfp4_w_layout(
             mx_axis=1


### PR DESCRIPTION

## Purpose
To check issues like https://github.com/vllm-project/vllm/issues/28451 for support gfx1100 type of devices to run gpt-oss models.

Fix the import issue when building with upstream triton as the `GFX950MXScaleLayout` is in ROCm/triton and not yet upstreamed :
```
"/app/vllm/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py", line 40, in _swizzle_mxfp4
(EngineCore_DP0 pid=471)     from triton_kernels.tensor_details.layout import (
(EngineCore_DP0 pid=471) ImportError: cannot import name 'GFX950MXScaleLayout' from 'triton_kernels.tensor_details.layout' 
```
Fixed it by conditionally import only for gfx950 devices.

Also clean up the code to remove the duplicated import of `StridedLayout`




## Test Result


the import error went away .


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

