### PR TITLE
[CI/build] Add libraries needed for building VLLM wheel to the test docker image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -473,8 +473,14 @@ ENV UV_LINK_MODE=copy
 
 RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
     && echo 'tzdata tzdata/Zones/America select Los_Angeles' | debconf-set-selections \
+    && CUDA_VERSION_DASH=$(echo $CUDA_VERSION | cut -d. -f1,2 | tr '.' '-') \
     && apt-get update -y \
-    && apt-get install -y git
+    && apt-get install -y git \
+    cuda-nvrtc-dev-${CUDA_VERSION_DASH} \
+    libcublas-dev-${CUDA_VERSION_DASH} \
+    libcusolver-dev-${CUDA_VERSION_DASH} \
+    libcusparse-dev-${CUDA_VERSION_DASH} && \
+    rm -rf /var/lib/apt/lists/*
 
 # install development dependencies (for testing)
 RUN --mount=type=cache,target=/root/.cache/uv \


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
Fix building VLLM wheel using VLLM docker image. Mostly fixes issue #29669.

In pull request #29270 we switched from devel to basic nvidia image as a base for the default and test VLLM docker image. This basic nvidia image doesn't contain all libraries needed to build a VLLM wheel. Even though we install nvrtc library in test VLLM docker image, CMake can't find it. But when I install dev version of nvrtc library, CMake does find it and fails while compiling kernels. I found the minimum set of dev libraries needed to compile VLLM wheel successfully. Original test image size is 24.8Gb. With dev libraries it is 28.6Gb. With devel nvidia image it is 34.4Gb. In any case, changes in test image do not increase the size of default docker image.

This change doesn't fix that build python package is missing in the test VLLM docker image.

## Test Plan
Build VLLM test docker image.
`docker build ./vllm --target test --tag ... --file ./vllm/docker/Dockerfile`
Run VLLM test docker image.
`docker container run --rm -it --network host --gpus all --shm-size=2g --entrypoint /bin/bash -v [map vllm dir] ... `
Build full VLLM wheel.
`pip install build && cd vllm && python3 -m build --wheel`

## Test Result
VLLM wheel is build.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

