### PR TITLE
[Misc] Throw error on unintended access to scheduler_config.max_model_len

### DIFF
--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -276,8 +276,6 @@ class SchedulerConfig:
         return self
 
     def __getattribute__(self, name: str) -> Any:
-        if name == 'max_model_len' or name == 'is_encoder_decoder':
-            raise AttributeError(
-                f"{name} is an init-only parameter. "
-            )
+        if name == "max_model_len" or name == "is_encoder_decoder":
+            raise AttributeError(f"{name} is an init-only parameter. ")
         return object.__getattribute__(self, name)

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -274,3 +274,11 @@ class SchedulerConfig:
             )
 
         return self
+
+    def __getattribute__(self, name: str) -> Any:
+        if name == 'max_model_len' or name == 'is_encoder_decoder':
+            raise AttributeError(
+                "max_model_len is an init-only parameter. "
+                "Access it from ModelConfig instead."
+            )
+        return object.__getattribute__(self, name)

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -278,7 +278,6 @@ class SchedulerConfig:
     def __getattribute__(self, name: str) -> Any:
         if name == 'max_model_len' or name == 'is_encoder_decoder':
             raise AttributeError(
-                "max_model_len is an init-only parameter. "
-                "Access it from ModelConfig instead."
+                f"{name} is an init-only parameter. "
             )
         return object.__getattribute__(self, name)


### PR DESCRIPTION
## Purpose
There is a risk when people unintentionally try to access scheduler_config.max_model_len and it is returned as 8192. SInce it is removed in https://github.com/vllm-project/vllm/pull/28733, we should give people AttributeError as alert.
## Test Plan

## Test Result
Before the fix:
>>> from vllm.config import VllmConfig
>>> vllm_config = VllmConfig()
INFO 11-30 22:40:59 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
>>> vllm_config.scheduler_config.max_model_len
8192

After the fix:
>>> from vllm.config import VllmConfig
>>> vllm_config = VllmConfig()
INFO 11-30 22:40:08 [scheduler.py:207] Chunked prefill is enabled with max_num_batched_tokens=2048.
>>> vllm_config.scheduler_config.max_model_len
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data/users/wwei6/gitrepos/vllm-main-frank-branch/vllm/config/scheduler.py", line 280, in __getattribute__
    raise AttributeError(
AttributeError: max_model_len is an init-only parameter.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

