### PR TITLE
[Bugfix][offline_inference][data_parallel] Fix race condition in data_parallel by utilizing distributed barrier

### DIFF
--- a/examples/offline_inference/data_parallel.py
+++ b/examples/offline_inference/data_parallel.py
@@ -203,7 +203,8 @@ def main(
     # This prevents the "Connection reset by peer" error when one process
     # finishes early and destroys the process group while others are still working.
     if dist.is_initialized():
-        dist.barrier()
+        from vllm.distributed import get_world_group
+        get_world_group().barrier()
 
 
 if __name__ == "__main__":

--- a/examples/offline_inference/data_parallel.py
+++ b/examples/offline_inference/data_parallel.py
@@ -204,6 +204,7 @@ def main(
     # finishes early and destroys the process group while others are still working.
     if dist.is_initialized():
         from vllm.distributed import get_world_group
+
         get_world_group().barrier()
 
 


### PR DESCRIPTION
## Purpose
This PR addresses #23534.

The current implementation of examples/offline_inference/data_parallel.py relies on sleep(1) to synchronize processes at the end of execution. This approach is unreliable in distributed settings with uneven workloads (Rank 0 finishes significantly faster than other ranks).

**The Issue**
If a faster rank completes generation and exits (after the sleep duration) while slower ranks are still processing, the slower ranks will crash with a `Connection reset by peer` error when attempting subsequent collective operations (like all_reduce in forward_context).

**The Fix**
Replaced sleep(1) with torch.distributed.barrier(). This ensures that all processes wait for each other at a synchronization point before exiting, guaranteeing a clean shutdown regardless of workload execution time.

## Test Plan
I will verify this fix on a multi-GPU environment to ensure stability.

**Steps to reproduce/verify:**
1.  Modify `data_parallel.py` to artificially create an uneven workload (e.g., assign 1 token to Rank 0 and 200 tokens to Rank 1).
2.  Run the script with data parallelism enabled:
    python examples/offline_inference/data_parallel.py --dp-size 4
3.  **Before fix** The script crashes with `RuntimeError: Connection reset by peer`.
4.  **After fix** The script waits for the slowest rank and exits cleanly with exit code 0.

## Test Result
- [x] Verification on RunPod (4x A4000) - PASSED

The script ran successfully with `Qwen/Qwen2.5-3B-Instruct` on 4 GPUs. All ranks finished generation and exited cleanly without `Connection reset` errors.

<details>
<summary>Click to view full execution log</summary>

```text
(vllm-venv) root@cf45e84d6780:/workspace/vllm# python examples/offline_inference/data_parallel.py \
    --model Qwen/Qwen2.5-3B-Instruct \
    --dp-size 4 \
    --tp-size 1 \
    --disable-expert-parallel
DP rank 0 needs to process 100 prompts
DP rank 1 needs to process 100 prompts
INFO 11-24 14:52:10 [utils.py:253] non-default args: {'seed': None, 'gpu_memory_utilization': 0.8, 'max_num_seqs': 64, 'disable_log_stats': True, 'model': 'Qwen/Qwen2.5-3B-Instruct'}
DP rank 2 needs to process 100 prompts
INFO 11-24 14:52:10 [utils.py:253] non-default args: {'seed': None, 'gpu_memory_utilization': 0.8, 'max_num_seqs': 64, 'disable_log_stats': True, 'model': 'Qwen/Qwen2.5-3B-Instruct'}
DP rank 3 needs to process 100 prompts
INFO 11-24 14:52:10 [utils.py:253] non-default args: {'seed': None, 'gpu_memory_utilization': 0.8, 'max_num_seqs': 64, 'disable_log_stats': True, 'model': 'Qwen/Qwen2.5-3B-Instruct'}
INFO 11-24 14:52:10 [utils.py:253] non-default args: {'seed': None, 'gpu_memory_utilization': 0.8, 'max_num_seqs': 64, 'disable_log_stats': True, 'model': 'Qwen/Qwen2.5-3B-Instruct'}
WARNING 11-24 14:52:10 [arg_utils.py:1195] `seed=None` is equivalent to `seed=0` in V1 Engine. You will no longer be allowed to pass `None` in v0.13.
WARNING 11-24 14:52:10 [arg_utils.py:1195] `seed=None` is equivalent to `seed=0` in V1 Engine. You will no longer be allowed to pass `None` in v0.13.
WARNING 11-24 14:52:10 [arg_utils.py:1195] `seed=None` is equivalent to `seed=0` in V1 Engine. You will no longer be allowed to pass `None` in v0.13.
WARNING 11-24 14:52:10 [arg_utils.py:1195] `seed=None` is equivalent to `seed=0` in V1 Engine. You will no longer be allowed to pass `None` in v0.13.
INFO 11-24 14:52:11 [model.py:630] Resolved architecture: Qwen2ForCausalLM
INFO 11-24 14:52:11 [model.py:630] Resolved architecture: Qwen2ForCausalLM
INFO 11-24 14:52:11 [model.py:1745] Using max model len 32768
INFO 11-24 14:52:11 [model.py:1745] Using max model len 32768
INFO 11-24 14:52:11 [model.py:630] Resolved architecture: Qwen2ForCausalLM
INFO 11-24 14:52:11 [model.py:1745] Using max model len 32768
INFO 11-24 14:52:11 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=8192.
INFO 11-24 14:52:11 [model.py:630] Resolved architecture: Qwen2ForCausalLM
INFO 11-24 14:52:11 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=8192.
INFO 11-24 14:52:11 [model.py:1745] Using max model len 32768
INFO 11-24 14:52:11 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=8192.
INFO 11-24 14:52:12 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=8192.
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank [Gloo] Rank 3 is connected to 32 peer ranks.  is connected to Expected number of connected peer ranks is : 33 peer ranks. 
Expected number of connected peer ranks is : 3
(EngineCore_DP0 pid=7081) INFO 11-24 14:52:13 [core.py:93] Initializing a V1 LLM engine (v0.1.dev11598+g0ff70821c) with config: model='Qwen/Qwen2.5-3B-Instruct', speculative_config=None, tokenizer='Qwen/Qwen2.5-3B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=4, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None), seed=0, served_model_name=Qwen/Qwen2.5-3B-Instruct, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer'], 'compile_mm_encoder': False, 'use_inductor': None, 'compile_sizes': [], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {}, 'max_cudagraph_capture_size': 128, 'local_cache_dir': None}
(EngineCore_DP3 pid=7069) INFO 11-24 14:52:15 [parallel_state.py:1217] world_size=4 rank=3 local_rank=3 distributed_init_method=tcp://127.0.0.1:41364 backend=nccl
(EngineCore_DP1 pid=7074) INFO 11-24 14:52:15 [parallel_state.py:1217] world_size=4 rank=1 local_rank=1 distributed_init_method=tcp://127.0.0.1:41364 backend=nccl
(EngineCore_DP2 pid=7085) INFO 11-24 14:52:15 [parallel_state.py:1217] world_size=4 rank=2 local_rank=2 distributed_init_method=tcp://127.0.0.1:41364 backend=nccl
(EngineCore_DP0 pid=7081) INFO 11-24 14:52:15 [parallel_state.py:1217] world_size=4 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:41364 backend=nccl
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank [Gloo] Rank 00 is connected to  is connected to 00 peer ranks.  peer ranks. Expected number of connected peer ranks is : Expected number of connected peer ranks is : 00

[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : [Gloo] Rank 00
 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to [Gloo] Rank 00 peer ranks.  is connected to Expected number of connected peer ranks is : 00 peer ranks. 
Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. [Gloo] Rank Expected number of connected peer ranks is : 00 is connected to 
0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0[Gloo] Rank 
0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : [Gloo] Rank 31
 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
(EngineCore_DP0 pid=7081) INFO 11-24 14:52:15 [pynccl.py:111] vLLM is using nccl==2.27.5
[Gloo] Rank 0 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 1 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 2 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
[Gloo] Rank 3 is connected to 3 peer ranks. Expected number of connected peer ranks is : 3
(EngineCore_DP3 pid=7069) [2025-11-24 14:52:15] INFO _optional_torch_c_dlpack.py:88: JIT-compiling torch-c-dlpack-ext to cache...
(EngineCore_DP2 pid=7085) [2025-11-24 14:52:15] INFO _optional_torch_c_dlpack.py:88: JIT-compiling torch-c-dlpack-ext to cache...
(EngineCore_DP0 pid=7081) [2025-11-24 14:52:15] INFO _optional_torch_c_dlpack.py:88: JIT-compiling torch-c-dlpack-ext to cache...
(EngineCore_DP1 pid=7074) [2025-11-24 14:52:15] INFO _optional_torch_c_dlpack.py:88: JIT-compiling torch-c-dlpack-ext to cache...
(EngineCore_DP0 pid=7081) INFO 11-24 14:52:34 [cuda_communicator.py:120] Using AgRsAll2AllManager all2all manager.
(EngineCore_DP3 pid=7069) INFO 11-24 14:52:34 [parallel_state.py:1425] rank 3 in world size 4 is assigned as DP rank 3, PP rank 0, PCP rank 0, TP rank 0, EP rank 3
(EngineCore_DP0 pid=7081) INFO 11-24 14:52:34 [parallel_state.py:1425] rank 0 in world size 4 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0
(EngineCore_DP1 pid=7074) INFO 11-24 14:52:34 [parallel_state.py:1425] rank 1 in world size 4 is assigned as DP rank 1, PP rank 0, PCP rank 0, TP rank 0, EP rank 1
(EngineCore_DP2 pid=7085) INFO 11-24 14:52:34 [parallel_state.py:1425] rank 2 in world size 4 is assigned as DP rank 2, PP rank 0, PCP rank 0, TP rank 0, EP rank 2
(EngineCore_DP0 pid=7081) INFO 11-24 14:52:34 [gpu_model_runner.py:3259] Starting to load model Qwen/Qwen2.5-3B-Instruct...
(EngineCore_DP1 pid=7074) INFO 11-24 14:52:35 [cuda.py:415] Valid backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION']
(EngineCore_DP1 pid=7074) INFO 11-24 14:52:35 [cuda.py:424] Using FLASH_ATTN backend.
(EngineCore_DP2 pid=7085) INFO 11-24 14:52:35 [cuda.py:415] Valid backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION']
(EngineCore_DP2 pid=7085) INFO 11-24 14:52:35 [cuda.py:424] Using FLASH_ATTN backend.
(EngineCore_DP3 pid=7069) INFO 11-24 14:52:35 [cuda.py:415] Valid backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION']
(EngineCore_DP3 pid=7069) INFO 11-24 14:52:35 [cuda.py:424] Using FLASH_ATTN backend.
(EngineCore_DP0 pid=7081) INFO 11-24 14:52:35 [cuda.py:415] Valid backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION']
(EngineCore_DP0 pid=7081) INFO 11-24 14:52:35 [cuda.py:424] Using FLASH_ATTN backend.
model-00001-of-00002.safetensors: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3.97G/3.97G [00:07<00:00, 547MB/s]
model-00002-of-00002.safetensors: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2.20G/2.20G [00:03<00:00, 602MB/s]
(EngineCore_DP1 pid=7074) INFO 11-24 14:52:47 [weight_utils.py:441] Time spent downloading weights for Qwen/Qwen2.5-3B-Instruct: 11.719989 seconds
model.safetensors.index.json: 35.6kB [00:00, 54.6MB/s]
Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:00<00:00,  2.58it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00,  3.20it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00,  3.09it/s]
(EngineCore_DP0 pid=7081) 
(EngineCore_DP0 pid=7081) INFO 11-24 14:52:48 [default_loader.py:308] Loading weights took 0.69 seconds
(EngineCore_DP0 pid=7081) INFO 11-24 14:52:49 [gpu_model_runner.py:3341] Model loading took 5.7916 GiB memory and 13.160953 seconds
(EngineCore_DP0 pid=7081) INFO 11-24 14:52:55 [backends.py:648] Using cache directory: /root/.cache/vllm/torch_compile_cache/9850874f40/rank_0_0/backbone for vLLM's torch.compile
(EngineCore_DP0 pid=7081) INFO 11-24 14:52:55 [backends.py:708] Dynamo bytecode transform time: 5.24 s
(EngineCore_DP0 pid=7081) INFO 11-24 14:52:59 [backends.py:255] Cache the graph for dynamic shape for later use
(EngineCore_DP1 pid=7074) [rank1]:W1124 14:52:59.634000 7074 torch/_inductor/utils.py:1558] [0/0] Not enough SMs to use max_autotune_gemm mode
(EngineCore_DP3 pid=7069) [rank3]:W1124 14:52:59.727000 7069 torch/_inductor/utils.py:1558] [0/0] Not enough SMs to use max_autotune_gemm mode
(EngineCore_DP2 pid=7085) [rank2]:W1124 14:52:59.821000 7085 torch/_inductor/utils.py:1558] [0/0] Not enough SMs to use max_autotune_gemm mode
(EngineCore_DP0 pid=7081) [rank0]:W1124 14:52:59.922000 7081 torch/_inductor/utils.py:1558] [0/0] Not enough SMs to use max_autotune_gemm mode
(EngineCore_DP0 pid=7081) INFO 11-24 14:53:05 [backends.py:286] Compiling a graph for dynamic shape takes 8.87 s
(EngineCore_DP0 pid=7081) INFO 11-24 14:53:07 [monitor.py:34] torch.compile takes 14.10 s in total
(EngineCore_DP0 pid=7081) INFO 11-24 14:53:08 [gpu_worker.py:348] Available KV cache memory: 6.09 GiB
(EngineCore_DP0 pid=7081) INFO 11-24 14:53:09 [kv_cache_utils.py:1234] GPU KV cache size: 177,392 tokens
(EngineCore_DP0 pid=7081) INFO 11-24 14:53:09 [kv_cache_utils.py:1239] Maximum concurrency for 32,768 tokens per request: 5.41x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|███████████████████████████████████████████████████████████████████████████████████████████| 19/19 [00:00<00:00, 21.21it/s]
Capturing CUDA graphs (decode, FULL): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 11/11 [00:00<00:00, 23.95it/s]
(EngineCore_DP0 pid=7081) INFO 11-24 14:53:11 [gpu_model_runner.py:4252] Graph capturing finished in 2 secs, took 0.22 GiB
(EngineCore_DP0 pid=7081) INFO 11-24 14:53:11 [core.py:253] init engine (profile, create kv cache, warmup model) took 22.44 seconds
INFO 11-24 14:53:12 [llm.py:351] Supported tasks: ['generate']
Adding requests:   0%|                                                                                                                                           | 0/100 [00:00<?, ?it/s]INFO 11-24 14:53:12 [llm.py:351] Supported tasks: ['generate']
Adding requests:   0%|                                                                                                                                           | 0/100 [00:00<?, ?it/s]INFO 11-24 14:53:12 [llm.py:351] Supported tasks: ['generate']
Adding requests: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 2874.46it/s]
Processed prompts:   0%|                                                                                     | 0/100 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]INFO 11-24 14:53:12 [llm.py:351] Supported tasks: ['generate']
Adding requests: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 3411.95it/s]
Adding requests: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 2142.53it/s]
Adding requests: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:00<00:00, 3784.72it/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████| 100/100 [00:01<00:00, 64.45it/s, est. speed input: 457.18 toks/s, output: 1660.81 toks/s]
DP rank 3, Prompt: 'Hello, my name is', Generated text: ' Josh and I am a self-taught artist from the rugged, northern mountains of Colorado. I'
DP rank 3, Prompt: 'The president of the United States is', Generated text: ' a constitutional office, and the U.S. Constitution sets out the powers and duties of the office.'
DP rank 3, Prompt: 'The capital of France is', Generated text: ' one of the most beautiful cities in the world. Located in the north of the country, the city'
DP rank 3, Prompt: 'The future of AI is', Generated text: ' a topic that is often discussed, but it is difficult to predict exactly what will happen. Some believe'
DP rank 3, Prompt: 'Hello, my name is', Generated text: ' ________. ____\nA. I\nB. you\nC. my\nD. my name'
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████| 100/100 [00:01<00:00, 65.65it/s, est. speed input: 561.13 toks/s, output: 1632.37 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████| 100/100 [00:01<00:00, 66.10it/s, est. speed input: 472.55 toks/s, output: 1716.64 toks/s]
DP rank 0, Prompt: 'Hello, my name is', Generated text: ' Josh and I am a self-taught artist from the rugged, northern mountains'
DP rank 0, Prompt: 'The president of the United States is', Generated text: ' a constitutional office, and the U.S. Constitution sets out the powers and duties'
DP rank 0, Prompt: 'The capital of France is', Generated text: ' one of the most beautiful cities in the world. Located in the north of the'
DP rank 1, Prompt: 'Hello, my name is', Generated text: ' Josh and I am a self-taught artist from the rugged, northern mountains of Colorado. I'DP rank 0, Prompt: 'The future of AI is', Generated text: ' a topic that is often discussed, but it is difficult to predict exactly what will'

DP rank 1, Prompt: 'The president of the United States is', Generated text: ' a constitutional office, and the U.S. Constitution sets out the powers and duties of the office.'DP rank 0, Prompt: 'Hello, my name is', Generated text: ' ________. ____\nA. I\nB. you\nC. my\n'

DP rank 1, Prompt: 'The capital of France is', Generated text: ' one of the most beautiful cities in the world. Located in the north of the country, the city'
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████| 100/100 [00:01<00:00, 65.57it/s, est. speed input: 560.74 toks/s, output: 1631.24 toks/s]

DP rank 1, Prompt: 'Hello, my name is', Generated text: ' ________. ____\nA. I\nB. you\nC. my\nD. my name'
DP rank 2, Prompt: 'Hello, my name is', Generated text: ' Josh and I am a self-taught artist from the rugged, northern mountains'
DP rank 2, Prompt: 'The president of the United States is', Generated text: ' a constitutional office, and the U.S. Constitution sets out the powers and duties'
DP rank 2, Prompt: 'The capital of France is', Generated text: ' one of the most beautiful cities in the world. Located in the north of the'
DP rank 2, Prompt: 'The future of AI is', Generated text: ' a topic that is often discussed, but it is difficult to predict exactly what will'
DP rank 2, Prompt: 'Hello, my name is', Generated text: ' ________. ____\nA. I\nB. you\nC. my\n'