### PR TITLE
Update FAQ on interleaving sliding windows support

### DIFF
--- a/docs/contributing/model/basic.md
+++ b/docs/contributing/model/basic.md
@@ -113,8 +113,6 @@ See [this page](registration.md) for instructions on how to register your new mo
 
 ### How to support models with interleaving sliding windows?
 
-For models with interleaving sliding windows (e.g. `google/gemma-2-2b-it` and `mistralai/Ministral-8B-Instruct-2410`), the scheduler will treat the model as a full-attention model, i.e., kv-cache of all tokens will not be dropped. This is to make sure prefix caching works with these models. Sliding window only appears as a parameter to the attention kernel computation.
-
 To support a model with interleaving sliding windows, we need to take care of the following details:
 
 - Make sure the model's `config.json` contains `layer_types`.


### PR DESCRIPTION
## Purpose

Removes outdated documentation indicating that interleaved sliding windows are not supported in KV cache block allocation. This was fixed in February (https://github.com/vllm-project/vllm/pull/13296). 

## Test Plan

I will calculate the KV cache for various window sizes for a model with interleaved attention layers and look at the results. 

## Test Result

I have verified this manually by looking at the KV cache generated for Olmo 3. For [Olmo 3 7B](https://huggingface.co/allenai/Olmo-3-1025-7B), which has 3 SWA layers followed by a global attention layer, the KV cache for generating 6144 tokens is 2.58GiB per request [1], while for 34,048 tokens, it's 5.14 GiB per request [2]. If SWA was not supported, I would expect the KV cache to be 5.5x bigger; instead it's 2x bigger.

[1] `[gpu_worker.py:298] Available KV cache memory: 57.18 GiB`, `[kv_cache_utils.py:1091] Maximum concurrency for 6,144 tokens per request: 23.73x`
[2] `[gpu_worker.py:298] Available KV cache memory: 57.18 GiB`, `[kv_cache_utils.py:1091] Maximum concurrency for 34,048 tokens per request: 11.12x`.

<!-- markdownlint-disable -->


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

