### PR TITLE
[Core] Generalize Encoder-Decoder `seq_lens` computation to avoid Whisper hardcoded logic  

### DIFF
--- a/vllm/attention/layers/cross_attention.py
+++ b/vllm/attention/layers/cross_attention.py
@@ -103,7 +103,9 @@ def create_cross_attention_backend(
             # needed here to know how many tokens to attend to from the cached
             # cross-attention KV cache.
             new_metadata.seq_lens = common_attn_metadata.encoder_seq_lens
-            new_metadata.seq_lens_cpu = common_attn_metadata.encoder_seq_lens_cpu
+            new_metadata.seq_lens_cpu = torch.from_numpy(
+                common_attn_metadata.encoder_seq_lens_cpu
+            )
 
             # NOTE (NickLucche) use `new_metadata` instead of `common_*` (initial) here
             new_metadata.slot_mapping = _get_cross_slot_mapping(

--- a/vllm/attention/layers/cross_attention.py
+++ b/vllm/attention/layers/cross_attention.py
@@ -84,7 +84,7 @@ def create_cross_attention_backend(
         ) -> AttentionMetadata:
             new_metadata = copy(common_attn_metadata)
             new_metadata.causal = False
-            max_encoder_len = int(new_metadata.encoder_seq_lens.max().item())
+            max_encoder_len = int(new_metadata.encoder_seq_lens_cpu.max())
             new_metadata.max_seq_len = max_encoder_len
             # Any computed tokens indicated decode step>1 (no chunked prefill)
             num_cache_decodes = (
@@ -95,22 +95,19 @@ def create_cross_attention_backend(
                 # skip slot_mapping calculation for requests that do not need
                 # reshape_and_cache.
                 num_tokens = common_attn_metadata.num_computed_tokens_cpu.numpy()
-                new_metadata.encoder_seq_lens = np.where(
-                    num_tokens > 0, 0, new_metadata.encoder_seq_lens
+                new_metadata.encoder_seq_lens_cpu = np.where(
+                    num_tokens > 0, 0, new_metadata.encoder_seq_lens_cpu
                 )
 
             # seq_lens is provided by model runner: initial encoder input length is
             # needed here to know how many tokens to attend to from the cached
             # cross-attention KV cache.
-            new_metadata.seq_lens = torch.from_numpy(
-                common_attn_metadata.encoder_seq_lens
-            ).to(device=self.device)
-            new_metadata.seq_lens_cpu = torch.from_numpy(
-                common_attn_metadata.encoder_seq_lens
-            )
+            new_metadata.seq_lens = common_attn_metadata.encoder_seq_lens
+            new_metadata.seq_lens_cpu = common_attn_metadata.encoder_seq_lens_cpu
+
             # NOTE (NickLucche) use `new_metadata` instead of `common_*` (initial) here
             new_metadata.slot_mapping = _get_cross_slot_mapping(
-                new_metadata.encoder_seq_lens,
+                new_metadata.encoder_seq_lens_cpu,
                 new_metadata.block_table_tensor,
                 self.kv_cache_spec,
                 self.device,

--- a/vllm/attention/layers/cross_attention.py
+++ b/vllm/attention/layers/cross_attention.py
@@ -25,15 +25,6 @@ from vllm.v1.kv_cache_interface import CrossAttentionSpec, KVCacheSpec
 logger = init_logger(__name__)
 
 
-def _get_max_encoder_len(vllm_config: "VllmConfig") -> int:
-    """Gets the max number of encoder input tokens from the config."""
-    sc = vllm_config.scheduler_config
-    assert sc and isinstance(sc.max_num_encoder_input_tokens, int), (
-        "max_num_encoder_input_tokens must be int for enc-dec models"
-    )
-    return sc.max_num_encoder_input_tokens
-
-
 def _get_cross_slot_mapping(
     encoder_seq_lens: np.ndarray,
     block_table_tensor: torch.Tensor,
@@ -93,21 +84,31 @@ def create_cross_attention_backend(
         ) -> AttentionMetadata:
             new_metadata = copy(common_attn_metadata)
             new_metadata.causal = False
-            max_encoder_len = _get_max_encoder_len(self.vllm_config)
+            max_encoder_len = int(new_metadata.encoder_seq_lens.max().item())
             new_metadata.max_seq_len = max_encoder_len
+            # Any computed tokens indicated decode step>1 (no chunked prefill)
+            num_cache_decodes = (
+                (common_attn_metadata.num_computed_tokens_cpu > 0).sum().item()
+            )
+            if num_cache_decodes > 0:
+                # CrossAttn KV cache has already been populated on first decoder step,
+                # skip slot_mapping calculation for requests that do not need
+                # reshape_and_cache.
+                num_tokens = common_attn_metadata.num_computed_tokens_cpu.numpy()
+                new_metadata.encoder_seq_lens = np.where(
+                    num_tokens > 0, 0, new_metadata.encoder_seq_lens
+                )
 
-            new_metadata.seq_lens = torch.full(
-                (new_metadata.num_reqs,),
-                max_encoder_len,
-                dtype=torch.int32,
-                device=self.device,
+            # seq_lens is provided by model runner: initial encoder input length is
+            # needed here to know how many tokens to attend to from the cached
+            # cross-attention KV cache.
+            new_metadata.seq_lens = torch.from_numpy(
+                common_attn_metadata.encoder_seq_lens
+            ).to(device=self.device)
+            new_metadata.seq_lens_cpu = torch.from_numpy(
+                common_attn_metadata.encoder_seq_lens
             )
-            new_metadata.seq_lens_cpu = torch.full(
-                (new_metadata.num_reqs,),
-                max_encoder_len,
-                dtype=torch.int32,
-                device="cpu",
-            )
+            # NOTE (NickLucche) use `new_metadata` instead of `common_*` (initial) here
             new_metadata.slot_mapping = _get_cross_slot_mapping(
                 new_metadata.encoder_seq_lens,
                 new_metadata.block_table_tensor,

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -89,7 +89,8 @@ class CommonAttentionMetadata:
     num_logits_indices: int | None = None
 
     # Needed by CrossAttentionBuilder
-    encoder_seq_lens: np.ndarray | None = None
+    encoder_seq_lens: torch.Tensor | None = None
+    encoder_seq_lens_cpu: np.ndarray | None = None
 
     dcp_local_seq_lens: torch.Tensor | None = None
     dcp_local_seq_lens_cpu: torch.Tensor | None = None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1216,6 +1216,7 @@ class GPUModelRunner(
             req_index = self.input_batch.req_id_to_index[req_id]
             req_state = self.requests[req_id]
             if req_state.mm_features is None:
+                self.encoder_seq_lens.np[req_index] = 0
                 continue
 
             # Get the total number of encoder input tokens for running encoder requests


### PR DESCRIPTION
### Overview
This PR generalizes current encoder-decoder `attn_metadata.seq_lens` computation in order to fix some hard-coded assumptions that are only valid for Whisper and based on static config values, rather than scheduler output.

Currently, `GPUModelRunner._get_encoder_seq_lens` returns the number of scheduled encoder tokens, which is used to compute the slot_mapping needed when caching the cross attn kv cache. 
When no encoder tokens are scheduled, subsequent decoder step are able to attend to the previously cached encoder tokens by re-creating a fixed `attn_metadata.seq_lens` that is always of the same len (`max_encoder_len`) https://github.com/vllm-project/vllm/blob/6fb0215eee44cf5e4b28f57e6739ef4a51945127/vllm/attention/layers/cross_attention.py#L99-L104 
This only works because whisper encoder input size is fixed (padded or truncated to 1500), so `seq_lens` is basically immutable.

A more correct and general formulation would be that of returning the actual `encoder_seq_lens` to attend to on each step, while skipping the cross_slot_mapping computation for every step but the first decoder one (when we cache KV).
This is the gist of this PR that executes on that idea in 2 steps:
 - modifies `GPUModelRunner._get_encoder_seq_lens` to always return the number of tokens that were input to the encoder for each running request.
 - modifies `CrossAttentionBuilder.build` to skip slot_mapping computation on steps after the first decode one. Additionally, re-uses the newly computed `encoder_seq_lens` as **actual** `attn_metadata.seq_lens`, thus solving the need to create a fix `attn_metadata.seq_lens` that depends on a static config instead of scheduled tokens. 

This change will also enable OOT implementations of encoder-decoder models.

### Test with

No difference should be detected when running Whisper, the behavior should be unchanged as well as the produced attn_metadata.

Some exhaustive whisper tests:
```
pytest -v -s -x tests/entrypoints/openai/test_transcription_validation.py
```


cc @DarkLight1337 @russellb 
