### PR TITLE
[Test] Fix @create_new_process_for_each_test("fork") in interactive shell pipeline

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1261,9 +1261,6 @@ def fork_new_process_for_each_test(func: Callable[_P, None]) -> Callable[_P, Non
 
     @functools.wraps(func)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
-        # Make the process the leader of its own process group
-        # to avoid sending SIGTERM to the parent process
-        os.setpgrp()
         from _pytest.outcomes import Skipped
 
         # Create a unique temporary file to store exception info from child
@@ -1283,6 +1280,9 @@ def fork_new_process_for_each_test(func: Callable[_P, None]) -> Callable[_P, Non
             pid = os.fork()
             print(f"Fork a new process to run a test {pid}")
             if pid == 0:
+                # Make the child process the leader of its own process group
+                # to avoid sending SIGTERM to the parent process
+                os.setpgrp()
                 # Parent process responsible for deleting, don't delete
                 # in child.
                 delete_after.pop_all()
@@ -1322,14 +1322,12 @@ def fork_new_process_for_each_test(func: Callable[_P, None]) -> Callable[_P, Non
                 else:
                     os._exit(0)
             else:
-                pgid = os.getpgid(pid)
+                # After setpgrp(), the child's pgid equals its pid
+                pgid = pid
                 _pid, _exitcode = os.waitpid(pid, 0)
-                # ignore SIGTERM signal itself
-                old_signal_handler = signal.signal(signal.SIGTERM, signal.SIG_IGN)
-                # kill all child processes
-                os.killpg(pgid, signal.SIGTERM)
-                # restore the signal handler
-                signal.signal(signal.SIGTERM, old_signal_handler)
+                # kill all child processes - but they may already have exited cleanly
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(pgid, signal.SIGTERM)
                 if _exitcode != 0:
                     # Try to read the exception from the child process
                     exc_info = {}


### PR DESCRIPTION
Various engine core tests use @create_new_process_for_each_test() which defaults to "fork" mode:

```
$ pytest -vs tests/v1/engine/test_engine_core.py::test_engine_core
...
Running 1 items in this shard: tests/v1/engine/test_engine_core.py::test_engine_core

tests/v1/engine/test_engine_core.py::test_engine_core Fork a new process to run a test 3071367
...
PASSED

===================== 1 passed, 18 warnings in 31.07s ========================
```

If you attempt to capture the output in a pipeline with `tee`:

```
$ pytest -vs tests/v1/engine/test_engine_core.py::test_engine_core 2>&1 | tee output.log
...
INFO 04-15 07:27:52 [gpu_model_runner.py:6072] Graph capturing finished in 1 secs, took 0.04 GiB
INFO 04-15 07:27:52 [gpu_worker.py:597] CUDA graph pool memory: 0.04 GiB (actual), 0.07 GiB (estimated), difference: 0.03 GiB (81.0%).
INFO 04-15 07:27:52 [core.py:299] init engine (profile, create kv cache, warmup model) took 3.83 s (compilation: 0.96 s)
Terminated
```

This appears to be because in an interactive shell with job control enabled, tee is also part of the same process group as the python process so while the python process uses SIG_IGN to try to ensure it doesn't get killed, the tee process gets killed so the whole pipeline fails.

We can confirm this by showing it working fine with job control disabled:

```
$ set +m
$ pytest -vs tests/v1/engine/test_engine_core.py::test_engine_core 2>&1 | tee output.log
...
======================= 1 passed, 18 warnings in 14.95s ========================
```

The fix is to put the child process in its own process group, and terminate that ... rather than terminating the parent and relying on SIG_IGN.

Related past PRs: #23795 and #7054 (#7053)

/cc @njhill @youkaichao
