### PR TITLE
Change warning logs to debug for unimplemented MXFP4 Linear/Attention

### DIFF
--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -198,7 +198,8 @@ class Mxfp4Config(QuantizationConfig):
             # if you are interested in enabling MXFP4 here.
             logger.debug_once(
                 "MXFP4 linear layer is not implemented - falling back to "
-                "UnquantizedLinearMethod."
+                "UnquantizedLinearMethod.",
+                scope="local"
             )
             return UnquantizedLinearMethod()
         elif isinstance(layer, FusedMoE):

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -210,7 +210,8 @@ class Mxfp4Config(QuantizationConfig):
             # TODO: Add support for MXFP4 Attention.
             logger.debug_once(
                 "MXFP4 attention layer is not implemented. "
-                "Skipping quantization for this layer."
+                "Skipping quantization for this layer.",
+                scope="local"
             )
         return None
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -196,7 +196,7 @@ class Mxfp4Config(QuantizationConfig):
             # TODO: Add support for MXFP4 Linear Method.
             # MXFP4 LinearMethod is available in AMD-Quark, refer to that implementation
             # if you are interested in enabling MXFP4 here.
-            logger.warning_once(
+            logger.debug_once(
                 "MXFP4 linear layer is not implemented - falling back to "
                 "UnquantizedLinearMethod."
             )
@@ -208,7 +208,7 @@ class Mxfp4Config(QuantizationConfig):
                 return Mxfp4MoEMethod(layer.moe_config)
         elif isinstance(layer, Attention):
             # TODO: Add support for MXFP4 Attention.
-            logger.warning_once(
+            logger.debug_once(
                 "MXFP4 attention layer is not implemented. "
                 "Skipping quantization for this layer."
             )

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -199,7 +199,7 @@ class Mxfp4Config(QuantizationConfig):
             logger.debug_once(
                 "MXFP4 linear layer is not implemented - falling back to "
                 "UnquantizedLinearMethod.",
-                scope="local"
+                scope="local",
             )
             return UnquantizedLinearMethod()
         elif isinstance(layer, FusedMoE):
@@ -212,7 +212,7 @@ class Mxfp4Config(QuantizationConfig):
             logger.debug_once(
                 "MXFP4 attention layer is not implemented. "
                 "Skipping quantization for this layer.",
-                scope="local"
+                scope="local",
             )
         return None
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

These warnings are too loud for the user and confusing since gpt-oss doesn't have these layers quantized
```
(Worker_TP0 pid=3982331) INFO 11-25 20:04:34 [gpu_model_runner.py:3377] Starting to load model openai/gpt-oss-120b...
(Worker_TP1 pid=3982332) WARNING 11-25 20:04:34 [mxfp4.py:199] MXFP4 linear layer is not implemented - falling back to UnquantizedLinearMethod.
(Worker_TP1 pid=3982332) WARNING 11-25 20:04:34 [mxfp4.py:211] MXFP4 attention layer is not implemented. Skipping quantization for this layer.
(Worker_TP0 pid=3982331) WARNING 11-25 20:04:34 [mxfp4.py:199] MXFP4 linear layer is not implemented - falling back to UnquantizedLinearMethod.
(Worker_TP0 pid=3982331) WARNING 11-25 20:04:34 [mxfp4.py:211] MXFP4 attention layer is not implemented. Skipping quantization for this layer.
```

Not sure why they were added in https://github.com/vllm-project/vllm/pull/27334/ as unfinished

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

