### PR TITLE
[Bugfix] Fix logic for choosing default prefix caching setting

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -278,8 +278,9 @@ def test_prefix_cache_default():
     parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
     args = parser.parse_args([])
 
+    # should be None by default (depends on model).
     engine_args = EngineArgs.from_cli_args(args=args)
-    assert engine_args.enable_prefix_caching, "prefix caching should default to on."
+    assert engine_args.enable_prefix_caching is None
 
     # with flag to turn it on.
     args = parser.parse_args(["--enable-prefix-caching"])

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -878,7 +878,11 @@ class EngineArgs:
             "--num-gpu-blocks-override", **cache_kwargs["num_gpu_blocks_override"]
         )
         cache_group.add_argument(
-            "--enable-prefix-caching", **cache_kwargs["enable_prefix_caching"]
+            "--enable-prefix-caching",
+            **{
+                **cache_kwargs["enable_prefix_caching"],
+                "default": None,
+            },
         )
         cache_group.add_argument(
             "--prefix-caching-hash-algo", **cache_kwargs["prefix_caching_hash_algo"]


### PR DESCRIPTION
## Purpose

We have [this](https://github.com/vllm-project/vllm/blob/e1dd706cd1f2b008f6295a6a64634bf9e9b202c1/vllm/engine/arg_utils.py#L1963-L1980) whole logic for choosing the default setting for `enable_prefix_caching` based on the model (e.g., we want to disable it by default for hybrid models currently). However, it is totally ignored because `enable_prefix_caching` defaults to True when parsing the CLI args, so we never actually run any of these checks. Right now this means on main, we are enabling prefix caching by default for hybrid models. This is not the intended behaviour right now. 

## Test Plan

On main:
```
$ vllm serve ibm-granite/granite-4.0-h-small 
INFO 11-25 05:20:04 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(APIServer pid=3965788) INFO 11-25 05:20:04 [api_server.py:2056] vLLM API server version 0.11.2.dev265+gdb2906108
(APIServer pid=3965788) INFO 11-25 05:20:04 [utils.py:253] non-default args: {'model_tag': 'ibm-granite/granite-4.0-h-small', 'model': 'ibm-granite/granite-4.0-h-small'}
(APIServer pid=3965788) INFO 11-25 05:20:04 [model.py:641] Resolved architecture: GraniteMoeHybridForCausalLM
(APIServer pid=3965788) INFO 11-25 05:20:04 [model.py:1760] Using max model len 131072
(APIServer pid=3965788) INFO 11-25 05:20:04 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=8192.
(APIServer pid=3965788) INFO 11-25 05:20:04 [config.py:297] Warning: Prefix caching is currently enabled. Its support for Mamba layers is experimental. Please report any issues you may observe.
(APIServer pid=3965788) INFO 11-25 05:20:04 [config.py:310] Disabling cascade attention since it is not supported for hybrid models.
(APIServer pid=3965788) INFO 11-25 05:20:04 [config.py:434] Setting attention block size to 768 tokens to ensure that attention page size is >= mamba page size.
(APIServer pid=3965788) INFO 11-25 05:20:04 [config.py:458] Padding mamba page size by 46.46% to ensure that mamba page size and attention page size are exactly equal.
```


## Test Result

After this fix:
```
$ vllm serve ibm-granite/granite-4.0-h-small 
INFO 11-25 05:19:00 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(APIServer pid=3964846) INFO 11-25 05:19:00 [api_server.py:2056] vLLM API server version 0.11.2.dev265+gdb2906108
(APIServer pid=3964846) INFO 11-25 05:19:00 [utils.py:253] non-default args: {'model_tag': 'ibm-granite/granite-4.0-h-small', 'model': 'ibm-granite/granite-4.0-h-small'}
(APIServer pid=3964846) INFO 11-25 05:19:00 [model.py:641] Resolved architecture: GraniteMoeHybridForCausalLM
(APIServer pid=3964846) INFO 11-25 05:19:00 [model.py:1760] Using max model len 131072
(APIServer pid=3964846) INFO 11-25 05:19:00 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=8192.
(APIServer pid=3964846) INFO 11-25 05:19:00 [config.py:310] Disabling cascade attention since it is not supported for hybrid models.
(APIServer pid=3964846) INFO 11-25 05:19:00 [config.py:434] Setting attention block size to 528 tokens to ensure that attention page size is >= mamba page size.
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

