### PR TITLE
[Fix] EAGLE race conditions with async scheduling

### DIFF
--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -226,6 +226,11 @@ class EagleProposer:
         sampling_metadata: SamplingMetadata,
         mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
     ) -> torch.Tensor:
+        # Synchronize CUDA stream to avoid race conditions with async scheduling.
+        # This ensures all previous operations on shared tensors are complete
+        # before EAGLE modifies them.
+        torch.cuda.synchronize()
+
         num_tokens = target_token_ids.shape[0]
         batch_size = next_token_ids.shape[0]
 


### PR DESCRIPTION
Add torch.cuda.synchronize() at start of propose() method to avoid race conditions when async scheduling is enabled.

Root cause:
- Async scheduling (commit d8874c61a) allows concurrent CUDA operations between main model and EAGLE draft model
- EAGLE's propose() method may access shared tensors while they are still being modified by previous operations
- This creates race conditions leading to illegal memory access

## Purpose

Add synchronization barrier to ensure all previous CUDA operations complete before EAGLE accesses shared tensors.

```
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822] Traceback (most recent call last):                         14:27:38 [1175/128787]
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]   File "/home/bwasti/oss/vllm/vllm/v1/executor/multiproc_executor.py", line 817,
in worker_busy_loop
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]     output = func(*args, **kwargs)
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]              ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]   File "/home/bwasti/oss/.venv/lib/python3.12/site-packages/torch/utils/_contextl
ib.py", line 120, in decorate_context
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]     return func(*args, **kwargs)
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]   File "/home/bwasti/oss/vllm/vllm/v1/worker/gpu_worker.py", line 519, in sample_
tokens
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]     return self.model_runner.sample_tokens(grammar_output)
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]   File "/home/bwasti/oss/.venv/lib/python3.12/site-packages/torch/utils/_contextl
ib.py", line 120, in decorate_context
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]     return func(*args, **kwargs)
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]   File "/home/bwasti/oss/vllm/vllm/v1/worker/gpu_model_runner.py", line 2991, in
sample_tokens
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]     ) = self._bookkeeping_sync(
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]         ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]   File "/home/bwasti/oss/vllm/vllm/v1/worker/gpu_model_runner.py", line 2488, in
_bookkeeping_sync
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]     valid_sampled_token_ids = self.rejection_sampler.parse_output(
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]   File "/home/bwasti/oss/vllm/vllm/v1/sample/rejection_sampler.py", line 219, in
parse_output
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]     output_token_ids_np = output_token_ids.cpu().numpy()
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822]                           ^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822] torch.AcceleratorError: CUDA error: an illegal memory access was encountered
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822] Search for `cudaErrorIllegalAddress' in https://docs.nvidia.com/cuda/cuda-runtime
-api/group__CUDART__TYPES.html for more information.
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822] CUDA kernel errors might be asynchronously reported at some other API call, so th
e stacktrace below might be incorrect.
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822] For debugging consider passing CUDA_LAUNCH_BLOCKING=1
(EngineCore_DP0 pid=450944) (Worker_TP2 pid=451042) ERROR 11-21 14:27:38 [multiproc_executor.py:822] Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```
## Test Plan

Run a Llama4 EAGLE service and benchmark it

## Test Result

- Success rate on Llama4 EAGLE benchmarks
- No CUDA illegal memory access errors
- Maintains good performance without CUDA_LAUNCH_BLOCKING

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

