### PR TITLE
[BUGFIX] MistralTokenizer._call__ adds an invalid EOS token

### DIFF
--- a/tests/tokenization/test_mistral_tokenizer.py
+++ b/tests/tokenization/test_mistral_tokenizer.py
@@ -331,6 +331,7 @@ class TestMistralTokenizer:
             )
             == token_ids
         )
+        assert mistral_tokenizer.encode_one("") == []
 
     def test_encode(self, mistral_tokenizer: MistralTokenizer):
         token_ids = (
@@ -370,6 +371,7 @@ class TestMistralTokenizer:
             mistral_tokenizer.encode("Hello world !", add_special_tokens=False)
             == token_ids[1:]
         )
+        assert mistral_tokenizer.encode("", add_special_tokens=False) == []
 
     def test_call(self, mistral_tokenizer: MistralTokenizer):
         token_ids = (
@@ -379,7 +381,7 @@ class TestMistralTokenizer:
         )
         attn_mask = [1 for _ in range(len(token_ids))]
 
-        # Test 1: Default
+        # Test 1: default
         assert mistral_tokenizer("Hello world !") == {
             "attention_mask": attn_mask[1:],
             "input_ids": token_ids[1:],
@@ -402,6 +404,11 @@ class TestMistralTokenizer:
         ) == {
             "attention_mask": attn_mask,
             "input_ids": token_ids,
+        }
+        # Test 5: empty string
+        assert mistral_tokenizer("") == {
+            "attention_mask": [],
+            "input_ids": [],
         }
 
         with pytest.raises(
@@ -1126,6 +1133,24 @@ class TestMistralTokenizer:
             )
             == expected_tokens[mistral_tokenizer.is_tekken]
         )
+        assert (
+            mistral_tokenizer.decode(
+                ids[mistral_tokenizer.is_tekken],
+                skip_special_tokens=skip_special_tokens,
+            )
+            == expected_tokens[mistral_tokenizer.is_tekken]
+        )
+
+    def test_decode_empty(
+        self,
+        mistral_tokenizer: MistralTokenizer,
+    ):
+        assert (
+            mistral_tokenizer.decode(
+                [],
+            )
+            == ""
+        )
 
     def test_decode_int(
         self,
@@ -1428,6 +1453,8 @@ class TestMistralTokenizer:
             )
             == expected_strings[mistral_tokenizer.is_tekken]
         )
+
+        assert mistral_tokenizer.convert_tokens_to_string([]) == ""
 
     @pytest.mark.parametrize(
         "skip_special_tokens,tuple_expected_tokens",
@@ -2259,3 +2286,5 @@ class TestMistralTokenizer:
             ids, skip_special_tokens=skip_special_tokens
         )
         assert actual_tokens == expected_tokens
+
+        assert mistral_tokenizer.convert_ids_to_tokens([]) == []

--- a/tests/tokenization/test_mistral_tokenizer.py
+++ b/tests/tokenization/test_mistral_tokenizer.py
@@ -371,6 +371,45 @@ class TestMistralTokenizer:
             == token_ids[1:]
         )
 
+    def test_call(self, mistral_tokenizer: MistralTokenizer):
+        token_ids = (
+            [1, 22177, 4304, 2662]
+            if mistral_tokenizer.is_tekken
+            else [1, 23325, 2294, 1686]
+        )
+        attn_mask = [1 for _ in range(len(token_ids))]
+
+        # Test 1: Default
+        assert mistral_tokenizer("Hello world !") == {
+            "attention_mask": attn_mask[1:],
+            "input_ids": token_ids[1:],
+        }
+        # Test 2: special tokens
+        assert mistral_tokenizer("Hello world !", add_special_tokens=True) == {
+            "attention_mask": attn_mask,
+            "input_ids": token_ids,
+        }
+        # Test 3: special tokens + truncation
+        assert mistral_tokenizer(
+            "Hello world !", add_special_tokens=True, truncation=True, max_length=3
+        ) == {
+            "attention_mask": attn_mask[:-1],
+            "input_ids": token_ids[:-1],
+        }
+        # Test 4: special tokens + no truncation + max length
+        assert mistral_tokenizer(
+            "Hello world !", add_special_tokens=True, max_length=3
+        ) == {
+            "attention_mask": attn_mask,
+            "input_ids": token_ids,
+        }
+
+        with pytest.raises(
+            ValueError,
+            match=(r"`text_pair` is not supported by `MistralTokenizer.__call__`."),
+        ):
+            mistral_tokenizer("Hello world !", "invalid pair")
+
     @pytest.mark.parametrize(
         "openai_request,add_generation_prompt,continue_final_message,expected_output,decoded_expected_output",
         [

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -404,6 +404,8 @@ class MistralTokenizer(TokenizerBase):
         )
 
     def decode(self, ids: list[int] | int, skip_special_tokens: bool = True) -> str:
+        # TODO(juliendenize): once https://github.com/huggingface/transformers/pull/41962
+        # is in, directly call self.transformers_tokenizer.decode(...).
         if isinstance(ids, int):
             ids = [ids]
 

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -312,13 +312,28 @@ class MistralTokenizer(TokenizerBase):
         truncation: bool = False,
         max_length: int | None = None,
     ):
-        return self.transformers_tokenizer(
+        if text_pair is not None:
+            raise ValueError(
+                "`text_pair` is not supported by `MistralTokenizer.__call__`."
+            )
+
+        encoded = self.transformers_tokenizer(
             text=text,
             text_pair=text_pair,
             add_special_tokens=add_special_tokens,
             truncation=truncation,
             max_length=max_length,
         )
+        # TODO(juliendenize): once https://github.com/huggingface/transformers/pull/41962
+        # is in, revert to only call self.transformers_tokenizer(...).
+        # Hack to fix wrongly added eos token, when fix will be supported the condition
+        # below will be False even before the revert is done.
+        has_eos = encoded["input_ids"][-1] == self.eos_token_id
+        if has_eos:
+            encoded["input_ids"].pop(-1)
+            if attention_mask := encoded.get("attention_mask"):
+                attention_mask.pop(-1)
+        return encoded
 
     @property
     def vocab(self) -> list[str]:
@@ -349,6 +364,8 @@ class MistralTokenizer(TokenizerBase):
         max_length: int | None = None,
         add_special_tokens: bool | None = None,
     ) -> list[int]:
+        # TODO(juliendenize): once https://github.com/huggingface/transformers/pull/41962
+        # is in, directly call self.transformers_tokenizer.encode(...).
         encoded = self.tokenizer.encode(
             text, bos=add_special_tokens is not False, eos=False
         )

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -328,8 +328,7 @@ class MistralTokenizer(TokenizerBase):
         # is in, revert to only call self.transformers_tokenizer(...).
         # Hack to fix wrongly added eos token, when fix will be supported the condition
         # below will be False even before the revert is done.
-        has_eos = encoded["input_ids"][-1] == self.eos_token_id
-        if has_eos:
+        if encoded["input_ids"] and encoded["input_ids"][-1] == self.eos_token_id:
             encoded["input_ids"].pop(-1)
             if attention_mask := encoded.get("attention_mask"):
                 attention_mask.pop(-1)


### PR DESCRIPTION
## Purpose

https://github.com/juliendenize/vllm/commit/c6187f55f7c4844ed9ff5630d41114cbe6fccb6b refactored MistralTokenizer to use the implementation inside Transformers.

However some functionalities were missing or bugged which caused issues for vLLM implementation. Parts were fixed in https://github.com/juliendenize/vllm/commit/a404e2c0f1bf100d28453a5a2ab7bd2a29d9aa31 but there is still an issue when calling `__call__`: the EOS token id is added at the end.

The issue originates from the Transformers implem and will be fixed by https://github.com/huggingface/transformers/pull/41962. However in the meantime we have to add a hack to avoid it by removing the added EOS token.

I also added TODO to remove duplicated code from Transformers inside vLLM once https://github.com/huggingface/transformers/pull/41962 is merged and used by vLLM.  

## Test Plan

I added tests to ensure this won't happen again.

## Test Result

The tests added all pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
