### PR TITLE
[BugFix] Fix DBO assert `assert B_block_table == B_q`

### DIFF
--- a/tests/v1/attention/test_attention_splitting.py
+++ b/tests/v1/attention/test_attention_splitting.py
@@ -13,7 +13,7 @@ from vllm.v1.attention.backends.utils import (
     split_attn_metadata,
     split_decodes_and_prefills,
 )
-from vllm.v1.worker.ubatch_utils import create_ubatch_slices
+from vllm.v1.worker.ubatch_utils import maybe_create_ubatch_slices
 
 
 @pytest.fixture
@@ -294,7 +294,9 @@ def test_prefill_split_across_ubatches(
     qsl_np = common.query_start_loc_cpu.numpy()
     num_tokens = common.num_actual_tokens
 
-    ubatch_slices = create_ubatch_slices(num_scheduled_tokens, split_point)
+    ubatch_slices = maybe_create_ubatch_slices(
+        True, num_scheduled_tokens, num_tokens, batch_spec.batch_size
+    )
     assert len(ubatch_slices) == 2
 
     first_meta = _make_metadata_with_slice(ubatch_slices[0], common)

--- a/tests/v1/attention/test_attention_splitting.py
+++ b/tests/v1/attention/test_attention_splitting.py
@@ -294,10 +294,14 @@ def test_prefill_split_across_ubatches(
     qsl_np = common.query_start_loc_cpu.numpy()
     num_tokens = common.num_actual_tokens
 
-    ubatch_slices = maybe_create_ubatch_slices(
-        True, num_scheduled_tokens, num_tokens, batch_spec.batch_size
+    ubatch_slices, _ = maybe_create_ubatch_slices(
+        True,
+        num_scheduled_tokens,
+        num_tokens,
+        batch_spec.batch_size,
+        split_point=split_point,
     )
-    assert len(ubatch_slices) == 2
+    assert ubatch_slices is not None and len(ubatch_slices) == 2
 
     first_meta = _make_metadata_with_slice(ubatch_slices[0], common)
     second_meta = _make_metadata_with_slice(ubatch_slices[1], common)

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1258,7 +1258,7 @@ class EagleProposer:
         num_tokens_padded: int,
     ) -> tuple[int, torch.Tensor]:
         # TODO(Flechman): support DBO ubatching
-        ubatch_slices, num_toks_across_dp = coordinate_batch_across_dp(
+        should_ubatch, num_toks_across_dp = coordinate_batch_across_dp(
             num_tokens_unpadded=num_tokens_unpadded,
             parallel_config=self.vllm_config.parallel_config,
             allow_microbatching=False,
@@ -1267,7 +1267,7 @@ class EagleProposer:
             uniform_decode=None,
             num_scheduled_tokens_per_request=None,
         )
-        assert ubatch_slices is None, "DBO ubatching not implemented for EAGLE"
+        assert not should_ubatch, "DBO ubatching not implemented for EAGLE"
 
         num_tokens_dp_padded = num_tokens_padded
         if num_toks_across_dp is not None:

--- a/vllm/v1/worker/dp_utils.py
+++ b/vllm/v1/worker/dp_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+
 import numpy as np
 import torch
 import torch.distributed as dist
@@ -9,10 +10,7 @@ from vllm.config import ParallelConfig
 from vllm.distributed.parallel_state import get_dp_group
 from vllm.logger import init_logger
 from vllm.v1.worker.ubatch_utils import (
-    UBatchSlice,
-    UBatchSlices,
     check_ubatch_thresholds,
-    create_ubatch_slices,
     is_second_ubatch_empty,
 )
 
@@ -91,20 +89,6 @@ def _post_process_dp_padding(tensor: torch.Tensor, should_dp_pad: bool) -> torch
         return num_tokens_across_dp.cpu()
 
 
-# This just pads the second ubatch slice out to the total number of tokens
-# (num_tokens + padding) since we do `create_ubatch_slices` before applying DP padding.
-def _pad_out_ubatch_slice(
-    ubatch_slices: UBatchSlices, num_total_tokens: int
-) -> UBatchSlices:
-    padded_second_token_slice = slice(
-        ubatch_slices[1].token_slice.start, num_total_tokens
-    )
-    ubatch_slices[1] = UBatchSlice(
-        ubatch_slices[1].request_slice, padded_second_token_slice
-    )
-    return ubatch_slices
-
-
 def _synchronize_dp_ranks(
     num_tokens_unpadded: int,
     num_tokens_padded: int,
@@ -175,7 +159,7 @@ def coordinate_batch_across_dp(
     num_tokens_padded: int | None = None,
     uniform_decode: bool | None = None,
     num_scheduled_tokens_per_request: np.ndarray | None = None,
-) -> tuple[UBatchSlices | None, torch.Tensor | None]:
+) -> tuple[bool, torch.Tensor | None]:
     """
     Coordinates amongst all DP ranks to determine if and how the full batch
     should be split into microbatches.
@@ -204,7 +188,7 @@ def coordinate_batch_across_dp(
     """
     if parallel_config.data_parallel_size == 1:
         # Early exit.
-        return None, None
+        return False, None
 
     # If the caller has explicitly enabled microbatching.
     should_attempt_ubatching = False
@@ -228,23 +212,4 @@ def coordinate_batch_across_dp(
         parallel_config,
     )
 
-    # Don't microbatch unless every other DP worker is also microbatching
-    if not should_ubatch:
-        return (None, num_tokens_after_padding)
-
-    # This doesn't actually pad the ubatch slices. It just initializes the
-    # split point to the padded value so that padding can be applied
-    # to the second ubatch in pad_out_ubatch_slice after attention
-    # metadata creation
-    assert num_tokens_after_padding is not None
-    num_tokens_padded = int(num_tokens_after_padding[0].item())
-    token_split_point = int(num_tokens_padded) // 2
-
-    assert num_scheduled_tokens_per_request is not None
-    ubatch_slices = create_ubatch_slices(
-        num_scheduled_tokens_per_request, token_split_point
-    )
-    ubatch_slices = _pad_out_ubatch_slice(ubatch_slices, num_tokens_padded)
-    assert sum(s.num_tokens for s in ubatch_slices) == num_tokens_padded
-
-    return (ubatch_slices, num_tokens_after_padding)
+    return (should_ubatch, num_tokens_after_padding)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2806,7 +2806,7 @@ class GPUModelRunner(
             )
 
             should_ubatch, num_tokens_across_dp = coordinate_batch_across_dp(
-                num_tokens_unpadded=num_tokens_padded,
+                num_tokens_unpadded=num_tokens,
                 parallel_config=self.parallel_config,
                 allow_microbatching=allow_microbatching,
                 allow_dp_padding=allow_dp_padding,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -153,7 +153,7 @@ from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
 from vllm.v1.worker.ubatch_utils import (
     UBatchSlices,
     check_ubatch_thresholds,
-    create_ubatch_slices,
+    maybe_create_ubatch_slices,
 )
 from vllm.v1.worker.utils import is_residual_scattered_for_sp
 
@@ -2962,7 +2962,7 @@ class GPUModelRunner(
                 num_reqs_padded = (
                     batch_desc.num_reqs if batch_desc.num_reqs is not None else num_reqs
                 )
-                ubatch_slices, ubatch_slices_padded = create_ubatch_slices(
+                ubatch_slices, ubatch_slices_padded = maybe_create_ubatch_slices(
                     should_ubatch,
                     num_scheduled_tokens_np,
                     num_tokens_padded,
@@ -4004,7 +4004,7 @@ class GPUModelRunner(
         num_reqs_padded = (
             batch_desc.num_reqs if batch_desc.num_reqs is not None else num_reqs
         )
-        ubatch_slices, ubatch_slices_padded = create_ubatch_slices(
+        ubatch_slices, ubatch_slices_padded = maybe_create_ubatch_slices(
             should_ubatch, num_scheduled_tokens, num_tokens_padded, num_reqs_padded
         )
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2962,13 +2962,12 @@ class GPUModelRunner(
                 num_reqs_padded = (
                     batch_desc.num_reqs if batch_desc.num_reqs is not None else num_reqs
                 )
-
-                ubatch_slices, ubatch_slices_padded = None, None
-                if should_ubatch:
-                    ubatch_slices, ubatch_slices_padded = create_ubatch_slices(
-                        num_scheduled_tokens, num_tokens_padded, num_reqs_padded
-                    )
-
+                ubatch_slices, ubatch_slices_padded = create_ubatch_slices(
+                    should_ubatch,
+                    num_scheduled_tokens_np,
+                    num_tokens_padded,
+                    num_reqs_padded,
+                )
                 pad_attn = cudagraph_mode == CUDAGraphMode.FULL
 
                 use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
@@ -4005,12 +4004,9 @@ class GPUModelRunner(
         num_reqs_padded = (
             batch_desc.num_reqs if batch_desc.num_reqs is not None else num_reqs
         )
-
-        ubatch_slices, ubatch_slices_padded = None, None
-        if should_ubatch:
-            ubatch_slices, ubatch_slices_padded = create_ubatch_slices(
-                num_scheduled_tokens, num_tokens_padded, num_reqs_padded
-            )
+        ubatch_slices, ubatch_slices_padded = create_ubatch_slices(
+            should_ubatch, num_scheduled_tokens, num_tokens_padded, num_reqs_padded
+        )
 
         attn_metadata: PerLayerAttnMetadata | None = None
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2843,7 +2843,6 @@ class GPUModelRunner(
             cudagraph_stats,
         )
 
-
     @torch.inference_mode()
     def execute_model(
         self,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2968,6 +2968,7 @@ class GPUModelRunner(
                     num_tokens_padded,
                     num_reqs_padded,
                 )
+
                 pad_attn = cudagraph_mode == CUDAGraphMode.FULL
 
                 use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -65,11 +65,13 @@ def maybe_create_ubatch_slices(
     num_scheduled_tokens: np.ndarray,
     num_tokens_padded: int,
     num_reqs_padded: int,
+    split_point: int | None = None,
 ) -> tuple[UBatchSlices | None, UBatchSlices | None]:
     if not should_ubatch:
         return None, None
 
-    split_point = int(num_tokens_padded) // 2
+    if split_point is None:
+        split_point = int(num_tokens_padded) // 2
 
     # TODO(lucas): Refactor the gpu_model_runner.py so we can pass
     # in cu_num_tokens directly (i.e. query_start_loc)

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -20,10 +20,6 @@ class UBatchSlice:
         )
 
     @property
-    def num_reqs(self) -> int:
-        return self.request_slice.stop - self.request_slice.start
-
-    @property
     def num_tokens(self) -> int:
         return self.token_slice.stop - self.token_slice.start
 
@@ -65,8 +61,14 @@ def _pad_out_ubatch_slices(
 
 
 def create_ubatch_slices(
-    num_scheduled_tokens: np.ndarray, num_tokens_padded: int, num_reqs_padded: int
-) -> tuple[UBatchSlices, UBatchSlices]:
+    should_ubatch: bool,
+    num_scheduled_tokens: np.ndarray,
+    num_tokens_padded: int,
+    num_reqs_padded: int,
+) -> tuple[UBatchSlices | None, UBatchSlices | None]:
+    if not should_ubatch:
+        return None, None
+
     split_point = int(num_tokens_padded) // 2
 
     # TODO(lucas): Refactor the gpu_model_runner.py so we can pass
@@ -101,6 +103,5 @@ def create_ubatch_slices(
     )
 
     assert sum(s.num_tokens for s in ubatch_slices_padded) == num_tokens_padded
-    assert sum(s.num_reqs for s in ubatch_slices_padded) == num_reqs_padded
 
     return ubatch_slices, ubatch_slices_padded

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -20,6 +20,10 @@ class UBatchSlice:
         )
 
     @property
+    def num_reqs(self) -> int:
+        return self.request_slice.stop - self.request_slice.start
+
+    @property
     def num_tokens(self) -> int:
         return self.token_slice.stop - self.token_slice.start
 
@@ -42,9 +46,29 @@ def check_ubatch_thresholds(
         return num_tokens >= config.dbo_prefill_token_threshold
 
 
-def create_ubatch_slices(
-    num_scheduled_tokens: np.ndarray, split_point: int
+# This just pads the second ubatch slice out to the total number of tokens
+# (num_tokens + padding) since we do `create_ubatch_slices` before applying DP padding.
+def _pad_out_ubatch_slices(
+    ubatch_slices: UBatchSlices, num_total_tokens: int, num_reqs_padded: int
 ) -> UBatchSlices:
+    # TODO(lucas): handle empty second ubatch
+    padded_second_request_slice = slice(
+        ubatch_slices[1].request_slice.start, num_reqs_padded
+    )
+    padded_second_token_slice = slice(
+        ubatch_slices[1].token_slice.start, num_total_tokens
+    )
+    ubatch_slices[1] = UBatchSlice(
+        padded_second_request_slice, padded_second_token_slice
+    )
+    return ubatch_slices
+
+
+def create_ubatch_slices(
+    num_scheduled_tokens: np.ndarray, num_tokens_padded: int, num_reqs_padded: int
+) -> tuple[UBatchSlices, UBatchSlices]:
+    split_point = int(num_tokens_padded) // 2
+
     # TODO(lucas): Refactor the gpu_model_runner.py so we can pass
     # in cu_num_tokens directly (i.e. query_start_loc)
     cu_num_tokens = np.zeros(len(num_scheduled_tokens) + 1, dtype=np.int32)
@@ -67,7 +91,16 @@ def create_ubatch_slices(
     )
     second_ubatch_req_slice = slice(second_ubatch_req_start, len(cu_num_tokens) - 1)
 
-    return [
+    ubatch_slices = [
         UBatchSlice(first_ubatch_req_slice, first_ubatch_token_slice),
         UBatchSlice(second_ubatch_req_slice, second_ubatch_token_slice),
     ]
+
+    ubatch_slices_padded = _pad_out_ubatch_slices(
+        ubatch_slices, num_tokens_padded, num_reqs_padded
+    )
+
+    assert sum(s.num_tokens for s in ubatch_slices_padded) == num_tokens_padded
+    assert sum(s.num_reqs for s in ubatch_slices_padded) == num_reqs_padded
+
+    return (ubatch_slices, ubatch_slices_padded)

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -54,10 +54,10 @@ def _pad_out_ubatch_slices(
     padded_second_token_slice = slice(
         ubatch_slices[1].token_slice.start, num_total_tokens
     )
-    ubatch_slices[1] = UBatchSlice(
-        padded_second_request_slice, padded_second_token_slice
-    )
-    return ubatch_slices
+    return [
+        ubatch_slices[0],
+        UBatchSlice(padded_second_request_slice, padded_second_token_slice),
+    ]
 
 
 def maybe_create_ubatch_slices(

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -103,4 +103,4 @@ def create_ubatch_slices(
     assert sum(s.num_tokens for s in ubatch_slices_padded) == num_tokens_padded
     assert sum(s.num_reqs for s in ubatch_slices_padded) == num_reqs_padded
 
-    return (ubatch_slices, ubatch_slices_padded)
+    return ubatch_slices, ubatch_slices_padded

--- a/vllm/v1/worker/ubatch_utils.py
+++ b/vllm/v1/worker/ubatch_utils.py
@@ -60,7 +60,7 @@ def _pad_out_ubatch_slices(
     return ubatch_slices
 
 
-def create_ubatch_slices(
+def maybe_create_ubatch_slices(
     should_ubatch: bool,
     num_scheduled_tokens: np.ndarray,
     num_tokens_padded: int,


### PR DESCRIPTION
Since https://github.com/vllm-project/vllm/pull/28579 we could end up building with padded ubatch slices for PIECEWISE/NONE cudagraphs, since CUTLASS MLA assumes num_decodes_reqs == num_decode_tokens this could cause issues since only the tokens were padded; this fixes it by making sure we only use padded ubatch slices for metadata construction when using FULL cudagraphs

Failing CI: https://buildkite.com/organizations/vllm/pipelines/ci/builds/41668/jobs/019ae1ba-2178-4a96-adba-97fb4a46fe4f/log

Test Plan:

`python -m pytest tests/v1/distributed/test_dbo.py ` was failing on B200 machines (was passing on H100s due to the backends not asserting on this)

Passes now 

