### PR TITLE
[Platform] Make forward context manager pluggable for other device

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -51,7 +51,6 @@ from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig
 from vllm.distributed import parallel_state
 from vllm.distributed import utils as dist_utils
-from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import get_act_and_mul_fn
 from vllm.model_executor.layers.conv import Conv3dLayer
@@ -1316,6 +1315,10 @@ class Qwen2_5_VLForConditionalGeneration(
             image_embeds = image_input["image_embeds"].type(self.visual.dtype)
         else:
             pixel_values = image_input["pixel_values"]
+
+            from vllm.platforms import current_platform
+
+            set_forward_context = current_platform.get_forward_context_manager()
             with set_forward_context(None, self.vllm_config):
                 if self.use_data_parallel:
                     return run_dp_sharded_mrope_vision_model(
@@ -1371,6 +1374,10 @@ class Qwen2_5_VLForConditionalGeneration(
             video_embeds = video_input["video_embeds"].type(self.visual.dtype)
         else:
             pixel_values_videos = video_input["pixel_values_videos"]
+
+            from vllm.platforms import current_platform
+
+            set_forward_context = current_platform.get_forward_context_manager()
             with set_forward_context(None, self.vllm_config):
                 if self.use_data_parallel:
                     return run_dp_sharded_mrope_vision_model(

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -80,6 +80,7 @@ from vllm.multimodal.inputs import (
 )
 from vllm.multimodal.parse import MultiModalDataItems
 from vllm.multimodal.processing import PromptReplacement, PromptUpdate
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
@@ -352,8 +353,6 @@ class Qwen2_5_VisionAttention(nn.Module):
             )
         )
         # On ROCm with FLASH_ATTN backend, upstream flash_attn is used
-        from vllm.platforms import current_platform
-
         if (
             current_platform.is_rocm()
             and self.attn_backend == AttentionBackendEnum.FLASH_ATTN
@@ -418,8 +417,6 @@ class Qwen2_5_VisionAttention(nn.Module):
             )
         elif self.attn_backend == AttentionBackendEnum.TORCH_SDPA:
             # Execute attention entry by entry for speed & less VRAM.
-            from vllm.platforms import current_platform
-
             # Never remove the next contiguous logic
             # Without it, hallucinations occur with the backend
             if current_platform.is_rocm():
@@ -1245,8 +1242,6 @@ class Qwen2_5_VLForConditionalGeneration(
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors
         )
-
-        from vllm.platforms import current_platform
 
         self.set_forward_context = current_platform.get_forward_context_manager()
 

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -1314,10 +1314,9 @@ class Qwen2_5_VLForConditionalGeneration(
         if image_input["type"] == "image_embeds":
             image_embeds = image_input["image_embeds"].type(self.visual.dtype)
         else:
-            pixel_values = image_input["pixel_values"]
-
             from vllm.platforms import current_platform
 
+            pixel_values = image_input["pixel_values"]
             set_forward_context = current_platform.get_forward_context_manager()
             with set_forward_context(None, self.vllm_config):
                 if self.use_data_parallel:
@@ -1373,10 +1372,9 @@ class Qwen2_5_VLForConditionalGeneration(
         if video_input["type"] == "video_embeds":
             video_embeds = video_input["video_embeds"].type(self.visual.dtype)
         else:
-            pixel_values_videos = video_input["pixel_values_videos"]
-
             from vllm.platforms import current_platform
 
+            pixel_values_videos = video_input["pixel_values_videos"]
             set_forward_context = current_platform.get_forward_context_manager()
             with set_forward_context(None, self.vllm_config):
                 if self.use_data_parallel:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -6,6 +6,7 @@ import os
 import platform
 import random
 import sys
+from collections.abc import Callable
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -654,7 +655,7 @@ class Platform:
         return max_model_len
 
     @classmethod
-    def get_forward_context_manager(cls):
+    def get_forward_context_manager(cls) -> Callable:
         """
         Returns forward context manager for the current platform.
         """

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -653,6 +653,15 @@ class Platform:
         """
         return max_model_len
 
+    @classmethod
+    def get_forward_context_manager(cls):
+        """
+        Returns forward context manager for the current platform.
+        """
+        from vllm.forward_context import set_forward_context
+
+        return set_forward_context
+
 
 class UnspecifiedPlatform(Platform):
     _enum = PlatformEnum.UNSPECIFIED


### PR DESCRIPTION
## Purpose

Currently, `set_forward_context` is directly used in some modeling files, such as `Qwen2.5-VL` (when process image/video input with ViT).

We want to use some custom forward context here (without modifying the modeling files in the plugin), such as https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/ascend_forward_context.py#L58.

Thus, this PR has made forward context manager pluggable for other device.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

