### PR TITLE
[FIX]Patch run-cluster.sh (fix for #28328)

### DIFF
--- a/examples/online_serving/run_cluster.sh
+++ b/examples/online_serving/run_cluster.sh
@@ -21,7 +21,7 @@
 #         --worker \
 #         /abs/path/to/huggingface/cache \
 #         -e VLLM_HOST_IP=<worker_node_ip>
-# 
+#
 # Each worker requires a unique VLLM_HOST_IP value.
 # Keep each terminal session open. Closing a session stops the associated Ray
 # node and thereby shuts down the entire cluster.
@@ -59,6 +59,34 @@ if [ "${NODE_TYPE}" != "--head" ] && [ "${NODE_TYPE}" != "--worker" ]; then
     exit 1
 fi
 
+# Extract VLLM_HOST_IP from ADDITIONAL_ARGS (e.g. "-e VLLM_HOST_IP=...").
+VLLM_HOST_IP=""
+for ((i = 0; i < ${#ADDITIONAL_ARGS[@]}; i++)); do
+    arg="${ADDITIONAL_ARGS[$i]}"
+    case "${arg}" in
+        -e)
+            next="${ADDITIONAL_ARGS[$((i + 1))]:-}"
+            if [[ "${next}" == VLLM_HOST_IP=* ]]; then
+                VLLM_HOST_IP="${next#VLLM_HOST_IP=}"
+                break
+            fi
+            ;;
+        -eVLLM_HOST_IP=* | VLLM_HOST_IP=*)
+            VLLM_HOST_IP="${arg#*=}"
+            break
+            ;;
+    esac
+done
+
+# For the head node, HEAD_NODE_ADDRESS and VLLM_HOST_IP should be consistent.
+if [[ "${NODE_TYPE}" == "--head" && -n "${VLLM_HOST_IP}" ]]; then
+    if [[ "${VLLM_HOST_IP}" != "${HEAD_NODE_ADDRESS}" ]]; then
+        echo "Warning: VLLM_HOST_IP (${VLLM_HOST_IP}) differs from head_node_ip (${HEAD_NODE_ADDRESS})."
+        echo "Using VLLM_HOST_IP as the head node address."
+        HEAD_NODE_ADDRESS="${VLLM_HOST_IP}"
+    fi
+fi
+
 # Generate a unique container name with random suffix.
 # Docker container names must be unique on each host.
 # The random suffix allows multiple Ray containers to run simultaneously on the same machine,
@@ -74,7 +102,7 @@ cleanup() {
 trap cleanup EXIT
 
 # Build the Ray start command based on the node role.
-# The head node manages the cluster and accepts connections on port 6379, 
+# The head node manages the cluster and accepts connections on port 6379,
 # while workers connect to the head's address.
 RAY_START_CMD="ray start --block"
 if [ "${NODE_TYPE}" == "--head" ]; then

--- a/examples/online_serving/run_cluster.sh
+++ b/examples/online_serving/run_cluster.sh
@@ -80,7 +80,19 @@ RAY_START_CMD="ray start --block"
 if [ "${NODE_TYPE}" == "--head" ]; then
     RAY_START_CMD+=" --head --node-ip-address=${HEAD_NODE_ADDRESS} --port=6379"
 else
-    RAY_START_CMD+=" --address=${HEAD_NODE_ADDRESS}:6379 --node-ip-address=${VLLM_HOST_IP}"
+    # Parse VLLM_HOST_IP from additional args if present
+    VLLM_HOST_IP=""
+    for arg in "${ADDITIONAL_ARGS[@]}"; do
+        if [[ $arg == VLLM_HOST_IP=* ]]; then
+            VLLM_HOST_IP="${arg#VLLM_HOST_IP=}"
+            break
+        fi
+    done
+
+    RAY_START_CMD+=" --address=${HEAD_NODE_ADDRESS}:6379"
+    if [ -n "${VLLM_HOST_IP}" ]; then
+        RAY_START_CMD+=" --node-ip-address=${VLLM_HOST_IP}"
+    fi
 fi
 
 # Launch the container with the assembled parameters.

--- a/examples/online_serving/run_cluster.sh
+++ b/examples/online_serving/run_cluster.sh
@@ -80,14 +80,6 @@ RAY_START_CMD="ray start --block"
 if [ "${NODE_TYPE}" == "--head" ]; then
     RAY_START_CMD+=" --head --node-ip-address=${HEAD_NODE_ADDRESS} --port=6379"
 else
-    # Parse VLLM_HOST_IP from additional args if present
-    VLLM_HOST_IP=""
-    for arg in "${ADDITIONAL_ARGS[@]}"; do
-        if [[ $arg == VLLM_HOST_IP=* ]]; then
-            VLLM_HOST_IP="${arg#VLLM_HOST_IP=}"
-            break
-        fi
-    done
 
     RAY_START_CMD+=" --address=${HEAD_NODE_ADDRESS}:6379"
     if [ -n "${VLLM_HOST_IP}" ]; then


### PR DESCRIPTION
## Purpose
This PR corrects the addition for [28328](https://github.com/vllm-project/vllm/pull/28328) by removing the new block to build vLLM variables and instead just adds the node ip address to the ray start command. This fixes any issues when a device has multiple interfaces. 
Use case: Device has ethernet & QSFP cabling and we want ray to serve over the high speed link.
## Test Plan
In our scenario we are running 2x devices with 2 interfaces each -- one ethernet cable providing internet access and one QSFP cable connecting the two servers directly (P2P). We want to confirm the arguments passed to the run_cluster.sh script respect these input arguments and that Ray itself selects the P2P QSFP interfaces, instead of the default behavior to select the ethernet interface (public IP address) of both nodes.


## Test Result
From node 1:
```
$ export VLLM_IMAGE=nvcr.io/nvidia/vllm:25.11-py3
$ export MN_IF_NAME=enp1s0f1np1
$ export VLLM_HOST_IP=$(ip -4 addr show $MN_IF_NAME | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
$ echo "Using interface $MN_IF_NAME with IP $VLLM_HOST_IP"
Using interface enp1s0f1np1 with IP 192.168.200.12

$ bash run_cluster.sh $VLLM_IMAGE $VLLM_HOST_IP --head ~/.cache/huggingface   -e VLLM_HOST_IP=$VLLM_HOST_IP   -e UCX_NET_DEVICES=$MN_IF_NAME   -e NCCL_SOCKET_IFNAME=$MN_IF_NAME   -e OMPI_MCA_btl_tcp_if_include=$MN_IF_NAME   -e GLOO_SOCKET_IFNAME=$MN_IF_NAME   -e TP_SOCKET_IFNAME=$MN_IF_NAME   -e RAY_memory_monitor_refresh_ms=0   -e MASTER_ADDR=$VLLM_HOST_IP
2025-12-05 20:17:59,542	INFO usage_lib.py:473 -- Usage stats collection is enabled by default without user confirmation because this terminal is detected to be non-interactive. To disable this, add `--disable-usage-stats` to the command that starts the cluster, or run the following command: `ray disable-usage-stats` before starting the cluster. See https://docs.ray.io/en/master/cluster/usage-stats.html for more details.
2025-12-05 20:17:59,542	INFO scripts.py:914 -- Local node IP: 192.168.200.12
2025-12-05 20:18:00,748	SUCC scripts.py:950 -- --------------------
2025-12-05 20:18:00,748	SUCC scripts.py:951 -- Ray runtime started.
2025-12-05 20:18:00,748	SUCC scripts.py:952 -- --------------------
2025-12-05 20:18:00,748	INFO scripts.py:954 -- Next steps
2025-12-05 20:18:00,748	INFO scripts.py:957 -- To add another node to this Ray cluster, run
2025-12-05 20:18:00,748	INFO scripts.py:960 --   ray start --address='192.168.200.12:6379'
2025-12-05 20:18:00,748	INFO scripts.py:969 -- To connect to this Ray cluster:
2025-12-05 20:18:00,748	INFO scripts.py:971 -- import ray
2025-12-05 20:18:00,748	INFO scripts.py:972 -- ray.init(_node_ip_address='192.168.200.12')
2025-12-05 20:18:00,748	INFO scripts.py:984 -- To submit a Ray job using the Ray Jobs CLI:
2025-12-05 20:18:00,749	INFO scripts.py:985 --   RAY_API_SERVER_ADDRESS='http://127.0.0.1:8265/' ray job submit --working-dir . -- python my_script.py
2025-12-05 20:18:00,749	INFO scripts.py:994 -- See https://docs.ray.io/en/latest/cluster/running-applications/job-submission/index.html 
2025-12-05 20:18:00,749	INFO scripts.py:998 -- for more information on submitting Ray jobs to the Ray cluster.
2025-12-05 20:18:00,749	INFO scripts.py:1003 -- To terminate the Ray runtime, run
2025-12-05 20:18:00,749	INFO scripts.py:1004 --   ray stop
2025-12-05 20:18:00,749	INFO scripts.py:1007 -- To view the status of the cluster, use
2025-12-05 20:18:00,749	INFO scripts.py:1008 --   ray status
2025-12-05 20:18:00,749	INFO scripts.py:1012 -- To monitor and debug Ray, view the dashboard at 
2025-12-05 20:18:00,749	INFO scripts.py:1013 --   127.0.0.1:8265
2025-12-05 20:18:00,749	INFO scripts.py:1020 -- If connection to the dashboard fails, check your firewall settings and network configuration.
2025-12-05 20:18:00,749	INFO scripts.py:1121 -- --block
2025-12-05 20:18:00,749	INFO scripts.py:1122 -- This command will now block forever until terminated by a signal.
2025-12-05 20:18:00,749	INFO scripts.py:1125 -- Running subprocesses are monitored and a message will be printed if any of them terminate unexpectedly. Subprocesses exit with SIGTERM will be treated as graceful, thus NOT reported.
```
From Node 2
```
$ export VLLM_IMAGE=nvcr.io/nvidia/vllm:25.11-py3
$ export MN_IF_NAME=enp1s0f1np1
$ export VLLM_HOST_IP=$(ip -4 addr show $MN_IF_NAME | grep -oP '(?<=inet\s)\d+(\.\d+){3}')
$ echo "Using interface $MN_IF_NAME with IP $VLLM_HOST_IP"
Using interface enp1s0f1np1 with IP 192.168.200.13
$ export HEAD_NODE_IP=192.168.200.12

$ bash run_cluster.sh $VLLM_IMAGE $HEAD_NODE_IP --worker ~/.cache/huggingface   -e VLLM_HOST_IP=$VLLM_HOST_IP   -e UCX_NET_DEVICES=$MN_IF_NAME   -e NCCL_SOCKET_IFNAME=$MN_IF_NAME   -e OMPI_MCA_btl_tcp_if_include=$MN_IF_NAME   -e GLOO_SOCKET_IFNAME=$MN_IF_NAME   -e TP_SOCKET_IFNAME=$MN_IF_NAME   -e RAY_memory_monitor_refresh_ms=0   -e MASTER_ADDR=$HEAD_NODE_IP
2025-12-05 20:19:22,139	INFO scripts.py:1095 -- Local node IP: 192.168.200.13
2025-12-05 20:19:22,350	SUCC scripts.py:1108 -- --------------------
2025-12-05 20:19:22,350	SUCC scripts.py:1109 -- Ray runtime started.
2025-12-05 20:19:22,350	SUCC scripts.py:1110 -- --------------------
2025-12-05 20:19:22,350	INFO scripts.py:1112 -- To terminate the Ray runtime, run
2025-12-05 20:19:22,350	INFO scripts.py:1113 --   ray stop
2025-12-05 20:19:22,351	INFO scripts.py:1121 -- --block
2025-12-05 20:19:22,351	INFO scripts.py:1122 -- This command will now block forever until terminated by a signal.
2025-12-05 20:19:22,351	INFO scripts.py:1125 -- Running subprocesses are monitored and a message will be printed if any of them terminate unexpectedly. Subprocesses exit with SIGTERM will be treated as graceful, thus NOT reported.
```
Ray status:
```
$ docker exec $VLLM_CONTAINER ray status
======== Autoscaler status: 2025-12-05 20:19:35.263362 ========
Node status
---------------------------------------------------------------
Active:
 1 node_e4e6c7bbd25f4ce2fa1ed0cf2e71680b425d7b06922120a28cc5d371
 1 node_b3d73a90f8f40ad9f1aeefcbe7653e04cfe80c7f22b511f78349edf9
Pending:
 (no pending nodes)
Recent failures:
 (no failures)

Resources
---------------------------------------------------------------
Total Usage:
 0.0/40.0 CPU
 0.0/2.0 GPU
 0B/218.88GiB memory
 0B/19.46GiB object_store_memory

From request_resources:
 (none)
Pending Demands:
 (no resource demands)
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

