### PR TITLE
[ROCm][CI] Fix v1/logits_processors failure on ROCm

### DIFF
--- a/tests/v1/logits_processors/test_custom_offline.py
+++ b/tests/v1/logits_processors/test_custom_offline.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import random
-import sys
 from typing import Any
 
 import pytest
@@ -10,7 +9,6 @@ from tests.utils import create_new_process_for_each_test
 from tests.v1.logits_processors.utils import (
     DUMMY_LOGITPROC_ARG,
     DUMMY_LOGITPROC_FQCN,
-    DUMMY_LOGITPROC_MODULE,
     MAX_TOKENS,
     MODEL_NAME,
     POOLING_MODEL_NAME,
@@ -18,7 +16,6 @@ from tests.v1.logits_processors.utils import (
     CustomLogitprocSource,
     DummyLogitsProcessor,
     WrappedPerReqLogitsProcessor,
-    dummy_module,
     prompts,
 )
 from tests.v1.logits_processors.utils import entry_points as fake_entry_points
@@ -162,8 +159,6 @@ def test_custom_logitsprocs(monkeypatch, logitproc_source: CustomLogitprocSource
     kwargs: dict[str, list[str | type[LogitsProcessor]]] = {}
     if logitproc_source == CustomLogitprocSource.LOGITPROC_SOURCE_FQCN:
         # Scenario: load logitproc based on fully-qualified class name (FQCN)
-        # Inject dummy module which defines logitproc
-        sys.modules[DUMMY_LOGITPROC_MODULE] = dummy_module
         kwargs["logits_processors"] = [DUMMY_LOGITPROC_FQCN]
     elif logitproc_source == CustomLogitprocSource.LOGITPROC_SOURCE_CLASS:
         # Scenario: load logitproc from provided class object

--- a/tests/v1/logits_processors/utils.py
+++ b/tests/v1/logits_processors/utils.py
@@ -27,7 +27,7 @@ DUMMY_LOGITPROC_ARG = "target_token"
 TEMP_GREEDY = 0.0
 MAX_TOKENS = 20
 DUMMY_LOGITPROC_ENTRYPOINT = "dummy_logitproc"
-DUMMY_LOGITPROC_MODULE = "DummyModule"
+DUMMY_LOGITPROC_MODULE = "tests.v1.logits_processors.utils"
 DUMMY_LOGITPROC_FQCN = f"{DUMMY_LOGITPROC_MODULE}:DummyLogitsProcessor"
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
Without this PR, we are seeing failures on ROCm in `pytest -v -s v1/logits_processors` (part of the "V1 Test others" test group) with the following error:

```
pytest -v -s v1/logits_processors

(EngineCore_DP0 pid=632406)   File "/projects/vllm/vllm/v1/sample/logits_processor/__init__.py", line 141, in _load_logitsprocs_by_fqcns
(EngineCore_DP0 pid=632406)     raise RuntimeError(
(EngineCore_DP0 pid=632406) RuntimeError: Failed to load 0th LogitsProcessor plugin DummyModule:DummyLogitsProcessor

...

========================================================================================================================= short test summary info =========================================================================================================================
ERROR v1/logits_processors/test_custom_online.py::test_custom_logitsprocs[server1-facebook/opt-125m] - RuntimeError: Server exited unexpectedly.
ERROR v1/logits_processors/test_custom_online.py::test_invalid_custom_logitsproc_arg[server1-facebook/opt-125m] - RuntimeError: Server exited unexpectedly.
========================================================================================================== 23 passed, 6 warnings, 2 errors in 209.37s (0:03:29) ==========================================================================================================
```
The problem is ultimately caused by using this sys modules patch `sys.modules[DUMMY_LOGITPROC_MODULE] = dummy_module` in a spawned subprocess as opposed to forked. With spawn, child processes apparently don't inherit `sys.modules` patches. ROCm forces spawned multiprocessing because without it you get errors like `RuntimeError: Cannot re-initialize CUDA in forked subprocess`. That issue doesn't occur on CUDA which is why the above error is not observed on NVIDIA machines (the test uses forked multiprocessing on NVIDIA machines). I've observed that most vllm imports trigger CUDA initialization on ROCm systems, but not on NVIDIA. which is ultimately why that error mentions re-initializing CUDA in a forked subprocess. 

My solution is to use an importable module so that we don't have to rely on sys.modules patching at all. I hope this upholds the integrity of the test and correctly tests the "fully-qualified class name (FQCN)" functionality.

With this PR, I am seeing the following when running `pytest -v -s v1/logits_processors`:

```
============================================================================================================================ warnings summary =============================================================================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../vllm/entrypoints/openai/parser/responses_parser.py:16
  /projects/vllm/vllm/entrypoints/openai/parser/responses_parser.py:16: DeprecationWarning: `vllm.transformers_utils.tokenizer.AnyTokenizer` has been moved to `vllm.tokenizers.TokenizerLike`. The old name will be removed in v0.13.
    from vllm.transformers_utils.tokenizer import AnyTokenizer

../vllm/entrypoints/context.py:33
  /projects/vllm/vllm/entrypoints/context.py:33: DeprecationWarning: `vllm.transformers_utils.tokenizer.AnyTokenizer` has been moved to `vllm.tokenizers.TokenizerLike`. The old name will be removed in v0.13.
    from vllm.transformers_utils.tokenizer import AnyTokenizer

../../../usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305
  /usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    ref_error: type[Exception] = jsonschema.RefResolutionError,

tests/v1/logits_processors/test_custom_online.py::test_custom_logitsprocs[server0-facebook/opt-125m]
  tests/v1/logits_processors/test_custom_online.py:122: PytestWarning: The test <Function test_custom_logitsprocs[server0-facebook/opt-125m]> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove the asyncio mark. If the test is not marked explicitly, check for global marks applied via 'pytestmark'.
    @create_new_process_for_each_test()

tests/v1/logits_processors/test_custom_online.py::test_custom_logitsprocs[server1-facebook/opt-125m]
  tests/v1/logits_processors/test_custom_online.py:122: PytestWarning: The test <Function test_custom_logitsprocs[server1-facebook/opt-125m]> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove the asyncio mark. If the test is not marked explicitly, check for global marks applied via 'pytestmark'.
    @create_new_process_for_each_test()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================================== 25 passed, 7 warnings in 226.82s (0:03:46) ================================================================================================================
```