### PR TITLE
[CI]Fix tests/v1/sample/test_logprobs.py

### DIFF
--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -64,7 +64,7 @@ class LogprobsTensors(NamedTuple):
     def tolists(self, cu_num_generated_tokens: list[int] | None = None):
         return LogprobsLists(
             self.logprob_token_ids.cpu().numpy(),
-            self.logprobs.cpu().numpy(),
+            self.logprobs.float().cpu().numpy(),
             self.selected_token_ranks.cpu().numpy(),
             cu_num_generated_tokens,
         )


### PR DESCRIPTION
Error msg:
```Shell
(EngineCore_DP0 pid=462918) Process EngineCore_DP0:
(EngineCore_DP0 pid=462918) Traceback (most recent call last):
(EngineCore_DP0 pid=462918)   File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore_DP0 pid=462918)     self.run()
(EngineCore_DP0 pid=462918)   File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
(EngineCore_DP0 pid=462918)     self._target(*self._args, **self._kwargs)
(EngineCore_DP0 pid=462918)   File "/workspace/vllm/vllm/v1/engine/core.py", line 846, in run_engine_core
(EngineCore_DP0 pid=462918)     raise e
(EngineCore_DP0 pid=462918)   File "/workspace/vllm/vllm/v1/engine/core.py", line 835, in run_engine_core
(EngineCore_DP0 pid=462918)     engine_core.run_busy_loop()
(EngineCore_DP0 pid=462918)   File "/workspace/vllm/vllm/v1/engine/core.py", line 862, in run_busy_loop
(EngineCore_DP0 pid=462918)     self._process_engine_step()
(EngineCore_DP0 pid=462918)   File "/workspace/vllm/vllm/v1/engine/core.py", line 891, in _process_engine_step
(EngineCore_DP0 pid=462918)     outputs, model_executed = self.step_fn()
(EngineCore_DP0 pid=462918)                               ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=462918)   File "/workspace/vllm/vllm/v1/engine/core.py", line 347, in step
(EngineCore_DP0 pid=462918)     model_output = self.model_executor.sample_tokens(grammar_output)
(EngineCore_DP0 pid=462918)                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=462918)   File "/workspace/vllm/vllm/v1/executor/uniproc_executor.py", line 107, in sample_tokens
(EngineCore_DP0 pid=462918)     return self.collective_rpc(
(EngineCore_DP0 pid=462918)            ^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=462918)   File "/workspace/vllm/vllm/v1/executor/uniproc_executor.py", line 75, in collective_rpc
(EngineCore_DP0 pid=462918)     result = run_method(self.driver_worker, method, args, kwargs)
(EngineCore_DP0 pid=462918)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=462918)   File "/workspace/vllm/vllm/v1/serial_utils.py", line 479, in run_method
(EngineCore_DP0 pid=462918)     return func(*args, **kwargs)
(EngineCore_DP0 pid=462918)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=462918)   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(EngineCore_DP0 pid=462918)     return func(*args, **kwargs)
(EngineCore_DP0 pid=462918)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=462918)   File "/workspace/vllm/vllm/v1/worker/gpu_worker.py", line 519, in sample_tokens
(EngineCore_DP0 pid=462918)     return self.model_runner.sample_tokens(grammar_output)
(EngineCore_DP0 pid=462918)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=462918)   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(EngineCore_DP0 pid=462918)     return func(*args, **kwargs)
(EngineCore_DP0 pid=462918)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=462918)   File "/workspace/vllm/vllm/v1/worker/gpu_model_runner.py", line 3001, in sample_tokens
(EngineCore_DP0 pid=462918)     ) = self._bookkeeping_sync(
(EngineCore_DP0 pid=462918)         ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=462918)   File "/workspace/vllm/vllm/v1/worker/gpu_model_runner.py", line 2570, in _bookkeeping_sync
(EngineCore_DP0 pid=462918)     logprobs_tensors.tolists(cu_num_accepted_tokens)
(EngineCore_DP0 pid=462918)   File "/workspace/vllm/vllm/v1/outputs.py", line 67, in tolists
(EngineCore_DP0 pid=462918)     self.logprobs.cpu().numpy(),
(EngineCore_DP0 pid=462918)     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=462918) TypeError: Got unsupported ScalarType BFloat16
```