### PR TITLE
[Docs] Improve `priority` parameter documentation

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -406,7 +406,7 @@ class LLM:
             priority: The priority of the requests, if any.
                 Only applicable when priority scheduling policy is enabled.
                 If provided, must be a list of integers matching the length
-                of `prompts`,where each priority value corresponds to the prompt
+                of `prompts`, where each priority value corresponds to the prompt
                 at the same index.
 
         Returns:

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -405,6 +405,8 @@ class LLM:
             lora_request: LoRA request to use for generation, if any.
             priority: The priority of the requests, if any.
                 Only applicable when priority scheduling policy is enabled.
+                If provided, must be a list matching the length of `prompts`,
+                where each priority value corresponds to the prompt at the same index.
 
         Returns:
             A list of `RequestOutput` objects containing the

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -405,8 +405,9 @@ class LLM:
             lora_request: LoRA request to use for generation, if any.
             priority: The priority of the requests, if any.
                 Only applicable when priority scheduling policy is enabled.
-                If provided, must be a list matching the length of `prompts`,
-                where each priority value corresponds to the prompt at the same index.
+                If provided, must be a list of integers matching the length
+                of `prompts`,where each priority value corresponds to the prompt
+                at the same index.
 
         Returns:
             A list of `RequestOutput` objects containing the


### PR DESCRIPTION
## Purpose
Improved the documentation for the `priority` parameter in `LLM.generate()` method to make it clearer that it must be a list (not a single int) when provided.
