### PR TITLE
[BugFix] Fix initialization of draft model. 

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3345,7 +3345,9 @@ class GPUModelRunner(
             scope="local",
         )
         prepare_communication_buffer_for_model(self.model)
-        if (drafter := getattr(self, "drafter", None)) and (drafter_model := getattr(drafter, 'model', None)):
+        if (drafter := getattr(self, "drafter", None)) and (
+            drafter_model := getattr(drafter, "model", None)
+        ):
             prepare_communication_buffer_for_model(drafter_model)
         mm_config = self.model_config.multimodal_config
         self.is_multimodal_pruning_enabled = (

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3345,6 +3345,8 @@ class GPUModelRunner(
             scope="local",
         )
         prepare_communication_buffer_for_model(self.model)
+        if hasattr(self, "drafter") and hasattr(self.drafter, 'model'):
+            prepare_communication_buffer_for_model(self.drafter.model)
         mm_config = self.model_config.multimodal_config
         self.is_multimodal_pruning_enabled = (
             supports_multimodal_pruning(self.get_model())

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3345,8 +3345,8 @@ class GPUModelRunner(
             scope="local",
         )
         prepare_communication_buffer_for_model(self.model)
-        if hasattr(self, "drafter") and hasattr(self.drafter, 'model'):
-            prepare_communication_buffer_for_model(self.drafter.model)
+        if (drafter := getattr(self, "drafter", None)) and (drafter_model := getattr(drafter, 'model', None)):
+            prepare_communication_buffer_for_model(drafter_model)
         mm_config = self.model_config.multimodal_config
         self.is_multimodal_pruning_enabled = (
             supports_multimodal_pruning(self.get_model())


### PR DESCRIPTION
This initialization is needed to make MTP for DeepSeek V3 work with high-throughput backend.

DeepSeek V3 draft model also has a MoE layer.  The method `DeviceCommunicationBase.prepare_communication_buffer_for_model` calls `FusedMoEMethodBase.init_prepare_finalize` method which in turn sets `fused_experts` field of the layer. During MTP calculation without this field `FusedMoE.forward_impl` method sees that `using_modular_kernel` property is false and sets `do_naive_dispatch_combine` flag and as a consequence calls `get_ep_group().dispatch()`. But `dispatch` method is not implemented in `DeepEPHTAll2AllManager` class which throws an exception.

Calling `prepare_communication_buffer_for_model` on a draft model makes this exception go away and makes MTP working.
