### PR TITLE
Attempt to fix GPU OOM in a spec-decoding test

### DIFF
--- a/examples/offline_inference/spec_decode.py
+++ b/examples/offline_inference/spec_decode.py
@@ -133,7 +133,7 @@ def main(args):
         tensor_parallel_size=args.tp,
         enable_chunked_prefill=args.enable_chunked_prefill,
         enforce_eager=args.enforce_eager,
-        gpu_memory_utilization=0.8,
+        gpu_memory_utilization=0.9,
         speculative_config=speculative_config,
         disable_log_stats=False,
         max_model_len=args.max_model_len,


### PR DESCRIPTION
More context: this [PR](https://github.com/vllm-project/vllm/pull/29086) is causing one of the examples test to fail in CI.

The reason the test is failing is CUDA OOM, because after this PR, we are **correctly** loading weights of a speculator model in that specific test, whereas in the previous version we were **incorrectly** skipping its `embed_tokens.weight` layer and we were just overriding it with verifier's weights.
Because right now, we are correctly loading the weights of the model, we are consuming ~1GB more of the GPU memory which is causing CUDA OOM in the CI on this specific test: https://buildkite.com/vllm/ci/builds/40604/steps/canvas?sid=019abae0-0d4c-420a-bb72-8ae60a879d2e

```
python3 offline_inference/spec_decode.py --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
```
Side note: I have also tried to reproduce the issue locally on a 24GB GPU (though not L4 as in the CI, but RTX 3090) and both, with and without the PR, there are no issues with CUDA OOM (in fact the max concurrency is ~4) (edited)