### PR TITLE
[CI/Build] Disable test_gptoss_tp.py in 'LoRA TP Test' group for ROCm platform

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1308,7 +1308,10 @@ steps:
     - pytest -v -s -x lora/test_llama_tp.py
     - pytest -v -s -x lora/test_llm_with_multi_loras.py
     - pytest -v -s -x lora/test_olmoe_tp.py
-    - pytest -v -s -x lora/test_gptoss_tp.py
+
+    # Disabled for now because MXFP4 backend on non-cuda platform 
+    # doesn't support LoRA yet
+    #- pytest -v -s -x lora/test_gptoss_tp.py
 
 
 - label: Weight Loading Multiple GPU Test  # 33min


### PR DESCRIPTION
This PR is to disable test_gptoss_tp.py in test group "LoRA TP Test" because MXFP4 backend on non-cuda platform does not support LoRA yet.