### PR TITLE
[CI] Bug: Fix triton import issue

### DIFF
--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -3,10 +3,9 @@
 from collections.abc import Iterable
 
 import torch
-import triton
-import triton.language as tl
 
 from vllm.attention.backends.utils import PAD_SLOT_ID
+from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv
 from vllm.v1.utils import CpuGpuBuffer
 

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -7,9 +7,8 @@ import numba
 import numba.types as types
 import numpy as np
 import torch
-import triton
-import triton.language as tl
 
+from vllm.triton_utils import tl, triton
 from vllm.utils import random_uuid
 from vllm.utils.math_utils import cdiv
 from vllm.v1.utils import CpuGpuBuffer

--- a/vllm/v1/worker/gpu/sampler.py
+++ b/vllm/v1/worker/gpu/sampler.py
@@ -3,10 +3,9 @@
 from collections.abc import Callable
 
 import torch
-import triton
-import triton.language as tl
 
 from vllm.config.model import LogprobsMode
+from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsTensors, SamplerOutput
 from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
 from vllm.v1.worker.gpu.states import SamplingMetadata


### PR DESCRIPTION
## Purpose

Pre-commit fails, complaining

```bash
❌ Forbidden direct `import triton` detected. ➤ Use `from vllm.triton_utils import triton` instead.

❌ vllm/v1/worker/gpu/block_table.py:6: import triton
❌ vllm/v1/worker/gpu/block_table.py:7: import triton.language as tl
❌ vllm/v1/worker/gpu/input_batch.py:10: import triton
❌ vllm/v1/worker/gpu/input_batch.py:11: import triton.language as tl
❌ vllm/v1/worker/gpu/sampler.py:6: import triton
❌ vllm/v1/worker/gpu/sampler.py:7: import triton.language as tl
```

This PR fixes the issue
