### PR TITLE
[Bugfix] Use HF config fields as fallback when loading Mistral config

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -754,6 +754,7 @@ steps:
   torch_nightly: true
   source_file_dependencies:
   - vllm/model_executor/models/
+  - vllm/transformers_utils/
   - tests/models/test_initialization.py
   commands:
     # Only when vLLM model source is modified - test initialization of a large

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -691,6 +691,7 @@ steps:
   torch_nightly: true
   source_file_dependencies:
   - vllm/model_executor/models/
+  - vllm/transformers_utils/
   - tests/models/test_initialization.py
   commands:
     # Only when vLLM model source is modified - test initialization of a large

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -204,7 +204,19 @@ class MistralConfigParser(ConfigParserBase):
 
         from vllm.transformers_utils.configs.mistral import adapt_config_dict
 
-        config = adapt_config_dict(config_dict)
+        # Get missing fields from HF config if available
+        try:
+            hf_config_dict, _ = PretrainedConfig.get_config_dict(
+                model,
+                revision=revision,
+                code_revision=code_revision,
+                token=_get_hf_token(),
+                **kwargs,
+            )
+        except OSError:
+            hf_config_dict = {}
+
+        config = adapt_config_dict(config_dict, defaults=hf_config_dict)
 
         # Mistral configs may define sliding_window as list[int]. Convert it
         # to int and add the layer_types list[str] to make it HF compatible

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -213,7 +213,7 @@ class MistralConfigParser(ConfigParserBase):
                 token=_get_hf_token(),
                 **kwargs,
             )
-        except OSError:
+        except OSError:  # Not found
             hf_config_dict = {}
 
         config = adapt_config_dict(config_dict, defaults=hf_config_dict)


### PR DESCRIPTION
## Purpose

- Detect `model_type = "mamba"` to load the correct architecture for `mistralai/Mamba-Codestral-7B-v0.1`
- If the HF Hub repo has a HF config, fallback to its fields if they are missing from the Mistral config after remapping. This is required to load `mistralai/Mamba-Codestral-7B-v0.1`.
- To avoid similar CI breakages in the future, added `vllm/transformers_utils/` to the dependencies of `Basic Models Tests (Extra Initialization)`

FIX https://github.com/vllm-project/vllm/pull/28659#issuecomment-3566815762 which caused `Basic Models Tests (Extra Initialization)` to fail

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

