### PR TITLE
[CI/Build][AMD] Skip test_multi_shared_storage_connector_consistency  in test_multi_connector.py due to hipErrorLaunchFailure  when calling .cpu()

### DIFF
--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -20,6 +20,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
     NixlKVConnectorStats,
 )
+from vllm.platforms import current_platform
 
 MODEL_NAME = "meta-llama/Llama-3.2-1B-Instruct"
 
@@ -69,6 +70,13 @@ def _compare_directories(dir1: Path, dir2: Path) -> bool:
     return True
 
 
+@pytest.mark.skipif(
+    current_platform.is_rocm(),
+    reason=(
+        "hipErrorLaunchFailure when running this test, see issue:"
+        "https://github.com/ROCm/pytorch/issues/2822"
+    ),
+)
 def test_multi_shared_storage_connector_consistency():
     """
     Tests that MultiConnector with two SharedStorageConnectors saves


### PR DESCRIPTION
When running 

` pytest v1/kv_connector/unit/test_multi_connector.py::test_multi_shared_storage_connector_consistency`

a `hipErrorLaunchFailure` in [shared_storage_connector.py:251](https://github.com/vllm-project/vllm/blob/main/vllm/distributed/kv_transfer/kv_connector/v1/shared_storage_connector.py#L251) due to a call to `Tensor.cpu()`.

I tried using:

```
kv_cache_detach = kv_cache.detach()
kv_cache_cpu = kv_cache.cpu()
```

and the failure occurred in the call to `Tensor.cpu()`.

I filed an [Pytorch issue](https://github.com/ROCm/pytorch/issues/2822) for this.  I was running on MI300.

Skipping this test for now until the issue is resolved.