### PR TITLE
[CI/Build] Enable eager mode for Samplers-Test group

### DIFF
--- a/tests/samplers/test_logprobs.py
+++ b/tests/samplers/test_logprobs.py
@@ -25,7 +25,7 @@ def test_ranks(
     flat_logprobs,
     example_prompts,
 ):
-    with vllm_runner(model, dtype=dtype, max_logprobs=MAX_LOGPROBS) as vllm_model:
+    with vllm_runner(model, dtype=dtype, max_logprobs=MAX_LOGPROBS, enforce_eager=True) as vllm_model:
         tokenizer = vllm_model.llm.get_tokenizer()
         example_prompt_tokens = [tokenizer.encode(prompt) for prompt in example_prompts]
         sampling_params = SamplingParams(

--- a/tests/samplers/test_no_bad_words.py
+++ b/tests/samplers/test_no_bad_words.py
@@ -71,6 +71,8 @@ class TestOneTokenBadWord:
 class TestTwoTokenBadWord:
     # Another model (with a different tokenizer behaviour)
     MODEL = "distilbert/distilgpt2"
+    #MODEL = "microsoft/Phi-3.5-mini-instruct"
+    #MODEL = "openai-community/gpt2"
 
     PROMPT = "How old are you? I am 10"
     TARGET_TOKEN1 = "years"
@@ -94,7 +96,7 @@ class TestTwoTokenBadWord:
         )[0]
 
     def test_two_token_bad_word(self, vllm_runner):
-        with vllm_runner(self.MODEL, dtype="half") as llm:
+        with vllm_runner(self.MODEL, dtype="half", enforce_eager=True) as llm:
             output_token_ids = self._generate(llm)
             assert output_token_ids[:2] == [
                 self.target_token_id1,


### PR DESCRIPTION
<!-- markdownlint-disable -->
This PR is to enable eager mode for "Samplers Test" test group. For now model distilbert/distilgpt2 does not work correctly in graph mode and will break CI. We will fix this graph-mode problem ASAP.

