### PR TITLE
[Kernel] Support rms_norm kernel for Gemma

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -86,10 +86,11 @@ void convert_vertical_slash_indexes_mergehead(
 #endif
 
 void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,
-              double epsilon);
+              double epsilon, bool is_gemma = false);
 
 void fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
-                        torch::Tensor& weight, double epsilon);
+                        torch::Tensor& weight, double epsilon,
+                        bool is_gemma = false);
 
 void fused_qk_norm_rope(torch::Tensor& qkv, int64_t num_heads_q,
                         int64_t num_heads_k, int64_t num_heads_v,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -152,14 +152,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   // Layernorm
   // Apply Root Mean Square (RMS) Normalization to the input tensor.
   ops.def(
-      "rms_norm(Tensor! result, Tensor input, Tensor weight, float epsilon) -> "
-      "()");
+      "rms_norm(Tensor! result, Tensor input, Tensor weight, float epsilon, "
+      "bool is_gemma=False) -> ()");
   ops.impl("rms_norm", torch::kCUDA, &rms_norm);
 
   // In-place fused Add and RMS Normalization.
   ops.def(
       "fused_add_rms_norm(Tensor! input, Tensor! residual, Tensor weight, "
-      "float epsilon) -> ()");
+      "float epsilon, bool is_gemma=False) -> ()");
   ops.impl("fused_add_rms_norm", torch::kCUDA, &fused_add_rms_norm);
 
   // Function for fused QK Norm and RoPE

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -326,15 +326,23 @@ def rotary_embedding(
 
 # layer norm ops
 def rms_norm(
-    out: torch.Tensor, input: torch.Tensor, weight: torch.Tensor, epsilon: float
+    out: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+    is_gemma: bool = False,
 ) -> None:
-    torch.ops._C.rms_norm(out, input, weight, epsilon)
+    torch.ops._C.rms_norm(out, input, weight, epsilon, is_gemma)
 
 
 def fused_add_rms_norm(
-    input: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, epsilon: float
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    epsilon: float,
+    is_gemma: bool = False,
 ) -> None:
-    torch.ops._C.fused_add_rms_norm(input, residual, weight, epsilon)
+    torch.ops._C.fused_add_rms_norm(input, residual, weight, epsilon, is_gemma)
 
 
 def fused_qk_norm_rope(

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -53,6 +53,42 @@ def fused_add_rms_norm(
     return x, residual
 
 
+def gemma_rms_norm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    variance_epsilon: float,
+) -> torch.Tensor:
+    from vllm import _custom_ops as ops
+
+    out = torch.empty(x.shape, dtype=x.dtype, device=x.device)
+    ops.rms_norm(
+        out,
+        x,
+        weight,
+        variance_epsilon,
+        is_gemma=True,
+    )
+    return out
+
+
+def gemma_fused_add_rms_norm(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    variance_epsilon: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from vllm import _custom_ops as ops
+
+    ops.fused_add_rms_norm(
+        x,
+        residual,
+        weight,
+        variance_epsilon,
+        is_gemma=True,
+    )
+    return x, residual
+
+
 def poly_norm(
     x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor, variance_epsilon: float
 ) -> torch.Tensor:
@@ -310,15 +346,13 @@ class GemmaRMSNorm(CustomOp):
         x: torch.Tensor,
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        if torch.compiler.is_compiling():
-            return self.forward_native(x, residual)
-
-        if not getattr(self, "_is_compiled", False):
-            self.forward_static = torch.compile(  # type: ignore
-                self.forward_static
+        add_residual = residual is not None
+        if add_residual:
+            return gemma_fused_add_rms_norm(
+                x, residual, self.weight.data, self.variance_epsilon
             )
-            self._is_compiled = True
-        return self.forward_native(x, residual)
+        else:
+            return gemma_rms_norm(x, self.weight.data, self.variance_epsilon)
 
 
 @CustomOp.register("rms_norm_gated")


### PR DESCRIPTION
## Purpose

This PR add Gemma style rms_norm kernel support:

* Current GemmaRMSNorm `forward_cuda` is calling `forward_native` or `forward_static` with `torch.compile`. This PR modify rms_norm and fused_add_rms_norm custom CUDA kernel to support Gemma: `y = x / sqrt(mean(x^2) + epsilon) * (1.0 + weight)`

## Test Plan

* Added test cases in test_layernorm.py

```
pytest -s -v tests/kernels/core/test_layernorm.py
```

## Test Result

Unit tests passed.

## Microbenchmark

* gemma rms_norm

```
python3 benchmarks/kernels/benchmark_rmsnorm.py --is-gemma
```

```
    head_num  batch_size  seq_len  HuggingFace   FlashInfer        vLLM
0       32.0         1.0     64.0   213.919997     8.960000   11.168000
1       32.0         1.0    128.0   213.376001     9.664000   11.040000
2       32.0         1.0    256.0   209.664002    11.040000   12.480000
3       32.0         1.0    512.0   210.960001    12.480000   14.944000
4       32.0         1.0   1024.0   213.343993    15.840000   19.168001
5       32.0         4.0     64.0   209.743999    11.168000   12.416000
6       32.0         4.0    128.0   212.544002    12.544000   15.008000
7       32.0         4.0    256.0   216.864005    15.840000   18.255999
8       32.0         4.0    512.0   214.208007    24.512000   26.176000
9       32.0         4.0   1024.0   277.408004    47.263999   45.536000
10      32.0        16.0     64.0   215.264007    15.840000   18.495999
11      32.0        16.0    128.0   213.088006    24.512000   26.208000
12      32.0        16.0    256.0   277.503997    47.231998   45.568001
13      32.0        16.0    512.0   501.151979    84.096000   79.568002
14      32.0        16.0   1024.0   960.959971   156.575993  144.896001
15      32.0        64.0     64.0   276.832014    47.263999   45.472000
16      32.0        64.0    128.0   504.207999    84.288001   79.520002
17      32.0        64.0    256.0   958.335996   156.512007  144.991994
18      32.0        64.0    512.0  1864.159942   302.751988  276.288003
19      32.0        64.0   1024.0  3678.816080   599.744022  544.448018
20      48.0         1.0     64.0   212.591998     9.312000   11.776000
21      48.0         1.0    128.0   205.343999    10.816000   12.960000
22      48.0         1.0    256.0   205.392003    11.984000   14.368000
23      48.0         1.0    512.0   205.663994    14.208000   16.287999
24      48.0         1.0   1024.0   206.767999    21.568000   22.688000
25      48.0         4.0     64.0   214.655995    11.936000   14.464000
26      48.0         4.0    128.0   212.224007    14.144000   16.287999
27      48.0         4.0    256.0   209.248006    21.568000   22.752000
28      48.0         4.0    512.0   222.335994    38.208000   34.784000
29      48.0         4.0   1024.0   395.007998    73.824003   63.487999
30      48.0        16.0     64.0   218.208000    21.600001   22.688000
31      48.0        16.0    128.0   222.335994    38.176000   34.784000
32      48.0        16.0    256.0   392.255992    73.856004   63.423999
33      48.0        16.0    512.0   730.239987   136.639997  111.904003
34      48.0        16.0   1024.0  1408.928037   263.327986  209.248006
35      48.0        64.0     64.0   392.383993    73.792003   63.487999
36      48.0        64.0    128.0   730.304003   136.703998  111.840002
37      48.0        64.0    256.0  1410.896003   263.088003  209.312007
38      48.0        64.0    512.0  2765.664101   517.551988  405.472010
39      48.0        64.0   1024.0  5476.239920  1024.464011  797.663987
```

* gemma fused_add_rms_norm

```
python3 benchmarks/kernels/benchmark_rmsnorm.py --is-gemma --use-residual
```

```
    head_num  batch_size  seq_len  HuggingFace   FlashInfer         vLLM
0       32.0         1.0     64.0   252.704009    12.864000    13.952000
1       32.0         1.0    128.0   252.080008    12.928000    15.296000
2       32.0         1.0    256.0   243.487999    14.784000    17.376000
3       32.0         1.0    512.0   245.792001    18.560000    22.080000
4       32.0         1.0   1024.0   247.935995    26.303999    29.664000
5       32.0         4.0     64.0   244.512007    14.336000    17.408000
6       32.0         4.0    128.0   243.359998    17.503999    22.048000
7       32.0         4.0    256.0   246.592000    26.496001    29.600000
8       32.0         4.0    512.0   253.536001    42.528000    45.423999
9       32.0         4.0   1024.0   423.871994    77.983998    79.264000
10      32.0        16.0     64.0   248.576000    26.464000    26.815999
11      32.0        16.0    128.0   255.903989    42.272002    42.528000
12      32.0        16.0    256.0   424.192011    76.895997    80.704004
13      32.0        16.0    512.0   780.095994   141.087994   140.640005
14      32.0        16.0   1024.0  1496.783972   267.520010   268.480003
15      32.0        64.0     64.0   426.847994    76.736003    79.296000
16      32.0        64.0    128.0   778.752029   141.295999   140.656002
17      32.0        64.0    256.0  1496.992052   267.423987   268.512011
18      32.0        64.0    512.0  2925.407887   524.207979   519.440025
19      32.0        64.0   1024.0  5790.847778  1045.216024  1033.280015
20      48.0         1.0     64.0   247.360006    12.704000    15.264000
21      48.0         1.0    128.0   242.431998    13.824000    15.360000
22      48.0         1.0    256.0   243.359998    16.511999    19.392001
23      48.0         1.0    512.0   252.016008    22.175999    24.896000
24      48.0         1.0   1024.0   247.999996    33.984002    38.656000
25      48.0         4.0     64.0   245.072000    16.287999    18.271999
26      48.0         4.0    128.0   248.607993    23.200000    24.960000
27      48.0         4.0    256.0   246.607997    34.175999    36.991999
28      48.0         4.0    512.0   337.727994    61.407998    60.063999
29      48.0         4.0   1024.0   606.527984   113.055997   112.032004
30      48.0        16.0     64.0   250.128001    35.712000    38.304001
31      48.0        16.0    128.0   339.168012    62.784001    60.063999
32      48.0        16.0    256.0   606.559992   113.055997   112.063996
33      48.0        16.0    512.0  1137.503982   210.815996   205.183998
34      48.0        16.0   1024.0  2208.912015   405.375987   394.463986
35      48.0        64.0     64.0   607.456028   113.343999   112.319998
36      48.0        64.0    128.0  1137.791991   210.815996   206.624001
37      48.0        64.0    256.0  2211.840034   406.751990   395.776004
38      48.0        64.0    512.0  4352.479935   799.839973   777.823985
39      48.0        64.0   1024.0  8632.479668  1580.480039  1529.872000
```

## Profiling

```
VLLM_TORCH_PROFILER_DIR=/tmp/vllm_profile vllm serve unsloth/gemma-3-27b-it \
    --tensor-parallel-size 1 \
    --pipeline-parallel-size 1 \
    --max-num-seqs 32 \
    --compilation-config '{"custom_ops":["+gemma_rms_norm"]}'
```

```
vllm bench serve \
  --backend vllm \
  --model unsloth/gemma-3-27b-it \
  --dataset-name sharegpt \
  --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \
  --profile \
  --num-prompts 2
```

Baseline:

<img width="1673" height="792" alt="Screenshot 2025-12-05 at 5 25 25 PM" src="https://github.com/user-attachments/assets/c3eceba5-f24c-4ed6-8726-5d6df38b42ee" />

PR:

<img width="1680" height="797" alt="Screenshot 2025-12-05 at 4 46 53 PM" src="https://github.com/user-attachments/assets/b8797c5e-d8a5-4940-bfd3-6b4d26af383c" />

Baseline: With `torch.compile`, compiler optimized the Gemma RMSNorm computation (mean, variance, rsqrt) into a single Triton reduction kernel `triton_red_fused__to_copy_add_mean_mul_pow_rsqrt`. It takes ~6µs.

After the PR: The custom `rms_norm_kernel` takes ~2µs. So it's around 3x improment.

## Accuracy Testing

```
vllm serve unsloth/gemma-3-27b-it \
    --tensor-parallel-size 8 \
    --pipeline-parallel-size 1 \
    --max-num-seqs 32 \
    --compilation-config '{"custom_ops":["+gemma_rms_norm"]}'
```

```
python3 -m lm_eval --model local-completions \
  --model_args model=unsloth/gemma-3-27b-it,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=32 \
  --tasks gsm8k
```

Baseline:

```
local-completions (model=unsloth/gemma-3-27b-it,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=32), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8522|±  |0.0098|
|     |       |strict-match    |     5|exact_match|↑  |0.8446|±  |0.0100|
```

PR:

```
local-completions (model=unsloth/gemma-3-27b-it,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=32), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8560|±  |0.0097|
|     |       |strict-match    |     5|exact_match|↑  |0.8484|±  |0.0099|
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

