### PR TITLE
[CI][AMD] spec_decode:eagle skip FLASH_ATTN for deepseek on ROCm

### DIFF
--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -414,6 +414,8 @@ def test_eagle_correctness(
             )
 
         if attn_backend == "FLASH_ATTN" and current_platform.is_rocm():
+            if "deepseek" in model_setup[1].lower():
+                pytest.skip("FLASH_ATTN for deepseek not supported on ROCm platform")
             m.setenv("VLLM_ROCM_USE_AITER", "1")
 
         method, model_name, spec_model_name, tp_size = model_setup

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -416,7 +416,8 @@ def test_eagle_correctness(
         if attn_backend == "FLASH_ATTN" and current_platform.is_rocm():
             if "deepseek" in model_setup[1].lower():
                 pytest.skip("FLASH_ATTN for deepseek not supported on ROCm platform")
-            m.setenv("VLLM_ROCM_USE_AITER", "1")
+            else:
+                m.setenv("VLLM_ROCM_USE_AITER", "1")
 
         method, model_name, spec_model_name, tp_size = model_setup
         max_model_len = 2048


### PR DESCRIPTION
This PR skips FLASH_ATTN for deepseek model as it is not supported on ROCm. 
[CI][ROCM] pytest:  
`pytest -s -v test_spec_decode.py::test_eagle_correctness -k deepseek_eagle`