### PR TITLE
[BugFix] Fix assertion for single world use case (uni)

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -595,7 +595,8 @@ class ParallelConfig:
             )
         if self.distributed_executor_backend not in ("mp", "uni") and self.nnodes > 1:
             raise ValueError(
-                f"nnodes > 1 can only be set when distributed exectuor backend is mp or uni"
+                "nnodes > 1 can only be set when distributed executor "
+                "backend is mp or uni."
             )
 
     @property

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -593,9 +593,9 @@ class ParallelConfig:
                 "max_parallel_loading_workers is currently "
                 "not supported and will be ignored."
             )
-        if self.distributed_executor_backend != "mp" and self.nnodes > 1:
+        if self.distributed_executor_backend not in ("mp", "uni") and self.nnodes > 1:
             raise ValueError(
-                "nnodes > 1 can only be set when distributed exectuor backend is mp."
+                f"nnodes > 1 can only be set when distributed exectuor backend is mp or uni"
             )
 
     @property


### PR DESCRIPTION
Summary: we don't have limitation of using nnodes when it is uni, so add back uni in assertion for config

Differential Revision: D87877588

**Test Plan**

Test with TP=1 DP=4
```
CUDA_VISIBLE_DEVICES=0,1 vllm serve "Qwen/Qwen3-1.7B" -dp=4 -tp=1 --max-model-len=32768 --nnodes 2 --node-rank 0 --master-addr 127.0.0.1 --port 8000 > /tmp/test_dp0.log 2>&1 &

CUDA_VISIBLE_DEVICES=2,3 vllm serve "Qwen/Qwen3-1.7B" -dp=4 -tp=1 --max-model-len=32768 --nnodes 2 --node-rank 1 --master-addr 127.0.0.1 --headless > /tmp/test_dp1.log 2>&1 &
```

```
lm_eval --model local-completions --tasks gsm8k     --model_args model=Qwen/Qwen3-1.7B,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=200,max_retries=3,tokenized_requests=False     --limit 1000
```
**Test Results**

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.691|±  |0.0146|
|     |       |strict-match    |     5|exact_match|↑  |0.688|±  |0.0147|

