### PR TITLE
[Misc] Remove redundant engine arg tokens_only

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -571,7 +571,6 @@ class EngineArgs:
     kv_offloading_backend: KVOffloadingBackend | None = (
         CacheConfig.kv_offloading_backend
     )
-    tokens_only: bool = False
 
     def __post_init__(self):
         # support `EngineArgs(compilation_config={...})`
@@ -1570,10 +1569,6 @@ class EngineArgs:
             if (self.data_parallel_rpc_port is not None)
             else ParallelConfig.data_parallel_rpc_port
         )
-
-        if self.tokens_only and not model_config.skip_tokenizer_init:
-            model_config.skip_tokenizer_init = True
-            logger.info("Skipping tokenizer initialization for tokens-only mode.")
 
         if self.async_scheduling and not self.disable_nccl_for_dp_synchronization:
             logger.info(


### PR DESCRIPTION
## Purpose

Remove redundant engine arg `token_only`, which does exactly the same thing as `skip_tokenizer_init`.

## Test Plan

All existing tests should pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

