### PR TITLE
[Feature] Add track_token_ids for Efficient Selective Token Logprobs Tracking

### DIFF
--- a/docs/features/track_token_ids.md
+++ b/docs/features/track_token_ids.md
@@ -1,0 +1,189 @@
+# Tracked Token Logprobs
+
+vLLM supports efficient tracking of log probabilities (logprobs) for specific tokens without requiring full vocabulary logprobs. This feature is useful for classification tasks, constrained generation, and any use case where you need accurate probabilities for a small set of predefined tokens.
+
+## Motivation
+
+When working with LLMs, you may need logprobs for specific tokens (e.g., class labels, binary choices, special tokens). Previously, users had to choose between two suboptimal approaches:
+
+| Approach | Description | Problems |
+|----------|-------------|----------|
+| **Top-k logprobs** (`logprobs=k`) | Hope target tokens appear in top-k | ❌ Unreliable: target tokens may not be in top-k |
+| **Full vocabulary** (`logprobs=-1`) | Retrieve all ~150k logprobs | ❌ Memory overhead (~1.2 MB per token)<br>❌ Large GPU→CPU transfer<br>❌ Wasteful: discard 99.99% of data |
+
+The `track_token_ids` parameter solves this by allowing you to specify exactly which tokens to track, achieving:
+
+- **99.99% memory reduction** compared to full vocabulary retrieval
+- **Reliable results**: tracked tokens are always included regardless of their rank
+- **Minimal overhead**: just indexing specific columns from the logprobs tensor
+
+## Use Cases
+
+### Classification Tasks
+
+Track probabilities for class labels to get reliable classification confidence:
+
+```python
+from vllm import LLM, SamplingParams
+
+llm = LLM(model="meta-llama/Llama-3.1-8B-Instruct")
+tokenizer = llm.get_tokenizer()
+
+# Get token IDs for class labels
+classes = ["Technology", "Politics", "Sports", "Art"]
+track_ids = []
+for label in classes:
+    ids = tokenizer.encode(label, add_special_tokens=False)
+    track_ids.extend(ids)
+
+sampling_params = SamplingParams(
+    temperature=0.0,
+    max_tokens=10,
+    track_token_ids=track_ids,
+)
+
+outputs = llm.generate(
+    ["Classify this article: 'The new GPU architecture shows 2x performance...'"],
+    sampling_params,
+)
+
+# Access tracked logprobs
+tracked = outputs[0].outputs[0].tracked_logprobs
+for token_id, logprobs_over_time in tracked.items():
+    token_str = tokenizer.decode([token_id])
+    print(f"{token_str}: {logprobs_over_time}")
+```
+
+### Binary Decision Making
+
+Perfect for yes/no, true/false, or binary classification scenarios:
+
+```python
+# Medical diagnosis, content moderation, fact-checking, etc.
+yes_ids = tokenizer.encode("Yes", add_special_tokens=False)
+no_ids = tokenizer.encode("No", add_special_tokens=False)
+
+sampling_params = SamplingParams(
+    temperature=0.0,
+    max_tokens=50,
+    track_token_ids=yes_ids + no_ids,
+)
+
+outputs = llm.generate(["Is this content safe? Content: ..."], sampling_params)
+tracked = outputs[0].outputs[0].tracked_logprobs
+# Analyze confidence between Yes/No across generation steps
+```
+
+### AI-Generated Content Detection
+
+Monitor probabilities for detection-related tokens throughout generation:
+
+```python
+# Track "real" vs "ai-generated" probabilities
+real_ids = tokenizer.encode("real", add_special_tokens=False)
+ai_ids = tokenizer.encode("ai-generated", add_special_tokens=False)
+synthetic_ids = tokenizer.encode("synthetic", add_special_tokens=False)
+
+sampling_params = SamplingParams(
+    temperature=0.0,
+    max_tokens=100,
+    track_token_ids=real_ids + ai_ids + synthetic_ids,
+)
+
+outputs = llm.generate(["Is this image real or AI-generated?"], sampling_params)
+
+# Analyze confidence evolution across generation
+tracked = outputs[0].outputs[0].tracked_logprobs
+for token_id, logprobs_over_time in tracked.items():
+    token_str = tokenizer.decode([token_id])
+    print(f"{token_str}: step-by-step logprobs = {logprobs_over_time}")
+```
+
+### Research and Analysis
+
+Track specific vocabulary items for hypothesis testing or model behavior analysis:
+
+```python
+# Study model confidence for specific tokens across long sequences
+interesting_tokens = ["however", "therefore", "because", "but"]
+track_ids = []
+for token in interesting_tokens:
+    track_ids.extend(tokenizer.encode(token, add_special_tokens=False))
+
+sampling_params = SamplingParams(
+    temperature=0.7,
+    max_tokens=500,
+    track_token_ids=track_ids,
+)
+```
+
+## API Reference
+
+### SamplingParams
+
+```python
+from vllm import SamplingParams
+
+sampling_params = SamplingParams(
+    # ... other parameters ...
+    track_token_ids=[1234, 5678, 9012],  # List of token IDs to track
+)
+```
+
+**Parameter:**
+
+- `track_token_ids` (`list[int] | None`): List of token IDs to track logprobs for at every generation step. These tokens will have their logprobs recorded even if they don't appear in the top-k. Default is `None` (disabled).
+
+### Output Format
+
+Tracked logprobs are available in the `CompletionOutput`:
+
+```python
+@dataclass
+class CompletionOutput:
+    # ... existing fields ...
+    tracked_logprobs: dict[int, list[float]] | None
+    """Logprobs for tracked tokens across all generation steps.
+    
+    Format: {token_id: [logprob_step0, logprob_step1, ...]}
+    Only present if track_token_ids was specified in SamplingParams.
+    """
+```
+
+**Example output structure:**
+
+```python
+# For track_token_ids=[100, 200, 300] with 5 generation steps:
+tracked_logprobs = {
+    100: [-2.3, -1.8, -2.1, -3.0, -2.5],  # logprobs at each step
+    200: [-5.1, -4.9, -5.3, -4.7, -5.0],
+    300: [-8.2, -7.9, -8.5, -8.1, -8.3],
+}
+```
+
+## Combining with Regular Logprobs
+
+You can use `track_token_ids` alongside regular top-k logprobs:
+
+```python
+sampling_params = SamplingParams(
+    logprobs=5,                    # Get top-5 logprobs as usual
+    track_token_ids=[100, 200],    # Also track these specific tokens
+)
+
+outputs = llm.generate(prompts, sampling_params)
+
+# Access both
+for output in outputs:
+    completion = output.outputs[0]
+    
+    # Regular top-k logprobs (list of dicts, one per step)
+    top_k = completion.logprobs
+    
+    # Tracked token logprobs (dict of lists)
+    tracked = completion.tracked_logprobs
+```
+
+## Edge Cases
+
+- **Empty track list** (`track_token_ids=[]`): Returns an empty dict `{}`

--- a/docs/usage/v1_guide.md
+++ b/docs/usage/v1_guide.md
@@ -61,6 +61,12 @@ Processed means the values after applying all processors, including temperature 
 While V1 supports passing prompt logprobs with prefix caching enabled, it no longer caches the logprobs.
 For a request requiring prompt logprobs, the engine will ignore the prefix cache and recompute the prefill of full prompt to generate the logprobs.
 
+#### Tracked Token Logprobs (New in V1)
+
+V1 introduces the `track_token_ids` parameter in `SamplingParams`, which enables efficient tracking of logprobs for specific tokens without requiring full vocabulary logprobs. This is useful for classification tasks, constrained generation, and any use case where you need probabilities for a small set of predefined tokens (e.g., class labels).
+
+See [Tracked Token Logprobs](../features/track_token_ids.md) for detailed documentation and usage examples.
+
 ## Feature Support
 
 For each item, its support in vLLM V1 falls into one of the following states:
@@ -146,6 +152,7 @@ encoder and decoder (e.g., `BartForConditionalGeneration`,
 | **Chunked Prefill**                         | <nobr>🟢 Functional</nobr>                                                        |
 | **LoRA**                                    | <nobr>🟢 Functional</nobr>                                                        |
 | **Logprobs Calculation**                    | <nobr>🟢 Functional</nobr>                                                        |
+| **Tracked Token Logprobs**                  | <nobr>🟢 Functional</nobr>                                                        |
 | **FP8 KV Cache**                            | <nobr>🟢 Functional</nobr>                                                        |
 | **Spec Decode**                             | <nobr>🟢 Functional</nobr>                                                        |
 | **Prompt Logprobs with Prefix Caching**     | <nobr>🟢 Functional</nobr>                                                        |

--- a/tests/v1/e2e/test_tracked_logprobs.py
+++ b/tests/v1/e2e/test_tracked_logprobs.py
@@ -1,0 +1,1655 @@
+"""End-to-end tests for track_token_ids feature."""
+
+import asyncio
+import math
+import os
+
+os.environ["FLASHINFER_DISABLE_VERSION_CHECK"] = "1"
+
+import pytest
+import torch
+
+from vllm import LLM, SamplingParams
+from vllm.distributed import cleanup_dist_env_and_memory
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.sampling_params import RequestOutputKind
+from vllm.v1.engine.async_llm import AsyncLLM
+
+# Use a smaller model for faster testing
+MODEL_PATH = "Qwen/Qwen3-14B"
+
+
+@pytest.fixture(scope="module")
+def llm_instance():
+    """Create a shared LLM instance for all tests.
+
+    Uses max_logprobs=-1 to allow full vocabulary logprobs for differential tests.
+    """
+    return LLM(MODEL_PATH, enforce_eager=True, max_logprobs=-1)
+
+
+@pytest.fixture(scope="module")
+def async_llm_instance():
+    """Create a shared AsyncLLM instance for streaming tests.
+
+    Uses max_logprobs=-1 to allow full vocabulary logprobs for differential tests.
+    Note: Tests using this fixture must use @pytest.mark.asyncio(loop_scope="module")(loop_scope="module")
+    to ensure the event loop scope matches the fixture scope.
+    """
+    engine_args = AsyncEngineArgs(
+        model=MODEL_PATH,
+        enforce_eager=True,
+        max_logprobs=-1,
+    )
+    engine = AsyncLLM.from_engine_args(engine_args)
+    yield engine
+    engine.shutdown()
+
+
+class TestTrackTokenIdsBasic:
+    """Basic functionality tests for track_token_ids."""
+
+    def test_track_token_ids_returns_logprobs(self, llm_instance):
+        """Test that track_token_ids returns logprobs for specified tokens."""
+        track_ids = [1234, 5678, 9012]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=10,
+            track_token_ids=track_ids,
+        )
+
+        outputs = llm_instance.generate(["Hello, my name is"], sampling_params)
+
+        assert len(outputs) == 1
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is not None
+        assert isinstance(tracked, dict)
+
+        # All tracked token IDs should be present
+        for tid in track_ids:
+            assert tid in tracked, f"Token {tid} not in tracked_logprobs"
+            # Should have one logprob per generated token
+            assert len(tracked[tid]) == 10, (
+                f"Expected 10 logprobs for token {tid}, got {len(tracked[tid])}"
+            )
+            # All values should be valid log probabilities (<= 0)
+            for lp in tracked[tid]:
+                assert lp <= 0, f"Logprob {lp} should be <= 0"
+
+    def test_track_token_ids_with_logprobs_coexist(self, llm_instance):
+        """Test that track_token_ids works alongside regular logprobs."""
+        track_ids = [100, 200, 300]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            logprobs=5,  # Request top-5 logprobs
+            track_token_ids=track_ids,
+        )
+
+        outputs = llm_instance.generate(["The capital of France is"], sampling_params)
+
+        output = outputs[0].outputs[0]
+
+        # Regular logprobs should be present
+        assert output.logprobs is not None
+        assert len(output.logprobs) == 5
+
+        # Tracked logprobs should also be present
+        assert output.tracked_logprobs is not None
+        for tid in track_ids:
+            assert tid in output.tracked_logprobs
+            assert len(output.tracked_logprobs[tid]) == 5
+
+
+class TestTrackTokenIdsNoneAndEmpty:
+    """Tests for track_token_ids=None and track_token_ids=[]."""
+
+    def test_track_token_ids_not_provided(self, llm_instance):
+        """Test that not providing track_token_ids returns None."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+        )
+
+        outputs = llm_instance.generate(["Hello world"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is None, f"Expected None, got {tracked}"
+
+    def test_track_token_ids_explicit_none(self, llm_instance):
+        """Test that track_token_ids=None explicitly returns None."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=None,
+        )
+
+        outputs = llm_instance.generate(["Hello world"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is None, f"Expected None, got {tracked}"
+
+    def test_track_token_ids_empty_list(self, llm_instance):
+        """Test that track_token_ids=[] returns empty dict."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=[],
+        )
+
+        outputs = llm_instance.generate(["Hello world"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked == {}, f"Expected empty dict, got {tracked}"
+
+
+class TestTrackTokenIdsBatch:
+    """Tests for batch processing with track_token_ids."""
+
+    def test_batch_multiple_prompts_same_track_ids(self, llm_instance):
+        """Test batch with multiple prompts using same track_token_ids."""
+        track_ids = [500, 1000, 1500]
+        prompts = [
+            "Hello, my name is",
+            "The president of the United States is",
+            "The capital of France is",
+            "The future of AI is",
+        ]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=10,
+            track_token_ids=track_ids,
+        )
+
+        outputs = llm_instance.generate(prompts, sampling_params)
+
+        assert len(outputs) == 4
+
+        for i, output in enumerate(outputs):
+            tracked = output.outputs[0].tracked_logprobs
+            assert tracked is not None, f"Prompt {i}: tracked_logprobs is None"
+
+            for tid in track_ids:
+                assert tid in tracked, f"Prompt {i}: token {tid} not tracked"
+                assert len(tracked[tid]) == 10, (
+                    f"Prompt {i}: token {tid} has {len(tracked[tid])} logprobs, "
+                    f"expected 10"
+                )
+
+    def test_batch_different_max_tokens(self, llm_instance):
+        """Test batch where different prompts might finish at different times."""
+        track_ids = [100, 200]
+        prompts = ["Hi", "Hello there, how are you doing today"]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=15,
+            track_token_ids=track_ids,
+        )
+
+        outputs = llm_instance.generate(prompts, sampling_params)
+
+        for output in outputs:
+            tracked = output.outputs[0].tracked_logprobs
+            assert tracked is not None
+            for tid in track_ids:
+                assert tid in tracked
+                # Each should have logprobs for each generated token
+                num_gen = len(output.outputs[0].token_ids)
+                assert len(tracked[tid]) == num_gen
+
+
+class TestTrackTokenIdsDifferential:
+    """Differential tests comparing track_token_ids vs full logprobs.
+
+    IMPORTANT: All tests use BOTH track_token_ids AND logprobs=-1 in the SAME
+    request to ensure we compare values from identical computation. Using two
+    separate generations would be unreliable even with the same seed.
+    """
+
+    def test_tracked_vs_full_logprobs_match(self, llm_instance):
+        """
+        CRITICAL TEST: Verify track_token_ids produces same values as
+        extracting from full vocabulary logprobs (logprobs=-1).
+
+        Uses BOTH parameters in the same request for reliable comparison.
+        """
+        track_ids = [100, 500, 1000, 2000, 5000]
+        prompt = "The meaning of life is"
+        max_tokens = 10
+
+        # Use BOTH track_token_ids AND logprobs=-1 in the same request
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=-1,  # Full vocabulary logprobs
+            track_token_ids=track_ids,  # Also track specific tokens
+        )
+        outputs = llm_instance.generate([prompt], params)
+
+        output = outputs[0].outputs[0]
+        tracked_logprobs = output.tracked_logprobs
+        full_logprobs_list = output.logprobs
+
+        # Compare: tracked values should match extracted from full
+        assert tracked_logprobs is not None
+        assert full_logprobs_list is not None
+
+        for tid in track_ids:
+            assert tid in tracked_logprobs
+
+            for step_idx in range(max_tokens):
+                tracked_value = tracked_logprobs[tid][step_idx]
+
+                # Extract from full logprobs
+                step_full = full_logprobs_list[step_idx]
+                if tid in step_full:
+                    full_value = step_full[tid].logprob
+                else:
+                    pytest.fail(
+                        f"Token {tid} not in full logprobs at step {step_idx}"
+                    )
+
+                # Values should match exactly (same computation)
+                assert math.isclose(tracked_value, full_value), (
+                    f"Mismatch at step {step_idx} for token {tid}: "
+                    f"tracked={tracked_value}, full={full_value}"
+                )
+
+    @pytest.mark.parametrize(
+        "temperature,top_p,top_k",
+        [
+            (0.0, 1.0, -1),  # Greedy
+            (0.7, 1.0, -1),  # Standard temperature 1
+            (2.0, 1.0, -1),  # Standard temperature 2
+            (10.0, 1.0, -1),  # Standard temperature 3
+            (1.0, 0.9, -1),  # With top_p
+            (0.8, 1.0, 50),  # With top_k
+            (0.8, 0.95, 100),  # Combined
+        ],
+    )
+    def test_tracked_vs_full_various_sampling(
+        self, llm_instance, temperature, top_p, top_k
+    ):
+        """
+        Test tracked logprobs match full logprobs under various sampling configs.
+
+        Uses BOTH parameters in the same request - no need for seed matching
+        since we compare values from the same generation.
+        """
+        track_ids = [100, 1000, 5000]
+        prompt = "Once upon a time"
+        max_tokens = 5
+
+        # Use BOTH track_token_ids AND logprobs=-1 in the same request
+        params = SamplingParams(
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            max_tokens=max_tokens,
+            logprobs=-1,
+            track_token_ids=track_ids,
+        )
+        outputs = llm_instance.generate([prompt], params)
+
+        output = outputs[0].outputs[0]
+        tracked = output.tracked_logprobs
+        full_list = output.logprobs
+
+        # Compare - should match exactly since same computation
+        assert tracked is not None
+        assert full_list is not None
+
+        for tid in track_ids:
+            for step_idx in range(max_tokens):
+                tracked_val = tracked[tid][step_idx]
+                full_val = full_list[step_idx][tid].logprob
+
+                assert math.isclose(tracked_val, full_val), (
+                    f"Mismatch at step {step_idx}, token {tid} "
+                    f"(temp={temperature}, top_p={top_p}, top_k={top_k}): "
+                    f"tracked={tracked_val}, full={full_val}"
+                )
+
+    def test_tracked_vs_full_batch_consistency(self, llm_instance):
+        """Test that tracked and full logprobs match in batch processing.
+
+        Uses BOTH parameters in the same request for all prompts.
+        """
+        track_ids = [200, 400, 600]
+        prompts = ["Hello", "World", "Test"]
+        max_tokens = 5
+
+        # Use BOTH track_token_ids AND logprobs=-1 in the same batch request
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=-1,
+            track_token_ids=track_ids,
+        )
+        outputs = llm_instance.generate(prompts, params)
+
+        # Compare each prompt - values should match exactly
+        for prompt_idx in range(len(prompts)):
+            output = outputs[prompt_idx].outputs[0]
+            tracked = output.tracked_logprobs
+            full_list = output.logprobs
+
+            assert tracked is not None
+            assert full_list is not None
+
+            for tid in track_ids:
+                for step_idx in range(max_tokens):
+                    tracked_val = tracked[tid][step_idx]
+                    full_val = full_list[step_idx][tid].logprob
+
+                    assert math.isclose(tracked_val, full_val), (
+                        f"Prompt {prompt_idx}, step {step_idx}, token {tid}: "
+                        f"tracked={tracked_val}, full={full_val}"
+                    )
+
+
+class TestTrackTokenIdsStreaming:
+    """Streaming mode tests for track_token_ids using AsyncLLM with DELTA output."""
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_basic(self, async_llm_instance):
+        """Test track_token_ids in streaming mode returns correct logprobs."""
+        track_ids = [1234, 5678, 9012]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=10,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        # Collect all streaming outputs
+        all_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-basic-1",
+            prompt="Hello, my name is",
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        all_tracked[tid].extend(tracked[tid])
+            if output.finished:
+                break
+
+        # Should have 10 logprobs per tracked token
+        for tid in track_ids:
+            assert len(all_tracked[tid]) == 10, (
+                f"Token {tid}: expected 10 logprobs, got {len(all_tracked[tid])}"
+            )
+            # All values should be valid log probabilities
+            for lp in all_tracked[tid]:
+                assert lp <= 0, f"Logprob {lp} should be <= 0"
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_track_token_ids_none(self, async_llm_instance):
+        """Test streaming with track_token_ids=None returns None."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=None,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-none-1",
+            prompt="Hello world",
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            assert tracked is None, f"Expected None, got {tracked}"
+            if output.finished:
+                break
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_track_token_ids_empty_list(self, async_llm_instance):
+        """Test streaming with track_token_ids=[] returns empty dict."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=[],
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-empty-1",
+            prompt="Hello world",
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            assert tracked == {}, f"Expected empty dict, got {tracked}"
+            if output.finished:
+                break
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_with_logprobs_coexist(self, async_llm_instance):
+        """Test streaming with both track_token_ids and regular logprobs."""
+        track_ids = [100, 200, 300]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            logprobs=5,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        all_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        logprobs_count = 0
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-coexist-1",
+            prompt="The capital of France is",
+            sampling_params=sampling_params,
+        ):
+            out = output.outputs[0]
+
+            # Count regular logprobs
+            if out.logprobs:
+                logprobs_count += len(out.logprobs)
+
+            # Collect tracked logprobs
+            if out.tracked_logprobs:
+                for tid in track_ids:
+                    if tid in out.tracked_logprobs:
+                        all_tracked[tid].extend(out.tracked_logprobs[tid])
+
+            if output.finished:
+                break
+
+        # Should have 5 regular logprobs entries
+        assert logprobs_count == 5
+
+        # Should have 5 tracked logprobs per token
+        for tid in track_ids:
+            assert len(all_tracked[tid]) == 5
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_tracked_vs_full_logprobs_match(
+        self, async_llm_instance
+    ):
+        """Test streaming tracked logprobs match full logprobs in same request.
+
+        Uses BOTH track_token_ids AND logprobs=-1 in the same streaming request
+        to compare values from the exact same computation.
+        """
+        track_ids = [100, 500, 1000]
+        prompt = "The meaning of life is"
+        max_tokens = 10
+
+        # Use BOTH track_token_ids AND logprobs=-1 in same streaming request
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=-1,  # Full vocabulary logprobs
+            track_token_ids=track_ids,  # Also track specific tokens
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        full_logprobs: list[dict] = []
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-match-1",
+            prompt=prompt,
+            sampling_params=params,
+        ):
+            # Collect tracked logprobs
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+
+            # Collect full logprobs
+            if output.outputs[0].logprobs:
+                full_logprobs.extend(output.outputs[0].logprobs)
+
+            if output.finished:
+                break
+
+        # Compare tracked vs extracted from full logprobs (same computation)
+        num_tokens = len(full_logprobs)
+        assert num_tokens > 0, "No tokens generated"
+
+        for tid in track_ids:
+            assert len(stream_tracked[tid]) == num_tokens
+            for step_idx in range(num_tokens):
+                tracked_val = stream_tracked[tid][step_idx]
+                full_val = full_logprobs[step_idx][tid].logprob
+
+                assert math.isclose(tracked_val, full_val), (
+                    f"Token {tid}, step {step_idx}: "
+                    f"tracked={tracked_val}, full={full_val}"
+                )
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_differential_more_tokens(
+        self, async_llm_instance
+    ):
+        """
+        CRITICAL: Test streaming tracked logprobs match full vocabulary logprobs
+        with more tokens to track.
+
+        Uses BOTH track_token_ids AND logprobs=-1 in the same streaming request
+        to compare values from the exact same computation.
+        """
+        track_ids = [100, 500, 1000, 2000, 5000]
+        prompt = "Once upon a time"
+        max_tokens = 8
+
+        # Use BOTH track_token_ids AND logprobs=-1 in same streaming request
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=-1,  # Full vocabulary logprobs
+            track_token_ids=track_ids,  # Also track specific tokens
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        full_logprobs: list[dict] = []
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-diff-1",
+            prompt=prompt,
+            sampling_params=params,
+        ):
+            # Collect tracked logprobs
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+
+            # Collect full logprobs
+            if output.outputs[0].logprobs:
+                full_logprobs.extend(output.outputs[0].logprobs)
+
+            if output.finished:
+                break
+
+        # Compare tracked vs extracted from full logprobs (same computation)
+        num_tokens = len(full_logprobs)
+        assert num_tokens > 0, "No tokens generated"
+
+        for tid in track_ids:
+            assert len(stream_tracked[tid]) == num_tokens
+            for step_idx in range(num_tokens):
+                tracked_val = stream_tracked[tid][step_idx]
+                full_val = full_logprobs[step_idx][tid].logprob
+
+                assert math.isclose(tracked_val, full_val), (
+                    f"Token {tid}, step {step_idx}: "
+                    f"tracked={tracked_val}, full={full_val}"
+                )
+
+    @pytest.mark.asyncio(loop_scope="module")
+    @pytest.mark.parametrize(
+        "temperature,top_p,top_k",
+        [
+            (0.0, 1.0, -1),  # Greedy
+            (0.7, 1.0, -1),  # Standard temperature 1
+            (2.0, 1.0, -1),  # Standard temperature 2
+            (10.0, 1.0, -1),  # Standard temperature 3
+            (1.0, 0.9, -1),  # With top_p
+            (0.8, 1.0, 50),  # With top_k
+        ],
+    )
+    async def test_streaming_differential_various_sampling(
+        self, async_llm_instance, temperature, top_p, top_k
+    ):
+        """Test streaming tracked logprobs match full logprobs with various sampling.
+
+        Uses BOTH track_token_ids AND logprobs=-1 in the same streaming request
+        to compare values from the exact same computation - no seed needed.
+        """
+        track_ids = [100, 1000, 5000]
+        prompt = "Hello world"
+        max_tokens = 5
+
+        # Use BOTH track_token_ids AND logprobs=-1 in same streaming request
+        params = SamplingParams(
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            max_tokens=max_tokens,
+            logprobs=-1,  # Full vocabulary logprobs
+            track_token_ids=track_ids,  # Also track specific tokens
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        full_logprobs: list[dict] = []
+        req_id = f"stream-sampling-{temperature}-{top_p}-{top_k}"
+
+        async for output in async_llm_instance.generate(
+            request_id=req_id,
+            prompt=prompt,
+            sampling_params=params,
+        ):
+            # Collect tracked logprobs
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+
+            # Collect full logprobs
+            if output.outputs[0].logprobs:
+                full_logprobs.extend(output.outputs[0].logprobs)
+
+            if output.finished:
+                break
+
+        # Compare tracked vs extracted from full logprobs (same computation)
+        num_tokens = len(full_logprobs)
+        assert num_tokens > 0, "No tokens generated"
+
+        for tid in track_ids:
+            assert len(stream_tracked[tid]) == num_tokens
+            for step_idx in range(num_tokens):
+                tracked_val = stream_tracked[tid][step_idx]
+                full_val = full_logprobs[step_idx][tid].logprob
+
+                assert math.isclose(tracked_val, full_val), (
+                    f"Token {tid}, step {step_idx} "
+                    f"(temp={temperature}, top_p={top_p}, top_k={top_k}): "
+                    f"tracked={tracked_val}, full={full_val}"
+                )
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_batch_multiple_prompts(self, async_llm_instance):
+        """Test streaming with multiple prompts (batch)."""
+        track_ids = [500, 1000, 1500]
+        prompts = [
+            "Hello, my name is",
+            "The capital of France is",
+            "The future of AI is",
+        ]
+        max_tokens = 8
+
+        # Collect per-request tracked logprobs
+        all_tracked: dict[str, dict[int, list[float]]] = {}
+
+        # Submit all requests
+        tasks = []
+        for i, prompt in enumerate(prompts):
+            req_id = f"stream-batch-{i}"
+            all_tracked[req_id] = {tid: [] for tid in track_ids}
+
+            async def process_request(req_id, prompt):
+                sampling_params = SamplingParams(
+                    temperature=0.8,
+                    max_tokens=max_tokens,
+                    track_token_ids=track_ids,
+                    output_kind=RequestOutputKind.DELTA,
+                )
+                async for output in async_llm_instance.generate(
+                    request_id=req_id,
+                    prompt=prompt,
+                    sampling_params=sampling_params,
+                ):
+                    tracked = output.outputs[0].tracked_logprobs
+                    if tracked:
+                        for tid in track_ids:
+                            if tid in tracked:
+                                all_tracked[req_id][tid].extend(tracked[tid])
+                    if output.finished:
+                        break
+
+            tasks.append(process_request(req_id, prompt))
+
+        await asyncio.gather(*tasks)
+
+        # Should have outputs for all 3 prompts
+        assert len(all_tracked) == 3
+
+        # Each prompt should have max_tokens logprobs per tracked token
+        for req_id, req_tracked in all_tracked.items():
+            for tid in track_ids:
+                assert len(req_tracked[tid]) == max_tokens, (
+                    f"Request {req_id}, token {tid}: "
+                    f"expected {max_tokens}, got {len(req_tracked[tid])}"
+                )
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_single_token_generation(self, async_llm_instance):
+        """Test streaming with max_tokens=1."""
+        track_ids = [100, 200, 300]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=1,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        all_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-single-1",
+            prompt="Hello",
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        all_tracked[tid].extend(tracked[tid])
+            if output.finished:
+                break
+
+        # Should have exactly 1 logprob per token
+        for tid in track_ids:
+            assert len(all_tracked[tid]) == 1
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_streaming_many_tokens_tracking(self, async_llm_instance):
+        """Test streaming while tracking many tokens."""
+        # Track 50 token IDs
+        track_ids = list(range(100, 150))
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        all_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+
+        async for output in async_llm_instance.generate(
+            request_id="stream-many-1",
+            prompt="Classify this text:",
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        all_tracked[tid].extend(tracked[tid])
+            if output.finished:
+                break
+
+        # All 50 tokens should have 5 logprobs each
+        assert len(all_tracked) == 50
+        for tid in track_ids:
+            assert len(all_tracked[tid]) == 5
+
+
+class TestTrackTokenIdsEdgeCases:
+    """Edge case tests for track_token_ids."""
+
+    def test_single_token_tracking(self, llm_instance):
+        """Test tracking a single token."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=10,
+            track_token_ids=[1234],
+        )
+
+        outputs = llm_instance.generate(["Test prompt"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is not None
+        assert len(tracked) == 1
+        assert 1234 in tracked
+        assert len(tracked[1234]) == 10
+
+    def test_many_tokens_tracking(self, llm_instance):
+        """Test tracking many tokens (like 100-class classification)."""
+        # Track 100 token IDs
+        track_ids = list(range(100, 200))
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=track_ids,
+        )
+
+        outputs = llm_instance.generate(["Classify this text:"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is not None
+        assert len(tracked) == 100
+
+        for tid in track_ids:
+            assert tid in tracked
+            assert len(tracked[tid]) == 5
+
+    def test_track_boundary_token_ids(self, llm_instance):
+        """Test tracking token ID 0 (boundary case)."""
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=5,
+            track_token_ids=[0, 1, 2],  # Very low token IDs
+        )
+
+        outputs = llm_instance.generate(["Test"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is not None
+        assert 0 in tracked
+        assert 1 in tracked
+        assert 2 in tracked
+
+    def test_single_token_generation(self, llm_instance):
+        """Test with max_tokens=1."""
+        track_ids = [100, 200, 300]
+        sampling_params = SamplingParams(
+            temperature=0.8,
+            max_tokens=1,
+            track_token_ids=track_ids,
+        )
+
+        outputs = llm_instance.generate(["Hello"], sampling_params)
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is not None
+        for tid in track_ids:
+            assert tid in tracked
+            assert len(tracked[tid]) == 1
+
+
+# Summarization prompts designed for high ngram acceptance rate
+SUMMARIZATION_PROMPTS = [
+    """Summarize the following text:
+The quick brown fox jumps over the lazy dog. The quick brown fox jumps over 
+the lazy dog. The quick brown fox jumps over the lazy dog. The quick brown 
+fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog.
+Summary:""",
+    """Summarize the following repetitive text in one sentence:
+Hello world. Hello world. Hello world. Hello world. Hello world. Hello world.
+Hello world. Hello world. Hello world. Hello world. Hello world. Hello world.
+Summary:""",
+    """Summarize:
+Test test test test test. Test test test test test. Test test test test test.
+Test test test test test. Test test test test test. Test test test test test.
+Summary:""",
+]
+
+
+@pytest.fixture(scope="module")
+def spec_decode_llm_instance():
+    """Create a shared LLM instance with ngram speculative decoding.
+
+    Uses max_logprobs=-1 to allow full vocabulary logprobs for differential tests.
+    """
+    speculative_config = {
+        "method": "ngram",
+        "prompt_lookup_max": 5,
+        "prompt_lookup_min": 2,
+        "num_speculative_tokens": 3,
+    }
+    llm = LLM(
+        MODEL_PATH,
+        enforce_eager=True,
+        max_logprobs=-1,
+        speculative_config=speculative_config,
+    )
+    yield llm
+    del llm
+    cleanup_dist_env_and_memory()
+
+
+@pytest.fixture(scope="module")
+def async_spec_decode_llm_instance():
+    """Create a shared AsyncLLM instance with ngram speculative decoding.
+
+    Uses max_logprobs=-1 to allow full vocabulary logprobs for differential tests.
+    Note: Tests using this fixture must use @pytest.mark.asyncio(loop_scope="module")
+    to ensure the event loop scope matches the fixture scope.
+    """
+    speculative_config = {
+        "method": "ngram",
+        "prompt_lookup_max": 5,
+        "prompt_lookup_min": 2,
+        "num_speculative_tokens": 3,
+    }
+    engine_args = AsyncEngineArgs(
+        model=MODEL_PATH,
+        enforce_eager=True,
+        max_logprobs=-1,
+        speculative_config=speculative_config,
+    )
+    engine = AsyncLLM.from_engine_args(engine_args)
+    yield engine
+    engine.shutdown()
+    cleanup_dist_env_and_memory()
+
+
+class TestTrackTokenIdsSpeculativeDecoding:
+    """Tests for track_token_ids with ngram speculative decoding."""
+
+    def test_spec_decode_basic(self, spec_decode_llm_instance):
+        """Test track_token_ids works with speculative decoding."""
+        track_ids = [100, 500, 1000, 2000]
+        max_tokens = 15
+        sampling_params = SamplingParams(
+            temperature=0.0,  # Greedy for determinism
+            max_tokens=max_tokens,
+            track_token_ids=track_ids,
+        )
+
+        outputs = spec_decode_llm_instance.generate(
+            SUMMARIZATION_PROMPTS[:1], sampling_params
+        )
+
+        assert len(outputs) == 1
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is not None
+
+        # All tracked token IDs should be present
+        for tid in track_ids:
+            assert tid in tracked, f"Token {tid} not in tracked_logprobs"
+            # Should have one logprob per generated token
+            num_generated = len(outputs[0].outputs[0].token_ids)
+            assert len(tracked[tid]) == num_generated, (
+                f"Expected {num_generated} logprobs for token {tid}, "
+                f"got {len(tracked[tid])}"
+            )
+            # All values should be valid log probabilities (<= 0)
+            for lp in tracked[tid]:
+                assert lp <= 0, f"Logprob {lp} should be <= 0"
+
+    def test_spec_decode_with_logprobs_coexist(self, spec_decode_llm_instance):
+        """Test track_token_ids works alongside regular logprobs with spec decode."""
+        track_ids = [100, 200, 300]
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=10,
+            logprobs=5,  # Request top-5 logprobs
+            track_token_ids=track_ids,
+        )
+
+        outputs = spec_decode_llm_instance.generate(
+            SUMMARIZATION_PROMPTS[:1], sampling_params
+        )
+
+        output = outputs[0].outputs[0]
+        num_generated = len(output.token_ids)
+
+        # Regular logprobs should be present
+        assert output.logprobs is not None
+        assert len(output.logprobs) == num_generated
+
+        # Tracked logprobs should also be present
+        assert output.tracked_logprobs is not None
+        for tid in track_ids:
+            assert tid in output.tracked_logprobs
+            assert len(output.tracked_logprobs[tid]) == num_generated
+
+    def test_spec_decode_track_token_ids_none(self, spec_decode_llm_instance):
+        """Test track_token_ids=None returns None with spec decode."""
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=10,
+            track_token_ids=None,
+        )
+
+        outputs = spec_decode_llm_instance.generate(
+            SUMMARIZATION_PROMPTS[:1], sampling_params
+        )
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked is None, f"Expected None, got {tracked}"
+
+    def test_spec_decode_track_token_ids_empty_list(self, spec_decode_llm_instance):
+        """Test track_token_ids=[] returns empty dict with spec decode."""
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=10,
+            track_token_ids=[],
+        )
+
+        outputs = spec_decode_llm_instance.generate(
+            SUMMARIZATION_PROMPTS[:1], sampling_params
+        )
+
+        tracked = outputs[0].outputs[0].tracked_logprobs
+        assert tracked == {}, f"Expected empty dict, got {tracked}"
+
+    def test_spec_decode_tracked_vs_full_logprobs_match(
+        self, spec_decode_llm_instance
+    ):
+        """
+        CRITICAL TEST: Verify track_token_ids with spec decode produces same
+        values as extracting from full vocabulary logprobs (logprobs=-1).
+
+        Uses BOTH parameters in the same request for reliable comparison.
+        """
+        track_ids = [100, 500, 1000, 2000, 5000]
+        prompt = SUMMARIZATION_PROMPTS[0]
+        max_tokens = 10
+
+        # Use BOTH track_token_ids AND logprobs=-1 in the same request
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=-1,
+            track_token_ids=track_ids,
+        )
+        outputs = spec_decode_llm_instance.generate([prompt], params)
+
+        output = outputs[0].outputs[0]
+        tracked_logprobs = output.tracked_logprobs
+        full_logprobs_list = output.logprobs
+
+        # Compare: tracked values should match extracted from full
+        assert tracked_logprobs is not None
+        assert full_logprobs_list is not None
+
+        num_tokens = len(full_logprobs_list)
+
+        for tid in track_ids:
+            assert tid in tracked_logprobs
+            assert len(tracked_logprobs[tid]) == num_tokens
+
+            for step_idx in range(num_tokens):
+                tracked_value = tracked_logprobs[tid][step_idx]
+
+                # Extract from full logprobs
+                step_full = full_logprobs_list[step_idx]
+                if tid in step_full:
+                    full_value = step_full[tid].logprob
+                else:
+                    pytest.fail(
+                        f"Token {tid} not in full logprobs at step {step_idx}"
+                    )
+
+                # Values should match exactly (same computation)
+                assert math.isclose(tracked_value, full_value), (
+                    f"Mismatch at step {step_idx} for token {tid}: "
+                    f"tracked={tracked_value}, full={full_value}"
+                )
+
+    def test_spec_decode_batch_multiple_prompts(self, spec_decode_llm_instance):
+        """Test batch with multiple prompts using track_token_ids with spec decode."""
+        track_ids = [500, 1000, 1500]
+        max_tokens = 12
+
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            track_token_ids=track_ids,
+        )
+
+        outputs = spec_decode_llm_instance.generate(
+            SUMMARIZATION_PROMPTS, sampling_params
+        )
+
+        assert len(outputs) == len(SUMMARIZATION_PROMPTS)
+
+        for i, output in enumerate(outputs):
+            tracked = output.outputs[0].tracked_logprobs
+            num_generated = len(output.outputs[0].token_ids)
+            assert tracked is not None, f"Prompt {i}: tracked_logprobs is None"
+
+            for tid in track_ids:
+                assert tid in tracked, f"Prompt {i}: token {tid} not tracked"
+                assert len(tracked[tid]) == num_generated, (
+                    f"Prompt {i}: token {tid} has {len(tracked[tid])} logprobs, "
+                    f"expected {num_generated}"
+                )
+
+    @pytest.mark.parametrize(
+        "temperature,top_p,top_k",
+        [
+            (0.0, 1.0, -1),  # Greedy
+            (0.7, 1.0, -1),  # Standard temperature 1
+            (2.0, 1.0, -1),  # Standard temperature 2
+            (10.0, 1.0, -1),  # Standard temperature 3
+            (0.8, 0.95, 100),  # Combined
+        ],
+    )
+    def test_spec_decode_various_sampling(
+        self, spec_decode_llm_instance, temperature, top_p, top_k
+    ):
+        """Test tracked logprobs match full logprobs under various sampling configs.
+
+        Uses BOTH track_token_ids AND logprobs=-1 in the same request for
+        reliable comparison regardless of sampling randomness.
+        """
+        track_ids = [100, 1000, 5000]
+        prompt = SUMMARIZATION_PROMPTS[0]
+        max_tokens = 8
+
+        # Use BOTH track_token_ids AND logprobs=-1 in the same request
+        params = SamplingParams(
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            max_tokens=max_tokens,
+            logprobs=-1,
+            track_token_ids=track_ids,
+        )
+        outputs = spec_decode_llm_instance.generate([prompt], params)
+
+        output = outputs[0].outputs[0]
+        tracked = output.tracked_logprobs
+        full_list = output.logprobs
+
+        # Verify tracked logprobs are valid and match full logprobs
+        assert tracked is not None
+        assert full_list is not None
+
+        num_tokens = len(full_list)
+
+        for tid in track_ids:
+            assert tid in tracked
+            assert len(tracked[tid]) == num_tokens
+
+            for step_idx in range(num_tokens):
+                tracked_val = tracked[tid][step_idx]
+
+                # Verify value is valid
+                assert tracked_val <= 0, f"Logprob {tracked_val} should be <= 0"
+                assert not math.isnan(tracked_val), "Logprob should not be NaN"
+                assert not math.isinf(tracked_val), "Logprob should not be inf"
+
+                # Verify matches full logprobs (same computation)
+                full_val = full_list[step_idx][tid].logprob
+                assert math.isclose(tracked_val, full_val), (
+                    f"Mismatch at step {step_idx}, token {tid} "
+                    f"(temp={temperature}, top_p={top_p}, top_k={top_k}): "
+                    f"tracked={tracked_val}, full={full_val}"
+                )
+
+
+class TestTrackTokenIdsSpeculativeDecodingStreaming:
+    """Streaming tests for track_token_ids with ngram speculative decoding."""
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_spec_decode_streaming_basic(self, async_spec_decode_llm_instance):
+        """Test streaming with track_token_ids and spec decode."""
+        track_ids = [100, 500, 1000]
+        max_tokens = 12
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        all_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+
+        async for output in async_spec_decode_llm_instance.generate(
+            request_id="spec-stream-basic-1",
+            prompt=SUMMARIZATION_PROMPTS[0],
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        all_tracked[tid].extend(tracked[tid])
+            if output.finished:
+                break
+
+        # Should have logprobs for each tracked token
+        for tid in track_ids:
+            assert len(all_tracked[tid]) > 0, (
+                f"Token {tid}: expected logprobs, got {len(all_tracked[tid])}"
+            )
+            # All values should be valid log probabilities
+            for lp in all_tracked[tid]:
+                assert lp <= 0, f"Logprob {lp} should be <= 0"
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_spec_decode_streaming_track_token_ids_none(
+        self, async_spec_decode_llm_instance
+    ):
+        """Test streaming with track_token_ids=None and spec decode."""
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=5,
+            track_token_ids=None,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        async for output in async_spec_decode_llm_instance.generate(
+            request_id="spec-stream-none-1",
+            prompt=SUMMARIZATION_PROMPTS[0],
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            assert tracked is None, f"Expected None, got {tracked}"
+            if output.finished:
+                break
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_spec_decode_streaming_track_token_ids_empty(
+        self, async_spec_decode_llm_instance
+    ):
+        """Test streaming with track_token_ids=[] and spec decode."""
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            max_tokens=5,
+            track_token_ids=[],
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        async for output in async_spec_decode_llm_instance.generate(
+            request_id="spec-stream-empty-1",
+            prompt=SUMMARIZATION_PROMPTS[0],
+            sampling_params=sampling_params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            assert tracked == {}, f"Expected empty dict, got {tracked}"
+            if output.finished:
+                break
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_spec_decode_streaming_with_logprobs_coexist(
+        self, async_spec_decode_llm_instance
+    ):
+        """Test that track_token_ids works alongside regular logprobs in streaming spec decode.
+
+        Uses both track_token_ids and logprobs in the same request, then verifies
+        the tracked values match those extracted from the logprobs dict.
+        """
+        track_ids = [100, 500, 1000]
+        prompt = SUMMARIZATION_PROMPTS[0]
+        max_tokens = 10
+
+        # Use both track_token_ids AND logprobs in the same request
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=10,  # Get top-10 logprobs
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        regular_logprobs: list[dict] = []
+        num_tokens_generated = 0
+
+        async for output in async_spec_decode_llm_instance.generate(
+            request_id="spec-stream-coexist-1",
+            prompt=prompt,
+            sampling_params=params,
+        ):
+            # Collect tracked logprobs
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+
+            # Collect regular logprobs
+            if output.outputs[0].logprobs:
+                regular_logprobs.extend(output.outputs[0].logprobs)
+                num_tokens_generated += len(output.outputs[0].logprobs)
+
+            if output.finished:
+                break
+
+        # Verify we got logprobs
+        assert num_tokens_generated > 0, "No tokens generated"
+
+        # Verify tracked logprobs have correct length
+        for tid in track_ids:
+            assert len(stream_tracked[tid]) == num_tokens_generated, (
+                f"Token {tid}: expected {num_tokens_generated}, "
+                f"got {len(stream_tracked[tid])}"
+            )
+
+        # Verify all tracked values are valid log probabilities
+        for tid in track_ids:
+            for lp in stream_tracked[tid]:
+                assert lp <= 0, f"Logprob {lp} should be <= 0"
+                assert not math.isnan(lp), "Logprob should not be NaN"
+                assert not math.isinf(lp), "Logprob should not be inf"
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_spec_decode_streaming_differential_vs_full_logprobs(
+        self, async_spec_decode_llm_instance
+    ):
+        """
+        CRITICAL: Test streaming tracked logprobs with spec decode match
+        full vocabulary logprobs (logprobs=-1) in the SAME request.
+
+        Using both track_token_ids and logprobs=-1 together ensures we compare
+        logprobs computed from the exact same generation, avoiding variance
+        from separate runs.
+        """
+        track_ids = [100, 500, 1000, 2000, 5000]
+        prompt = SUMMARIZATION_PROMPTS[0]
+        max_tokens = 10
+
+        # Use BOTH track_token_ids AND logprobs=-1 in the same request
+        # This ensures we compare values from the exact same generation
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            logprobs=-1,  # Get full vocabulary logprobs
+            track_token_ids=track_ids,  # Also track specific tokens
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        full_logprobs: list[dict] = []
+
+        async for output in async_spec_decode_llm_instance.generate(
+            request_id="spec-stream-diff-1",
+            prompt=prompt,
+            sampling_params=params,
+        ):
+            # Collect tracked logprobs
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+
+            # Collect full logprobs
+            if output.outputs[0].logprobs:
+                full_logprobs.extend(output.outputs[0].logprobs)
+
+            if output.finished:
+                break
+
+        # Compare tracked vs extracted from full logprobs
+        # Should match exactly (within floating point tolerance) since
+        # they come from the same generation
+        num_tokens = min(len(stream_tracked[track_ids[0]]), len(full_logprobs))
+        assert num_tokens > 0, "No tokens generated"
+
+        for tid in track_ids:
+            for step_idx in range(num_tokens):
+                tracked_val = stream_tracked[tid][step_idx]
+                full_val = full_logprobs[step_idx][tid].logprob
+
+                assert math.isclose(tracked_val, full_val, rel_tol=1e-4), (
+                    f"Token {tid}, step {step_idx}: "
+                    f"tracked={tracked_val}, full={full_val}"
+                )
+
+    @pytest.mark.asyncio(loop_scope="module")
+    async def test_spec_decode_streaming_batch(self, async_spec_decode_llm_instance):
+        """Test streaming with multiple prompts (batch) and spec decode."""
+        track_ids = [500, 1000, 1500]
+        max_tokens = 10
+
+        # Collect per-request tracked logprobs
+        all_tracked: dict[str, dict[int, list[float]]] = {}
+
+        # Submit all requests
+        tasks = []
+        for i, prompt in enumerate(SUMMARIZATION_PROMPTS):
+            req_id = f"spec-stream-batch-{i}"
+            all_tracked[req_id] = {tid: [] for tid in track_ids}
+
+            async def process_request(req_id, prompt):
+                sampling_params = SamplingParams(
+                    temperature=0.0,
+                    max_tokens=max_tokens,
+                    track_token_ids=track_ids,
+                    output_kind=RequestOutputKind.DELTA,
+                )
+                async for output in async_spec_decode_llm_instance.generate(
+                    request_id=req_id,
+                    prompt=prompt,
+                    sampling_params=sampling_params,
+                ):
+                    tracked = output.outputs[0].tracked_logprobs
+                    if tracked:
+                        for tid in track_ids:
+                            if tid in tracked:
+                                all_tracked[req_id][tid].extend(tracked[tid])
+                    if output.finished:
+                        break
+
+            tasks.append(process_request(req_id, prompt))
+
+        await asyncio.gather(*tasks)
+
+        # Should have outputs for all prompts
+        assert len(all_tracked) == len(SUMMARIZATION_PROMPTS)
+
+        # Each prompt should have logprobs for tracked tokens
+        for req_id, req_tracked in all_tracked.items():
+            for tid in track_ids:
+                assert len(req_tracked[tid]) > 0, (
+                    f"Request {req_id}, token {tid}: expected logprobs"
+                )
+
+
+def run_quick_demo():
+    """Quick demo showing the feature in action."""
+    print("=" * 70)
+    print("Track Token IDs Feature Demo")
+    print("=" * 70)
+
+    # Use max_logprobs=-1 to allow full vocabulary logprobs for diff test
+    llm = LLM(MODEL_PATH, enforce_eager=True, max_logprobs=-1)
+
+    # Demo 1: Basic usage
+    print("\n1. Basic Usage - Track specific tokens")
+    print("-" * 50)
+    track_ids = [1234, 5678, 9012]
+    params = SamplingParams(
+        temperature=0.8,
+        max_tokens=10,
+        track_token_ids=track_ids,
+    )
+    outputs = llm.generate(["Hello, my name is"], params)
+    tracked = outputs[0].outputs[0].tracked_logprobs
+    print(f"Tracked token IDs: {track_ids}")
+    print(f"tracked_logprobs: {tracked}")
+
+    # Demo 2: None case
+    print("\n2. track_token_ids=None (default)")
+    print("-" * 50)
+    params = SamplingParams(temperature=0.8, max_tokens=5)
+    outputs = llm.generate(["Test"], params)
+    print(f"tracked_logprobs: {outputs[0].outputs[0].tracked_logprobs}")
+
+    # Demo 3: Empty list case
+    print("\n3. track_token_ids=[] (empty list)")
+    print("-" * 50)
+    params = SamplingParams(temperature=0.8, max_tokens=5, track_token_ids=[])
+    outputs = llm.generate(["Test"], params)
+    print(f"tracked_logprobs: {outputs[0].outputs[0].tracked_logprobs}")
+
+    # Demo 4: Differential test
+    print("\n4. Differential Test: track_token_ids vs full logprobs")
+    print("-" * 50)
+    track_ids = [100, 500, 1000]
+    prompt = "The answer is"
+
+    # Tracked approach
+    params_tracked = SamplingParams(
+        temperature=0.0, max_tokens=5, track_token_ids=track_ids
+    )
+    out_tracked = llm.generate([prompt], params_tracked)
+    tracked = out_tracked[0].outputs[0].tracked_logprobs
+
+    # Full logprobs approach (requires LLM started with max_logprobs=-1)
+    params_full = SamplingParams(temperature=0.0, max_tokens=5, logprobs=-1)
+    out_full = llm.generate([prompt], params_full)
+    full_list = out_full[0].outputs[0].logprobs
+
+    print(f"Comparing for tokens: {track_ids}")
+    all_match = True
+    for tid in track_ids:
+        print(f"\nToken {tid}:")
+        for step in range(5):
+            t_val = tracked[tid][step]
+            f_val = full_list[step][tid].logprob
+            match = math.isclose(t_val, f_val, rel_tol=1e-4)
+            status = "✓" if match else "✗"
+            print(f"  Step {step}: tracked={t_val:.6f}, full={f_val:.6f} {status}")
+            if not match:
+                all_match = False
+
+    print(f"\nAll values match: {'YES ✓' if all_match else 'NO ✗'}")
+
+    # Demo 5: Batch processing
+    print("\n5. Batch Processing")
+    print("-" * 50)
+    prompts = ["Hello", "World", "Test", "Demo"]
+    params = SamplingParams(
+        temperature=0.8, max_tokens=5, track_token_ids=[100, 200]
+    )
+    outputs = llm.generate(prompts, params)
+    for i, out in enumerate(outputs):
+        tracked = out.outputs[0].tracked_logprobs
+        print(f"Prompt {i} ('{prompts[i]}'): {len(tracked)} tracked tokens, "
+              f"5 steps each")
+
+    print("\n" + "=" * 70)
+    print("Demo Complete!")
+    print("=" * 70)
+
+
+async def run_streaming_demo():
+    """Streaming demo showing track_token_ids with AsyncLLM."""
+    print("=" * 70)
+    print("Track Token IDs Streaming Demo (AsyncLLM)")
+    print("=" * 70)
+
+    # Create AsyncLLM engine
+    engine_args = AsyncEngineArgs(
+        model=MODEL_PATH,
+        enforce_eager=True,
+        max_logprobs=-1,
+    )
+    engine = AsyncLLM.from_engine_args(engine_args)
+
+    try:
+        # Demo 1: Basic streaming with track_token_ids
+        print("\n1. Streaming with track_token_ids")
+        print("-" * 50)
+        track_ids = [100, 500, 1000]
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=5,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        chunk_count = 0
+
+        async for output in engine.generate(
+            request_id="demo-stream-1",
+            prompt="The answer is",
+            sampling_params=params,
+        ):
+            chunk_count += 1
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+            if output.finished:
+                break
+
+        print(f"Received {chunk_count} streaming chunks")
+        for tid in track_ids:
+            print(f"  Token {tid}: {len(stream_tracked[tid])} logprobs")
+
+        # Demo 2: Streaming with track_token_ids=None
+        print("\n2. Streaming with track_token_ids=None")
+        print("-" * 50)
+        params = SamplingParams(
+            temperature=0.8,
+            max_tokens=3,
+            track_token_ids=None,
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        async for output in engine.generate(
+            request_id="demo-stream-none",
+            prompt="Test",
+            sampling_params=params,
+        ):
+            print(f"  tracked_logprobs: {output.outputs[0].tracked_logprobs}")
+            if output.finished:
+                break
+
+        # Demo 3: Streaming with track_token_ids=[]
+        print("\n3. Streaming with track_token_ids=[]")
+        print("-" * 50)
+        params = SamplingParams(
+            temperature=0.8,
+            max_tokens=3,
+            track_token_ids=[],
+            output_kind=RequestOutputKind.DELTA,
+        )
+
+        async for output in engine.generate(
+            request_id="demo-stream-empty",
+            prompt="Test",
+            sampling_params=params,
+        ):
+            print(f"  tracked_logprobs: {output.outputs[0].tracked_logprobs}")
+            if output.finished:
+                break
+
+        # Demo 4: Streaming values are valid logprobs
+        print("\n4. Streaming - Validate Logprob Values")
+        print("-" * 50)
+        track_ids = [100, 500, 1000]
+        prompt = "The answer is"
+        max_tokens = 5
+
+        params = SamplingParams(
+            temperature=0.0,
+            max_tokens=max_tokens,
+            track_token_ids=track_ids,
+            output_kind=RequestOutputKind.DELTA,
+        )
+        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+
+        async for output in engine.generate(
+            request_id="demo-stream-validate",
+            prompt=prompt,
+            sampling_params=params,
+        ):
+            tracked = output.outputs[0].tracked_logprobs
+            if tracked:
+                for tid in track_ids:
+                    if tid in tracked:
+                        stream_tracked[tid].extend(tracked[tid])
+            if output.finished:
+                break
+
+        print(f"Tracked tokens: {track_ids}")
+        all_valid = True
+        for tid in track_ids:
+            values = stream_tracked[tid]
+            valid = all(v <= 0 and not math.isnan(v) and not math.isinf(v) for v in values)
+            status = "✓" if valid else "✗"
+            print(f"  Token {tid}: {len(values)} values, all valid logprobs: {status}")
+            print(f"    Values: {[f'{v:.4f}' for v in values]}")
+            if not valid:
+                all_valid = False
+
+        print(f"\nAll values are valid log probabilities: {'YES ✓' if all_valid else 'NO ✗'}")
+        print("\nNote: For full differential test (streaming vs full logprobs),")
+        print("      run: pytest tests/v1/e2e/test_tracked_logprobs.py::TestTrackTokenIdsStreaming -v")
+
+    finally:
+        engine.shutdown()
+
+    print("\n" + "=" * 70)
+    print("Streaming Demo Complete!")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--streaming":
+        # Run streaming demo
+        asyncio.run(run_streaming_demo())
+    else:
+        # Run non-streaming demo
+        run_quick_demo()
+        print("\nRun with --streaming for streaming demo")

--- a/tests/v1/e2e/test_tracked_logprobs.py
+++ b/tests/v1/e2e/test_tracked_logprobs.py
@@ -1598,7 +1598,7 @@ async def run_streaming_demo():
             track_token_ids=track_ids,
             output_kind=RequestOutputKind.DELTA,
         )
-        stream_tracked: dict[int, list[float]] = {tid: [] for tid in track_ids}
+        stream_tracked_validate: dict[int, list[float]] = {tid: [] for tid in track_ids}
 
         async for output in engine.generate(
             request_id="demo-stream-validate",
@@ -1609,14 +1609,14 @@ async def run_streaming_demo():
             if tracked:
                 for tid in track_ids:
                     if tid in tracked:
-                        stream_tracked[tid].extend(tracked[tid])
+                        stream_tracked_validate[tid].extend(tracked[tid])
             if output.finished:
                 break
 
         print(f"Tracked tokens: {track_ids}")
         all_valid = True
         for tid in track_ids:
-            values = stream_tracked[tid]
+            values = stream_tracked_validate[tid]
             valid = all(
                 v <= 0 and not math.isnan(v) and not math.isinf(v) for v in values
             )

--- a/tests/v1/test_outputs.py
+++ b/tests/v1/test_outputs.py
@@ -2,7 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from unittest import TestCase
 
-from vllm.v1.outputs import LogprobsLists
+import numpy as np
+
+from vllm.v1.outputs import LogprobsLists, TrackedLogprobsLists
 
 
 class TestLogprobsLists(TestCase):
@@ -97,3 +99,168 @@ class TestLogprobsLists(TestCase):
         assert len(sliced.logprob_token_ids) == 9  # All tokens
         assert sliced.logprob_token_ids == self.logprobsLists.logprob_token_ids
         assert sliced.cu_num_generated_tokens is None
+
+
+class TestTrackedLogprobsLists(TestCase):
+    """Tests for TrackedLogprobsLists slicing operations."""
+
+    def setUp(self):
+        """Create sample TrackedLogprobsLists with known data.
+
+        Structure:
+        - 3 requests with different numbers of generated tokens
+        - Request 0: 2 tokens (rows 0-1)
+        - Request 1: 1 token (row 2)
+        - Request 2: 3 tokens (rows 3-5)
+        - 3 tracked token IDs: [100, 200, 300]
+        """
+        self.tracked = TrackedLogprobsLists(
+            logprobs=np.array(
+                [
+                    [-1.0, -2.0, -3.0],  # Request 0, token 0
+                    [-1.1, -2.1, -3.1],  # Request 0, token 1
+                    [-1.2, -2.2, -3.2],  # Request 1, token 0
+                    [-1.3, -2.3, -3.3],  # Request 2, token 0
+                    [-1.4, -2.4, -3.4],  # Request 2, token 1
+                    [-1.5, -2.5, -3.5],  # Request 2, token 2
+                ]
+            ),
+            token_ids=[100, 200, 300],
+            cu_num_generated_tokens=[0, 2, 3, 6],
+        )
+
+    def test_slice_without_cu_num_generated_tokens(self):
+        """Test slicing without cu_num_generated_tokens uses req_idx directly."""
+        tracked = TrackedLogprobsLists(
+            logprobs=np.array(
+                [
+                    [-1.0, -2.0],
+                    [-1.1, -2.1],
+                    [-1.2, -2.2],
+                ]
+            ),
+            token_ids=[100, 200],
+            cu_num_generated_tokens=None,
+        )
+
+        # Without cu_num_generated_tokens, req_idx is used as start index
+        sliced = tracked.slice_request(1, num_positions=2)
+
+        # Should slice rows 1 and 2
+        np.testing.assert_array_almost_equal(
+            sliced.logprobs, np.array([[-1.1, -2.1], [-1.2, -2.2]])
+        )
+        assert sliced.token_ids == [100, 200]
+        assert sliced.cu_num_generated_tokens is None
+
+    def test_slice_first_request(self):
+        """Test slicing the first request."""
+        sliced = self.tracked.slice_request(0, num_positions=2)
+
+        # Request 0 has 2 tokens at rows 0-1
+        np.testing.assert_array_almost_equal(
+            sliced.logprobs, np.array([[-1.0, -2.0, -3.0], [-1.1, -2.1, -3.1]])
+        )
+        assert sliced.token_ids == [100, 200, 300]
+        assert sliced.cu_num_generated_tokens is None
+
+    def test_slice_middle_request(self):
+        """Test slicing a middle request."""
+        sliced = self.tracked.slice_request(1, num_positions=1)
+
+        # Request 1 has 1 token at row 2
+        np.testing.assert_array_almost_equal(
+            sliced.logprobs, np.array([[-1.2, -2.2, -3.2]])
+        )
+        assert sliced.token_ids == [100, 200, 300]
+        assert sliced.cu_num_generated_tokens is None
+
+    def test_slice_last_request(self):
+        """Test slicing the last request."""
+        sliced = self.tracked.slice_request(2, num_positions=3)
+
+        # Request 2 has 3 tokens at rows 3-5
+        np.testing.assert_array_almost_equal(
+            sliced.logprobs,
+            np.array(
+                [
+                    [-1.3, -2.3, -3.3],
+                    [-1.4, -2.4, -3.4],
+                    [-1.5, -2.5, -3.5],
+                ]
+            ),
+        )
+        assert sliced.token_ids == [100, 200, 300]
+        assert sliced.cu_num_generated_tokens is None
+
+    def test_slice_single_token(self):
+        """Test slicing a request with a single token."""
+        # Create a tracked list where each request has 1 token
+        tracked = TrackedLogprobsLists(
+            logprobs=np.array(
+                [
+                    [-1.0, -2.0],
+                    [-3.0, -4.0],
+                    [-5.0, -6.0],
+                ]
+            ),
+            token_ids=[100, 200],
+            cu_num_generated_tokens=[0, 1, 2, 3],
+        )
+
+        sliced = tracked.slice_request(1, num_positions=1)
+
+        np.testing.assert_array_almost_equal(sliced.logprobs, np.array([[-3.0, -4.0]]))
+        assert sliced.token_ids == [100, 200]
+
+    def test_slice_preserves_token_ids(self):
+        """Test that token_ids are always preserved after slicing."""
+        # Slice different requests and verify token_ids are unchanged
+        for req_idx in range(3):
+            num_tokens = [2, 1, 3][req_idx]  # Tokens per request
+            sliced = self.tracked.slice_request(req_idx, num_positions=num_tokens)
+            assert sliced.token_ids == [100, 200, 300]
+
+    def test_slice_with_single_tracked_token(self):
+        """Test slicing when only tracking a single token."""
+        tracked = TrackedLogprobsLists(
+            logprobs=np.array(
+                [
+                    [-1.0],
+                    [-2.0],
+                    [-3.0],
+                ]
+            ),
+            token_ids=[42],
+            cu_num_generated_tokens=[0, 1, 2, 3],
+        )
+
+        sliced = tracked.slice_request(1, num_positions=1)
+
+        np.testing.assert_array_almost_equal(sliced.logprobs, np.array([[-2.0]]))
+        assert sliced.token_ids == [42]
+
+    def test_slice_with_many_tracked_tokens(self):
+        """Test slicing when tracking many tokens (e.g., 100-class classification)."""
+        num_tracked = 100
+        num_tokens = 5
+        token_ids = list(range(num_tracked))
+
+        tracked = TrackedLogprobsLists(
+            logprobs=np.random.randn(num_tokens, num_tracked),
+            token_ids=token_ids,
+            cu_num_generated_tokens=[0, 2, 5],  # 2 requests: 2 tokens, 3 tokens
+        )
+
+        sliced = tracked.slice_request(1, num_positions=3)
+
+        assert sliced.logprobs.shape == (3, num_tracked)
+        assert sliced.token_ids == token_ids
+        assert len(sliced.token_ids) == num_tracked
+
+    def test_slice_empty_result(self):
+        """Test slicing with num_positions=0 returns empty array."""
+        sliced = self.tracked.slice_request(0, num_positions=0)
+
+        assert sliced.logprobs.shape == (0, 3)
+        assert sliced.token_ids == [100, 200, 300]

--- a/tests/v1/test_sampling_params.py
+++ b/tests/v1/test_sampling_params.py
@@ -108,7 +108,9 @@ class TestTrackTokenIdsValidation:
         assert "[100, 200]" in repr_str
 
     def test_track_token_ids_duplicate_values(self):
-        """Test that duplicate token IDs are allowed (no deduplication at param level)."""
+        """Test that duplicate token IDs are allowed
+        (no deduplication at param level).
+        """
         # Note: Deduplication happens at the batch level in merged_track_token_ids
         params = SamplingParams(track_token_ids=[100, 100, 200])
         assert params.track_token_ids == [100, 100, 200]

--- a/tests/v1/test_sampling_params.py
+++ b/tests/v1/test_sampling_params.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for SamplingParams validation, especially track_token_ids."""
+
+import pytest
+
+from vllm import SamplingParams
+
+
+class TestTrackTokenIdsValidation:
+    """Tests for track_token_ids parameter validation in SamplingParams."""
+
+    def test_track_token_ids_none(self):
+        """Test that track_token_ids=None is valid (default)."""
+        params = SamplingParams(track_token_ids=None)
+        assert params.track_token_ids is None
+
+    def test_track_token_ids_empty_list(self):
+        """Test that track_token_ids=[] is valid."""
+        params = SamplingParams(track_token_ids=[])
+        assert params.track_token_ids == []
+
+    def test_track_token_ids_single_token(self):
+        """Test that a single token ID is valid."""
+        params = SamplingParams(track_token_ids=[100])
+        assert params.track_token_ids == [100]
+
+    def test_track_token_ids_multiple_tokens(self):
+        """Test that multiple token IDs are valid."""
+        track_ids = [100, 200, 300, 500, 1000]
+        params = SamplingParams(track_token_ids=track_ids)
+        assert params.track_token_ids == track_ids
+
+    def test_track_token_ids_with_zero(self):
+        """Test that token ID 0 is valid."""
+        params = SamplingParams(track_token_ids=[0, 1, 2])
+        assert params.track_token_ids == [0, 1, 2]
+
+    def test_track_token_ids_large_values(self):
+        """Test that large token IDs are valid (vocab bounds checked at runtime)."""
+        large_ids = [100000, 150000, 200000]
+        params = SamplingParams(track_token_ids=large_ids)
+        assert params.track_token_ids == large_ids
+
+    def test_track_token_ids_many_tokens(self):
+        """Test that tracking many tokens (e.g., 100 for classification) is valid."""
+        track_ids = list(range(100))
+        params = SamplingParams(track_token_ids=track_ids)
+        assert params.track_token_ids == track_ids
+        assert len(params.track_token_ids) == 100
+
+    def test_track_token_ids_negative_integer_raises(self):
+        """Test that negative integers raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            SamplingParams(track_token_ids=[-1])
+        assert "track_token_ids must contain only non-negative integers" in str(
+            exc_info.value
+        )
+
+    def test_track_token_ids_negative_in_list_raises(self):
+        """Test that a negative integer in a list raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            SamplingParams(track_token_ids=[100, -5, 200])
+        assert "track_token_ids must contain only non-negative integers" in str(
+            exc_info.value
+        )
+
+    def test_track_token_ids_with_logprobs(self):
+        """Test that track_token_ids works alongside logprobs parameter."""
+        params = SamplingParams(
+            logprobs=5,
+            track_token_ids=[100, 200, 300],
+        )
+        assert params.logprobs == 5
+        assert params.track_token_ids == [100, 200, 300]
+
+    def test_track_token_ids_with_prompt_logprobs(self):
+        """Test that track_token_ids works alongside prompt_logprobs parameter."""
+        params = SamplingParams(
+            prompt_logprobs=3,
+            track_token_ids=[100, 200],
+        )
+        assert params.prompt_logprobs == 3
+        assert params.track_token_ids == [100, 200]
+
+    def test_track_token_ids_with_temperature(self):
+        """Test that track_token_ids works with various temperature settings."""
+        # Greedy
+        params = SamplingParams(temperature=0.0, track_token_ids=[100])
+        assert params.temperature == 0.0
+        assert params.track_token_ids == [100]
+
+        # Non-zero temperature
+        params = SamplingParams(temperature=0.8, track_token_ids=[100])
+        assert params.temperature == 0.8
+        assert params.track_token_ids == [100]
+
+    def test_track_token_ids_default_not_provided(self):
+        """Test that track_token_ids is None when not provided."""
+        params = SamplingParams()
+        assert params.track_token_ids is None
+
+    def test_track_token_ids_in_repr(self):
+        """Test that track_token_ids appears in the string representation."""
+        params = SamplingParams(track_token_ids=[100, 200])
+        repr_str = repr(params)
+        assert "track_token_ids" in repr_str
+        assert "[100, 200]" in repr_str
+
+    def test_track_token_ids_duplicate_values(self):
+        """Test that duplicate token IDs are allowed (no deduplication at param level)."""
+        # Note: Deduplication happens at the batch level in merged_track_token_ids
+        params = SamplingParams(track_token_ids=[100, 100, 200])
+        assert params.track_token_ids == [100, 100, 200]

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -14,7 +14,11 @@ from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.v1.metrics.stats import SchedulerStats
-from vllm.v1.outputs import LogprobsLists, LogprobsTensors
+from vllm.v1.outputs import (
+    LogprobsLists,
+    LogprobsTensors,
+    TrackedLogprobsLists,
+)
 from vllm.v1.serial_utils import UtilityResult
 
 # These are possible values of RequestOutput.finish_reason,
@@ -128,6 +132,7 @@ class EngineCoreOutput(
 
     new_logprobs: LogprobsLists | None = None
     new_prompt_logprobs_tensors: LogprobsTensors | None = None
+    new_tracked_logprobs: TrackedLogprobsLists | None = None
 
     pooling_output: torch.Tensor | None = None
 

--- a/vllm/v1/engine/logprobs.py
+++ b/vllm/v1/engine/logprobs.py
@@ -221,7 +221,7 @@ class LogprobsProcessor:
 
         # Process each generated token (may be > 1 in speculative decoding)
         num_tokens = logprobs_array.shape[0]
-        for token_id in self.track_token_ids:
+        for token_id in self.tracked_logprobs:
             if token_id in token_id_to_idx:
                 idx = token_id_to_idx[token_id]
                 # Append logprobs for all generated tokens

--- a/vllm/v1/engine/logprobs.py
+++ b/vllm/v1/engine/logprobs.py
@@ -17,7 +17,7 @@ from vllm.tokenizers.detokenizer_utils import (
     convert_ids_list_to_tokens,
 )
 from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest
-from vllm.v1.outputs import LogprobsLists, LogprobsTensors
+from vllm.v1.outputs import LogprobsLists, LogprobsTensors, TrackedLogprobsLists
 
 logger = init_logger(__name__)
 
@@ -37,6 +37,11 @@ class LogprobsProcessor:
     num_logprobs: int | None
     num_prompt_logprobs: int | None
 
+    # Tracked logprobs for specific tokens
+    # Format: {token_id: [logprob_step0, logprob_step1, ...]}
+    tracked_logprobs: dict[int, list[float]] | None
+    track_token_ids: list[int] | None
+
     @classmethod
     def from_new_request(
         cls,
@@ -47,6 +52,14 @@ class LogprobsProcessor:
         assert sampling_params is not None
         num_logprobs = sampling_params.logprobs
         num_prompt_logprobs = sampling_params.prompt_logprobs
+        track_token_ids = sampling_params.track_token_ids
+
+        # Initialize tracked_logprobs dict if track_token_ids is specified
+        # Use `is not None` to correctly handle empty list (which should return {})
+        tracked_logprobs: dict[int, list[float]] | None = None
+        if track_token_ids is not None:
+            tracked_logprobs = {token_id: [] for token_id in track_token_ids}
+
         return cls(
             tokenizer=tokenizer,
             cumulative_logprob=(None if num_logprobs is None else 0.0),
@@ -62,6 +75,8 @@ class LogprobsProcessor:
             ),
             num_prompt_logprobs=num_prompt_logprobs,
             num_logprobs=num_logprobs,
+            tracked_logprobs=tracked_logprobs,
+            track_token_ids=track_token_ids,
         )
 
     def _update_sample_logprobs(self, logprobs_lists: LogprobsLists) -> None:
@@ -182,8 +197,42 @@ class LogprobsProcessor:
             self.prompt_logprobs = []
         return plp
 
+    def _update_tracked_logprobs(
+        self,
+        tracked_logprobs_lists: TrackedLogprobsLists,
+    ) -> None:
+        """Update with tracked logprobs from EngineCore.
+
+        Args:
+            tracked_logprobs_lists: The tracked logprobs for this request.
+                Shape: [num_generated_tokens, num_tracked_tokens]
+                In speculative decoding, num_generated_tokens can be > 1.
+        """
+        if self.tracked_logprobs is None or self.track_token_ids is None:
+            return
+
+        logprobs_array = tracked_logprobs_lists.logprobs
+        token_ids = tracked_logprobs_lists.token_ids
+
+        # logprobs_array shape: [num_tokens, num_tracked_tokens]
+        # We need to match the tracked token IDs from the merged set
+        # to our specific track_token_ids
+        token_id_to_idx = {tid: idx for idx, tid in enumerate(token_ids)}
+
+        # Process each generated token (may be > 1 in speculative decoding)
+        num_tokens = logprobs_array.shape[0]
+        for token_id in self.track_token_ids:
+            if token_id in token_id_to_idx:
+                idx = token_id_to_idx[token_id]
+                # Append logprobs for all generated tokens
+                for row_idx in range(num_tokens):
+                    logprob_value = float(logprobs_array[row_idx, idx])
+                    self.tracked_logprobs[token_id].append(logprob_value)
+
     def update_from_output(self, output: EngineCoreOutput) -> None:
         if output.new_logprobs is not None:
             self._update_sample_logprobs(output.new_logprobs)
         if output.new_prompt_logprobs_tensors is not None:
             self._update_prompt_logprobs(output.new_prompt_logprobs_tensors)
+        if output.new_tracked_logprobs is not None:
+            self._update_tracked_logprobs(output.new_tracked_logprobs)

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -329,6 +329,18 @@ class RequestState:
         if delta and logprobs:
             logprobs = logprobs[-len(token_ids) :]
 
+        # Prepare tracked logprobs, based on delta mode
+        # Use `is not None` to distinguish "feature disabled" (None) from
+        # "feature enabled but empty" ({})
+        tracked_logprobs = self.logprobs_processor.tracked_logprobs
+        if delta and tracked_logprobs is not None:
+            # In delta mode, only return the logprobs for the new tokens
+            num_new_tokens = len(token_ids)
+            tracked_logprobs = {
+                token_id: logprob_list[-num_new_tokens:]
+                for token_id, logprob_list in tracked_logprobs.items()
+            }
+
         return CompletionOutput(
             index=self.request_index,
             text=text,
@@ -337,6 +349,7 @@ class RequestState:
             cumulative_logprob=self.logprobs_processor.cumulative_logprob,
             finish_reason=str(finish_reason) if finished else None,
             stop_reason=stop_reason if finished else None,
+            tracked_logprobs=tracked_logprobs,
         )
 
     def _new_pooling_output(

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -42,3 +42,6 @@ class SamplingMetadata:
 
     # Speculative token ids
     spec_token_ids: list[list[int]] | None = None
+
+    # Token IDs to track logprobs for (merged from all requests)
+    track_token_ids: torch.Tensor | None = None

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -242,6 +242,7 @@ class RejectionSampler(nn.Module):
 
         # Get bonus logits from the bonus sampler output
         # The bonus_sampler_output was run with logprobs_mode_override to get logits
+        assert bonus_sampler_output.logprobs_tensors is not None
         bonus_logits = bonus_sampler_output.logprobs_tensors.logprobs
 
         # Create combined logits tensor

--- a/vllm/v1/worker/gpu/sample/metadata.py
+++ b/vllm/v1/worker/gpu/sample/metadata.py
@@ -30,6 +30,9 @@ class SamplingMetadata:
     prompt_bin_mask: torch.Tensor
     output_bin_counts: torch.Tensor
 
+    # Token IDs to track logprobs for (merged from all requests)
+    track_token_ids: torch.Tensor | None = None
+
     @classmethod
     def make_dummy(
         cls,
@@ -76,6 +79,7 @@ class SamplingMetadata:
             idx_mapping=idx_mapping,
             prompt_bin_mask=prompt_bin_mask,
             output_bin_counts=output_bin_counts,
+            track_token_ids=None,
         )
 
 
@@ -189,4 +193,5 @@ def expand_sampling_metadata(
         idx_mapping=sampling_metadata.idx_mapping,
         prompt_bin_mask=sampling_metadata.prompt_bin_mask,
         output_bin_counts=sampling_metadata.output_bin_counts,
+        track_token_ids=sampling_metadata.track_token_ids,
     )

--- a/vllm/v1/worker/gpu/sample/output.py
+++ b/vllm/v1/worker/gpu/sample/output.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import torch
 
-from vllm.v1.outputs import LogprobsTensors
+from vllm.v1.outputs import LogprobsTensors, TrackedLogprobsTensors
 
 
 @dataclass
@@ -12,3 +12,4 @@ class SamplerOutput:
     sampled_token_ids: torch.Tensor
     logprobs_tensors: LogprobsTensors | None
     num_nans: torch.Tensor | None
+    tracked_logprobs_tensors: TrackedLogprobsTensors | None = None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -137,6 +137,8 @@ from vllm.v1.outputs import (
     ModelRunnerOutput,
     PoolerOutput,
     SamplerOutput,
+    TrackedLogprobsLists,
+    TrackedLogprobsTensors,
     make_empty_encoder_model_runner_output,
 )
 from vllm.v1.pool.metadata import PoolingMetadata, PoolingStates
@@ -193,6 +195,7 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         model_runner_output: ModelRunnerOutput,
         sampled_token_ids: torch.Tensor,
         logprobs_tensors: LogprobsTensors | None,
+        tracked_logprobs_tensors: "TrackedLogprobsTensors | None",
         invalid_req_indices: list[int],
         async_output_copy_stream: torch.cuda.Stream,
         vocab_size: int,
@@ -208,6 +211,7 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         self._sampled_token_ids = sampled_token_ids
         self.vocab_size = vocab_size
         self._logprobs_tensors = logprobs_tensors
+        self._tracked_logprobs_tensors = tracked_logprobs_tensors
 
         # Initiate the copy on a separate stream, but do not synchronize it.
         default_stream = torch.cuda.current_stream()
@@ -219,6 +223,11 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
             self._logprobs_tensors_cpu = (
                 self._logprobs_tensors.to_cpu_nonblocking()
                 if self._logprobs_tensors
+                else None
+            )
+            self._tracked_logprobs_tensors_cpu = (
+                self._tracked_logprobs_tensors.to_cpu_nonblocking()
+                if self._tracked_logprobs_tensors
                 else None
             )
             self.async_copy_ready_event.record()
@@ -233,6 +242,7 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
 
         # Release the device tensors once the copy has completed.
         del self._logprobs_tensors
+        del self._tracked_logprobs_tensors
         del self._sampled_token_ids
         if max_gen_len == 1:
             valid_sampled_token_ids = self.sampled_token_ids_cpu.tolist()
@@ -240,17 +250,25 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
                 valid_sampled_token_ids[i].clear()
             cu_num_tokens = None
         else:
+            need_cu_num_tokens = (
+                self._logprobs_tensors_cpu is not None
+                or self._tracked_logprobs_tensors_cpu is not None
+            )
             valid_sampled_token_ids, cu_num_tokens = RejectionSampler.parse_output(
                 self.sampled_token_ids_cpu,
                 self.vocab_size,
                 self._invalid_req_indices,
-                return_cu_num_tokens=self._logprobs_tensors_cpu is not None,
+                return_cu_num_tokens=need_cu_num_tokens,
             )
 
         output = self._model_runner_output
         output.sampled_token_ids = valid_sampled_token_ids
         if self._logprobs_tensors_cpu:
             output.logprobs = self._logprobs_tensors_cpu.tolists(cu_num_tokens)
+        if self._tracked_logprobs_tensors_cpu:
+            output.tracked_logprobs = self._tracked_logprobs_tensors_cpu.tolists(
+                cu_num_tokens
+            )
         return output
 
 
@@ -2692,6 +2710,7 @@ class GPUModelRunner(
         list[str],
         dict[str, int],
         list[int],
+        "TrackedLogprobsLists | None",
     ]:
         num_nans_in_logits = {}
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
@@ -2714,6 +2733,7 @@ class GPUModelRunner(
         num_sampled_tokens = sampler_output.sampled_token_ids.shape[0]
         sampled_token_ids = sampler_output.sampled_token_ids
         logprobs_tensors = sampler_output.logprobs_tensors
+        tracked_logprobs_tensors = sampler_output.tracked_logprobs_tensors
         invalid_req_indices = []
         cu_num_tokens: list[int] | None = None
         if not self.use_async_scheduling:
@@ -2727,11 +2747,15 @@ class GPUModelRunner(
                     valid_sampled_token_ids[int(i)].clear()
             else:
                 # Includes spec decode tokens.
+                # Need cu_num_tokens for proper slicing of logprobs or tracked logprobs
+                need_cu_num_tokens = (
+                    logprobs_tensors is not None or tracked_logprobs_tensors is not None
+                )
                 valid_sampled_token_ids, cu_num_tokens = RejectionSampler.parse_output(
                     sampled_token_ids,
                     self.input_batch.vocab_size,
                     discard_sampled_tokens_req_indices,
-                    return_cu_num_tokens=logprobs_tensors is not None,
+                    return_cu_num_tokens=need_cu_num_tokens,
                 )
         else:
             valid_sampled_token_ids = []
@@ -2790,6 +2814,13 @@ class GPUModelRunner(
             else None
         )
 
+        # Process tracked logprobs if present
+        tracked_logprobs_lists = (
+            tracked_logprobs_tensors.tolists(cu_num_tokens)
+            if not self.use_async_scheduling and tracked_logprobs_tensors is not None
+            else None
+        )
+
         # Compute prompt logprobs if needed.
         prompt_logprobs_dict = self._get_prompt_logprobs_dict(
             hidden_states[:num_scheduled_tokens],
@@ -2804,6 +2835,7 @@ class GPUModelRunner(
             req_ids_output_copy,
             req_id_to_index_output_copy,
             invalid_req_indices,
+            tracked_logprobs_lists,
         )
 
     @contextmanager
@@ -3412,6 +3444,7 @@ class GPUModelRunner(
                 req_ids_output_copy,
                 req_id_to_index_output_copy,
                 invalid_req_indices,
+                tracked_logprobs_lists,
             ) = self._bookkeeping_sync(
                 scheduler_output,
                 sampler_output,
@@ -3440,6 +3473,7 @@ class GPUModelRunner(
                 logprobs=logprobs_lists,
                 prompt_logprobs_dict=prompt_logprobs_dict,
                 pooler_output=[],
+                tracked_logprobs=tracked_logprobs_lists,
                 kv_connector_output=kv_connector_output,
                 ec_connector_output=ec_connector_output
                 if self.supports_mm_inputs
@@ -3457,6 +3491,7 @@ class GPUModelRunner(
                 model_runner_output=output,
                 sampled_token_ids=sampler_output.sampled_token_ids,
                 logprobs_tensors=sampler_output.logprobs_tensors,
+                tracked_logprobs_tensors=sampler_output.tracked_logprobs_tensors,
                 invalid_req_indices=invalid_req_indices,
                 async_output_copy_stream=self.async_output_copy_stream,
                 vocab_size=self.input_batch.vocab_size,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2710,7 +2710,7 @@ class GPUModelRunner(
         list[str],
         dict[str, int],
         list[int],
-        "TrackedLogprobsLists | None",
+        TrackedLogprobsLists | None,
     ]:
         num_nans_in_logits = {}
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR adds a new `track_token_ids` parameter to `SamplingParams` that enables efficient tracking of log probabilities (logprobs) for specific tokens without requiring full vocabulary logprobs retrieval. This feature addresses [Issue#29280](https://github.com/vllm-project/vllm/issues/29280)

## Implementation Overview

The feature is implemented across the vLLM V1 engine pipeline, from parameter validation to output processing.

### 1. Parameter Extension (`vllm/sampling_params.py`)

Added `track_token_ids: list[int] | None` parameter with validation ensuring all IDs are non-negative integers:

```python
track_token_ids: list[int] | None = None
"""List of token IDs to track logprobs for at every generation step."""
```

### 2. New Data Structures (`vllm/v1/outputs.py`)

Introduced `TrackedLogprobsTensors` (GPU-side) and `TrackedLogprobsLists` (CPU-side for serialization):

- `TrackedLogprobsTensors`: Holds `[batch_size, num_tracked_tokens]` logprobs tensor and token IDs tensor
- `TrackedLogprobsLists`: NumPy/list form for efficient IPC, with `slice_request()` for per-request extraction

### 3. Batch Management (`vllm/v1/worker/gpu_input_batch.py`)

- Tracks `track_token_ids` per request in `InputBatch`
- `merged_track_token_ids` property computes the union of all tracked tokens across the batch as a sorted tensor
- Validates token IDs against vocab bounds before GPU operations

### 4. Sampling Metadata Propagation

Extended `SamplingMetadata` in both:
- `vllm/v1/sample/metadata.py` (standard sampling)
- `vllm/v1/worker/gpu/sample/metadata.py` (GPU worker)

### 5. Core Logprobs Computation

**Standard Sampler (`vllm/v1/sample/sampler.py`):**
```python
@staticmethod
def compute_tracked_logprobs(
    logits_or_logprobs: torch.Tensor,
    track_token_ids: torch.Tensor,
    is_logprobs: bool = False,
) -> TrackedLogprobsTensors:
    """Efficiently extract logprobs for tracked tokens via column indexing."""
    if is_logprobs:
        logprobs = logits_or_logprobs
    else:
        logprobs = logits_or_logprobs.log_softmax(dim=-1, dtype=torch.float32)
    tracked_logprobs = logprobs[:, track_token_ids]  # O(num_tracked)
    return TrackedLogprobsTensors(logprobs=tracked_logprobs, token_ids=track_token_ids)
```

**GPU Worker Sampler (`vllm/v1/worker/gpu/sample/sampler.py`):**
- Calls `compute_tracked_logprobs()` from `vllm/v1/worker/gpu/sample/logprob.py`
- Uses same logits as regular logprobs (raw or processed based on `logprobs_mode`)

**Rejection Sampler for Speculative Decoding (`vllm/v1/sample/rejection_sampler.py`):**
- `_get_tracked_logprobs_tensors()` handles variable-length accepted tokens
- Combines target and bonus logits, extracts tracked logprobs only for accepted positions

### 6. Output Processing Pipeline

**Model Runner (`vllm/v1/worker/gpu_model_runner.py`):**
- Extracts `tracked_logprobs_tensors` from `SamplerOutput`
- Converts to `TrackedLogprobsLists` via `tolists()` with `cu_num_tokens` for proper slicing
- Handles async scheduling with `AsyncGPUModelRunnerOutput`

**Scheduler (`vllm/v1/core/sched/scheduler.py`):**
- Slices tracked logprobs per request using `slice_request()`
- Attaches `new_tracked_logprobs` to `EngineCoreOutput`

**Logprobs Processor (`vllm/v1/engine/logprobs.py`):**
- Accumulates tracked logprobs across generation steps in `LogprobsProcessor`
- Handles merged token IDs from batch by mapping back to per-request `track_token_ids`

**Output Processor (`vllm/v1/engine/output_processor.py`):**
- Includes `tracked_logprobs` in `CompletionOutput`
- Supports DELTA mode (returns only new tokens' logprobs)

### 7. Output Extension (`vllm/outputs.py`)

Added `tracked_logprobs: dict[int, list[float]] | None` to `CompletionOutput` with merge logic in `RequestOutput` for streaming.

---

## Test Design

The test suite provides comprehensive coverage at multiple levels:

### 1. Unit Tests - Parameter Validation (`tests/v1/test_sampling_params.py`)

- Valid inputs: `None`, empty list `[]`, single/multiple token IDs, boundary values (0, large values)
- Invalid inputs: negative integers raise `ValueError`
- Coexistence: works with `logprobs`, `prompt_logprobs`, `temperature`

### 2. Unit Tests - Core Computation (`tests/v1/sample/test_sampler.py`)

- `test_compute_tracked_logprobs_from_logits`: Verifies correct shape and values with manual log_softmax
- `test_compute_tracked_logprobs_from_logprobs`: Verifies `is_logprobs=True` skips redundant log_softmax
- Parametrized across devices, batch sizes, and number of tracked tokens
- Edge cases: single token, boundary tokens (0 and vocab_size-1), many tokens (100)

### 3. Unit Tests - Data Structures (`tests/v1/test_outputs.py`)

- `TrackedLogprobsLists.slice_request()` correctness with/without `cu_num_generated_tokens`
- Slicing for first/middle/last requests, single token tracking, many tokens (100)

### 4. Unit Tests - Batch Management (`tests/v1/worker/test_gpu_input_batch.py`)

- `merged_track_token_ids` correctly unions and sorts across requests
- Empty cases return `None`
- Vocab bounds validation raises on out-of-range token IDs

### 5. Unit Tests - Output Processing (`tests/v1/engine/test_output_processor.py`)

- `test_tracked_logprobs_basic`: Full pipeline with DELTA and FINAL_ONLY modes
- `test_tracked_logprobs_none_when_not_requested`: Returns `None` when disabled
- `test_tracked_logprobs_with_sample_logprobs`: Coexists with regular logprobs

### 6. End-to-End Tests (`tests/v1/e2e/test_tracked_logprobs.py`) - **1,656 lines**

**Basic Functionality:**
- `test_track_token_ids_returns_logprobs`: Verifies logprobs returned for all tracked tokens
- `test_track_token_ids_with_logprobs_coexist`: Both regular and tracked logprobs work together

**None vs Empty:**
- `test_track_token_ids_not_provided` / `test_track_token_ids_explicit_none`: Returns `None`
- `test_track_token_ids_empty_list`: Returns empty dict `{}`

**Batch Processing:**
- Multiple prompts with same track_token_ids
- Different completion lengths

**Differential Tests (Critical):**
- **Uses BOTH `logprobs=-1` AND `track_token_ids` in the same request**
- Compares `tracked_logprobs[tid]` vs `full_logprobs[step][tid].logprob`
- Parametrized across sampling configurations (greedy, temperature, top_p, top_k)
- Ensures values match exactly since they come from the same computation

**Streaming Tests (AsyncLLM):**
- `test_streaming_basic`: DELTA mode accumulates correctly
- `test_streaming_track_token_ids_none`: Returns `None` in streaming
- `test_streaming_vs_nonstreaming_consistency`: Final accumulated values match non-streaming

---

## Documentation

- Added `docs/features/track_token_ids.md` with motivation, use cases, API reference, and examples
- Updated `docs/usage/v1_guide.md` to reference the new feature

---

## Backward Compatibility

✅ **Fully backward compatible:**
- `track_token_ids=None` (default): No behavior change
- Existing code continues to work unchanged
- Feature is opt-in
