### PR TITLE
[compile] Include `enable_sleep_mode` into caching factors.

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -349,7 +349,6 @@ class ModelConfig:
             "hf_token",
             "hf_overrides",
             "logits_processor_pattern",
-            "enable_sleep_mode",
             "override_attention_dtype",
             "logits_processors",
             "io_processor_plugin",


### PR DESCRIPTION
Summary:

`enable_sleep_mode` will introduce a new allocation context which subtly changes dynamo compilation results.
Therefore we should include it into caching factors (similar to https://github.com/vllm-project/vllm/pull/29435).

Test Plan:

First run test_cumem.py
pytest tests/basic_correctness/test_cumem.py

Second run test_cpu_offload.py
pytest tests/basic_correctness/test_cpu_offload.py

This fails without including enable_sleep_mode into caching factors.
After adding `enable_sleep_mode`, these two tests can pass.

Reviewers:

Subscribers:

Tasks:

Tags:

Signed-off-by: zhxchen17 <zhxchen17@fb.com>


## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

