### PR TITLE
Wide-EP benchmark example

### DIFF
--- a/examples/online_serving/wide_ep/README.md
+++ b/examples/online_serving/wide_ep/README.md
@@ -54,3 +54,16 @@ export GLOO_SOCKET_IFNAME=eth0
 export START_RANK=<0|8|16|24>
 ./launch_server.sh
 ```
+
+## Benchmark Driver
+
+Use `run_benchmark.sh` to recreate the load sweep used in the repo:
+
+```bash
+cd examples/online_serving/wide_ep
+./run_benchmark.sh dpep32
+```
+
+- Hits the coordinator endpoint at `http://127.0.0.1:8000` (change `HOST_URL` if your API server is elsewhere).
+- Issues 4096 concurrent requests with input length 2 / output length 256; results land in `results/<tag>/`.
+- Repeat on each of the four nodes in cluster to saturate deployment

--- a/examples/online_serving/wide_ep/README.md
+++ b/examples/online_serving/wide_ep/README.md
@@ -2,12 +2,11 @@
 
 Minimal recipe for reproducing the Nebius-wide DeepSeek-V3 run (4 × 8xH200) with DeepGEMM + DeepEP inside vLLM. This is the config we ship in the accompanying `launch_server.sh`.
 
-## Cluster Snapshot
+## Cluster Snapshot and Dependencies
+
 - 4 nodes, each with 8xH200
 - CUDA 12.8 + NVSHMEM 3.4.5
-- GPUDirect RDMA enabled
-
-## Required Bits
+- Infinband GPUDirect RDMA enabled
 - DeepGEMM `c9f8b34dcdacc20aa746b786f983492c51072870`
 - DeepEP `92fe2deaec24bc92ebd9de276daa6ca9ed602ed4`
 - vLLM v0.11.1rc5 (precompiled wheels)
@@ -20,6 +19,7 @@ VLLM_USE_PRECOMPILED=1 uv pip install \
 ```
 
 ## Base Environment
+
 Set once per node before launching:
 
 ```bash
@@ -36,15 +36,20 @@ export GLOO_SOCKET_IFNAME=eth0
 ```
 
 ## Launch
+
 > This script is only for the benchmarking recipe; change knobs via the raw command if you need a different setup.
+
 1. Pick a coordinator IP/port that all nodes can reach:
+
    ```bash
    export COORDINATOR_IP=<head-node-ip>
    export COORDINATOR_RPC_PORT=8888
    ```
+
 2. On each node run either the script or the raw command below. Only argument that changes between nodes is `START_RANK`.
 
 ### Script (preferred for benchmark reproduction)
+
 ```bash
 export START_RANK=<0|8|16|24>
 ./launch_server.sh

--- a/examples/online_serving/wide_ep/README.md
+++ b/examples/online_serving/wide_ep/README.md
@@ -1,0 +1,51 @@
+# Wide-EP DeepSeek-V3 Benchmark
+
+Minimal recipe for reproducing the Nebius-wide DeepSeek-V3 run (4 × 8xH200) with DeepGEMM + DeepEP inside vLLM. This is the config we ship in the accompanying `launch_server.sh`.
+
+## Cluster Snapshot
+- 4 nodes, each with 8xH200
+- CUDA 12.8 + NVSHMEM 3.4.5
+- GPUDirect RDMA enabled
+
+## Required Bits
+- DeepGEMM `c9f8b34dcdacc20aa746b786f983492c51072870`
+- DeepEP `92fe2deaec24bc92ebd9de276daa6ca9ed602ed4`
+- vLLM v0.11.1rc5 (precompiled wheels)
+
+```bash
+VLLM_USE_PRECOMPILED=1 uv pip install \
+  "git+https://github.com/vllm-project/vllm.git@v0.11.1rc5" \
+  --extra-index-url https://download.pytorch.org/whl/cu128 \
+  --index-strategy unsafe-best-match --prerelease=allow
+```
+
+## Base Environment
+Set once per node before launching:
+
+```bash
+export VLLM_USE_DEEP_GEMM=1
+export VLLM_ALL2ALL_BACKEND=deepep_low_latency
+export VLLM_MOE_DP_CHUNK_SIZE=512
+export VLLM_SKIP_P2P_CHECK=1
+export VLLM_RANDOMIZE_DP_DUMMY_INPUTS=1
+export NVIDIA_GDRCOPY=enabled
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export VLLM_MOE_ROUTING_SIMULATION_STRATEGY=uniform_random
+export NVSHMEM_QP_DEPTH=1512
+export GLOO_SOCKET_IFNAME=eth0
+```
+
+## Launch
+> This script is only for the benchmarking recipe; change knobs via the raw command if you need a different setup.
+1. Pick a coordinator IP/port that all nodes can reach:
+   ```bash
+   export COORDINATOR_IP=<head-node-ip>
+   export COORDINATOR_RPC_PORT=8888
+   ```
+2. On each node run either the script or the raw command below. Only argument that changes between nodes is `START_RANK`.
+
+### Script (preferred for benchmark reproduction)
+```bash
+export START_RANK=<0|8|16|24>
+./launch_server.sh
+```

--- a/examples/online_serving/wide_ep/launch_server.sh
+++ b/examples/online_serving/wide_ep/launch_server.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Launch script for the DeepSeek-V3 Wide-EP benchmarking recipe.
+# Only COORDINATOR_IP and START_RANK come from the caller; everything else
+# matches the published benchmark so results stay reproducible.
+#
+# Required environment variables:
+#   COORDINATOR_IP   - IP address of the coordinator node
+#   START_RANK       - Starting rank for this node (0, 8, 16, 24)
+#
+set -euo pipefail
+
+COORDINATOR_IP=${COORDINATOR_IP:-}
+START_RANK=${START_RANK:-}
+
+COORDINATOR_PORT=13345
+DATA_PARALLEL_SIZE=32
+DATA_PARALLEL_SIZE_LOCAL=8
+API_SERVER_COUNT=8
+MAX_MODEL_LEN=16384
+MAX_NUM_SEQS=512
+MODEL="deepseek-ai/DeepSeek-V3-0324"
+
+if [[ -z "$COORDINATOR_IP" || -z "$START_RANK" ]]; then
+    echo "Error: set COORDINATOR_IP and START_RANK before running this benchmark script."
+    echo "Example: COORDINATOR_IP=10.0.0.1 START_RANK=8 ./launch_server.sh"
+    exit 1
+fi
+
+# Set environment variables
+export VLLM_USE_DEEP_GEMM=1
+export VLLM_ALL2ALL_BACKEND=deepep_low_latency
+export VLLM_MOE_DP_CHUNK_SIZE=512
+export VLLM_SKIP_P2P_CHECK=1
+export VLLM_RANDOMIZE_DP_DUMMY_INPUTS=1
+export NVIDIA_GDRCOPY=enabled
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export VLLM_MOE_ROUTING_SIMULATION_STRATEGY=uniform_random
+export NVSHMEM_QP_DEPTH=1512
+export GLOO_SOCKET_IFNAME=eth0
+
+# Launch vLLM server
+uv run vllm serve "$MODEL" \
+  --data-parallel-hybrid-lb \
+  --api-server-count "$API_SERVER_COUNT" \
+  --data-parallel-address "$COORDINATOR_IP" \
+  --data-parallel-rpc-port "$COORDINATOR_PORT" \
+  --tensor-parallel-size 1 \
+  --data-parallel-size "$DATA_PARALLEL_SIZE" \
+  --data-parallel-size-local "$DATA_PARALLEL_SIZE_LOCAL" \
+  --data-parallel-start-rank "$START_RANK" \
+  --enable-expert-parallel \
+  --no-enable-prefix-caching \
+  --max-model-len "$MAX_MODEL_LEN" \
+  --enable-dbo \
+  --dbo-decode-token-threshold 32 \
+  --async-scheduling \
+  --enable-eplb \
+  --eplb-config '{"window_size":"1000","step_interval":"3000","num_redundant_experts":"32","log_balancedness":"False"}' \
+  --max-num-seqs "$MAX_NUM_SEQS" \
+  --compilation_config '{"pass_config":{"enable_fusion":true,"enable_attn_fusion":true,"enable_noop":true},"custom_ops":["+rms_norm"],"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+  --kv-transfer-config '{"kv_connector":"DecodeBenchConnector","kv_role":"kv_both"}'
+

--- a/examples/online_serving/wide_ep/run_benchmark.sh
+++ b/examples/online_serving/wide_ep/run_benchmark.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+    echo "Error: Experiment tag required"
+    echo "Usage: $0 <experiment_tag>"
+    echo "Example: $0 dpep16"
+    exit 1
+fi
+
+EXPERIMENT_TAG="$1"
+
+# Configuration
+HOST_URL="http://127.0.0.1:8000"
+MODEL_NAME="dsv3"
+CONCURRENCY_LEVELS=(4096) # 512 conccurency per rank, 8 ranks per node
+PROMPTS_PER_CONCURRENCY=10
+RESULT_DIR="results/${EXPERIMENT_TAG}"
+MODEL_PATH="deepseek-ai/DeepSeek-V3-0324"
+
+# Create output directory
+mkdir -p $RESULT_DIR
+timestamp=$(date +%Y%m%d_%H%M%S)
+
+# Workload configuration
+ITL=2 # ITL > 1 required for DeepSeek BOS token
+OTL=256
+
+echo "Starting benchmark sweep: $EXPERIMENT_TAG at $(date)"
+echo "Workload: ITL=$ITL, OTL=$OTL"
+echo "=========================================="
+
+for concurrency in "${CONCURRENCY_LEVELS[@]}"; do
+    output_file="c${concurrency}_${timestamp}.json"
+
+    echo "Running concurrency=${concurrency} users..."
+    NUM_REQUESTS=$((PROMPTS_PER_CONCURRENCY * concurrency))
+
+    vllm bench serve \
+        --base-url "$HOST_URL" \
+        --model "$MODEL_PATH" \
+        --served-model-name "$MODEL_NAME" \
+        --random-input-len "$ITL" \
+        --random-output-len "$OTL" \
+        --num-prompts "$NUM_REQUESTS" \
+        --max-concurrency "$concurrency" \
+        --ready-check-timeout-sec 0 \
+        --save-result \
+        --result-dir "$RESULT_DIR" \
+        --request-id-prefix "$EXPERIMENT_TAG" \
+        --result-filename "$output_file"
+
+    sleep 2
+done
+
+
+echo ""
+echo "=========================================="
+echo "Benchmark completed at $(date)"
+echo "Results saved to: $RESULT_DIR"
+
+


### PR DESCRIPTION
## Purpose
Add reproducible Wide Expert Parallelism (Wide-EP) benchmarking recipe for DeepSeek-V3 on multi-node clusters. This example demonstrates the configuration used for high-performance serving on four 8xH200 nodes with DeepGEMM and DeepEP.

## Test Plan
This configuration was used as the standard benchmarking recipe across all my Wide-EP experiments on a Nebius cluster. The `launch_server.sh` script and environment variables match the exact setup used for performance validation.

## Test Result
Validated on Nebius four 8xH200 cluster, reached 2387 tps/H200 with concurrency 512/rank, 1:512 workload

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>