### PR TITLE
[Perf] Disable DeepGEMM MoE by default when TP=8 is used

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -28,6 +28,7 @@ from vllm.model_executor.layers.fused_moe import (
     FusedMoeWeightScaleSupported,
 )
 from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEParallelConfig,
     FusedMoEQuantConfig,
     RoutingMethodType,
     fp8_w8a8_moe_quant_config,
@@ -118,7 +119,9 @@ class Fp8MoeBackend(Enum):
     TRITON = 6
 
 
-def get_fp8_moe_backend(block_quant: bool) -> Fp8MoeBackend:
+def get_fp8_moe_backend(
+    block_quant: bool, moe_parallel_config: FusedMoEParallelConfig
+) -> Fp8MoeBackend:
     """
     Select the primary FP8 MoE backend
     Note: Shape-specific fallbacks may still occur at runtime.
@@ -159,8 +162,20 @@ def get_fp8_moe_backend(block_quant: bool) -> Fp8MoeBackend:
         logger.info_once("Using Marlin backend for FP8 MoE")
         return Fp8MoeBackend.MARLIN
 
-    # deepGEMM on supported platforms with block-quantized weights
-    if envs.VLLM_USE_DEEP_GEMM and envs.VLLM_MOE_USE_DEEP_GEMM and block_quant:
+    # Determine if we should use DeepGEMM with block-quantized weights:
+    # - If explicitly set by user, respect their choice
+    # - If not explicitly set (default), disable when TP size is 8
+    moe_use_deep_gemm = envs.VLLM_MOE_USE_DEEP_GEMM
+    if not envs.is_set("VLLM_MOE_USE_DEEP_GEMM") and moe_parallel_config.tp_size == 8:
+        # Disable DeepGEMM by default when TP size is 8
+        moe_use_deep_gemm = False
+        logger.info_once(
+            "DeepGEMM MoE is disabled by default when TP size is 8. "
+            "Set VLLM_MOE_USE_DEEP_GEMM=1 to enable it.",
+            scope="local",
+        )
+
+    if envs.VLLM_USE_DEEP_GEMM and moe_use_deep_gemm and block_quant:
         if not has_deep_gemm():
             logger.warning_once(
                 "DeepGEMM backend requested but not available.", scope="local"
@@ -641,7 +656,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         self.quant_config = quant_config
         self.weight_block_size = self.quant_config.weight_block_size
         self.block_quant: bool = self.weight_block_size is not None
-        self.fp8_backend = get_fp8_moe_backend(self.block_quant)
+        self.fp8_backend = get_fp8_moe_backend(
+            self.block_quant, layer.moe_parallel_config
+        )
 
         self.use_marlin = self.fp8_backend == Fp8MoeBackend.MARLIN
         self.flashinfer_moe_backend: FlashinferMoeBackend | None = None

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -164,13 +164,12 @@ def get_fp8_moe_backend(
 
     # Determine if we should use DeepGEMM with block-quantized weights:
     # - If explicitly set by user, respect their choice
-    # - If not explicitly set (default), disable when TP size is 8
+    # - If not explicitly set (default), disable when TP size is >= 8
     moe_use_deep_gemm = envs.VLLM_MOE_USE_DEEP_GEMM
-    if not envs.is_set("VLLM_MOE_USE_DEEP_GEMM") and moe_parallel_config.tp_size == 8:
-        # Disable DeepGEMM by default when TP size is 8
+    if not envs.is_set("VLLM_MOE_USE_DEEP_GEMM") and moe_parallel_config.tp_size >= 8:
         moe_use_deep_gemm = False
         logger.info_once(
-            "DeepGEMM MoE is disabled by default when TP size is 8. "
+            "DeepGEMM MoE is disabled by default when TP size is >= 8. "
             "Set VLLM_MOE_USE_DEEP_GEMM=1 to enable it.",
             scope="local",
         )


### PR DESCRIPTION
## Purpose

Recent benchmarks have shown that the best performance for DeepSeek V3 TP=8 on Hopper/Blackwell is with `VLLM_MOE_USE_DEEP_GEMM=0 VLLM_USE_DEEP_GEMM=1` i.e. use DeepGEMM for the GEMM and Triton for the MoE. This PR sets that heuristic by default for any block fp8 model running at TP=8, which I think this fairly conservative. 
We could be more aggressive in the future by doing the same for smaller TP sizes or building rules based on weight shapes.

## Test Plan

```
vllm serve deepseek-ai/DeepSeek-R1 -tp=8 --load-format=dummy
```

## Test Result

Before:
```
(Worker_TP0 pid=3873256) INFO 11-24 21:09:50 [fp8.py:184] Using DeepGEMM backend for FP8 MoE
```

After:
```
(Worker_TP0 pid=3884711) INFO 11-24 21:12:23 [fp8.py:172] DeepGEMM MoE is disabled by default when TP size is 8. Set VLLM_MOE_USE_DEEP_GEMM=1 to enable it.
(Worker_TP0 pid=3884711) INFO 11-24 21:12:23 [fp8.py:199] Using Triton backend for FP8 MoE
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

