### PR TITLE
[Core] Generalize Encoder Decoder arch to support variable encoder length beyond Whisper

### DIFF
--- a/vllm/attention/layers/cross_attention.py
+++ b/vllm/attention/layers/cross_attention.py
@@ -25,15 +25,6 @@ from vllm.v1.kv_cache_interface import CrossAttentionSpec, KVCacheSpec
 logger = init_logger(__name__)
 
 
-def _get_max_encoder_len(vllm_config: "VllmConfig") -> int:
-    """Gets the max number of encoder input tokens from the config."""
-    sc = vllm_config.scheduler_config
-    assert sc and isinstance(sc.max_num_encoder_input_tokens, int), (
-        "max_num_encoder_input_tokens must be int for enc-dec models"
-    )
-    return sc.max_num_encoder_input_tokens
-
-
 def _get_cross_slot_mapping(
     scheduled_encoder_req_index: list[int],
     encoder_seq_lens: np.ndarray,

--- a/vllm/attention/layers/cross_attention.py
+++ b/vllm/attention/layers/cross_attention.py
@@ -45,12 +45,16 @@ def _get_cross_slot_mapping(
     block_size = kv_cache_spec.block_size
     slot_mappings = []
 
+    # REMOVE
+    # print(f"Encoder seq lens: {encoder_seq_lens}, type: {type(encoder_seq_lens)}")
+
     # Find indices with non-zero encoder sequence lengths
     # The majority of parallel requests will be running the
     # decoder, so this list should be relatively small.
-    active_indices = np.nonzero(encoder_seq_lens)
-    # REMOVE
-    print(f"Active indices for cross-attention: {active_indices}, [0]: {active_indices[0]}, type: {type(active_indices)}, type of first element: {type(active_indices[0])}, type encoder_seq_lens: {type(encoder_seq_lens)}")
+    # active_indices = np.nonzero(encoder_seq_lens)[0]
+    active_indices = torch.nonzero(encoder_seq_lens, as_tuple=True)[0]
+    # # REMOVE
+    # print(f"Active indices for cross-attention: {active_indices}, [0]: {active_indices[0]}, type: {type(active_indices)}, type of first element: {type(active_indices[0])}, type encoder_seq_lens: {type(encoder_seq_lens)}")
 
     for req_index in active_indices:
         encoder_seq_len = encoder_seq_lens[req_index].item()

--- a/vllm/attention/layers/cross_attention.py
+++ b/vllm/attention/layers/cross_attention.py
@@ -46,7 +46,7 @@ def _get_cross_slot_mapping(
     slot_mappings = []
 
     # REMOVE
-    # print(f"Encoder seq lens: {encoder_seq_lens}, type: {type(encoder_seq_lens)}")
+    print(f"Encoder seq lens: {encoder_seq_lens}, type: {type(encoder_seq_lens)}")
 
     # Find indices with non-zero encoder sequence lengths
     # The majority of parallel requests will be running the
@@ -54,7 +54,7 @@ def _get_cross_slot_mapping(
     # active_indices = np.nonzero(encoder_seq_lens)[0]
     active_indices = torch.nonzero(encoder_seq_lens, as_tuple=True)[0]
     # # REMOVE
-    # print(f"Active indices for cross-attention: {active_indices}, [0]: {active_indices[0]}, type: {type(active_indices)}, type of first element: {type(active_indices[0])}, type encoder_seq_lens: {type(encoder_seq_lens)}")
+    print(f"Active indices for cross-attention: {active_indices}, type: {type(active_indices)}")
 
     for req_index in active_indices:
         encoder_seq_len = encoder_seq_lens[req_index].item()

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -92,6 +92,7 @@ class CommonAttentionMetadata:
     encoder_seq_lens: torch.Tensor | None = None
     encoder_seq_lens_cpu: np.ndarray | None = None
     max_encoder_seq_len: int | None = None
+    scheduled_encoder_req_index: list[int] | None = None
 
     dcp_local_seq_lens: torch.Tensor | None = None
     dcp_local_seq_lens_cpu: torch.Tensor | None = None

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -89,7 +89,9 @@ class CommonAttentionMetadata:
     num_logits_indices: int | None = None
 
     # Needed by CrossAttentionBuilder
-    encoder_seq_lens: np.ndarray | None = None
+    encoder_seq_lens: torch.Tensor | None = None
+    encoder_seq_lens_cpu: np.ndarray | None = None
+    max_encoder_seq_len: int | None = None
 
     dcp_local_seq_lens: torch.Tensor | None = None
     dcp_local_seq_lens_cpu: torch.Tensor | None = None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1188,13 +1188,6 @@ class GPUModelRunner(
             )
             self.encoder_seq_lens.np[req_index] = encoder_input_tokens
 
-        # for req_id, req_index in self.input_batch.req_id_to_index.items():
-        #     req_state = self.requests[req_id]
-        #     encoder_input_tokens = sum(
-        #         feature.mm_position.length for feature in req_state.mm_features
-        #     )
-        #     self.encoder_seq_lens.np[req_index] = encoder_input_tokens
-
         self.encoder_seq_lens.copy_to_gpu(num_reqs)
         encoder_seq_lens = self.encoder_seq_lens.gpu[:num_reqs]
         encoder_seq_lens_cpu = self.encoder_seq_lens.cpu[:num_reqs]
@@ -1515,13 +1508,6 @@ class GPUModelRunner(
             )
             self.num_accepted_tokens.np[num_reqs:].fill(1)
             self.num_accepted_tokens.copy_to_gpu()
-
-        # encoder_inputs = None
-        # scheduled_encoder_req_index = []
-        # if (self.model_config.is_encoder_decoder
-        #     and scheduler_output.scheduled_encoder_inputs):
-        #     encoder_inputs = self._extract_encoder_inputs(scheduler_output)
-        #     scheduled_encoder_req_index = [self.input_batch.req_id_to_index[req_id] for req_id in scheduler_output.scheduled_encoder_inputs.keys()]
 
         # Prepare the attention metadata for each KV cache group and make layers
         # in the same group share the same metadata.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1171,7 +1171,7 @@ class GPUModelRunner(
         num_scheduled_tokens: dict[str, int],
         kv_cache_spec: KVCacheSpec,
         num_reqs: int,
-    ) -> np.ndarray | None:
+    ) -> tuple[torch.Tensor | None, np.ndarray | None, int | None, list[int] | None]:
         if not isinstance(kv_cache_spec, CrossAttentionSpec):
             return None, None, None, None
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1167,9 +1167,9 @@ class GPUModelRunner(
 
     def _get_encoder_seq_lens(
         self,
+        scheduled_encoder_inputs: dict[str, list[int]],
         num_scheduled_tokens: dict[str, int],
         kv_cache_spec: KVCacheSpec,
-        scheduled_encoder_inputs: dict[str, list[int]],
         num_reqs: int,
     ) -> np.ndarray | None:
         if not isinstance(kv_cache_spec, CrossAttentionSpec):
@@ -1537,9 +1537,9 @@ class GPUModelRunner(
                 max_encoder_seq_len,
                 scheduled_encoder_req_index,
             ) = self._get_encoder_seq_lens(
+                scheduled_encoder_inputs or {},
                 num_scheduled_tokens or {},
                 kv_cache_group.kv_cache_spec,
-                scheduled_encoder_inputs,
                 num_reqs,
             )
 


### PR DESCRIPTION
Encoder Decoder in vLLM is limited to Whisper style model which has fixed encoder len of 1500. 
This PR generalizes the Encoder decoder arch in vLLM to support variable len encoder inputs.

### Test
* WER: 
```
time pytest -sv tests/entrypoints/openai/correctness/test_transcription_api_correctness.py::test_wer_correctness
```

* offline inference: 
```
VLLM_USE_V1=1 VLLM_WORKER_MULTIPROC_METHOD='spawn' python3 examples/offline_inference/audio_language.py -m whisper
```
Output: `The first words I spoke in the original phonograph, a little piece of practical poetry. Mary had a little lamb, its streets were quite as slow, and everywhere that Mary went the lamb was sure to go.`