### PR TITLE
[DOC][ROCm]: Add attention backend guide

### DIFF
--- a/docs/features/attention_backend.md
+++ b/docs/features/attention_backend.md
@@ -1,10 +1,16 @@
-# ROCm Attention Backends
+# Attention Backend
 
-vLLM on the AMD ROCm platform supports multiple attention backends to optimize performance across a wide range of hardware architectures (e.g., AMD Instinct MI200/MI300 series, Radeon consumer cards) and model architectures (e.g., Llama, DeepSeek-V3/R1).
+vLLM supports multiple attention backends to optimize performance across different hardware architectures (e.g., NVIDIA, AMD ROCm, TPU, CPU). Users can select the specific backend to achieve the best latency or throughput for their workloads.
+
+You can control the backend selection using the `VLLM_ATTENTION_BACKEND` environment variable.
+
+## ROCm
+
+On the AMD ROCm platform, vLLM supports multiple attention backends to optimize performance across different hardware architectures (e.g., AMD Instinct MI200/MI300 series, Radeon consumer cards) and model architectures (e.g., Llama, DeepSeek-V3/R1).
 
 While vLLM attempts to select the best default backend for your hardware, explicitly selecting a backend allows for fine-grained performance tuning, especially on high-end datacenter GPUs like the MI300X.
 
-## Why Multiple Backends?
+### Why Multiple Backends?
 
 The choice of attention backend affects **latency**, **throughput**, and **memory usage**. The primary difference lies in the underlying kernel implementation:
 
@@ -12,9 +18,9 @@ The choice of attention backend affects **latency**, **throughput**, and **memor
 * **HIP C++ Kernels**: Native AMD ROCm implementations. Historically used for PagedAttention, providing stable performance.
 * **AITER (Assembly/CK) Kernels**: Kernels from the **A**MD **I**nference **Te**nso**R** library. These are highly optimized, low-level kernels (often written in Assembly or Composable Kernel) specifically tuned for **Matrix Core** architectures like CDNA3 (MI300 series). They typically offer the highest performance but have stricter hardware requirements.
 
-## Backend Architecture Explained
+### Backend Architecture Explained
 
-### Standard Attention Backends
+#### Standard Attention Backends
 
 These backends are used for standard Transformers models (Llama 3, Qwen 2, Mistral, etc.).
 
@@ -26,7 +32,7 @@ These backends are used for standard Transformers models (Llama 3, Qwen 2, Mistr
 | **ROCM_AITER_UNIFIED_ATTN** | Uses AITER's unified attention implementation. | Alternative AITER path for unified prefill/decode. |
 | **FLEX_ATTENTION** | Uses vLLM's FlexAttention implementation. | Experimental or specific model requirements. |
 
-### MLA Backends (DeepSeek-V3/R1)
+#### MLA Backends (DeepSeek-V3/R1)
 
 DeepSeek models use **Multi-Head Latent Attention (MLA)**, which requires specialized memory handling.
 
@@ -37,13 +43,13 @@ DeepSeek models use **Multi-Head Latent Attention (MLA)**, which requires specia
 
 ---
 
-## Usage Examples
+### Usage Examples
 
-### Attention Backend on ROCm
+#### Attention Backend on ROCm
 
 You can control the backend selection using the `VLLM_ATTENTION_BACKEND` environment variable.
 
-### 1. TRITON_ATTN (Default)
+#### 1. TRITON_ATTN (Default)
 
 Uses vLLM's triton unified attention backend.
 
@@ -62,7 +68,7 @@ VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MHA=0 vllm serve meta-llama/Llama-3.1-
 
 ```
 
-### 2. ROCM_ATTN (Hybrid)
+#### 2. ROCM_ATTN (Hybrid)
 
 Uses vLLM's chunked prefill (Triton) and paged decode (HIP) kernel.
 
@@ -82,7 +88,7 @@ VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MHA=0 VLLM_V1_USE_PREFILL_DECODE_ATTEN
 
 ```
 
-### 3. ROCM_AITER_FA (Flash Attention)
+#### 3. ROCM_AITER_FA (Flash Attention)
 
 Use the AITER Flash Attention backend. Requires gfx9 architecture.
 
@@ -96,7 +102,7 @@ VLLM_ROCM_USE_AITER=1 vllm serve meta-llama/Llama-3.1-8B-Instruct
 
 ```
 
-### 4. ROCM_AITER_UNIFIED_ATTN
+#### 4. ROCM_AITER_UNIFIED_ATTN
 
 Use AITER unified attention backend.
 
@@ -113,11 +119,11 @@ VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MHA=0 VLLM_ROCM_USE_AITER_UNIFIED_ATTE
 
 ```
 
-### MLA Backend
+#### MLA Backend
 
 On AMD ROCm, there are TRITON_MLA and ROCM_AITER_MLA
 
-### 5. DeepSeek MLA (TRITON_MLA)
+#### 5. DeepSeek MLA (TRITON_MLA)
 
 Uses vLLM's triton MLA backend. The prefill uses triton flash attention/ CK flash attention varlen, and decode uses triton mla decode kernel. Requires block_size >= 16.
 
@@ -131,7 +137,7 @@ VLLM_ROCM_USE_AITER=1 VLLM_ATTENTION_BACKEND="TRITON_MLA" vllm serve deepseek-ai
 
 ```
 
-### 6. DeepSeek MLA (ROCM_AITER_MLA)
+#### 6. DeepSeek MLA (ROCM_AITER_MLA)
 
 For DeepSeek models, vLLM defaults to ROCM_AITER_MLA on supported hardware.
 
@@ -150,7 +156,7 @@ VLLM_ROCM_USE_AITER=1 vllm serve deepseek-ai/DeepSeek-R1 \
   
 ```
 
-## Selection Priority
+### Selection Priority
 
 When multiple configurations are provided, vLLM follows this strict priority order:
 
@@ -167,3 +173,6 @@ When multiple configurations are provided, vLLM follows this strict priority ord
 
 !!! note
     Explicitly setting `VLLM_ATTENTION_BACKEND` is the recommended way to debug backend issues, as it bypasses complex flag combinations.
+
+## NVIDIA
+## TPU

--- a/docs/features/attention_backend.md
+++ b/docs/features/attention_backend.md
@@ -175,4 +175,5 @@ When multiple configurations are provided, vLLM follows this strict priority ord
     Explicitly setting `VLLM_ATTENTION_BACKEND` is the recommended way to debug backend issues, as it bypasses complex flag combinations.
 
 ## NVIDIA
+
 ## TPU

--- a/docs/features/rocm_attention_backend.md
+++ b/docs/features/rocm_attention_backend.md
@@ -131,7 +131,6 @@ VLLM_ROCM_USE_AITER=1 VLLM_ATTENTION_BACKEND="TRITON_MLA" vllm serve deepseek-ai
 
 ```
 
-
 ### 6. DeepSeek MLA (ROCM_AITER_MLA)
 
 For DeepSeek models, vLLM defaults to ROCM_AITER_MLA on supported hardware.
@@ -155,13 +154,15 @@ VLLM_ROCM_USE_AITER=1 vllm serve deepseek-ai/DeepSeek-R1 \
 
 When multiple configurations are provided, vLLM follows this strict priority order:
 
-1.  **Explicit Selection**:
+1. **Explicit Selection**:
     * `VLLM_ATTENTION_BACKEND` takes the highest precedence. If set, other flags are ignored.
-2.  **Implicit Flags** (only checked if no explicit backend is set):
+
+2. **Implicit Flags** (only checked if no explicit backend is set):
     * **Priority 1**: `ROCM_AITER_UNIFIED_ATTN` (if `VLLM_ROCM_USE_AITER=1` AND `VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1`).
     * **Priority 2**: `ROCM_AITER_FA` (if `VLLM_ROCM_USE_AITER=1` AND hardware is `gfx9`).
     * **Priority 3**: `ROCM_ATTN` (if `VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1`).
-3.  **Default**:
+
+3. **Default**:
     * Falls back to `TRITON_ATTN`.
 
 !!! note

--- a/docs/features/rocm_attention_backend.md
+++ b/docs/features/rocm_attention_backend.md
@@ -167,4 +167,3 @@ When multiple configurations are provided, vLLM follows this strict priority ord
 
 !!! note
     Explicitly setting `VLLM_ATTENTION_BACKEND` is the recommended way to debug backend issues, as it bypasses complex flag combinations.
-    

--- a/docs/features/rocm_attention_backend.md
+++ b/docs/features/rocm_attention_backend.md
@@ -167,3 +167,4 @@ When multiple configurations are provided, vLLM follows this strict priority ord
 
 !!! note
     Explicitly setting `VLLM_ATTENTION_BACKEND` is the recommended way to debug backend issues, as it bypasses complex flag combinations.
+    

--- a/docs/features/rocm_attention_backend.md
+++ b/docs/features/rocm_attention_backend.md
@@ -1,0 +1,165 @@
+# ROCm Attention Backends
+
+vLLM on the AMD ROCm platform supports multiple attention backends to optimize performance across a wide range of hardware architectures (e.g., AMD Instinct MI200/MI300 series, Radeon consumer cards) and model architectures (e.g., Llama, DeepSeek-V3/R1).
+
+While vLLM attempts to select the best default backend for your hardware, explicitly selecting a backend allows for fine-grained performance tuning, especially on high-end datacenter GPUs like the MI300X.
+
+## Why Multiple Backends?
+
+The choice of attention backend affects **latency**, **throughput**, and **memory usage**. The primary difference lies in the underlying kernel implementation:
+
+* **Triton Kernels**: Written in OpenAI Triton. They offer excellent portability across different ROCm versions and GPU architectures but might not always squeeze the last bit of performance out of specific hardware.
+* **HIP C++ Kernels**: Native AMD ROCm implementations. Historically used for PagedAttention, providing stable performance.
+* **AITER (Assembly/CK) Kernels**: Kernels from the **A**MD **I**nference **Te**nso**R** library. These are highly optimized, low-level kernels (often written in Assembly or Composable Kernel) specifically tuned for **Matrix Core** architectures like CDNA3 (MI300 series). They typically offer the highest performance but have stricter hardware requirements.
+
+## Backend Architecture Explained
+
+### Standard Attention Backends
+
+These backends are used for standard Transformers models (Llama 3, Qwen 2, Mistral, etc.).
+
+| Backend Name | Description | Use Case |
+| :--- | :--- | :--- |
+| **TRITON_ATTN** | **Default.** Uses vLLM's unified attention implementation written in Triton. Both prefill and decode phases use Triton kernels. | General purpose, high portability, ease of debugging. |
+| **ROCM_ATTN** | Uses a hybrid approach: Triton for chunked prefill and custom HIP C++ kernels for paged attention decode. | Scenarios where specific HIP optimizations outperform Triton. |
+| **ROCM_AITER_FA** | Uses **AITER** (AMD Inference TensoR) Flash Attention kernels. Highly optimized assembly kernels. | **Recommended for MI300 (gfx94x).** Requires `gfx9` architecture. |
+| **ROCM_AITER_UNIFIED_ATTN** | Uses AITER's unified attention implementation. | Alternative AITER path for unified prefill/decode. |
+| **FLEX_ATTENTION** | Uses vLLM's FlexAttention implementation. | Experimental or specific model requirements. |
+
+### MLA Backends (DeepSeek-V3/R1)
+
+DeepSeek models use **Multi-Head Latent Attention (MLA)**, which requires specialized memory handling.
+
+| Backend Name | Description | Configuration |
+| :--- | :--- | :--- |
+| **ROCM_AITER_MLA** | **Recommended.** Optimized AITER Assembly kernels tuned for DeepSeek on AMD hardware. | Supports default `block_size` (16) and `block_size=1`. |
+| **TRITON_MLA** | Portable Triton implementation. | Requires `block_size >= 16`. |
+
+---
+
+## Usage Examples
+
+### Attention Backend on ROCm
+
+You can control the backend selection using the `VLLM_ATTENTION_BACKEND` environment variable.
+
+### 1. TRITON_ATTN (Default)
+
+Uses vLLM's triton unified attention backend.
+
+```bash
+# Example 1: Default behavior (no flags needed)
+vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+# Example 2: Explicitly set the backend
+VLLM_ATTENTION_BACKEND="TRITON_ATTN" vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+# Example 3: Force Triton even if AITER is enabled
+VLLM_ROCM_USE_AITER=1 VLLM_ATTENTION_BACKEND="TRITON_ATTN" vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+# Example 4: Fallback to Triton by disabling AITER MHA
+VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MHA=0 vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+```
+
+### 2. ROCM_ATTN (Hybrid)
+
+Uses vLLM's chunked prefill (Triton) and paged decode (HIP) kernel.
+
+```bash
+
+# Example 1: Explicit selection
+VLLM_ATTENTION_BACKEND="ROCM_ATTN" vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+# Example 2: When enable AITER but still want to use TRITON_ATTN
+VLLM_ROCM_USE_AITER=1 VLLM_ATTENTION_BACKEND="ROCM_ATTN" vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+# Example 3
+VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MHA=0 VLLM_ATTENTION_BACKEND="ROCM_ATTN" vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+# Example 4: Legacy flag combination
+VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MHA=0 VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1 vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+```
+
+### 3. ROCM_AITER_FA (Flash Attention)
+
+Use the AITER Flash Attention backend. Requires gfx9 architecture.
+
+```bash
+
+# Example 1: Only use AITER FA backend without enabling other AITER kernels
+VLLM_ATTENTION_BACKEND="ROCM_AITER_FA" vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+# Example 2: Auto-selection via convenience flag
+VLLM_ROCM_USE_AITER=1 vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+```
+
+### 4. ROCM_AITER_UNIFIED_ATTN
+Use AITER unified attention backend.
+
+```bash
+
+# Example 1: Only use AITER FA backend without enabling other AITER kernels
+VLLM_ATTENTION_BACKEND="ROCM_AITER_UNIFIED_ATTN" vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+# Example 2: Force Unified even if AITER flag is set
+VLLM_ROCM_USE_AITER=1 VLLM_ATTENTION_BACKEND="ROCM_AITER_UNIFIED_ATTN" vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+# Example 3:
+VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MHA=0 VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1 vllm serve meta-llama/Llama-3.1-8B-Instruct
+
+```
+
+### MLA Backend:
+On AMD ROCm, there are TRITON_MLA and ROCM_AITER_MLA
+
+### 5. DeepSeek MLA (TRITON_MLA)
+Uses vLLM's triton MLA backend. The prefill uses triton flash attention/ CK flash attention varlen, and decode uses triton mla decode kernel. Requires block_size >= 16.
+
+```bash
+
+# Example 1: Explicit selection (Requires block_size >= 16)
+VLLM_ATTENTION_BACKEND="TRITON_MLA" vllm serve deepseek-ai/DeepSeek-R1 -tp 8
+
+# Example 2:
+VLLM_ROCM_USE_AITER=1 VLLM_ATTENTION_BACKEND="TRITON_MLA" vllm serve deepseek-ai/DeepSeek-R1 -tp 8
+
+```
+
+
+### 6. DeepSeek MLA (ROCM_AITER_MLA)
+For DeepSeek models, vLLM defaults to ROCM_AITER_MLA on supported hardware.
+
+```bash
+
+# Example 1: Explicit selection
+VLLM_ATTENTION_BACKEND="ROCM_AITER_MLA" vllm serve deepseek-ai/DeepSeek-R1 -tp 8
+
+# Example 2: Implicit selection via AITER flag
+VLLM_ROCM_USE_AITER=1 vllm serve deepseek-ai/DeepSeek-R1 -tp 8
+
+# Example 3: Legacy support (block-size 1)
+VLLM_ROCM_USE_AITER=1 vllm serve deepseek-ai/DeepSeek-R1 -tp 8 --block-size 1
+
+```
+
+
+## Selection Priority
+
+When multiple configurations are provided, vLLM follows this strict priority order:
+
+1.  **Explicit Selection**:
+    * `VLLM_ATTENTION_BACKEND` takes the highest precedence. If set, other flags are ignored.
+
+2.  **Implicit Flags** (only checked if no explicit backend is set):
+    * **Priority 1**: `ROCM_AITER_UNIFIED_ATTN` (if `VLLM_ROCM_USE_AITER=1` AND `VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1`).
+    * **Priority 2**: `ROCM_AITER_FA` (if `VLLM_ROCM_USE_AITER=1` AND hardware is `gfx9`).
+    * **Priority 3**: `ROCM_ATTN` (if `VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1`).
+
+3.  **Default**:
+    * Falls back to `TRITON_ATTN`.
+
+!!! note
+    Explicitly setting `VLLM_ATTENTION_BACKEND` is the recommended way to debug backend issues, as it bypasses complex flag combinations.

--- a/docs/features/rocm_attention_backend.md
+++ b/docs/features/rocm_attention_backend.md
@@ -97,6 +97,7 @@ VLLM_ROCM_USE_AITER=1 vllm serve meta-llama/Llama-3.1-8B-Instruct
 ```
 
 ### 4. ROCM_AITER_UNIFIED_ATTN
+
 Use AITER unified attention backend.
 
 ```bash
@@ -112,10 +113,12 @@ VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MHA=0 VLLM_ROCM_USE_AITER_UNIFIED_ATTE
 
 ```
 
-### MLA Backend:
+### MLA Backend
+
 On AMD ROCm, there are TRITON_MLA and ROCM_AITER_MLA
 
 ### 5. DeepSeek MLA (TRITON_MLA)
+
 Uses vLLM's triton MLA backend. The prefill uses triton flash attention/ CK flash attention varlen, and decode uses triton mla decode kernel. Requires block_size >= 16.
 
 ```bash
@@ -130,6 +133,7 @@ VLLM_ROCM_USE_AITER=1 VLLM_ATTENTION_BACKEND="TRITON_MLA" vllm serve deepseek-ai
 
 
 ### 6. DeepSeek MLA (ROCM_AITER_MLA)
+
 For DeepSeek models, vLLM defaults to ROCM_AITER_MLA on supported hardware.
 
 ```bash
@@ -141,10 +145,11 @@ VLLM_ATTENTION_BACKEND="ROCM_AITER_MLA" vllm serve deepseek-ai/DeepSeek-R1 -tp 8
 VLLM_ROCM_USE_AITER=1 vllm serve deepseek-ai/DeepSeek-R1 -tp 8
 
 # Example 3: Legacy support (block-size 1)
-VLLM_ROCM_USE_AITER=1 vllm serve deepseek-ai/DeepSeek-R1 -tp 8 --block-size 1
-
+VLLM_ROCM_USE_AITER=1 vllm serve deepseek-ai/DeepSeek-R1 \
+  --tp 8 \
+  --block-size 1
+  
 ```
-
 
 ## Selection Priority
 
@@ -152,12 +157,10 @@ When multiple configurations are provided, vLLM follows this strict priority ord
 
 1.  **Explicit Selection**:
     * `VLLM_ATTENTION_BACKEND` takes the highest precedence. If set, other flags are ignored.
-
 2.  **Implicit Flags** (only checked if no explicit backend is set):
     * **Priority 1**: `ROCM_AITER_UNIFIED_ATTN` (if `VLLM_ROCM_USE_AITER=1` AND `VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1`).
     * **Priority 2**: `ROCM_AITER_FA` (if `VLLM_ROCM_USE_AITER=1` AND hardware is `gfx9`).
     * **Priority 3**: `ROCM_ATTN` (if `VLLM_V1_USE_PREFILL_DECODE_ATTENTION=1`).
-
 3.  **Default**:
     * Falls back to `TRITON_ATTN`.
 


### PR DESCRIPTION
## Purpose
This PR adds a new documentation page `attention_backends.md` under the "Features" section.

It provides a comprehensive guide on:
- The differences between available ROCm attention backends (`TRITON_ATTN`, `ROCM_ATTN`, `ROCM_AITER_FA`, etc.).
- How to use the `VLLM_ATTENTION_BACKEND` environment variable to select specific backends.
- Backend selection priority logic.
- Configuration for DeepSeek MLA models on ROCm.

This documentation corresponds to the changes and features solidified in PR #26980.

## Test Plan
- Built the documentation locally using `mkdocs serve`.
- Verified the rendering of tables, code blocks, and admonitions.

## Test Result
The documentation renders correctly.

**Preview:**
<img width="1678" height="1007" alt="Screenshot 2025-11-25 at 20 26 15" src="https://github.com/user-attachments/assets/b51b1ac0-146a-4511-a007-84511d9e57e9" />

