### PR TITLE
[ROCm] [Fused Moe EP] Use binary expert mask for aiter fused moe kernel

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -94,9 +94,6 @@ def _rocm_aiter_fused_moe_impl(
     activation = ActivationType(activation_method)
     quant_type = QuantType(quant_method)
 
-    assert expert_mask is None or torch.all((expert_mask == 0) | (expert_mask == 1)), (
-        "Aiter Fused MoE kernel only supports expert_map with 0 and 1s."
-    )
     return fused_moe(
         hidden_states,
         w1,

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -94,7 +94,7 @@ def _rocm_aiter_fused_moe_impl(
     activation = ActivationType(activation_method)
     quant_type = QuantType(quant_method)
 
-    assert torch.all((expert_mask == 0) | (expert_mask == 1)), (
+    assert expert_mask is None or torch.all((expert_mask == 0) | (expert_mask == 1)), (
         "Aiter Fused MoE kernel only supports expert_map with 0 and 1s."
     )
     return fused_moe(

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -94,6 +94,9 @@ def _rocm_aiter_fused_moe_impl(
     activation = ActivationType(activation_method)
     quant_type = QuantType(quant_method)
 
+    assert torch.all((expert_mask == 0) | (expert_mask == 1)), (
+        "Aiter Fused MoE kernel only supports expert_map with 0 and 1s."
+    )
     return fused_moe(
         hidden_states,
         w1,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -520,6 +520,28 @@ class FusedMoE(CustomOp):
         self._init_aiter_shared_experts_topK_buffer(
             vllm_config=vllm_config, dp_size=dp_size_
         )
+        if self.use_ep and self.rocm_aiter_fmoe_enabled:
+            # Aiter requires mask to be in binary format.
+            expert_mask = torch.ones(
+                (self.global_num_experts + self.num_fused_shared_experts + 1,),
+                dtype=torch.int32,
+            )
+            expert_mask[-1] = 0
+            expert_mask[: self.global_num_experts] = self.expert_map > -1
+            self.expert_mask = expert_mask
+            self.expert_map = torch.cat(
+                (
+                    self.expert_map,
+                    torch.tensor(
+                        [
+                            self.local_num_experts + i
+                            for i in range(self.num_fused_shared_experts)
+                        ],
+                        dtype=torch.int32,
+                    ),
+                ),
+                dim=0,
+            )
 
         assert intermediate_size % self.tp_size == 0
         self.hidden_size = hidden_size

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -633,6 +633,7 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
                 topk_ids=topk_ids,
                 activation=activation,
                 quant_config=self.moe_quant_config,
+                expert_map=expert_map,
             )
         else:
             from vllm.model_executor.layers.fused_moe import fused_experts


### PR DESCRIPTION
## Purpose

Quark Fused Moe meets acc issue in DeepSeek-R1 Expert Parallelism. This PR fixes it through setting the right expert mask with format required by aiter kernel. The aiter kernel requires the mask to be a bitmask. 1 means the expert is on current rank, while 0 is not.

## Test Plan

Server Launch

```bash
export VLLM_USE_V1=1
# export VLLM_LOGGING_LEVEL=DEBUG
export VLLM_RPC_TIMEOUT=1800000
export VLLM_USE_TRITON_FLASH_ATTN=1
export VLLM_ROCM_USE_AITER=1
export VLLM_ROCM_USE_AITER_MHA=0
export VLLM_ROCM_USE_AITER_MLA=0
export VLLM_ROCM_USE_AITER_MOE=1
export VLLM_ROCM_USE_AITER_TRITON_ROPE=1
export VLLM_DISABLE_COMPILE_CACHE=1
export VLLM_ROCM_USE_AITER_FP4_ASM_GEMM=0
export VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=0 

export TRITON_HIP_ASYNC_COPY_BYPASS_PERMUTE=1
export TRITON_HIP_USE_ASYNC_COPY=1
export TRITON_HIP_USE_BLOCK_PINGPONG=1
export TRITON_HIP_ASYNC_FAST_SWIZZLE=1
export NCCL_DEBUG=WARN
export AMDGCN_USE_BUFFER_OPS=1
export SAFETENSORS_FAST_GPU=1

model_path=amd/DeepSeek-R1-MXFP4-Preview
echo "running $model_path"

vllm serve $model_path \
  --host localhost \
  --port 9000 \
  --data-parallel-size 8 \
  --enable-expert-parallel \
  --max-num-batched-tokens 32768 \
  --trust-remote-code \
  --no-enable-prefix-caching \
  --disable-log-requests \
  --compilation-config '{"cudagraph_mode": "FULL_AND_PIECEWISE"}' \
  --gpu_memory_utilization 0.8 \
  --async-scheduling \
  --load-format fastsafetensors \
  --block-size 16 \
  --seed 123 2>&1 | tee log.server.log &
```

Bechmark

```
addr=localhost
port=9000
url=http://${addr}:${port}/v1/completions
model=amd/DeepSeek-R1-MXFP4-Preview
bs=50
task=gsm8k

echo "url=${url}"
echo "model=${model}"
echo "task=${task}"

lm_eval \
    --model local-completions \
    --tasks ${task} \
    --model_args model=${model},base_url=${url} \
    --batch_size ${bs} \
    --seed 123 \
    2>&1 | tee log.lmeval.log
```



## Test Result

Following are the benchmark results on dataset gsm8k

* FULL_AND_PIECEWISE mode
<img width="898" height="161" alt="image" src="https://github.com/user-attachments/assets/04d34ea4-2718-47f9-80fe-e78adc26c35a" />

* Eager mode

<img width="1029" height="274" alt="image" src="https://github.com/user-attachments/assets/a4273c94-8fa5-439c-a94a-7b0573a862e7" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

