### PR TITLE
[Perf] use cpu all reduce to avoid sync when async_scheduling & dp > 1

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1614,7 +1614,7 @@ class EngineArgs:
 
         if self.async_scheduling and not self.disable_nccl_for_dp_synchronization:
             logger.info(
-                "Disabling NCCL for DP synchronization since async scheduling is enabled."
+                "Disabling NCCL for DP synchronization when using async scheduling."
             )
             self.disable_nccl_for_dp_synchronization = True
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1612,6 +1612,12 @@ class EngineArgs:
             model_config.skip_tokenizer_init = True
             logger.info("Skipping tokenizer initialization for tokens-only mode.")
 
+        if self.async_scheduling and not self.disable_nccl_for_dp_synchronization:
+            logger.info(
+                "Disabling NCCL for DP synchronization since async scheduling is enabled."
+            )
+            self.disable_nccl_for_dp_synchronization = True
+
         # Forward the deprecated CLI args to the EPLB config.
         if self.num_redundant_experts is not None:
             self.eplb_config.num_redundant_experts = self.num_redundant_experts


### PR DESCRIPTION

## Purpose

Disable NCCL-based DP synchronization whenever async scheduling is enabled. This forces `_synchronize_dp_ranks` to use the CPU all-reduce path , which avoids GPU tensor copy staging and the ensuing NCCL all-reduce sync that was stalling the async scheduling pipeline.

https://github.com/vllm-project/vllm/blob/4de87866a8fdc9395ccd40e00c0f9075439b07ae/vllm/v1/worker/dp_utils.py#L37-L53

## Test Result

- Main

<img width="1442" height="329" alt="image" src="https://github.com/user-attachments/assets/f10af96d-b761-4299-8c8e-5cd52aeba290" />


- This PR

<img width="1357" height="348" alt="image" src="https://github.com/user-attachments/assets/812657c3-3814-463d-bf09-f395a3eaaba8" />

