### PR TITLE
[bugfix] Pass globals to aot_compiled function

### DIFF
--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -409,7 +409,9 @@ def _support_torch_compile(
                     open(aot_compilation_path, "rb") as f,
                 ):
                     start_monitoring_torch_compile(self.vllm_config)
-                    loaded_fn = torch.compiler.load_compiled_function(f)
+                    loaded_fn = torch.compiler.load_compiled_function(
+                        f, f_globals=self.forward.__globals__
+                    )
                 _verify_source_unchanged(loaded_fn.source_info(), self.vllm_config)
                 loaded_fn.disable_guard_check()
                 self.aot_compiled_fn = loaded_fn


### PR DESCRIPTION
We need to pass additional globals such as `IntermediateTensors` to the AOT compiled function.

Corresponding pytorch change: https://github.com/pytorch/pytorch/pull/169070
Fixes https://github.com/vllm-project/vllm/issues/27591

Also confirmed this fixes the distributed/test_sequence_parallel.py tests that are failing in https://github.com/pytorch/pytorch/actions/runs/19794165965/job/56713564450?pr=166494

cc @zhxchen17 