### PR TITLE
Add logging for cudagraph related info

### DIFF
--- a/vllm/compilation/cuda_graph.py
+++ b/vllm/compilation/cuda_graph.py
@@ -44,8 +44,8 @@ class CUDAGraphLogging:
     def observe(self, cudagraph_stats: CUDAGraphStats):
         self.rows.append(
             (
-                cudagraph_stats.num_unpadded_tokens,
                 cudagraph_stats.num_padded_tokens,
+                cudagraph_stats.num_unpadded_tokens,
                 cudagraph_stats.num_padded_tokens - cudagraph_stats.num_unpadded_tokens,
                 cudagraph_stats.runtime_mode,
             )

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -500,6 +500,11 @@ class CompilationConfig:
     capture ignores all partitioning.
     """
 
+    log_cudagraph_info: bool = False
+    """Whether to enable logging information about cudagraph dispatch, e.g. 
+    number of tokens with and without padding and cudagraph dispatch modes
+    """
+
     pass_config: PassConfig = field(default_factory=PassConfig)
     """Custom inductor passes, see PassConfig for more details"""
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -500,11 +500,6 @@ class CompilationConfig:
     capture ignores all partitioning.
     """
 
-    log_cudagraph_info: bool = False
-    """Whether to enable logging information about cudagraph dispatch, e.g. 
-    number of tokens with and without padding and cudagraph dispatch modes
-    """
-
     pass_config: PassConfig = field(default_factory=PassConfig)
     """Custom inductor passes, see PassConfig for more details"""
 

--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -55,6 +55,10 @@ class ObservabilityConfig:
     kv_cache_metrics_sample: float = Field(default=0.01, gt=0, le=1)
     """Sampling rate for KV cache metrics (0.0, 1.0]. Default 0.01 = 1% of blocks."""
 
+    cudagraph_metrics: bool = False
+    """Enable CUDA graph metrics (number of padded/unpadded tokens, runtime cudagraph
+    dispatch modes, and their observed frequencies at every logging interval)."""
+
     @cached_property
     def collect_model_forward_time(self) -> bool:
         """Whether to collect model forward time for the request."""

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -518,6 +518,7 @@ class EngineArgs:
     kv_cache_metrics_sample: float = get_field(
         ObservabilityConfig, "kv_cache_metrics_sample"
     )
+    cudagraph_metrics: bool = ObservabilityConfig.cudagraph_metrics
     scheduling_policy: SchedulerPolicy = SchedulerConfig.policy
     scheduler_cls: str | type[object] | None = SchedulerConfig.scheduler_cls
 
@@ -1021,6 +1022,10 @@ class EngineArgs:
             "--kv-cache-metrics-sample",
             **observability_kwargs["kv_cache_metrics_sample"],
         )
+        observability_group.add_argument(
+            "--cudagraph-metrics",
+            **observability_kwargs["cudagraph_metrics"],
+        )
 
         # Scheduler arguments
         scheduler_kwargs = get_kwargs(SchedulerConfig)
@@ -1103,9 +1108,6 @@ class EngineArgs:
         compilation_group.add_argument(
             "--max-cudagraph-capture-size",
             **compilation_kwargs["max_cudagraph_capture_size"],
-        )
-        compilation_group.add_argument(
-            "--log-cudagraph-info", **compilation_kwargs["log_cudagraph_info"]
         )
 
         # vLLM arguments
@@ -1701,6 +1703,7 @@ class EngineArgs:
             collect_detailed_traces=self.collect_detailed_traces,
             kv_cache_metrics=self.kv_cache_metrics,
             kv_cache_metrics_sample=self.kv_cache_metrics_sample,
+            cudagraph_metrics=self.cudagraph_metrics,
         )
 
         # Compilation config overrides

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1104,6 +1104,9 @@ class EngineArgs:
             "--max-cudagraph-capture-size",
             **compilation_kwargs["max_cudagraph_capture_size"],
         )
+        compilation_group.add_argument(
+            "--log-cudagraph-info", **compilation_kwargs["log_cudagraph_info"]
+        )
 
         # vLLM arguments
         vllm_kwargs = get_kwargs(VllmConfig)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 from typing import Any
 
 from vllm import envs
+from vllm.compilation.cuda_graph import CUDAGraphStats
 from vllm.config import VllmConfig
 from vllm.distributed.ec_transfer.ec_connector.base import (
     ECConnectorMetadata,
@@ -1037,6 +1038,7 @@ class Scheduler(SchedulerInterface):
         pooler_outputs = model_runner_output.pooler_output
         num_nans_in_logits = model_runner_output.num_nans_in_logits
         kv_connector_output = model_runner_output.kv_connector_output
+        cudagraph_stats = model_runner_output.cudagraph_stats
 
         outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
         spec_decoding_stats: SpecDecodingStats | None = None
@@ -1219,7 +1221,9 @@ class Scheduler(SchedulerInterface):
             finished_req_ids.clear()
 
         if (
-            stats := self.make_stats(spec_decoding_stats, kv_connector_stats)
+            stats := self.make_stats(
+                spec_decoding_stats, kv_connector_stats, cudagraph_stats
+            )
         ) is not None:
             # Return stats to only one of the front-ends.
             if (eco := next(iter(engine_core_outputs.values()), None)) is None:
@@ -1420,6 +1424,7 @@ class Scheduler(SchedulerInterface):
         self,
         spec_decoding_stats: SpecDecodingStats | None = None,
         kv_connector_stats: KVConnectorStats | None = None,
+        cudagraph_stats: CUDAGraphStats | None = None,
     ) -> SchedulerStats | None:
         if not self.log_stats:
             return None
@@ -1444,6 +1449,7 @@ class Scheduler(SchedulerInterface):
             kv_cache_eviction_events=eviction_events,
             spec_decoding_stats=spec_stats,
             kv_connector_stats=connector_stats_payload,
+            cudagraph_stats=cudagraph_stats,
         )
 
     def make_spec_decoding_stats(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from typing import Any
 
 from vllm import envs
-from vllm.compilation.cuda_graph import CUDAGraphStats
+from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.config import VllmConfig
 from vllm.distributed.ec_transfer.ec_connector.base import (
     ECConnectorMetadata,
@@ -1424,7 +1424,7 @@ class Scheduler(SchedulerInterface):
         self,
         spec_decoding_stats: SpecDecodingStats | None = None,
         kv_connector_stats: KVConnectorStats | None = None,
-        cudagraph_stats: CUDAGraphStats | None = None,
+        cudagraph_stats: CUDAGraphStat | None = None,
     ) -> SchedulerStats | None:
         if not self.log_stats:
             return None

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -108,7 +108,7 @@ class LoggingStatLogger(StatLoggerBase):
         kv_transfer_config = self.vllm_config.kv_transfer_config
         self.kv_connector_logging = KVConnectorLogging(kv_transfer_config)
         self.cudagraph_logging = None
-        if self.vllm_config.compilation_config.log_cudagraph_info:
+        if self.vllm_config.observability_config.cudagraph_metrics:
             self.cudagraph_logging = CUDAGraphLogging(
                 self.vllm_config.compilation_config.cudagraph_mode,
                 self.vllm_config.compilation_config.cudagraph_capture_sizes,

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -10,6 +10,7 @@ from typing import TypeAlias
 from prometheus_client import Counter, Gauge, Histogram
 
 import vllm.envs as envs
+from vllm.compilation.cuda_graph import CUDAGraphLogging
 from vllm.config import SupportsMetricsInfo, VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
     KVConnectorLogging,
@@ -106,6 +107,12 @@ class LoggingStatLogger(StatLoggerBase):
         self.spec_decoding_logging = SpecDecodingLogging()
         kv_transfer_config = self.vllm_config.kv_transfer_config
         self.kv_connector_logging = KVConnectorLogging(kv_transfer_config)
+        self.cudagraph_logging = None
+        if self.vllm_config.compilation_config.log_cudagraph_info:
+            self.cudagraph_logging = CUDAGraphLogging(
+                self.vllm_config.compilation_config.cudagraph_mode,
+                self.vllm_config.compilation_config.cudagraph_capture_sizes,
+            )
         self.last_prompt_throughput: float = 0.0
         self.last_generation_throughput: float = 0.0
         self.engine_is_idle = False
@@ -161,6 +168,11 @@ class LoggingStatLogger(StatLoggerBase):
                 self.spec_decoding_logging.observe(scheduler_stats.spec_decoding_stats)
             if kv_connector_stats := scheduler_stats.kv_connector_stats:
                 self.kv_connector_logging.observe(kv_connector_stats)
+            if (
+                self.cudagraph_logging is not None
+                and scheduler_stats.cudagraph_stats is not None
+            ):
+                self.cudagraph_logging.observe(scheduler_stats.cudagraph_stats)
             if not self.aggregated:
                 self.last_scheduler_stats = scheduler_stats
         if mm_cache_stats:
@@ -240,6 +252,8 @@ class LoggingStatLogger(StatLoggerBase):
 
         self.spec_decoding_logging.log(log_fn=log_fn)
         self.kv_connector_logging.log(log_fn=log_fn)
+        if self.cudagraph_logging is not None:
+            self.cudagraph_logging.log(log_fn=log_fn)
 
     def log_engine_initialized(self):
         if self.vllm_config.cache_config.num_gpu_blocks:

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import vllm.envs as envs
+from vllm.compilation.cuda_graph import CUDAGraphStats
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 
 if TYPE_CHECKING:
@@ -182,6 +183,8 @@ class SchedulerStats:
 
     waiting_lora_adapters: dict[str, int] = field(default_factory=dict)
     running_lora_adapters: dict[str, int] = field(default_factory=dict)
+
+    cudagraph_stats: CUDAGraphStats | None = None
 
 
 @dataclass

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import vllm.envs as envs
-from vllm.compilation.cuda_graph import CUDAGraphStats
+from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 
 if TYPE_CHECKING:
@@ -184,7 +184,7 @@ class SchedulerStats:
     waiting_lora_adapters: dict[str, int] = field(default_factory=dict)
     running_lora_adapters: dict[str, int] = field(default_factory=dict)
 
-    cudagraph_stats: CUDAGraphStats | None = None
+    cudagraph_stats: CUDAGraphStat | None = None
 
 
 @dataclass

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, NamedTuple
 import numpy as np
 import torch
 
+from vllm.compilation.cuda_graph import CUDAGraphStats
 from vllm.v1.core.sched.output import SchedulerOutput
 
 if TYPE_CHECKING:
@@ -168,6 +169,9 @@ class ModelRunnerOutput:
 
     # req_id -> num_nans_in_logits
     num_nans_in_logits: dict[str, int] | None = None
+
+    # information related to cudagraph execution
+    cudagraph_stats: CUDAGraphStats | None = None
 
 
 # ModelRunnerOutput wrapper for async scheduling.

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, NamedTuple
 import numpy as np
 import torch
 
-from vllm.compilation.cuda_graph import CUDAGraphStats
+from vllm.compilation.cuda_graph import CUDAGraphStat
 from vllm.v1.core.sched.output import SchedulerOutput
 
 if TYPE_CHECKING:
@@ -171,7 +171,7 @@ class ModelRunnerOutput:
     num_nans_in_logits: dict[str, int] | None = None
 
     # information related to cudagraph execution
-    cudagraph_stats: CUDAGraphStats | None = None
+    cudagraph_stats: CUDAGraphStat | None = None
 
 
 # ModelRunnerOutput wrapper for async scheduling.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2763,7 +2763,7 @@ class GPUModelRunner(
         BatchDescriptor,
         UBatchSlices | None,
         torch.Tensor | None,
-        CUDAGraphStat,
+        CUDAGraphStat | None,
     ]:
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
         uniform_decode = (
@@ -2828,12 +2828,14 @@ class GPUModelRunner(
                 # num_tokens_across_dp will no-longer be valid
                 assert batch_descriptor.num_tokens == num_tokens_padded
 
-        cudagraph_stats = CUDAGraphStat(
-            num_unpadded_tokens=num_tokens,
-            num_padded_tokens=batch_descriptor.num_tokens,
-            num_paddings=batch_descriptor.num_tokens - num_tokens,
-            runtime_mode=str(cudagraph_mode),
-        )
+        cudagraph_stats = None
+        if self.vllm_config.observability_config.cudagraph_metrics:
+            cudagraph_stats = CUDAGraphStat(
+                num_unpadded_tokens=num_tokens,
+                num_padded_tokens=batch_descriptor.num_tokens,
+                num_paddings=batch_descriptor.num_tokens - num_tokens,
+                runtime_mode=str(cudagraph_mode),
+            )
 
         return (
             cudagraph_mode,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -27,7 +27,7 @@ from vllm.attention.backends.abstract import (
 )
 from vllm.attention.layer import Attention, MLAAttention
 from vllm.compilation.counter import compilation_counter
-from vllm.compilation.cuda_graph import CUDAGraphStats, CUDAGraphWrapper
+from vllm.compilation.cuda_graph import CUDAGraphStat, CUDAGraphWrapper
 from vllm.compilation.monitor import set_cudagraph_capturing_enabled
 from vllm.config import (
     CompilationMode,
@@ -257,7 +257,7 @@ class ExecuteModelState(NamedTuple):
     sample_hidden_states: torch.Tensor
     aux_hidden_states: list[torch.Tensor] | None
     ec_connector_output: ECConnectorOutput | None
-    cudagraph_stats: CUDAGraphStats | None
+    cudagraph_stats: CUDAGraphStat | None
 
 
 class GPUModelRunner(
@@ -2763,7 +2763,7 @@ class GPUModelRunner(
         BatchDescriptor,
         UBatchSlices | None,
         torch.Tensor | None,
-        CUDAGraphStats,
+        CUDAGraphStat,
     ]:
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
         uniform_decode = (
@@ -2828,9 +2828,10 @@ class GPUModelRunner(
                 # num_tokens_across_dp will no-longer be valid
                 assert batch_descriptor.num_tokens == num_tokens_padded
 
-        cudagraph_stats = CUDAGraphStats(
+        cudagraph_stats = CUDAGraphStat(
             num_unpadded_tokens=num_tokens,
             num_padded_tokens=batch_descriptor.num_tokens,
+            num_paddings=batch_descriptor.num_tokens - num_tokens,
             runtime_mode=str(cudagraph_mode),
         )
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -27,7 +27,7 @@ from vllm.attention.backends.abstract import (
 )
 from vllm.attention.layer import Attention, MLAAttention
 from vllm.compilation.counter import compilation_counter
-from vllm.compilation.cuda_graph import CUDAGraphWrapper
+from vllm.compilation.cuda_graph import CUDAGraphStats, CUDAGraphWrapper
 from vllm.compilation.monitor import set_cudagraph_capturing_enabled
 from vllm.config import (
     CompilationMode,
@@ -257,6 +257,7 @@ class ExecuteModelState(NamedTuple):
     sample_hidden_states: torch.Tensor
     aux_hidden_states: list[torch.Tensor] | None
     ec_connector_output: ECConnectorOutput | None
+    cudagraph_stats: CUDAGraphStats | None
 
 
 class GPUModelRunner(
@@ -2758,7 +2759,11 @@ class GPUModelRunner(
         force_uniform_decode: bool | None = None,
         force_has_lora: bool | None = None,
     ) -> tuple[
-        CUDAGraphMode, BatchDescriptor, UBatchSlices | None, torch.Tensor | None
+        CUDAGraphMode,
+        BatchDescriptor,
+        UBatchSlices | None,
+        torch.Tensor | None,
+        CUDAGraphStats,
     ]:
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
         uniform_decode = (
@@ -2823,7 +2828,19 @@ class GPUModelRunner(
                 # num_tokens_across_dp will no-longer be valid
                 assert batch_descriptor.num_tokens == num_tokens_padded
 
-        return cudagraph_mode, batch_descriptor, ubatch_slices, num_tokens_across_dp
+        cudagraph_stats = CUDAGraphStats(
+            num_unpadded_tokens=num_tokens,
+            num_padded_tokens=batch_descriptor.num_tokens,
+            runtime_mode=str(cudagraph_mode),
+        )
+
+        return (
+            cudagraph_mode,
+            batch_descriptor,
+            ubatch_slices,
+            num_tokens_across_dp,
+            cudagraph_stats,
+        )
 
     @torch.inference_mode()
     def execute_model(
@@ -2921,6 +2938,7 @@ class GPUModelRunner(
                     batch_desc,
                     ubatch_slices,
                     num_tokens_across_dp,
+                    cudagraph_stats,
                 ) = self._determine_batch_execution_and_padding(
                     num_tokens=num_tokens_unpadded,
                     num_reqs=num_reqs,
@@ -3070,6 +3088,7 @@ class GPUModelRunner(
             sample_hidden_states,
             aux_hidden_states,
             ec_connector_output,
+            cudagraph_stats,
         )
         self.kv_connector_output = kv_connector_output
         return None
@@ -3105,6 +3124,7 @@ class GPUModelRunner(
             sample_hidden_states,
             aux_hidden_states,
             ec_connector_output,
+            cudagraph_stats,
         ) = self.execute_model_state
         # Clear ephemeral state.
         self.execute_model_state = None
@@ -3220,6 +3240,7 @@ class GPUModelRunner(
                 if self.supports_mm_inputs
                 else None,
                 num_nans_in_logits=num_nans_in_logits,
+                cudagraph_stats=cudagraph_stats,
             )
 
         if not self.use_async_scheduling:
@@ -3940,7 +3961,7 @@ class GPUModelRunner(
 
         num_sampled_tokens = np.ones(num_reqs, dtype=np.int32)
 
-        _cudagraph_mode, batch_desc, ubatch_slices, num_tokens_across_dp = (
+        _cudagraph_mode, batch_desc, ubatch_slices, num_tokens_across_dp, _ = (
             self._determine_batch_execution_and_padding(
                 num_tokens=num_tokens_unpadded,
                 num_reqs=num_reqs,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -564,7 +564,7 @@ class Worker(WorkerBase):
             # TODO(lucas): This is pretty gross; ideally we should only ever call
             # `_determine_batch_execution_and_padding` once (will get called again
             # in `execute_model`) but this requires a larger refactor of PP.
-            _, batch_desc, _, _ = (
+            _, batch_desc, _, _, _ = (
                 self.model_runner._determine_batch_execution_and_padding(
                     num_tokens=num_scheduled_tokens,
                     num_reqs=len(num_scheduled_tokens_np),


### PR DESCRIPTION
## Purpose

Add logging related to cudagraph dispatch, namely the distribution of padded/unpadded tokens and the runtime modes over a period of time. This info can be useful for cudagraph capture size tuning.

Adds user-facing `--cudagraph-metrics` flag to enable this.

## Test Plan
```
VLLM_LOGGING_LEVEL=DEBUG vllm serve meta-llama/Llama-3.1-8B --cudagraph-metrics
```

## Test Result

Logs:
```
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] **CUDAGraph Config Settings:**
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] 
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] - Mode: FULL_AND_PIECEWISE
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] - Capture sizes: [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512]
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] 
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] **CUDAGraph Stats:**
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] 
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | Unpadded Tokens | Padded Tokens | Num Paddings | Runtime Mode | Count |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] |-----------------|---------------|--------------|--------------|-------|
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1               | 1             | 0            | FULL         | 1687  |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1200            | 1200          | 0            | NONE         | 2     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1275            | 1275          | 0            | NONE         | 1     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1189            | 1189          | 0            | NONE         | 1     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1226            | 1226          | 0            | NONE         | 1     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1179            | 1179          | 0            | NONE         | 1     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1300            | 1300          | 0            | NONE         | 1     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1247            | 1247          | 0            | NONE         | 1     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1254            | 1254          | 0            | NONE         | 1     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1202            | 1202          | 0            | NONE         | 1     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1230            | 1230          | 0            | NONE         | 1     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1112            | 1112          | 0            | NONE         | 1     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1255            | 1255          | 0            | NONE         | 1     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1267            | 1267          | 0            | NONE         | 1     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] | 1151            | 1151          | 0            | NONE         | 1     |
(APIServer pid=3606348) INFO 12-02 16:51:04 [compilation/cuda_graph.py:108] 
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

