### PR TITLE
[Core] Enable `inputs_embeds_size` separate from `hidden_size`

### DIFF
--- a/tests/models/multimodal/pooling/test_siglip.py
+++ b/tests/models/multimodal/pooling/test_siglip.py
@@ -19,7 +19,12 @@ HF_IMAGE_PROMPTS = IMAGE_ASSETS.prompts(
     }
 )
 
-MODELS = ["google/siglip-base-patch16-224", "google/siglip2-base-patch16-224"]
+MODELS = [
+    "google/siglip-base-patch16-224",
+    "google/siglip2-base-patch16-224",
+    # Different image embedding dim than text_config.hidden_size
+    "google/siglip2-giant-opt-patch16-384",
+]
 
 
 def _run_test(

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1202,6 +1202,16 @@ class ModelConfig:
     def get_hidden_size(self) -> int:
         return getattr(self.hf_text_config, "hidden_size", 0)
 
+    def get_inputs_embeds_size(self) -> int:
+        # in most cases the size of inputs_embeds is identical to the size
+        # of the hidden states, however there are exceptions, for example for
+        # embedding models like CLIP and SigLIP
+        for target_attr in ("inputs_embeds_size", "projection_dim", "projection_size"):
+            if hasattr(self.hf_text_config, target_attr):
+                return getattr(self.hf_text_config, target_attr)
+
+        return self.get_hidden_size()
+
     @property
     def is_deepseek_mla(self) -> bool:
         if not hasattr(self.hf_text_config, "model_type"):

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1203,8 +1203,8 @@ class ModelConfig:
         return getattr(self.hf_text_config, "hidden_size", 0)
 
     def get_inputs_embeds_size(self) -> int:
-        # in most cases the size of inputs_embeds is identical to the size
-        # of the hidden states, however there are exceptions, for example
+        # The size of inputs_embeds is usually identical to the size
+        # of the hidden states, however there are exceptions, such as
         # embedding models like CLIP and SigLIP
         for target_attr in ("projection_dim", "projection_size"):
             if hasattr(self.hf_text_config, target_attr):

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1204,7 +1204,7 @@ class ModelConfig:
 
     def get_inputs_embeds_size(self) -> int:
         # in most cases the size of inputs_embeds is identical to the size
-        # of the hidden states, however there are exceptions, for example for
+        # of the hidden states, however there are exceptions, for example
         # embedding models like CLIP and SigLIP
         for target_attr in ("inputs_embeds_size", "projection_dim", "projection_size"):
             if hasattr(self.hf_text_config, target_attr):

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1206,7 +1206,7 @@ class ModelConfig:
         # in most cases the size of inputs_embeds is identical to the size
         # of the hidden states, however there are exceptions, for example
         # embedding models like CLIP and SigLIP
-        for target_attr in ("inputs_embeds_size", "projection_dim", "projection_size"):
+        for target_attr in ("projection_dim", "projection_size"):
             if hasattr(self.hf_text_config, target_attr):
                 return getattr(self.hf_text_config, target_attr)
 

--- a/vllm/model_executor/models/clip.py
+++ b/vllm/model_executor/models/clip.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from functools import cached_property
 from typing import Annotated, Literal
 
@@ -903,6 +903,38 @@ class CLIPEmbeddingModel(nn.Module, SupportsMultiModal, SupportsQuant):
     def get_language_model(self) -> torch.nn.Module:
         return self.text_model
 
+    def _embed_text_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        embed_input_ids: Callable[[torch.Tensor], torch.Tensor],
+        *,
+        is_multimodal: torch.Tensor | None,
+        handle_oov_mm_token: bool,
+    ) -> torch.Tensor:
+        inputs_embeds = super()._embed_text_input_ids(
+            input_ids,
+            embed_input_ids,
+            is_multimodal=is_multimodal,
+            handle_oov_mm_token=handle_oov_mm_token,
+        )
+
+        # NOTE: inputs_embeds in model runner has size
+        # text_config.projection_dim to accommodate image embeddings
+        inputs_embeds_size = self.projection_dim
+        if inputs_embeds.shape[1] != inputs_embeds_size:
+            inputs_embeds = torch.cat(
+                [
+                    inputs_embeds,
+                    inputs_embeds.new_empty(
+                        inputs_embeds.shape[0],
+                        inputs_embeds_size - inputs_embeds.shape[1],
+                    ),
+                ],
+                dim=1,
+            )
+
+        return inputs_embeds
+
     def embed_input_ids(
         self,
         input_ids: torch.Tensor,
@@ -949,10 +981,13 @@ class CLIPEmbeddingModel(nn.Module, SupportsMultiModal, SupportsQuant):
         if not self._is_text_input:
             return inputs_embeds
 
-        # Text inputs
-        return self.get_text_features(
-            input_ids=input_ids, position_ids=positions, inputs_embeds=inputs_embeds
-        )
+        # NOTE: inputs_embeds in model runner has size
+        # text_config.projection_size to accommodate image embeddings
+        hidden_size = self.text_embed_dim
+        if inputs_embeds.shape[1] != hidden_size:
+            inputs_embeds = inputs_embeds[:, :hidden_size]
+
+        return self.get_text_features(input_ids, positions, inputs_embeds)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         loader = AutoWeightsLoader(

--- a/vllm/model_executor/models/clip.py
+++ b/vllm/model_executor/models/clip.py
@@ -982,7 +982,7 @@ class CLIPEmbeddingModel(nn.Module, SupportsMultiModal, SupportsQuant):
             return inputs_embeds
 
         # NOTE: inputs_embeds in model runner has size
-        # text_config.projection_size to accommodate image embeddings
+        # text_config.projection_dim to accommodate image embeddings
         hidden_size = self.text_embed_dim
         if inputs_embeds.shape[1] != hidden_size:
             inputs_embeds = inputs_embeds[:, :hidden_size]

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -990,7 +990,8 @@ class SiglipTextEmbeddings(nn.Module):
                 embeddings.new_empty(
                     len(embeddings), config.projection_size - embeddings.shape[1]
                 ),
-            ]
+            ],
+            dim=1,
         )
 
 

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Implementation of SiglipVisionModel intended to be only used
-within a vision language model."""
 
 import math
 from collections.abc import Iterable, Mapping
@@ -1168,8 +1166,8 @@ class SiglipEmbeddingModel(nn.Module, SupportsMultiModal, SupportsQuant):
                 handle_oov_mm_token=handle_oov_mm_token,
             )
 
-        # NOTE: inputs_embeds has size text_config.projection_size
-        # to accommodate image embeddings
+        # NOTE: inputs_embeds in model runner has hidden dimension
+        # text_config.projection_size to accommodate image embeddings
         text_config = self.config.text_config
         return torch.cat(
             [
@@ -1204,8 +1202,8 @@ class SiglipEmbeddingModel(nn.Module, SupportsMultiModal, SupportsQuant):
         if not self._is_text_input:
             return inputs_embeds
 
-        # NOTE: inputs_embeds has size text_config.projection_size
-        # to accommodate image embeddings
+        # NOTE: inputs_embeds in model runner has hidden dimension
+        # text_config.projection_size to accommodate image embeddings
         text_config = self.config.text_config
         inputs_embeds = inputs_embeds[:, : text_config.hidden_size]
 

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -1159,10 +1159,10 @@ class SiglipEmbeddingModel(nn.Module, SupportsMultiModal, SupportsQuant):
             handle_oov_mm_token=handle_oov_mm_token,
         )
 
-        # NOTE: inputs_embeds in model runner has size
-        # text_config.projection_size to accommodate image embeddings
+        # NOTE: inputs_embeds in model runner has size text_config.projection_size
+        # (instead of text_config.hidden_size) to accommodate image embeddings
         inputs_embeds_size = self.text_projection_size
-        if inputs_embeds.shape[1] != inputs_embeds_size:
+        if inputs_embeds.shape[1] < inputs_embeds_size:
             inputs_embeds = torch.cat(
                 [
                     inputs_embeds,
@@ -1173,6 +1173,9 @@ class SiglipEmbeddingModel(nn.Module, SupportsMultiModal, SupportsQuant):
                 ],
                 dim=1,
             )
+        elif inputs_embeds.shape[1] > inputs_embeds_size:
+            # No need to handle this case for now
+            raise NotImplementedError
 
         return inputs_embeds
 
@@ -1221,11 +1224,14 @@ class SiglipEmbeddingModel(nn.Module, SupportsMultiModal, SupportsQuant):
         if not self._is_text_input:
             return inputs_embeds
 
-        # NOTE: inputs_embeds in model runner has size
-        # text_config.projection_size to accommodate image embeddings
+        # NOTE: inputs_embeds in model runner has size text_config.projection_size
+        # (instead of text_config.hidden_size) to accommodate image embeddings
         hidden_size = self.text_embed_dim
-        if inputs_embeds.shape[1] != hidden_size:
+        if inputs_embeds.shape[1] > hidden_size:
             inputs_embeds = inputs_embeds[:, :hidden_size]
+        elif inputs_embeds.shape[1] < hidden_size:
+            # No need to handle this case for now
+            raise NotImplementedError
 
         return self.get_text_features(input_ids, positions, inputs_embeds)
 

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -976,14 +976,14 @@ class SiglipTextEmbeddings(nn.Module):
         if inputs_embeds is None:
             inputs_embeds = self.token_embedding(input_ids)
         else:
-            # NOTE: inputs_embeds has size self.config.projection_size
+            # NOTE: inputs_embeds has size config.projection_size
             # to accommodate image embeddings
             inputs_embeds = inputs_embeds[:, : config.hidden_size]
 
         position_embeddings = self.position_embedding(position_ids)
         embeddings = inputs_embeds + position_embeddings
 
-        # NOTE: Need to match self.config.projection_size
+        # NOTE: Need to match config.projection_size
         return torch.cat(
             [
                 embeddings,

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -973,6 +973,10 @@ class SiglipTextEmbeddings(nn.Module):
     ) -> torch.Tensor:
         if inputs_embeds is None:
             inputs_embeds = self.token_embedding(input_ids)
+        else:
+            # NOTE: inputs_embeds has size self.config.projection_size
+            # to accommodate image embeddings
+            inputs_embeds = inputs_embeds[:, : self.config.hidden_size]
 
         position_embeddings = self.position_embedding(position_ids)
         embeddings = inputs_embeds + position_embeddings

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -80,6 +80,7 @@ class EagleProposer:
         # the draft model's hidden size can be different from the target model's
         # hidden size (e.g., Llama 3.3 70B).
         self.hidden_size = self.draft_model_config.get_hidden_size()
+        self.inputs_embeds_size = self.draft_model_config.get_inputs_embeds_size()
 
         # Multi-modal data support
         self.mm_registry = MULTIMODAL_REGISTRY
@@ -151,7 +152,9 @@ class EagleProposer:
         )
 
         self.inputs_embeds = torch.zeros(
-            (self.max_num_tokens, self.hidden_size), dtype=self.dtype, device=device
+            (self.max_num_tokens, self.inputs_embeds_size),
+            dtype=self.dtype,
+            device=device,
         )
 
         self.backup_next_token_ids = CpuGpuBuffer(

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -17,7 +17,7 @@ class InputBuffers:
         self,
         max_num_reqs: int,
         max_num_tokens: int,
-        hidden_size: int,
+        inputs_embeds_size: int,
         vocab_size: int,
         dtype: torch.dtype,
         device: torch.device,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -98,7 +98,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.max_model_len = self.model_config.max_model_len
         self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
         self.max_num_reqs = self.scheduler_config.max_num_seqs
-        self.hidden_size = self.model_config.get_hidden_size()
+        self.inputs_embeds_size = self.model_config.get_inputs_embeds_size()
 
         self.dp_size = self.parallel_config.data_parallel_size
         self.dp_rank = self.parallel_config.data_parallel_rank
@@ -134,7 +134,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.input_buffers = InputBuffers(
             max_num_reqs=self.max_num_reqs,
             max_num_tokens=self.max_num_tokens,
-            hidden_size=self.hidden_size,
+            inputs_embeds_size=self.inputs_embeds_size,
             vocab_size=self.vocab_size,
             dtype=self.dtype,
             device=self.device,

--- a/vllm/v1/worker/gpu/spec_decode/eagle.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle.py
@@ -44,6 +44,7 @@ class EagleSpeculator:
         # the draft model's hidden size can be different from the target model's
         # hidden size (e.g., Llama 3.3 70B).
         self.hidden_size = self.draft_model_config.get_hidden_size()
+        self.inputs_embeds_size = self.draft_model_config.get_inputs_embeds_size()
         self.vocab_size = self.draft_model_config.get_vocab_size()
         self.pin_memory = is_pin_memory_available()
         self.dtype = vllm_config.model_config.dtype
@@ -51,7 +52,7 @@ class EagleSpeculator:
         self.input_buffers = InputBuffers(
             max_num_reqs=self.max_num_reqs,
             max_num_tokens=self.max_num_tokens,
-            hidden_size=self.hidden_size,
+            inputs_embeds_size=self.inputs_embeds_size,
             vocab_size=self.vocab_size,
             dtype=self.dtype,
             device=device,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -320,7 +320,7 @@ class GPUModelRunner(
 
         # Model-related.
         self.num_query_heads = model_config.get_num_attention_heads(parallel_config)
-        self.hidden_size = model_config.get_hidden_size()
+        self.inputs_embeds_size = model_config.get_inputs_embeds_size()
         self.attention_chunk_size = model_config.attention_chunk_size
         # Only relevant for models using ALiBi (e.g, MPT)
         self.use_alibi = model_config.uses_alibi
@@ -485,7 +485,7 @@ class GPUModelRunner(
         # version of this tensor, avoid a RuntimeError by not creating a
         # numpy buffer.
         self.inputs_embeds = self._make_buffer(
-            self.max_num_tokens, self.hidden_size, dtype=self.dtype, numpy=False
+            self.max_num_tokens, self.inputs_embeds_size, dtype=self.dtype, numpy=False
         )
         self.is_token_ids = self._make_buffer(self.max_num_tokens, dtype=torch.bool)
         self.discard_request_mask = self._make_buffer(

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -215,7 +215,7 @@ class TPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.num_query_heads = model_config.get_num_attention_heads(parallel_config)
         self.num_kv_heads = model_config.get_num_kv_heads(parallel_config)
         self.head_size = model_config.get_head_size()
-        self.hidden_size = model_config.get_hidden_size()
+        self.inputs_embeds_size = model_config.get_inputs_embeds_size()
         self.vocab_size = model_config.get_vocab_size()
 
         # Multi-modal data support
@@ -1406,7 +1406,9 @@ class TPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if self.supports_mm_inputs:
             input_ids = None
             inputs_embeds = torch.zeros(
-                (num_tokens, self.hidden_size), dtype=self.dtype, device=self.device
+                (num_tokens, self.inputs_embeds_size),
+                dtype=self.dtype,
+                device=self.device,
             )
         else:
             input_ids = torch.zeros((num_tokens), dtype=torch.int32).to(self.device)


### PR DESCRIPTION
## Purpose

- Add a new method `ModelConfig.get_inputs_embeds_size` to distinguish the hidden dimension of `inputs_embeds` from `ModelConfig.get_hidden_size`.
- Update model runners to use  `ModelConfig.get_inputs_embeds_size`. **(Notable for OOT model runners)**
- Update CLIP and SigLIP to handle the case when `get_inputs_embeds_size` and `get_hidden_size` return different values.

FIX https://github.com/vllm-project/vllm/pull/27566#issuecomment-3592118365

cc @piood @patrickvonplaten @wangxiyuan 

## Test Plan

Add `google/siglip2-giant-opt-patch16-384` to SigLIP tests

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

