### PR TITLE
[Bugfix] [ROCm] [UX]: revert Flex attention backend

### DIFF
--- a/tests/v1/attention/test_rocm_attention_backends_selection.py
+++ b/tests/v1/attention/test_rocm_attention_backends_selection.py
@@ -36,6 +36,12 @@ def mock_on_gfx9():
 @pytest.mark.parametrize(
     "env_vars, selected_backend, expected_backend_path",
     [
+        # Test Case: Explicit FLEX_ATTENTION backend
+        (
+            {},
+            "FLEX_ATTENTION",
+            AttentionBackendEnum.FLEX_ATTENTION.get_path(),
+        ),
         # Test Case 1: Default (no env vars, no explicit backend)
         (
             {},

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -262,6 +262,10 @@ class RocmPlatform(Platform):
                 f"is not MLA type while requested for MLA backend."
             )
 
+        if selected_backend == AttentionBackendEnum.FLEX_ATTENTION:
+            logger.info("Using FlexAttention backend.")
+            return AttentionBackendEnum.FLEX_ATTENTION.get_path()
+
         if selected_backend == AttentionBackendEnum.TRITON_ATTN:
             logger.info("Using Triton Attention backend on V1 engine.")
             return AttentionBackendEnum.TRITON_ATTN.get_path()


### PR DESCRIPTION
Description This PR restores the FLEX_ATTENTION backend selection logic that was accidentally removed in PR #26980. 

Changes

Re-added explicit check for AttentionBackendEnum.FLEX_ATTENTION in vllm/platforms/rocm.py.

Added a corresponding unit test case in tests/v1/attention/test_rocm_attention_backends_selection.py to ensure it is correctly selected.