### PR TITLE
[Minor][Clean] Remove the legacy assertion in video

### DIFF
--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -113,11 +113,6 @@ class VideoLoader:
                 valid_num_frames,
             )
 
-        assert i == valid_num_frames, (
-            f"Expected reading {valid_num_frames} frames, "
-            f"but only loaded {i} frames from video."
-        )
-
         return frames[:valid_num_frames], valid_num_frames, valid_frame_indices
 
 


### PR DESCRIPTION
## Purpose

Following [[Bugfix] Handle broken frames in video loading #29001 ](https://github.com/vllm-project/vllm/pull/29001). Sorry for forgetting remove the legacy assertion. Now the video loading will skip the broken frames and give some WARNING logs. And `i` always equals `valid_num_frames`.

## Test Plan

```
pytest tests/multimodal/test_video.py::test_video_backend_handles_broken_frames -v --log-cli-level=WARNING
```

## Test Result

Pass.

## CC List

cc @Isotr0py 