### PR TITLE
dummy run corner case

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2792,7 +2792,7 @@ class GPUModelRunner(
                         # returns True. before returning early here we call
                         # dummy run to ensure coordinate_batch_across_dp
                         # is called into to avoid out of sync issues.
-                        self._dummy_run(1)
+                        self._dummy_run(self._get_num_input_tokens(1))
                     if not has_kv_transfer_group():
                         # Return empty ModelRunnerOutput if no work to do.
                         return EMPTY_MODEL_RUNNER_OUTPUT


### PR DESCRIPTION
Previous PR [#28774](https://github.com/vllm-project/vllm/pull/28774) attempts to fix DP out of sync issue by adding a dummy_run call from DP ranks without active requests. It works for most of the time except a even rarer case. When async scheduling is enabled, all DP ranks could issue a dummy microbatch at the same time. In this case coordinate_batch_across_dp() will pad to 1 instead of at least sequence_parallel_size.