### PR TITLE
Tool Call Parser logs should not contain user input / model output except on DEBUG

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/glm4_moe_tool_parser.py
@@ -78,7 +78,7 @@ class Glm4MoeModelToolParser(ToolParser):
                         .get("type", None)
                     )
                     return arg_type == "string"
-            logger.warning("No tool named '%s'.", tool_name)
+            logger.debug("No tool named '%s'.", tool_name)
             return False
 
         def _deserialize(value: str) -> Any:

--- a/vllm/entrypoints/openai/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/qwen3coder_tool_parser.py
@@ -128,7 +128,7 @@ class Qwen3CoderToolParser(ToolParser):
                     return params
                 else:
                     return {}
-        logger.warning("Tool '%s' is not defined in the tools list.", func_name)
+        logger.debug("Tool '%s' is not defined in the tools list.", func_name)
         return {}
 
     def _convert_param_value(
@@ -141,7 +141,7 @@ class Qwen3CoderToolParser(ToolParser):
 
         if param_name not in param_config:
             if param_config != {}:
-                logger.warning(
+                logger.debug(
                     "Parsed parameter '%s' is not defined in the tool "
                     "parameters for tool '%s', directly returning the "
                     "string value.",
@@ -169,7 +169,7 @@ class Qwen3CoderToolParser(ToolParser):
             try:
                 return int(param_value)
             except (ValueError, TypeError):
-                logger.warning(
+                logger.debug(
                     "Parsed value '%s' of parameter '%s' is not an "
                     "integer in tool '%s', degenerating to string.",
                     param_value,
@@ -186,7 +186,7 @@ class Qwen3CoderToolParser(ToolParser):
                     else int(float_param_value)
                 )
             except (ValueError, TypeError):
-                logger.warning(
+                logger.debug(
                     "Parsed value '%s' of parameter '%s' is not a float "
                     "in tool '%s', degenerating to string.",
                     param_value,
@@ -197,7 +197,7 @@ class Qwen3CoderToolParser(ToolParser):
         elif param_type in ["boolean", "bool", "binary"]:
             param_value = param_value.lower()
             if param_value not in ["true", "false"]:
-                logger.warning(
+                logger.debug(
                     "Parsed value '%s' of parameter '%s' is not a boolean "
                     "(`true` or `false`) in tool '%s', degenerating to "
                     "false.",
@@ -216,7 +216,7 @@ class Qwen3CoderToolParser(ToolParser):
                     param_value = json.loads(param_value)
                     return param_value
                 except (json.JSONDecodeError, TypeError, ValueError):
-                    logger.warning(
+                    logger.debug(
                         "Parsed value '%s' of parameter '%s' cannot be "
                         "parsed with json.loads in tool '%s', will try "
                         "other methods to parse it.",
@@ -227,7 +227,7 @@ class Qwen3CoderToolParser(ToolParser):
             try:
                 param_value = ast.literal_eval(param_value)  # safer
             except (ValueError, SyntaxError, TypeError):
-                logger.warning(
+                logger.debug(
                     "Parsed value '%s' of parameter '%s' cannot be "
                     "converted via Python `ast.literal_eval()` in tool "
                     "'%s', degenerating to string.",


### PR DESCRIPTION
For data privacy reason, logs by vllm should not contain user inputs or model outputs by default, maybe except for DEBUG purposes. 
Since the logger in tool call parser implementations does not respect the `--no-enable-log-requests` startup argument, the parsers should not log any input or output on WARN level or higher. 

I propose replacing all logs that contain user input or model output in the tool call parser implementations with `logger.debug`. 
Alternatively, we could leave the logs on WARN and just drop the input/output data. 