### PR TITLE
fix: Add validation for tool requests that the tool is available

### DIFF
--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 def _map_tool_name_to_tool_type(tool_name: str) -> str:
     if tool_name not in TOOL_NAME_TO_TYPE_MAP:
         available_tools = ", ".join(TOOL_NAME_TO_TYPE_MAP.keys())

--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -13,6 +13,7 @@ from openai_harmony import Author, Message, Role, StreamState, TextContent
 
 from vllm import envs
 from vllm.entrypoints.harmony_utils import (
+    TOOL_NAME_TO_TYPE_MAP,
     get_encoding,
     get_streamable_parser_for_assistant,
     render_for_completion,
@@ -26,24 +27,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# This is currently needed as the tool type doesn't 1:1 match the
-# tool namespace, which is what is used to look up the
-# connection to the tool server
-_TOOL_NAME_TO_TYPE_MAP = {
-    "browser": "web_search_preview",
-    "python": "code_interpreter",
-    "container": "container",
-}
-
-
 def _map_tool_name_to_tool_type(tool_name: str) -> str:
-    if tool_name not in _TOOL_NAME_TO_TYPE_MAP:
-        available_tools = ", ".join(_TOOL_NAME_TO_TYPE_MAP.keys())
+    if tool_name not in TOOL_NAME_TO_TYPE_MAP:
+        available_tools = ", ".join(TOOL_NAME_TO_TYPE_MAP.keys())
         raise ValueError(
             f"Built-in tool name '{tool_name}' not defined in mapping. "
             f"Available tools: {available_tools}"
         )
-    return _TOOL_NAME_TO_TYPE_MAP[tool_name]
+    return TOOL_NAME_TO_TYPE_MAP[tool_name]
 
 
 class TurnMetrics:

--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -67,6 +67,17 @@ MCP_BUILTIN_TOOLS: set[str] = {
     "container",
 }
 
+# Mapping between Harmony tool namespaces (used by ToolServer) and tool types
+# (used in the request payload). Keep a single source of truth here.
+TOOL_NAME_TO_TYPE_MAP: dict[str, str] = {
+    "browser": "web_search_preview",
+    "python": "code_interpreter",
+    "container": "container",
+}
+TYPE_TO_TOOL_NAME_MAP: dict[str, str] = {
+    tool_type: tool_name for tool_name, tool_type in TOOL_NAME_TO_TYPE_MAP.items()
+}
+
 
 def has_custom_tools(tool_types: set[str]) -> bool:
     """

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -63,6 +63,7 @@ from vllm.entrypoints.context import (
     StreamingHarmonyContext,
 )
 from vllm.entrypoints.harmony_utils import (
+    TYPE_TO_TOOL_NAME_MAP,
     construct_harmony_previous_input_messages,
     get_developer_message,
     get_stop_tokens_for_assistant_actions,
@@ -272,15 +273,8 @@ class OpenAIServingResponses(OpenAIServing):
 
         tool_types = extract_tool_types(request.tools)
 
-        # Map Harmony tool types to the corresponding ToolServer names.
-        required_tools = {
-            "web_search_preview": "browser",
-            "code_interpreter": "python",
-            "container": "container",
-        }
-
         missing_tools: list[str] = []
-        for tool_type, tool_name in required_tools.items():
+        for tool_type, tool_name in TYPE_TO_TOOL_NAME_MAP.items():
             if tool_type not in tool_types:
                 continue
             if self.tool_server is None or not self.tool_server.has_tool(tool_name):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

  - Add request-level validation so Harmony tool calls fail fast when the requested built-in tool is not available on the configured tool server (browser/
    code_interpreter/container). This prevents the silent “best-effort” behavior noted in the PR discussion and surfaces an invalid_request_error instead.

## Test Plan

  - .venv/bin/pytest tests/entrypoints/openai/test_serving_responses.py -q

## Test Result

  - 6 passed, 3 warnings (module-level tests including new coverage)

## Fix PR

https://github.com/vllm-project/vllm/issues/29432

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

