### PR TITLE
[llama4_eagle] add lm_head attribute to model class

### DIFF
--- a/vllm/model_executor/models/llama4_eagle.py
+++ b/vllm/model_executor/models/llama4_eagle.py
@@ -28,7 +28,10 @@ from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.layers.quantization.torchao import TorchAOConfig
-from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.llama4 import Llama4DecoderLayer, Llama4ForCausalLM
 from vllm.model_executor.models.utils import extract_layer_index
@@ -180,6 +183,12 @@ class EagleLlama4ForCausalLM(Llama4ForCausalLM):
         logit_scale = getattr(self.config, "logit_scale", 1.0)
         self.logits_processor = LogitsProcessor(
             self.config.vocab_size, scale=logit_scale
+        )
+
+        self.lm_head = ParallelLMHead(
+            self.config.draft_vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
         )
 
         # Set MoE hyperparameters


### PR DESCRIPTION
- This PR resolves the following error for llama4_eagle: 
    - `AttributeError: 'EagleLlama4ForCausalLM' object has no attribute 'lm_head' `
- Tested on H100 and mi300
- Output log: attached
- Test cmd:

> python examples/offline_inference/spec_decode.py  --num_spec_tokens 7 --num_prompts 1 --method eagle --model_dir meta-llama/Llama-4-Scout-17B-16E-Instruct --eagle_dir morgendave/EAGLE-Llama-4-Scout-17B-16E-Instruct --tp 4 2>&1 | tee logs_specdecode_llama4_fixed.txt
