### PR TITLE
[WIP][CI][GHA] Use linux.2xlarge GHA runner for pre-commit checks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+    labels:
+          - linux.2xlarge

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: linux.2xlarge # ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION
Testing out the linux.2xlarge GitHub Actions instances managed by PyTorch for pre-commit testing.

## Purpose

See if the linux.2xlarge queue/instance works here.

## Test Plan

Run CI

## Test Result

Hopefully success!
