### PR TITLE
[BugFix] Fix ValueError in NewRequestData repr methods

### DIFF
--- a/tests/v1/core/test_output.py
+++ b/tests/v1/core/test_output.py
@@ -1,0 +1,34 @@
+import torch
+
+from vllm.v1.core.sched.output import NewRequestData
+
+
+def _create_new_requests_data(prompt_embeds: torch.Tensor | None) -> NewRequestData:
+    return NewRequestData(
+        req_id="test_req",
+        prompt_token_ids=None,
+        mm_features=[],
+        sampling_params=None,
+        pooling_params=None,
+        block_ids=([], ),
+        num_computed_tokens=0,
+        lora_request=None,
+        prompt_embeds=prompt_embeds,
+    )
+
+
+def test_repr_with_none() -> None:
+    """Test repr when prompt_embeds is None."""
+    new_requests_data = _create_new_requests_data(None)
+
+    assert "prompt_embeds_shape=None" in repr(new_requests_data)
+    assert "prompt_embeds_shape=None" in new_requests_data.anon_repr()
+
+
+def test_repr_with_multi_element_tensor() -> None:
+    """Test repr when prompt_embeds is a multi-element tensor."""
+    prompt_embeds = torch.randn(10, 768)
+    new_requests_data = _create_new_requests_data(prompt_embeds)
+
+    assert "prompt_embeds_shape=torch.Size([10, 768])" in repr(new_requests_data)
+    assert "prompt_embeds_shape=torch.Size([10, 768])" in new_requests_data.anon_repr()

--- a/tests/v1/core/test_output.py
+++ b/tests/v1/core/test_output.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import torch
 
 from vllm.v1.core.sched.output import NewRequestData
@@ -10,7 +12,7 @@ def _create_new_requests_data(prompt_embeds: torch.Tensor | None) -> NewRequestD
         mm_features=[],
         sampling_params=None,
         pooling_params=None,
-        block_ids=([], ),
+        block_ids=([],),
         num_computed_tokens=0,
         lora_request=None,
         prompt_embeds=prompt_embeds,

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -68,7 +68,8 @@ class NewRequestData:
         )
 
     def __repr__(self) -> str:
-        prompt_embeds_shape = self.prompt_embeds.shape if self.prompt_embeds else None
+        prompt_embeds_shape = self.prompt_embeds.shape \
+            if self.prompt_embeds is not None else None
         return (
             f"NewRequestData("
             f"req_id={self.req_id},"
@@ -88,7 +89,8 @@ class NewRequestData:
         prompt_token_ids_len = (
             len(self.prompt_token_ids) if self.prompt_token_ids is not None else None
         )
-        prompt_embeds_shape = self.prompt_embeds.shape if self.prompt_embeds else None
+        prompt_embeds_shape = self.prompt_embeds.shape \
+            if self.prompt_embeds is not None else None
         return (
             f"NewRequestData("
             f"req_id={self.req_id},"

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -68,8 +68,9 @@ class NewRequestData:
         )
 
     def __repr__(self) -> str:
-        prompt_embeds_shape = self.prompt_embeds.shape \
-            if self.prompt_embeds is not None else None
+        prompt_embeds_shape = (
+            self.prompt_embeds.shape if self.prompt_embeds is not None else None
+        )
         return (
             f"NewRequestData("
             f"req_id={self.req_id},"
@@ -89,8 +90,9 @@ class NewRequestData:
         prompt_token_ids_len = (
             len(self.prompt_token_ids) if self.prompt_token_ids is not None else None
         )
-        prompt_embeds_shape = self.prompt_embeds.shape \
-            if self.prompt_embeds is not None else None
+        prompt_embeds_shape = (
+            self.prompt_embeds.shape if self.prompt_embeds is not None else None
+        )
         return (
             f"NewRequestData("
             f"req_id={self.req_id},"


### PR DESCRIPTION
## Purpose

Fix a critical bug in `NewRequestData.__repr__()` and `anon_repr()` methods that causes `ValueError` when `prompt_embeds` contains multi-element PyTorch tensors.

**Root Cause**: The methods use truthiness test (`if self.prompt_embeds`) instead of explicit None check (`if self.prompt_embeds is not None`). PyTorch raises `ValueError` when attempting boolean conversion of multi-element tensors to avoid ambiguity.

**Impact**: Any code path that calls `repr()` or `str()` on `NewRequestData` objects with multi-element `prompt_embeds` will crash. While this primarily affects debugging and logging, it's a crash bug that should be fixed.

**Changes**:
- `vllm/v1/core/sched/output.py` line 64: Fix `__repr__()` method
- `vllm/v1/core/sched/output.py` line 83: Fix `anon_repr()` method
- Add unit tests in `tests/v1/core/test_sched_output.py`

## Test Plan

# Run the new unit tests
pytest tests/v1/core/test_sched_output.py -v

# Run existing related tests to ensure no regression
pytest tests/v1/core/test_scheduler.py -vThe unit tests verify:
1. Correct behavior when `prompt_embeds` is `None` (most common case)
2. No `ValueError` when `prompt_embeds` is a multi-element tensor (the bug fix)

## Test Result
test_output.py::test_repr_with_none PASSED                               [ 50%]
test_output.py::test_repr_with_multi_element_tensor PASSED               [100%]
======================== 2 passed in 0.63s =========================
