### PR TITLE
Fix AttributeError about _use_fi_prefill

### DIFF
--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -2061,7 +2061,7 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
                     attn_out,
                     lse,
                     get_dcp_group(),
-                    is_lse_base_on_e=not self._use_fi_prefill,
+                    is_lse_base_on_e=not getattr(self, "_use_fi_prefill", False),
                 )
 
             # v_up projection


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

After https://github.com/vllm-project/vllm/pull/28840 , the nightly [Distributed Tests (H200)](https://buildkite.com/vllm/ci/builds/41171/steps/table?jid=019ace6a-57d7-4bc7-a3aa-c99174395dbd) and [Distributed Tests (B200)](https://buildkite.com/vllm/ci/builds/41171/steps/table?jid=019ace6a-57db-4e0b-9528-e04a0af07b6a) are failing due to 
```
AttributeError: 'FlashAttnMLAImpl' object has no attribute '_use_fi_prefill'
AttributeError: 'CutlassMLAImpl' object has no attribute '_use_fi_prefill'
```

This PR provides a simple fix such that if no `_use_fi_prefill` and avoiding the runtime error.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

