### PR TITLE
[Hybrid] Mamba2 metadata caching

### DIFF
--- a/vllm/v1/attention/backends/mamba2_attn.py
+++ b/vllm/v1/attention/backends/mamba2_attn.py
@@ -403,5 +403,10 @@ class CachedMamba2AttentionMetadataBuilder(Mamba2AttentionMetadataBuilder):
                 CachedMamba2AttentionMetadataBuilder.cache_content
             )
             # Update the part that changes across cache groups:
-            attn_metadata.state_indices_tensor = common_attn_metadata.block_table_tensor
+            if self.vllm_config.cache_config.enable_prefix_caching:
+                state_indices_t = common_attn_metadata.block_table_tensor
+            else:
+                # Always return just a single block per each request:
+                state_indices_t = common_attn_metadata.block_table_tensor[:, 0]
+            attn_metadata.state_indices_tensor = state_indices_t
         return attn_metadata


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model

## Purpose
This PR implements caching Mamba2 metadata across KVCache groups for hybrid models.

Logic before this PR:
- each KVCache group recomputes entire Mamba2 metadata for the same request
- if model has multiple KVCache groups, computation is duplicated
- metadata computation is especially heavy with APC turned on

This PR adds logic to reuse the computed metadata. It clones cached metadata, updates the block table, and returns such metadata to respective KVCache groups, avoiding recomputation. The benefits of this PR become especially evident for decode-heavy workloads with APC enabled, where metadata computation overhead becomes substantial.

@tdoublep @bohnstingl

## Test Plan
Decode-heavy workload with APC enabled => **latency reduction through this PR: 13%**
```
vllm bench latency --model ibm-granite/granite-4.0-tiny-preview --input-len 128  --output-len 2048 \
    --batch-size 8 --enable-prefix-caching --num-iters 10 --num-iters-warmup 2
```

Decode-heavy workload with APC disabled => **latency reduction through this PR: 1.5%**
```
vllm bench latency --model ibm-granite/granite-4.0-tiny-preview --input-len 128  --output-len 2048 \
    --batch-size 8 --num-iters 10 --num-iters-warmup 2
```

## Test Result

### APC enabled:

Main:
```
Avg latency: 17.038125047204083 seconds
10% percentile latency: 16.98981153902132 seconds
25% percentile latency: 16.993707616697066 seconds
50% percentile latency: 17.02577391010709 seconds
75% percentile latency: 17.05604780995054 seconds
90% percentile latency: 17.07584611333441 seconds
99% percentile latency: 17.1920812219684 seconds
```

This PR:
```
Avg latency: 15.131242127297446 seconds
10% percentile latency: 15.071378623321653 seconds
25% percentile latency: 15.074652562849224 seconds
50% percentile latency: 15.09004262345843 seconds
75% percentile latency: 15.137115802557673 seconds
90% percentile latency: 15.17231842649635 seconds
99% percentile latency: 15.398847624200862 seconds
```

### APC disabled:
Main:
```
Avg latency: 14.55005754402373 seconds
10% percentile latency: 14.531937776482664 seconds
25% percentile latency: 14.536305553978309 seconds
50% percentile latency: 14.546665354049765 seconds
75% percentile latency: 14.563693342497572 seconds
90% percentile latency: 14.572672403673641 seconds
99% percentile latency: 14.576146279859822 seconds
```

This PR:
```
Avg latency: 14.34330539361108 seconds
10% percentile latency: 14.328900095191784 seconds
25% percentile latency: 14.332552855426911 seconds
50% percentile latency: 14.3457251455402 seconds
75% percentile latency: 14.350063848076388 seconds
90% percentile latency: 14.354553794115782 seconds
99% percentile latency: 14.362273742058314 seconds
```