### PR TITLE
[CI/Build] Add terratorch for AMD

### DIFF
--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -41,4 +41,4 @@ mteb[bm25s]>=1.38.11, <2
 lm-eval[api] @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@206b7722158f58c35b7ffcd53b035fdbdda5126d
 
 # Plugins test
-terratorch==1.1.1
+terratorch @ git+https://github.com/IBM/terratorch.git@07184fcf91a1324f831ff521dd238d97fe350e3e

--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -39,3 +39,6 @@ mteb[bm25s]>=1.38.11, <2
 
 # Required for eval tests
 lm-eval[api] @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@206b7722158f58c35b7ffcd53b035fdbdda5126d
+
+# Plugins test
+terratorch==1.1.1


### PR DESCRIPTION
## Purpose

This PR adds the terratorch dependency to the ROCm CI such that the 'Plugin Tests (2 GPUs)' test group passes.

## Test Plan

See the [plugin tests group](https://github.com/vllm-project/vllm/blob/53a1ba6ec584ea93531a3195b3b9f8049786055b/.buildkite/test-amd.yaml#L1252).

## Test Result
<!--StartFragment--><html><head></head><body>
Test Command | Result
-- | --
pytest -v -s plugins_tests/test_platform_plugins.py | 2 passed, 3 warnings (1.44s)
pytest -v -s plugins_tests/test_io_processor_plugins.py | 3 passed, 6 warnings (55.99s)
pytest -v -s plugins_tests/test_stats_logger_plugins.py | 4 passed, 3 warnings (10.92s)
pytest -v -s plugins_tests/test_scheduler_plugins.py | 1 passed, 3 warnings (8.10s)
pytest -v -s distributed/test_distributed_oot.py | 1 passed, 3 warnings (34.44s)
pytest -v -s entrypoints/openai/test_oot_registration.p | 1 passed, 3 warnings (22.18s)
pytest -v -s models/test_oot_registration.py | 4 passed, 3 warnings (27.75s)
pytest -v -s plugins/lora_resolvers | 3 passed, 3 warnings (1.08s)
</body></html><!--EndFragment-->

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
