### PR TITLE
[Bug] Fix log issue with repeating useless information

### DIFF
--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -204,9 +204,10 @@ class SchedulerConfig:
         self.encoder_cache_size = self.max_num_batched_tokens
 
         if self.enable_chunked_prefill:
-            logger.info(
+            logger.info_once(
                 "Chunked prefill is enabled with max_num_batched_tokens=%d.",
                 self.max_num_batched_tokens,
+                scope="local",
             )
 
         if self.max_num_partial_prefills > 1:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1152,7 +1152,7 @@ def get_current_vllm_config() -> VllmConfig:
         # in ci, usually when we test custom ops/modules directly,
         # we don't set the vllm config. In that case, we set a default
         # config.
-        logger.warning("Current vLLM config is not set.")
+        logger.warning_once("Current vLLM config is not set.", scope="local")
         return VllmConfig()
     return _current_vllm_config
 


### PR DESCRIPTION
## Purpose

```bash
EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP5 pid=4095169) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP2 pid=4095166) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP3 pid=4095167) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP5 pid=4095169) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP1 pid=4095165) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP2 pid=4095166) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP5 pid=4095169) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP2 pid=4095166) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP3 pid=4095167) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP1 pid=4095165) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP5 pid=4095169) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP2 pid=4095166) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP5 pid=4095169) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP2 pid=4095166) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP3 pid=4095167) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP1 pid=4095165) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP2 pid=4095166) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP5 pid=4095169) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP2 pid=4095166) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP5 pid=4095169) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP3 pid=4095167) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP5 pid=4095169) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP2 pid=4095166) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP1 pid=4095165) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP0 pid=4095164) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP5 pid=4095169) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP2 pid=4095166) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP3 pid=4095167) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP5 pid=4095169) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP2 pid=4095166) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP1 pid=4095165) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP5 pid=4095169) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP2 pid=4095166) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP3 pid=4095167) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP5 pid=4095169) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP2 pid=4095166) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP1 pid=4095165) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP0 pid=4095164) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP5 pid=4095169) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP2 pid=4095166) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP3 pid=4095167) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP5 pid=4095169) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP1 pid=4095165) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP2 pid=4095166) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP5 pid=4095169) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP2 pid=4095166) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP3 pid=4095167) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP2 pid=4095166) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP1 pid=4095165) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP5 pid=4095169) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP2 pid=4095166) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP5 pid=4095169) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP3 pid=4095167) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP7 pid=4095171) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP1 pid=4095165) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP0 pid=4095164) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP5 pid=4095169) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP2 pid=4095166) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP5 pid=4095169) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP2 pid=4095166) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP3 pid=4095167) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP7 pid=4095171) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP0 pid=4095164) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP1 pid=4095165) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP2 pid=4095166) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP5 pid=4095169) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP2 pid=4095166) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP3 pid=4095167) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP5 pid=4095169) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP5 pid=4095169) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP2 pid=4095166) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP1 pid=4095165) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP5 pid=4095169) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP2 pid=4095166) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP3 pid=4095167) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP7 pid=4095171) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP1 pid=4095165) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP0 pid=4095164) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP5 pid=4095169) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP2 pid=4095166) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP3 pid=4095167) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP5 pid=4095169) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP2 pid=4095166) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP7 pid=4095171) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP1 pid=4095165) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP4 pid=4095168) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP6 pid=4095170) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP0 pid=4095164) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP2 pid=4095166) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP5 pid=4095169) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP3 pid=4095167) WARNING 11-25 21:32:26 [vllm.py:1155] Current vLLM config is not set.
(EngineCore_DP7 pid=4095171) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP4 pid=4095168) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP6 pid=4095170) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP1 pid=4095165) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
(EngineCore_DP0 pid=4095164) INFO 11-25 21:32:26 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tok
.....
```

Now only print once