### PR TITLE
[Bugfix][Quantization] Support BF16 tensors on GGUF

### DIFF
--- a/tests/models/quantization/test_gguf.py
+++ b/tests/models/quantization/test_gguf.py
@@ -47,6 +47,12 @@ QWEN2_CONFIG = GGUFTestConfig(
     gguf_filename="qwen2.5-1.5b-instruct-q6_k.gguf",
 )
 
+QWEN3_CONFIG = GGUFTestConfig(
+    original_model="Qwen/Qwen3-0.6B",
+    gguf_repo="unsloth/Qwen3-0.6B-GGUF",
+    gguf_filename="Qwen3-0.6B-BF16.gguf",
+)
+
 PHI3_CONFIG = GGUFTestConfig(
     original_model="microsoft/Phi-3.5-mini-instruct",
     gguf_repo="bartowski/Phi-3.5-mini-instruct-GGUF",
@@ -87,6 +93,7 @@ GEMMA3_CONFIG = GGUFTestConfig(
 MODELS = [
     # LLAMA_CONFIG, # broken: https://github.com/vllm-project/vllm/issues/19458
     QWEN2_CONFIG,
+    QWEN3_CONFIG,
     PHI3_CONFIG,
     GPT2_CONFIG,
     STABLELM_CONFIG,


### PR DESCRIPTION
## Purpose

This is on a border between a bug fix and a feature addition.

On GGUF, "BF16" (quantization type 30) is currently the only *quantization* type that isn't actually quantized but is read as a raw byte tensor.

cf. <https://github.com/ggml-org/llama.cpp/blob/381174bbdaf10d6a80dc2099f284b20544d86962/gguf-py/gguf/gguf_reader.py#L332-L366>

This is unlike any other non-quantized types (such like F32), that are read as a tensor of corresponding scalar type (float32 in this case).
This is possibly due to the lack of native BFloat16 support in NumPy.

This special behavior caused tensor size mismatches on the weight loader and caused various errors.

This commit handles BF16 *quantization* + uint8 tensor case and reinterprets such tensors as BFloat16 (`torch.bfloat16`; natively supported by PyTorch). It makes possible to run GGUF models with BF16 tensors (which is particularly useful to test quantization-specific issues on vLLM).

Note: This is a part of my attempt to improve GGUF file support and more specifically, my attempt to restore Qwen3 MoE + GGUF support (my WIP branch currently suffers from gibberish outputs on Qwen3 MoE GGUF models and encountered this bug while testing which part of GGUF handling is broken; that was reproducible on GGUF-compatible models like Llama and dense variants of Qwen3).

## Test Plan

`tests/models/quantization/test_gguf.py` is modified to test this case (using Unsloth's BF16 GGUF *quantization* of Qwen3-0.6B).

You can manually download or generate BF16-quantized GGUF file and try to run.  While I'm testing, I mainly used locally generated BF16 quantization of Qwen3-4B.

```sh
vllm serve --model Qwen3-4B-BF16.gguf
```

## Test Result

The model succeeds to load and run.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

