### PR TITLE
Fix: Re-enable prompt logging in log_requests

### DIFF
--- a/vllm/entrypoints/logger.py
+++ b/vllm/entrypoints/logger.py
@@ -45,8 +45,9 @@ class RequestLogger:
         )
 
         logger.info(
-            "Received request %s: params: %s, lora_request: %s.",
+            "Received request %s: prompt: %r, params: %s, lora_request: %s.",
             request_id,
+            prompt,
             params,
             lora_request,
         )


### PR DESCRIPTION
## Purpose
Fixes a regression where the `prompt` text was missing from the INFO logs when `--enable-log-requests` was set.

In previous versions (0.11.0), the prompt was logged. In 0.11.2, it was only being logged at the `DEBUG` level, causing `enable-log-requests` to print only metadata (params, LoRA ID) but not the actual input text.

Fixes #29208

## Test Plan
Verified locally using a mock script to instantiate `RequestLogger` and check the output stream.

**Verification:**
- **Before:** Log output contained `params` and `request_id` but no `prompt`.
- **After:** Log output correctly includes `prompt: '...'` (ofcource with `max_log_len` truncation).

```
r_logger = RequestLogger(max_log_len=20)
request_id = "test-req-1"
prompt = "This is a very long prompt that should be truncated."
params.__str__.return_value = "SamplingParams(n=1)"
```
## Test Result
```text
Log Output:
Received request test-req-1: prompt: 'This is a very long ', params: SamplingParams(n=1), lora_request: None.