### PR TITLE
Fix tool call id missing issue.

### DIFF
--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -846,14 +846,15 @@ class OpenAIServingResponses(OpenAIServing):
         if message_item:
             outputs.append(message_item)
         if tool_calls:
+            # tool_calls now contains ToolCall objects, extract function info
             tool_call_items = [
                 ResponseFunctionToolCall(
                     id=f"fc_{random_uuid()}",
                     call_id=f"call_{random_uuid()}",
                     type="function_call",
                     status="completed",
-                    name=tool_call.name,
-                    arguments=tool_call.arguments,
+                    name=tool_call.function.name,
+                    arguments=tool_call.function.arguments,
                 )
                 for tool_call in tool_calls
             ]


### PR DESCRIPTION
Fixes #29596 

This PR restores Kimi-style tool_call_id behavior for Kimi family models.

Originally, Kimi models (e.g. kimi-k2) produced deterministic, semantic tool call IDs such as functions.get_weather:0, which downstream tooling relied on for correctly correlating tool calls and results. A later change (shipped in v0.11.2) refactored tool call handling to go through generic ToolCall objects and default make_tool_call_id, which caused Kimi models to emit OpenAI-style random IDs like chatcmpl-tool-<uuid> instead, breaking that contract.

This fix makes three key changes:

- Detect any Kimi-family model via model_type.startswith("kimi") and set tool_call_id_type="kimi_k2".
- Preserve parser-generated ToolCall IDs for tool_choice="auto" instead of rebuilding them.
- For named and required tool choices (and streaming deltas), explicitly generate Kimi-style IDs via make_tool_call_id(id_type="kimi_k2", func_name, idx).

Together, these changes restore the original Kimi tool_call_id semantics while preserving random IDs for non-Kimi models.