### PR TITLE
[Perf] Introduce a quick access of logprob without creating intermediate Logprob dictionary

### DIFF
--- a/tests/test_logprobs.py
+++ b/tests/test_logprobs.py
@@ -84,7 +84,7 @@ def test_append_logprobs_for_next_position_flat() -> None:
         logprobs=[0.1],
         decoded_tokens=["1"],
         rank=10,
-        num_logprobs=-1,
+        num_logprobs=0,
     )
     append_logprobs_for_next_position(
         logprobs,
@@ -92,7 +92,7 @@ def test_append_logprobs_for_next_position_flat() -> None:
         logprobs=[0.2, 0.3],
         decoded_tokens=["2", "3"],
         rank=11,
-        num_logprobs=-1,
+        num_logprobs=1,
     )
     assert isinstance(logprobs, FlatLogprobs)
     assert logprobs.start_indices == [0, 1]
@@ -181,6 +181,17 @@ def test_flat_logprobs_access() -> None:
         [LOGPROBS_ONE_POSITION_1, LOGPROBS_ONE_POSITION_2, LOGPROBS_ONE_POSITION_0],
     ):
         assert actual_logprobs == expected_logprobs
+
+    # Test get_logprob
+    assert logprobs.get_logprob(0, 2) == 0.2
+    assert logprobs.get_logprob(0, 3) == 0.3
+    assert logprobs.get_logprob(1, 4) == 0.4
+    assert logprobs.get_logprob(1, 5) == 0.5
+    assert logprobs.get_logprob(1, 6) == 0.6
+    assert logprobs.get_logprob(2, 1) == 0.1
+    assert logprobs.get_logprob(0, 0) is None
+    assert logprobs.get_logprob(1, 1) is None
+    assert logprobs.get_logprob(2, 2) is None
 
     # Test __getitem__ : single item
     assert logprobs[0] == LOGPROBS_ONE_POSITION_1

--- a/vllm/logprobs.py
+++ b/vllm/logprobs.py
@@ -83,19 +83,23 @@ class FlatLogprobs(MutableSequence[LogprobsOnePosition]):
         the intermediate logprob dictionary.
         """
         self.start_indices.append(len(self.logprobs))
-        for token_id, logprob, rank, decoded_token in zip(
-            token_ids, logprobs, ranks, decoded_tokens
-        ):
-            self.token_ids.append(token_id)
-            self.logprobs.append(logprob)
-            self.ranks.append(rank)
-            self.decoded_tokens.append(decoded_token)
+        self.token_ids.extend(token_ids)
+        self.logprobs.extend(logprobs)
+        self.ranks.extend(ranks)
+        self.decoded_tokens.extend(decoded_tokens)
         self.end_indices.append(len(self.logprobs))
 
     def extend(self, logprobs_multi_positions) -> None:
         """Extends the container with logprobs for the next multiple positions"""
         for logprobs_one_position in logprobs_multi_positions:
             self.append(logprobs_one_position)
+
+    def get_logprob(self, position: int, token_id: int) -> float | None:
+        """Gets logprob of a given position and token ID"""
+        for i in range(self.start_indices[position], self.end_indices[position]):
+            if self.token_ids[i] == token_id:
+                return self.logprobs[i]
+        return None
 
     def __len__(self) -> int:
         """Gets number of positions stored in the container"""


### PR DESCRIPTION
## Purpose
Some clients might only need to access the logprob of the sampled token. Introduce FlatLogprob.get_logprob support which allow clients to do so without creating dictionaries.

Also incorporate further optimization suggested by @mgoin offline.

## Test Plan & Test Result
```
pytest -s -v tests/test_logprobs.py 
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

