### PR TITLE
optimize topk_topp_sampling.

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -106,7 +106,7 @@ class TopKTopPSampler(nn.Module):
             and k is not None
             and p is not None
         ):
-            return optimized_top_k_top_p(logits, generators, k, p, self.logprobs_mode)
+            return optimized_top_k_top_p_sample(logits, generators, k, p, self.logprobs_mode)
         logits_to_return = None
         logits = self.apply_top_k_top_p(logits, k, p)
         if self.logprobs_mode == "processed_logits":

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -307,9 +307,9 @@ def optimized_top_k_top_p_sample(
     top_p_mask.scatter_(dim=1, index=first_true_indices, value=False)
     topk_values.masked_fill_(top_p_mask, -float("inf"))
     logits_to_return = None
-    if self.logprobs_mode == "processed_logits":
+    if logprobs_mode == "processed_logits":
         logits_to_return = topk_values
-    elif self.logprobs_mode == "processed_logprobs":
+    elif logprobs_mode == "processed_logprobs":
         logits_to_return = topk_values.log_softmax(dim=-1, dtype=torch.float32)
     probs = topk_values.softmax(dim=-1, dtype=torch.float32)
     topk_indices = topk_indices


### PR DESCRIPTION
<!-- markdownlint-disable -->
Optimizing topk_topp_sampling performance.

## Purpose

## Test Plan

## Test Result
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [optimize the performance] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
L20
vllm bench serve --dataset-name random --max-concurrency 8 --model Qwen/Qwen2.5-0.5B-Instruct --random-input-len 100 --random-output-len 10 --temperature 1 --top-k 5 --top-p 0.9
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
before


============ Serving Benchmark Result ============
Successful requests:                     1000      
Maximum request concurrency:             8         
Benchmark duration (s):                  6.37      
Total input tokens:                      99825     
Total generated tokens:                  9989      
Request throughput (req/s):              156.99    
Output token throughput (tok/s):         1568.20   
Peak output token throughput (tok/s):    1644.00   
Peak concurrent requests:                172.00    
Total Token throughput (tok/s):          17240.02  
---------------Time to First Token----------------
Mean TTFT (ms):                          15.61     
Median TTFT (ms):                        14.68     
P99 TTFT (ms):                           22.92     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          3.90      
Median TPOT (ms):                        3.90      
P99 TPOT (ms):                           4.25      
---------------Inter-token Latency----------------
Mean ITL (ms):                           3.90      
Median ITL (ms):                         3.65      
P99 ITL (ms):                            7.22      
==================================================
after
============ Serving Benchmark Result ============
Successful requests:                     1000      
Maximum request concurrency:             8         
Benchmark duration (s):                  6.01      
Total input tokens:                      99825     
Total generated tokens:                  9974      
Request throughput (req/s):              166.28    
Output token throughput (tok/s):         1658.52   
Peak output token throughput (tok/s):    1686.00   
Peak concurrent requests:                178.00    
Total Token throughput (tok/s):          18257.89  
---------------Time to First Token----------------
Mean TTFT (ms):                          15.70     
Median TTFT (ms):                        16.19     
P99 TTFT (ms):                           21.57     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          3.58      
Median TPOT (ms):                        3.51      
P99 TPOT (ms):                           3.95      
---------------Inter-token Latency----------------
Mean ITL (ms):                           3.58      
Median ITL (ms):                         3.32      
P99 ITL (ms):                            6.88      
==================================================
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

