### PR TITLE
hfrunner.classify should return list[list[float]] not list[str]

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -478,6 +478,9 @@ class HfRunner:
         for inputs in all_inputs:
             output = self.model(**self.wrap_device(inputs))
             # NOTE: In practice, HF models return ModelOutput with a `logits` attribute (torch.Tensor).
+            if not hasattr(output, "logits"):
+                raise TypeError("Model output does not have a 'logits' attribute.")
+
             if not isinstance(output.logits, torch.Tensor):
                 raise TypeError(
                     f"'logits' is {type(output.logits)}, expected torch.Tensor"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -467,7 +467,7 @@ class HfRunner:
 
         for inputs in all_inputs:
             output = self.model(**self.wrap_device(inputs))
-            # NOTE: In practice, HF models return ModelOutput with a `logits` attribute (torch.Tensor).
+            # NOTE: In practice, HF models return ModelOutput with a `logits` attribute (torch.Tensor)
             if not hasattr(output, "logits"):
                 raise TypeError("Model output does not have a 'logits' attribute.")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -460,6 +460,16 @@ class HfRunner:
         return embeddings
 
     def classify(self, prompts: list[str]) -> list[list[float]]:
+        from sentence_transformers import SentenceTransformer, CrossEncoder
+
+        # Prevent misuse with incompatible model types
+        if isinstance(self.model, (SentenceTransformer, CrossEncoder)):
+            raise TypeError(
+                "classify() is only supported for standard Hugging Face classification models "
+                "(e.g., AutoModelForSequenceClassification). "
+                "SentenceTransformer and CrossEncoder are not supported."
+            )
+
         # output is final logits
         all_inputs = self.get_inputs(prompts)
         outputs: list[list[float]] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -467,14 +467,8 @@ class HfRunner:
 
         for inputs in all_inputs:
             output = self.model(**self.wrap_device(inputs))
-            # NOTE: In practice, HF models return ModelOutput with a `logits` attribute (torch.Tensor)
-            if not hasattr(output, "logits"):
-                raise TypeError("Model output does not have a 'logits' attribute.")
 
-            if not isinstance(output.logits, torch.Tensor):
-                raise TypeError(
-                    f"'logits' is {type(output.logits)}, expected torch.Tensor"
-                )
+            assert isinstance(output.logits, torch.Tensor)
 
             if problem_type == "regression":
                 logits = output.logits[0].tolist()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -460,16 +460,6 @@ class HfRunner:
         return embeddings
 
     def classify(self, prompts: list[str]) -> list[list[float]]:
-        from sentence_transformers import SentenceTransformer, CrossEncoder
-
-        # Prevent misuse with incompatible model types
-        if isinstance(self.model, (SentenceTransformer, CrossEncoder)):
-            raise TypeError(
-                "classify() is only supported for standard Hugging Face classification models "
-                "(e.g., AutoModelForSequenceClassification). "
-                "SentenceTransformer and CrossEncoder are not supported."
-            )
-
         # output is final logits
         all_inputs = self.get_inputs(prompts)
         outputs: list[list[float]] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -459,14 +459,20 @@ class HfRunner:
             embeddings.append(embedding)
         return embeddings
 
-    def classify(self, prompts: list[str]) -> list[str]:
+    def classify(self, prompts: list[str]) -> list[list[float]]:
         # output is final logits
         all_inputs = self.get_inputs(prompts)
-        outputs = []
+        outputs: list[list[float]] = []
         problem_type = getattr(self.config, "problem_type", "")
 
         for inputs in all_inputs:
             output = self.model(**self.wrap_device(inputs))
+            # NOTE: In practice, HF models return ModelOutput with a `logits` attribute (torch.Tensor).
+            if not isinstance(output.logits, torch.Tensor):
+                raise TypeError(
+                    f"'logits' is {type(output.logits)}, expected torch.Tensor"
+                )
+
             if problem_type == "regression":
                 logits = output.logits[0].tolist()
             elif problem_type == "multi_label_classification":


### PR DESCRIPTION
## Purpose
Fix the return type of HfRunner.classify - should be list[list[float]] and not list[str]

## Test Plan
> N/A

## Test Result
> N/A