### PR TITLE
[Bugfix] respect user-defined flash attention version in ViT attentions

### DIFF
--- a/vllm/attention/ops/vit_attn_wrappers.py
+++ b/vllm/attention/ops/vit_attn_wrappers.py
@@ -37,7 +37,9 @@ def flash_attn_maxseqlen_wrapper(
             get_flash_attn_version,
         )
 
-        kwargs["fa_version"] = get_flash_attn_version()
+        # check if we can use vllm's FA3
+        if get_flash_attn_version() == 3:
+            kwargs["fa_version"] = 3
     q, k, v = (einops.rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
     output = flash_attn_varlen_func(
         q,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

After xformers MHA is removed, we are using flash-attn as the default attention backend for the vision encoders. But in the ViT attention wrapper, we do not pass the `fa_version` argument, hence we always use FA2 regardless of the HW support.

This behavior change makes some confusion among many vllm users (c.f. the issues I mentioned below) on H100 worker nodes as the nightly vllm wheel does not build FA2 with SM90, and not that intuitive in terms of the presence of environment variable `VLLM_FLASH_ATTN_VERSION` which gives users the control over which FA backend for the decoder attention counterpart.

Hence I suggest to respect the user-defined FA version through pre-existing helper function `get_flash_attn_version`, which I think follows the same pattern as what is currently written in the decoder ops.

Complementary to ##28305, fix #27103, #25143, #17392, #28903 in better way.

## Test Plan

Run `Qwen/Qwen3-VL-32B-Instruct` successfully with the default FA backend on H100.

```bash
vllm serve Qwen/Qwen3-VL-32B-Instruct \
  --gpu-memory-utilization 0.9 \
  --tensor-parallel-size 4 \
  --mm-encoder-tp-mode data \
  --async-scheduling \
  --max-model-len 256K \
  --limit-mm-per-prompt '{"image":10,"video":0}'
```

```python
messages = [
    {"role": "user", "content": [{"type": "text", "text": "Explain the image."}, {"type": "image_url", "image_url": {"url": image_url}}]}],
]
for t in client.chat.completions.create(model="Qwen/Qwen3-VL-32B-Instruct", messages=messages, stream=True):
    print(t.choices[0].delta.content or "", end="", flush=True)
```

## Test Result

```
The image shows four translucent, colorful dice in mid-air against a plain white background. ...
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>

