### PR TITLE
[Frontend] Add streaming tool-call support to Responses API (non-Harmony)

### DIFF
--- a/tests/entrypoints/openai/test_responses_streaming_tool_calls.py
+++ b/tests/entrypoints/openai/test_responses_streaming_tool_calls.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import pytest_asyncio
+from openai.types.responses import (
+    ResponseFunctionCallArgumentsDeltaEvent,
+    ResponseFunctionCallArgumentsDoneEvent,
+    ResponseOutputItemAddedEvent,
+)
+
+from tests.utils import RemoteOpenAIServer
+
+MODEL_NAME = "Qwen/Qwen3-0.6B"
+
+INTEGRATION_TOOLS = [
+    {
+        "type": "function",
+        "name": "get_current_weather",
+        "description": "Get the current weather in a given location",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"},
+                "country": {"type": "string"},
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+            },
+            "required": ["city", "country", "unit"],
+        },
+    }
+]
+
+
+@pytest.fixture(scope="module")
+def responses_server():
+    args = [
+        "--dtype",
+        "half",
+        "--enable-auto-tool-choice",
+        "--structured-outputs-config.backend",
+        "xgrammar",
+        "--tool-call-parser",
+        "hermes",
+        "--reasoning-parser",
+        "qwen3",
+        "--gpu-memory-utilization",
+        "0.3",
+        "--max-model-len",
+        "2048",
+    ]
+    with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
+        yield remote_server
+
+
+@pytest_asyncio.fixture
+async def responses_client(responses_server):
+    async with responses_server.get_async_client() as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        "auto",
+    ],
+)
+async def test_responses_streaming_tool_calls_e2e(responses_client, tool_choice):
+    stream = await responses_client.responses.create(
+        model=MODEL_NAME,
+        input=(
+            "Use the weather tool to get the temperature for Berlin, Germany in "
+            "fahrenheit"
+        ),
+        tools=INTEGRATION_TOOLS,
+        tool_choice=tool_choice,
+        stream=True,
+        temperature=0,
+    )
+
+    added_event = None
+    arg_chunks: list[str] = []
+    final_arguments: str | None = None
+    async for event in stream:
+        if (
+            isinstance(event, ResponseOutputItemAddedEvent)
+            and getattr(event.item, "type", None) == "function_call"
+        ):
+            added_event = event
+        if isinstance(event, ResponseFunctionCallArgumentsDeltaEvent):
+            arg_chunks.append(event.delta)
+        if isinstance(event, ResponseFunctionCallArgumentsDoneEvent):
+            final_arguments = event.arguments
+
+    assert added_event is not None
+    assert final_arguments is not None
+    assert final_arguments == "".join(arg_chunks)
+    args_text = final_arguments.lower()
+    assert "berlin" in args_text
+    assert "germany" in args_text
+    assert "fahrenheit" in args_text


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix for #29725, 

### Summary
This pull request fixes an issue where non harmony models using the Responses API with streaming and tools emit only ResponseTextDeltaEvent events, instead of ResponseFunctionCallArgumentsDeltaEvent when a tool call is selected. This prevents clients from reliably detecting and parsing tool call arguments from the stream.

### Fix
This change updates the streaming path for non harmony models so that:

When the model selects a tool call, the arguments are surfaced as ResponseFunctionCallArgumentsDeltaEvent instead of plain text deltas. The event structure is now consistent with harmony models and with the non streaming Responses API behavior. With this, clients can treat harmony and non harmony models uniformly when handling tool calls during streaming.

## Test Plan
Added a e2e test 

## Test Result:
For the example mentioned in the issue, the events emitted are as:
```
ResponseOutputItemAddedEvent(item=ResponseFunctionToolCall(arguments='', call_id='call_89716b1d95f08274', name='get_weather', type='function_call', id='chatcmpl-tool-a36680e5d0778655', status='in_progress'), output_index=0, sequence_number=2, type='response.output_item.added')
ResponseFunctionCallArgumentsDeltaEvent(delta='{"location": "', item_id='chatcmpl-tool-a36680e5d0778655', output_index=0, sequence_number=3, type='response.function_call_arguments.delta')
ResponseFunctionCallArgumentsDeltaEvent(delta='Paris', item_id='chatcmpl-tool-a36680e5d0778655', output_index=0, sequence_number=4, type='response.function_call_arguments.delta')
ResponseFunctionCallArgumentsDeltaEvent(delta='"}', item_id='chatcmpl-tool-a36680e5d0778655', output_index=0, sequence_number=5, type='response.function_call_arguments.delta')
ResponseFunctionCallArgumentsDoneEvent(arguments='{"location": "Paris"}', item_id='chatcmpl-tool-a36680e5d0778655', name='get_weather', output_index=0, sequence_number=6, type='response.function_call_arguments.done')
ResponseOutputItemDoneEvent(item=ResponseFunctionToolCall(arguments='{"location": "Paris"}', call_id='call_89716b1d95f08274', name='get_weather', type='function_call', id='chatcmpl-tool-a36680e5d0778655', status='completed'), output_index=0, sequence_number=7, type='response.output_item.done')
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

