### PR TITLE
[Bugfix] Fix infinite loop in V1 scheduler with max-length prompts (#…

### DIFF
--- a/tests/v1/core/test_async_scheduler.py
+++ b/tests/v1/core/test_async_scheduler.py
@@ -38,11 +38,11 @@ def test_stop_by_max_tokens(max_tokens: int):
     sched_outputs: deque[SchedulerOutput] = deque()
     scheduler.add_request(req0)
     sched_outputs.append(scheduler.schedule())
-    expected_total_num_scheduled_tokens += req0.num_prompt_tokens + max_tokens - 1
+    expected_total_num_scheduled_tokens += req0.num_prompt_tokens + max_tokens
 
     scheduler.add_request(req1)
     sched_outputs.append(scheduler.schedule())
-    expected_total_num_scheduled_tokens += req1.num_prompt_tokens + max_tokens - 1
+    expected_total_num_scheduled_tokens += req1.num_prompt_tokens + max_tokens
 
     total_num_scheduled_tokens = 0
     while sched_outputs:

--- a/tests/v1/core/test_scheduler_max_tokens_fix.py
+++ b/tests/v1/core/test_scheduler_max_tokens_fix.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Test cases for the scheduler fix that removes the off-by-one error
+when scheduling tokens at max_model_len.
+
+These tests verify that:
+1. Requests with prompts at max_model_len can be fully processed
+2. No infinite loops occur when the final token needs to be scheduled
+3. The scheduler correctly handles edge cases around capacity limits
+"""
+
+import numpy as np
+import pytest
+
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.request import RequestStatus
+
+from .utils import create_requests, create_scheduler
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_schedule_max_model_len_prompt():
+    """Test that prompts filling max_model_len can be fully scheduled.
+
+    This test verifies the fix for the off-by-one error where prompts
+    at max_model_len would get stuck at max_model_len-1 tokens.
+    """
+    max_model_len = 1024
+    token_budget = 512
+
+    scheduler = create_scheduler(
+        max_model_len=max_model_len,
+        max_num_batched_tokens=token_budget,
+    )
+
+    # Create a request with prompt exactly at max_model_len
+    requests = create_requests(
+        num_requests=1,
+        num_tokens=max_model_len,
+        max_tokens=1,  # Pooling model scenario
+    )
+    scheduler.add_request(requests[0])
+
+    # First schedule: should process token_budget tokens
+    output1 = scheduler.schedule()
+    assert output1.num_scheduled_tokens[requests[0].request_id] == token_budget
+    assert requests[0].num_computed_tokens == token_budget
+
+    # Simulate model execution
+    model_output1 = ModelRunnerOutput(
+        req_ids=[requests[0].request_id],
+        req_id_to_index={requests[0].request_id: 0},
+        sampled_token_ids=[np.array([])],  # Still prefilling
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output1, model_output1)
+    assert requests[0].num_computed_tokens == token_budget
+
+    # Second schedule: should process remaining tokens
+    remaining = max_model_len - token_budget
+    output2 = scheduler.schedule()
+    assert output2.num_scheduled_tokens[requests[0].request_id] == remaining
+
+    model_output2 = ModelRunnerOutput(
+        req_ids=[requests[0].request_id],
+        req_id_to_index={requests[0].request_id: 0},
+        sampled_token_ids=[np.array([])],  # Still prefilling
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output2, model_output2)
+
+    # Verify all tokens were processed
+    assert requests[0].num_computed_tokens == max_model_len
+    assert requests[0].num_tokens == max_model_len
+
+    # Request should complete successfully (no infinite loop)
+    assert (
+        requests[0].status == RequestStatus.RUNNING
+        or requests[0].status == RequestStatus.FINISHED_LENGTH_CAPPED
+    )
+
+
+def test_schedule_max_model_len_no_infinite_loop():
+    """Test that scheduler doesn't enter infinite loop at max capacity.
+
+    This reproduces the bug scenario where a prompt at max_model_len
+    would cause an infinite loop because the final token couldn't be scheduled.
+    """
+    max_model_len = 2048
+    token_budget = 1024
+
+    scheduler = create_scheduler(
+        max_model_len=max_model_len,
+        max_num_batched_tokens=token_budget,
+    )
+
+    # Create request with prompt exactly at max_model_len
+    requests = create_requests(
+        num_requests=1,
+        num_tokens=max_model_len,
+        max_tokens=1,
+    )
+    scheduler.add_request(requests[0])
+
+    # Iteration 1: Schedule first batch
+    output1 = scheduler.schedule()
+    assert output1.num_scheduled_tokens[requests[0].request_id] == token_budget
+
+    model_output1 = ModelRunnerOutput(
+        req_ids=[requests[0].request_id],
+        req_id_to_index={requests[0].request_id: 0},
+        sampled_token_ids=[np.array([])],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output1, model_output1)
+    assert requests[0].num_computed_tokens == token_budget
+
+    # Iteration 2: Schedule second batch
+    output2 = scheduler.schedule()
+    # Should schedule exactly token_budget tokens (not token_budget-1)
+    assert output2.num_scheduled_tokens[requests[0].request_id] == token_budget
+
+    model_output2 = ModelRunnerOutput(
+        req_ids=[requests[0].request_id],
+        req_id_to_index={requests[0].request_id: 0},
+        sampled_token_ids=[np.array([])],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output2, model_output2)
+    assert requests[0].num_computed_tokens == 2 * token_budget
+
+    # Iteration 3: Should be able to schedule the final token
+    # This is where the bug would manifest - num_new_tokens would be 0
+    output3 = scheduler.schedule()
+
+    # With the fix, we should be able to schedule the remaining token
+    # Without the fix, this would be 0, causing an infinite loop
+    expected_remaining = max_model_len - (2 * token_budget)
+    assert (
+        output3.num_scheduled_tokens.get(requests[0].request_id, 0)
+        == expected_remaining
+    )
+
+    # If remaining is 0, request should have finished
+    if expected_remaining == 0:
+        assert requests[0].num_computed_tokens == max_model_len
+    else:
+        model_output3 = ModelRunnerOutput(
+            req_ids=[requests[0].request_id],
+            req_id_to_index={requests[0].request_id: 0},
+            sampled_token_ids=[np.array([])],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        )
+        scheduler.update_from_output(output3, model_output3)
+        assert requests[0].num_computed_tokens == max_model_len
+
+
+def test_schedule_respects_max_tokens_exactly():
+    """Test that scheduler respects max_tokens without off-by-one error.
+
+    Verifies that users receive exactly max_tokens outputs, not max_tokens-1.
+    """
+    max_model_len = 2048
+    num_prompt_tokens = 100
+    max_tokens = 50
+
+    scheduler = create_scheduler(
+        max_model_len=max_model_len,
+        max_num_batched_tokens=1024,
+    )
+
+    requests = create_requests(
+        num_requests=1,
+        num_tokens=num_prompt_tokens,
+        max_tokens=max_tokens,
+    )
+    scheduler.add_request(requests[0])
+
+    # Schedule and process the prompt
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens[requests[0].request_id] == num_prompt_tokens
+
+    model_output = ModelRunnerOutput(
+        req_ids=[requests[0].request_id],
+        req_id_to_index={requests[0].request_id: 0},
+        sampled_token_ids=[np.array([1])],  # First output token
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    # Generate tokens until we reach max_tokens
+    for i in range(1, max_tokens):
+        output = scheduler.schedule()
+        assert output.num_scheduled_tokens[requests[0].request_id] == 1
+
+        model_output = ModelRunnerOutput(
+            req_ids=[requests[0].request_id],
+            req_id_to_index={requests[0].request_id: 0},
+            sampled_token_ids=[np.array([i + 1])],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        )
+        scheduler.update_from_output(output, model_output)
+
+    # Verify we generated exactly max_tokens outputs
+    assert requests[0].num_output_tokens == max_tokens
+    assert requests[0].num_tokens == num_prompt_tokens + max_tokens
+    assert requests[0].status == RequestStatus.FINISHED_LENGTH_CAPPED
+
+
+@pytest.mark.parametrize(
+    "max_model_len,prompt_len,token_budget",
+    [
+        (2048, 2048, 512),  # Exact match
+        (2048, 2047, 512),  # One token short
+        (2048, 2040, 512),  # Few tokens short
+    ],
+)
+def test_schedule_various_capacity_scenarios(max_model_len, prompt_len, token_budget):
+    """Test scheduler handles various capacity scenarios correctly.
+
+    Parametrized test to ensure the fix works across different configurations.
+    """
+    scheduler = create_scheduler(
+        max_model_len=max_model_len,
+        max_num_batched_tokens=token_budget,
+    )
+
+    requests = create_requests(
+        num_requests=1,
+        num_tokens=prompt_len,
+        max_tokens=1,
+    )
+    scheduler.add_request(requests[0])
+
+    total_scheduled = 0
+    max_iterations = 100  # Prevent actual infinite loops in test
+    iteration = 0
+
+    while requests[0].num_computed_tokens < prompt_len and iteration < max_iterations:
+        output = scheduler.schedule()
+
+        if requests[0].request_id in output.num_scheduled_tokens:
+            scheduled = output.num_scheduled_tokens[requests[0].request_id]
+            total_scheduled += scheduled
+
+            model_output = ModelRunnerOutput(
+                req_ids=[requests[0].request_id],
+                req_id_to_index={requests[0].request_id: 0},
+                sampled_token_ids=[np.array([])],
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[],
+            )
+            scheduler.update_from_output(output, model_output)
+
+        iteration += 1
+
+    # Verify all tokens were scheduled
+    assert total_scheduled == prompt_len, (
+        f"Expected {prompt_len} tokens, but scheduled {total_scheduled}"
+    )
+    assert requests[0].num_computed_tokens == prompt_len
+    assert iteration < max_iterations, "Scheduler entered infinite loop"

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -241,7 +241,7 @@ class Scheduler(SchedulerInterface):
                 request.num_prompt_tokens + request.max_tokens, self.max_model_len
             )
             num_new_tokens = min(
-                num_new_tokens, max_total_tokens - 1 - request.num_computed_tokens
+                num_new_tokens, max_total_tokens - request.num_computed_tokens
             )
 
             # Schedule encoder inputs.


### PR DESCRIPTION
Fixes #29496

<!-- markdownlint-disable -->
This PR fixes a critical bug in the V1 scheduler that causes an **infinite loop** when processing prompts at `max_model_len`. An incorrect `-1` offset in the token scheduling constraint prevents the final token from being scheduled, leaving the request stuck in the `running` queue indefinitely.

## Purpose
In [scheduler.py:239](https://github.com/vllm-project/vllm/blob/be493e0b3cfb5810d254e9845217878a39a4853b/vllm/v1/core/sched/scheduler.py#L244), the scheduler applies an unnecessary `-1` offset:

```python
# Buggy code (line 239)
num_new_tokens = min(
    num_new_tokens, max_total_tokens - 1 - request.num_computed_tokens  # ← Bug: -1
)
```

**Impact:** When a prompt fills the model capacity (e.g., 16384 tokens with `max_model_len=16384`), the scheduler can only schedule up to 16383 tokens. The final token can never be scheduled (`min(1, 16384-1-16383) = 0`), so the request never completes.

### Why This Causes an Infinite Loop

1. Request has 1 unprocessed token but `-1` constraint forces `num_new_tokens = 0`
2. Stop condition requires `num_tokens >= max_model_len`, but we're stuck at 16383
3. Request remains in `self.running` queue
4. `has_unfinished_requests()` returns `True` → engine keeps calling `schedule()` forever

**Example with `num_prompt_tokens=16384`, `max_model_len=16384`, token budget=8192:**
- Iteration 1: Schedules 8192 tokens → total: 8192 ✅
- Iteration 2: Schedules 8191 tokens (shortchanged! because of -1 offset) → total: 16383 ⚠️
- Iteration 3+: Cannot schedule final token (`min(1, 0) = 0`) → **infinite loop** 💥

### The Fix

Remove the incorrect `-1` offset:

```python
# Fixed code
num_new_tokens = min(
    num_new_tokens, max_total_tokens - request.num_computed_tokens  # ← Removed -1
)
```

The stop condition in `utils.py:67` uses `>=`, so scheduling exactly `max_model_len` tokens is correct and expected.

## Test Plan

Added a new test file `tests/v1/core/test_scheduler_max_tokens_fix.py` covering:
1. **Max Length Prompts**: Verifies that prompts with length equal to `max_model_len` are fully scheduled and do not get stuck at `max_model_len - 1`.
2. **Infinite Loop Regression**: Reproduces the infinite loop scenario where the final token could not be scheduled, ensuring the scheduler now correctly processes it.
3. **Exact Token Limits**: Confirms that requests generate exactly `max_tokens` outputs, ensuring no off-by-one errors in generation length.
4. **Capacity Edge Cases**: Parametrized tests for various combinations of `max_model_len` and prompt lengths.

Removed -1 offset from test function `tests/v1/core/test_async_scheduler::test_stop_by_max_tokens` to comply with the fix in the `scheduler.py`

## Test Result

- **New Tests**: All tests in `tests/v1/core/test_scheduler_max_tokens_fix.py` passed.
- **Manual Verification**: Confirmed fix with Qwen3-Embedding-8B (pooling model) using a 16384-token prompt:
  - **Before:** System hangs indefinitely after processing 16383 tokens.
  - **After:** Successfully processes all 16384 tokens and completes.
  
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing the test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

