### PR TITLE
[CI/Build Don't add FLASHINFER backend in test_cpu_offloading.py

### DIFF
--- a/tests/v1/kv_offload/test_cpu_offloading.py
+++ b/tests/v1/kv_offload/test_cpu_offloading.py
@@ -12,10 +12,14 @@ from tqdm import tqdm
 from vllm import LLM, SamplingParams, TokensPrompt
 from vllm.config import KVEventsConfig, KVTransferConfig
 from vllm.distributed.kv_events import BlockStored, KVEventBatch
+from vllm.platforms import current_platform
 from vllm.utils.system_utils import set_env_var
 
 CPU_BLOCK_SIZES = [48]
-ATTN_BACKENDS = ["FLASH_ATTN", "FLASHINFER"]
+ATTN_BACKENDS = ["FLASH_ATTN"]
+
+if current_platform.is_cuda():
+    ATTN_BACKENDS.append("FLASHINFER")
 
 
 class MockSubscriber:

--- a/tests/v1/sample/test_sampling_params_e2e.py
+++ b/tests/v1/sample/test_sampling_params_e2e.py
@@ -119,6 +119,7 @@ def test_bad_words(llm):
     params = SamplingParams(temperature=0, bad_words=[bad_words_1, bad_words_2])
     output = llm.generate(PROMPT, params)
     new_text = output[0].outputs[0].text
+    print(f"new_text={new_text}")
     assert bad_words_1 not in new_text
     assert bad_words_2 not in new_text
 

--- a/tests/v1/sample/test_sampling_params_e2e.py
+++ b/tests/v1/sample/test_sampling_params_e2e.py
@@ -119,7 +119,6 @@ def test_bad_words(llm):
     params = SamplingParams(temperature=0, bad_words=[bad_words_1, bad_words_2])
     output = llm.generate(PROMPT, params)
     new_text = output[0].outputs[0].text
-    print(f"new_text={new_text}")
     assert bad_words_1 not in new_text
     assert bad_words_2 not in new_text
 


### PR DESCRIPTION
This fixes a test failure where` tests/v1/kv_offload/test_cpu_offloading.py` adds the `FLASHINFER `backend to the test, but ROCm platform does not support `flashinfer` library.  Doing this allows the test to be successful in AMD CI.  The test runs to completion and the result is:

 1 passed, 3 warnings 
