### PR TITLE
[CI/Build][Kernel][AMD] Move extra dim to after load in _fwd_kv_parallel in lighting_attn.py

### DIFF
--- a/vllm/model_executor/layers/lightning_attn.py
+++ b/vllm/model_executor/layers/lightning_attn.py
@@ -198,7 +198,7 @@ def _fwd_kv_parallel(
     )
 
     # Load the decay factors for the current head and block
-    k_decay_ptr = K_decay + off_h * BLOCK + tl.arange(0, CBLOCK)[None, :]
+    k_decay_ptr = K_decay + off_h * BLOCK + tl.arange(0, CBLOCK)
 
     kv_index = tl.arange(0, CBLOCK)
 
@@ -228,6 +228,12 @@ def _fwd_kv_parallel(
 
         # Load decay factor and compute weighted key-value outer product
         k_decay = tl.load(k_decay_ptr)
+
+        # NOTE: Need to add the extra dim here due to AMD MLIR lowering error.
+        # Please don't move it back until issue is resolved.
+        # Issue: https://github.com/ROCm/triton/issues/907
+        k_decay = k_decay[None, :]
+
         kv += tl.dot(k_trans * k_decay, v)
 
         # Move to the next sub-block


### PR DESCRIPTION
Due to a compiler error generated by Triton compiler for AMD during MLIR lowering, I had to move the extra dim in `_fwd_kv_parallel `in `lightning_attn.py` to after the `tl.load` of `k_decay`.

This was causing a test failure in `test_lightning_attn.py` and it was also not possible to run this model on AMD hardware.  It should not be possible to run this model and other models that use lightning attention on AMD hardware.

This preserves correctness and fixes the issue.  I tested with `test_lightning_attn.py` and `multimodal/processing/test_minimax_vl_01.py` and also ran the model with no errors.

I filed an issue with ROCm Triton team: https://github.com/ROCm/triton/issues/907 and when it gets resolved it should be safe to move it back.