### PR TITLE
[Perf] Early return in KVCacheManager.allocate_slots

### DIFF
--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -284,9 +284,11 @@ class KVCacheManager:
 
         if (
             num_blocks_to_allocate == 0
-            and new_computed_block_list is self.empty_kv_cache_blocks.blocks
+            and new_computed_blocks is None
+            and request.num_output_tokens > 0
         ):
-            # Early return: no new blocks needed to be allocated
+            # Early return: no new blocks needed to be allocated for decode steps
+            # (excluding the first decode steps).
             #
             # NOTE: This optimization may delay block cleanup (remove_skipped_blocks)
             # in rare edge cases, but the impact is negligible.

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -286,7 +286,16 @@ class KVCacheManager:
             num_blocks_to_allocate == 0
             and new_computed_block_list is self.empty_kv_cache_blocks.blocks
         ):
-            # Early return as no new blocks needed to be allocated
+            # Early return: no new blocks needed to be allocated
+            #
+            # NOTE: This optimization may delay block cleanup (remove_skipped_blocks)
+            # in rare edge cases, but the impact is negligible.
+            #
+            # Example: With sliding windows whose size is
+            # not divisible by block size, the first block
+            # may slide out of the window (becoming eligible for removal)
+            # even when no new blocks are allocated at the end. In the worst case,
+            # this delays removal of 1 block per request per single type manager.
             return self.empty_kv_cache_blocks
 
         # Free the blocks that are skipped during the attention computation

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -288,7 +288,10 @@ class KVCacheManager:
             and request.num_output_tokens > 0
         ):
             # Early return: no new blocks needed to be allocated for decode steps
-            # (excluding the first decode steps).
+            # (excluding the first decode steps). DO NOT early return for
+            # - prefill steps: to ensure cache_blocks are running
+            # - first decode steps: to ensure remove_skipped_blocks remove
+            #   prompt token blocks slided out of the context window
             #
             # NOTE: This optimization may delay block cleanup (remove_skipped_blocks)
             # in rare edge cases, but the impact is negligible.


### PR DESCRIPTION
## Purpose
As the title, early return in KVCacheManager.allocate_slots to speed up scheduling, as most of the requests only allocate a block every 16 steps.

## Test Plan && Test Result
With the change, we could observed allocate slots cost is cut by half from 17.24% to 8.24% over the total runtime (with async scheduling enabled)
<img width="395" height="172" alt="Screenshot 2025-11-21 at 1 36 40 PM" src="https://github.com/user-attachments/assets/f9266e65-98aa-44f6-b75e-2ed8676333e4" />

Total runtime distribution for allocate_slots per engine step
<img width="1287" height="697" alt="Screenshot 2025-11-21 at 1 35 50 PM" src="https://github.com/user-attachments/assets/8ae37f0f-7af4-4aab-b482-445301167b68" />

### Public benchmarks
- Before: 171.53s
- After: 165.90s (~3.3% total runtime reduction)

```
vllm bench latency --model facebook/opt-125m \
  --dtype bfloat16 \
  --batch-size 3000 \
  --input-len 128 \
  --output-len 1800 \
  -tp 1 \
  --num-iters-warmup 1 \
  --num-iters 3
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

