### PR TITLE
[Hybrid Allocator] Better layer padding strategy for gpt-oss eagle

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -971,7 +971,15 @@ def _get_kv_cache_groups_uniform_page_size(
     # is the minimum number of layers among all attention types. Need a better
     # strategy if we want to support more complex patterns (e.g., 20 full + 30
     # sw, where the group size should be 10).
-    group_size = min([len(layers) for layers in same_type_layers.values()])
+    min_num_layers = min([len(layers) for layers in same_type_layers.values()])
+    group_size = min_num_layers
+    max_num_layers = max([len(layers) for layers in same_type_layers.values()])
+    if max_num_layers < min_num_layers * 1.2:
+        # If the number of layers is not much larger than the minimum number of layers,
+        # use the maximum number of layers as the group size to avoid too many padding
+        # layers. A typical example is gpt-oss-20b + eagle, with 12 sw + 13 full. We
+        # pad it to (13 sw, 13 full) instead of (12 sw, 24 full)
+        group_size = max_num_layers
     grouped_layers = []
     for layers in same_type_layers.values():
         num_padding_layers = group_size - len(layers) % group_size

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -974,11 +974,12 @@ def _get_kv_cache_groups_uniform_page_size(
     min_num_layers = min([len(layers) for layers in same_type_layers.values()])
     group_size = min_num_layers
     max_num_layers = max([len(layers) for layers in same_type_layers.values()])
-    if max_num_layers < min_num_layers * 1.2:
+    if max_num_layers < min_num_layers * 1.25:
         # If the number of layers is not much larger than the minimum number of layers,
         # use the maximum number of layers as the group size to avoid too many padding
         # layers. A typical example is gpt-oss-20b + eagle, with 12 sw + 13 full. We
-        # pad it to (13 sw, 13 full) instead of (12 sw, 24 full)
+        # pad it to (13 sw, 13 full) instead of (12 sw, 24 full). 1.25 is just a
+        # magic number to avoid too many padding layers.
         group_size = max_num_layers
     grouped_layers = []
     for layers in same_type_layers.values():


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Hybrid allocator does some layer padding to make sure each group has the same number of layers. The current strategy doesn't work well on gpt-oss + eagle (`vllm serve openai/gpt-oss-120b --speculative-config '{"method": "eagle3", "model": "nvidia/gpt-oss-120b-Eagle3", "num_speculative_tokens": 1}'`):

```
Add 17 padding layers, may waste at most 89.47% KV cache memory
```

Because it will group 19 full + 18 sliding window to 
```
group 0: 18 full
group 1: 1 full + 17 padding
group2:   18 sliding
```
This PR add a special code path to this case to change it to:
```
group 0: 19 full
group 1: 18 sliding + 1 padding
```

## Test Plan
`vllm serve openai/gpt-oss-120b --speculative-config '{"method": "eagle3", "model": "nvidia/gpt-oss-120b-Eagle3", "num_speculative_tokens": 1}'`
## Test Result
before this PR
```
Add 17 padding layers, may waste at most 89.47% KV cache memory
```
After this PR
```
Add 1 padding layers, may waste at most 5.56% KV cache memory
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

