### PR TITLE
[CI][AMD] Match Main CI Behavior By Skipping test_eplb_spec_decode In AMD CI

### DIFF
--- a/tests/distributed/test_eplb_spec_decode.py
+++ b/tests/distributed/test_eplb_spec_decode.py
@@ -6,6 +6,7 @@ import lm_eval
 import pytest
 
 from tests.utils import large_gpu_mark
+from vllm.platforms import current_platform
 
 
 def get_model_args(
@@ -43,6 +44,12 @@ def get_model_args(
         "max_model_len": model_max_len,
     }
     return model_args
+
+
+pytestmark = pytest.mark.skipif(
+    current_platform.is_rocm(),
+    reason="EPLB with Spec Decode is a work in progress on ROCm.",
+)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- markdownlint-disable -->
Currently, `pytest -v -s distributed/test_eplb_spec_decode.py` fails on ROCm. As we work on implementing support for this feature, we skip these tests so that we can get a green status for the other functional tests in the EPLB Execution Test group. Also, this actually matches the behavior of main CI as the tests in `test_eplb_spec_decode.py` have never run there (as far as I could tell by looking on Buildkite) due to the `large_gpu_mark(min_gb=80)` marks. I am not sure if that is expected or not, but either way we would like to skip this in AMD CI for now as we work towards fixing the features being tested there.