### PR TITLE
[Doc] Update description disable_any_whitespace

### DIFF
--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -28,8 +28,10 @@ class StructuredOutputsConfig:
     disable_fallback: bool = False
     """If `True`, vLLM will not fallback to a different backend on error."""
     disable_any_whitespace: bool = False
-    """If `True`, the model will not generate any whitespace during structured
-    outputs. This is only supported for xgrammar and guidance backends."""
+    """If `True`, json output will always be compact without any whitespace.
+    If `False`, the model may generate whitespace between JSON fields,
+    which is still valid JSON. This is only supported for xgrammar
+    and guidance backends."""
     disable_additional_properties: bool = False
     """If `True`, the `guidance` backend will not use `additionalProperties`
     in the JSON schema. This is only supported for the `guidance` backend and


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Hi @russellb and @mgoin 

Thanks for your great work on structured outputs in VLLM.

I've been working with both xgrammar and llguidance through VLLM for a while with `json`, `regex` and `lark/grammar` and found the description for `disable_any_whitespace` to be quite general:

```
If `True`, the model will not generate any whitespace during structured
outputs. This is only supported for xgrammar and guidance backends.
```

Two goals:
- specify that this only applies to `json` output, which it does
- give a note of what the reason for the flag is

Proposal:

```python
disable_any_whitespace: bool = False
  """If `True`, guided_json output will always be compact without any
  whitespace. If `False`, the model may generate whitespace between JSON
  fields, which is still valid JSON. This is only supported for xgrammar
  and guidance backends."""
```

## Test Plan
None
## Test Result
None