### PR TITLE
[Docs] Discuss api key limitations in security guide

### DIFF
--- a/vllm/entrypoints/cli/openai.py
+++ b/vllm/entrypoints/cli/openai.py
@@ -109,6 +109,10 @@ def _add_query_options(parser: FlexibleArgumentParser) -> FlexibleArgumentParser
         help=(
             "API key for OpenAI services. If provided, this api key "
             "will overwrite the api key obtained through environment variables."
+            " It is important to note that this option only applies to the "
+            "OpenAI-compatible API endpoints and NOT other endpoints that may "
+            "be present in the server. See the security guide in the vLLM docs "
+            "for more details."
         ),
     )
     return parser


### PR DESCRIPTION
The use of `--api-key` only applies to the OpenAI-comaptible API
endpoints under `v1/`. It does not apply to other endpoints exposed
via the same HTTP server in vLLM. This doc update discusses why it is
important not to rely on `--api-key` exclusively for securing access
to vLLM.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
