### PR TITLE
[Core] Fix standalone runs of test_reset_prefix_cache_e2e

### DIFF
--- a/tests/v1/core/test_reset_prefix_cache_e2e.py
+++ b/tests/v1/core/test_reset_prefix_cache_e2e.py
@@ -11,7 +11,9 @@ PROMPTS = [
 ]
 
 
-def test_reset_prefix_cache_e2e():
+def test_reset_prefix_cache_e2e(monkeypatch):
+    # "spawn" is required for test to be deterministic
+    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
     engine_args = EngineArgs(
         model="Qwen/Qwen3-0.6B",
         gpu_memory_utilization=0.2,


### PR DESCRIPTION
This test was added by #28827 and in CI it passes with:

```
[2025-12-02T03:08:44Z] v1/core/test_reset_prefix_cache_e2e.py::test_reset_prefix_cache_e2e INFO 12-01 19:08:44 [model.py:637] Resolved architecture: Qwen3ForCausalLM
...
[2025-12-02T03:08:45Z] WARNING 12-01 19:08:45 [system_utils.py:136] [..] Overriding VLLM_WORKER_MULTIPROC_METHOD to 'spawn'. [..] Reasons: CUDA is initialized
```

This doesn't happen if you run locally, standalone, and the test fails with:

```
E           AssertionError: ground_truth_results['ground_truth_0'].outputs[0].text= -  but it could cause serious harm.  -  It is a human preempted_results['preempted_0'].outputs[0].text= -  but it could cause serious harm.  -  This is the case
E           assert ' -  but it c...It is a human' == ' -  but it c...s is the case'
E
E             -  -  but it could cause serious harm.  -  This is the case
E             ?                                          ^^   ^^^^ ^^^ ^^
E             +  -  but it could cause serious harm.  -  It is a human
E             ?                                          ^^^   ^^ ^^ ^

tests/v1/core/test_reset_prefix_cache_e2e.py:60: AssertionError
```

Forcing "spawn" fixes it.