### PR TITLE
[CI/Build][AMD] Use float16 in test_reset_prefix_cache_e2e to avoid accuracy issues

### DIFF
--- a/tests/v1/core/test_reset_prefix_cache_e2e.py
+++ b/tests/v1/core/test_reset_prefix_cache_e2e.py
@@ -19,6 +19,7 @@ def test_reset_prefix_cache_e2e():
         max_num_batched_tokens=32,
         max_model_len=2048,
         compilation_config={"mode": 0},
+        dtype="float16",
     )
     engine = LLMEngine.from_engine_args(engine_args)
     sampling_params = SamplingParams(


### PR DESCRIPTION
This test adds `dtype="float16"` to the `engine_args` in `test_reset_prefix_cache_e2e `in `test_reset_prefix_cache_e2e.py`  to avoid accuracy issues during the test, since preemption is being tested instead of accuracy.