### PR TITLE
[Bugfix] Fix default MM LoRA alignment for single str prompts

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -466,7 +466,7 @@ class LLM:
         ):
             return lora_request
 
-        if not isinstance(prompts, Sequence):
+        if not isinstance(prompts, Sequence) or isinstance(prompts, str):
             prompts = [prompts]
 
         optional_loras = (


### PR DESCRIPTION
## Purpose
Fixes a bug in the offline case for resolving default multimodal LoRA - if a single string prompt is passed when default multimodal lora is active, it currently is not wrapped as a list for consideration when expanding the LoRA requests in the same func, which results in the lora resolution setting `[None] * (len(prompt))` instead of `None`.

## Test Plan
When we submit a single str only request with a default multimodal LoRA present (but inactive), we should submit one request to the LLM's engine, and that request should have `None` as its lora request + the correct text prompt instead of failing in validation of the lora / prompt alignment.

## Test Result
The added test patches the engine to inspect the relevant kwargs in the request to be added are correct (fails with an incorrect `ValueError: The lengths of prompts and lora_request must be the same.` on current main)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

