### PR TITLE
[CI/Build][AMD] Add check for flash_att_varlen_func to test_tree_attention.py

### DIFF
--- a/tests/v1/spec_decode/test_tree_attention.py
+++ b/tests/v1/spec_decode/test_tree_attention.py
@@ -3,6 +3,7 @@
 
 import math
 
+import pytest
 import torch
 
 from tests.v1.attention.utils import (
@@ -11,8 +12,15 @@ from tests.v1.attention.utils import (
     try_get_attention_backend,
 )
 from vllm.attention.backends.registry import AttentionBackendEnum
+from vllm.attention.utils.fa_utils import is_flash_attn_varlen_func_available
 from vllm.config import ParallelConfig, SpeculativeConfig
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
+
+if not is_flash_attn_varlen_func_available():
+    pytest.skip(
+        "This test requires flash_attn_varlen_func, but it's not available.",
+        allow_module_level=True,
+    )
 
 
 class MockAttentionLayer(torch.nn.Module):


### PR DESCRIPTION
The` test_tree_attention.py` test requires `flash_attn_varlen_func`, but it's not available on ROCm and is causing failures in AMD CI.

The test now results:

1 skipped, 2 warning

on ROCm.