### PR TITLE
[BugFix] Use unique ids for different transcription prompts

### DIFF
--- a/vllm/entrypoints/openai/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text.py
@@ -201,10 +201,10 @@ class OpenAISpeechToText(OpenAIServing):
                 self.engine_client.generate(
                     prompt,
                     sampling_params,
-                    request_id,
+                    f"{request_id}_{i}",
                     lora_request=lora_request,
                 )
-                for prompt in prompts
+                for i, prompt in enumerate(prompts)
             ]
         except ValueError as e:
             # TODO: Use a vllm-specific Validation Error


### PR DESCRIPTION
Using duplicate ids back-to-back causes a problem with async scheduling, equivalent to the one described here https://github.com/vllm-project/vllm/pull/29355.