### PR TITLE
[Perf] Optimize flashinfer sampling via 'filter_apply_order="joint"'

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -371,7 +371,7 @@ def flashinfer_sample(
     else:
         # Both top-k and top-p.
         next_token_ids = flashinfer.sampling.top_k_top_p_sampling_from_logits(
-            logits, k, p, deterministic=True
+            logits, k, p, filter_apply_order="joint", deterministic=True
         )
 
     return next_token_ids.view(-1)


### PR DESCRIPTION
## Purpose
When `min_tokens` is set in Sampling Params, using FlashInfer's `top_k_top_p_sampling_from_logits` kernel causes a significant increase in TPOT and TTFT. This is because the default `filter_apply_order="top_k_first"` is sensitive to `-inf` logit values, causing severe performance degradation when they are present. Switching the order to `"joint"` fixes this regression and additionally improves performance in general scenarios where `min_tokens` is not set.

Without min_tokens in request:
<img width="2122" height="108" alt="image" src="https://github.com/user-attachments/assets/7812b09f-d4a1-4b9a-851d-d0e61412e697" />
With min_tokens in request:
<img width="2222" height="136" alt="image" src="https://github.com/user-attachments/assets/f6667cb8-dde0-445d-a946-dd7e72f7e51a" />
Setting `filter_apply_order` to `"joint"` reduces **TPOT by 50% and doubles throughput** when logits contain -inf values. In scenarios without -inf, decode throughput also improves by **10%**.


## Test Plan && Test Result(Qwen3-32B TP4)
### Accuracy(GPQA)
PR:


```
Writing report to /tmp/gpqa___data__models__qwen3-32B-low_temp1.0_20251204_015701.html
{'chars': 39526.768939393936, 'chars:std': 45477.087889340975, 'score': 0.5258838383838383, 'score:std': 0.4993295774441158}
```


main:


```
Writing report to /tmp/gpqa___data__models__qwen3-32B-low_temp1.0_20251204_015713.html
{'chars': 38334.38762626263, 'chars:std': 44710.574518580775, 'score': 0.5132575757575758, 'score:std': 0.49982420578142484}
```


### Perf


Input seqlen/Output seqlen: 300/300


```shell
# server
VLLM_USE_FLASHINFER_SAMPLER=1 vllm serve /data/models/qwen3-32B --tensor-parallel-size 4 --port 9000 --no-enable-prefix-caching
# client
vllm bench serve --num-prompts 256 --dataset-name random --port 9000 --max-concurrency 1 --model /data/models/qwen3-32B --random-input-len 300 --random-output-len 300 --ignore-eos --extra-body '{"min_tokens": 300}' --temperature 0.6
```


**High Concurrency (cc=64)**


With `min_tokens` (introduces `-inf`):


| Branch | Mean TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | P99 TPOT (ms) | Output Throughput (tok/s) | Total Token Throughput (tok/s) |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| `main` | 503.55 | 826.61 | 27.59 | 28.99 | 2191.16 | 4382.32 |
| **This PR** | **479.67** | **776.98** | **13.42** | **14.84** | **4268.78** | **8537.55** |
| *Improvement* | *↓ 4.7%* | *↓ 6.0%* | *↓ 51.4%* | *↓ 48.8%* | *↑ 94.8%* | *↑ 94.8%* |


Without `min_tokens` (no `-inf`):


| Branch | Mean TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | P99 TPOT (ms) | Output Throughput (tok/s) | Total Token Throughput (tok/s) |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| `main` | 476.39 | 782.38 | 14.84 | 16.24 | 3902.48 | 7804.96 |
| **This PR** | **482.90** | **766.32** | **13.43** | **14.81** | **4262.07** | **8524.15** |
| *Improvement* | *↑ 1.4%* | *↓ 2.1%* | *↓ 9.5%* | *↓ 8.8%* | *↑ 9.2%* | *↑ 9.2%* |


**Single Request (cc=1)**


With `min_tokens` (introduces `-inf`)


| Branch | Mean TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | P99 TPOT (ms) | Output Throughput (tok/s) | Total Token Throughput (tok/s) |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| `main` | 42.29 | 44.94 | 22.90 | 23.03 | 43.55 | 87.10 |
| **This PR** | **28.38** | **31.85** | **9.41** | **9.55** | **105.55** | **211.11** |
| *Improvement* | *↓ 32.9%* | *↓ 29.1%* | *↓ 58.9%* | *↓ 58.5%* | *↑ 142.4%* | *↑ 142.4%* |


Without `min_tokens` (no `-inf`)


| Branch | Mean TTFT (ms) | P99 TTFT (ms) | Mean TPOT (ms) | P99 TPOT (ms) | Output Throughput (tok/s) | Total Token Throughput (tok/s) |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| `main` | 29.52 | 32.03 | 10.52 | 10.60 | 94.52 | 189.04 |
| **This PR** | **28.33** | **30.91** | **9.39** | **9.51** | **105.83** | **211.66** |
| *Improvement* | *↓ 4.0%* | *↓ 3.5%* | *↓ 10.7%* | *↓ 10.3%* | *↑ 12.0%* | *↑ 12.0%* |


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>


- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>



