### PR TITLE
[CI/Build] Add dtype to LLM creation in v1/sample/test_logprobs.py

### DIFF
--- a/tests/v1/sample/test_logprobs.py
+++ b/tests/v1/sample/test_logprobs.py
@@ -556,6 +556,7 @@ def test_spec_decode_logprobs(
         seed=42,
         logprobs_mode=logprobs_mode,
         gpu_memory_utilization=0.4,
+        dtype=DTYPE,
     )
     ref_results = ref_llm.generate([prompt], sampling_params)
     # Collect logprobs outputs from reference LLM.
@@ -582,6 +583,7 @@ def test_spec_decode_logprobs(
         seed=42,
         logprobs_mode=logprobs_mode,
         gpu_memory_utilization=0.4,
+        dtype=DTYPE,
     )
     spec_results = spec_llm.generate([prompt], sampling_params)
     # Collect logprobs outputs from spec decode LLM.


### PR DESCRIPTION
This PR adds the `dtype` to LLM creation in `v1/sample/test_logprobs.py` since the model will use `bfloat16 `if the dtype is not specified which leads to a `numpy` error, where `numpy` does not support `bfloat16 `for lists.

Adding the `dtype` allows all the tests to pass.

The test now returns:

23 passed, 7 skipped, 4 warnings 
