### PR TITLE
[CI/Build] Only use supported types and features on ROCm in MoE kernel tests

### DIFF
--- a/tests/kernels/moe/test_batched_moe.py
+++ b/tests/kernels/moe/test_batched_moe.py
@@ -41,7 +41,7 @@ TOP_KS = [1, 2, 6]
 
 DTYPES = [torch.bfloat16]
 
-if current_platform.is_rocm() and not current_platform.is_fp8_fnuz():
+if not current_platform.is_fp8_fnuz():
     DTYPES.append(torch.float8_e4m3fn)
 
 vllm_config = VllmConfig()

--- a/tests/kernels/moe/test_batched_moe.py
+++ b/tests/kernels/moe/test_batched_moe.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
@@ -38,6 +39,11 @@ MNK_FACTORS = [
 ]
 NUM_EXPERTS = [8, 64]
 TOP_KS = [1, 2, 6]
+
+DTYPES = [torch.bfloat16]
+
+if current_platform.is_rocm() and not current_platform.is_fp8_fnuz():
+    DTYPES.append(torch.float8_e4m3fn)
 
 vllm_config = VllmConfig()
 
@@ -96,7 +102,7 @@ class BatchedMMTensors:
 @pytest.mark.parametrize("max_tokens_per_expert", [32, 224, 512])
 @pytest.mark.parametrize("K", [128, 1024])
 @pytest.mark.parametrize("N", [128, 1024])
-@pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.bfloat16])
+@pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("block_shape", [None, [128, 128]])
 @pytest.mark.parametrize("per_act_token_quant", [False, True])
 def test_batched_mm(
@@ -229,7 +235,7 @@ def test_batched_mm(
 @pytest.mark.parametrize(("m", "n", "k"), MNK_FACTORS)
 @pytest.mark.parametrize("e", NUM_EXPERTS)
 @pytest.mark.parametrize("topk", TOP_KS)
-@pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.bfloat16])
+@pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("per_act_token_quant", [False, True])
 @pytest.mark.parametrize("block_shape", [None, [128, 128]])
 @pytest.mark.parametrize("input_scales", [False])

--- a/tests/kernels/moe/test_batched_moe.py
+++ b/tests/kernels/moe/test_batched_moe.py
@@ -1,4 +1,3 @@
-# SPDX-License-Identifier: Apache-2.
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 

--- a/tests/kernels/moe/test_block_fp8.py
+++ b/tests/kernels/moe/test_block_fp8.py
@@ -31,6 +31,11 @@ dg_available = has_deep_gemm()
 
 if current_platform.get_device_capability() < (9, 0):
     pytest.skip("FP8 Triton requires CUDA 9.0 or higher", allow_module_level=True)
+if current_platform.is_fp8_fnuz():
+    pytest.skip(
+        "Tests in this file require float8_e4m3fn and platform does not support",
+        allow_module_level=True,
+    )
 
 vllm_config = VllmConfig()
 
@@ -136,8 +141,6 @@ def test_w8a8_block_fp8_fused_moe(
 ):
     if topk > E:
         pytest.skip(f"Skipping test; topk={topk} > E={E}")
-    if current_platform.is_fp8_fnuz():
-        pytest.skip("Test requires e4m3fn and platform does not support it.")
 
     torch.manual_seed(seed)
 
@@ -195,8 +198,6 @@ def test_w8a8_block_fp8_fused_moe(
 def test_w8a8_block_fp8_deep_gemm_fused_moe(M, N, K, E, topk, seed, monkeypatch):
     if topk > E:
         pytest.skip(f"Skipping test: topk={topk} > E={E}")
-    if current_platform.is_fp8_fnuz():
-        pytest.skip("Test requires e4m3fn and platform does not support it.")
 
     if not _valid_deep_gemm_shape(M, N, K):
         pytest.skip(f"Skipping test: invalid size m={M}, n={N}, k={K}")

--- a/tests/kernels/moe/test_block_fp8.py
+++ b/tests/kernels/moe/test_block_fp8.py
@@ -136,6 +136,8 @@ def test_w8a8_block_fp8_fused_moe(
 ):
     if topk > E:
         pytest.skip(f"Skipping test; topk={topk} > E={E}")
+    if current_platform.is_fp8_fnuz():
+        pytest.skip("Test requires e4m3fn and platform does not support it.")
 
     torch.manual_seed(seed)
 
@@ -193,6 +195,8 @@ def test_w8a8_block_fp8_fused_moe(
 def test_w8a8_block_fp8_deep_gemm_fused_moe(M, N, K, E, topk, seed, monkeypatch):
     if topk > E:
         pytest.skip(f"Skipping test: topk={topk} > E={E}")
+    if current_platform.is_fp8_fnuz():
+        pytest.skip("Test requires e4m3fn and platform does not support it.")
 
     if not _valid_deep_gemm_shape(M, N, K):
         pytest.skip(f"Skipping test: invalid size m={M}, n={N}, k={K}")

--- a/tests/kernels/moe/test_gpt_oss_triton_kernels.py
+++ b/tests/kernels/moe/test_gpt_oss_triton_kernels.py
@@ -271,7 +271,8 @@ class Case:
 @pytest.mark.parametrize("tp", [1, 2, 4, 8])
 def test_equiv(num_token, a_dtype, w_dtype, tp):
     from triton_kernels.tensor_details import layout
-    if not hasattr(layout,'make_default_matmul_mxfp4_w_layout'):
+
+    if not hasattr(layout, "make_default_matmul_mxfp4_w_layout"):
         pytest.skip("make_default_matmul_mxfp4_w_layout not available")
 
     M = num_token

--- a/tests/kernels/moe/test_gpt_oss_triton_kernels.py
+++ b/tests/kernels/moe/test_gpt_oss_triton_kernels.py
@@ -270,6 +270,10 @@ class Case:
 @pytest.mark.parametrize("num_token", [2])
 @pytest.mark.parametrize("tp", [1, 2, 4, 8])
 def test_equiv(num_token, a_dtype, w_dtype, tp):
+    from triton_kernels.tensor_details import layout
+    if not hasattr(layout,'make_default_matmul_mxfp4_w_layout'):
+        pytest.skip("make_default_matmul_mxfp4_w_layout not available")
+
     M = num_token
     E = ModelConfig.num_experts
     K = ModelConfig.hidden_size

--- a/tests/kernels/moe/test_modular_kernel_combinations.py
+++ b/tests/kernels/moe/test_modular_kernel_combinations.py
@@ -46,6 +46,12 @@ meets_multi_gpu_requirements = pytest.mark.skipif(
     reason="Requires deep_ep or deep_gemm or pplx or flashinfer packages",
 )
 
+if current_platform.is_fp8_fnuz():
+    pytest.skip(
+        "Tests in this file require float8_e4m3fn and platform does not support",
+        allow_module_level=True,
+    )
+
 
 def format_result(verbose, msg, ex=None):
     if ex is not None:

--- a/tests/kernels/moe/test_moe_permute_unpermute.py
+++ b/tests/kernels/moe/test_moe_permute_unpermute.py
@@ -24,8 +24,11 @@ EP_SIZE = [1, 4, 16]
 current_platform.seed_everything(0)
 
 if current_platform.is_rocm():
-    pytest.skip("moe_permute_unpermute_supported is not defined for ROCm",
-                allow_module_level=True)
+    pytest.skip(
+        "moe_permute_unpermute_supported is not defined for ROCm",
+        allow_module_level=True,
+    )
+
 
 def torch_permute(
     hidden_states: torch.Tensor,

--- a/tests/kernels/moe/test_moe_permute_unpermute.py
+++ b/tests/kernels/moe/test_moe_permute_unpermute.py
@@ -23,6 +23,9 @@ TOP_KS = [2, 6, 8]
 EP_SIZE = [1, 4, 16]
 current_platform.seed_everything(0)
 
+if current_platform.is_rocm():
+    pytest.skip("moe_permute_unpermute_supported is not defined for ROCm",
+                allow_module_level=True)
 
 def torch_permute(
     hidden_states: torch.Tensor,

--- a/tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py
+++ b/tests/kernels/moe/test_silu_mul_fp8_quant_deep_gemm.py
@@ -14,6 +14,12 @@ from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import DeepGemmQuantScaleFMT, has_deep_gemm
 from vllm.utils.math_utils import cdiv, round_up
 
+if current_platform.is_fp8_fnuz():
+    pytest.skip(
+        "Tests in this file require float8_e4m3fn and platform does not support",
+        allow_module_level=True,
+    )
+
 fp8_dtype = torch.float8_e4m3fn
 
 CASES = [

--- a/tests/kernels/moe/test_triton_moe_ptpc_fp8.py
+++ b/tests/kernels/moe/test_triton_moe_ptpc_fp8.py
@@ -19,6 +19,12 @@ if current_platform.get_device_capability() < (9, 0):
 
 vllm_config = VllmConfig()
 
+if current_platform.is_fp8_fnuz():
+    pytest.skip(
+        "Tests in this file require float8_e4m3fn and platform does not support",
+        allow_module_level=True,
+    )
+
 
 def native_w8a8_per_token_matmul(A, B, As, Bs, output_dtype=torch.float16):
     """Matrix multiplication function that supports per-token input


### PR DESCRIPTION
This PR changes `test_batched_moe.py` test so that it only uses supported types on AMD hardware.  For example, `torch.float8_e4m3fn` is not available on MI300 and the `batched_triton_kernel` in `fused_batched_moe.py` does not support `torch.float8_e4m3fn` or ` torch.float8_e4m3fnuz` on MI300.

This PR also changes `test_block_fp8.py` to avoid the tests that need `float8_e4m3fn`.

`test_gpt_oss_triton_kernels `is using  `triton_kernels.tensor_details.make_default_matmul_mxfp4_w_layout` which might not be available on some platforms, so the test now checks for it and skips if not available.

`test_moe_permute_unpermute.py` wants to use `moe_permute_unpermute_supported` but it is not defined for ROCm in torch_bindings.cpp.

`test_triton_moe_ptpc_fp8.py` also needs `float8_e4m3fn` and some platforms don't support it.

`test_modular_kernel_combinations.py` :same as above

`test_silu_mul_fp8_quant_deep_gemm.py`:same as above

Test results are now:

`test_batched_moe.py`: 96 passed, 288 skipped, 3 warnings
`test_block_fp8.py`: 1 skipped, 2 warnings
`test_gpt_oss_triton_kernels`:1 passed, 4 skipped, 3 warnings
`test_moe_permute_unpermute.py`:1 skipped, 2 warnings
`test_triton_moe_ptpc_fp8.py`:1 skipped, 2 warnings
`test_modular_kernel_combinations.py`:1 skipped, 2 warnings
`test_silu_mul_fp8_quant_deep_gemm.py`:1 skipped, 2 warnings