### PR TITLE
[CI] Fix re import error

### DIFF
--- a/.buildkite/scripts/generate-nightly-index.py
+++ b/.buildkite/scripts/generate-nightly-index.py
@@ -7,12 +7,13 @@
 
 import argparse
 import json
-import re
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
+
+import regex as re
 
 if not sys.version_info >= (3, 12):
     raise RuntimeError("This script requires Python 3.12 or higher.")

--- a/vllm/entrypoints/serve/instrumentator/metrics.py
+++ b/vllm/entrypoints/serve/instrumentator/metrics.py
@@ -2,9 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
-import re
-
 import prometheus_client
+import regex as re
 from fastapi import FastAPI, Response
 from prometheus_client import make_asgi_app
 from prometheus_fastapi_instrumentator import Instrumentator

--- a/vllm/tokenizers/deepseek_v32_encoding.py
+++ b/vllm/tokenizers/deepseek_v32_encoding.py
@@ -5,8 +5,9 @@
 # copy from https://huggingface.co/deepseek-ai/DeepSeek-V3.2/blob/main/encoding/encoding_dsv32.py
 import copy
 import json
-import re
 from typing import Any
+
+import regex as re
 
 # flake8: noqa: E501
 TOOLS_SYSTEM_TEMPLATE = """## Tools


### PR DESCRIPTION
## Purpose

```bash
Enforce import regex as re..........................................................................Failed
- hook id: enforce-import-regex-instead-of-re
- exit code: 1

❌ .buildkite/scripts/generate-nightly-index.py:
  Line 10: import re

❌ vllm/entrypoints/serve/instrumentator/metrics.py:
  Line 5: import re

❌ vllm/tokenizers/deepseek_v32_encoding.py:
  Line 8: import re

💡 Found 3 violation(s).
❌ Please replace 'import re' with 'import regex as re'
   Also replace 'from re import ...' with 'from regex import ...'
✅ Allowed imports:
   - import regex as re
   - import regex
```

Now it is fixed