### PR TITLE
Update abort the waiting queue of requests

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -101,7 +101,6 @@ plugins:
           - https://pillow.readthedocs.io/en/stable/objects.inv
           - https://numpy.org/doc/stable/objects.inv
           - https://pytorch.org/docs/stable/objects.inv
-          - https://psutil.readthedocs.io/en/stable/objects.inv
 
 markdown_extensions:
   - attr_list

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -10,6 +10,7 @@ from pydantic import Field, field_validator
 from pydantic.dataclasses import dataclass
 from typing_extensions import Self, deprecated
 
+from vllm import envs
 from vllm.config.utils import config
 from vllm.logger import init_logger
 from vllm.utils.import_utils import resolve_obj_by_qualname
@@ -69,6 +70,10 @@ class SchedulerConfig:
     The default value here is mainly for convenience when testing.
     In real usage, this should be set in `EngineArgs.create_engine_config`.
     """
+
+    max_wait_time_s: float = None
+    """Maximum seconds for a request may stay in the waiting queue before it is
+    automatically aborted. Set to 0 or None to disable."""
 
     is_multimodal_model: bool = False
     """True if the model is multimodal."""
@@ -190,6 +195,14 @@ class SchedulerConfig:
         return handler(value)
 
     def __post_init__(self, max_model_len: int, is_encoder_decoder: bool) -> None:
+        if self.max_wait_time_s is None:
+            env_sched_timeout = envs.VLLM_SCHEDULER_MAX_WAIT_TIME_S
+            if env_sched_timeout is not None:
+                self.max_wait_time_s = env_sched_timeout
+
+        if self.max_wait_time_s is not None and self.max_wait_time_s <= 0:
+            self.max_wait_time_s = None
+
         if is_encoder_decoder:
             # Chunked prefill should be disabled for encoder-decoder models.
             self.disable_chunked_mm_input = True

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -731,6 +731,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_AUDIO_FETCH_TIMEOUT": lambda: int(
         os.getenv("VLLM_AUDIO_FETCH_TIMEOUT", "10")
     ),
+    # Maximum seconds for a request is allowed to stay in the scheduler's waiting
+    # Default is None
+    "VLLM_SCHEDULER_MAX_WAIT_TIME_S": lambda: (
+        float(os.environ["VLLM_SCHEDULER_MAX_WAIT_TIME_S"])
+        if "VLLM_SCHEDULER_MAX_WAIT_TIME_S" in os.environ
+        else None
+    ),
     # Whether to allow HTTP redirects when fetching from media URLs.
     # Default to True
     "VLLM_MEDIA_URL_ALLOW_REDIRECTS": lambda: bool(

--- a/vllm/model_executor/models/interfaces_base.py
+++ b/vllm/model_executor/models/interfaces_base.py
@@ -168,7 +168,7 @@ class VllmModelForPooling(VllmModel[T_co], Protocol[T_co]):
     default_pooling_type: ClassVar[str] = "LAST"
     """
     Indicates the
-    [vllm.model_executor.layers.pooler.PoolerConfig.pooling_type][]
+    [vllm.config.pooler.PoolerConfig.pooling_type][]
     to use by default.
 
     You can use the


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
When a large number of requests arrive, especially those involving long inputs or outputs, it can put pressure on the KV cache, causing the waiting queue to grow rapidly. A timeout should be set for requests in the waiting queue; once the set value is exceeded, the request should be aborted.This ensures higher availability for production services.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

