### PR TITLE
[CI] fix url-encoding behavior in nightly metadata generation

### DIFF
--- a/.buildkite/scripts/generate-nightly-index.py
+++ b/.buildkite/scripts/generate-nightly-index.py
@@ -113,10 +113,9 @@ def generate_package_index_and_metadata(
             wheel_base_dir.relative_to(index_base_dir, walk_up=True) / file.filename
         )
         # handle with '+' in URL, and avoid double-encoding '/' and already-encoded '%2B'
+        # NOTE: this is AWS S3 specific behavior!
         file_path_quoted = quote(relative_path.as_posix(), safe=":%/")
-        href_tags.append(
-            f'    <a href="{file_path_quoted}">{file.filename}</a><br/>'
-        )
+        href_tags.append(f'    <a href="{file_path_quoted}">{file.filename}</a><br/>')
         file_meta = asdict(file)
         file_meta["path"] = file_path_quoted
         metadata.append(file_meta)

--- a/.buildkite/scripts/generate-nightly-index.py
+++ b/.buildkite/scripts/generate-nightly-index.py
@@ -112,11 +112,13 @@ def generate_package_index_and_metadata(
         relative_path = (
             wheel_base_dir.relative_to(index_base_dir, walk_up=True) / file.filename
         )
+        # handle with '+' in URL, and avoid double-encoding '/' and already-encoded '%2B'
+        file_path_quoted = quote(relative_path.as_posix(), safe=":%/")
         href_tags.append(
-            f'    <a href="{quote(relative_path.as_posix())}">{file.filename}</a><br/>'
+            f'    <a href="{file_path_quoted}">{file.filename}</a><br/>'
         )
         file_meta = asdict(file)
-        file_meta["path"] = relative_path.as_posix()
+        file_meta["path"] = file_path_quoted
         metadata.append(file_meta)
     index_str = INDEX_HTML_TEMPLATE.format(items="\n".join(href_tags))
     metadata_str = json.dumps(metadata, indent=2)
@@ -185,7 +187,7 @@ def generate_index_and_metadata(
                 "platform_tag": "manylinux2014_aarch64",
                 "variant": "cu129",
                 "filename": "vllm-0.10.2rc2+cu129-cp38-abi3-manylinux2014_aarch64.whl",
-                "path": "../vllm-0.10.2rc2+cu129-cp38-abi3-manylinux2014_aarch64.whl" # to be concatenated with the directory URL
+                "path": "../vllm-0.10.2rc2%2Bcu129-cp38-abi3-manylinux2014_aarch64.whl" # to be concatenated with the directory URL and URL-encoded
             },
             ...
         ]

--- a/setup.py
+++ b/setup.py
@@ -686,17 +686,17 @@ if envs.VLLM_USE_PRECOMPILED:
             precompiled_wheel_utils.get_base_commit_in_main_branch(),
         )
         logger.info(
-            "Using precompiled wheel commit {} with variant {}", commit, variant
+            "Using precompiled wheel commit %s with variant %s", commit, variant
         )
         try_default = False
         wheels, repo_url = None, None
         try:
             wheels, repo_url = _fetch_metadata_for_variant(commit, variant)
-        except Exception as e:
+        except Exception:
             logger.warning(
-                "Failed to fetch precompiled wheel metadata for variant {}",
+                "Failed to fetch precompiled wheel metadata for variant %s",
                 variant,
-                exc_info=e,
+                exc_info=True,
             )
             try_default = True  # try outside handler to keep the stacktrace simple
         if try_default:
@@ -725,17 +725,18 @@ if envs.VLLM_USE_PRECOMPILED:
             if wheel.get("package_name") == "vllm" and arch in wheel.get(
                 "platform_tag", ""
             ):
-                logger.info("Found precompiled wheel metadata: {}", wheel)
+                logger.info("Found precompiled wheel metadata: %s", wheel)
                 if "path" not in wheel:
                     raise ValueError(f"Wheel metadata missing path: {wheel}")
                 path = wheel["path"]
                 # path may contain '+' which needs to be URL-encoded
-                if '+' in path:
+                if "+" in path:
                     from urllib.parse import quote
+
                     path = quote(path, safe=":%/")
-                    logger.info("Encoded wheel path to {}", path)
+                    logger.info("Encoded wheel path to %s", path)
                 wheel_url = repo_url + path
-                logger.info("Using precompiled wheel URL: {}", wheel_url)
+                logger.info("Using precompiled wheel URL: %s", wheel_url)
                 break
         else:
             raise ValueError(

--- a/setup.py
+++ b/setup.py
@@ -717,18 +717,24 @@ if envs.VLLM_USE_PRECOMPILED:
 "platform_tag": "manylinux1_x86_64",
 "variant": null,
 "filename": "vllm-0.11.2.dev278+gdbc3d9991-cp38-abi3-manylinux1_x86_64.whl",
-"path": "../vllm-0.11.2.dev278+gdbc3d9991-cp38-abi3-manylinux1_x86_64.whl"
+"path": "../vllm-0.11.2.dev278%2Bgdbc3d9991-cp38-abi3-manylinux1_x86_64.whl"
 },
 ...]"""
         for wheel in wheels:
+            # TODO: maybe check more compatibility later? (python_tag, abi_tag, etc)
             if wheel.get("package_name") == "vllm" and arch in wheel.get(
                 "platform_tag", ""
             ):
                 logger.info("Found precompiled wheel metadata: {}", wheel)
                 if "path" not in wheel:
                     raise ValueError(f"Wheel metadata missing path: {wheel}")
-                # TODO: maybe check more compatibility later? (python_tag, abi_tag, etc)
-                wheel_url = repo_url + wheel["path"]
+                path = wheel["path"]
+                # path may contain '+' which needs to be URL-encoded
+                if '+' in path:
+                    from urllib.parse import quote
+                    path = quote(path, safe=":%/")
+                    logger.info("Encoded wheel path to {}", path)
+                wheel_url = repo_url + path
                 logger.info("Using precompiled wheel URL: {}", wheel_url)
                 break
         else:


### PR DESCRIPTION
## Purpose

After #29690 is merged, nightly index and metadata can be generated as expected, but the `metadata.json` generated will cause HTTP 404 errors when `setup.py` tries to download pre-compiled wheel from S3 with URLs like `https://wheels.vllm.ai/nightly/vllm/../../36db0a35e45f32f7c37f6f1967dc8d6ff301d882/vllm-0.11.2.dev428+g36db0a35e-cp38-abi3-manylinux_2_31_x86_64.whl`.

This is due to AWS S3 encoding filenames [at its discretion](https://stackoverflow.com/questions/21067141/amazon-s3-url-encoding), where the `+` in the filename will become `%2B`. This encoding must be handled on index generation (but not `setup.py`), because `metadata.json` should contain the final path for any client (e.g. `setup.py`) to consume.

## Test Plan

Test by CI.

## Test Result

Waiting...

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

