### PR TITLE
[WIP][ROCm] Add AITER hipblaslt preshuffled gemm kernel

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -8,6 +8,9 @@ import torch
 import vllm.envs as envs
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op, is_torch_equal_or_newer
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
 
 
 def is_aiter_found() -> bool:
@@ -352,6 +355,69 @@ def _rocm_aiter_gemm_w8a8_blockscale_fake(
     return Y
 
 
+@functools.lru_cache(maxsize=1)
+def _initialize_hipblaslt():
+    from aiter import hipb_create_extension
+    hipb_create_extension()
+
+
+def _gemm_weight_bpreshuffle_impl(
+    input: torch.Tensor, # [M, K]
+    weight: torch.Tensor, # [K, N]
+    bias: torch.Tensor | None = None, # [N]
+    out_dtype: torch.dtype | None = None,
+    scale_a: torch.Tensor | None = None, # None, (1,) or (M,1)
+    scale_b: torch.Tensor | None = None, # None, (1,) or (1,N)
+) -> torch.Tensor:
+    _initialize_hipblaslt()
+        
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+
+    assert out_dtype == torch.bfloat16, (
+        f"hip_bpreshuffle_gemm only supports bfloat16 output dtype"
+        f", you have passed in {out_dtype}"
+    )
+    if input.dim() >= 3:
+        inp_view = input.view(-1, input.size(-1))
+        batched = True
+    else:
+        inp_view = input
+        batched = False
+
+    from aiter import hipb_mm
+
+    output = hipb_mm(
+        inp_view,
+        weight,
+        solution_index=-1,
+        bias=bias,
+        out_dtype=out_dtype,
+        scaleA=scale_a,
+        scaleB=scale_b,
+        scaleOut=None,
+        bpreshuffle=True,
+    )
+
+    if batched:
+        output = output.view(*input.shape[:-1], weight.shape[1])
+    
+    return output
+
+
+def _gemm_weight_bpreshuffle_fake(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    scale_a: torch.Tensor | None = None,
+    scale_b: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if out_dtype is None:
+        out_dtype = torch.bfloat16
+    return torch.empty(*input.shape[:-1], weight.shape[1], dtype=out_dtype, device=input.device)
+
+
 def _rocm_aiter_rms_norm_impl(
     x: torch.Tensor, weight: torch.Tensor, variance_epsilon: float
 ) -> torch.Tensor:
@@ -409,6 +475,7 @@ _OPS_REGISTERED = False
 class rocm_aiter_ops:
     _AITER_ENABLED = envs.VLLM_ROCM_USE_AITER
     _LINEAR_ENABLED = envs.VLLM_ROCM_USE_AITER_LINEAR
+    _LINEAR_SHUFFLE_ENABLED = envs.VLLM_ROCM_USE_AITER_LINEAR_SHUFFLE
     _RMSNORM_ENABLED = envs.VLLM_ROCM_USE_AITER_RMSNORM
     _FMOE_ENABLED = envs.VLLM_ROCM_USE_AITER_MOE
     _MLA_ENABLED = envs.VLLM_ROCM_USE_AITER_MLA
@@ -437,6 +504,12 @@ class rocm_aiter_ops:
     def is_linear_fp8_enaled(cls) -> bool:
         """ "Verifies device specs and availability of env variable."""
         return cls.is_linear_enabled() and current_platform.is_fp8_fnuz()
+    
+    @classmethod
+    @if_aiter_supported
+    def is_linear_shuffle_enabled(cls) -> bool:
+        """ "Verifies device specs and availability of env variable."""
+        return cls._AITER_ENABLED and cls.is_linear_enabled() and cls._LINEAR_SHUFFLE_ENABLED
 
     @classmethod
     @if_aiter_supported
@@ -569,6 +642,14 @@ class rocm_aiter_ops:
                 fake_impl=_rocm_aiter_gemm_w8a8_blockscale_fake,
                 dispatch_key=current_platform.dispatch_key,
             )
+            
+            direct_register_custom_op(
+                op_name="gemm_weight_bpreshuffle",
+                op_func=_gemm_weight_bpreshuffle_impl,
+                mutates_args=[],
+                fake_impl=_gemm_weight_bpreshuffle_fake,
+                dispatch_key=current_platform.dispatch_key,
+            )
 
             direct_register_custom_op(
                 op_name="rocm_aiter_rms_norm",
@@ -628,6 +709,30 @@ class rocm_aiter_ops:
         return torch.ops.vllm.rocm_aiter_gemm_w8a8_blockscale(
             A, B, As, Bs, output_dtype
         )
+    
+    @staticmethod
+    def gemm_weight_bpreshuffle(
+        input: torch.Tensor, # [M, K]
+        weight: torch.Tensor, # [K, N]
+        bias: torch.Tensor | None = None, # [N]
+        out_dtype: torch.dtype | None = None,
+        scale_a: torch.Tensor | None = None, # None, (1,) or (M,1)
+        scale_b: torch.Tensor | None = None, # None, (1,) or (1,N)
+    ) -> torch.Tensor:
+        return torch.ops.vllm.gemm_weight_bpreshuffle(
+            input=input,
+            weight=weight,
+            bias=bias,
+            out_dtype=out_dtype,
+            scale_a=scale_a,
+            scale_b=scale_b,
+        )
+
+    @staticmethod
+    def gemm_weight_can_shuffle(n: int, k: int, layout: tuple[int, int]) -> bool:
+        IN, IK = layout
+        BK = IK * 2
+        return (n % 64 == 0) and (k % 64 == 0)
 
     @staticmethod
     def fused_moe(
@@ -908,7 +1013,7 @@ class rocm_aiter_ops:
 
     @staticmethod
     def shuffle_weight(
-        self, tensor: torch.Tensor, layout: tuple[int, int] = (16, 16)
+        tensor: torch.Tensor, layout: tuple[int, int] = (16, 16)
     ) -> torch.Tensor:
         from aiter.ops.shuffle import shuffle_weight
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -104,6 +104,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER: bool = False
     VLLM_ROCM_USE_AITER_PAGED_ATTN: bool = False
     VLLM_ROCM_USE_AITER_LINEAR: bool = True
+    VLLM_ROCM_USE_AITER_LINEAR_SHUFFLE: bool = True
     VLLM_ROCM_USE_AITER_MOE: bool = True
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
@@ -900,6 +901,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # - scaled_mm (per-tensor / rowwise)
     "VLLM_ROCM_USE_AITER_LINEAR": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_LINEAR", "True").lower() in ("true", "1")
+    ),
+    # Whether to use aiter linear with weights shuffled.
+    # This flag is only used in development. It will be removed in the future
+    # By default is enabled.
+    "VLLM_ROCM_USE_AITER_LINEAR_SHUFFLE": lambda: (
+        os.getenv("VLLM_ROCM_USE_AITER_LINEAR_SHUFFLE", "True").lower() in ("true", "1")
     ),
     # Whether to use aiter moe ops.
     # By default is enabled.

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -8,6 +8,7 @@ from typing import Any
 import torch
 from torch.nn.parameter import Parameter, UninitializedParameter
 
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
@@ -224,12 +225,25 @@ class UnquantizedLinearMethod(LinearMethodBase):
 
         layer.register_parameter("weight", weight)
         set_weight_attrs(weight, extra_weight_attrs)
+        
+        self.weight_shuffled = False
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if current_platform.is_cpu():
             from vllm.model_executor.layers.utils import dispatch_cpu_unquantized_gemm
 
             dispatch_cpu_unquantized_gemm(layer, remove_weight=True)
+            
+        if rocm_aiter_ops.is_linear_shuffle_enabled():
+            weight = layer.weight
+            layout = (16, 16)
+
+            if rocm_aiter_ops.gemm_weight_can_shuffle(weight.shape[0], weight.shape[1], layout):
+                shuffled_weight = rocm_aiter_ops.shuffle_weight(weight, layout).t()
+                self.weight_shuffled = True
+                layer.register_parameter("weight", Parameter(shuffled_weight.data, requires_grad=False))
+                
+        layer.weight_shuffled = self.weight_shuffled
 
     def apply(
         self,
@@ -237,7 +251,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        return dispatch_unquantized_gemm()(layer, x, layer.weight, bias)
+        return dispatch_unquantized_gemm(rocm_aiter_weight_shuffled=self.weight_shuffled)(layer, x, layer.weight, bias)
 
 
 class LinearBase(CustomOp):

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -148,6 +148,25 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
             weight, weight_scale, input_scale = process_fp8_weight_channel_strategy(
                 layer.weight, layer.weight_scale, getattr(layer, "input_scale", None)
             )
+            
+            if (self.use_aiter_and_is_supported
+                and rocm_aiter_ops.is_linear_shuffle_enabled()
+            ):
+                layout = (16, 16)
+                use_swizzle_gemm = rocm_aiter_ops.gemm_weight_can_shuffle(weight.shape[0], weight.shape[1], layout=layout)
+                
+                self.use_aiter_and_is_supported = self.use_aiter_and_is_supported and use_swizzle_gemm
+                
+                if self.use_aiter_and_is_supported:
+                    weight = rocm_aiter_ops.shuffle_weight(weight, layout)
+                    weight_scale = weight_scale.t()
+                    
+                    self.fp8_linear = Fp8LinearOp(
+                        act_quant_static=self.is_static_input_scheme,
+                        act_quant_group_shape=self.act_q_group_shape,
+                        rocm_aiter_weight_shuffled=True,
+                    )
+
             weight = weight.t()
 
         elif self.strategy == QuantizationStrategy.BLOCK:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -148,19 +148,24 @@ class CompressedTensorsW8A8Fp8(CompressedTensorsScheme):
             weight, weight_scale, input_scale = process_fp8_weight_channel_strategy(
                 layer.weight, layer.weight_scale, getattr(layer, "input_scale", None)
             )
-            
-            if (self.use_aiter_and_is_supported
+
+            if (
+                self.use_aiter_and_is_supported
                 and rocm_aiter_ops.is_linear_shuffle_enabled()
             ):
                 layout = (16, 16)
-                use_swizzle_gemm = rocm_aiter_ops.gemm_weight_can_shuffle(weight.shape[0], weight.shape[1], layout=layout)
-                
-                self.use_aiter_and_is_supported = self.use_aiter_and_is_supported and use_swizzle_gemm
-                
+                use_swizzle_gemm = rocm_aiter_ops.gemm_weight_can_shuffle(
+                    weight.shape[0], weight.shape[1], layout=layout
+                )
+
+                self.use_aiter_and_is_supported = (
+                    self.use_aiter_and_is_supported and use_swizzle_gemm
+                )
+
                 if self.use_aiter_and_is_supported:
                     weight = rocm_aiter_ops.shuffle_weight(weight, layout)
                     weight_scale = weight_scale.t()
-                    
+
                     self.fp8_linear = Fp8LinearOp(
                         act_quant_static=self.is_static_input_scheme,
                         act_quant_group_shape=self.act_q_group_shape,

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -97,7 +97,7 @@ class QuantFP8(CustomOp):
         x: torch.Tensor,
         scale: torch.Tensor | None = None,
         scale_ub: torch.Tensor | None = None,
-    ):
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         if self.is_group_quant:
             assert scale is None, "Group quantization is always dynamic"
             return self._quantize_group_native(x)

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 import torch
 from torch.nn import Parameter
 
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.model_executor.layers.quantization.quark.schemes import QuarkScheme
 from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
@@ -96,6 +97,21 @@ class QuarkW8A8Fp8(QuarkScheme):
                 weight_scale = layer.weight_scale.data
             if self.act_quant_group_shape == GroupShape.PER_TOKEN:
                 weight_scale = weight_scale.view(-1, 1)
+
+            if rocm_aiter_ops.is_linear_shuffle_enabled():
+                layout = (16, 16)
+                use_swizzle_gemm = rocm_aiter_ops.gemm_weight_can_shuffle(weight.shape[0], weight.shape[1], layout=layout)
+                
+                if use_swizzle_gemm:
+                    weight = rocm_aiter_ops.shuffle_weight(weight, layout)
+                    weight_scale = weight_scale.t()
+                    
+                    self.fp8_linear = Fp8LinearOp(
+                        act_quant_static=self.is_static_input_scheme,
+                        act_quant_group_shape=self.act_quant_group_shape,
+                        rocm_aiter_weight_shuffled=True,
+                    )
+
             layer.weight = Parameter(weight.t(), requires_grad=False)
             # required by torch.compile to be torch.nn.Parameter
             layer.weight_scale = Parameter(weight_scale, requires_grad=False)

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
@@ -100,12 +100,14 @@ class QuarkW8A8Fp8(QuarkScheme):
 
             if rocm_aiter_ops.is_linear_shuffle_enabled():
                 layout = (16, 16)
-                use_swizzle_gemm = rocm_aiter_ops.gemm_weight_can_shuffle(weight.shape[0], weight.shape[1], layout=layout)
-                
+                use_swizzle_gemm = rocm_aiter_ops.gemm_weight_can_shuffle(
+                    weight.shape[0], weight.shape[1], layout=layout
+                )
+
                 if use_swizzle_gemm:
                     weight = rocm_aiter_ops.shuffle_weight(weight, layout)
                     weight_scale = weight_scale.t()
-                    
+
                     self.fp8_linear = Fp8LinearOp(
                         act_quant_static=self.is_static_input_scheme,
                         act_quant_group_shape=self.act_quant_group_shape,

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 import torch
 from packaging import version
 
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm import _custom_ops as ops
 from vllm import envs
 from vllm.config import CompilationMode, get_current_vllm_config
@@ -357,8 +358,40 @@ def torch_channelwise_w8a8_scaled_mm(
     return output.to(out_dtype).view(*output_shape)
 
 
+def aiter_ptpc_w8a8_scaled_mm_bpreshuffled(
+    *,
+    qinput: torch.Tensor,
+    weight: torch.Tensor,
+    out_dtype: torch.dtype,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    bias: torch.Tensor,
+    output_shape: list,
+) -> torch.Tensor:
+    # K_size = qinput.shape[-1]
+    # if K_size == 8192:
+    #     output = rocm_aiter_ops.gemm_weight_bpreshuffle_fp8_ck(
+    #         input=qinput,
+    #         weight=weight.t(),
+    #         bias=bias,
+    #         out_dtype=out_dtype,
+    #         scale_a=scale_a,
+    #         scale_b=scale_b.t(),
+    #     )
+    #     return output.view(*output_shape)
+
+    return rocm_aiter_ops.gemm_weight_bpreshuffle(
+        input=qinput,
+        weight=weight,
+        bias=bias,
+        out_dtype=out_dtype,
+        scale_a=scale_a,
+        scale_b=scale_b,
+    ).view(*output_shape)
+
+
 def dispatch_w8a8_scaled_mm(
-    preferred_backend: str, per_tensor_weights: bool, per_tensor_activations: bool
+    preferred_backend: str, per_tensor_weights: bool, per_tensor_activations: bool, rocm_aiter_weight_shuffled: bool = False
 ) -> Callable[..., torch.Tensor]:
     if per_tensor_weights and per_tensor_activations:
         if preferred_backend == "rocm":
@@ -377,9 +410,11 @@ def dispatch_w8a8_scaled_mm(
     if (
         not per_tensor_weights
         and not per_tensor_activations
-        and USE_ROWWISE_TORCH_SCALED_MM
     ):
-        return torch_per_token_w8a8_scaled_mm
+        if rocm_aiter_weight_shuffled:
+            return aiter_ptpc_w8a8_scaled_mm_bpreshuffled
+        if USE_ROWWISE_TORCH_SCALED_MM:
+            return torch_per_token_w8a8_scaled_mm
     # Normally, torch.scaled_mm supports per tensor weights + activations only
     # so fallback to naive if per channel or per token
     return torch_channelwise_w8a8_scaled_mm
@@ -400,6 +435,7 @@ class Fp8LinearOp:
         act_quant_static: bool,
         act_quant_group_shape: GroupShape = GroupShape.PER_TENSOR,
         pad_output: bool | None = None,
+        rocm_aiter_weight_shuffled: bool | None = None,
     ):
         if current_platform.is_rocm():
             self.preferred_backend = "rocm"
@@ -431,6 +467,8 @@ class Fp8LinearOp:
             group_shape=act_quant_group_shape,
             num_token_padding=self.output_padding,
         )
+        
+        self.rocm_aiter_weight_shuffled = False if rocm_aiter_weight_shuffled is None else rocm_aiter_weight_shuffled
 
     def apply(
         self,
@@ -477,7 +515,8 @@ class Fp8LinearOp:
 
         # TODO(luka) do this dispatch during init (after ScaledMM refactor)
         w8a8_scaled_mm_func = dispatch_w8a8_scaled_mm(
-            self.preferred_backend, per_tensor_weights, per_tensor_activations
+            self.preferred_backend, per_tensor_weights, per_tensor_activations,
+            self.rocm_aiter_weight_shuffled,
         )
 
         return w8a8_scaled_mm_func(

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -6,9 +6,9 @@ from collections.abc import Callable
 
 import torch
 
-from vllm._aiter_ops import rocm_aiter_ops
 from vllm import _custom_ops as ops
 from vllm import envs
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.logger import init_logger
 from vllm.platforms import CpuArchEnum, current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
@@ -256,7 +256,9 @@ def cpu_unquantized_gemm(
     return layer.cpu_linear(x, weight, bias)
 
 
-def dispatch_unquantized_gemm(rocm_aiter_weight_shuffled: bool = False) -> Callable[..., torch.Tensor]:
+def dispatch_unquantized_gemm(
+    rocm_aiter_weight_shuffled: bool = False,
+) -> Callable[..., torch.Tensor]:
     if current_platform.is_rocm():
         if rocm_aiter_weight_shuffled:
             return aiter_unquantized_gemm_bpreshuffled

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 import torch
 
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm import _custom_ops as ops
 from vllm import envs
 from vllm.logger import init_logger
@@ -182,6 +183,20 @@ direct_register_custom_op(
 )
 
 
+def aiter_unquantized_gemm_bpreshuffled(
+    layer: torch.nn.Module,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return rocm_aiter_ops.gemm_weight_bpreshuffle(
+        input=x,
+        weight=weight,
+        bias=bias,
+        out_dtype=x.dtype,
+    )
+
+
 def check_cpu_sgl_kernel(n: int, k: int, dtype: torch.dtype) -> bool:
     return (
         torch._C._cpu._is_amx_tile_supported()
@@ -241,8 +256,10 @@ def cpu_unquantized_gemm(
     return layer.cpu_linear(x, weight, bias)
 
 
-def dispatch_unquantized_gemm() -> Callable[..., torch.Tensor]:
+def dispatch_unquantized_gemm(rocm_aiter_weight_shuffled: bool = False) -> Callable[..., torch.Tensor]:
     if current_platform.is_rocm():
+        if rocm_aiter_weight_shuffled:
+            return aiter_unquantized_gemm_bpreshuffled
         return rocm_unquantized_gemm
     elif current_platform.is_cpu():
         return cpu_unquantized_gemm

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -198,32 +198,11 @@ class Qwen2Attention(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
-        # start_event_qkv_proj = torch.cuda.Event(enable_timing=True)
-        # start_event_qkv_proj.record()
-        # end_event_qkv_proj = torch.cuda.Event(enable_timing=True)
         qkv, _ = self.qkv_proj(hidden_states)
-        # end_event_qkv_proj.record()
-        # end_event_qkv_proj.synchronize()
-        # qkv_proj_time = start_event_qkv_proj.elapsed_time(end_event_qkv_proj)
-        # print(f"qkv_proj_time: {qkv_proj_time} ms")
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         q, k = self.rotary_emb(positions, q, k)
-        # start_event_attn = torch.cuda.Event(enable_timing=True)
-        # start_event_attn.record()
-        # end_event_attn = torch.cuda.Event(enable_timing=True)
         attn_output = self.attn(q, k, v)
-        # end_event_attn.record()
-        # end_event_attn.synchronize()
-        # attn_time = start_event_attn.elapsed_time(end_event_attn)
-        # print(f"attn_time: {attn_time} ms")
-        # start_event_o_proj = torch.cuda.Event(enable_timing=True)
-        # start_event_o_proj.record()
-        # end_event_o_proj = torch.cuda.Event(enable_timing=True)
         output, _ = self.o_proj(attn_output)
-        # end_event_o_proj.record()
-        # end_event_o_proj.synchronize()
-        # o_proj_time = start_event_o_proj.elapsed_time(end_event_o_proj)
-        # print(f"o_proj_time: {o_proj_time} ms")
         return output
 
 

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -198,11 +198,32 @@ class Qwen2Attention(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
+        # start_event_qkv_proj = torch.cuda.Event(enable_timing=True)
+        # start_event_qkv_proj.record()
+        # end_event_qkv_proj = torch.cuda.Event(enable_timing=True)
         qkv, _ = self.qkv_proj(hidden_states)
+        # end_event_qkv_proj.record()
+        # end_event_qkv_proj.synchronize()
+        # qkv_proj_time = start_event_qkv_proj.elapsed_time(end_event_qkv_proj)
+        # print(f"qkv_proj_time: {qkv_proj_time} ms")
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         q, k = self.rotary_emb(positions, q, k)
+        # start_event_attn = torch.cuda.Event(enable_timing=True)
+        # start_event_attn.record()
+        # end_event_attn = torch.cuda.Event(enable_timing=True)
         attn_output = self.attn(q, k, v)
+        # end_event_attn.record()
+        # end_event_attn.synchronize()
+        # attn_time = start_event_attn.elapsed_time(end_event_attn)
+        # print(f"attn_time: {attn_time} ms")
+        # start_event_o_proj = torch.cuda.Event(enable_timing=True)
+        # start_event_o_proj.record()
+        # end_event_o_proj = torch.cuda.Event(enable_timing=True)
         output, _ = self.o_proj(attn_output)
+        # end_event_o_proj.record()
+        # end_event_o_proj.synchronize()
+        # o_proj_time = start_event_o_proj.elapsed_time(end_event_o_proj)
+        # print(f"o_proj_time: {o_proj_time} ms")
         return output
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR adds weight-shuffled gemm kernel from aiter for ROCm.
The kernel supports weight shuffling for both quantized and unquantized gemm, and in this PR unquantized linear and PTPC GEMMs are targeted.
Note: In #28837 the post-processing of FP8 weights and the linear weights will be refactored, and this PR will adapt to the refactoring after it gets merged.

## Test Plan
lm_eval accuracy test and benchmarking of PTPC-FP8 models.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

