### PR TITLE
[CI] Skip paddleocr_vl for transformer 4.57.3

### DIFF
--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -708,6 +708,12 @@ VLM_TEST_SETTINGS = {
         max_num_seqs=2,
         auto_cls=AutoModelForCausalLM,
         image_size_factors=[(), (0.25,)],
+        marks=[
+            pytest.mark.skipif(
+                Version(TRANSFORMERS_VERSION) == Version("4.57.3"),
+                reason="This model is broken in Transformers v4.57.3",
+            )
+        ],
     ),
     "phi3v": VLMTestInfo(
         models=["microsoft/Phi-3.5-vision-instruct"],


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

See slack [discussion](https://vllm-dev.slack.com/archives/C07R5PAL2L9/p1764309302685079), [Multi-Modal Models Test (Extended) 2](https://buildkite.com/vllm/ci/builds/41259/steps/canvas?sid=019ad6c8-ac34-4ae1-a72d-6b7ad7f07ae4) is failing on `models/multimodal/generation/test_common.py::test_single_image_models[paddleocr_vl-test_case46]` and `models/multimodal/generation/test_common.py::test_multi_image_models[paddleocr_vl-test_case46]`. This PR will skip the two tests if transformer version is 4.57.3

Once `check_model_inputs` is fixed from upstream, we can remove the skip

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

