### PR TITLE
[Misc] Add token breakdown to throughput benchmark JSON output

### DIFF
--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -791,8 +791,11 @@ def main(args: argparse.Namespace):
             "elapsed_time": elapsed_time,
             "num_requests": len(requests),
             "total_num_tokens": total_num_tokens,
+            "total_input_tokens": total_prompt_tokens,
+            "total_output_tokens": total_output_tokens,
             "requests_per_second": len(requests) / elapsed_time,
             "tokens_per_second": total_num_tokens / elapsed_time,
+            "output_tokens_per_second": total_output_tokens / elapsed_time,
         }
         with open(args.output_json, "w") as f:
             json.dump(results, f, indent=4)


### PR DESCRIPTION
## Purpose

This PR added three new fields to the JSON output for `vllm bench throughput` to include token-level metrics that are currently only printed to console.

Example new JSON output:

```diff
{
    "elapsed_time": 120.5,
    "num_requests": 1000,
    "total_num_tokens": 6514,
+    "total_input_tokens": 5014,
+    "total_output_tokens": 1500,
    "requests_per_second": 8.30,
    "tokens_per_second": 1244.81,
+    "output_tokens_per_second": 1072.15
}
```

The existing fields (`requests_per_second`, `tokens_per_second`) are preserved for backward compatibility. The new field name follows the same `_per_second` suffix convention for consistency.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

