### PR TITLE
[Bugfix] Add audio-overlap-chunk-second CLI arg to prevent word duplication on audio transcription

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -291,6 +291,9 @@ class ModelConfig:
     multimodal_config: MultiModalConfig | None = None
     """Configuration for multimodal model. If `None`, this will be inferred
     from the architecture of `self.model`."""
+    audio_overlap_chunk_second: int = 1
+    """Number of seconds of overlap between consecutive audio chunks
+    when processing long audio files."""
     limit_mm_per_prompt: InitVar[dict[str, int | dict[str, int]] | None] = None
     enable_mm_embeds: InitVar[bool | None] = None
     media_io_kwargs: InitVar[dict[str, dict[str, Any]] | None] = None

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -475,6 +475,7 @@ class EngineArgs:
     io_processor_plugin: str | None = None
     skip_mm_profiling: bool = MultiModalConfig.skip_mm_profiling
     video_pruning_rate: float = MultiModalConfig.video_pruning_rate
+    audio_overlap_chunk_second: int = ModelConfig.audio_overlap_chunk_second
     # LoRA fields
     enable_lora: bool = False
     max_loras: int = LoRAConfig.max_loras
@@ -699,6 +700,9 @@ class EngineArgs:
         )
         model_group.add_argument(
             "--io-processor-plugin", **model_kwargs["io_processor_plugin"]
+        )
+        model_group.add_argument(
+            "--audio-overlap-chunk-second", **model_kwargs["audio_overlap_chunk_second"]
         )
 
         # Model loading arguments
@@ -1253,6 +1257,7 @@ class EngineArgs:
             logits_processors=self.logits_processors,
             video_pruning_rate=self.video_pruning_rate,
             io_processor_plugin=self.io_processor_plugin,
+            audio_overlap_chunk_second=self.audio_overlap_chunk_second,
         )
 
     def validate_tensorizer_args(self):

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -870,6 +870,7 @@ class WhisperForConditionalGeneration(
         return SpeechToTextConfig(
             max_audio_clip_s=processor.feature_extractor.chunk_length,
             sample_rate=processor.feature_extractor.sampling_rate,
+            overlap_chunk_second=model_config.audio_overlap_chunk_second,
         )
 
     @classmethod


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Add a new `--audio-overlap-chunk-second` CLi arg to allow configuring the `overlap_chunk_second` for Whisper models 
Fixes #29350 

## Test Plan

Start a new Whisper Large V3 model with arg "--audio-overlap-chunk-second=2" 

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

