### PR TITLE
Fix missing as_list() conversion in streaming chat completion

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1031,7 +1031,7 @@ class OpenAIServingChat(OpenAIServing):
                             delta_text=delta_text,
                             previous_token_ids=previous_token_ids,
                             current_token_ids=current_token_ids,
-                            delta_token_ids=output.token_ids,
+                            delta_token_ids=as_list(output.token_ids),
                             request=request,
                         )
                         if delta_message and delta_message.tool_calls:
@@ -1045,7 +1045,7 @@ class OpenAIServingChat(OpenAIServing):
                             delta_text,
                             previous_token_ids,
                             current_token_ids,
-                            output.token_ids,
+                            as_list(output.token_ids),
                         )
                     # handle streaming just a content delta
                     else:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes #29763
Add as_list() wrapper to output.token_ids in two code paths that were missing it:
- Line 1034: tool_choice_auto only path
- Line 1048: reasoning only path

This fixes GLM-4.5 reasoning parser streaming when no tools are included in the request. The token_ids field is a GenericSequence which may not be a list, causing issues with the `in` operator in parser methods.


