### PR TITLE
[Frontend][Model] Add 'float16' to possible mamba cache dtype values, override mamba SSM cache dtype value for NemotronH

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -29,7 +29,7 @@ CacheDType = Literal[
     "fp8_inc",
     "fp8_ds_mla",
 ]
-MambaDType = Literal["auto", "float32", "half"]
+MambaDType = Literal["auto", "float32", "float16"]
 PrefixCachingHashAlgo = Literal["sha256", "sha256_cbor", "xxhash", "xxhash_cbor"]
 KVOffloadingBackend = Literal["native", "lmcache"]
 

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -29,7 +29,7 @@ CacheDType = Literal[
     "fp8_inc",
     "fp8_ds_mla",
 ]
-MambaDType = Literal["auto", "float32"]
+MambaDType = Literal["auto", "float32", "half"]
 PrefixCachingHashAlgo = Literal["sha256", "sha256_cbor", "xxhash", "xxhash_cbor"]
 KVOffloadingBackend = Literal["native", "lmcache"]
 

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -490,6 +490,24 @@ class DeepseekV32ForCausalLM(VerifyAndUpdateConfig):
             logger.info("Using bfloat16 kv-cache for DeepSeekV3.2")
 
 
+class NemotronHForCausalLMConfig(VerifyAndUpdateConfig):
+    @staticmethod
+    def verify_and_update_config(vllm_config: "VllmConfig") -> None:
+        """Update mamba_ssm_cache_dtype for NemotronH models when set to 'auto'
+        (or not explicitly set), to the value specified in the HF config, or to
+        FP16 if not specified.
+        """
+        cache_config = vllm_config.cache_config
+        if cache_config.mamba_ssm_cache_dtype == "auto":
+            hf_config = vllm_config.model_config.hf_config
+            mamba_ssm_cache_dtype = getattr(hf_config, "mamba_ssm_cache_dtype", "half")
+            logger.info(
+                "Updating mamba_ssm_cache_dtype to '%s' for NemotronH model",
+                mamba_ssm_cache_dtype,
+            )
+            cache_config.mamba_ssm_cache_dtype = mamba_ssm_cache_dtype
+
+
 MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "GteModel": SnowflakeGteNewModelConfig,
     "GteNewModel": GteNewModelConfig,
@@ -507,4 +525,5 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "Mamba2ForCausalLM": MambaModelConfig,
     "FalconMambaForCausalLM": MambaModelConfig,
     "DeepseekV32ForCausalLM": DeepseekV32ForCausalLM,
+    "NemotronHForCausalLM": NemotronHForCausalLMConfig,
 }

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -495,12 +495,14 @@ class NemotronHForCausalLMConfig(VerifyAndUpdateConfig):
     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
         """Update mamba_ssm_cache_dtype for NemotronH models when set to 'auto'
         (or not explicitly set), to the value specified in the HF config, or to
-        FP16 if not specified.
+        float16 if not specified.
         """
         cache_config = vllm_config.cache_config
         if cache_config.mamba_ssm_cache_dtype == "auto":
             hf_config = vllm_config.model_config.hf_config
-            mamba_ssm_cache_dtype = getattr(hf_config, "mamba_ssm_cache_dtype", "half")
+            mamba_ssm_cache_dtype = getattr(
+                hf_config, "mamba_ssm_cache_dtype", "float16"
+            )
             logger.info(
                 "Updating mamba_ssm_cache_dtype to '%s' for NemotronH model",
                 mamba_ssm_cache_dtype,

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -28,6 +28,7 @@ else:
 STR_DTYPE_TO_TORCH_DTYPE = {
     "float32": torch.float32,
     "half": torch.half,
+    "float16": torch.float16,
     "bfloat16": torch.bfloat16,
     "float": torch.float,
     "fp8": torch.uint8,


### PR DESCRIPTION
## Purpose

1. Add `float16` to the set of valid values of mamba cache dtype.
2. For NemotronH models only, override the value of `mamba_ssm_cache_dtype` when it wasn't explicitly set in the CLI (has the value `auto`) with the value of `mamba_ssm_cache_dtype` field in the model's HF config, or if not set there, use float16. Or more simply, its value would be determined by the following order of precedence:
  2.1. CLI (`--mamba-ssm-cache-dtype`).
  2.2. `mamba_ssm_cache_dtype` field value in model's HF config.
  2.3. float16

## Test Plan

1. `mamba-ssm-cache-dtype` wasn't set in CLI and wasn't set in model's HF config -> it's value should be updated to "float16".
2. `mamba-ssm-cache-dtype` wasn't set in CLI and was set in model's HF config -> it's value should be updated to the value in the model's HF config.
3. `mamba-ssm-cache-dtype` was set in CLI and wasn't set in model's HF config -> it's value should be as set in the CLI.
4. `mamba-ssm-cache-dtype` was set in CLI and was set in model's HF config -> it's value should be as set in the CLI.

## Test Result

All 4 cases worked as expected.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

