### PR TITLE
[CI/Build] Skip ray tests on ROCm

### DIFF
--- a/tests/v1/distributed/test_async_llm_dp.py
+++ b/tests/v1/distributed/test_async_llm_dp.py
@@ -12,6 +12,7 @@ from vllm import SamplingParams
 from vllm.config import VllmConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.inputs import PromptType
+from vllm.platforms import current_platform
 from vllm.sampling_params import RequestOutputKind
 from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.v1.engine.core_client import DPAsyncMPClient
@@ -84,6 +85,10 @@ async def test_load(
     if async_scheduling and data_parallel_backend == "ray":
         # TODO(NickLucche) Re-enable when async scheduling is supported
         pytest.skip("Async scheduling is not supported with ray")
+    elif data_parallel_backend == "ray" and current_platform.is_rocm():
+        pytest.skip(
+            "Ray as the distributed executor backend is not supported with ROCm."
+        )
     stats_loggers = {}
 
     @dataclass


### PR DESCRIPTION
## Purpose

This PR skips tests with ray as the distributed executor backend on ROCm, in order to make the AMD run of the testgroup [Distributed Tests (2 GPUs)](https://github.com/vllm-project/vllm/blob/ba1fcd84a7f1dc907c17bf4ba4fab6762a9f33a1/.buildkite/test-amd.yaml#L1195) slightly more successful.

Setting ray as data parallel backend in vLLM fails on ROCm due to how ray manages GPU resources, how vLLM allocates resources via ray and how importing torch on ROCm caches the value of `CUDA_VISIBLE_DEVICES`. Ray manages GPU resources per actor with `CUDA_VISIBLE_DEVICES`, but vLLM doesn't bundle a GPU resource with a CPU resource when spawning a `DPEngineCoreActor` and consequently must [set that value at runtime](https://github.com/vllm-project/vllm/blob/ba1fcd84a7f1dc907c17bf4ba4fab6762a9f33a1/vllm/v1/engine/core.py#L1372). Unfortunately for the ROCm flow, `CUDA_VISIBLE_DEVICES=""` is cached upon importing torch and subsequent value changes won't convince torch that any GPUs are available on the system, resulting in an error.
> (TemporaryActor pid=3615141) RuntimeError: No HIP GPUs are available

Setting `RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0` such that ray won't set `CUDA_VISIBLE_DEVICES=""` for GPU-less actors also fails due to collisions.
> NCCL WARN Duplicate GPU detected : rank 0 and rank 1 both on CUDA device 75000

## Test Plan

In the tests directory using the ROCm docker image, `TP_SIZE=1 DP_SIZE=2 pytest -s -v v1/distributed/test_async_llm_dp.py::test_load`.

## Test Result

| Status  | Before                               | After                              |
|---------|----------------------------------------|-------------------------------------|
| Summary | 4 failed, 8 passed, 4 skipped, 3 warnings in 213.90s | 8 passed, 8 skipped, 3 warnings in 180.29s |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
