### PR TITLE
[Bugfix] Fix the issue with interleaved thinking when using streaming

### DIFF
--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -112,7 +112,7 @@ class TestBaseThinkingReasoningParserMethods:
         """Test the is_reasoning_end method."""
         parser = TestThinkingReasoningParser(test_tokenizer)
         end_token_id = parser.end_token_id
-
+        start_token_id = parser.start_token_id
         # Test with end token present
         assert parser.is_reasoning_end([1, 2, end_token_id, 4]) is True
 
@@ -121,6 +121,16 @@ class TestBaseThinkingReasoningParserMethods:
 
         # Test with empty list
         assert parser.is_reasoning_end([]) is False
+
+        # Test with interleaved thinking
+        assert parser.is_reasoning_end([1, start_token_id, 2, end_token_id]) is True
+        assert parser.is_reasoning_end([1, start_token_id, 2, 3]) is False
+        assert (
+            parser.is_reasoning_end(
+                [1, start_token_id, 2, end_token_id, 2, 2, start_token_id]
+            )
+            is True
+        )
 
     def test_extract_content_ids(self, test_tokenizer):
         """Test the extract_content_ids method."""

--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -129,7 +129,7 @@ class TestBaseThinkingReasoningParserMethods:
             parser.is_reasoning_end(
                 [1, start_token_id, 2, end_token_id, 2, 2, start_token_id]
             )
-            is True
+            is False
         )
 
     def test_extract_content_ids(self, test_tokenizer):

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -64,10 +64,13 @@ class BaseThinkingReasoningParser(ReasoningParser):
             )
 
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
+        start_token_id = self.start_token_id
+        end_token_id = self.end_token_id
+
         for i in range(len(input_ids) - 1, -1, -1):
-            if input_ids[i] == self.start_token_id:
+            if input_ids[i] == start_token_id:
                 return False
-            if input_ids[i] == self.end_token_id:
+            if input_ids[i] == end_token_id:
                 return True
         return False
 

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -64,8 +64,12 @@ class BaseThinkingReasoningParser(ReasoningParser):
             )
 
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
-        end_token_id = self.end_token_id
-        return any(input_id == end_token_id for input_id in reversed(input_ids))
+        for i in range(len(input_ids) - 1, -1, -1):
+            if input_ids[i] == self.start_token_id:
+                return False
+            if input_ids[i] == self.end_token_id:
+                return True
+        return False
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         """


### PR DESCRIPTION
## Purpose
Fix the issue with interleaved thinking when using streaming.

```
｜begin▁of▁sentence｜>

## Tools
You have access to a set of tools you can use to answer the user's question.

<think>...thinking about results</think>

The current date is: 2024-09-30<｜User｜> What is the weather like in 
Beijing today? And tomorrow? <｜Assistant｜><think>


```

When the user's prompt contains something like `<think>...</think> ... <think>`, `is_reasoning_end` incorrectly determines that reasoning has already ended. In reality, because the last token is `<think>`, the reasoning has just begun. This causes reasoning to fail to work properly.


Especially in interleaved thinking mode, where the chat_template renders a `<think>...</think> ... <think>` prompt with 100% consistency.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

