### PR TITLE
[compile] add sequence parallelism for moe

### DIFF
--- a/tests/compile/distributed/test_sequence_parallelism_moe.py
+++ b/tests/compile/distributed/test_sequence_parallelism_moe.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+import vllm.envs as envs
+from vllm.compilation.noop_elimination import NoOpEliminationPass
+from vllm.compilation.post_cleanup import PostCleanupPass
+from vllm.compilation.sequence_parallelism_moe import SequenceParallelismMoEPass
+from vllm.compilation.vllm_inductor_pass import VllmInductorPass
+from vllm.config import (
+    CompilationConfig,
+    CUDAGraphMode,
+    DeviceConfig,
+    ModelConfig,
+    PassConfig,
+    VllmConfig,
+    set_current_vllm_config,
+)
+from vllm.distributed import tensor_model_parallel_all_reduce
+from vllm.distributed.parallel_state import (
+    get_tensor_model_parallel_world_size,
+    get_tp_group,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.model_executor.models.utils import sequence_parallel_chunk
+from vllm.platforms import current_platform
+from vllm.utils.system_utils import update_environment_variables
+
+from ...utils import multi_gpu_test
+from ..backend import TestBackend
+
+
+class TestMoEModel(torch.nn.Module):
+    def __init__(self, hidden_size=64, intermediate_size=128):
+        super().__init__()
+        self.w_up = torch.nn.Parameter(torch.rand(hidden_size, intermediate_size))
+        self.w_down = torch.nn.Parameter(torch.rand(intermediate_size, hidden_size))
+
+    def forward(self, x):
+        h = torch.mm(x, self.w_up)
+
+        h_reduced = tensor_model_parallel_all_reduce(h)
+        h_sharded = sequence_parallel_chunk(h_reduced)
+
+        h_act = torch.relu(h_sharded)
+
+        h_out_sharded = torch.mm(h_act, self.w_down)
+
+        tp_group = get_tp_group()
+        tp_size = get_tensor_model_parallel_world_size()
+
+        h_final = torch.ops.vllm.all_gather.default(
+            h_out_sharded, dim=0, world_size=tp_size, group_name=tp_group.unique_name
+        )
+
+        return h_final
+
+    def ops_in_model_before(self):
+        return [
+            torch.ops.vllm.all_reduce.default,
+            torch.ops.vllm.sequence_parallel_chunk_impl.default,
+        ]
+
+    def ops_in_model_after(self):
+        return [
+            torch.ops.vllm.reduce_scatter.default,
+        ]
+
+    def ops_in_model(self):
+        return []
+
+
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize(
+    "test_model_cls, custom_ops",
+    [
+        (TestMoEModel, "+sequence_parallel_chunk_impl"),
+    ],
+)
+@pytest.mark.parametrize("batch_size", [8])
+@pytest.mark.parametrize("seq_len", [16])
+@pytest.mark.parametrize("hidden_size", [16])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dynamic", [False, True])
+@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
+def test_sequence_parallelism_moe_pass(
+    test_model_cls: type[torch.nn.Module],
+    custom_ops: str,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    dynamic: bool,
+):
+    num_processes = 2
+
+    def run_torch_spawn(fn, nprocs):
+        # need to use torch.mp.spawn otherwise will have problems with
+        # torch.distributed and cuda
+        torch.multiprocessing.spawn(
+            fn,
+            args=(
+                num_processes,
+                test_model_cls,
+                custom_ops,
+                batch_size,
+                seq_len,
+                hidden_size,
+                dtype,
+                dynamic,
+            ),
+            nprocs=nprocs,
+        )
+
+    run_torch_spawn(sequence_parallelism_moe_pass_on_test_model, num_processes)
+
+
+def sequence_parallelism_moe_pass_on_test_model(
+    local_rank: int,
+    world_size: int,
+    test_model_cls: type[torch.nn.Module],
+    custom_ops: str,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    dynamic: bool,
+):
+    current_platform.seed_everything(0)
+
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    torch.set_default_device(device)
+    torch.set_default_dtype(dtype)
+
+    update_environment_variables(
+        {
+            "RANK": str(local_rank),
+            "LOCAL_RANK": str(local_rank),
+            "WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": "12345",
+        }
+    )
+
+    init_distributed_environment()
+    initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    custom_ops_list = custom_ops.split(",") if custom_ops else []
+    compilation_config = CompilationConfig(
+        splitting_ops=[],
+        cudagraph_mode=CUDAGraphMode.NONE,
+        custom_ops=custom_ops_list,
+        pass_config=PassConfig(
+            enable_sp_moe=True,
+            enable_noop=True,
+        ),
+    )
+    device_config = DeviceConfig(device=torch.device("cuda"))
+
+    model_name = "RedHatAI/Llama-3.2-1B-Instruct-FP8"
+    model_config = ModelConfig(
+        model=model_name, trust_remote_code=True, dtype=dtype, seed=42
+    )
+
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        device_config=device_config,
+        compilation_config=compilation_config,
+    )
+
+    with set_current_vllm_config(vllm_config):
+        noop_pass = NoOpEliminationPass(vllm_config)
+        sp_moe_pass = SequenceParallelismMoEPass(vllm_config)
+        cleanup_pass = PostCleanupPass(vllm_config)
+        assert (
+            sp_moe_pass.compilation_config.splitting_ops
+            == vllm_config.compilation_config.splitting_ops
+        )
+        assert (
+            sp_moe_pass.compilation_config.use_inductor_graph_partition
+            == vllm_config.compilation_config.use_inductor_graph_partition
+        )
+        passes_for_backend: list[VllmInductorPass] = [
+            noop_pass,
+            sp_moe_pass,
+        ]
+
+        passes_for_backend.append(cleanup_pass)
+
+        backend = TestBackend(*passes_for_backend)
+
+        model = test_model_cls(hidden_size)
+
+        hidden_states = torch.randn((batch_size * seq_len, hidden_size), dtype=dtype)
+
+        if dynamic:
+            torch._dynamo.mark_dynamic(hidden_states, 0)
+
+        compiled_model = torch.compile(model, backend=backend)
+        compiled_model(hidden_states)
+
+        assert sp_moe_pass.matched_count == 1
+
+        # In pre-nodes, all reduce should be there,
+        # reduce scatter and all gather should not
+        for op in model.ops_in_model_before():
+            assert backend.op_count(op, before=True) == 1
+
+        # In post-nodes, reduce scatter and all gather should be there,
+        # all reduce should not
+        for op in model.ops_in_model_after():
+            assert backend.op_count(op, before=False) == 1

--- a/tests/compile/distributed/test_sequence_parallelism_moe.py
+++ b/tests/compile/distributed/test_sequence_parallelism_moe.py
@@ -84,7 +84,6 @@ class TestMoEModel(torch.nn.Module):
 @pytest.mark.parametrize("seq_len", [16])
 @pytest.mark.parametrize("hidden_size", [16])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("dynamic", [False, True])
 @pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
 def test_sequence_parallelism_moe_pass(
     test_model_cls: type[torch.nn.Module],

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -19,6 +19,7 @@ if current_platform.is_cuda_alike():
     from .fusion_attn import AttnFusionPass
     from .qk_norm_rope_fusion import QKNormRoPEFusionPass
     from .sequence_parallelism import SequenceParallelismPass
+    from .sequence_parallelism_moe import SequenceParallelismMoEPass
 
 if current_platform.is_cuda():
     from .collective_fusion import AllReduceFusionPass, AsyncTPPass
@@ -99,6 +100,9 @@ class PostGradPassManager(CustomGraphPass):
                 self.passes += [SequenceParallelismPass(config)]
                 if self.pass_config.enable_async_tp:
                     self.passes += [AsyncTPPass(config)]
+
+            if self.pass_config.enable_sp_moe:
+                self.passes += [SequenceParallelismMoEPass(config)]
 
             if self.pass_config.enable_fi_allreduce_fusion:
                 self.passes += [AllReduceFusionPass(config)]

--- a/vllm/compilation/sequence_parallelism_moe.py
+++ b/vllm/compilation/sequence_parallelism_moe.py
@@ -62,15 +62,10 @@ class AllReduceMoePattern(_SequenceParallelMOEPatternHelper):
 
         def replacement(input: torch.Tensor):
             seq_len = input.size(0)
-            remainder = seq_len % self.tp_size
-            if remainder != 0:
-                pad_len = self.tp_size - remainder
-                y = nn.functional.pad(input, (0, 0, 0, pad_len))
-            else:
-                y = input
-            reduce_scatter = self._reduce_scatter(y)
+            pad_len = (-seq_len) % self.tp_size
+            y = nn.functional.pad(input, (0, 0, 0, pad_len))
 
-            return reduce_scatter
+            return y
 
         pm.register_replacement(
             pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass

--- a/vllm/compilation/sequence_parallelism_moe.py
+++ b/vllm/compilation/sequence_parallelism_moe.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+import torch._inductor.pattern_matcher as pm
+import torch.fx as fx
+import torch.nn as nn
+from torch._inductor.pattern_matcher import PatternMatcherPass
+
+from vllm.config import VllmConfig
+from vllm.distributed import get_tp_group, tensor_model_parallel_all_reduce
+from vllm.distributed.parallel_state import get_tensor_model_parallel_world_size
+from vllm.logger import init_logger
+
+from .inductor_pass import enable_fake_mode
+from .noop_elimination import NoOpEliminationPass
+from .vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
+
+logger = init_logger(__name__)
+
+
+class _SequenceParallelMOEPatternHelper:
+    """Helper for sequence parallelism patterns."""
+
+    def __init__(
+        self,
+        dtype: torch.dtype,
+        device: str,
+    ):
+        self.dtype = dtype
+        self.device = device
+        self.tp_group = get_tp_group()
+        self.tp_size = get_tensor_model_parallel_world_size()
+
+    def _all_reduce(self, x: torch.Tensor) -> torch.Tensor:
+        return tensor_model_parallel_all_reduce(x)
+
+    def _reduce_scatter(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.vllm.reduce_scatter.default(
+            x, dim=0, world_size=self.tp_size, group_name=self.tp_group.unique_name
+        )
+
+    def _sequence_parallel_chunk(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.vllm.sequence_parallel_chunk_impl.default(x)
+
+
+class AllReduceMoePattern(_SequenceParallelMOEPatternHelper):
+    def __init__(self, dtype: torch.dtype, device: str):
+        super().__init__(dtype, device)
+        self.tp_size = get_tensor_model_parallel_world_size()
+
+    def get_inputs(self):
+        input = torch.empty([16, 16], device=self.device, dtype=self.dtype)
+        return [input]
+
+    def register(self, pm_pass: PatternMatcherPass):
+        def pattern(input: torch.Tensor):
+            all_reduce = self._all_reduce(input)
+            chunks = self._sequence_parallel_chunk(all_reduce)
+
+            return all_reduce, chunks
+
+        def replacement(input: torch.Tensor):
+            seq_len = input.size(0)
+            remainder = seq_len % self.tp_size
+            if remainder != 0:
+                pad_len = self.tp_size - remainder
+                y = nn.functional.pad(input, (0, 0, 0, pad_len))
+            else:
+                y = input
+            reduce_scatter = self._reduce_scatter(y)
+
+            return None, reduce_scatter
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class SequenceParallelismMoEPass(VllmPatternMatcherPass):
+    """
+    The general transformation is:
+    Input -> AllReduce -> Chunk -> Output
+    becomes
+    Input -> ReduceScatter -> Output
+    """
+
+    @enable_fake_mode
+    def __init__(self, config: VllmConfig):
+        super().__init__(config)
+        self.noop_cleanup = NoOpEliminationPass(config)
+        self.noop_cleanup.pass_name = f"{self.pass_name}.{self.noop_cleanup.pass_name}"
+
+        self.patterns: PatternMatcherPass = PatternMatcherPass(
+            pass_name="sequence_parallelism_moe_pass",
+        )
+
+        AllReduceMoePattern(self.model_dtype, self.device).register(self.patterns)
+
+        self.dump_patterns(config, self.patterns)
+
+    def is_applicable(self, shape: int | None) -> bool:
+        # When sequence parallelism is enabled, the residual tensor from RMSNorm
+        # needs to be split along the sequence dimension. However, this dimension
+        # is symbolic during piecewise compilation, and splitting symbolic shapes
+        # is not supported.
+        #
+        # This pass is therefore only applied when the sequence dimension is
+        # concrete:
+        # 1. In full-graph compilation mode (no Dynamo splitting ops are used).
+        #   For this case we always pad num_tokens to be a multiple of
+        #   tensor_parallel_size, so there's no need to check shape % tp_size == 0.
+        # 2. For specific shape provided during compilation (e.g., from
+        #    `compile_sizes`), which must be divisible by the tensor-parallel
+        #    size.
+        if (
+            not self.compilation_config.splitting_ops
+            or self.compilation_config.use_inductor_graph_partition
+        ):
+            return True
+        tp_size = get_tensor_model_parallel_world_size()
+        return shape is not None and shape % tp_size == 0
+
+    @VllmInductorPass.time_and_log
+    def __call__(self, graph: fx.Graph):
+        self.matched_count = self.patterns.apply(graph)
+        logger.debug("Replaced %s patterns", self.matched_count)
+        self.noop_cleanup(graph)

--- a/vllm/compilation/sequence_parallelism_moe.py
+++ b/vllm/compilation/sequence_parallelism_moe.py
@@ -58,7 +58,7 @@ class AllReduceMoePattern(_SequenceParallelMOEPatternHelper):
             all_reduce = self._all_reduce(input)
             chunks = self._sequence_parallel_chunk(all_reduce)
 
-            return all_reduce, chunks
+            return chunks
 
         def replacement(input: torch.Tensor):
             seq_len = input.size(0)
@@ -70,7 +70,7 @@ class AllReduceMoePattern(_SequenceParallelMOEPatternHelper):
                 y = input
             reduce_scatter = self._reduce_scatter(y)
 
-            return None, reduce_scatter
+            return reduce_scatter
 
         pm.register_replacement(
             pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -113,6 +113,8 @@ class PassConfig:
     """Whether to enable the custom no-op elimination pass."""
     enable_sequence_parallelism: bool = Field(default=None)
     """Whether to enable sequence parallelism."""
+    enable_sp_moe: bool = Field(default=None)
+    """Whether to enable sequence parallelism for moe"""
     enable_async_tp: bool = Field(default=None)
     """Whether to enable async TP."""
     enable_fi_allreduce_fusion: bool = Field(default=None)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2419,8 +2419,8 @@ class GPUModelRunner(
         tp_size = self.vllm_config.parallel_config.tensor_parallel_size
         if (
             self.compilation_config.pass_config.enable_sequence_parallelism
-            and tp_size > 1
-        ):
+            or self.compilation_config.pass_config.enable_sp_moe
+        ) and tp_size > 1:
             return round_up(num_scheduled_tokens, tp_size)
         return num_scheduled_tokens
 


### PR DESCRIPTION
## Purpose
Tranform a sequence of `allreduce->chunk` to `reduce_scatter` for moe models with `sequence_parallel_chunk` ops. Resolves #29139 
## Test Plan
`pytest -v tests/compile/distributed/test_sequence_parallelism_moe.py`
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

