### PR TITLE
[CI/Build] Add MM code path to Examples Test

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -387,6 +387,7 @@ steps:
   working_dir: "/vllm-workspace/examples"
   source_file_dependencies:
   - vllm/entrypoints
+  - vllm/multimodal
   - examples/
   commands:
     - pip install tensorizer # for tensorizer test


### PR DESCRIPTION
## Purpose
#29621 broke Examples Test on CI, and we don't have MM code path currently so the test suite is fragile - this PR adds MM code path coverage to the test suite, so that changes can be caught