### PR TITLE
[Frontend] Add MCP type support infrastructure to Responses API

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -25,6 +25,10 @@ from openai.types.responses import (
     ResponseContentPartDoneEvent,
     ResponseFunctionToolCall,
     ResponseInputItemParam,
+    ResponseMcpCallArgumentsDeltaEvent,
+    ResponseMcpCallArgumentsDoneEvent,
+    ResponseMcpCallCompletedEvent,
+    ResponseMcpCallInProgressEvent,
     ResponseOutputItem,
     ResponseOutputItemAddedEvent,
     ResponseOutputItemDoneEvent,
@@ -1790,6 +1794,10 @@ StreamingResponsesResponse: TypeAlias = (
     | ResponseCodeInterpreterCallCodeDoneEvent
     | ResponseCodeInterpreterCallInterpretingEvent
     | ResponseCodeInterpreterCallCompletedEvent
+    | ResponseMcpCallArgumentsDeltaEvent
+    | ResponseMcpCallArgumentsDoneEvent
+    | ResponseMcpCallInProgressEvent
+    | ResponseMcpCallCompletedEvent
 )
 
 


### PR DESCRIPTION
# Add MCP type support infrastructure to Responses API

## Summary
Add MCP type support infrastructure to Responses API

## Changes
- Import and use `McpCall` type from openai library
- Add `_parse_mcp_call()` function to parse MCP tool calls into properly typed output items
- Update `parse_output_message()` to route unknown recipients (not `browser.*`, `functions.*`, or built-in tools) to MCP parsing
- Update `parse_remaining_state()` to handle in-progress MCP calls
- Add `server_label` field to `McpCall` objects (extracted from recipient name)

## Test Plan

**Unit tests:**
```bash
python3 -m pytest tests/entrypoints/test_harmony_utils.py -k "mcp" -v
```

**Manual test - Before this change (missing `server_label` field):**
```bash
curl -X POST "http://localhost:8000/v1/responses" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer dummy-api-key" \
  -d '{
    "model": "default",
    "input": "Use the filesystem tool to list files in /tmp directory",
    "tools": [{
      "type": "mcp",
      "server_label": "filesystem",
      "headers": {"test": "test"}
    }],
    "enable_response_messages": true
  }'
```
Response: `{"error":{"message":"unhandled errors in a TaskGroup (1 sub-exception)","type":"BadRequestError","param":null,"code":400}}`

**After this change:**
Same curl command now returns:
```json
{
  "output": [
    ...reasoning items...,
    {
      "id": "mcp_bc8c1958cd96823c",
      "arguments": "{\"path\": \"/tmp\"}",
      "name": "filesystem",
      "server_label": "filesystem",
      "type": "mcp_call",
      "status": "completed"
    }
  ]
}
```
