### PR TITLE
[CI] fix silent error in nightly wheel index generation script, add generation time to HTML index

### DIFF
--- a/.buildkite/scripts/generate-nightly-index.py
+++ b/.buildkite/scripts/generate-nightly-index.py
@@ -21,7 +21,7 @@ if not sys.version_info >= (3, 12):
 
 INDEX_HTML_TEMPLATE = """<!DOCTYPE html>
 <html>
-  <!-- Generated on {time}{comment} -->
+  <!-- {comment} -->
   <meta name="pypi:repository-version" content="1.0">
   <body>
 {items}
@@ -100,10 +100,7 @@ def generate_project_list(subdir_names: list[str], comment: str = "") -> str:
     for name in sorted(subdir_names):
         name = name.strip("/").strip(".")
         href_tags.append(f'    <a href="{name}/">{name}/</a><br/>')
-    comment_str = f" ({comment})" if comment else ""
-    return INDEX_HTML_TEMPLATE.format(
-        items="\n".join(href_tags), time=datetime.now().isoformat(), comment=comment_str
-    )
+    return INDEX_HTML_TEMPLATE.format(items="\n".join(href_tags), comment=comment)
 
 
 def generate_package_index_and_metadata(
@@ -128,10 +125,7 @@ def generate_package_index_and_metadata(
         file_meta = asdict(file)
         file_meta["path"] = file_path_quoted
         metadata.append(file_meta)
-    comment_str = f" ({comment})" if comment else ""
-    index_str = INDEX_HTML_TEMPLATE.format(
-        items="\n".join(href_tags), time=datetime.now().isoformat(), comment=comment_str
-    )
+    index_str = INDEX_HTML_TEMPLATE.format(items="\n".join(href_tags), comment=comment)
     metadata_str = json.dumps(metadata, indent=2)
     return index_str, metadata_str
 
@@ -247,6 +241,10 @@ def generate_index_and_metadata(
             variant_to_files[alias_to_default] = variant_to_files["default"].copy()
             print(f"Alias variant '{alias_to_default}' created for default variant.")
 
+    # Generate comment in HTML header
+    comment_str = f" ({comment})" if comment else ""
+    comment_tmpl = f"Generated on {datetime.now().isoformat()}{comment_str}"
+
     # Generate index for each variant
     subdir_names = set()
     for variant, files in variant_to_files.items():
@@ -266,7 +264,7 @@ def generate_index_and_metadata(
             subdir_names = subdir_names.union(packages)
         else:
             # generate project list for this variant directly
-            project_list_str = generate_project_list(sorted(packages), comment)
+            project_list_str = generate_project_list(sorted(packages), comment_tmpl)
             with open(variant_dir / "index.html", "w") as f:
                 f.write(project_list_str)
 
@@ -284,7 +282,7 @@ def generate_index_and_metadata(
                 f.write(metadata_str)
 
     # Generate top-level project list index
-    project_list_str = generate_project_list(sorted(subdir_names), comment)
+    project_list_str = generate_project_list(sorted(subdir_names), comment_tmpl)
     with open(index_base_dir / "index.html", "w") as f:
         f.write(project_list_str)
 

--- a/.buildkite/scripts/generate-nightly-index.py
+++ b/.buildkite/scripts/generate-nightly-index.py
@@ -9,6 +9,7 @@ import argparse
 import json
 import sys
 from dataclasses import asdict, dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -20,6 +21,7 @@ if not sys.version_info >= (3, 12):
 
 INDEX_HTML_TEMPLATE = """<!DOCTYPE html>
 <html>
+  <!-- Generated on {time}{comment} -->
   <meta name="pypi:repository-version" content="1.0">
   <body>
 {items}
@@ -90,7 +92,7 @@ def parse_from_filename(file: str) -> WheelFileInfo:
     )
 
 
-def generate_project_list(subdir_names: list[str]) -> str:
+def generate_project_list(subdir_names: list[str], comment: str = "") -> str:
     """
     Generate project list HTML content linking to each project & variant sub-directory.
     """
@@ -98,11 +100,17 @@ def generate_project_list(subdir_names: list[str]) -> str:
     for name in sorted(subdir_names):
         name = name.strip("/").strip(".")
         href_tags.append(f'    <a href="{name}/">{name}/</a><br/>')
-    return INDEX_HTML_TEMPLATE.format(items="\n".join(href_tags))
+    comment_str = f" ({comment})" if comment else ""
+    return INDEX_HTML_TEMPLATE.format(
+        items="\n".join(href_tags), time=datetime.now().isoformat(), comment=comment_str
+    )
 
 
 def generate_package_index_and_metadata(
-    wheel_files: list[WheelFileInfo], wheel_base_dir: Path, index_base_dir: Path
+    wheel_files: list[WheelFileInfo],
+    wheel_base_dir: Path,
+    index_base_dir: Path,
+    comment: str = "",
 ) -> tuple[str, str]:
     """
     Generate package index HTML content for a specific package, linking to actual wheel files.
@@ -120,7 +128,10 @@ def generate_package_index_and_metadata(
         file_meta = asdict(file)
         file_meta["path"] = file_path_quoted
         metadata.append(file_meta)
-    index_str = INDEX_HTML_TEMPLATE.format(items="\n".join(href_tags))
+    comment_str = f" ({comment})" if comment else ""
+    index_str = INDEX_HTML_TEMPLATE.format(
+        items="\n".join(href_tags), time=datetime.now().isoformat(), comment=comment_str
+    )
     metadata_str = json.dumps(metadata, indent=2)
     return index_str, metadata_str
 
@@ -131,6 +142,7 @@ def generate_index_and_metadata(
     index_base_dir: Path,
     default_variant: str | None = None,
     alias_to_default: str | None = None,
+    comment: str = "",
 ):
     """
     Generate index for all wheel files.
@@ -141,6 +153,7 @@ def generate_index_and_metadata(
         index_base_dir (Path): Base directory to store index files.
         default_variant (str | None): The default variant name, if any.
         alias_to_default (str | None): Alias variant name for the default variant, if any.
+        comment (str | None): Optional comment to include in the generated HTML files.
 
     First, parse all wheel files to extract metadata.
     We need to collect all wheel files for each variant, and generate an index for it (in a sub-directory).
@@ -253,7 +266,7 @@ def generate_index_and_metadata(
             subdir_names = subdir_names.union(packages)
         else:
             # generate project list for this variant directly
-            project_list_str = generate_project_list(sorted(packages))
+            project_list_str = generate_project_list(sorted(packages), comment)
             with open(variant_dir / "index.html", "w") as f:
                 f.write(project_list_str)
 
@@ -263,7 +276,7 @@ def generate_index_and_metadata(
             package_dir = variant_dir / package
             package_dir.mkdir(parents=True, exist_ok=True)
             index_str, metadata_str = generate_package_index_and_metadata(
-                package_files, wheel_base_dir, package_dir
+                package_files, wheel_base_dir, package_dir, comment
             )
             with open(package_dir / "index.html", "w") as f:
                 f.write(index_str)
@@ -271,7 +284,7 @@ def generate_index_and_metadata(
                 f.write(metadata_str)
 
     # Generate top-level project list index
-    project_list_str = generate_project_list(sorted(subdir_names))
+    project_list_str = generate_project_list(sorted(subdir_names), comment)
     with open(index_base_dir / "index.html", "w") as f:
         f.write(project_list_str)
 
@@ -283,6 +296,7 @@ if __name__ == "__main__":
         --current-objects <path_to_json> : path to JSON file containing current S3 objects listing in this version directory
         --output-dir <output_directory> : directory to store generated index files
         --alias-to-default <alias_variant_name> : (optional) alias variant name for the default variant
+        --comment <comment_string> : (optional) comment string to include in generated HTML files
     """
 
     parser = argparse.ArgumentParser(
@@ -311,6 +325,12 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help="Alias variant name for the default variant",
+    )
+    parser.add_argument(
+        "--comment",
+        type=str,
+        default="",
+        help="Optional comment string to include in generated HTML files",
     )
 
     args = parser.parse_args()
@@ -366,5 +386,6 @@ if __name__ == "__main__":
         index_base_dir=index_base_dir,
         default_variant=None,
         alias_to_default=args.alias_to_default,
+        comment=args.comment.strip(),
     )
     print(f"Successfully generated index and metadata in {output_dir}")

--- a/.buildkite/scripts/upload-wheels.sh
+++ b/.buildkite/scripts/upload-wheels.sh
@@ -81,7 +81,10 @@ else
     alias_arg=""
 fi
 
-$PYTHON pip install regex && .buildkite/scripts/generate-nightly-index.py --version "$SUBPATH" --current-objects "$obj_json" --output-dir "$INDICES_OUTPUT_DIR" $alias_arg
+# HACK: we do not need regex module here, but it is required by pre-commit hook
+# To avoid any external dependency, we simply replace it back to the stdlib re module
+sed -i 's/import regex as re/import re/g' .buildkite/scripts/generate-nightly-index.py
+$PYTHON .buildkite/scripts/generate-nightly-index.py --version "$SUBPATH" --current-objects "$obj_json" --output-dir "$INDICES_OUTPUT_DIR" $alias_arg
 
 # copy indices to /<commit>/ unconditionally
 echo "Uploading indices to $S3_COMMIT_PREFIX"

--- a/.buildkite/scripts/upload-wheels.sh
+++ b/.buildkite/scripts/upload-wheels.sh
@@ -84,7 +84,7 @@ fi
 # HACK: we do not need regex module here, but it is required by pre-commit hook
 # To avoid any external dependency, we simply replace it back to the stdlib re module
 sed -i 's/import regex as re/import re/g' .buildkite/scripts/generate-nightly-index.py
-$PYTHON .buildkite/scripts/generate-nightly-index.py --version "$SUBPATH" --current-objects "$obj_json" --output-dir "$INDICES_OUTPUT_DIR" $alias_arg
+$PYTHON .buildkite/scripts/generate-nightly-index.py --version "$SUBPATH" --current-objects "$obj_json" --output-dir "$INDICES_OUTPUT_DIR" --comment "commit $BUILDKITE_COMMIT" $alias_arg
 
 # copy indices to /<commit>/ unconditionally
 echo "Uploading indices to $S3_COMMIT_PREFIX"


### PR DESCRIPTION
## Purpose

#30008 introduced a silent error when generating nightly wheel indices. `$PYTHON pip install regex && .buildkite/scripts/generate-nightly-index.py --version "$SUBPATH" --current-objects "$obj_json" --output-dir "$INDICES_OUTPUT_DIR" $alias_arg` is wrong because: (1) it should be `$PYTHON -m pip` (2) the second half is not run with the same python (3) former half failure in `&&` shortcut will not be caught by bash.

So currently the `generate-nightly-index.py` is not run at all, thus no indices are generated. Wheels are uploaded nonetheless. The logs look like:

```text
[2025-12-04T11:26:21Z] + docker run --rm -v /var/lib/buildkite-agent/builds/bk-arm64-cpu-queue-postmerge-i-04192f6325ee0943d-1/vllm/release:/app -w /app python:3-slim python3 pip install regex
[2025-12-04T11:26:21Z] python3: can't open file '/app/pip': [Errno 2] No such file or directory
[2025-12-04T11:26:22Z] + echo 'Uploading indices to s3://vllm-wheels/1b7c7f5159484063af28cb47809d79e83d3301ec/'
[2025-12-04T11:26:22Z] Uploading indices to s3://vllm-wheels/1b7c7f5159484063af28cb47809d79e83d3301ec/
[2025-12-04T11:26:22Z] + aws s3 cp --recursive indices/ s3://vllm-wheels/1b7c7f5159484063af28cb47809d79e83d3301ec/
```

This PR fixes this issue by monkey-patching `regex` back to `re` in that script to both (1) make pre-commit linter happy and (2) get rid of any external dependencies. We are using very simple regexes and do not need the performance brought by `regex` here.

I also added comments in the generated HTML index to clearly specify the generation time and commit.

## Test Plan

Tested by CI.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

