### PR TITLE
[CI][ROCm] Install arctic-inference on ROCm tests

### DIFF
--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -45,3 +45,6 @@ multiprocess==0.70.16
 
 # Plugins test
 terratorch @ git+https://github.com/IBM/terratorch.git@07184fcf91a1324f831ff521dd238d97fe350e3e
+
+# Required for suffix decoding test
+arctic-inference == 0.1.1


### PR DESCRIPTION
This PR installs arctic-inference for ROCm tests
 
Fixes:
- `test_spec_decode.py::test_ngram_and_suffix_correctness`
- `test_spec_decode.py::test_suffix_decoding_acceptance`