### PR TITLE
[amd][ci] update mteb version for ROCM

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -889,7 +889,7 @@ steps:
 
 - label: Language Models Test (MTEB)
   timeout_in_minutes: 110
-  mirror_hardwares: [amdexperimental]
+  mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
   # grade: Blocking
   optional: true

--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -35,7 +35,7 @@ blobfile==3.0.0
 schemathesis==3.39.15
 
 # Required for mteb test
-mteb[bm25s]>=1.38.11, <2
+mteb[bm25s]>=2, <3 # required for mteb test
 
 # Required for eval tests
 lm-eval[api] @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@206b7722158f58c35b7ffcd53b035fdbdda5126d


### PR DESCRIPTION
## Purpose
MTEB Language Models Tests are failing on MI300 only after non-MI300 tests were updated to use mteb > 2, which has a new 'types' module.

## Test Plan
CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

