### PR TITLE
[Bugfix] Fix incorrect `image_grid_thw` rank for HunyuanOCR from missing `merge_by_field_config=True`

### DIFF
--- a/examples/offline_inference/vision_language_multi_image.py
+++ b/examples/offline_inference/vision_language_multi_image.py
@@ -311,7 +311,7 @@ def load_h2ovl(question: str, image_urls: list[str]) -> ModelRequestData:
 
 # HunyuanOCR
 def load_hunyuan_vl(question: str, image_urls: list[str]) -> ModelRequestData:
-    model_name = "/home/mozf/LLM/HunyuanOCR"
+    model_name = "tencent/HunyuanOCR"
 
     engine_args = EngineArgs(
         model=model_name,
@@ -324,16 +324,10 @@ def load_hunyuan_vl(question: str, image_urls: list[str]) -> ModelRequestData:
     ) * len(image_urls)
     prompt = f"<｜hy_begin▁of▁sentence｜>{placeholder}{question}<｜hy_User｜>"
 
-    from vllm.assets.image import ImageAsset
-
     return ModelRequestData(
         engine_args=engine_args,
         prompt=prompt,
-        image_data=[
-            ImageAsset("cherry_blossom").pil_image.resize((256, 256 * i))
-            for i, _ in enumerate(image_urls, start=1)
-        ],
-        # image_data=[fetch_image(url) for url in image_urls],
+        image_data=[fetch_image(url) for url in image_urls],
     )
 
 

--- a/examples/offline_inference/vision_language_multi_image.py
+++ b/examples/offline_inference/vision_language_multi_image.py
@@ -309,6 +309,34 @@ def load_h2ovl(question: str, image_urls: list[str]) -> ModelRequestData:
     )
 
 
+# HunyuanOCR
+def load_hunyuan_vl(question: str, image_urls: list[str]) -> ModelRequestData:
+    model_name = "/home/mozf/LLM/HunyuanOCR"
+
+    engine_args = EngineArgs(
+        model=model_name,
+        max_model_len=8192,
+        limit_mm_per_prompt={"image": len(image_urls)},
+    )
+
+    placeholder = (
+        "<｜hy_place▁holder▁no▁100｜><｜hy_place▁holder▁no▁102｜><｜hy_place▁holder▁no▁101｜>"  # noqa: E501
+    ) * len(image_urls)
+    prompt = f"<｜hy_begin▁of▁sentence｜>{placeholder}{question}<｜hy_User｜>"
+
+    from vllm.assets.image import ImageAsset
+
+    return ModelRequestData(
+        engine_args=engine_args,
+        prompt=prompt,
+        image_data=[
+            ImageAsset("cherry_blossom").pil_image.resize((256, 256 * i))
+            for i, _ in enumerate(image_urls, start=1)
+        ],
+        # image_data=[fetch_image(url) for url in image_urls],
+    )
+
+
 def load_hyperclovax_seed_vision(
     question: str, image_urls: list[str]
 ) -> ModelRequestData:
@@ -1319,6 +1347,7 @@ model_example_map = {
     "deepseek_ocr": load_deepseek_ocr,
     "gemma3": load_gemma3,
     "h2ovl_chat": load_h2ovl,
+    "hunyuan_vl": load_hunyuan_vl,
     "hyperclovax_seed_vision": load_hyperclovax_seed_vision,
     "idefics3": load_idefics3,
     "interns1": load_interns1,

--- a/vllm/model_executor/models/hunyuan_vision.py
+++ b/vllm/model_executor/models/hunyuan_vision.py
@@ -785,6 +785,7 @@ class HunYuanVLForConditionalGeneration(
     SupportsQuant,
     SupportsXDRoPE,
 ):
+    merge_by_field_config = True
     multimodal_cpu_fields = {"image_grid_thw"}
 
     # To ensure correct weight loading and mapping.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Fix #29812
- Add missing `merge_by_field_config=True` for HunyuanOCR-VL to make sure image_grid_thw has correct rank.

## Test Plan
A minor reproducing example via `vision_language_multi_image.py`:
```python3
# HunyuanOCR
def load_hunyuan_vl(question: str, image_urls: list[str]) -> ModelRequestData:
    model_name = "/home/mozf/LLM/HunyuanOCR"

    engine_args = EngineArgs(
        model=model_name,
        max_model_len=8192,
        limit_mm_per_prompt={"image": len(image_urls)},
    )

    placeholder = (
        "<｜hy_place▁holder▁no▁100｜><｜hy_place▁holder▁no▁102｜><｜hy_place▁holder▁no▁101｜>"  # noqa: E501
    ) * len(image_urls)
    prompt = f"<｜hy_begin▁of▁sentence｜>{placeholder}{question}<｜hy_User｜>"

    from vllm.assets.image import ImageAsset

    return ModelRequestData(
        engine_args=engine_args,
        prompt=prompt,
        image_data=[
            ImageAsset("cherry_blossom").pil_image.resize((256, 256 * i))
            for i, _ in enumerate(image_urls, start=1)
        ],
        # image_data=[fetch_image(url) for url in image_urls],
    )
```

## Test Result
The reproducing example can work now with this fix.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

