### PR TITLE
[XPU] Fix AWQ skipped layer detection in IPEX quantization

### DIFF
--- a/vllm/model_executor/layers/quantization/ipex_quant.py
+++ b/vllm/model_executor/layers/quantization/ipex_quant.py
@@ -150,7 +150,10 @@ class IPEXConfig(QuantizationConfig):
         if isinstance(layer, LinearBase):
             if self.method == "awq":
                 if is_layer_skipped(
-                    prefix, self.modules_to_not_convert, self.packed_modules_mapping
+                    prefix,
+                    self.modules_to_not_convert,
+                    self.packed_modules_mapping,
+                    skip_with_substr=True,
                 ):
                     return UnquantizedLinearMethod()
                 return IPEXAWQLinearMethod(self)


### PR DESCRIPTION
## Purpose
When running Qwen/Qwen2.5-VL-7B-Instruct-AWQ on XPU with Tensor Parallelism (TP=4), the engine failed to start with the following error:
```bash
ValueError: The input size is not aligned with the quantized weight shape. This can be caused by too large tensor parallel size.
```
This occurred because the visual encoder layers (e.g., visual.blocks.0.attn.proj) were not being identified as skipped layers. The IPEXConfig, which performs an exact string match, still uses the old logic, resulting in a validation error.

Analog to PR: https://github.com/vllm-project/vllm/pull/27416 , we need to add skip_with_substr=True to IPEXConfig.

## Test Plan
```bash
VLLM_USE_V1=1 VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 python3 -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-VL-7B-Instruct-AWQ --enforce-eager --port 8000 --host 0.0.0.0 --trust-remote-code --gpu-memory-util=0.9 --no-enable-prefix-caching --max-num-batched-tokens=8192 --disable-log-requests --max-model-len=30000 --block-size 64 --dtype=float16 -tp=4
```
## Test Result
Engine can be started.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>