### PR TITLE
[Core] Whisper Enable Encoder Batching

### DIFF
--- a/tests/entrypoints/openai/test_transcription_validation_whisper.py
+++ b/tests/entrypoints/openai/test_transcription_validation_whisper.py
@@ -49,6 +49,7 @@ async def test_basic_audio(whisper_client, mary_had_lamb):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skip(reason="Skipping batched test due to interaction with other tests")
 async def test_basic_audio_batched(mary_had_lamb, winning_call, whisper_client):
     transcription = whisper_client.audio.transcriptions.create(
         model=MODEL_NAME,

--- a/tests/entrypoints/openai/test_transcription_validation_whisper.py
+++ b/tests/entrypoints/openai/test_transcription_validation_whisper.py
@@ -143,7 +143,6 @@ async def test_streaming_response(winning_call, whisper_client):
         language="en",
         temperature=0.0,
         stream=True,
-        timeout=30,
     )
     # Reconstruct from chunks and validate
     async for chunk in res:
@@ -162,7 +161,6 @@ async def test_stream_options(winning_call, whisper_client):
         temperature=0.0,
         stream=True,
         extra_body=dict(stream_include_usage=True, stream_continuous_usage_stats=True),
-        timeout=30,
     )
     final = False
     continuous = True

--- a/tests/entrypoints/openai/test_transcription_validation_whisper.py
+++ b/tests/entrypoints/openai/test_transcription_validation_whisper.py
@@ -220,6 +220,8 @@ async def test_audio_prompt(mary_had_lamb, whisper_client):
         temperature=0.0,
     )
     out = json.loads(transcription)["text"]
+    # Might cause timeout if the file is not seekable.
+    mary_had_lamb.seek(0)
     assert prefix in out
     transcription_wprompt = await whisper_client.audio.transcriptions.create(
         model=MODEL_NAME,

--- a/tests/entrypoints/openai/test_transcription_validation_whisper.py
+++ b/tests/entrypoints/openai/test_transcription_validation_whisper.py
@@ -49,7 +49,6 @@ async def test_basic_audio(whisper_client, mary_had_lamb):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Skipping batched test due to interaction with other tests")
 async def test_basic_audio_batched(mary_had_lamb, winning_call, whisper_client):
     transcription = whisper_client.audio.transcriptions.create(
         model=MODEL_NAME,

--- a/tests/entrypoints/openai/test_transcription_validation_whisper.py
+++ b/tests/entrypoints/openai/test_transcription_validation_whisper.py
@@ -136,6 +136,7 @@ async def test_streaming_response(winning_call, whisper_client):
         language="en",
         temperature=0.0,
     )
+    winning_call.seek(0)
     res = await whisper_client.audio.transcriptions.create(
         model=MODEL_NAME,
         file=winning_call,

--- a/tests/entrypoints/openai/test_transcription_validation_whisper.py
+++ b/tests/entrypoints/openai/test_transcription_validation_whisper.py
@@ -136,13 +136,13 @@ async def test_streaming_response(winning_call, whisper_client):
         language="en",
         temperature=0.0,
     )
-    winning_call.seek(0)
     res = await whisper_client.audio.transcriptions.create(
         model=MODEL_NAME,
         file=winning_call,
         language="en",
         temperature=0.0,
         stream=True,
+        timeout=30,
     )
     # Reconstruct from chunks and validate
     async for chunk in res:
@@ -161,6 +161,7 @@ async def test_stream_options(winning_call, whisper_client):
         temperature=0.0,
         stream=True,
         extra_body=dict(stream_include_usage=True, stream_continuous_usage_stats=True),
+        timeout=30,
     )
     final = False
     continuous = True
@@ -219,8 +220,6 @@ async def test_audio_prompt(mary_had_lamb, whisper_client):
         temperature=0.0,
     )
     out = json.loads(transcription)["text"]
-    # Might cause timeout if the file is not seekable.
-    mary_had_lamb.seek(0)
     assert prefix in out
     transcription_wprompt = await whisper_client.audio.transcriptions.create(
         model=MODEL_NAME,

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -539,6 +539,11 @@ class ModelConfig:
 
         self.original_max_model_len = self.max_model_len
         self.max_model_len = self.get_and_verify_max_len(self.max_model_len)
+
+        if self.is_encoder_decoder:
+            self.mm_processor_cache_gb = 0
+            logger.info("Encoder-decoder model detected, disabling mm processor cache.")
+
         # Init multimodal config if needed
         if self._model_info.supports_multimodal:
             if (

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -753,9 +753,9 @@ class VllmConfig:
         if self.model_config and self.model_config.is_encoder_decoder:
             from vllm.multimodal import MULTIMODAL_REGISTRY
 
-            self.scheduler_config.max_num_encoder_input_tokens = (
-                MULTIMODAL_REGISTRY.get_encdec_max_encoder_len(self.model_config)
-            )
+            # self.scheduler_config.max_num_encoder_input_tokens = (
+            #     MULTIMODAL_REGISTRY.get_encdec_max_encoder_len(self.model_config)
+            # )
             logger.debug(
                 "Encoder-decoder model detected: setting "
                 "`max_num_encoder_input_tokens` to encoder length (%s)",

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -751,7 +751,8 @@ class VllmConfig:
         self._set_compile_ranges()
 
         if (
-            self.model_config.architecture == "WhisperForConditionalGeneration"
+            self.model_config
+            and self.model_config.architecture == "WhisperForConditionalGeneration"
             and os.environ.get("VLLM_WORKER_MULTIPROC_METHOD") != "spawn"
         ):
             logger.warning(

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -750,27 +750,16 @@ class VllmConfig:
         # TODO: Move after https://github.com/vllm-project/vllm/pull/26847 lands
         self._set_compile_ranges()
 
-        if self.model_config and self.model_config.is_encoder_decoder:
-            from vllm.multimodal import MULTIMODAL_REGISTRY
-
-            # self.scheduler_config.max_num_encoder_input_tokens = (
-            #     MULTIMODAL_REGISTRY.get_encdec_max_encoder_len(self.model_config)
-            # )
-            logger.debug(
-                "Encoder-decoder model detected: setting "
-                "`max_num_encoder_input_tokens` to encoder length (%s)",
-                self.scheduler_config.max_num_encoder_input_tokens,
+        if (
+            self.model_config.architecture == "WhisperForConditionalGeneration"
+            and os.environ.get("VLLM_WORKER_MULTIPROC_METHOD") != "spawn"
+        ):
+            logger.warning(
+                "Whisper is known to have issues with "
+                "forked workers. If startup is hanging, "
+                "try setting 'VLLM_WORKER_MULTIPROC_METHOD' "
+                "to 'spawn'."
             )
-            if (
-                self.model_config.architecture == "WhisperForConditionalGeneration"
-                and os.environ.get("VLLM_WORKER_MULTIPROC_METHOD") != "spawn"
-            ):
-                logger.warning(
-                    "Whisper is known to have issues with "
-                    "forked workers. If startup is hanging, "
-                    "try setting 'VLLM_WORKER_MULTIPROC_METHOD' "
-                    "to 'spawn'."
-                )
 
         if (
             self.kv_events_config is not None

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -604,8 +604,7 @@ class WhisperModel(nn.Module):
         positions: torch.Tensor,
         encoder_outputs: list[torch.Tensor],
     ) -> torch.Tensor:
-        assert len(encoder_outputs) in (0, 1)
-        enc_states = encoder_outputs[0] if len(encoder_outputs) == 1 else None
+        enc_states = torch.cat(encoder_outputs, dim=0) if len(encoder_outputs) else None
         decoder_outputs = self.decoder(
             input_ids=input_ids,
             positions=positions,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -941,15 +941,18 @@ class Scheduler(SchedulerInterface):
                 # in the decoder's KV cache.
                 continue
 
+            # Check and update encoder cache accounting.
+            # This ensures proper tracking of freeable entries.
+            is_cached = self.encoder_cache_manager.check_and_update_cache(request, i)
             if not self.is_encoder_decoder:
-                # We are not using the encoder cache for encoder-decoder models,
-                # yet.
+                # We are not using the cache for encoder-decoder models -schedule even
+                # if cached- but we have to update the encoder cache state regardless.
                 if request.mm_features[i].identifier in mm_hashes_to_schedule:
                     # The same encoder input has already been scheduled in the
                     # current step.
                     continue
 
-                if self.encoder_cache_manager.check_and_update_cache(request, i):
+                if is_cached:
                     # The encoder input is already computed and cached from a
                     # previous step.
                     continue


### PR DESCRIPTION
This PR addresses an important performance limitation of our current Whisper implementation, that is the encoder is only running one request at a time, instead of scheduling multiple audios and batching them in a single (encoder) forward. 
This is particularly bad at high-memory/high request rates deployments.  

To summarize changes with some examples:
```
# MAIN

(EngineCore_DP0 pid=2996843) INFO 11-25 18:02:30 [gpu_model_runner.py:4220] Encoder cache will be initialized with a budget of 1500 tokens, and profiled with 1 audio items of the maximum feature size.

# Extra-logging added for debugging 
***ENCODER INPUT HIDDEN STATES*** torch.Size([1500, 1280])

```
---
```
# PR

Encoder cache will be initialized with a budget of 32768 tokens, and profiled with 21 audio items of the maximum feature size.

# Extra-logging added for debugging 
***ENCODER INPUT HIDDEN STATES*** torch.Size([12, 1500, 1280])
```

These changes build on top of this PR https://github.com/vllm-project/vllm/pull/29268 to generalize seq_lens.

Changes here are confined to:
 
 Whisper: just batching hidden states properly before MHA
 
 Scheduling: avoid constraining `self.scheduler_config.max_num_encoder_input_tokens` to max size of one item. This effectively inhibits the EncoderCache from allowing multiple items in a scheduling step.
 
 ~~More scheduling: there's an issue related to skipping `check_and_update_cache` for requests with same input.  
 The problem is that `EncoderCacheManager.allocate()` always decrements slots, even when reusing an entry from freeable. This causes `num_freeable_slots` and `freeable` to get out of sync, as `check_and_update_cache()` is always skipped for encoder-decoder.~~
~~What I did in this PR is to have encoder-decoder models call `check_and_update_cache`, but stil schedule the encoder input even if cached. This allows to keep the cache state in sync while retaining previous behavior.~~
 Future work can focus on enabling the cache for Whisper, now that the flow is getting more and more aligned with MM models.

EDIT: I have instead provided a much simpler alternative cache that clearly highlights the workflow of enc-dec models (for scheduling only).

## Results

```
# MAIN


# 10
RESULTS SUMMARY
================================================================================
Total samples: 10
Successful: 10
Failed: 0
Total time: 0.39s
Average latency: 0.19s
Throughput: 25.96 requests/s

# 50

================================================================================
RESULTS SUMMARY
================================================================================
Total samples: 73
Successful: 73
Failed: 0
Total time: 1.35s
Average latency: 0.63s
Throughput: 54.27 requests/s

==========================================================================
```

```
# This PR

# 10
================================================================================
RESULTS SUMMARY
================================================================================
Total samples: 10
Successful: 10
Failed: 0
Total time: 0.35s
Average latency: 0.15s
Throughput: 28.83 requests/s

# 50
================================================================================
RESULTS SUMMARY
================================================================================
Total samples: 73
Successful: 73
Failed: 0
Total time: 0.98s
Average latency: 0.49s
Throughput: 74.32 requests/s
```


cc @DarkLight1337 @russellb 