### PR TITLE
[ROCm][CI] Fix test_cpu_offloading for ROCm

### DIFF
--- a/tests/v1/kv_offload/test_cpu_offloading.py
+++ b/tests/v1/kv_offload/test_cpu_offloading.py
@@ -20,6 +20,8 @@ ATTN_BACKENDS = ["FLASH_ATTN"]
 
 if current_platform.is_cuda():
     ATTN_BACKENDS.append("FLASHINFER")
+elif current_platform.is_rocm():
+    ATTN_BACKENDS = ["TRITON_ATTN"]
 
 
 class MockSubscriber:


### PR DESCRIPTION
<!-- markdownlint-disable -->
This PR fixes the test_cpu_offloading.py test. With the fix applied, we see:
```
pytest -v -s v1/kv_offload
========================================================================================= warnings summary =========================================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================= 16 passed, 2 warnings in 24.66s ==================================================================================
```

The issue was that it tested an attention backend that is not supported on ROCm.