### PR TITLE
[MoE-FP8-modelopt] Add FlashInfer alignment padding for intermediate dimensions

### DIFF
--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -793,10 +793,6 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
                 "Expected activation to be in ('silu', 'relu2_no_mul'),"
                 f"but got {activation}"
             )
-            print(f"daniel FlashinferMoeBackend is here!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-            print(f"shape of x: {x.shape}")
-            print(f"shape of layer.w13_weight: {layer.w13_weight.shape}")
-            print(f"shape of layer.w2_weight: {layer.w2_weight.shape}")
             return flashinfer_cutlass_moe_fp8(
                 x,
                 layer,


### PR DESCRIPTION
This PR adds support for FlashInfer MoE FP8 kernels that require the intermediate (gated) dimension to be aligned.
Some models break when the intermediate size isn’t divisible by 16, especially under different TP.


This PR introduces `_maybe_pad_intermediate_for_flashinfer`, which pads w13 and w2 along the intermediate dim so the weights meet FlashInfer’s alignment constraints.

If padding is needed, we zero-pad the up/gate and down projection weights and update intermediate_size_per_partition accordingly. This keeps the model numerically correct while avoiding kernel launch failures.