### PR TITLE
[Frontend][Responses API] Multi-turn (with type: "output_text") support for non-harmony requests

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1463,7 +1463,7 @@ def _parse_chat_message_content_part(
         )
         return None
 
-    if part_type in ("text", "input_text", "refusal", "thinking"):
+    if part_type in ("text", "input_text", "output_text", "refusal", "thinking"):
         str_content = cast(str, content)
         if wrap_dicts:
             return {"type": "text", "text": str_content}

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1283,6 +1283,7 @@ MM_PARSER_MAP: dict[
     "text": lambda part: _TextParser(part).get("text", None),
     "thinking": lambda part: _ThinkParser(part).get("thinking", None),
     "input_text": lambda part: _TextParser(part).get("text", None),
+    "output_text": lambda part: _TextParser(part).get("text", None),
     "input_image": lambda part: _ResponsesInputImageParser(part).get("image_url", None),
     "image_url": lambda part: _ImageParser(part).get("image_url", {}).get("url", None),
     "image_embeds": lambda part: _ImageEmbedsParser(part).get("image_embeds", None),


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Add support for multi-turn requests that has content with type `output_text` on the Responses API for non-harmony messages.

## Test Plan

Currently this request:
```
{
  "model": "google/gemma-3-27b-it",
  "input": [
    {
      "role": "user",
      "content": [
        {
          "type": "input_text",
          "text": "Hello there!"
        }
      ]
    },
    {
      "role": "assistant",
      "content": [
        {
          "type": "output_text",
          "text": "Hi, how can I help you?"
        }
      ]
    },
    {
      "role": "user",
      "content": [
        {
          "type": "input_text",
          "text": "What did I just type?"
        }
      ]
    }
  ]
}
```

returns:
```
{
  "error": {
    "message": "Unknown part type: output_text",
    "type": "BadRequestError",
    "param": null,
    "code": 400
  }
}
```

## Test Result

When adding `"output_text"` to the supported content part types the request succeeds:
```
{
  ...
  "output": [
    {
      "id": "ad1be50b-0449-4bd2-90bb-ac2b7d597b22",
      "content": [
        {
          "annotations": [],
          "text": "You typed \"Hello there!\".",
          "type": "output_text",
          "logprobs": []
        }
      ],
      "role": "assistant",
      "status": "completed",
      "type": "message"
    }
  ],
  ...
}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results

