### PR TITLE
[BugFix] skip combo kernel on cpu

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -8,7 +8,6 @@ from dataclasses import asdict, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
-import torch
 from pydantic import TypeAdapter, field_validator
 from pydantic.dataclasses import dataclass
 
@@ -666,7 +665,7 @@ class CompilationConfig:
             and "combo_kernels" not in self.inductor_compile_config
             and "benchmark_combo_kernel" not in self.inductor_compile_config
             # (fixme @boyuan) combo kernel does not support cpu yet.
-            and torch.cuda.is_available()
+            and not current_platform.is_cpu()
         ):
             # use horizontal fusion, which is useful for fusing qk-norm and
             # qk-rope when query and key have different shapes.

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -8,6 +8,7 @@ from dataclasses import asdict, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
+import torch
 from pydantic import TypeAdapter, field_validator
 from pydantic.dataclasses import dataclass
 
@@ -664,6 +665,8 @@ class CompilationConfig:
             is_torch_equal_or_newer("2.9.0.dev")
             and "combo_kernels" not in self.inductor_compile_config
             and "benchmark_combo_kernel" not in self.inductor_compile_config
+            # (fixme @boyuan) combo kernel does not support cpu yet.
+            and torch.cuda.is_available()
         ):
             # use horizontal fusion, which is useful for fusing qk-norm and
             # qk-rope when query and key have different shapes.


### PR DESCRIPTION
combo kernel does not support cpu yet. we have a fix but need pytorch 2.10. This pr skips combo kernel on cpu to unblock users.

Close #28982

cc @Radu2k @zou3519 @angelayi @ProExpertProg 