### PR TITLE
[Bugfix][ROCm] Guard the check for flashinfer_trtllm_fused_allreduce_norm under is_cuda

### DIFF
--- a/vllm/compilation/fix_functionalization.py
+++ b/vllm/compilation/fix_functionalization.py
@@ -103,7 +103,7 @@ class FixFunctionalizationPass(VllmInductorPass):
             ]:
                 mutated_args = {1: "result"}
                 self.defunctionalize(graph, node, mutated_args)
-            elif (
+            elif current_platform.is_cuda() and (
                 at_target
                 == torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default
             ):


### PR DESCRIPTION
Fix the error from #29631 

Running with `-O.custom_ops+=+rms_norm -O.custom_ops+=+silu_and_mul -O.custom_ops+=+quant_fp8 -O.pass_config.enable_noop=true -O.pass_config.enable_fusion=true -O.pass_config.enable_attn_fusion=true -O.splitting_ops=[]` on ROCm would result in
```
RuntimeError: Worker failed with error 'AttributeError: '_OpNamespace' 'vllm' object has no attribute 'flashinfer_trtllm_fused_allreduce_norm'
```
cc @elvischenv 
