### PR TITLE
Add missing return in _check_vllm_model_embed_input_ids

### DIFF
--- a/vllm/model_executor/models/interfaces_base.py
+++ b/vllm/model_executor/models/interfaces_base.py
@@ -76,6 +76,7 @@ def _check_vllm_model_embed_input_ids(model: type[object] | object) -> bool:
                 "this method to `embed_input_ids`."
             )
             model.embed_input_ids = model_get_input_embeddings
+            return True
         logger.warning(
             "The model (%s) is missing the `embed_input_ids` method.",
             model,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Add missing return in _check_vllm_model_embed_input_ids. Without the missing return statement, the method will return False on the first time but True on subsequent times. Adds the missing return to ensure consistency and avoid confusion. 

Thanks [@richjames0](https://github.com/richjames0) for identifying the issue & the fix. 

## Test Plan
E2E tests & CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

