### PR TITLE
[BugFix] Fix returned logprobs with spec decode + prefill chunking

### DIFF
--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -81,7 +81,10 @@ class Sampler(nn.Module):
             if logprobs_mode == "raw_logprobs":
                 raw_logprobs = self.compute_logprobs(logits)
             elif logprobs_mode == "raw_logits":
-                raw_logprobs = logits.clone()
+                if logits.dtype == torch.float32:
+                    raw_logprobs = logits.clone()
+                else:
+                    raw_logprobs = logits.to(torch.float32)
 
         # Use float32 for the logits.
         logits = logits.to(torch.float32)


### PR DESCRIPTION
The produced logprobs lists in this case were incorrect due incorrectly taking into account sampled token "discards" when computing offsets into the logprobs tensors.

Also:
- Fix error with bf16 models and "raw_logits" mode
- Use smaller model for test

Original PR which had this mistake: https://github.com/vllm-project/vllm/pull/26060

cc @TheEpicDolphin 