### PR TITLE
[BugFix] Fix new nightly failures

### DIFF
--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -97,6 +97,32 @@ class CommonAttentionMetadata:
     dcp_local_seq_lens_cpu: torch.Tensor | None = None
     """Sequence lengths of the local rank in decode context parallelism world"""
 
+    # TODO(lucas): remove once we have FULL-CG spec-decode support
+    def unpadded(
+        self, num_actual_tokens: int, num_actual_reqs: int
+    ) -> "CommonAttentionMetadata":
+        maybe_slice_reqs = lambda x: x[:num_actual_reqs] if x is not None else None
+        return CommonAttentionMetadata(
+            query_start_loc=self.query_start_loc[: num_actual_reqs + 1],
+            query_start_loc_cpu=self.query_start_loc_cpu[: num_actual_reqs + 1],
+            seq_lens=self.seq_lens[:num_actual_reqs],
+            seq_lens_cpu=self.seq_lens_cpu[:num_actual_reqs],
+            num_computed_tokens_cpu=self.num_computed_tokens_cpu[:num_actual_reqs],
+            num_reqs=num_actual_reqs,
+            num_actual_tokens=num_actual_tokens,
+            max_query_len=self.max_query_len,
+            max_seq_len=self.max_seq_len,
+            block_table_tensor=self.block_table_tensor[:num_actual_reqs],
+            slot_mapping=self.slot_mapping[:num_actual_tokens],
+            causal=self.causal,
+            logits_indices_padded=self.logits_indices_padded,
+            num_logits_indices=self.num_logits_indices,
+            encoder_seq_lens=maybe_slice_reqs(self.encoder_seq_lens),
+            encoder_seq_lens_cpu=maybe_slice_reqs(self.encoder_seq_lens_cpu),
+            dcp_local_seq_lens=maybe_slice_reqs(self.dcp_local_seq_lens),
+            dcp_local_seq_lens_cpu=maybe_slice_reqs(self.dcp_local_seq_lens_cpu),
+        )
+
 
 def slice_query_start_locs(
     query_start_loc: torch.Tensor,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1655,8 +1655,9 @@ class GPUModelRunner(
         if spec_decode_common_attn_metadata is not None and (
             num_reqs != num_reqs_padded or num_tokens != num_tokens_padded
         ):
-            # Currently the drafter still only uses piecewise cudagraphs, and
-            # therefore does not want to use padded attention metadata.
+            # Currently the drafter still only uses piecewise cudagraphs (and modifies
+            # the attention metadata in directly), and therefore does not want to use
+            # padded attention metadata.
             spec_decode_common_attn_metadata = (
                 spec_decode_common_attn_metadata.unpadded(num_tokens, num_reqs)
             )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1652,6 +1652,15 @@ class GPUModelRunner(
                     for layer_name in attn_group.layer_names:
                         attn_metadata[layer_name] = attn_metadata_i
 
+        if spec_decode_common_attn_metadata is not None and (
+            num_reqs != num_reqs_padded or num_tokens != num_tokens_padded
+        ):
+            # Currently the drafter still only uses piecewise cudagraphs, and
+            # therefore does not want to use padded attention metadata.
+            spec_decode_common_attn_metadata = (
+                spec_decode_common_attn_metadata.unpadded(num_tokens, num_reqs)
+            )
+
         return attn_metadata, spec_decode_common_attn_metadata
 
     def _compute_cascade_attn_prefix_lens(
@@ -2910,15 +2919,6 @@ class GPUModelRunner(
                         cascade_attn_prefix_lens=cascade_attn_prefix_lens,
                     )
                 )
-
-                if spec_decode_common_attn_metadata is not None and pad_attn:
-                    # Currently the drafter still only uses piecewise cudagraphs, and
-                    # therefore does not want to use padded attention metadata.
-                    spec_decode_common_attn_metadata = (
-                        spec_decode_common_attn_metadata.unpadded(
-                            num_tokens_unpadded, num_reqs
-                        )
-                    )
 
             (
                 input_ids,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1551,7 +1551,7 @@ class GPUModelRunner(
                 # Encoder-only layers do not have KV cache, so we need to
                 # create a dummy block table and slot mapping for them.
                 blk_table_tensor = torch.zeros(
-                    (num_tokens_padded, 1),
+                    (num_reqs_padded, 1),
                     dtype=torch.int32,
                     device=self.device,
                 )
@@ -2910,6 +2910,15 @@ class GPUModelRunner(
                         cascade_attn_prefix_lens=cascade_attn_prefix_lens,
                     )
                 )
+
+                if spec_decode_common_attn_metadata is not None and pad_attn:
+                    # Currently the drafter still only uses piecewise cudagraphs, and
+                    # therefore does not want to use padded attention metadata.
+                    spec_decode_common_attn_metadata = (
+                        spec_decode_common_attn_metadata.unpadded(
+                            num_tokens_unpadded, num_reqs
+                        )
+                    )
 
             (
                 input_ids,


### PR DESCRIPTION
Fix nightly failures:
```
tests/models/language/pooling_mteb_test/test_jina.py::test_embed_models_mteb[model_info0]
tests/models/language/pooling/test_token_classification.py::test_modernbert_models[float-disham993/electrical-ner-ModernBERT-base]
tests/models/language/pooling_mteb_test/test_st_projector.py::test_embed_models_mteb[model_info1]
tests/models/multimodal/pooling/test_siglip.py::test_models_text[float-google/siglip-base-patch16-224]
tests/models/multimodal/pooling/test_siglip.py::test_models_text[float-google/siglip2-base-patch16-224]
tests/models/multimodal/pooling/test_siglip.py::test_models_text_image_no_crash[float-google/siglip-base-patch16-224]
tests/models/multimodal/pooling/test_siglip.py::test_models_text_image_no_crash[float-google/siglip2-base-patch16-224]
```
```
examples/offline_inference/spec_decode.py --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
```

Caused by https://github.com/vllm-project/vllm/pull/28579

All tests above pass; running `ready-run-all-tests`