### PR TITLE
[XPU]fix Kimi-VL-A3B-thinking on xpu

### DIFF
--- a/vllm/model_executor/models/moonvit.py
+++ b/vllm/model_executor/models/moonvit.py
@@ -56,10 +56,13 @@ from transformers.utils import is_flash_attn_2_available
 from vllm.model_executor.layers.conv import Conv2dLayer
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.models.utils import maybe_prefix
+from vllm.platforms import current_platform
 from vllm.transformers_utils.configs.moonvit import MoonViTConfig
 
 if is_flash_attn_2_available():
     from flash_attn import flash_attn_varlen_func
+elif current_platform.is_xpu():
+    from vllm.attention.utils.fa_utils import flash_attn_varlen_func
 else:
     flash_attn_varlen_func = None
 
@@ -106,10 +109,10 @@ def multihead_attention(
         q,
         k,
         v,
-        q_cu_seqlens,
-        k_cu_seqlens,
-        max_seqlen_q,
-        max_seqlen_k,
+        cu_seqlens_q=q_cu_seqlens,
+        cu_seqlens_k=k_cu_seqlens,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
         causal=False,
     )
     attn_out = attn_out.flatten(start_dim=-2)
@@ -291,7 +294,12 @@ class Rope2DPosEmb(nn.Module):
     """
 
     def __init__(
-        self, dim: int, max_height: int, max_width: int, theta_base=10000, device="cuda"
+        self,
+        dim: int,
+        max_height: int,
+        max_width: int,
+        theta_base=10000,
+        device=current_platform.device_type,
     ):
         super().__init__()
         self.dim = dim
@@ -437,7 +445,7 @@ class MoonVitEncoderLayer(nn.Module):
         self.hidden_size_per_attention_head = self.hidden_dim // self.num_heads
         self.attn_implementation = attn_implementation
         # use fa2 in vllm by default
-        if is_flash_attn_2_available():
+        if is_flash_attn_2_available() or current_platform.is_xpu():
             self.attn_implementation = "flash_attention_2"
 
         self.norm0 = nn.LayerNorm(hidden_dim)


### PR DESCRIPTION
## Purpose
enable Kimi-VL-A3B-thinking text/image support on xpu. For image processing, we route to `flash_attn` backend and use `varlen_attention`. `torch.SDPA` path can't work due to OOM issue.
## Test Plan
`VLLM_MLA_DISABLE=1 python examples/offline_inference/vision_language.py  --model-type kimi_vl`
## Test Result
```
--------------------------------------------------
The image is a photograph that falls under the category of architecture. It features a tall, white tower with a pointed spire, which is the Tokyo Tower. The tower is surrounded by a clear blue sky, and there are pink cherry blossom trees in the foreground. The trees partially obscure the view of the tower, adding
--------------------------------------------------
The image is a beautiful representation of a tower, which is the main subject of the image. The tower is tall and slender, with a pointed top that reaches towards the sky. The structure of the tower is made of a series of geometric shapes, giving it a very modern and sleek appearance. The tower is surrounded by
--------------------------------------------------
The image shows a tower with a pointed top, which is the Tokyo Skytree, a famous landmark in Tokyo, Japan. In the foreground, there are branches of cherry blossom trees in full bloom, with delicate pink flowers. The sky is clear and blue, providing a beautiful backdrop for the scene. The combination of
--------------------------------------------------
The image is a beautiful representation of a well-known landmark, the Tokyo Tower, located in Japan. The tower is captured from a low angle, emphasizing its height and grandeur. The tower is surrounded by a profusion of pink cherry blossoms, also known as 'sakura', which are in full bloom, adding a
--------------------------------------------------

```