### PR TITLE
[Kernels] Unify CPU-to-device tensor view API as get_device_view_from_cpu_tensor

### DIFF
--- a/csrc/cuda_view.cu
+++ b/csrc/cuda_view.cu
@@ -4,7 +4,7 @@
 
 // This function assumes that `cpu_tensor` is a CPU tensor allocated with pinned
 // memory, and that UVA (Unified Virtual Addressing) is enabled.
-torch::Tensor get_cuda_view_from_cpu_tensor(torch::Tensor& cpu_tensor) {
+torch::Tensor get_device_view_from_cpu_tensor(torch::Tensor& cpu_tensor) {
   TORCH_CHECK(cpu_tensor.device().is_cpu(), "Input tensor must be on CPU");
 
   // Get raw host pointer from CPU tensor

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -174,7 +174,7 @@ void cutlass_mla_decode(torch::Tensor const& out, torch::Tensor const& q_nope,
                         torch::Tensor const& seq_lens,
                         torch::Tensor const& page_table, double scale);
 
-torch::Tensor get_cuda_view_from_cpu_tensor(torch::Tensor& cpu_tensor);
+torch::Tensor get_device_view_from_cpu_tensor(torch::Tensor& cpu_tensor);
 
 #ifndef USE_ROCM
 

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -30,9 +30,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("weak_ref_tensor(Tensor input) -> Tensor");
   ops.impl("weak_ref_tensor", torch::kCUDA, &weak_ref_tensor);
 
-  ops.def("get_cuda_view_from_cpu_tensor(Tensor cpu_tensor) -> Tensor");
-  ops.impl("get_cuda_view_from_cpu_tensor", torch::kCPU,
-           &get_cuda_view_from_cpu_tensor);
+  ops.def("get_device_view_from_cpu_tensor(Tensor cpu_tensor) -> Tensor");
+  ops.impl("get_device_view_from_cpu_tensor", torch::kCPU,
+           &get_device_view_from_cpu_tensor);
 
   // Attention ops
   // Compute the attention between an input query and the cached

--- a/tests/kernels/core/test_uva.py
+++ b/tests/kernels/core/test_uva.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 from vllm.utils.platform_utils import is_uva_available
-from vllm.utils.torch_utils import get_cuda_view_from_cpu_tensor
+from vllm.utils.torch_utils import get_device_view_from_cpu_tensor
 
 CUDA_DEVICES = [f"cuda:{i}" for i in range(1 if torch.cuda.device_count() == 1 else 2)]
 
@@ -14,7 +14,7 @@ CUDA_DEVICES = [f"cuda:{i}" for i in range(1 if torch.cuda.device_count() == 1 e
 def test_cpu_write(device):
     torch.set_default_device(device)
     cpu_tensor = torch.zeros(10, 10, device="cpu", pin_memory=True, dtype=torch.int32)
-    cuda_view = get_cuda_view_from_cpu_tensor(cpu_tensor)
+    cuda_view = get_device_view_from_cpu_tensor(cpu_tensor)
     assert cuda_view.device.type == "cuda"
 
     assert cuda_view[0, 0] == 0
@@ -36,7 +36,7 @@ def test_cpu_write(device):
 def test_gpu_write(device):
     torch.set_default_device(device)
     cpu_tensor = torch.zeros(10, 10, device="cpu", pin_memory=True, dtype=torch.int32)
-    cuda_view = get_cuda_view_from_cpu_tensor(cpu_tensor)
+    cuda_view = get_device_view_from_cpu_tensor(cpu_tensor)
     assert cuda_view.device.type == "cuda"
 
     assert cuda_view[0, 0] == 0

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -35,7 +35,7 @@ from vllm.utils.platform_utils import (
 )
 from vllm.utils.torch_utils import (
     direct_register_custom_op,
-    get_cuda_view_from_cpu_tensor,
+    get_device_view_from_cpu_tensor,
 )
 
 logger = init_logger(__name__)
@@ -611,7 +611,7 @@ def maybe_offload_to_cpu(module: torch.nn.Module) -> torch.nn.Module:
         else:
             # keep the cpu data alive
             p._vllm_offloaded_cpu_data = cpu_data
-            p.data = get_cuda_view_from_cpu_tensor(cpu_data)
+            p.data = get_device_view_from_cpu_tensor(cpu_data)
         _CPU_OFFLOAD_BYTES += p.data.numel() * p.data.element_size()
         offloaded_parameters = True
 

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -515,12 +515,12 @@ def weak_ref_tensors(
     raise ValueError("Invalid type for tensors")
 
 
-def get_cuda_view_from_cpu_tensor(cpu_tensor: torch.Tensor) -> torch.Tensor:
+def get_device_view_from_cpu_tensor(cpu_tensor: torch.Tensor) -> torch.Tensor:
     """
-    Get a CUDA view of a CPU tensor using Unified Virtual Addressing (UVA).
+    Get a DEVICE view of a CPU tensor using Unified Virtual Addressing (UVA).
     """
     assert cpu_tensor.is_pinned(), "CPU tensor must be pinned"
-    return torch.ops._C.get_cuda_view_from_cpu_tensor(cpu_tensor)
+    return torch.ops._C.get_device_view_from_cpu_tensor(cpu_tensor)
 
 
 # Helper function used in testing.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Rename get_cuda_view_from_cpu_tensor to get_device_view_from_cpu_tensor to support other devices (e.g. XPU) with minimal Python code changes.

## Test Plan
pytest -s -v tests/kernels/core/test_uva.py

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

