### PR TITLE
[Bugfix][MM] Move `grid_thw` tensor to cpu before directly converting to numpy

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -538,6 +538,7 @@ class Qwen3_VisionTransformer(nn.Module):
             grid_thw_list = grid_thw
             grid_thw = np.array(grid_thw, dtype=np.int32)
         else:
+            grid_thw = grid_thw.to("cpu")
             grid_thw_list = grid_thw.tolist()
             grid_thw = grid_thw.numpy()
 


### PR DESCRIPTION
## Purpose

When `grid_thw` in ViT forward is a tensor, it should be moved to cpu before directly converting to numpy, otherwise there could be error like:

```bash
TypeError: can't convert npu:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

