### PR TITLE
[draft] OptionalCUDAGuard --> DeviceGuard

### DIFF
--- a/csrc/activation_kernels.cu
+++ b/csrc/activation_kernels.cu
@@ -1,6 +1,6 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/all.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 
 #include <cmath>
 
@@ -73,7 +73,7 @@ __device__ __forceinline__ T gelu_tanh_kernel(const T& x) {
   if (num_tokens == 0) {                                                 \
     return;                                                              \
   }                                                                      \
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));      \
+  const c10::DeviceGuard device_guard(input.device());      \
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();          \
   VLLM_DISPATCH_FLOATING_TYPES(                                          \
       input.scalar_type(), "act_and_mul_kernel", [&] {                   \
@@ -174,7 +174,7 @@ __global__ void swigluoai_and_mul_kernel(
   int64_t num_tokens = input.numel() / input.size(-1);                  \
   dim3 grid(num_tokens);                                                \
   dim3 block(std::min(d, 1024));                                        \
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));     \
+  const c10::DeviceGuard device_guard(input.device());     \
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();         \
   VLLM_DISPATCH_FLOATING_TYPES(                                         \
       input.scalar_type(), "act_and_mul_kernel_with_param", [&] {       \
@@ -189,7 +189,7 @@ __global__ void swigluoai_and_mul_kernel(
   int64_t num_tokens = input.numel() / input.size(-1);                         \
   dim3 grid(num_tokens);                                                       \
   dim3 block(std::min(d, 1024));                                               \
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));            \
+  const c10::DeviceGuard device_guard(input.device());            \
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();                \
   VLLM_DISPATCH_FLOATING_TYPES(                                                \
       input.scalar_type(), "clamp_swiglu_kernel_with_params", [&] {            \
@@ -232,7 +232,7 @@ __global__ void activation_kernel(
   int64_t num_tokens = input.numel() / d;                                      \
   dim3 grid(num_tokens);                                                       \
   dim3 block(std::min(d, 1024));                                               \
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));            \
+  const c10::DeviceGuard device_guard(input.device());            \
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();                \
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "activation_kernel", [&] { \
     vllm::activation_kernel<scalar_t, KERNEL<scalar_t>>                        \

--- a/csrc/attention/attention_kernels.cuh
+++ b/csrc/attention/attention_kernels.cuh
@@ -19,7 +19,7 @@
 
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include <algorithm>
 
 #include "attention_dtypes.h"

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -1,7 +1,7 @@
 #include <optional>
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include <algorithm>
 
 #include "attention_dtypes.h"
@@ -186,7 +186,7 @@ void merge_attn_states_launcher(torch::Tensor& output,
   dim3 block(NUM_THREADS);
   dim3 grid((total_threads + NUM_THREADS - 1) / NUM_THREADS);
 
-  const c10::cuda::OptionalCUDAGuard device_guard(prefix_output.device());
+  const c10::DeviceGuard device_guard(prefix_output.device());
   auto stream = at::cuda::getCurrentCUDAStream();
 
   LAUNCH_MERGE_ATTN_STATES(scalar_t, NUM_THREADS);

--- a/csrc/attention/paged_attention_v1.cu
+++ b/csrc/attention/paged_attention_v1.cu
@@ -85,7 +85,7 @@ void paged_attention_v1_launcher(
 
   dim3 grid(num_heads, num_seqs, 1);
   dim3 block(NUM_THREADS);
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(query));
+  const c10::DeviceGuard device_guard(query.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   switch (head_size) {
     // NOTE(woosuk): To reduce the compilation time, we only compile for the

--- a/csrc/attention/paged_attention_v2.cu
+++ b/csrc/attention/paged_attention_v2.cu
@@ -91,7 +91,7 @@ void paged_attention_v2_launcher(
   int reduce_shared_mem_size = 2 * max_num_partitions * sizeof(float);
 
   dim3 block(NUM_THREADS);
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(query));
+  const c10::DeviceGuard device_guard(query.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   switch (head_size) {
     // NOTE(woosuk): To reduce the compilation time, we only compile for the

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -1,6 +1,6 @@
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include <c10/cuda/CUDAException.h>
 
 #include "cuda_utils.h"
@@ -52,7 +52,7 @@ void swap_blocks(torch::Tensor& src, torch::Tensor& dst,
   // alignment reasons, we assume the blocks data (inclusive of any padding)
   // is contiguous in memory
   const int64_t block_size_in_bytes = src.element_size() * src.stride(0);
-  const at::cuda::OptionalCUDAGuard device_guard(
+  const c10::DeviceGuard device_guard(
       src_device.is_cuda() ? src_device : dst_device);
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   // NOTE(woosuk): This can be slow if the number of blocks is large.
@@ -159,7 +159,7 @@ void copy_blocks(std::vector<torch::Tensor> const& key_caches,
   const int numel_per_block = key_caches[0][0].numel();
   dim3 grid(num_layers, num_pairs);
   dim3 block(std::min(1024, numel_per_block));
-  const at::cuda::OptionalCUDAGuard device_guard(cache_device);
+  const c10::DeviceGuard device_guard(cache_device);
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   VLLM_DISPATCH_FLOATING_AND_BYTE_TYPES(
       key_caches[0].scalar_type(), "copy_blocks_kernel", ([&] {
@@ -196,7 +196,7 @@ void copy_blocks_mla(std::vector<torch::Tensor> const& kv_caches,
   int mem_footprint_per_block = kv_caches[0].stride(0);
   dim3 grid(num_layers, num_pairs);
   dim3 block(std::min(1024, mem_footprint_per_block));
-  const at::cuda::OptionalCUDAGuard device_guard(cache_device);
+  const c10::DeviceGuard device_guard(cache_device);
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   VLLM_DISPATCH_FLOATING_AND_BYTE_TYPES(
       kv_caches[0].scalar_type(), "copy_blocks_mla_kernel", ([&] {
@@ -679,7 +679,7 @@ void reshape_and_cache(
 
   dim3 grid(num_tokens);
   dim3 block(std::min(num_heads * head_div_x, 512));
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(key));
+  const c10::DeviceGuard device_guard(key.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   DISPATCH_BY_KV_CACHE_DTYPE(key.dtype(), kv_cache_dtype,
@@ -734,7 +734,7 @@ void reshape_and_cache_flash(
 
   dim3 grid(num_tokens);
   dim3 block(std::min(num_heads * head_size, 512));
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(key));
+  const c10::DeviceGuard device_guard(key.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   DISPATCH_BY_KV_CACHE_DTYPE(key.dtype(), kv_cache_dtype,
@@ -806,7 +806,7 @@ void concat_and_cache_mla(
   int block_stride = kv_cache.stride(0);
   int entry_stride = kv_cache.stride(1);
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(kv_c));
+  const c10::DeviceGuard device_guard(kv_c.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   if (kv_cache_dtype == "fp8_ds_mla") {
@@ -858,7 +858,7 @@ void convert_fp8(torch::Tensor& dst_cache, torch::Tensor& src_cache,
   TORCH_CHECK(dst_device.is_cuda(), "dst must be on a GPU")
   TORCH_CHECK(src_device.index() == dst_device.index(),
               "src and dst must be on the same GPU");
-  at::cuda::OptionalCUDAGuard device_guard(src_device);
+  c10::DeviceGuard device_guard(src_device);
 
   int64_t num_blocks = src_cache.size(0);
   int64_t block_stride = src_cache.stride(0);
@@ -1016,7 +1016,7 @@ void gather_and_maybe_dequant_cache(
     int64_t num_tokens, const std::string& kv_cache_dtype,
     torch::Tensor const& scale,
     std::optional<torch::Tensor> seq_starts = std::nullopt) {
-  at::cuda::OptionalCUDAGuard device_guard(src_cache.device());
+  c10::DeviceGuard device_guard(src_cache.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   int32_t block_size = src_cache.size(1);
@@ -1148,7 +1148,7 @@ void cp_gather_cache(
     torch::Tensor const& cu_seq_lens,  // [BATCH+1]
     int64_t batch_size,
     std::optional<torch::Tensor> seq_starts = std::nullopt) {
-  at::cuda::OptionalCUDAGuard device_guard(src_cache.device());
+  c10::DeviceGuard device_guard(src_cache.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   int32_t block_size = src_cache.size(1);
@@ -1234,7 +1234,7 @@ void indexer_k_quant_and_cache(
   dim3 grid(num_tokens, (head_dim + quant_block_size * vec_size - 1) /
                             (quant_block_size * vec_size));
   dim3 block(32, vec_size);
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(k));
+  const c10::DeviceGuard device_guard(k.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   DISPATCH_BY_KV_CACHE_DTYPE(k.dtype(), "fp8_e4m3",
@@ -1279,7 +1279,7 @@ void cp_gather_indexer_k_quant_cache(
               "head_dim must be divisible by quant_block_size");
 
   constexpr int vec_size = 16;
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(kv_cache));
+  const c10::DeviceGuard device_guard(kv_cache.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   if (num_tokens < 32) {

--- a/csrc/custom_all_reduce.cu
+++ b/csrc/custom_all_reduce.cu
@@ -1,5 +1,5 @@
 #include <ATen/cuda/Exceptions.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include <c10/cuda/CUDAStream.h>
 #include <torch/all.h>
 
@@ -62,7 +62,7 @@ bool _is_weak_contiguous(torch::Tensor& t) {
 void all_reduce(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out,
                 fptr_t _reg_buffer, int64_t reg_buffer_sz_bytes) {
   auto fa = reinterpret_cast<vllm::CustomAllreduce*>(_fa);
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(inp));
+  const c10::DeviceGuard device_guard(inp.device());
   auto stream = c10::cuda::getCurrentCUDAStream().stream();
 
   TORCH_CHECK_EQ(inp.scalar_type(), out.scalar_type());

--- a/csrc/custom_quickreduce.cu
+++ b/csrc/custom_quickreduce.cu
@@ -1,5 +1,5 @@
 #include <ATen/cuda/Exceptions.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include <c10/cuda/CUDAStream.h>
 #include <torch/all.h>
 
@@ -58,7 +58,7 @@ void qr_open_handles(quickreduce::fptr_t _fa,
 void qr_all_reduce(quickreduce::fptr_t _fa, torch::Tensor& inp,
                    torch::Tensor& out, int64_t quant_level, bool cast_bf2half) {
   auto fa = reinterpret_cast<quickreduce::DeviceComms*>(_fa);
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(inp));
+  const c10::DeviceGuard device_guard(inp.device());
   auto stream = at::cuda::getCurrentHIPStreamMasqueradingAsCUDA();
 
   TORCH_CHECK_EQ(inp.scalar_type(), out.scalar_type());

--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -5,7 +5,8 @@
 #include "quantization/vectorization_utils.cuh"
 
 #include <torch/cuda.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
+#include <c10/cuda/CUDAStream.h>
 
 namespace vllm {
 
@@ -205,7 +206,7 @@ void rms_norm(torch::Tensor& out,     // [..., hidden_size]
   // For large num_tokens, use smaller blocks to increase SM concurrency.
   const int max_block_size = (num_tokens < 256) ? 1024 : 256;
   dim3 grid(num_tokens);
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const c10::DeviceGuard device_guard(input.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   VLLM_DISPATCH_RANK234(num_dims, [&] {
     VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "rms_norm_kernel", [&] {
@@ -255,7 +256,7 @@ void fused_add_rms_norm(torch::Tensor& input,     // [..., hidden_size]
      hiding on global mem ops. */
   const int max_block_size = (num_tokens < 256) ? 1024 : 256;
   dim3 block(std::min(hidden_size, max_block_size));
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const c10::DeviceGuard device_guard(input.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   /*If the tensor types are FP16/BF16, try to use the optimized kernel
     with packed + vectorized ops.

--- a/csrc/mamba/mamba_ssm/selective_scan_fwd.cu
+++ b/csrc/mamba/mamba_ssm/selective_scan_fwd.cu
@@ -2,7 +2,7 @@
 // adapted from https://github.com/state-spaces/mamba/blob/main/csrc/selective_scan/selective_scan_fwd_kernel.cuh
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include "selective_scan.h"
 
 #include <c10/util/BFloat16.h>
@@ -782,7 +782,7 @@ void selective_scan_fwd(const torch::Tensor &u, const torch::Tensor &delta,
                        );
 
     
-    const at::cuda::OptionalCUDAGuard device_guard(device_of(u));
+    const c10::DeviceGuard device_guard(u.device());
     auto stream = at::cuda::getCurrentCUDAStream().stream();
     DISPATCH_WTYPE_ITYPE_FLOAT_AND_HALF_AND_BF16(u.scalar_type(), ssm_states.scalar_type(), "selective_scan_fwd", [&] {
         selective_scan_fwd_cuda<input_t, weight_t, state_t>(params, stream);

--- a/csrc/moe/marlin_moe_wna16/ops.cu
+++ b/csrc/moe/marlin_moe_wna16/ops.cu
@@ -661,7 +661,7 @@ torch::Tensor moe_wna16_marlin_gemm(
   cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, a.get_device());
 
   // Alloc buffers
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(a));
+  const c10::DeviceGuard device_guard(a.device());
   torch::Tensor c;
   if (c_or_none.has_value()) {
     c = c_or_none.value();

--- a/csrc/moe/moe_align_sum_kernels.cu
+++ b/csrc/moe/moe_align_sum_kernels.cu
@@ -1,6 +1,6 @@
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include <cub/cub.cuh>
 
 #include <ATen/ATen.h>
@@ -381,7 +381,7 @@ void moe_sum(torch::Tensor& input,   // [num_tokens, topk, hidden_size]
 
   dim3 grid(num_tokens);
   dim3 block(std::min(hidden_size, 1024));
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(output));
+  const c10::DeviceGuard device_guard(output.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   switch (topk) {

--- a/csrc/moe/moe_wna16.cu
+++ b/csrc/moe/moe_wna16.cu
@@ -1,6 +1,6 @@
 
 #include <torch/all.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <cuda_runtime.h>
 
@@ -280,7 +280,7 @@ torch::Tensor moe_wna16_gemm(torch::Tensor input, torch::Tensor output,
                              torch::Tensor num_tokens_post_pad, int64_t top_k,
                              int64_t BLOCK_SIZE_M, int64_t BLOCK_SIZE_N,
                              int64_t BLOCK_SIZE_K, int64_t bit) {
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const c10::DeviceGuard device_guard(input.device());
   output.zero_();
 
   const int num_experts = b_qweight.size(0);

--- a/csrc/moe/topk_softmax_kernels.cu
+++ b/csrc/moe/topk_softmax_kernels.cu
@@ -19,7 +19,7 @@
 #include <type_traits>
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include "../cuda_compat.h"
 #include "../cub_helpers.h"
 
@@ -687,7 +687,7 @@ void topk_softmax(
     const bool needs_workspace = !is_pow_2 || num_experts > 256;
     const int64_t workspace_size = needs_workspace ? num_tokens * num_experts : 0;
 
-    const at::cuda::OptionalCUDAGuard device_guard(device_of(gating_output));
+    const c10::DeviceGuard device_guard(gating_output.device());
     const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
     const auto workspace_options = gating_output.options().dtype(at::ScalarType::Float);
     torch::Tensor softmax_workspace = torch::empty({workspace_size}, workspace_options);

--- a/csrc/permute_cols.cu
+++ b/csrc/permute_cols.cu
@@ -1,7 +1,7 @@
 #include <torch/all.h>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 
 #include <cuda_fp16.h>
 
@@ -65,7 +65,7 @@ __global__ void permute_cols_kernel(int4 const* __restrict__ a_int4_ptr,
 // More efficient version of A[..., perm]
 //  taken from gptq_marlin.cu
 torch::Tensor permute_cols(torch::Tensor const& A, torch::Tensor const& perm) {
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
+  const c10::DeviceGuard device_guard(A.device());
   auto dev = A.get_device();
   auto stream = at::cuda::getCurrentCUDAStream(dev);
 

--- a/csrc/pos_encoding_kernels.cu
+++ b/csrc/pos_encoding_kernels.cu
@@ -1,6 +1,6 @@
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 
 #include "cuda_compat.h"
 #include "dispatch_utils.h"
@@ -163,7 +163,7 @@ void rotary_embedding(
 
   dim3 grid(num_tokens);
   dim3 block(std::min<int64_t>(num_heads * rot_dim / 2, 512));
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(query));
+  const c10::DeviceGuard device_guard(query.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   VLLM_DISPATCH_FLOATING_TYPES(query.scalar_type(), "rotary_embedding", [&] {
     if (is_neox) {

--- a/csrc/quantization/awq/gemm_kernels.cu
+++ b/csrc/quantization/awq/gemm_kernels.cu
@@ -8,7 +8,8 @@ Shang and Dang, Xingyu and Han, Song}, journal={arXiv}, year={2023}
  */
 
 #include <torch/all.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
+#include <c10/cuda/CUDAStream.h>
 
 #include "dequantize.cuh"
 
@@ -437,7 +438,7 @@ torch::Tensor awq_dequantize(torch::Tensor _kernel,
     y_blocks = (int)(in_c / 8);
   }
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(_scaling_factors));
+  const c10::DeviceGuard device_guard(_scaling_factors.device());
 
   auto options = torch::TensorOptions()
                      .dtype(_scaling_factors.dtype())
@@ -471,7 +472,7 @@ torch::Tensor awq_gemm(torch::Tensor _in_feats, torch::Tensor _kernel,
                        int64_t split_k_iters) {
   int num_in_feats = _in_feats.size(0);
   int num_in_channels = _in_feats.size(1);
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(_in_feats));
+  const c10::DeviceGuard device_guard(_in_feats.device());
 
   auto options = torch::TensorOptions()
                      .dtype(_in_feats.dtype())

--- a/csrc/quantization/cutlass_w4a8/w4a8_mm_entry.cu
+++ b/csrc/quantization/cutlass_w4a8/w4a8_mm_entry.cu
@@ -4,7 +4,7 @@
 //
 
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include <torch/all.h>
 #include "cutlass_extensions/torch_utils.hpp"
 
@@ -178,7 +178,7 @@ struct W4A8GemmKernel {
     int const group_size_int = static_cast<int>(group_size);
 
     // Allocate output
-    const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
+    const c10::DeviceGuard device_guard(A.device());
     auto device = A.device();
     auto stream = at::cuda::getCurrentCUDAStream(device.index());
     torch::Tensor D =

--- a/csrc/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu
+++ b/csrc/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu
@@ -20,7 +20,7 @@
 #include <cuda_runtime.h>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 
 #include <cuda_fp8.h>
 #include "dispatch_utils.h"
@@ -129,7 +129,7 @@ void silu_and_mul_nvfp4_quant_sm1xxa(torch::Tensor& output,  // [..., d]
   auto input_sf_ptr = static_cast<float const*>(input_sf.data_ptr());
   auto sf_out = static_cast<int32_t*>(output_sf.data_ptr());
   auto output_ptr = static_cast<int64_t*>(output.data_ptr());
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const c10::DeviceGuard device_guard(input.device());
   auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
   dim3 block(std::min(int(n / ELTS_PER_THREAD), 1024));
   int const numBlocksPerSM =

--- a/csrc/quantization/fp4/nvfp4_experts_quant.cu
+++ b/csrc/quantization/fp4/nvfp4_experts_quant.cu
@@ -20,7 +20,7 @@
 #include <cuda_runtime.h>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 
 #include <cuda_fp8.h>
 #include "dispatch_utils.h"
@@ -352,7 +352,7 @@ void scaled_fp4_experts_quant_sm1xxa(
   // 4 means 4 fp8 values are packed into one int32
   TORCH_CHECK(output_scale.size(1) * 4 == padded_k);
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const c10::DeviceGuard device_guard(input.device());
   const cudaStream_t stream =
       at::cuda::getCurrentCUDAStream(input.get_device());
 

--- a/csrc/quantization/fp4/nvfp4_quant_kernels.cu
+++ b/csrc/quantization/fp4/nvfp4_quant_kernels.cu
@@ -20,7 +20,7 @@
 #include <cuda_runtime.h>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 
 #include <cuda_fp8.h>
 #include "dispatch_utils.h"
@@ -144,7 +144,7 @@ void scaled_fp4_quant_sm1xxa(torch::Tensor const& output,
   auto input_sf_ptr = static_cast<float const*>(input_sf.data_ptr());
   auto sf_out = static_cast<int32_t*>(output_sf.data_ptr());
   auto output_ptr = static_cast<int64_t*>(output.data_ptr());
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const c10::DeviceGuard device_guard(input.device());
   auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
 
   // We don't support e8m0 scales at this moment.

--- a/csrc/quantization/fp4/nvfp4_scaled_mm_entry.cu
+++ b/csrc/quantization/fp4/nvfp4_scaled_mm_entry.cu
@@ -15,7 +15,7 @@
  */
 
 #include <torch/all.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include "cutlass_extensions/common.hpp"
 
 #if defined ENABLE_NVFP4_SM100 && ENABLE_NVFP4_SM100
@@ -39,7 +39,7 @@ void cutlass_scaled_fp4_mm(torch::Tensor& D, const torch::Tensor& A,
                            const torch::Tensor& B_sf,
                            const torch::Tensor& alpha) {
   // Make sure we’re on A’s device.
-  const c10::cuda::OptionalCUDAGuard device_guard(device_of(A));
+  const c10::DeviceGuard device_guard(A.device());
   const int32_t sm = get_sm_version_num();
 
 #if defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100

--- a/csrc/quantization/fp4/nvfp4_scaled_mm_kernels.cu
+++ b/csrc/quantization/fp4/nvfp4_scaled_mm_kernels.cu
@@ -17,7 +17,7 @@
 #include <torch/all.h>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 
 #include "cutlass_extensions/common.hpp"
 
@@ -301,7 +301,7 @@ void cutlass_scaled_fp4_mm_sm100a(torch::Tensor& D, torch::Tensor const& A,
               B_sf.sizes()[1], ")");
 
   auto out_dtype = D.dtype();
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
+  const c10::DeviceGuard device_guard(A.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream(A.get_device());
 
   if (out_dtype == at::ScalarType::Half) {

--- a/csrc/quantization/fp4/nvfp4_scaled_mm_sm120_kernels.cu
+++ b/csrc/quantization/fp4/nvfp4_scaled_mm_sm120_kernels.cu
@@ -17,7 +17,7 @@
 #include <torch/all.h>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 
 #include "cutlass_extensions/common.hpp"
 
@@ -264,7 +264,7 @@ void cutlass_scaled_fp4_mm_sm120a(torch::Tensor& D, torch::Tensor const& A,
               B_sf.sizes()[1], ")");
 
   auto out_dtype = D.dtype();
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
+  const c10::DeviceGuard device_guard(A.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream(A.get_device());
 
   if (out_dtype == at::ScalarType::BFloat16) {

--- a/csrc/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu
+++ b/csrc/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu
@@ -1,6 +1,6 @@
 
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 
 #include "../../dispatch_utils.h"
 #include "layernorm_utils.cuh"
@@ -100,7 +100,7 @@ void rms_norm_dynamic_per_token_quant_dispatch(
 
   dim3 grid(num_tokens);
   dim3 block(std::min(hidden_size, 1024));
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const c10::DeviceGuard device_guard(input.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   if (residual.has_value()) {

--- a/csrc/quantization/gptq/q_gemm.cu
+++ b/csrc/quantization/gptq/q_gemm.cu
@@ -7,7 +7,7 @@ https://github.com/qwopqwop200/GPTQ-for-LLaMa
 #include <cstdio>
 
 #include <torch/all.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -1855,7 +1855,7 @@ torch::Tensor gptq_gemm(torch::Tensor a, torch::Tensor b_q_weight,
                         torch::Tensor b_gptq_qzeros,
                         torch::Tensor b_gptq_scales, torch::Tensor b_g_idx,
                         bool use_exllama, bool use_v2_format, int64_t bit) {
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(a));
+  const c10::DeviceGuard device_guard(a.device());
   auto options = torch::TensorOptions().dtype(a.dtype()).device(a.device());
   at::Tensor c = torch::empty({a.size(0), b_q_weight.size(1)}, options);
   at::Tensor temp_dq = torch::empty(
@@ -1877,7 +1877,7 @@ torch::Tensor gptq_gemm(torch::Tensor a, torch::Tensor b_q_weight,
 }
 
 void gptq_shuffle(torch::Tensor q_weight, torch::Tensor q_perm, int64_t bit) {
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(q_weight));
+  const c10::DeviceGuard device_guard(q_weight.device());
   vllm::gptq::shuffle_exllama_weight(
       (uint32_t*)q_weight.data_ptr(),
       q_perm.device().is_meta() || q_perm.numel() == 0

--- a/csrc/quantization/gptq_allspark/allspark_qgemm_w8a16.cu
+++ b/csrc/quantization/gptq_allspark/allspark_qgemm_w8a16.cu
@@ -950,7 +950,7 @@ torch::Tensor allspark_w8a16_gemm(
 
   TORCH_CHECK(group_size == -1, "Currently only supports group_size = -1");
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(a));
+  const c10::DeviceGuard device_guard(a.device());
   const void* a_ptr = reinterpret_cast<const void*>(a.data_ptr());
   const uint8_t* b_ptr = reinterpret_cast<const uint8_t*>(b_qweight.data_ptr());
   const void* b_scale_ptr = reinterpret_cast<const void*>(b_scales.data_ptr());

--- a/csrc/quantization/gptq_marlin/awq_marlin_repack.cu
+++ b/csrc/quantization/gptq_marlin/awq_marlin_repack.cu
@@ -245,7 +245,7 @@ torch::Tensor awq_marlin_repack(torch::Tensor& b_q_weight, int64_t size_k,
   TORCH_CHECK(b_q_weight.dtype() == at::kInt, "b_q_weight type is not kInt");
 
   // Alloc buffers
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(b_q_weight));
+  const c10::DeviceGuard device_guard(b_q_weight.device());
   auto options = torch::TensorOptions()
                      .dtype(b_q_weight.dtype())
                      .device(b_q_weight.device());

--- a/csrc/quantization/gptq_marlin/gptq_marlin.cu
+++ b/csrc/quantization/gptq_marlin/gptq_marlin.cu
@@ -652,7 +652,7 @@ torch::Tensor gptq_marlin_gemm(
   cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, a.get_device());
 
   // Alloc buffers
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(a));
+  const c10::DeviceGuard device_guard(a.device());
   torch::Tensor c;
   if (c_or_none.has_value()) {
     c = c_or_none.value();

--- a/csrc/quantization/gptq_marlin/gptq_marlin_repack.cu
+++ b/csrc/quantization/gptq_marlin/gptq_marlin_repack.cu
@@ -306,7 +306,7 @@ torch::Tensor gptq_marlin_repack(torch::Tensor& b_q_weight, torch::Tensor& perm,
   TORCH_CHECK(perm.dtype() == at::kInt, "perm type is not at::kInt");
 
   // Alloc buffers
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(b_q_weight));
+  const c10::DeviceGuard device_guard(b_q_weight.device());
   auto options = torch::TensorOptions()
                      .dtype(b_q_weight.dtype())
                      .device(b_q_weight.device());

--- a/csrc/quantization/gptq_marlin/marlin_int4_fp8_preprocess.cu
+++ b/csrc/quantization/gptq_marlin/marlin_int4_fp8_preprocess.cu
@@ -62,7 +62,7 @@ torch::Tensor marlin_int4_fp8_preprocess(
   TORCH_CHECK(qweight.scalar_type() == at::ScalarType::Int,
               "qweight.dtype != torch.int32");
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(qweight));
+  const c10::DeviceGuard device_guard(qweight.device());
 
   torch::Tensor output = inplace ? qweight : torch::empty_like(qweight);
 
@@ -82,7 +82,7 @@ torch::Tensor marlin_int4_fp8_preprocess(
     TORCH_CHECK(qzeros.device().is_cuda(), "qzeros is not on GPU");
     TORCH_CHECK(qzeros.scalar_type() == at::ScalarType::Int,
                 "qweight.dtype != torch.int32");
-    TORCH_CHECK(device_of(qweight) == device_of(qzeros),
+    TORCH_CHECK(qweight.device() == qzeros.device(),
                 "qzeros is not on the same device with qweight");
 
     int32_t group_size = qweight.size(0) / qzeros.size(0);

--- a/csrc/quantization/machete/machete_mm_launcher.cuh
+++ b/csrc/quantization/machete/machete_mm_launcher.cuh
@@ -39,7 +39,7 @@ std::vector<std::string> supported_schedules_dispatch(
 
 template <typename MacheteKernel>
 torch::Tensor run_impl(MMArgs args) {
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(args.A));
+  const c10::DeviceGuard device_guard(args.A.device());
 
   auto device = args.A.device();
   auto stream = at::cuda::getCurrentCUDAStream(device.index());

--- a/csrc/quantization/machete/machete_prepack_launcher.cuh
+++ b/csrc/quantization/machete/machete_prepack_launcher.cuh
@@ -15,7 +15,7 @@ struct PrepackBArgs {
 
 template <typename PrepackedLayoutB>
 torch::Tensor prepack_impl(torch::Tensor const B) {
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(B));
+  const c10::DeviceGuard device_guard(B.device());
   using ElementB = typename PrepackedLayoutB::ElementB;
   using PPBlockShape_NK = typename PrepackedLayoutB::PPBlockShape_NK;
 

--- a/csrc/quantization/marlin/sparse/marlin_24_cuda_kernel.cu
+++ b/csrc/quantization/marlin/sparse/marlin_24_cuda_kernel.cu
@@ -19,7 +19,7 @@
 #include <torch/all.h>
 
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include <cuda.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
@@ -1096,7 +1096,7 @@ torch::Tensor gptq_marlin_24_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
               "A is not float16, currently only float16 is supported");
 
   // Alloc C matrix
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(a));
+  const c10::DeviceGuard device_guard(a.device());
   auto options = torch::TensorOptions().dtype(a.dtype()).device(a.device());
   torch::Tensor c = torch::empty({size_m, size_n}, options);
 

--- a/csrc/quantization/w8a8/cutlass/scaled_mm_entry.cu
+++ b/csrc/quantization/w8a8/cutlass/scaled_mm_entry.cu
@@ -1,6 +1,6 @@
 #include <cudaTypedefs.h>
 
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include <torch/all.h>
 
 #include "cutlass_extensions/common.hpp"
@@ -192,7 +192,7 @@ void cutlass_scaled_mm(torch::Tensor& c, torch::Tensor const& a,
                 bias->dim() == 1);
   }
 
-  at::cuda::OptionalCUDAGuard const device_guard(device_of(a));
+  c10::DeviceGuard const device_guard(a.device());
   int32_t version_num = get_sm_version_num();
 
 #if defined ENABLE_SCALED_MM_SM120 && ENABLE_SCALED_MM_SM120
@@ -382,7 +382,7 @@ void cutlass_scaled_mm_azp(torch::Tensor& c, torch::Tensor const& a,
   TORCH_CHECK(!bias || bias->dtype() == c.dtype(),
               "currently bias dtype must match output dtype ", c.dtype());
 
-  at::cuda::OptionalCUDAGuard const device_guard(device_of(a));
+  c10::DeviceGuard const device_guard(a.device());
 
   int32_t version_num = get_sm_version_num();
 

--- a/csrc/quantization/w8a8/fp8/common.cu
+++ b/csrc/quantization/w8a8/fp8/common.cu
@@ -2,7 +2,8 @@
 #include "dispatch_utils.h"
 #include "cub_helpers.h"
 #include "quantization/vectorization_utils.cuh"
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
+#include <c10/cuda/CUDAStream.h>
 #include <ATen/cuda/Exceptions.h>
 
 namespace vllm {
@@ -151,7 +152,7 @@ void static_scaled_fp8_quant(torch::Tensor& out,          // [..., d]
   const int64_t in_row_stride = input.stride(-2);
   const int64_t out_row_stride = out.stride(-2);
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const c10::DeviceGuard device_guard(input.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "scaled_fp8_quant_kernel_scalar_type", [&] {
@@ -184,7 +185,7 @@ void dynamic_scaled_fp8_quant(torch::Tensor& out,          // [..., d]
   const int64_t in_row_stride = input.stride(-2);
   const int64_t out_row_stride = out.stride(-2);
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const c10::DeviceGuard device_guard(input.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   // scale tensor should be initialised to <=0 before reduction
@@ -228,7 +229,7 @@ void dynamic_per_token_scaled_fp8_quant(
   const int64_t in_row_stride = input.stride(-2);
   const int64_t out_row_stride = out.stride(-2);
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const c10::DeviceGuard device_guard(input.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(),

--- a/csrc/quantization/w8a8/int8/scaled_quant.cu
+++ b/csrc/quantization/w8a8/int8/scaled_quant.cu
@@ -1,6 +1,6 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/all.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 
 #include <cmath>
 
@@ -276,7 +276,7 @@ void static_scaled_int8_quant(torch::Tensor& out,          // [..., hidden_size]
   int const num_tokens = input.numel() / hidden_size;
   dim3 const grid(num_tokens);
   dim3 const block(std::min(hidden_size, 256));
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const c10::DeviceGuard device_guard(input.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "static_scaled_int8_quant_kernel", [&] {
@@ -308,7 +308,7 @@ void dynamic_scaled_int8_quant(
   int const num_tokens = input.numel() / hidden_size;
   dim3 const grid(num_tokens);
   dim3 const block(std::min(hidden_size, 256));
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const c10::DeviceGuard device_guard(input.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "dynamic_scaled_int8_quant_kernel", [&] {

--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -16,7 +16,7 @@
 
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include <hip/hip_fp8.h>
 #include <hip/hip_bf16.h>
 #include "../cuda_compat.h"
@@ -3287,7 +3287,7 @@ void paged_attention_custom_launcher(
   constexpr int NTHR = 256;
   dim3 grid(num_seqs, max_num_partitions, num_kv_heads);
   dim3 block(NTHR);
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(query));
+  const c10::DeviceGuard device_guard(query.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   // mfma4 kernel is faster than mfma16 for gqa_ratio <= 4
@@ -3436,7 +3436,7 @@ void paged_attention_custom_launcher_navi(
   constexpr int NTHR = 256;
   dim3 grid(num_seqs, max_num_partitions, num_kv_heads);
   dim3 block(NTHR);
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(query));
+  const c10::DeviceGuard device_guard(query.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   switch (gqa_ratio) {

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1,6 +1,6 @@
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -248,7 +248,7 @@ torch::Tensor LLMM1(at::Tensor& in_a, at::Tensor& in_b,
 
   int NUM_BLOCKS = M / rows_per_block;
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_b));
+  const c10::DeviceGuard device_guard(in_b.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   // call the kernel function...
@@ -1296,7 +1296,7 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
 
   dim3 grid(CuCount);
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_a));
+  const c10::DeviceGuard device_guard(in_a.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   const int max_lds_len = get_lds_size() / 2;
 
@@ -1754,7 +1754,7 @@ void wvSplitKQ(const at::Tensor& in_a, const at::Tensor& in_b,
               out_c.dtype() == torch::kBFloat16);
 
   dim3 grid(CuCount);
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_a));
+  const c10::DeviceGuard device_guard(in_a.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   const int max_lds_len = get_lds_size();
 

--- a/csrc/sampler.cu
+++ b/csrc/sampler.cu
@@ -1,7 +1,8 @@
 #include "dispatch_utils.h"
 
 #include <torch/cuda.h>
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
+#include <c10/cuda/CUDAStream.h>
 
 #ifndef USE_ROCM
   #include <cub/cub.cuh>
@@ -324,7 +325,7 @@ void apply_repetition_penalties_(
   // Each block handles one sequence and a tile of vocab
   dim3 grid(num_seqs, tile_num);
   dim3 block(std::min(tile_size, 1024));
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(logits));
+  const c10::DeviceGuard device_guard(logits.device());
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   VLLM_DISPATCH_FLOATING_TYPES(
       logits.scalar_type(), "apply_repetition_penalties_kernel", [&] {

--- a/csrc/sparse/cutlass/sparse_scaled_mm_entry.cu
+++ b/csrc/sparse/cutlass/sparse_scaled_mm_entry.cu
@@ -1,6 +1,6 @@
 #include <cudaTypedefs.h>
 
-#include <c10/cuda/CUDAGuard.h>
+#include <c10/core/DeviceGuard.h>
 #include <torch/all.h>
 
 #include "cutlass_extensions/common.hpp"
@@ -53,7 +53,7 @@ void cutlass_scaled_sparse_mm(torch::Tensor& c, torch::Tensor const& a,
                 bias->dim() == 1);
   }
 
-  at::cuda::OptionalCUDAGuard const device_guard(device_of(a));
+  c10::DeviceGuard const device_guard(a.device());
   int32_t version_num = get_sm_version_num();
 
   // Guard against compilation issues for sm90 kernels
@@ -79,7 +79,7 @@ std::vector<torch::Tensor> cutlass_sparse_compress(torch::Tensor const& a) {
   TORCH_CHECK(a.stride(1) == 1);      // Row-major
   TORCH_CHECK(a.stride(0) % 8 == 0);  // 8 Byte Alignment for Compression
 
-  at::cuda::OptionalCUDAGuard const device_guard(device_of(a));
+  c10::DeviceGuard const device_guard(a.device());
   int32_t version_num = get_sm_version_num();
 
   // Guard against compilation issues for sm90 kernels


### PR DESCRIPTION

## Purpose
Migrate usage of OptionalCUDAGuard to DeviceGuard. The main purpose of this is to prepare for migration to the stable ABI see https://github.com/vllm-project/vllm/issues/26946, which doesn't have plans to support OptionalCUDAGuard today.

DeviceGuard instead of OptionalCUDAGuard should be viable because none of the tensors that we get device from are `std::optional` and all should be defined.

## Test Plan
CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

