### PR TITLE
Improve and supplement LoRA tuning documentation

### DIFF
--- a/benchmarks/kernels/benchmark_lora.py
+++ b/benchmarks/kernels/benchmark_lora.py
@@ -867,7 +867,7 @@ class BenchmarkTensors:
             "expert_ids": expert_ids,
             "num_tokens_post_padded": num_tokens_post_padded,
             "top_k_num": ctx.top_k_num,
-             # Use lora_ids from LoRAKernelMeta and synthetic adapter_enabled.
+            # Use lora_ids from LoRAKernelMeta and synthetic adapter_enabled.
             "lora_ids": self.lora_kernel_meta.active_lora_ids,
             "adapter_enabled": adapter_enabled,
             "device": self.input.device,
@@ -1001,9 +1001,7 @@ class BenchmarkTensors:
         ref_output = self.output.clone()
 
         self.output.zero_()
-        op_type.bench_fn()(
-            **self.bench_fn_kwargs(ctx, op_type, expand_fn_add_inputs)
-        )
+        op_type.bench_fn()(**self.bench_fn_kwargs(ctx, op_type, expand_fn_add_inputs))
 
         op_type.run_ref_group_gemm(
             ref_output,

--- a/benchmarks/kernels/benchmark_lora.py
+++ b/benchmarks/kernels/benchmark_lora.py
@@ -654,10 +654,12 @@ class BenchmarkTensors:
             )
             # Newer ops.moe_lora_align_block_size signature requires
             # adapter_enabled and lora_ids. For benchmarking we can use
-            # synthetic values that enable all loras.
+            # synthetic values that enable all loras. The last entry represents
+            # the base model (no LoRA) and should be disabled.
             adapter_enabled = torch.ones(
                 (max_loras + 1,), dtype=torch.int32, device=topk_ids.device
             )
+            adapter_enabled[-1] = 0
             lora_ids = torch.arange(
                 max_loras + 1, dtype=torch.int32, device=topk_ids.device
             )

--- a/benchmarks/kernels/benchmark_lora_tuning.py
+++ b/benchmarks/kernels/benchmark_lora_tuning.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import argparse
 import csv
 import json

--- a/benchmarks/kernels/benchmark_lora_tuning.py
+++ b/benchmarks/kernels/benchmark_lora_tuning.py
@@ -1,0 +1,801 @@
+import argparse
+import csv
+import json
+import os
+from itertools import product
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+
+import benchmark_lora as _benchmark_lora_mod
+from benchmark_lora import BenchmarkContext, OpType, bench_optype, dtype_to_str
+from vllm.triton_utils import HAS_TRITON, triton
+
+from vllm.lora.ops.triton_ops import lora_expand, lora_shrink  # noqa: F401
+from vllm.lora.ops.triton_ops import (
+    fused_moe_lora_expand,
+    fused_moe_lora_shrink,
+)  # noqa: F401
+from vllm.lora.ops.triton_ops import (
+    lora_expand_op as _lora_expand_mod,
+)
+from vllm.lora.ops.triton_ops import (
+    lora_shrink_op as _lora_shrink_mod,
+)
+from vllm.lora.ops.triton_ops import (
+    fused_moe_lora_op as _fused_moe_lora_mod,
+)
+from vllm.lora.ops.triton_ops import utils as _lora_utils_mod
+
+try:
+    from transformers import AutoConfig
+
+    _HAS_TRANSFORMERS = True
+except Exception:  # pragma: no cover - optional dependency
+    AutoConfig = None  # type: ignore[assignment]
+    _HAS_TRANSFORMERS = False
+
+try:
+    from safetensors.torch import load_file as _load_safetensors
+except Exception:  # pragma: no cover - optional dependency
+    _load_safetensors = None
+
+
+_ORIGINAL_GET_LORA_OP_CONFIGS = _lora_utils_mod.get_lora_op_configs
+_CURRENT_LORA_KERNEL_CONFIG: Optional[Dict[str, Any]] = None
+_PATCHED = False
+
+
+def _find_first_key(
+    dct: Dict[str, Any], candidates: List[str]
+) -> Tuple[Optional[Any], Optional[str]]:
+    for key in candidates:
+        if key in dct:
+            return dct[key], key
+    return None, None
+
+
+def _infer_lora_rank_from_config(lora_dir: str) -> Tuple[Optional[int], str]:
+    for fname in ("adapter_config.json", "adapter_config.bin", "config.json"):
+        path = os.path.join(lora_dir, fname)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                cfg = json.load(f)
+        except Exception:
+            continue
+
+        val, key = _find_first_key(cfg, ["r", "lora_r", "lora_rank"])
+        if isinstance(val, int):
+            return val, f"{fname}:{key}"
+    return None, ""
+
+
+def _infer_lora_rank_from_safetensors(lora_dir: str) -> Tuple[Optional[int], str]:
+    if _load_safetensors is None:
+        return None, ""
+
+    safepath: Optional[str] = None
+    for fname in ("adapter_model.safetensors", "lora.safetensors"):
+        path = os.path.join(lora_dir, fname)
+        if os.path.isfile(path):
+            safepath = path
+            break
+
+    if safepath is None:
+        for fname in os.listdir(lora_dir):
+            if fname.endswith(".safetensors"):
+                safepath = os.path.join(lora_dir, fname)
+                break
+
+    if safepath is None:
+        return None, ""
+
+    try:
+        tensors = _load_safetensors(safepath)
+    except Exception:
+        return None, ""
+
+    preferred_keys = [k for k in tensors.keys() if "lora_" in k.lower()]
+    keys_to_check = preferred_keys or list(tensors.keys())
+
+    for name in keys_to_check:
+        w = tensors[name]
+        if w.ndim >= 2:
+            rank = int(min(w.shape))
+            return rank, f"{os.path.basename(safepath)}:{name}"
+
+    return None, ""
+
+
+def _maybe_auto_infer_dims(args: argparse.Namespace, is_fused_moe: bool) -> None:
+    if is_fused_moe and getattr(args, "model_path", None) and _HAS_TRANSFORMERS:
+        cfg = AutoConfig.from_pretrained(args.model_path)
+        cfg_dict = cfg.to_dict()
+
+        hidden_size, _ = _find_first_key(
+            cfg_dict, ["hidden_size", "n_embd", "d_model"]
+        )
+        num_experts, _ = _find_first_key(
+            cfg_dict,
+            [
+                "num_experts",
+                "moe_num_experts",
+                "num_local_experts",
+                "n_routed_experts",
+            ],
+        )
+        moe_inter_size, _ = _find_first_key(
+            cfg_dict,
+            ["moe_intermediate_size", "ffn_hidden_size", "intermediate_size"],
+        )
+        top_k, _ = _find_first_key(
+            cfg_dict,
+            [
+                "num_experts_per_tok",
+                "num_experts_per_token",
+                "moe_top_k",
+                "top_k",
+            ],
+        )
+
+        if args.hidden_size is None and hidden_size is not None:
+            args.hidden_size = int(hidden_size)
+        if num_experts is not None:
+            args.num_experts = int(num_experts)
+        if moe_inter_size is not None and args.moe_intermediate_size is None:
+            args.moe_intermediate_size = int(moe_inter_size)
+        if top_k is not None:
+            args.top_k_num = int(top_k)
+
+    if getattr(args, "lora_path", None):
+        lora_dir = args.lora_path
+        if os.path.isdir(lora_dir):
+            rank_cfg, _ = _infer_lora_rank_from_config(lora_dir)
+            rank_safe, _ = _infer_lora_rank_from_safetensors(lora_dir)
+            rank = rank_cfg if rank_cfg is not None else rank_safe
+            if rank is not None and args.lora_rank is None:
+                args.lora_rank = int(rank)
+
+
+def _patched_get_lora_op_configs(
+    op_type: str,
+    max_loras: int,
+    batch: int,
+    hidden_size: int,
+    rank: int,
+    num_slices: int,
+    add_inputs: Optional[bool] = None,
+    moe_intermediate_size: Optional[int] = None,
+) -> Dict[str, Any]:
+    if _CURRENT_LORA_KERNEL_CONFIG is not None:
+        cfg = _CURRENT_LORA_KERNEL_CONFIG
+        # For fused_moe_lora ops, benchmark_lora expects BLOCK_SIZE_*/GROUP_SIZE_M/NUM_WARPS/NUM_STAGES/SPLIT_K
+        # style keys, while our search space uses lower-case names. Convert here.
+        if op_type.startswith("fused_moe_lora_"):
+            return {
+                "BLOCK_SIZE_M": cfg["block_m"],
+                "BLOCK_SIZE_N": cfg["block_n"],
+                "BLOCK_SIZE_K": cfg["block_k"],
+                "GROUP_SIZE_M": cfg.get("group_size_m", 8),
+                "NUM_WARPS": cfg["num_warps"],
+                "NUM_STAGES": cfg["num_stages"],
+                "SPLIT_K": cfg.get("split_k", 1),
+            }
+        # For regular shrink/expand, Triton kernels consume lower-case keys directly.
+        return cfg
+
+    return _ORIGINAL_GET_LORA_OP_CONFIGS(
+        op_type,
+        max_loras,
+        batch,
+        hidden_size,
+        rank,
+        num_slices,
+        add_inputs,
+        moe_intermediate_size,
+    )
+
+
+def _ensure_patched() -> None:
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    # Patch utils, benchmarking module, and Triton op modules to use the patched
+    # get_lora_op_configs so that the benchmark uses our current candidate
+    # kernel configuration.
+    for mod in (
+        _lora_utils_mod,
+        _lora_shrink_mod,
+        _lora_expand_mod,
+        _fused_moe_lora_mod,
+        _benchmark_lora_mod,
+    ):
+        if hasattr(mod, "get_lora_op_configs"):
+            setattr(mod, "get_lora_op_configs", _patched_get_lora_op_configs)
+
+    _PATCHED = True
+
+
+def _build_search_space() -> List[Dict[str, Any]]:
+    # Search space as suggested in README_TUNING.md.
+    block_m_range = [16, 32, 64, 128, 256]
+    block_n_range = [32, 64, 128, 256]
+    block_k_range = [16, 32, 64, 128, 256]
+    num_warps_range = [4, 8]
+    num_stage_range = [2, 3, 4, 5]
+    num_ctas_range = [1]
+    split_k_range = [4, 8, 16, 32, 64]
+
+    search_space: List[Dict[str, Any]] = []
+    for (
+        block_m,
+        block_n,
+        block_k,
+        num_warps,
+        num_stages,
+        num_ctas,
+        split_k,
+    ) in product(
+        block_m_range,
+        block_n_range,
+        block_k_range,
+        num_warps_range,
+        num_stage_range,
+        num_ctas_range,
+        split_k_range,
+    ):
+        cfg: Dict[str, Any] = {
+            "block_m": block_m,
+            "block_n": block_n,
+            "block_k": block_k,
+            "num_warps": num_warps,
+            "num_stages": num_stages,
+            "num_ctas": num_ctas,
+            "split_k": split_k,
+            # Fields used by shrink / fused-moe kernels; safe for expand too.
+            "group_size_m": 8,
+            "max_nreg": None,
+        }
+        search_space.append(cfg)
+
+    return search_space
+
+
+def _to_torch_dtype(dt: str) -> torch.dtype:
+    if dt == "torch.float16":
+        return torch.float16
+    if dt == "torch.bfloat16":
+        return torch.bfloat16
+    if dt == "torch.float32":
+        return torch.float32
+    raise ValueError(f"Unsupported dtype string: {dt}")
+
+
+def _benchmark_single_config(
+    cfg: Dict[str, Any],
+    ctx: BenchmarkContext,
+    op_type: OpType,
+    arg_pool_size: int,
+    cuda_graph_nops: Optional[int],
+    expand_fn_add_inputs: Optional[bool],
+    test_correctness: bool,
+) -> Optional[float]:
+    global _CURRENT_LORA_KERNEL_CONFIG
+
+    _CURRENT_LORA_KERNEL_CONFIG = cfg
+
+    try:
+        timer = bench_optype(
+            ctx,
+            arg_pool_size,
+            op_type,
+            cuda_graph_nops,
+            expand_fn_add_inputs,
+            test_correctness,
+        )
+    except triton.runtime.autotuner.OutOfResources:
+        return None
+
+    # torch.utils.benchmark.Measurement.median is in seconds; convert to ms.
+    return float(timer.median) * 1e3
+
+
+def main(args: argparse.Namespace) -> None:
+    if not HAS_TRITON:
+        raise RuntimeError("Triton is not available; LoRA Triton kernels cannot run.")
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is not available; this benchmark requires a GPU.")
+
+    _ensure_patched()
+
+    op_type = OpType.from_str(args.op_type)
+    if op_type not in (
+        OpType.LORA_SHRINK,
+        OpType.LORA_EXPAND,
+        OpType.FUSED_MOE_LORA_GATE_UP_SHRINK,
+        OpType.FUSED_MOE_LORA_GATE_UP_EXPAND,
+        OpType.FUSED_MOE_LORA_DOWN_SHRINK,
+        OpType.FUSED_MOE_LORA_DOWN_EXPAND,
+    ):
+        raise ValueError("Unsupported op_type for tuning.")
+
+    dtype = _to_torch_dtype(args.dtype)
+
+    num_active_loras = (
+        args.num_active_loras if args.num_active_loras is not None else args.num_loras
+    )
+
+    is_fused_moe = op_type in (
+        OpType.FUSED_MOE_LORA_GATE_UP_SHRINK,
+        OpType.FUSED_MOE_LORA_GATE_UP_EXPAND,
+        OpType.FUSED_MOE_LORA_DOWN_SHRINK,
+        OpType.FUSED_MOE_LORA_DOWN_EXPAND,
+    )
+
+    _maybe_auto_infer_dims(args, is_fused_moe)
+
+    if args.hidden_size is None:
+        raise ValueError(
+            "--hidden-size must be set explicitly or inferable from --model-path"
+        )
+    if args.lora_rank is None:
+        raise ValueError(
+            "--lora-rank must be set explicitly or inferable from --lora-path"
+        )
+
+    # For fused_moe_lora JSON configs, moe_intermediate_size is part of the
+    # key hierarchy used at runtime (see get_lora_op_configs). If we save
+    # JSON without this dimension, later loading will fail. Enforce that
+    # users provide it when tuning fused_moe_lora ops with JSON output.
+    if is_fused_moe and args.save_json_dir and args.moe_intermediate_size is None:
+        raise ValueError(
+            "For fused_moe_lora op types, --moe-intermediate-size must be set "
+            "when using --save-json-dir."
+        )
+
+    # Build a list of BenchmarkContext objects to support tuning multiple
+    # M values (num_tokens) in a single run. When --m-values is provided,
+    # each M is mapped to (batch_size=M, seq_length=1). Otherwise, a single
+    # context is created from --batch-size and --seq-length.
+    ctx_list: list[BenchmarkContext] = []
+    if getattr(args, "m_values", None):
+        for m in args.m_values:
+            ctx_list.append(
+                BenchmarkContext(
+                    batch_size=m,
+                    hidden_size=args.hidden_size,
+                    num_loras=args.num_loras,
+                    num_active_loras=num_active_loras,
+                    lora_rank=args.lora_rank,
+                    sort_by_lora_id=bool(args.sort_by_lora_id),
+                    dtype=dtype,
+                    seq_length=1,
+                    num_experts=args.num_experts if is_fused_moe else None,
+                    top_k_num=args.top_k_num if is_fused_moe else None,
+                    num_slices=args.num_slices,
+                )
+            )
+    else:
+        ctx_list.append(
+            BenchmarkContext(
+                batch_size=args.batch_size,
+                hidden_size=args.hidden_size,
+                num_loras=args.num_loras,
+                num_active_loras=num_active_loras,
+                lora_rank=args.lora_rank,
+                sort_by_lora_id=bool(args.sort_by_lora_id),
+                dtype=dtype,
+                seq_length=args.seq_length,
+                num_experts=args.num_experts if is_fused_moe else None,
+                top_k_num=args.top_k_num if is_fused_moe else None,
+                num_slices=args.num_slices,
+            )
+        )
+
+    expand_fn_add_inputs: Optional[bool]
+    # For shrink or any fused_moe_lora op, benchmark_lora expects add_inputs to be None.
+    if op_type.is_shrink_fn() or op_type.is_fused_moe_lora_fn():
+        expand_fn_add_inputs = None
+    else:
+        expand_fn_add_inputs = bool(args.expand_add_inputs)
+
+    search_space = _build_search_space()
+    if args.max_configs is not None and args.max_configs > 0:
+        search_space = search_space[: args.max_configs]
+
+    fieldnames = [
+        "op_type",
+        "dtype",
+        "batch_size",
+        "seq_length",
+        "hidden_size",
+        "lora_rank",
+        "num_loras",
+        "num_active_loras",
+        "num_slices",
+        "block_m",
+        "block_n",
+        "block_k",
+        "num_warps",
+        "num_stages",
+        "num_ctas",
+        "split_k",
+        "group_size_m",
+        "max_nreg",
+        "median_time_ms",
+        "status",
+    ]
+
+    # Write CSV rows to os.devnull so no CSV file is created.
+    with open(os.devnull, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+
+        # Tune over each BenchmarkContext (potentially different M values)
+        for ctx in ctx_list:
+            total_configs = len(search_space)
+            m_val = ctx.batch_size * ctx.seq_length
+            print(f"Tuning M={m_val} over {total_configs} kernel configs")
+            log_interval = max(1, total_configs // 10)
+
+            best_cfg: Optional[Dict[str, Any]] = None
+            best_time_ms: float = float("inf")
+
+            for idx, cfg in enumerate(search_space, start=1):
+                median_time_ms = _benchmark_single_config(
+                    cfg=cfg,
+                    ctx=ctx,
+                    op_type=op_type,
+                    arg_pool_size=args.arg_pool_size,
+                    cuda_graph_nops=args.cuda_graph_nops,
+                    expand_fn_add_inputs=expand_fn_add_inputs,
+                    test_correctness=args.test_correctness,
+                )
+
+                status = "ok" if median_time_ms is not None else "out_of_resources"
+                if median_time_ms is not None and median_time_ms < best_time_ms:
+                    best_time_ms = median_time_ms
+                    best_cfg = dict(cfg)
+
+                row: Dict[str, Any] = {
+                    "op_type": op_type.name,
+                    "dtype": dtype_to_str(dtype),
+                    "batch_size": ctx.batch_size,
+                    "seq_length": ctx.seq_length,
+                    "hidden_size": ctx.hidden_size,
+                    "lora_rank": ctx.lora_rank,
+                    "num_loras": ctx.num_loras,
+                    "num_active_loras": ctx.num_active_loras,
+                    "num_slices": ctx.num_slices,
+                    "median_time_ms": median_time_ms
+                    if median_time_ms is not None
+                    else "",
+                    "status": status,
+                }
+
+                for key in (
+                    "block_m",
+                    "block_n",
+                    "block_k",
+                    "num_warps",
+                    "num_stages",
+                    "num_ctas",
+                    "split_k",
+                    "group_size_m",
+                    "max_nreg",
+                ):
+                    row[key] = cfg.get(key)
+
+                writer.writerow(row)
+
+                if idx % log_interval == 0 or idx == total_configs:
+                    if best_cfg is not None and best_time_ms != float("inf"):
+                        print(
+                            f"[M={m_val}] [{idx}/{total_configs}] "
+                            f"current best median_time_ms={best_time_ms:.3f}"
+                        )
+                    else:
+                        print(f"[M={m_val}] [{idx}/{total_configs}] benchmarking...")
+
+            # Optionally save best configuration for this ctx into JSON.
+            if args.save_json_dir and best_cfg is not None:
+                save_dir = Path(args.save_json_dir)
+                save_dir.mkdir(parents=True, exist_ok=True)
+
+                gpu_name = torch.cuda.get_device_name()
+                gpu_name = gpu_name.replace(" ", "_").replace("-", "_")
+
+                # Determine op name for JSON file
+                # NOTE: fused_moe_lora_* 使用单独的 *_shrink / *_expand 名称，不能依赖
+                # is_shrink_fn()（它只对 LORA_SHRINK 为 True），否则 shrink/expand 会写到同一个文件。
+                if op_type in (
+                    OpType.FUSED_MOE_LORA_GATE_UP_SHRINK,
+                    OpType.FUSED_MOE_LORA_GATE_UP_EXPAND,
+                ):
+                    op_name = (
+                        "fused_moe_lora_w13_shrink"
+                        if op_type.is_fused_moe_lora_shrink_fn()
+                        else "fused_moe_lora_w13_expand"
+                    )
+                elif op_type in (
+                    OpType.FUSED_MOE_LORA_DOWN_SHRINK,
+                    OpType.FUSED_MOE_LORA_DOWN_EXPAND,
+                ):
+                    op_name = (
+                        "fused_moe_lora_w2_shrink"
+                        if op_type.is_fused_moe_lora_shrink_fn()
+                        else "fused_moe_lora_w2_expand"
+                    )
+                else:
+                    op_name = "shrink" if op_type.is_shrink_fn() else "expand"
+
+                if op_name == "expand":
+                    add_inputs = bool(args.expand_add_inputs)
+                    json_name = (
+                        f"{gpu_name}_{op_name.upper()}_{str(add_inputs).upper()}.json"
+                    )
+                else:
+                    json_name = f"{gpu_name}_{op_name.upper()}.json"
+
+                json_path = save_dir / json_name
+
+                if json_path.exists() and not args.json_overwrite:
+                    base = json_name[:-5] if json_name.endswith(".json") else json_name
+                    idx = 1
+                    while True:
+                        candidate = save_dir / f"{base}_tuned_{idx}.json"
+                        if not candidate.exists():
+                            json_path = candidate
+                            break
+                        idx += 1
+                    print(
+                        f"JSON file {json_name} exists and --json-overwrite is not set; "
+                        f"writing tuned config to {json_path.name} instead."
+                    )
+                    config_data = {}
+                else:
+                    if json_path.exists():
+                        with json_path.open("r") as jf:
+                            config_data = json.load(jf)
+                    else:
+                        config_data = {}
+
+                max_loras_key = str(ctx.num_loras)
+                num_slices_key = str(ctx.num_slices)
+
+                # m, k, n follow the same convention as get_lora_op_configs.
+                m_val = ctx.batch_size * ctx.seq_length
+                is_shrink = op_type.is_shrink_fn()
+                if is_shrink:
+                    k_val = ctx.hidden_size
+                    n_val = ctx.lora_rank
+                else:
+                    k_val = ctx.lora_rank
+                    n_val = ctx.hidden_size
+
+                m_key = str(m_val)
+                k_key = str(k_val)
+                n_key = str(n_val)
+
+                config_data.setdefault(max_loras_key, {})
+                config_data[max_loras_key].setdefault(num_slices_key, {})
+                config_data[max_loras_key][num_slices_key].setdefault(m_key, {})
+                config_data[max_loras_key][num_slices_key][m_key].setdefault(
+                    k_key, {}
+                )
+
+                # For fused_moe_lora, add moe_intermediate_size dimension if needed
+                if (
+                    is_fused_moe
+                    and hasattr(args, "moe_intermediate_size")
+                    and args.moe_intermediate_size
+                ):
+                    i_key = str(args.moe_intermediate_size)
+                    config_data[max_loras_key][num_slices_key][m_key][k_key].setdefault(
+                        n_key, {}
+                    )
+                    config_data[max_loras_key][num_slices_key][m_key][k_key][n_key][
+                        i_key
+                    ] = best_cfg
+                else:
+                    config_data[max_loras_key][num_slices_key][m_key][k_key][
+                        n_key
+                    ] = best_cfg
+
+                with json_path.open("w") as jf:
+                    json.dump(config_data, jf)
+                print(f"Tuned JSON config saved to {json_path}")
+
+    # CSV results are no longer saved; tuned configs are written to JSON only.
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=(
+            "Grid-search LoRA Triton kernel configs over a predefined "
+            "search space and save benchmark results to CSV."
+        )
+    )
+
+    parser.add_argument(
+        "--op-type",
+        type=str,
+        default="lora_shrink",
+        choices=[
+            "lora_shrink",
+            "lora_expand",
+            "fused_moe_lora_gate_up_shrink",
+            "fused_moe_lora_gate_up_expand",
+            "fused_moe_lora_down_shrink",
+            "fused_moe_lora_down_expand",
+        ],
+        help="LoRA op type to benchmark.",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="torch.float16",
+        help="Data type string, e.g. 'torch.float16' or 'torch.bfloat16'.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        required=True,
+        help="Batch size used in the benchmark.",
+    )
+    parser.add_argument(
+        "--seq-length",
+        type=int,
+        required=True,
+        help="Sequence length used in the benchmark.",
+    )
+    parser.add_argument(
+        "--hidden-size",
+        type=int,
+        required=False,
+        default=None,
+        help="Hidden size (K dimension for shrink).",
+    )
+    parser.add_argument(
+        "--lora-rank",
+        type=int,
+        required=False,
+        default=None,
+        help="LoRA rank (N dimension for shrink).",
+    )
+    parser.add_argument(
+        "--num-loras",
+        type=int,
+        required=True,
+        help="Total number of LoRA adapters.",
+    )
+    parser.add_argument(
+        "--num-active-loras",
+        type=int,
+        default=None,
+        help="Number of active LoRAs. Defaults to num-loras.",
+    )
+    parser.add_argument(
+        "--num-slices",
+        type=int,
+        default=1,
+        help="Number of slices for the LoRA kernel.",
+    )
+    parser.add_argument(
+        "--sort-by-lora-id",
+        type=int,
+        default=1,
+        help="Whether to sort by LoRA ID (1 or 0).",
+    )
+    parser.add_argument(
+        "--arg-pool-size",
+        type=int,
+        default=32,
+        help="Argument pool size reused from benchmark_lora.",
+    )
+    parser.add_argument(
+        "--cuda-graph-nops",
+        type=int,
+        default=None,
+        help="Number of ops inside a CUDA graph; forwarded to benchmark_lora.",
+    )
+    parser.add_argument(
+        "--expand-add-inputs",
+        dest="expand_add_inputs",
+        type=int,
+        default=0,
+        help="For lora_expand, whether to add inputs (1 or 0).",
+    )
+    parser.add_argument(
+        "--test-correctness",
+        action="store_true",
+        help="Whether to run correctness checks in benchmark_lora.",
+    )
+    parser.add_argument(
+        "--output-csv",
+        type=str,
+        default="lora_tuning_results.csv",
+        help="Path to output CSV file.",
+    )
+    parser.add_argument(
+        "--max-configs",
+        type=int,
+        default=None,
+        help="Limit the number of kernel configs to benchmark (for quick demos).",
+    )
+    parser.add_argument(
+        "--save-json-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory to save tuned JSON config files. "
+            "When set, the best configuration is written to a JSON file "
+            "compatible with get_lora_op_configs."
+        ),
+    )
+    parser.add_argument(
+        "--json-overwrite",
+        action="store_true",
+        help=(
+            "When used with --save-json-dir, overwrite an existing JSON file "
+            "with the tuned config. By default, a new file name is generated "
+            "if the target file already exists."
+        ),
+    )
+    parser.add_argument(
+        "--num-experts",
+        type=int,
+        default=8,
+        help="Number of experts for fused MoE LoRA.",
+    )
+    parser.add_argument(
+        "--top-k-num",
+        type=int,
+        default=2,
+        help="Top-k value for fused MoE LoRA.",
+    )
+    parser.add_argument(
+        "--moe-intermediate-size",
+        type=int,
+        default=None,
+        help="MoE intermediate size (optional, for JSON config hierarchy).",
+    )
+    parser.add_argument(
+        "--m-values",
+        type=int,
+        nargs="+",
+        default=None,
+        help=(
+            "Optional list of M values (num_tokens = batch_size * seq_length) "
+            "to tune in a single run. When set, each M is mapped to a separate "
+            "BenchmarkContext with batch_size=M and seq_length=1, and results "
+            "for all Ms are written into the same CSV/JSON."
+        ),
+    )
+    parser.add_argument(
+        "--model-path",
+        type=str,
+        default=None,
+        help=(
+            "Optional base model path or Hugging Face repo id. "
+            "When tuning fused_moe_lora ops and transformers is installed, "
+            "hidden_size/num_experts/moe_intermediate_size/top_k_num can be "
+            "auto-inferred from the model config if not explicitly set."
+        ),
+    )
+    parser.add_argument(
+        "--lora-path",
+        type=str,
+        default=None,
+        help=(
+            "Optional LoRA weights directory. When provided and --lora-rank "
+            "is not set, the script will try to infer lora_rank from "
+            "adapter_config.json or safetensors weights."
+        ),
+    )
+
+    main(parser.parse_args())

--- a/benchmarks/kernels/benchmark_lora_tuning.py
+++ b/benchmarks/kernels/benchmark_lora_tuning.py
@@ -510,8 +510,8 @@ def main(args: argparse.Namespace) -> None:
                 gpu_name = gpu_name.replace(" ", "_").replace("-", "_")
 
                 # Determine op name for JSON file
-                # NOTE: fused_moe_lora_* 使用单独的 *_shrink / *_expand 名称，不能依赖
-                # is_shrink_fn()（它只对 LORA_SHRINK 为 True），否则 shrink/expand 会写到同一个文件。
+                # NOTE: fused_moe_lora_* uses separate *_shrink / *_expand names and cannot rely on
+                # is_shrink_fn() (which only returns True for LORA_SHRINK), otherwise shrink/expand would write to the same file.
                 if op_type in (
                     OpType.FUSED_MOE_LORA_GATE_UP_SHRINK,
                     OpType.FUSED_MOE_LORA_GATE_UP_EXPAND,

--- a/vllm/lora/ops/triton_ops/README_LORA_TUNING.md
+++ b/vllm/lora/ops/triton_ops/README_LORA_TUNING.md
@@ -1,0 +1,435 @@
+# LoRA Triton Kernel Tuning Script (`benchmark_lora_tuning.py`)
+
+This document explains how to use `benchmark_lora_tuning.py` to grid-search
+LoRA Triton kernel configurations and generate JSON config files that are
+consumed at runtime by `vllm.lora.ops.triton_ops.utils.get_lora_op_configs`.
+
+The script lives at:
+
+`vllm/benchmarks/kernels/benchmark_lora_tuning.py`
+
+and is meant as a **standalone tuning tool** for:
+
+- `lora_shrink`
+- `lora_expand`
+- `fused_moe_lora_gate_up_shrink`
+- `fused_moe_lora_gate_up_expand`
+- `fused_moe_lora_down_shrink`
+- `fused_moe_lora_down_expand`
+
+It runs a predefined search space of Triton kernel parameters, benchmarks
+each candidate, and writes the **best config** into JSON files under a
+user-specified directory.
+
+---
+
+## 1. Prerequisites
+
+- A CUDA GPU and a working CUDA driver.
+- Triton kernels enabled in vLLM (`HAS_TRITON` must be `True`).
+- PyTorch with CUDA support.
+- (Optional) `transformers` and `safetensors` if you want
+  `benchmark_lora_tuning.py` to **auto-infer** dimensions from
+  `--model-path` / `--lora-path` (see section 3.6). If these are not
+  installed, you can simply pass `--hidden-size` / `--lora-rank`
+  explicitly.
+
+At runtime, vLLM will read tuned configs from the directory pointed to:
+
+```bash
+export VLLM_TUNED_CONFIG_FOLDER=/path/to/tuned/configs
+```
+
+This folder must contain JSON files named according to
+`vllm/vllm/lora/ops/triton_ops/README_TUNING.md`, for example:
+
+- `NVIDIA_H200_SHRINK.json`
+- `NVIDIA_H200_EXPAND_TRUE.json`
+- `NVIDIA_H200_FUSED_MOE_LORA_W13_SHRINK.json`
+- `NVIDIA_H200_FUSED_MOE_LORA_W2_EXPAND.json`
+
+`benchmark_lora_tuning.py` generates these files for you.
+
+---
+
+## 2. What the script does
+
+High-level flow inside `main()`:
+
+1. Checks that Triton and CUDA are available.
+2. Patches `get_lora_op_configs` so that **during tuning**, the runtime
+   LoRA ops use the current candidate kernel config instead of the default.
+3. Builds a search space over:
+   - `block_m`, `block_n`, `block_k`
+   - `num_warps`, `num_stages`, `num_ctas`
+   - `split_k`
+4. For each `BenchmarkContext` (specified by batch/seq/hidden/rank/etc.):
+   - Benchmarks all candidate configs using `bench_optype`.
+   - Tracks the best (lowest median time) config.
+5. If `--save-json-dir` is set:
+   - Writes the best config to a JSON file named according to the kernel type
+     and GPU name (`torch.cuda.get_device_name()`).
+   - The JSON structure matches `get_lora_op_configs` expectations:
+     `config_data[max_loras][num_slices][m][k][n]` for regular LoRA, and
+     `config_data[max_loras][num_slices][m][k][n][i]` for fused MoE LoRA.
+6. Optionally auto-infers dimensions:
+   - When `--model-path` is provided (and `transformers` is installed),
+     `hidden_size`, `num_experts`, `moe_intermediate_size`, and `top_k_num`
+     can be filled from the base model config if not explicitly set.
+   - When `--lora-path` points to a LoRA weights directory, `lora_rank`
+     can be inferred from `adapter_config.json` or `.safetensors` files
+     if not passed explicitly.
+
+Note: CSV timing data is still streamed through the `csv` module, but in the
+current version it is written to `os.devnull`, so **no `.csv` file is created**.
+The only persisted outputs are the tuned JSON configs.
+
+---
+
+## 3. Command-line arguments
+
+### 3.1 Core arguments
+
+- `--op-type`  
+  LoRA op to tune:
+
+  ```text
+  lora_shrink
+  lora_expand
+  fused_moe_lora_gate_up_shrink
+  fused_moe_lora_gate_up_expand
+  fused_moe_lora_down_shrink
+  fused_moe_lora_down_expand
+  ```
+
+- `--dtype`  
+  Data type string, e.g.:
+
+  ```text
+  torch.float16
+  torch.bfloat16
+  torch.float32
+  ```
+
+- `--batch-size` / `--seq-length`  
+  Defines the logical M dimension: `M = batch_size * seq_length`.
+
+- `--hidden-size`  
+  Hidden size of the model:
+
+  - For `lora_shrink`: `K = hidden_size`, `N = lora_rank`.
+  - For `lora_expand` and fused MoE: `K = lora_rank`, `N = hidden_size`.
+  - Required unless it can be **auto-inferred** from `--model-path`
+    (see section 3.6).
+
+- `--lora-rank`  
+  LoRA rank (N dimension in shrink).
+  - Required unless it can be **auto-inferred** from `--lora-path`
+    (see section 3.6).
+
+- `--num-loras` / `--num-active-loras`  
+  Total number of LoRA adapters and number of active LoRAs.
+  If `--num-active-loras` is omitted, it defaults to `num_loras`.
+
+- `--num-slices`  
+  Number of slices for the LoRA kernel (e.g. 1 or 2).
+
+### 3.2 Benchmarking behavior
+
+- `--sort-by-lora-id` (int, 0 or 1)  
+  Whether to sort tokens by LoRA ID in the benchmark.
+
+- `--arg-pool-size`  
+  Number of `BenchmarkTensors` instances reused for timing to reduce caching
+  effects. Values like 8–32 are typical. Larger values increase tuning time.
+
+- `--cuda-graph-nops`  
+  If set, uses CUDA Graph to benchmark `N` consecutive ops inside a captured
+  graph, which reduces Python overhead but increases the per-run cost.
+
+- `--test-correctness`  
+  If set, calls the reference implementation to verify correctness **for
+  `lora_shrink` and `lora_expand` only**. Correctness testing is not supported
+  for fused MoE LoRA ops.
+
+- `--max-configs`  
+  Optional limit on the number of kernel configs to benchmark. Useful for
+  quick runs:
+
+  ```bash
+  --max-configs 512
+  ```
+
+### 3.3 Output control
+
+- `--save-json-dir` (recommended)  
+  Directory to write tuned JSON configs. For example:
+
+  ```bash
+  --save-json-dir /model/hdj/tuning
+  ```
+
+  Files are named as:
+
+  - `"{gpu_name}_SHRINK.json"` for `lora_shrink`
+  - `"{gpu_name}_EXPAND_{add_inputs}.json"` for `lora_expand`
+  - `"{gpu_name}_FUSED_MOE_LORA_W13_SHRINK.json"` / `EXPAND.json`
+  - `"{gpu_name}_FUSED_MOE_LORA_W2_SHRINK.json"` / `EXPAND.json`
+
+  The script automatically normalizes `gpu_name` (spaces and `-` replaced by `_`).
+
+- `--json-overwrite`  
+  When the target JSON file already exists:
+
+  - If `--json-overwrite` **is not** set, the script will create a new file
+    with a `_tuned_{idx}.json` suffix.
+  - If `--json-overwrite` **is** set, the existing file is overwritten.
+
+- `--output-csv`  
+  Path to an output CSV file (kept for CLI compatibility). Internally, the
+  script still streams timing data through the `csv` module but writes it
+  to `os.devnull`, so **no `.csv` file is actually created** and timing
+  info is not persisted in CSV form.
+
+### 3.4 Fused MoE-specific arguments
+
+These are relevant when `--op-type` is one of the fused MoE LoRA ops:
+
+- `--num-experts`  
+  Number of experts in the MoE layer. Default: `8`.
+
+- `--top-k-num`  
+  Top-K routing value used in MoE. Default: `2`.
+
+- `--moe-intermediate-size`  
+  Intermediate size of the MoE layer. When **saving JSON for fused MoE LoRA**,
+  this value becomes the final index `i` in:
+
+  ```text
+  config_data[max_loras][num_slices][m][k][n][i]
+  ```
+
+  To generate usable fused MoE LoRA JSON for runtime, you must provide the
+  correct intermediate size of your model’s MoE FFN (often equal to
+  `intermediate_size` or `moe_intermediate_size` in the model config).
+
+### 3.5 Multi-M tuning
+
+- `--m-values`  
+  A list of explicit `M` (num_tokens) values to tune in a single run. When
+  provided, the script creates one `BenchmarkContext` per `M` with:
+
+  ```text
+  batch_size = M
+  seq_length = 1
+  ```
+
+  and tunes each context sequentially, saving all results into the same JSON.
+
+### 3.6 Dimension auto-inference (optional)
+
+These convenience arguments let the script infer dimensions for you instead
+of requiring every value on the command line:
+
+- `--model-path`  
+  A base model path or Hugging Face repo id. When tuning fused MoE LoRA ops
+  and `transformers` is installed, the script will try to infer:
+
+  - `hidden_size` (e.g. from `hidden_size`, `n_embd`, or `d_model`),
+  - `num_experts` (e.g. `num_experts`, `moe_num_experts`, `num_local_experts`,
+    `n_routed_experts`),
+  - `moe_intermediate_size` (e.g. `moe_intermediate_size`,
+    `ffn_hidden_size`, `intermediate_size`),
+  - `top_k_num` (e.g. `num_experts_per_tok`, `num_experts_per_token`,
+    `moe_top_k`, `top_k`),
+
+  filling in any of these that you did not explicitly set.
+
+- `--lora-path`  
+  Directory containing LoRA adapter weights. The script looks for common
+  config and weight files such as:
+
+  - `adapter_config.json`, `adapter_config.bin`, `config.json`, and
+  - `*.safetensors` (preferring keys that contain `lora_`).
+
+  If a valid rank can be inferred from these files, `lora_rank` is filled
+  automatically when you omit `--lora-rank`.
+
+> Note: if auto-inference fails (e.g. files are missing or not readable),
+> you must still provide `--hidden-size` / `--lora-rank` explicitly. The
+> script will raise a clear error in that case.
+
+---
+
+## 4. Typical usage examples
+
+### 4.1 Basic `lora_shrink` tuning (single workload)
+
+```bash
+python3 benchmark_lora_tuning.py \
+  --op-type lora_shrink \
+  --dtype torch.float16 \
+  --batch-size 16 \
+  --seq-length 1 \
+  --hidden-size 5120 \
+  --lora-rank 16 \
+  --num-loras 4 \
+  --num-active-loras 4 \
+  --num-slices 1 \
+  --arg-pool-size 8 \
+  --max-configs 50 \
+  --save-json-dir /model/hdj/tuning \
+  --json-overwrite
+```
+
+This will:
+
+- Search over the first 50 configs from the search space.
+- Tune a single workload (`M=16`, `K=5120`, `N=16`).
+- Save the best config into `/model/hdj/tuning/{gpu_name}_SHRINK.json`.
+
+### 4.2 `lora_expand` tuning (with add_inputs flag)
+
+```bash
+python3 benchmark_lora_tuning.py \
+  --op-type lora_expand \
+  --dtype torch.float16 \
+  --batch-size 16 \
+  --seq-length 1 \
+  --hidden-size 5120 \
+  --lora-rank 16 \
+  --num-loras 4 \
+  --num-active-loras 4 \
+  --num-slices 1 \
+  --expand-add-inputs 0 \
+  --arg-pool-size 8 \
+  --max-configs 50 \
+  --save-json-dir /model/hdj/tuning \
+  --json-overwrite
+```
+
+This writes a config into:
+
+```text
+{gpu_name}_EXPAND_FALSE.json
+```
+
+If you set `--expand-add-inputs 1`, the filename becomes
+`{gpu_name}_EXPAND_TRUE.json`.
+
+### 4.3 Fused MoE LoRA tuning (gate_up / down)
+
+Gate/Up projection (`w13`):
+
+```bash
+python3 benchmark_lora_tuning.py \
+  --op-type fused_moe_lora_gate_up_shrink \
+  --dtype torch.float16 \
+  --batch-size 64 \
+  --seq-length 1 \
+  --hidden-size 8192 \
+  --lora-rank 64 \
+  --num-loras 8 \
+  --num-active-loras 8 \
+  --num-slices 2 \
+  --num-experts 8 \
+  --top-k-num 2 \
+  --moe-intermediate-size 14336 \
+  --arg-pool-size 8 \
+  --max-configs 256 \
+  --save-json-dir /model/hdj/tuning \
+  --json-overwrite
+```
+
+This will write the tuned config into:
+
+```text
+{gpu_name}_FUSED_MOE_LORA_W13_SHRINK.json
+```
+
+Similarly for `fused_moe_lora_gate_up_expand`, `fused_moe_lora_down_shrink`,
+and `fused_moe_lora_down_expand`, with appropriate filenames as documented
+in `README_TUNING.md`.
+
+> Important: for fused MoE LoRA JSON to be usable at runtime, you **must**
+> pass a correct `--moe-intermediate-size` so that `get_lora_op_configs(...)`
+> can index `[i]` properly.
+
+### 4.4 Longer tuning runs (larger search + workload)
+
+To run a heavier search that may take tens of minutes:
+
+```bash
+python3 benchmark_lora_tuning.py \
+  --op-type lora_shrink \
+  --dtype torch.float16 \
+  --batch-size 64 \
+  --seq-length 16 \
+  --hidden-size 8192 \
+  --lora-rank 64 \
+  --num-loras 8 \
+  --num-active-loras 8 \
+  --num-slices 2 \
+  --arg-pool-size 8 \
+  --cuda-graph-nops 16 \
+  --max-configs 512 \
+  --save-json-dir /model/hdj/tuning \
+  --json-overwrite
+```
+
+This keeps the search space fairly large and uses CUDA Graph to amortize
+Python overhead, at the cost of longer per-config benchmarking time.
+
+---
+
+## 5. JSON structure and runtime consumption
+
+The script writes JSONs that are loaded at runtime by
+`vllm/vllm/lora/ops/triton_ops/utils.py::get_lora_op_configs` via
+`load_lora_op_config`. The expected structure is:
+
+```text
+config_data[max_loras][num_slices][m][k][n] = cfg
+```
+
+for regular LoRA (`shrink`/`expand`), and:
+
+```text
+config_data[max_loras][num_slices][m][k][n][i] = cfg
+```
+
+for fused MoE LoRA, where:
+
+- `max_loras`: number of LoRA adapters supported.
+- `num_slices`: LoRA slices.
+- `m`: M dimension (`batch_size * seq_length`).
+- `k`, `n`: matrix dimensions as defined by `OpType.mkn(...)`.
+- `i`: MoE intermediate size (only for fused MoE LoRA).
+
+At runtime, vLLM will:
+
+1. Compute `(max_loras, num_slices, m, k, n, i)` from the actual workload.
+2. Look up the closest matching keys in the JSON.
+3. Fall back to default configs if no JSON is available.
+
+By using `benchmark_lora_tuning.py` to populate the JSON files under
+`VLLM_TUNED_CONFIG_FOLDER`, you ensure that the LoRA Triton kernels use
+*measured* best configs instead of generic defaults.
+
+---
+
+## 6. Relationship to `benchmark_lora.py`
+
+- `benchmark_lora.py` is a **general benchmarking tool** for LoRA, with
+  multiple modes (`list_bench`, `range_bench`, `model_bench`) and support for
+  saving raw `torch.utils.benchmark.Measurement` data to pickle/CSV.
+- `benchmark_lora_tuning.py` is a **focused tuner**:
+  - Uses a fixed search space.
+  - Integrates directly with runtime `get_lora_op_configs`.
+  - Writes only the final tuned configs (JSON) needed for production use.
+
+In a typical workflow, you:
+
+1. Use `benchmark_lora.py` for exploration and performance analysis.
+2. Use `benchmark_lora_tuning.py` to generate the JSON files actually used
+   by inference.

--- a/vllm/lora/ops/triton_ops/README_LORA_TUNING.md
+++ b/vllm/lora/ops/triton_ops/README_LORA_TUNING.md
@@ -126,14 +126,14 @@ The only persisted outputs are the tuned JSON configs.
 - `--hidden-size`  
   Hidden size of the model:
 
-  - For `lora_shrink`: `K = hidden_size`, `N = lora_rank`.
-  - For `lora_expand` and fused MoE: `K = lora_rank`, `N = hidden_size`.
-  - Required unless it can be **auto-inferred** from `--model-path`
+    - For `lora_shrink`: `K = hidden_size`, `N = lora_rank`.
+    - For `lora_expand` and fused MoE: `K = lora_rank`, `N = hidden_size`.
+    - Required unless it can be **auto-inferred** from `--model-path`
     (see section 3.6).
 
 - `--lora-rank`  
   LoRA rank (N dimension in shrink).
-  - Required unless it can be **auto-inferred** from `--lora-path`
+    - Required unless it can be **auto-inferred** from `--lora-path`
     (see section 3.6).
 
 - `--num-loras` / `--num-active-loras`  
@@ -180,19 +180,19 @@ The only persisted outputs are the tuned JSON configs.
 
   Files are named as:
 
-  - `"{gpu_name}_SHRINK.json"` for `lora_shrink`
-  - `"{gpu_name}_EXPAND_{add_inputs}.json"` for `lora_expand`
-  - `"{gpu_name}_FUSED_MOE_LORA_W13_SHRINK.json"` / `EXPAND.json`
-  - `"{gpu_name}_FUSED_MOE_LORA_W2_SHRINK.json"` / `EXPAND.json`
+    - `"{gpu_name}_SHRINK.json"` for `lora_shrink`
+    - `"{gpu_name}_EXPAND_{add_inputs}.json"` for `lora_expand`
+    - `"{gpu_name}_FUSED_MOE_LORA_W13_SHRINK.json"` / `EXPAND.json`
+    - `"{gpu_name}_FUSED_MOE_LORA_W2_SHRINK.json"` / `EXPAND.json`
 
   The script automatically normalizes `gpu_name` (spaces and `-` replaced by `_`).
 
 - `--json-overwrite`  
   When the target JSON file already exists:
 
-  - If `--json-overwrite` **is not** set, the script will create a new file
+    - If `--json-overwrite` **is not** set, the script will create a new file
     with a `_tuned_{idx}.json` suffix.
-  - If `--json-overwrite` **is** set, the existing file is overwritten.
+    - If `--json-overwrite` **is** set, the existing file is overwritten.
 
 - `--output-csv`  
   Path to an output CSV file (kept for CLI compatibility). Internally, the
@@ -270,12 +270,12 @@ of requiring every value on the command line:
   A base model path or Hugging Face repo id. When tuning fused MoE LoRA ops
   and `transformers` is installed, the script will try to infer:
 
-  - `hidden_size` (e.g. from `hidden_size`, `n_embd`, or `d_model`),
-  - `num_experts` (e.g. `num_experts`, `moe_num_experts`, `num_local_experts`,
+    - `hidden_size` (e.g. from `hidden_size`, `n_embd`, or `d_model`),
+    - `num_experts` (e.g. `num_experts`, `moe_num_experts`, `num_local_experts`,
     `n_routed_experts`),
-  - `moe_intermediate_size` (e.g. `moe_intermediate_size`,
+    - `moe_intermediate_size` (e.g. `moe_intermediate_size`,
     `ffn_hidden_size`, `intermediate_size`),
-  - `top_k_num` (e.g. `num_experts_per_tok`, `num_experts_per_token`,
+    - `top_k_num` (e.g. `num_experts_per_tok`, `num_experts_per_token`,
     `moe_top_k`, `top_k`),
 
   filling in any of these that you did not explicitly set.
@@ -284,8 +284,8 @@ of requiring every value on the command line:
   Directory containing LoRA adapter weights. The script looks for common
   config and weight files such as:
 
-  - `adapter_config.json`, `adapter_config.bin`, `config.json`, and
-  - `*.safetensors` (preferring keys that contain `lora_`).
+    - `adapter_config.json`, `adapter_config.bin`, `config.json`, and
+    - `*.safetensors` (preferring keys that contain `lora_`).
 
   If a valid rank can be inferred from these files, `lora_rank` is filled
   automatically when you omit `--lora-rank`.
@@ -459,9 +459,9 @@ By using `benchmark_lora_tuning.py` to populate the JSON files under
   multiple modes (`list_bench`, `range_bench`, `model_bench`) and support for
   saving raw `torch.utils.benchmark.Measurement` data to pickle/CSV.
 - `benchmark_lora_tuning.py` is a **focused tuner**:
-  - Uses a fixed search space.
-  - Integrates directly with runtime `get_lora_op_configs`.
-  - Writes only the final tuned configs (JSON) needed for production use.
+    - Uses a fixed search space.
+    - Integrates directly with runtime `get_lora_op_configs`.
+    - Writes only the final tuned configs (JSON) needed for production use.
 
 In a typical workflow, you:
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Improve and supplement LoRA tuning documentation
## Test Plan

## Test Result
<img width="416" height="158" alt="bc182bf14be8ee10687ffecfe0dda875" src="https://github.com/user-attachments/assets/8eada446-038a-4b05-8902-af39eb9740d9" />

## PR Content Description
This PR adds a standalone tuning script for Triton LoRA kernels, `vllm/benchmarks/kernels/benchmark_lora_tuning.py`.

**High‑level behavior**

- Performs a grid search over Triton kernel hyperparameters (e.g. `block_m/n/k`, `num_warps`, `num_stages`, `split_k`, etc.) for LoRA and fused MoE LoRA ops.
- Reuses the existing `benchmark_lora.bench_optype` harness to run the kernels and measure median latency per configuration.
- Optionally exports the best configuration(s) per setting to JSON files that are compatible with `get_lora_op_configs` (keyed by `max_loras`, `num_slices`, `m`, `k`, `n` and optionally `moe_intermediate_size` for fused MoE).

**Patching / config hijacking**

- The script introduces a small monkey‑patching layer around `get_lora_op_configs`:
  - `_CURRENT_LORA_KERNEL_CONFIG` holds the “current candidate” Triton config during tuning.
  - `_patched_get_lora_op_configs(...)` first checks `_CURRENT_LORA_KERNEL_CONFIG`:
    - If it is set, it returns this candidate config instead of running the original logic.
    - For fused MoE LoRA ops, it also maps the lower‑case search‑space keys (`block_m`, `num_warps`, `split_k`, …) to the macro‑style keys expected by the existing code (`BLOCK_SIZE_M`, `NUM_WARPS`, `SPLIT_K`, …).
    - If no candidate is set, it falls back to the original `_ORIGINAL_GET_LORA_OP_CONFIGS(...)`.
  - `_ensure_patched()` applies this patched function to all relevant modules (`utils`, `lora_shrink_op`, `lora_expand_op`, `fused_moe_lora_op`, and the `benchmark_lora` module itself) exactly once.
- `_benchmark_single_config(...)` simply sets `_CURRENT_LORA_KERNEL_CONFIG = cfg` before calling `bench_optype(...)`, so every benchmark run uses that specific kernel config via the patched `get_lora_op_configs`.
- If Triton reports `OutOfResources`, the script treats that configuration as invalid (marks status as `out_of_resources` and skips it when choosing the best config).
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

