### PR TITLE
Mark DBO test as flaky on b200 for Distributed B200 test

### DIFF
--- a/tests/v1/distributed/test_dbo.py
+++ b/tests/v1/distributed/test_dbo.py
@@ -9,9 +9,21 @@ correctly with the DeepSeek-V2-Lite model using GSM8K evaluation.
 """
 
 import pytest
+import torch
 
 from tests.evals.gsm8k.gsm8k_eval import evaluate_gsm8k
 from tests.utils import RemoteOpenAIServer
+
+# Detect Blackwell / B200 (compute capability 10.x)
+try:
+    if torch.cuda.is_available():
+        cap = torch.cuda.get_device_capability(0)
+        IS_BLACKWELL = cap[0] >= 10
+    else:
+        IS_BLACKWELL = False
+except Exception:
+    # Be conservative: if we can't detect, don't xfail by default
+    IS_BLACKWELL = False
 
 MODEL_NAME = "deepseek-ai/DeepSeek-V2-Lite-Chat"
 DP_SIZE = 2
@@ -33,6 +45,13 @@ DEEPEP_BACKENDS = [
 
 
 @pytest.mark.parametrize("all2all_backend", DEEPEP_BACKENDS)
+@pytest.mark.xfail(
+    IS_BLACKWELL,
+    reason=(
+        "Temporary: DBO accuracy unstable on Blackwell "
+        "(doesn't meet expectation of MIN_ACCURACY = 0.62)"
+    ),
+)
 def test_dbo_dp_ep_gsm8k(all2all_backend: str, num_gpus_available):
     """
     Test DBO with DP+EP using GSM8K evaluation.


### PR DESCRIPTION
## Purpose

Mark DBO test that is failing the expected accuracy as flaky until an SME can diagnose the issue at hand.

See also: https://buildkite.com/vllm/ci/builds/41525#019ade7c-198d-42ee-b5ba-4f7636f08e32/72-1786 -- which is introduced after #29822 fixes the nccl header issues.

## Test Plan

Plain CI run, especially passing on the Distributed B200 tests

## Test Result

Confirmed `Distributed Tests (B200)` "passes" -- test shows as green and pytest is properly marked xfail with appropriate outpu. See associated test: https://buildkite.com/vllm/ci/builds/41643#019ae11c-e39e-4aa7-8fd4-6c9830e38a34

e.g.

```
XFAIL (Temporary: DBO accuracy unstable on Blackwell (doesn't meet ex...)
```

---
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results

