### PR TITLE
[Docs] Add CLI reference doc for `vllm bench sweep plot_pareto`

### DIFF
--- a/docs/cli/bench/sweep/plot_pareto.md
+++ b/docs/cli/bench/sweep/plot_pareto.md
@@ -1,0 +1,9 @@
+# vllm bench sweep plot_pareto
+
+## JSON CLI Arguments
+
+--8<-- "docs/cli/json_tip.inc.md"
+
+## Arguments
+
+--8<-- "docs/argparse/bench_sweep_plot_pareto.inc.md"


### PR DESCRIPTION
This was missing from https://github.com/vllm-project/vllm/pull/29477