### PR TITLE
[Perf][Async] Implement zero-bubble async speculative decoding

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -103,6 +103,12 @@ class SpeculativeConfig:
     speculative input batches can contain sequences of different lengths,
     which may only be supported by certain attention backends. This currently
     only affects the EAGLE method of speculation."""
+    async_spec_zero_bubble_mode: bool = False
+    """Enable async speculative decoding zero bubble mode. If set to True,
+    optimistically assumes all pre-step speculated tokens were accepted to skip the
+    cpu sync in _update_states, and correct the inputs based on GPU operations. It
+    allowing current-step CPU preparation to fully overlap with previous-step target
+    model GPU execution, eliminating gpu timeline bubbles."""
 
     # Ngram proposer configuration
     prompt_lookup_max: int | None = Field(default=None, ge=1)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -645,6 +645,26 @@ class VllmConfig:
             else:
                 self.parallel_config.disable_nccl_for_dp_synchronization = False
 
+        if (
+            self.speculative_config is not None
+            and self.speculative_config.async_spec_zero_bubble_mode
+        ):
+            if not self.scheduler_config.async_scheduling:
+                logger.warning_once(
+                    "Disabling async_spec_zero_bubble_mode as async_scheduling is "
+                    "disabled."
+                )
+                self.speculative_config.async_spec_zero_bubble_mode = False
+            elif (
+                self.model_config is not None
+                and not self.model_config.disable_cascade_attn
+            ):
+                logger.warning_once(
+                    "Cascade attention is not compatible with "
+                    "async_spec_zero_bubble_mode now."
+                )
+                self.model_config.disable_cascade_attn = True
+
         from vllm.platforms import current_platform
 
         if (

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -604,11 +604,18 @@ class EagleProposer:
         """
         # Precompute get_token_id for when there is no valid next token
         num_reqs = gpu_input_batch.num_reqs
+        num_computed_tokens_cpu = gpu_input_batch.num_computed_tokens_cpu_tensor[
+            :num_reqs
+        ]
+        query_lens_cpu = (
+            common_attn_metadata.query_start_loc_cpu[1 : num_reqs + 1]
+            - common_attn_metadata.query_start_loc_cpu[:num_reqs]
+        )
+        seq_lens_cpu = num_computed_tokens_cpu + query_lens_cpu
+        seq_lens_list = seq_lens_cpu.tolist()
         self.backup_next_token_ids.np[:num_reqs] = np.array(
             [
-                requests[gpu_input_batch.req_ids[i]].get_token_id(
-                    common_attn_metadata.seq_lens_cpu[i].item()
-                )
+                requests[gpu_input_batch.req_ids[i]].get_token_id(seq_lens_list[i])
                 for i in range(num_reqs)
             ],
             dtype=np.int32,
@@ -693,7 +700,7 @@ class EagleProposer:
             num_reqs=common_attn_metadata.num_reqs,
             num_actual_tokens=total_num_tokens,
             max_query_len=new_query_len_per_req.max().item(),
-            max_seq_len=common_attn_metadata.seq_lens_cpu.max().item(),
+            max_seq_len=common_attn_metadata.max_seq_len,
             block_table_tensor=common_attn_metadata.block_table_tensor,
             slot_mapping=common_attn_metadata.slot_mapping[:total_num_tokens],
             causal=True,


### PR DESCRIPTION
## Related Issue

<img width="1057" height="437" alt="image" src="https://github.com/user-attachments/assets/d6c8e199-8288-4e00-854b-a598cb113798" />


#28947 mention: Improved overlapping beyond drafting time (todo, discussion https://github.com/vllm-project/vllm/pull/24799#issuecomment-3528663588)

## Problem

Previously, in async + spec mode, the `_get_valid_sampled_token_count` call in `_update_states` required CPU-GPU synchronization to determine how many tokens were accepted by the target model's rejection sampler. As a result, the prepare CPU work for the current step could only overlap with the draft model’s GPU execution from the previous step. This limited overlap created bubbles (idle periods) in the GPU pipeline, significantly reducing throughput during asynchronous execution.

## Solution
This PR introduces a zero-bubble async execution strategy that:

1. Enables non-blocking CPU execution by optimistically assuming all tokens from the previous speculation round were accepted, allowing `_update_states` and `_prepare_inputs` to proceed without waiting for GPU synchronization
2. Introduces a new `_maybe_adjust_inputs_on_gpu` method to correct any incorrect assumptions entirely on the GPU
3. Defers CPU-side state correction to `_update_states_after_model_execute`, which updates request states and input batch metadata after the target model's forward has been launched

## Test Result

Target model: Qwen3-235B-A22B-Thinking-2507-FP8
Draft Model: lmsys-Qwen3-235B-A22B-EAGLE3
Nvidia H20 GPUs

### bench serve

TP=4, num_speculative_tokens: 1

bench serve --dataset-name spec_bench --spec-bench-output-len 1024 --num-prompts 256

max concurrency | Main Mean TPOT | This PR Mean TPOT | speedup
-- | -- | -- | --
1 | 14.217 | 13.92 | 1.02133620689655
2 | 14.947 | 14.623 | 1.022156876154
4 | 18.157 | 17.82 | 1.018911335578
8 | 20.553 | 20.11 | 1.02202884137245
16 | 23.897 | 23.293 | 1.02593053707122
32 | 23.85 | 23.287 | 1.02417657920728
64 | 23.853 | 23.297 | 1.02386573378547
128 | 23.867 | 23.293 | 1.02464259648822

### GPU Trace

- Main
<img width="3132" height="902" alt="image" src="https://github.com/user-attachments/assets/28b0800c-d0ee-49b3-b07c-baaf50977225" />


- This PR **(No Bubble)**
<img width="2978" height="822" alt="image" src="https://github.com/user-attachments/assets/225f5f6a-515f-4007-9e7c-9b149d79a12b" />

### lm_eval

- Main
```
local-completions (model=/mnt/data/nas/models/Qwen3-235B-A22B-Thinking-2507-FP8,base_url=http://localhost:8000/v1/completions,max_retries=3), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 128
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6513|±  |0.0131|
|     |       |strict-match    |     5|exact_match|↑  |0.6118|±  |0.0134|
```

- This PR
```
local-completions (model=/mnt/data/nas/models/Qwen3-235B-A22B-Thinking-2507-FP8,base_url=http://localhost:8000/v1/completions,max_retries=3), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 128
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6535|±  |0.0131|
|     |       |strict-match    |     5|exact_match|↑  |0.6194|±  |0.0134|
```

