### PR TITLE
Remove VLLM_SKIP_WARMUP tip

### DIFF
--- a/docs/features/quantization/inc.md
+++ b/docs/features/quantization/inc.md
@@ -23,9 +23,6 @@ vllm serve meta-llama/Llama-3.1-405B-Instruct --quantization inc --kv-cache-dtyp
 ```
 
 !!! tip
-    If you are just prototyping or testing your model with FP8, you can use the `VLLM_SKIP_WARMUP=true` environment variable to disable the warmup stage, which can take a long time. However, we do not recommend disabling this feature in production environments as it causes a significant performance drop.
-
-!!! tip
     When using FP8 models, you may experience timeouts caused by the long compilation time of FP8 operations. To mitigate this problem, you can use the below environment variables:
     `VLLM_ENGINE_ITERATION_TIMEOUT_S` - to adjust the vLLM server timeout. You can set the value in seconds, e.g., 600 equals 10 minutes.
     `VLLM_RPC_TIMEOUT` - to adjust the RPC protocol timeout used by the OpenAI-compatible API. This value is in microseconds, e.g., 600000 equals 10 minutes.


### PR DESCRIPTION
Grepping for the env `VLLM_SKIP_WARMUP` shows no hits outside of the tip, so looks like this tip is out of date.