### PR TITLE
[CI/Build][BugFix][AMD] Fix rocm_aiter_grouped_topk_impl so that it passes correct value into aiter.grouped_topk

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -255,7 +255,6 @@ def _rocm_aiter_grouped_topk_impl(
     scoring_func: str = "softmax",
     routed_scaling_factor: float = 1.0,  # mul to topk_weights
 ) -> None:
-    is_softmax = scoring_func == "softmax"
     from aiter import grouped_topk
 
     grouped_topk(
@@ -265,7 +264,7 @@ def _rocm_aiter_grouped_topk_impl(
         num_expert_group,
         topk_group,
         need_renorm,
-        is_softmax,
+        scoring_func,
         routed_scaling_factor,
     )
 
@@ -280,7 +279,7 @@ def _rocm_aiter_grouped_topk_fake(
     scoring_func: str = "softmax",
     routed_scaling_factor: float = 1.0,  # mul to topk_weights
 ) -> None:
-    pass
+    return
 
 
 def _rocm_aiter_mla_decode_fwd_impl(

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -279,7 +279,7 @@ def _rocm_aiter_grouped_topk_fake(
     scoring_func: str = "softmax",
     routed_scaling_factor: float = 1.0,  # mul to topk_weights
 ) -> None:
-    return
+    pass
 
 
 def _rocm_aiter_mla_decode_fwd_impl(


### PR DESCRIPTION
`_rocm_aiter_grouped_topk_impl` was passing a bool into `grouped_topk` for `scoring_func`, but `grouped_topk` accepts a `str `type argument in the `aiter` that version that is currently installed.

This was causing `test_rocm_aiter_topk.py::test_rocm_aiter_grouped_topk_torch_compile_compatibility` to fail.

Now` kernels/moe/test_rocm_aiter_topk.py` runs with:

4 passed, 3 warnings