### PR TITLE
[Bugfix]: Fix missing SPLIT_K in GPTQ/AWQ MoE Triton config

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -614,6 +614,7 @@ def invoke_fused_moe_kernel(
             bit=4 if use_int4_w4a16 else 8,
         )
         config = config.copy()
+        config["SPLIT_K"] = 1
         config.update(
             get_moe_wna16_block_config(
                 config=config,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
 Fix issue: https://github.com/vllm-project/vllm/issues/29765

On vLLM 0.11.1 or 0.11.2, server launch failed when try to launch AWQ / GPTQ MoE Model.

The problem is introduced by this PR: https://github.com/vllm-project/vllm/pull/27291

The PR added SPLIT_K forfused_moe_kernel_gptq_awq, but ensured its presence only when using get_default_config.
In other code paths, the Triton config may not contain "SPLIT_K", leading to a failure during kernel selection.

The issue can be resolved by explicitly adding
config["SPLIT_K"] = 1
when constructing the Triton config.

## Test Plan
E2E test:
`python3 -m vllm.entrypoints.openai.api_server --trust-remote-code --host 0.0.0.0 --port 8999  --model QuixiAI/Qwen3-30B-A3B-AWQ --tensor-parallel-size 1 --distributed-executor-backend=mp --no-enable-prefix-caching`

## Test Result
Before: Server launch failed
After: Server launch Success

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

