### PR TITLE
[Bugfix] Fix flashinfer ar+norm kernel not available issue

### DIFF
--- a/vllm/compilation/fix_functionalization.py
+++ b/vllm/compilation/fix_functionalization.py
@@ -104,7 +104,8 @@ class FixFunctionalizationPass(VllmInductorPass):
                 mutated_args = {1: "result"}
                 self.defunctionalize(graph, node, mutated_args)
             elif (
-                at_target
+                hasattr(torch.ops.vllm, "flashinfer_trtllm_fused_allreduce_norm")
+                and at_target
                 == torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default
             ):
                 mutated_args = {


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix #29631

```
(EngineCore_DP0 pid=12345)   File "/src/vllm/vllm/compilation/fix_functionalization.py", line 108, in __call__
(EngineCore_DP0 pid=12345)     == torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default
(EngineCore_DP0 pid=12345)        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=12345)   File "/home/user/.venvs/vllm-rocm/lib/python3.13/site-packages/torch/_ops.py", line 1347, in __getattr__
(EngineCore_DP0 pid=12345)     raise AttributeError(
(EngineCore_DP0 pid=12345)         f"'_OpNamespace' '{self.name}' object has no attribute '{op_name}'"
(EngineCore_DP0 pid=12345)     )
(EngineCore_DP0 pid=12345) torch._inductor.exc.InductorError: AttributeError: '_OpNamespace' 'vllm' object has no attribute 'flashinfer_trtllm_fused_allreduce_norm'
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

