### PR TITLE
[KVConnector] OffloadingConnector: Fix bug in handling of preemptions

### DIFF
--- a/tests/v1/kv_offload/test_worker.py
+++ b/tests/v1/kv_offload/test_worker.py
@@ -63,6 +63,12 @@ class OffloadingHandler1To2(OffloadingHandler):
                 del self.transfers[job_id]
         return finished
 
+    def wait(self, job_ids: set[int]) -> None:
+        for job_id in job_ids:
+            spec = self.transfers.get(job_id)
+            if spec:
+                assert spec.finished
+
 
 class OffloadingHandler2To1(OffloadingHandler):
     def __init__(self):
@@ -83,6 +89,12 @@ class OffloadingHandler2To1(OffloadingHandler):
                 finished.append((job_id, spec.async_success))
                 del self.transfers[job_id]
         return finished
+
+    def wait(self, job_ids: set[int]) -> None:
+        for job_id in job_ids:
+            spec = self.transfers.get(job_id)
+            if spec:
+                assert spec.finished
 
 
 def test_offloading_worker():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -25,6 +25,9 @@ The class provides the following primitives:
 
     Worker-side: runs in each worker, loads/saves KV cache to/from
     the Connector based on the metadata.
+        handle_preemptions() - called if there are preempted requests,
+            before their blocks are overwritten
+
         start_load_kv() - starts loading all KVs (maybe async)
         wait_for_layer_load() - blocks until layer i load is done
 
@@ -259,6 +262,13 @@ class KVConnectorBase_V1(ABC):
         """
         Set the xPU-specific ops for copying KV between host and device.
         Needed when host buffer is used for kv transfer (e.g., in NixlConnector)
+        """
+        return
+
+    def handle_preemptions(self, preempted_req_ids: set[str]):
+        """
+        Handle preempted requests BEFORE their blocks are overwritten.
+        Needed for connectors which use async saves (e.g., OffloadingConnector)
         """
         return
 

--- a/vllm/v1/kv_offload/worker/worker.py
+++ b/vllm/v1/kv_offload/worker/worker.py
@@ -53,6 +53,15 @@ class OffloadingHandler(ABC):
         """
         pass
 
+    @abstractmethod
+    def wait(self, job_ids: set[int]) -> None:
+        """
+        Wait for jobs to finish (blocking).
+
+        Args:
+            job_ids: The set of job IDs to wait for.
+        """
+
 
 class OffloadingWorker:
     """
@@ -142,3 +151,13 @@ class OffloadingWorker:
         for handler in self.handlers:
             finished.extend(handler.get_finished())
         return finished
+
+    def wait(self, job_ids: set[int]) -> None:
+        """
+        Wait for jobs to finish (blocking).
+
+        Args:
+            job_ids: The set of job IDs to wait for.
+        """
+        for handler in self.handlers:
+            handler.wait(job_ids)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3112,6 +3112,11 @@ class GPUModelRunner(
                 "after execute_model() returns None."
             )
 
+        if scheduler_output.preempted_req_ids and has_kv_transfer_group():
+            get_kv_transfer_group().handle_preemptions(
+                scheduler_output.preempted_req_ids
+            )
+
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         with (
             record_function_or_nullcontext("gpu_model_runner: preprocess"),


### PR DESCRIPTION
This PR fixes the OffloadingConnector to fail any stores for a preempted request, as well as allowing to store the result of the request re-computed blocks.

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 77bab86e5a415ec6ae3be7ffa56aa6f3fe24c149. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures safe handling of preempted requests and completes/flushes in-flight KV offload transfers.
> 
> - Adds `handle_preemptions()` to KV connector base; OffloadingConnector worker now waits on pending store job IDs for preempted requests, and scheduler completes stores for preempted IDs in `build_connector_meta()`
> - Calls `handle_preemptions()` from `gpu_model_runner` before blocks are overwritten
> - Extends `OffloadingHandler`/`OffloadingWorker` with `wait(job_ids)`; CPU↔GPU handler tracks CUDA events per job and implements blocking `wait()`
> - Worker-side OffloadingConnector defers store submission to next step but can now force-wait on preemption; finished-getters unchanged besides plumbing
> - Tests: refactor mocks to track job/spec state and flushed jobs; add `test_request_preemption` validating flushed block indexes and re-load/store behavior; minor test harness updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f960add3709a8ba8bbf258c9039e58ce19eb698. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 5aa68e443d78f25f0bbd8d5fc6672cc6945a0191. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Fixes offload preemption handling and adds blocking wait support across KV transfer.
> 
> - Add `handle_preemptions()` to KV connector base; invoke from `gpu_model_runner` before blocks are overwritten
> - Scheduler side: in `OffloadingConnectorScheduler.build_connector_meta()`, mark in-flight stores complete for `preempted_req_ids`
> - Worker side: OffloadingConnector now submits deferred store jobs and `wait()`s on their job IDs for preempted requests
> - Extend `OffloadingHandler`/`OffloadingWorker` with `wait(job_ids)`; CPU↔GPU handler tracks CUDA events per job and implements blocking `wait()`
> - Tests: refactor mocks to track job/spec state and flushed jobs; add `test_request_preemption`; minor runner/test harness updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5aa68e443d78f25f0bbd8d5fc6672cc6945a0191. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
