### PR TITLE
[Bugfix] Fix HunyuanVL XD-RoPE and smart_resize bugs

### DIFF
--- a/vllm/model_executor/models/hunyuan_vision.py
+++ b/vllm/model_executor/models/hunyuan_vision.py
@@ -847,7 +847,7 @@ class HunYuanVLForConditionalGeneration(
                 .expand(-1, llm_grid_w + 1)
                 .reshape(-1)
             )
-            h_index[pos : pos + token_num] = 0
+            t_index[pos : pos + token_num] = 0
 
         if xd_num == 4:
             llm_positions = torch.stack([p_index, w_index, h_index, t_index])

--- a/vllm/transformers_utils/processors/hunyuan_vl_image.py
+++ b/vllm/transformers_utils/processors/hunyuan_vl_image.py
@@ -195,9 +195,9 @@ class HunYuanVLImageProcessor(BaseImageProcessor):
         processed_images = []
         for image in images:
             if do_resize:
-                resized_width, resized_height = smart_resize(
-                    width,
+                resized_height, resized_width = smart_resize(
                     height,
+                    width,
                     factor=patch_size * merge_size,
                     min_pixels=self.min_pixels,
                     max_pixels=self.max_pixels,


### PR DESCRIPTION
## Purpose
Fix two critical bugs in HunyuanVL implementation that cause incorrect spatial localization (e.g., "squeezed" Y coordinates in detection masks):
- XD-RoPE height index zeroing: In get_xdrope_input_positions, the h_index was incorrectly zeroed after being computed, removing vertical spatial awareness for image tokens. Fixed by setting t_index = 0 instead (correct for static images since temporal dimension is always 1).
- smart_resize argument swap: The function signature is smart_resize(height, width, ...) returning (h_bar, w_bar), but it was called with (width, height) and assigned to (resized_width, resized_height). This caused incorrect resizing for non-square aspect ratios.

## Test Plan
Tested with HunyuanOCR model on images with various aspect ratios. Before the fix, detected text bounding boxes were vertically compressed. After the fix, bounding boxes correctly match text positions.

## Test Result
- Before: Detection mask Y coordinates were "squeezed" - vertical positions incorrect
- After: Detection mask correctly covers full image height with accurate text localization
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
