### PR TITLE
[Hardware][AMD] Remove ROCm skip conditions for transformers backend tests

### DIFF
--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -6,8 +6,6 @@ from typing import Any
 
 import pytest
 
-from vllm.platforms import current_platform
-
 from ..conftest import HfRunner, VllmRunner
 from ..utils import multi_gpu_test, prep_prompts
 from .registry import HF_EXAMPLE_MODELS
@@ -59,10 +57,6 @@ def check_implementation(
     )
 
 
-@pytest.mark.skipif(
-    current_platform.is_rocm(),
-    reason="Llama-3.2-1B-Instruct, Ilama-3.2-1B produce memory access fault.",
-)
 @pytest.mark.parametrize(
     "model,model_impl",
     [
@@ -147,12 +141,6 @@ def test_quantization(
     max_tokens: int,
     num_logprobs: int,
 ) -> None:
-    if (
-        current_platform.is_rocm()
-        and quantization_kwargs.get("quantization", "") == "bitsandbytes"
-    ):
-        pytest.skip("bitsandbytes quantization is currently not supported in rocm.")
-
     with vllm_runner(
         model,
         model_impl="auto",

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import pytest
 
+from vllm.platforms import current_platform
+
 from ..conftest import HfRunner, VllmRunner
 from ..utils import multi_gpu_test, prep_prompts
 from .registry import HF_EXAMPLE_MODELS
@@ -141,6 +143,12 @@ def test_quantization(
     max_tokens: int,
     num_logprobs: int,
 ) -> None:
+    if (
+        current_platform.is_rocm()
+        and quantization_kwargs.get("quantization", "") == "bitsandbytes"
+    ):
+        pytest.skip("bitsandbytes quantization is currently not supported in rocm.")
+
     with vllm_runner(
         model,
         model_impl="auto",


### PR DESCRIPTION
## Summary

Removes skip conditions for transformers backend tests on ROCm platform. These tests now pass successfully, so the skips are no longer needed. 

@hmellor 