### PR TITLE
[ROCm][Perf] Enable shuffle kv cache layout and assembly paged attention kernel for `AiterFlashAttentionBackend`

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -833,6 +833,7 @@ class rocm_aiter_ops:
     _FMOE_ENABLED = envs.VLLM_ROCM_USE_AITER_MOE
     _MLA_ENABLED = envs.VLLM_ROCM_USE_AITER_MLA
     _MHA_ENABLED = envs.VLLM_ROCM_USE_AITER_MHA
+    _SHUFFLE_KV_CACHE_ENABLED = envs.VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT
     _TRITON_UNIFIED_ATTN_ENABLED = envs.VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION
     # TODO: Consolidate under _LINEAR_ENABLED
     _FP8BMM_ENABLED = envs.VLLM_ROCM_USE_AITER_FP8BMM
@@ -859,6 +860,7 @@ class rocm_aiter_ops:
         cls._FMOE_ENABLED = envs.VLLM_ROCM_USE_AITER_MOE
         cls._MLA_ENABLED = envs.VLLM_ROCM_USE_AITER_MLA
         cls._MHA_ENABLED = envs.VLLM_ROCM_USE_AITER_MHA
+        cls._SHUFFLE_KV_CACHE_ENABLED = envs.VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT
         cls._TRITON_UNIFIED_ATTN_ENABLED = envs.VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION
         cls._FP8BMM_ENABLED = envs.VLLM_ROCM_USE_AITER_FP8BMM
         cls._FP4_GEMM_DYNAMIC_QUANT_ASM = envs.VLLM_ROCM_USE_AITER_FP4_ASM_GEMM
@@ -905,6 +907,11 @@ class rocm_aiter_ops:
     @if_aiter_supported
     def is_mha_enabled(cls) -> bool:
         return cls._AITER_ENABLED and cls._MHA_ENABLED
+
+    @classmethod
+    @if_aiter_supported
+    def is_shuffle_kv_cache_enabled(cls) -> bool:
+        return cls._AITER_ENABLED and cls._SHUFFLE_KV_CACHE_ENABLED
 
     @classmethod
     @if_aiter_supported

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -128,6 +128,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_FP8_PADDING: bool = True
     VLLM_ROCM_MOE_PADDING: bool = True
     VLLM_ROCM_CUSTOM_PAGED_ATTN: bool = True
+    VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT: bool = False
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
     VLLM_DISABLE_COMPILE_CACHE: bool = False
@@ -1017,6 +1018,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # custom paged attention kernel for MI3* cards
     "VLLM_ROCM_CUSTOM_PAGED_ATTN": lambda: (
         os.getenv("VLLM_ROCM_CUSTOM_PAGED_ATTN", "True").lower() in ("true", "1")
+    ),
+    # Whether to use the shuffled kv cache layout
+    "VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT": lambda: (
+        os.getenv("VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT", "False").lower() in ("true", "1")
     ),
     # Custom quick allreduce kernel for MI3* cards
     # Choice of quantization level: FP, INT8, INT6, INT4 or NONE

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -537,6 +537,7 @@ class RocmPlatform(Platform):
         # only device 0 is checked, this assumes MI300 platforms are homogeneous
         return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
 
+    @cache
     @classmethod
     def fp8_dtype(cls) -> torch.dtype:
         if cls.is_fp8_fnuz():

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -537,7 +537,6 @@ class RocmPlatform(Platform):
         # only device 0 is checked, this assumes MI300 platforms are homogeneous
         return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
 
-    @cache
     @classmethod
     def fp8_dtype(cls) -> torch.dtype:
         if cls.is_fp8_fnuz():

--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -7,7 +7,7 @@ from typing import ClassVar
 
 import torch
 
-import vllm.envs as envs
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.attention.layer import Attention
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.logger import init_logger
@@ -464,7 +464,7 @@ class AiterFlashAttentionMetadataBuilder(
             decode_threshold=self.reorder_batch_threshold,
         )
         if (
-            envs.VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT
+            rocm_aiter_ops._SHUFFLE_KV_CACHE_ENABLED
             and len(self.k_scale) == 0
             and self.vllm_config.cache_config.cache_dtype.startswith("fp8")
         ):
@@ -892,7 +892,7 @@ class AiterFlashAttentionImpl(AttentionImpl):
                 seq_starts=chunk_starts[chunk_idx],
                 dequant=self.kv_cache_dtype.startswith("fp8"),
                 kv_cache_layout="SHUFFLE"
-                if envs.VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT
+                if rocm_aiter_ops._SHUFFLE_KV_CACHE_ENABLED
                 else "NHD",
                 total_tokens=total_token_per_batch[chunk_idx],
             )
@@ -1005,7 +1005,7 @@ class AiterFlashAttentionImpl(AttentionImpl):
             # key[:num_actual_tokens] and value[:num_actual_tokens] because
             # the reshape_and_cache_flash op uses the slot_mapping's shape
             # to determine the number of actual tokens.
-            if envs.VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT:
+            if rocm_aiter_ops._SHUFFLE_KV_CACHE_ENABLED:
                 # We may calculate per token quant scale in
                 # reshape_and_cache_shuffle_triton which might differ from
                 # vllm's style when shuffle layout is used.
@@ -1116,7 +1116,7 @@ class AiterFlashAttentionImpl(AttentionImpl):
             if num_decodes > 0:
                 assert attn_metadata.decode_metadata is not None
                 if self.sliding_window[0] != -1:
-                    assert not envs.VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT, (
+                    assert not rocm_aiter_ops._SHUFFLE_KV_CACHE_ENABLED, (
                         "Sliding window with shuffle layout is not supported yet."
                     )
                     from aiter.ops.triton.unified_attention import (
@@ -1149,7 +1149,7 @@ class AiterFlashAttentionImpl(AttentionImpl):
                     return
                 assert attn_metadata.decode_metadata is not None
 
-                if envs.VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT:
+                if rocm_aiter_ops._SHUFFLE_KV_CACHE_ENABLED:
                     num_blocks, block_size, num_kv_heads, head_size = key_cache.shape
                     x = 16 // key_cache.element_size()
                     k_cache_template = torch.empty(

--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -67,8 +67,12 @@ if current_platform.is_rocm():
         head_id = tl.program_id(1)
         col_offsets = tl.arange(0, BLOCK_SIZE)
 
-        key_ptr_offset = key_ptr + token_id * head_size * num_heads
-        value_ptr_offset = value_ptr + token_id * head_size * num_heads
+        key_ptr_offset = (
+            key_ptr + token_id * head_size * num_heads + head_id * head_size
+        )
+        value_ptr_offset = (
+            value_ptr + token_id * head_size * num_heads + head_id * head_size
+        )
         batch_idx = tl.load(token_to_batch_ptr + token_id)
         batch_start = tl.load(seq_start_ptr + batch_idx)
         token_start = tl.load(cu_seqlens_kv_ptr + batch_idx)


### PR DESCRIPTION

## Purpose
This PR add assembly paged attention kernel in aiter to `AiterFlashAttentionBackend`. We verify this implementation on `Qwen3-30B-A3B-FP8` Mi308 and observed at least about 20% thoughput gain and obvious latency reduction on tpot.

This PR add this flag `USING_SHUFFLE_LAYOUT` to control whether to enable assembly paged attention, and set it False by default to prevent any unexpected circumstance. This flag will be removed after assembly paged attention fully verified by the users.

## Test Plan
gsm8k for accuracy
vllm bench for performance
## Test Result
```
# normal aiter paged attention
============ Serving Benchmark Result ============
Successful requests:                     200       
Failed requests:                         0         
Maximum request concurrency:             200       
Benchmark duration (s):                  95.28     
Total input tokens:                      768000    
Total generated tokens:                  204800    
Request throughput (req/s):              2.10      
Output token throughput (tok/s):         2149.35   
Peak output token throughput (tok/s):    4000.00   
Peak concurrent requests:                200.00    
Total Token throughput (tok/s):          10209.43  
---------------Time to First Token----------------
Mean TTFT (ms):                          21644.01  
Median TTFT (ms):                        21321.70  
P99 TTFT (ms):                           41420.74  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          71.65     
Median TPOT (ms):                        72.00     
P99 TPOT (ms):                           90.40     
---------------Inter-token Latency----------------
Mean ITL (ms):                           71.65     
Median ITL (ms):                         53.10     
P99 ITL (ms):                            1744.72   
==================================================

# assembly aiter paged attention

============ Serving Benchmark Result ============
Successful requests:                     200       
Failed requests:                         0         
Maximum request concurrency:             200       
Benchmark duration (s):                  79.77     
Total input tokens:                      768000    
Total generated tokens:                  204800    
Request throughput (req/s):              2.51      
Output token throughput (tok/s):         2567.23   
Peak output token throughput (tok/s):    5400.00   
Peak concurrent requests:                200.00    
Total Token throughput (tok/s):          12194.33  
---------------Time to First Token----------------
Mean TTFT (ms):                          21566.08  
Median TTFT (ms):                        21239.65  
P99 TTFT (ms):                           41279.14  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          56.62     
Median TPOT (ms):                        56.95     
P99 TPOT (ms):                           75.42     
---------------Inter-token Latency----------------
Mean ITL (ms):                           56.62     
Median ITL (ms):                         37.89     
P99 ITL (ms):                            1742.49   
==================================================
```


accuracy result
```
# normal
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8264|±  |0.0104|
|     |       |strict-match    |     5|exact_match|↑  |0.8901|±  |0.0086|

# asm 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8294|±  |0.0104|
|     |       |strict-match    |     5|exact_match|↑  |0.8848|±  |0.0088|
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 0fa5c519e813e7e42d075da135ff86c47b776246. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces SHUFFLE KV-cache layout and an assembly decode path to improve ROCm performance.
> 
> - Adds `USING_SHUFFLE_LAYOUT` flag and extends gather kernel to run per-head, support `"SHUFFLE"` layout, and apply per-slot fp8 dequant scales
> - Implements Triton `reshape_and_cache_shuffle_*` to write K/V into shuffle layout and compute/store fp8 scales; registers per-block `k/v` scale buffers when needed
> - Extend/decode paths: use SHUFFLE in cache-gather, call `aiter.pa_fwd_asm` for decodes; keep NHD + `paged_attention_v1` as fallback; disallow sliding window with shuffle
> - Enables dequantization when `kv_cache_dtype` is fp8
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fa5c519e813e7e42d075da135ff86c47b776246. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
