### PR TITLE
[Bugfix] Only use triton_kernels for MXFP4 on SM90 and SM100

### DIFF
--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -132,10 +132,17 @@ def get_mxfp4_backend(with_lora_support: bool) -> Mxfp4Backend:
             )
 
         # If FlashInfer is not available, try either Marlin or Triton
+        triton_kernels_supported = (
+            has_triton_kernels()
+            and is_torch_equal_or_newer("2.8.0")
+            # NOTE: triton_kernels are only confirmed to work on SM90 and SM100
+            # SM110 fails with this error: https://github.com/vllm-project/vllm/issues/29317
+            # SM120 needs this fix: https://github.com/triton-lang/triton/pull/8498
+            and (9, 0) <= current_platform.get_device_capability() < (11, 0)
+        )
         if (
             envs.VLLM_MXFP4_USE_MARLIN
-            or current_platform.get_device_capability()[0] < 9
-            or not has_triton_kernels()
+            or not triton_kernels_supported
             or not is_torch_equal_or_newer("2.8.0")
         ):
             logger.info_once("Using Marlin backend")

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -140,11 +140,7 @@ def get_mxfp4_backend(with_lora_support: bool) -> Mxfp4Backend:
             # SM120 needs this fix: https://github.com/triton-lang/triton/pull/8498
             and (9, 0) <= current_platform.get_device_capability() < (11, 0)
         )
-        if (
-            envs.VLLM_MXFP4_USE_MARLIN
-            or not triton_kernels_supported
-            or not is_torch_equal_or_newer("2.8.0")
-        ):
+        if envs.VLLM_MXFP4_USE_MARLIN or not triton_kernels_supported:
             logger.info_once("Using Marlin backend")
             return Mxfp4Backend.MARLIN
         else:


### PR DESCRIPTION

## Purpose

After we landed triton_kernels as a default dep in https://github.com/vllm-project/vllm/pull/28788, we started seeing some issues appear for gpt-oss users on sm110 and sm120 (see https://github.com/vllm-project/vllm/issues/29317 and https://vllm-dev.slack.com/archives/C0990U53QBV/p1764009918189409). 
This PR disables that path for now and uses Marlin for those GPUs.



## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

