### PR TITLE
[Misc] Allow `fetch_*` utils to access local files by default

### DIFF
--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -490,6 +490,10 @@ def fetch_audio(
     Args:
         audio_url: URL of the audio file to fetch.
         audio_io_kwargs: Additional kwargs passed to handle audio IO.
+
+    Warning:
+        This method has direct access to local files and is only intended
+        to be called by user code. Never call this from the online server!
     """
     media_io_kwargs = None if not audio_io_kwargs else {"audio": audio_io_kwargs}
     media_connector = MediaConnector(
@@ -507,6 +511,10 @@ def fetch_image(
     Args:
         image_url: URL of the image file to fetch.
         image_io_kwargs: Additional kwargs passed to handle image IO.
+
+    Warning:
+        This method has direct access to local files and is only intended
+        to be called by user code. Never call this from the online server!
     """
     media_io_kwargs = None if not image_io_kwargs else {"image": image_io_kwargs}
     media_connector = MediaConnector(
@@ -524,6 +532,10 @@ def fetch_video(
     Args:
         video_url: URL of the video file to fetch.
         video_io_kwargs: Additional kwargs passed to handle video IO.
+
+    Warning:
+        This method has direct access to local files and is only intended
+        to be called by user code. Never call this from the online server!
     """
     media_io_kwargs = None if not video_io_kwargs else {"video": video_io_kwargs}
     media_connector = MediaConnector(

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -267,7 +267,7 @@ class OpenCVDynamicVideoBackend(OpenCVVideoBackend):
         return frames, metadata
 
 
-class VideoMediaIO(MediaIO[npt.NDArray]):
+class VideoMediaIO(MediaIO[tuple[npt.NDArray, dict[str, Any]]]):
     def __init__(
         self,
         image_io: ImageMediaIO,


### PR DESCRIPTION

## Purpose

- Since `vllm.multimodal.utils.fetch_*` is only supposed to be called directly by user code, allow those functions to access local files by default as it doesn't constitute a security vulnerability. This lets us simplify the code in https://github.com/vllm-project/vllm-omni/pull/131 and https://github.com/vllm-project/vllm-omni/pull/167 later on.
- Fix relative file paths not working.
- Fix some type checking errors along the way.

## Test Plan

```python
from vllm.multimodal.utils import fetch_image

# Implicit relative path
_ = fetch_image("file://docs/assets/contributing/dockerfile-stages-dependency.png")

# Explicit relative path
_ = fetch_image("file://./docs/assets/contributing/dockerfile-stages-dependency.png")

# Absolute path
_ = fetch_image("file:///path/to/vllm/docs/assets/contributing/dockerfile-stages-dependency.png")
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

