### PR TITLE
support skip tokenizer chat_template

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -51,6 +51,9 @@ from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalDataDict, MultiModalU
 from vllm.multimodal.utils import MEDIA_CONNECTOR_REGISTRY, MediaConnector
 from vllm.tokenizers import MistralTokenizer, TokenizerLike
 from vllm.transformers_utils.chat_templates import get_chat_template_fallback_path
+from vllm.transformers_utils.chat_templates.registry import (
+    _SKIP_TOKENIZER_CHAT_TEMPLATE,
+)
 from vllm.transformers_utils.processor import cached_get_processor
 from vllm.utils import random_uuid
 from vllm.utils.func_utils import supports_kw
@@ -504,10 +507,6 @@ def resolve_hf_chat_template(
             return chat_template
 
     # 3rd priority: AutoTokenizer chat template
-    from vllm.transformers_utils.chat_templates.registry import (
-        _SKIP_TOKENIZER_CHAT_TEMPLATE,
-    )
-
     if model_config.hf_config.model_type not in _SKIP_TOKENIZER_CHAT_TEMPLATE:
         try:
             return tokenizer.get_chat_template(chat_template, tools=tools)

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -504,14 +504,19 @@ def resolve_hf_chat_template(
             return chat_template
 
     # 3rd priority: AutoTokenizer chat template
-    try:
-        return tokenizer.get_chat_template(chat_template, tools=tools)
-    except Exception:
-        logger.debug(
-            "Failed to load AutoTokenizer chat template for %s",
-            tokenizer.name_or_path,
-            exc_info=True,
-        )
+    from vllm.transformers_utils.chat_templates.registry import (
+        _SKIP_TOKENIZER_CHAT_TEMPLATE,
+    )
+
+    if model_config.hf_config.model_type not in _SKIP_TOKENIZER_CHAT_TEMPLATE:
+        try:
+            return tokenizer.get_chat_template(chat_template, tools=tools)
+        except Exception:
+            logger.debug(
+                "Failed to load AutoTokenizer chat template for %s",
+                tokenizer.name_or_path,
+                exc_info=True,
+            )
 
     # 4th priority: Predefined fallbacks
     path = get_chat_template_fallback_path(

--- a/vllm/transformers_utils/chat_templates/registry.py
+++ b/vllm/transformers_utils/chat_templates/registry.py
@@ -43,6 +43,9 @@ _MODEL_TYPE_TO_CHAT_TEMPLATE_FALLBACK: dict[str, ChatTemplatePath] = {
     "siglip2": CHAT_TEMPLATES_DIR / "template_basic.jinja",
 }
 
+# These model types skip tokenizer chat template and use fallback directly
+_SKIP_TOKENIZER_CHAT_TEMPLATE: set[str] = {"siglip", "siglip2"}
+
 
 def register_chat_template_fallback_path(
     model_type: str,


### PR DESCRIPTION
## Purpose
This PR adds support for skipping tokenizer chat templates for SigLIP and SigLIP2 models. These models' tokenizer-provided chat templates may have issues, so we skip them and use vLLM's predefined fallback templates instead. 

The changes include:
- Added a new set `_SKIP_TOKENIZER_CHAT_TEMPLATE` containing "siglip" and "siglip2" model types
- Modified `resolve_hf_chat_template()` in `chat_utils.py` to check if the model type should skip tokenizer chat templates
- When skipping, the function directly falls back to predefined templates instead of attempting to load from tokenizer

Fix https://github.com/vllm-project/vllm/pull/27566#issuecomment-3475309680

## Test Plan

`vllm serve google/siglip2-base-patch16-224 --runner pooling --enforce-eager`
`python examples/online_serving/pooling/openai_chat_embedding_client_for_multimodal.py --model siglip`
## Test Result

Correct output, not occur error.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>