### PR TITLE
[Hybrid] Remove use of PAD_SLOT_ID for causal_conv_1d

### DIFF
--- a/vllm/v1/attention/backends/mamba2_attn.py
+++ b/vllm/v1/attention/backends/mamba2_attn.py
@@ -98,6 +98,7 @@ class Mamba2AttentionMetadata:
     num_prefill_tokens: int
     num_decodes: int
     num_decode_tokens: int
+    query_start_loc_d: torch.Tensor
     query_start_loc_p: torch.Tensor
     seq_lens: torch.Tensor
 
@@ -321,11 +322,14 @@ class Mamba2AttentionMetadataBuilder(
             ]
             block_idx_last_computed_token[num_decodes:] = 0
 
+        query_start_loc_d = common_attn_metadata.query_start_loc[: (1 + num_decodes)]
+
         attn_metadata = Mamba2AttentionMetadata(
             num_prefills=num_prefills,
             num_prefill_tokens=num_prefill_tokens,
             num_decodes=num_decodes,
             num_decode_tokens=num_decode_tokens,
+            query_start_loc_d=query_start_loc_d,
             query_start_loc_p=query_start_loc_p,
             seq_lens=seq_lens,
             prep_initial_states=prep_initial_states,

--- a/vllm/v1/attention/backends/mamba2_attn.py
+++ b/vllm/v1/attention/backends/mamba2_attn.py
@@ -10,7 +10,6 @@ from vllm.config import VllmConfig
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.mamba_attn import BaseMambaAttentionMetadataBuilder
 from vllm.v1.attention.backends.utils import (
-    PAD_SLOT_ID,
     CommonAttentionMetadata,
     compute_causal_conv1d_metadata,
     split_decodes_and_prefills,
@@ -303,31 +302,24 @@ class Mamba2AttentionMetadataBuilder(
         elif (
             num_decodes <= self.decode_cudagraph_max_bs
             and self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+            and self.vllm_config.cache_config.enable_prefix_caching
         ):
-            # Pad state tensor for CUDA graph
             num_input_tokens = self.vllm_config.pad_for_cudagraph(num_decodes)
-            self.state_indices_tensor[:num_decodes].copy_(
-                state_indices_tensor, non_blocking=True
+            self.block_idx_last_scheduled_token[:num_decodes].copy_(
+                block_idx_last_scheduled_token, non_blocking=True
             )
-            state_indices_tensor = self.state_indices_tensor[:num_input_tokens]
-            state_indices_tensor[num_decodes:] = PAD_SLOT_ID
+            block_idx_last_scheduled_token = self.block_idx_last_scheduled_token[
+                :num_input_tokens
+            ]
+            block_idx_last_scheduled_token[num_decodes:] = 0
 
-            if self.vllm_config.cache_config.enable_prefix_caching:
-                self.block_idx_last_scheduled_token[:num_decodes].copy_(
-                    block_idx_last_scheduled_token, non_blocking=True
-                )
-                block_idx_last_scheduled_token = self.block_idx_last_scheduled_token[
-                    :num_input_tokens
-                ]
-                block_idx_last_scheduled_token[num_decodes:] = 0
-
-                self.block_idx_last_computed_token[:num_decodes].copy_(
-                    block_idx_last_computed_token, non_blocking=True
-                )
-                block_idx_last_computed_token = self.block_idx_last_computed_token[
-                    :num_input_tokens
-                ]
-                block_idx_last_computed_token[num_decodes:] = 0
+            self.block_idx_last_computed_token[:num_decodes].copy_(
+                block_idx_last_computed_token, non_blocking=True
+            )
+            block_idx_last_computed_token = self.block_idx_last_computed_token[
+                :num_input_tokens
+            ]
+            block_idx_last_computed_token[num_decodes:] = 0
 
         attn_metadata = Mamba2AttentionMetadata(
             num_prefills=num_prefills,


### PR DESCRIPTION
## Purpose

The causal conv kernels use (/misuse) the `PAD_SLOT_ID` to indicate where padding in the state indices tensor exists. This creates a headache when doing meta-data building for FCG because we need to ensure that the PAD_SLOT_IDs are inserted in the right place all the time. This shouldn't actually be necessary 

This PR:

- Strips out the use of `PAD_SLOT_ID` from the kernels, instead relying on the varlen representation to do the correct thing if some sequences in the batch have query length 0
- Ensures we use the varlen representation when calling the "update" kernel for decode from the Mamba2 mixer
- Removes some of the weirdness regarding the "metadata" is passed to the kernels

cc @LucasWilkinson 

TODO:
- Change other models that use these kernels 

## Test Plan

I've verified that the mamba2 tests and the kernel tests are passing

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

