### PR TITLE
[Bugfix] Fix incorrect channel order for idefics3 in edge case

### DIFF
--- a/vllm/model_executor/models/idefics3.py
+++ b/vllm/model_executor/models/idefics3.py
@@ -183,7 +183,7 @@ class Idefics3ProcessingInfo(BaseProcessingInfo):
         resized_height, resized_width = self._get_resize_output_image_size(
             image_width=image_width,
             image_height=image_height,
-            resolution_max_side=size,
+            resolution_max_side=max_image_size,
         )
         if resized_height > max_image_size or resized_width > max_image_size:
             grid_h = math.ceil(resized_height / max_image_size)

--- a/vllm/model_executor/models/idefics3.py
+++ b/vllm/model_executor/models/idefics3.py
@@ -338,7 +338,7 @@ class Idefics3MultiModalProcessor(BaseMultiModalProcessor[Idefics3ProcessingInfo
             prompt_ids = self._apply_hf_processor_tokens_only(prompt_ids)
             return BatchFeature(dict(input_ids=[prompt_ids]), tensor_type="pt")
 
-        mm_kwargs["input_data_format"] = "channels_last"
+        mm_kwargs = {"input_data_format": "channels_last", **mm_kwargs}
         processed_outputs = super()._call_hf_processor(
             prompt,
             mm_data,

--- a/vllm/model_executor/models/idefics3.py
+++ b/vllm/model_executor/models/idefics3.py
@@ -183,7 +183,7 @@ class Idefics3ProcessingInfo(BaseProcessingInfo):
         resized_height, resized_width = self._get_resize_output_image_size(
             image_width=image_width,
             image_height=image_height,
-            resolution_max_side=max_image_size,
+            resolution_max_side=size,
         )
         if resized_height > max_image_size or resized_width > max_image_size:
             grid_h = math.ceil(resized_height / max_image_size)
@@ -338,6 +338,7 @@ class Idefics3MultiModalProcessor(BaseMultiModalProcessor[Idefics3ProcessingInfo
             prompt_ids = self._apply_hf_processor_tokens_only(prompt_ids)
             return BatchFeature(dict(input_ids=[prompt_ids]), tensor_type="pt")
 
+        mm_kwargs["input_data_format"] = "channels_last"
         processed_outputs = super()._call_hf_processor(
             prompt,
             mm_data,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
```
The channel dimension is ambiguous. Got image shape (3, 3, 3). Assuming channels are the first dimension. Use the [input_data_format](https://huggingface.co/docs/transformers/main/internal/image_processing_utils#transformers.image_transforms.rescale.input_data_format) parameter to assign the channel dimension.
```
- Idefics3's image processor will detect channel order incorrectly under edge case. This PR fixes it.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

