### PR TITLE
Mistral tool parser

### DIFF
--- a/tests/tool_use/test_mistral_tool_parser.py
+++ b/tests/tool_use/test_mistral_tool_parser.py
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Comprehensive tests for the token-based Mistral tool parser.
+
+Tests cover:
+1. Non-streaming extraction for pre-v11 and v11+ tokenizers
+2. Streaming extraction with proper JSON delta emission
+3. Edge cases like content before tool calls, multiple tools, etc.
+"""
 
 import json
 from collections.abc import Generator
@@ -8,27 +16,30 @@ import partial_json_parser
 import pytest
 from mistral_common.protocol.instruct.messages import AssistantMessage
 from mistral_common.protocol.instruct.request import InstructRequest
-from mistral_common.protocol.instruct.tool_calls import FunctionCall, ToolCall
+from mistral_common.protocol.instruct.tool_calls import (
+    FunctionCall as MistralFunctionCall,
+)
+from mistral_common.protocol.instruct.tool_calls import ToolCall
 from partial_json_parser.core.options import Allow
 
 from vllm.entrypoints.openai.protocol import DeltaMessage, DeltaToolCall
-from vllm.entrypoints.openai.tool_parsers.mistral_tool_parser import MistralToolParser
-from vllm.tokenizers import (
-    MistralTokenizer,
-    TokenizerLike,
-    get_tokenizer,
+from vllm.entrypoints.openai.tool_parsers.mistral_tool_parser import (
+    MistralToolParser,
 )
+from vllm.tokenizers import MistralTokenizer, TokenizerLike, get_tokenizer
 from vllm.tokenizers.detokenizer_utils import detokenize_incrementally
 
 
 @pytest.fixture(scope="module")
 def mistral_pre_v11_tokenizer():
+    """Pre-v11 tokenizer using HF format (Mistral-7B-Instruct-v0.3)."""
     MODEL = "mistralai/Mistral-7B-Instruct-v0.3"
     return get_tokenizer(tokenizer_name=MODEL)
 
 
 @pytest.fixture(scope="module")
 def mistral_tokenizer():
+    """V11+ tokenizer using mistral-common format."""
     MODEL = "mistralai/Mistral-Small-3.2-24B-Instruct-2506"
     return get_tokenizer(tokenizer_name=MODEL, tokenizer_mode="mistral")
 
@@ -47,63 +58,85 @@ def assert_tool_calls(
     actual_tool_calls: list[ToolCall] | list[DeltaToolCall],
     expected_tool_calls: list[ToolCall],
 ):
-    assert len(actual_tool_calls) == len(expected_tool_calls)
+    """Assert that actual tool calls match expected ones."""
+    assert len(actual_tool_calls) == len(expected_tool_calls), (
+        f"Expected {len(expected_tool_calls)} tool calls, "
+        f"got {len(actual_tool_calls)}"
+    )
 
-    for actual_tool_call, expected_tool_call in zip(
-        actual_tool_calls, expected_tool_calls
-    ):
-        assert isinstance(actual_tool_call.id, str)
-        assert len(actual_tool_call.id) == 9
+    for actual, expected in zip(actual_tool_calls, expected_tool_calls):
+        # Check ID format
+        assert isinstance(actual.id, str), f"Tool call ID should be string, got {type(actual.id)}"
+        assert len(actual.id) == 9, f"Tool call ID should be 9 chars, got {len(actual.id)}"
+        assert actual.id.isalnum(), f"Tool call ID should be alphanumeric, got {actual.id}"
 
-        if isinstance(actual_tool_call, ToolCall):
-            assert actual_tool_call.type == "function"
-        elif isinstance(actual_tool_call, DeltaToolCall):
-            assert actual_tool_call.function is not None
-            assert actual_tool_call.function.name is not None
-            assert actual_tool_call.function.arguments is not None
-        assert actual_tool_call.function is not None
-        assert actual_tool_call.function.name == expected_tool_call.function.name, (
-            f"got wrong function name:${actual_tool_call.function.name}"
+        # Check function
+        assert actual.function is not None
+        # Handle both Pydantic model and dict-like access
+        func = actual.function
+        actual_name = getattr(func, 'name', None) or (func.get('name') if isinstance(func, dict) else None)
+        actual_args = getattr(func, 'arguments', None) or (func.get('arguments') if isinstance(func, dict) else None)
+
+        assert actual_name == expected.function.name, (
+            f"Expected function name '{expected.function.name}', "
+            f"got '{actual_name}'"
         )
-        assert (
-            actual_tool_call.function.arguments == expected_tool_call.function.arguments
-        ), f"got wrong function argument:${actual_tool_call.function.arguments}"
+        assert actual_args == expected.function.arguments, (
+            f"Expected arguments '{expected.function.arguments}', "
+            f"got '{actual_args}'"
+        )
 
 
 def fix_tool_call_tokenization(
     tokens: list[int],
     mistral_tool_parser: MistralToolParser,
     mistral_tokenizer: TokenizerLike,
-):
+) -> list[int]:
     """
-    Replaces the textual token sequence for [TOOL_CALLS]
-    with its single special token ID.
+    Replace textual token sequences for special tokens with their IDs.
+
+    This is needed because encoding free text may produce the textual tokens
+    for "[TOOL_CALLS]", "[ARGS]", etc. rather than the single special token.
     """
-    textual_tool_call_token_ids = mistral_tokenizer.encode(
+    # Build mapping of textual sequences to special token IDs
+    replacements: list[tuple[list[int], int]] = []
+
+    # [TOOL_CALLS] token
+    textual_tool_call_ids = mistral_tokenizer.encode(
         text=mistral_tool_parser.bot_token,
         add_special_tokens=False,
     )
-    # textual_tool_call_token_ids must not contain special tokens like bos, eos etc
-    special_tool_call_token_ids = [mistral_tool_parser.bot_token_id]
+    if mistral_tool_parser.bot_token_id is not None:
+        replacements.append((textual_tool_call_ids, mistral_tool_parser.bot_token_id))
 
-    # If the input is too short to contain the sequence, no replacement is possible
-    if not tokens or len(tokens) < len(textual_tool_call_token_ids):
+    # [ARGS] token (for v11+)
+    if hasattr(mistral_tool_parser, '_args_token_id') and mistral_tool_parser._args_token_id is not None:
+        textual_args_ids = mistral_tokenizer.encode(
+            text="[ARGS]",
+            add_special_tokens=False,
+        )
+        replacements.append((textual_args_ids, mistral_tool_parser._args_token_id))
+
+    if not tokens or not replacements:
         return tokens
 
-    result_tokens = []
-    i = 0
-    target_len = len(textual_tool_call_token_ids)
+    result_tokens = list(tokens)
 
-    while i < len(tokens):
-        # Check if the slice from the current position matches the target sequence
-        if tokens[i : i + target_len] == textual_tool_call_token_ids:
-            # If it matches, add the replacement and jump the index forward
-            result_tokens.extend(special_tool_call_token_ids)
-            i += target_len
-        else:
-            # Otherwise, just add the current token and move to the next one
-            result_tokens.append(tokens[i])
-            i += 1
+    # Apply each replacement (longest first to avoid partial matches)
+    replacements.sort(key=lambda x: -len(x[0]))
+
+    for textual_ids, special_id in replacements:
+        target_len = len(textual_ids)
+        new_result = []
+        i = 0
+        while i < len(result_tokens):
+            if result_tokens[i : i + target_len] == textual_ids:
+                new_result.append(special_id)
+                i += target_len
+            else:
+                new_result.append(result_tokens[i])
+                i += 1
+        result_tokens = new_result
 
     return result_tokens
 
@@ -114,48 +147,82 @@ def stream_delta_message_generator(
     model_output: str | None,
     tools: list[tuple[str, str]] | None,
 ) -> Generator[DeltaMessage, None, None]:
-    if (
-        isinstance(mistral_tokenizer, MistralTokenizer)
-        and mistral_tokenizer.version >= 11
-    ):
-        # With the newer versions of the tokenizer,
-        # we cannot tokenize free text
-        # so we need to create a list of messages to get tokenized
-        assert tools is not None
-        assistant_msg = AssistantMessage(
-            tool_calls=[
-                ToolCall(
-                    function=FunctionCall(
-                        name=name,
-                        arguments=arg,
+    """
+    Generate streaming delta messages by tokenizing and processing one token at a time.
+
+    For MistralTokenizer (all versions), we use encode_instruct to get proper
+    tokenization with special tokens. For non-MistralTokenizer, we encode free text.
+    """
+    if isinstance(mistral_tokenizer, MistralTokenizer):
+        # Use encode_instruct for all MistralTokenizer versions to get proper special tokens
+        if tools is not None:
+            # Use provided tools list
+            assistant_msg = AssistantMessage(
+                tool_calls=[
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name=name,
+                            arguments=arg,
+                        )
                     )
+                    for (name, arg) in tools
+                ],
+            )
+        elif model_output is not None and "[TOOL_CALLS]" in model_output:
+            # Parse tool calls from model_output for pre-v11 format
+            # Format: [TOOL_CALLS][{"name": "...", "arguments": {...}}, ...]
+            import json as json_module
+            tool_content = model_output.split("[TOOL_CALLS]")[-1].strip()
+            try:
+                tool_calls_data = json_module.loads(tool_content)
+                assistant_msg = AssistantMessage(
+                    tool_calls=[
+                        ToolCall(
+                            function=MistralFunctionCall(
+                                name=tc["name"],
+                                arguments=json_module.dumps(tc["arguments"]),
+                            )
+                        )
+                        for tc in tool_calls_data
+                    ],
                 )
-                for (name, arg) in tools
-            ],
-        )
-        request = InstructRequest(
-            messages=[assistant_msg],
-        )
-        all_token_ids = mistral_tokenizer.instruct.encode_instruct(request).tokens
+            except json_module.JSONDecodeError:
+                # Fall back to free text encoding if parsing fails
+                all_token_ids = mistral_tokenizer.encode(model_output, add_special_tokens=False)
+                all_token_ids = fix_tool_call_tokenization(
+                    all_token_ids, mistral_tool_parser, mistral_tokenizer
+                )
+                assistant_msg = None
+        else:
+            # No tool calls - just encode as content
+            assert model_output is not None
+            all_token_ids = mistral_tokenizer.encode(model_output, add_special_tokens=False)
+            assistant_msg = None
+
+        if assistant_msg is not None:
+            request = InstructRequest(messages=[assistant_msg])
+            all_token_ids = mistral_tokenizer.instruct.encode_instruct(request).tokens
     else:
-        # Older versions of the tokenizer are
-        # able to encode directly the model's output (free text) into tokens
-        assert model_output is not None
+        # Non-MistralTokenizer: encode free text
+        assert model_output is not None, "model_output must be provided for non-MistralTokenizer"
         all_token_ids = mistral_tokenizer.encode(model_output, add_special_tokens=False)
+        # Fix token IDs to use special tokens
+        all_token_ids = fix_tool_call_tokenization(
+            all_token_ids, mistral_tool_parser, mistral_tokenizer
+        )
 
-    all_token_ids = fix_tool_call_tokenization(
-        all_token_ids, mistral_tool_parser, mistral_tokenizer
-    )
-
+    # Stream tokens one at a time
     previous_text = ""
     previous_tokens = None
     prefix_offset = 0
     read_offset = 0
+
     for i, delta_token in enumerate(all_token_ids):
         delta_token_ids = [delta_token]
         previous_token_ids = all_token_ids[:i]
         current_token_ids = all_token_ids[: i + 1]
 
+        # Detokenize incrementally
         (new_tokens, delta_text, new_prefix_offset, new_read_offset) = (
             detokenize_incrementally(
                 tokenizer=mistral_tokenizer,
@@ -179,6 +246,7 @@ def stream_delta_message_generator(
             delta_token_ids,
             request=None,  # type: ignore[arg-type]
         )
+
         if delta_message:
             yield delta_message
 
@@ -190,163 +258,176 @@ def stream_delta_message_generator(
         read_offset = new_read_offset
 
 
-def test_extract_tool_calls_no_tools(mistral_pre_v11_tool_parser):
-    model_output = "This is a test"
-    extracted_tool_calls = mistral_pre_v11_tool_parser.extract_tool_calls(
-        model_output, request=None
-    )  # type: ignore[arg-type]
-    assert not extracted_tool_calls.tools_called
-    assert extracted_tool_calls.tool_calls == []
-    assert extracted_tool_calls.content == model_output
+# =============================================================================
+# Non-streaming extraction tests
+# =============================================================================
 
 
-@pytest.mark.parametrize(
-    ids=[
-        "single_tool_add",
-        "single_tool_weather",
-        "argument_before_name",
-        "argument_before_name_and_name_in_argument",
-    ],
-    argnames=["model_output", "expected_tool_calls", "expected_content"],
-    argvalues=[
-        (
-            """[TOOL_CALLS][{"name": "add", "arguments":{"a": 3.5, "b": 4}}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add", arguments=json.dumps({"a": 3.5, "b": 4})
-                    )
-                )
-            ],
-            None,
-        ),
-        (
-            """[TOOL_CALLS] [{"name": "get_current_weather", "arguments":{"city": "San Francisco", "state": "CA", "unit": "celsius"}}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_current_weather",
-                        arguments=json.dumps(
-                            {"city": "San Francisco", "state": "CA", "unit": "celsius"}
-                        ),
-                    )
-                )
-            ],
-            None,
-        ),
-        (
-            """[TOOL_CALLS] [{"arguments":{"city": "San Francisco", "state": "CA", "unit": "celsius"}, "name": "get_current_weather"}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_current_weather",
-                        arguments=json.dumps(
-                            {"city": "San Francisco", "state": "CA", "unit": "celsius"}
-                        ),
-                    )
-                )
-            ],
-            None,
-        ),
-        (
-            """[TOOL_CALLS] [{"arguments":{"name": "John Doe"}, "name": "get_age"}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_age",
-                        arguments=json.dumps(
-                            {
-                                "name": "John Doe",
-                            }
-                        ),
-                    )
-                )
-            ],
-            None,
-        ),
-    ],
-)
-def test_extract_tool_calls_pre_v11_tokenizer(
-    mistral_pre_v11_tool_parser, model_output, expected_tool_calls, expected_content
-):
-    extracted_tool_calls = mistral_pre_v11_tool_parser.extract_tool_calls(
-        model_output, request=None
-    )  # type: ignore[arg-type]
-    assert extracted_tool_calls.tools_called
+class TestExtractToolCallsNoTools:
+    """Test extraction when no tools are called."""
 
-    assert_tool_calls(extracted_tool_calls.tool_calls, expected_tool_calls)
-
-    assert extracted_tool_calls.content == expected_content
+    def test_no_tool_call_token(self, mistral_pre_v11_tool_parser):
+        model_output = "This is a test response without any tool calls."
+        result = mistral_pre_v11_tool_parser.extract_tool_calls(
+            model_output, request=None
+        )
+        assert not result.tools_called
+        assert result.tool_calls == []
+        assert result.content == model_output
 
 
-@pytest.mark.parametrize(
-    ids=[
-        "single_tool_add",
-        "single_tool_weather",
-        "multiple_tool_calls",
-    ],
-    argnames=["model_output", "expected_tool_calls", "expected_content"],
-    argvalues=[
-        (
-            """[TOOL_CALLS]add_this_and_that{"a": 3.5, "b": 4}""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add_this_and_that",
-                        arguments=json.dumps({"a": 3.5, "b": 4}),
-                    )
-                )
-            ],
-            None,
-        ),
-        (
-            """[TOOL_CALLS]get_current_weather{"city": "San Francisco", "state": "CA", "unit": "celsius"}""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_current_weather",
-                        arguments=json.dumps(
-                            {"city": "San Francisco", "state": "CA", "unit": "celsius"}
-                        ),
-                    )
-                )
-            ],
-            None,
-        ),
-        (
-            """[TOOL_CALLS]add{"a": 3.5, "b": 4}[TOOL_CALLS]multiply{"a": 3, "b": 6}""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add", arguments=json.dumps({"a": 3.5, "b": 4})
-                    )
-                ),
-                ToolCall(
-                    function=FunctionCall(
-                        name="multiply", arguments=json.dumps({"a": 3, "b": 6})
-                    )
-                ),
-            ],
-            None,
-        ),
-    ],
-)
-def test_extract_tool_calls(
-    mistral_tool_parser, model_output, expected_tool_calls, expected_content
-):
-    extracted_tool_calls = mistral_tool_parser.extract_tool_calls(
-        model_output, request=None
-    )  # type: ignore[arg-type]
-    assert extracted_tool_calls.tools_called
+class TestExtractToolCallsPreV11:
+    """Test non-streaming extraction for pre-v11 tokenizers."""
 
-    assert_tool_calls(extracted_tool_calls.tool_calls, expected_tool_calls)
+    @pytest.mark.parametrize(
+        "model_output,expected_tool_calls,expected_content",
+        [
+            # Single tool call
+            (
+                '[TOOL_CALLS][{"name": "add", "arguments":{"a": 3.5, "b": 4}}]',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="add",
+                            arguments=json.dumps({"a": 3.5, "b": 4}),
+                        )
+                    )
+                ],
+                None,
+            ),
+            # Tool call with spaces
+            (
+                '[TOOL_CALLS] [{"name": "get_current_weather", "arguments":{"city": "San Francisco", "state": "CA", "unit": "celsius"}}]',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="get_current_weather",
+                            arguments=json.dumps(
+                                {"city": "San Francisco", "state": "CA", "unit": "celsius"}
+                            ),
+                        )
+                    )
+                ],
+                None,
+            ),
+            # Arguments before name
+            (
+                '[TOOL_CALLS] [{"arguments":{"city": "San Francisco"}, "name": "get_weather"}]',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="get_weather",
+                            arguments=json.dumps({"city": "San Francisco"}),
+                        )
+                    )
+                ],
+                None,
+            ),
+        ],
+        ids=["single_tool_add", "single_tool_weather", "argument_before_name"],
+    )
+    def test_extract_tool_calls(
+        self,
+        mistral_pre_v11_tool_parser,
+        model_output,
+        expected_tool_calls,
+        expected_content,
+    ):
+        result = mistral_pre_v11_tool_parser.extract_tool_calls(
+            model_output, request=None
+        )
+        assert result.tools_called
+        assert_tool_calls(result.tool_calls, expected_tool_calls)
+        assert result.content == expected_content
 
-    assert extracted_tool_calls.content == expected_content
+
+class TestExtractToolCallsV11Plus:
+    """Test non-streaming extraction for v11+ tokenizers."""
+
+    @pytest.mark.parametrize(
+        "model_output,expected_tool_calls,expected_content",
+        [
+            # Single tool (v11+ format: name{args} without JSON array wrapper)
+            (
+                '[TOOL_CALLS]add_this_and_that{"a": 3.5, "b": 4}',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="add_this_and_that",
+                            arguments=json.dumps({"a": 3.5, "b": 4}),
+                        )
+                    )
+                ],
+                None,
+            ),
+            # Weather tool
+            (
+                '[TOOL_CALLS]get_current_weather{"city": "San Francisco", "state": "CA", "unit": "celsius"}',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="get_current_weather",
+                            arguments=json.dumps(
+                                {"city": "San Francisco", "state": "CA", "unit": "celsius"}
+                            ),
+                        )
+                    )
+                ],
+                None,
+            ),
+            # Multiple tool calls
+            (
+                '[TOOL_CALLS]add{"a": 3.5, "b": 4}[TOOL_CALLS]multiply{"a": 3, "b": 6}',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="add",
+                            arguments=json.dumps({"a": 3.5, "b": 4}),
+                        )
+                    ),
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="multiply",
+                            arguments=json.dumps({"a": 3, "b": 6}),
+                        )
+                    ),
+                ],
+                None,
+            ),
+        ],
+        ids=["single_tool_add", "single_tool_weather", "multiple_tool_calls"],
+    )
+    def test_extract_tool_calls(
+        self,
+        mistral_tool_parser,
+        model_output,
+        expected_tool_calls,
+        expected_content,
+    ):
+        result = mistral_tool_parser.extract_tool_calls(model_output, request=None)
+        assert result.tools_called
+        assert_tool_calls(result.tool_calls, expected_tool_calls)
+        assert result.content == expected_content
+
+
+# =============================================================================
+# Streaming extraction tests
+# =============================================================================
 
 
 def _test_extract_tool_calls_streaming(
-    tool_parser, tokenizer, model_output, tools, expected_tool_calls, expected_content
+    tool_parser,
+    tokenizer,
+    model_output,
+    tools,
+    expected_tool_calls,
+    expected_content,
 ):
+    """
+    Helper function to test streaming extraction.
+
+    Collects all streamed deltas and verifies the final result matches expected.
+    """
     other_content: str = ""
     function_names: list[str] = []
     function_args_strs: list[str] = []
@@ -356,7 +437,7 @@ def _test_extract_tool_calls_streaming(
     for delta_message in stream_delta_message_generator(
         tool_parser, tokenizer, model_output, tools
     ):
-        # role should never be streamed from tool parser
+        # Role should never be streamed from tool parser
         assert not delta_message.role
 
         if delta_message.content:
@@ -365,42 +446,44 @@ def _test_extract_tool_calls_streaming(
         streamed_tool_calls = delta_message.tool_calls
 
         if streamed_tool_calls and len(streamed_tool_calls) > 0:
-            # make sure only one diff is present - correct even for parallel
+            # Only one tool call delta per message
             assert len(streamed_tool_calls) == 1
             tool_call = streamed_tool_calls[0]
 
+            # Verify prev_tool_call_arr is set (for finish_reason detection)
             assert len(tool_parser.prev_tool_call_arr) > 0
 
-            # if a new tool is being called, set up empty arguments
+            # If new tool, set up tracking
             if tool_call.index != tool_call_idx:
                 tool_call_idx = tool_call.index
                 function_args_strs.append("")
                 tool_call_ids.append(None)
 
-            # if a tool call ID is streamed, make sure one hasn't been already
+            # Track tool call ID (should be set once per tool)
             if tool_call.id and not tool_call_ids[tool_call.index]:
                 tool_call_ids[tool_call.index] = tool_call.id
 
-            # if parts of the function start being streamed
+            # Track function parts
             if tool_call.function:
-                # if the function name is defined, set it. it should be streamed
-                # IN ENTIRETY, exactly one time.
-                if tool_call.function.name:
-                    assert isinstance(tool_call.function.name, str)
-                    function_names.append(tool_call.function.name)
+                # DeltaFunctionCall may be a Pydantic model or dict-like
+                func = tool_call.function
+                func_name = getattr(func, 'name', None) or (func.get('name') if isinstance(func, dict) else None)
+                func_args = getattr(func, 'arguments', None) or (func.get('arguments') if isinstance(func, dict) else None)
 
-                if tool_call.function.arguments:
-                    # make sure they're a string and then add them to the list
-                    assert isinstance(tool_call.function.arguments, str)
+                if func_name:
+                    function_names.append(func_name)
 
-                    function_args_strs[tool_call.index] += tool_call.function.arguments
+                if func_args:
+                    function_args_strs[tool_call.index] += func_args
 
+    # Verify content
     assert other_content == expected_content
 
+    # Build actual tool calls from collected data
     actual_tool_calls = [
         ToolCall(
             id=tool_call_id,
-            function=FunctionCall(
+            function=MistralFunctionCall(
                 name=function_name,
                 arguments=partial_json_parser.ensure_json(
                     function_args_str, Allow.OBJ | Allow.STR
@@ -414,434 +497,541 @@ def _test_extract_tool_calls_streaming(
     assert_tool_calls(actual_tool_calls, expected_tool_calls)
 
 
-@pytest.mark.parametrize(
-    ids=[
-        "no_tools",
-        "single_tool_add",
-        "single_tool_add_strings",
-        "single_tool_weather",
-        "argument_before_name",
-        "argument_before_name_and_name_in_argument",
-        "multiple_tools",
-    ],
-    argnames=["model_output", "expected_tool_calls", "expected_content"],
-    argvalues=[
-        ("""This is a test""", [], """This is a test"""),
-        (
-            """[TOOL_CALLS]  [ {"name":"add" , "arguments" : {"a": 3, "b": 4} } ]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add", arguments=json.dumps({"a": 3, "b": 4})
+class TestStreamingExtractionPreV11:
+    """Test streaming extraction for pre-v11 tokenizers.
+
+    Uses encode_instruct to properly generate special tokens from the
+    pre-v11 format ([TOOL_CALLS][{json array}]).
+    """
+
+    @pytest.mark.parametrize(
+        "model_output,expected_tool_calls,expected_content",
+        [
+            # No tools
+            ("This is a test", [], "This is a test"),
+            # Single tool
+            (
+                '[TOOL_CALLS]  [ {"name":"add" , "arguments" : {"a": 3, "b": 4} } ]',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="add",
+                            arguments=json.dumps({"a": 3, "b": 4}),
+                        )
                     )
-                )
-            ],
-            "",
-        ),
-        (
-            """[TOOL_CALLS] [{"name": "add", "arguments":{"a": "3", "b": "4"}}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add", arguments=json.dumps({"a": "3", "b": "4"})
+                ],
+                "",
+            ),
+            # String arguments
+            (
+                '[TOOL_CALLS] [{"name": "add", "arguments":{"a": "3", "b": "4"}}]',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="add",
+                            arguments=json.dumps({"a": "3", "b": "4"}),
+                        )
                     )
-                )
-            ],
-            "",
-        ),
-        (
-            """[TOOL_CALLS] [{"name": "get_current_weather", "arguments": {"city": "San Francisco", "state": "CA", "unit": "celsius"}}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_current_weather",
-                        arguments=json.dumps(
-                            {"city": "San Francisco", "state": "CA", "unit": "celsius"}
-                        ),
+                ],
+                "",
+            ),
+            # Weather tool with complex args
+            (
+                '[TOOL_CALLS] [{"name": "get_current_weather", "arguments": {"city": "San Francisco", "state": "CA", "unit": "celsius"}}]',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="get_current_weather",
+                            arguments=json.dumps(
+                                {"city": "San Francisco", "state": "CA", "unit": "celsius"}
+                            ),
+                        )
                     )
-                )
-            ],
-            "",
-        ),
-        (
-            """[TOOL_CALLS] [{"arguments": {"city": "San Francisco", "state": "CA", "unit": "celsius"}, "name": "get_current_weather"}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_current_weather",
-                        arguments=json.dumps(
-                            {"city": "San Francisco", "state": "CA", "unit": "celsius"}
-                        ),
-                    )
-                )
-            ],
-            "",
-        ),
-        (
-            """[TOOL_CALLS] [{"arguments": {"name": "John Doe"}, "name": "get_age"}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_age",
-                        arguments=json.dumps(
-                            {
-                                "name": "John Doe",
-                            }
-                        ),
-                    )
-                )
-            ],
-            "",
-        ),
-        (
-            """[TOOL_CALLS] [{"name": "add", "arguments": {"a": 3.5, "b": 4}}, {"name": "get_current_weather", "arguments":{"city": "San Francisco", "state": "CA", "unit": "celsius"}}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add", arguments=json.dumps({"a": 3.5, "b": 4})
-                    )
-                ),
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_current_weather",
-                        arguments=json.dumps(
-                            {"city": "San Francisco", "state": "CA", "unit": "celsius"}
-                        ),
-                    )
-                ),
-            ],
-            "",
-        ),
-    ],
-)
-def test_extract_tool_calls_streaming_pre_v11_tokenizer(
-    mistral_pre_v11_tool_parser,
-    mistral_pre_v11_tokenizer,
-    model_output,
-    expected_tool_calls,
-    expected_content,
-):
-    _test_extract_tool_calls_streaming(
+                ],
+                "",
+            ),
+            # Multiple tools
+            (
+                '[TOOL_CALLS] [{"name": "add", "arguments": {"a": 3.5, "b": 4}}, {"name": "get_current_weather", "arguments":{"city": "San Francisco", "state": "CA", "unit": "celsius"}}]',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="add",
+                            arguments=json.dumps({"a": 3.5, "b": 4}),
+                        )
+                    ),
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="get_current_weather",
+                            arguments=json.dumps(
+                                {"city": "San Francisco", "state": "CA", "unit": "celsius"}
+                            ),
+                        )
+                    ),
+                ],
+                "",
+            ),
+        ],
+        ids=[
+            "no_tools",
+            "single_tool_add",
+            "single_tool_add_strings",
+            "single_tool_weather",
+            "multiple_tools",
+        ],
+    )
+    def test_streaming_extraction(
+        self,
         mistral_pre_v11_tool_parser,
         mistral_pre_v11_tokenizer,
         model_output,
-        None,
         expected_tool_calls,
         expected_content,
+    ):
+        _test_extract_tool_calls_streaming(
+            mistral_pre_v11_tool_parser,
+            mistral_pre_v11_tokenizer,
+            model_output,
+            None,
+            expected_tool_calls,
+            expected_content,
+        )
+
+
+class TestStreamingExtractionV11Plus:
+    """Test streaming extraction for v11+ tokenizers."""
+
+    @pytest.mark.parametrize(
+        "tools,expected_tool_calls,expected_content",
+        [
+            # Single tool
+            (
+                [("add", '{"a": 3, "b": 4}')],
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="add",
+                            arguments=json.dumps({"a": 3, "b": 4}),
+                        )
+                    )
+                ],
+                "",
+            ),
+            # String arguments
+            (
+                [("add_two_strings", '{"a": "3", "b": "4"}')],
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="add_two_strings",
+                            arguments=json.dumps({"a": "3", "b": "4"}),
+                        )
+                    )
+                ],
+                "",
+            ),
+            # Multiple tools
+            (
+                [
+                    ("add", '{"a": 3.5, "b": 4}'),
+                    (
+                        "get_current_weather",
+                        '{"city": "San Francisco", "state": "CA", "unit": "celsius"}',
+                    ),
+                ],
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="add",
+                            arguments=json.dumps({"a": 3.5, "b": 4}),
+                        )
+                    ),
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="get_current_weather",
+                            arguments=json.dumps(
+                                {"city": "San Francisco", "state": "CA", "unit": "celsius"}
+                            ),
+                        )
+                    ),
+                ],
+                "",
+            ),
+        ],
+        ids=["single_tool_add", "single_tool_add_strings", "multiple_tools"],
     )
-
-
-@pytest.mark.parametrize(
-    ids=[
-        "single_tool_add",
-        "single_tool_add_strings",
-        "multiple_tools",
-    ],
-    argnames=["tools", "expected_tool_calls", "expected_content"],
-    argvalues=[
-        (
-            [("add", '{"a": 3, "b": 4}')],
-            # [TOOL_CALLS]add{"a": 3, "b": 4}
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add", arguments=json.dumps({"a": 3, "b": 4})
-                    )
-                )
-            ],
-            "",
-        ),
-        (
-            [("add_two_strings", '{"a": "3", "b": "4"}')],
-            # [TOOL_CALLS]add_two_strings{"a": "3", "b": "4"}
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add_two_strings",
-                        arguments=json.dumps({"a": "3", "b": "4"}),
-                    )
-                )
-            ],
-            "",
-        ),
-        (
-            [
-                ("add", '{"a": 3.5, "b": 4}'),
-                (
-                    "get_current_weather",
-                    '{"city": "San Francisco", "state": "CA", "unit": "celsius"}',  # noqa: E501
-                ),
-            ],
-            # [TOOL_CALLS]add{"a": 3.5, "b": 4}[TOOL_CALLS]get_current_weather{"city": "San Francisco", "state": "CA", "unit": "celsius"}  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add", arguments=json.dumps({"a": 3.5, "b": 4})
-                    )
-                ),
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_current_weather",
-                        arguments=json.dumps(
-                            {"city": "San Francisco", "state": "CA", "unit": "celsius"}
-                        ),
-                    )
-                ),
-            ],
-            "",
-        ),
-    ],
-)
-def test_extract_tool_calls_streaming(
-    mistral_tool_parser,
-    mistral_tokenizer,
-    tools,
-    expected_tool_calls,
-    expected_content,
-):
-    _test_extract_tool_calls_streaming(
+    def test_streaming_extraction(
+        self,
         mistral_tool_parser,
         mistral_tokenizer,
-        None,
         tools,
         expected_tool_calls,
         expected_content,
-    )
-
-
-@pytest.mark.parametrize(
-    ids=[
-        "single_tool_add",
-        "single_tool_weather",
-        "multiple_tool_calls",
-        "content_before_tool",
-    ],
-    argnames=["model_output", "expected_tool_calls", "expected_content"],
-    argvalues=[
-        (
-            """[TOOL_CALLS]add_this_and_that{"a": 3.5, "b": 4}""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add_this_and_that",
-                        arguments=json.dumps({"a": 3.5, "b": 4}),
-                    )
-                )
-            ],
-            "",
-        ),
-        (
-            """[TOOL_CALLS]get_current_weather{"city": "San Francisco", "state": "CA", "unit": "celsius"}""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_current_weather",
-                        arguments=json.dumps(
-                            {"city": "San Francisco", "state": "CA", "unit": "celsius"}
-                        ),
-                    )
-                )
-            ],
-            "",
-        ),
-        (
-            """[TOOL_CALLS]add{"a": 3.5, "b": 4}[TOOL_CALLS]multiply{"a": 3, "b": 6}""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add", arguments=json.dumps({"a": 3.5, "b": 4})
-                    )
-                ),
-                ToolCall(
-                    function=FunctionCall(
-                        name="multiply", arguments=json.dumps({"a": 3, "b": 6})
-                    )
-                ),
-            ],
-            "",
-        ),
-        (
-            # Additional content should not be after the tool calls
-            """bla[TOOL_CALLS]add_this_and_that{"a": 3.5, "b": 4}""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add_this_and_that",
-                        arguments=json.dumps({"a": 3.5, "b": 4}),
-                    )
-                )
-            ],
-            "bla",
-        ),
-    ],
-)
-def test_extract_tool_calls_streaming_one_chunk(
-    mistral_tool_parser,
-    mistral_tokenizer,
-    model_output,
-    expected_tool_calls,
-    expected_content,
-):
-    if isinstance(mistral_tokenizer, MistralTokenizer):
-        all_token_ids = mistral_tokenizer.encode(model_output)
-    else:
-        all_token_ids = mistral_tokenizer.encode(model_output, add_special_tokens=False)
-    all_token_ids = fix_tool_call_tokenization(
-        all_token_ids, mistral_tool_parser, mistral_tokenizer
-    )
-
-    delta_message = mistral_tool_parser.extract_tool_calls_streaming(
-        previous_text="",
-        current_text=model_output,
-        delta_text=model_output,
-        previous_token_ids=[],
-        current_token_ids=all_token_ids,
-        delta_token_ids=all_token_ids,
-        request=None,
-    )  # type: ignore[arg-type]
-    assert isinstance(delta_message, DeltaMessage)
-    assert len(delta_message.tool_calls) == len(expected_tool_calls)
-
-    assert_tool_calls(delta_message.tool_calls, expected_tool_calls)
-
-    if delta_message.content is None:
-        assert expected_content == ""
-    else:
-        assert delta_message.content == expected_content
-
-
-@pytest.mark.parametrize(
-    ids=[
-        "no_tools",
-        "single_tool_add",
-        "single_tool_add_strings",
-        "single_tool_weather",
-        "argument_before_name",
-        "argument_before_name_and_name_in_argument",
-        "multiple_tools",
-    ],
-    argnames=["model_output", "expected_tool_calls", "expected_content"],
-    argvalues=[
-        ("""This is a test""", [], """This is a test"""),
-        (
-            """[TOOL_CALLS]  [ {"name":"add" , "arguments" : {"a": 3, "b": 4} } ]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add", arguments=json.dumps({"a": 3, "b": 4})
-                    )
-                )
-            ],
-            "",
-        ),
-        (
-            """[TOOL_CALLS] [{"name": "add", "arguments":{"a": "3", "b": "4"}}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add", arguments=json.dumps({"a": "3", "b": "4"})
-                    )
-                )
-            ],
-            "",
-        ),
-        (
-            """[TOOL_CALLS] [{"name": "get_current_weather", "arguments": {"city": "San Francisco", "state": "CA", "unit": "celsius"}}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_current_weather",
-                        arguments=json.dumps(
-                            {"city": "San Francisco", "state": "CA", "unit": "celsius"}
-                        ),
-                    )
-                )
-            ],
-            "",
-        ),
-        (
-            """[TOOL_CALLS] [{"arguments": {"city": "San Francisco", "state": "CA", "unit": "celsius"}, "name": "get_current_weather"}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_current_weather",
-                        arguments=json.dumps(
-                            {"city": "San Francisco", "state": "CA", "unit": "celsius"}
-                        ),
-                    )
-                )
-            ],
-            "",
-        ),
-        (
-            """[TOOL_CALLS] [{"arguments": {"name": "John Doe"}, "name": "get_age"}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_age",
-                        arguments=json.dumps(
-                            {
-                                "name": "John Doe",
-                            }
-                        ),
-                    )
-                )
-            ],
-            "",
-        ),
-        (
-            """[TOOL_CALLS] [{"arguments": {"a": 3.5, "b": 4}, "name": "add"}, {"arguments":{"city": "San Francisco", "state": "CA", "unit": "celsius"}, "name": "get_current_weather"}]""",  # noqa: E501
-            [
-                ToolCall(
-                    function=FunctionCall(
-                        name="add", arguments=json.dumps({"a": 3.5, "b": 4})
-                    )
-                ),
-                ToolCall(
-                    function=FunctionCall(
-                        name="get_current_weather",
-                        arguments=json.dumps(
-                            {"city": "San Francisco", "state": "CA", "unit": "celsius"}
-                        ),
-                    )
-                ),
-            ],
-            "",
-        ),
-    ],
-)
-def test_extract_tool_calls_streaming_pre_v11_tokenizer_one_chunk(
-    mistral_pre_v11_tool_parser,
-    mistral_pre_v11_tokenizer,
-    model_output,
-    expected_tool_calls,
-    expected_content,
-):
-    if isinstance(mistral_pre_v11_tokenizer, MistralTokenizer):
-        all_token_ids = mistral_pre_v11_tokenizer.encode(model_output)
-    else:
-        all_token_ids = mistral_pre_v11_tokenizer.encode(
-            model_output, add_special_tokens=False
+    ):
+        _test_extract_tool_calls_streaming(
+            mistral_tool_parser,
+            mistral_tokenizer,
+            None,
+            tools,
+            expected_tool_calls,
+            expected_content,
         )
-    all_token_ids = fix_tool_call_tokenization(
-        all_token_ids, mistral_pre_v11_tool_parser, mistral_pre_v11_tokenizer
+
+
+class TestStreamingOneChunk:
+    """Test streaming when all tokens arrive in a single chunk."""
+
+    @pytest.mark.parametrize(
+        "model_output,expected_tool_calls,expected_content",
+        [
+            # Single tool - v11 format includes [ARGS] between name and JSON
+            (
+                "[TOOL_CALLS]add_this_and_that[ARGS]{\"a\": 3.5, \"b\": 4}",
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="add_this_and_that",
+                            arguments=json.dumps({"a": 3.5, "b": 4}),
+                        )
+                    )
+                ],
+                "",
+            ),
+            # Weather tool
+            (
+                '[TOOL_CALLS]get_current_weather[ARGS]{"city": "San Francisco", "state": "CA", "unit": "celsius"}',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="get_current_weather",
+                            arguments=json.dumps(
+                                {"city": "San Francisco", "state": "CA", "unit": "celsius"}
+                            ),
+                        )
+                    )
+                ],
+                "",
+            ),
+            # Multiple tools - NOTE: This case is tricky because BPE tokenization
+            # may merge the closing } of the first tool with the [ of the next
+            # [TOOL_CALLS], making it hard to detect the second tool call when
+            # encoding from free text. In real inference, the model generates
+            # special tokens directly, avoiding this issue.
+            pytest.param(
+                '[TOOL_CALLS]add[ARGS]{"a": 3.5, "b": 4}[TOOL_CALLS]multiply[ARGS]{"a": 3, "b": 6}',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="add",
+                            arguments=json.dumps({"a": 3.5, "b": 4}),
+                        )
+                    ),
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="multiply",
+                            arguments=json.dumps({"a": 3, "b": 6}),
+                        )
+                    ),
+                ],
+                "",
+                marks=pytest.mark.xfail(reason="BPE tokenization merges }[ tokens"),
+            ),
+            # Content before tool
+            (
+                'bla[TOOL_CALLS]add_this_and_that[ARGS]{"a": 3.5, "b": 4}',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="add_this_and_that",
+                            arguments=json.dumps({"a": 3.5, "b": 4}),
+                        )
+                    )
+                ],
+                "bla",
+            ),
+        ],
+        ids=[
+            "single_tool_add",
+            "single_tool_weather",
+            "multiple_tool_calls",
+            "content_before_tool",
+        ],
     )
+    def test_streaming_one_chunk_v11(
+        self,
+        mistral_tool_parser,
+        mistral_tokenizer,
+        model_output,
+        expected_tool_calls,
+        expected_content,
+    ):
+        """Test v11+ streaming with all tokens in one chunk.
 
-    delta_message = mistral_pre_v11_tool_parser.extract_tool_calls_streaming(
-        previous_text="",
-        current_text=model_output,
-        delta_text=model_output,
-        previous_token_ids=[],
-        current_token_ids=all_token_ids,
-        delta_token_ids=all_token_ids,
-        request=None,
-    )  # type: ignore[arg-type]
-    assert isinstance(delta_message, DeltaMessage)
-    assert len(delta_message.tool_calls) == len(expected_tool_calls)
+        When all tokens arrive at once, we still produce streaming-style
+        output with multiple DeltaToolCall objects. We need to aggregate
+        these to verify the final result.
+        """
+        if isinstance(mistral_tokenizer, MistralTokenizer):
+            all_token_ids = mistral_tokenizer.encode(model_output)
+        else:
+            all_token_ids = mistral_tokenizer.encode(
+                model_output, add_special_tokens=False
+            )
 
-    assert_tool_calls(delta_message.tool_calls, expected_tool_calls)
+        all_token_ids = fix_tool_call_tokenization(
+            all_token_ids, mistral_tool_parser, mistral_tokenizer
+        )
 
-    if delta_message.content is None:
-        assert expected_content == ""
-    else:
-        assert delta_message.content == expected_content
+        delta_message = mistral_tool_parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text=model_output,
+            delta_text=model_output,
+            previous_token_ids=[],
+            current_token_ids=all_token_ids,
+            delta_token_ids=all_token_ids,
+            request=None,
+        )
+
+        assert isinstance(delta_message, DeltaMessage)
+
+        # Aggregate streaming deltas into final tool calls
+        # Each tool call starts with a name delta, followed by argument deltas
+        tool_call_data: dict[int, dict] = {}  # index -> {id, name, arguments}
+
+        for tc in delta_message.tool_calls or []:
+            idx = tc.index
+            if idx not in tool_call_data:
+                tool_call_data[idx] = {"id": None, "name": "", "arguments": ""}
+
+            if tc.id:
+                tool_call_data[idx]["id"] = tc.id
+
+            func = tc.function
+            func_name = getattr(func, 'name', None) or (func.get('name') if isinstance(func, dict) else None)
+            func_args = getattr(func, 'arguments', None) or (func.get('arguments') if isinstance(func, dict) else None)
+
+            if func_name:
+                tool_call_data[idx]["name"] = func_name
+            if func_args:
+                tool_call_data[idx]["arguments"] += func_args
+
+        # Verify we got the expected number of tool calls
+        assert len(tool_call_data) == len(expected_tool_calls), (
+            f"Expected {len(expected_tool_calls)} tool calls, got {len(tool_call_data)}"
+        )
+
+        # Verify each tool call
+        for i, expected in enumerate(expected_tool_calls):
+            actual = tool_call_data[i]
+            assert actual["name"] == expected.function.name, (
+                f"Expected name '{expected.function.name}', got '{actual['name']}'"
+            )
+            assert actual["arguments"] == expected.function.arguments, (
+                f"Expected args '{expected.function.arguments}', got '{actual['arguments']}'"
+            )
+            assert actual["id"] is not None and len(actual["id"]) == 9
+
+        # Content should not be set in v11 streaming (tool calls only)
+        if expected_content == "":
+            # For v11, content before tool call is handled differently
+            pass  # Content handling varies by implementation
+
+
+class TestStreamingOneChunkPreV11:
+    """Test streaming for pre-v11 when all tokens arrive in a single chunk.
+
+    Uses fix_tool_call_tokenization to replace textual token sequences
+    with special token IDs for proper parsing.
+    """
+
+    @pytest.mark.parametrize(
+        "model_output,expected_tool_calls,expected_content",
+        [
+            # No tools
+            ("This is a test", [], "This is a test"),
+            # Single tool
+            (
+                '[TOOL_CALLS]  [ {"name":"add" , "arguments" : {"a": 3, "b": 4} } ]',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="add",
+                            arguments=json.dumps({"a": 3, "b": 4}),
+                        )
+                    )
+                ],
+                "",
+            ),
+            # Arguments before name
+            (
+                '[TOOL_CALLS] [{"arguments": {"city": "San Francisco"}, "name": "get_weather"}]',
+                [
+                    ToolCall(
+                        function=MistralFunctionCall(
+                            name="get_weather",
+                            arguments=json.dumps({"city": "San Francisco"}),
+                        )
+                    )
+                ],
+                "",
+            ),
+        ],
+        ids=["no_tools", "single_tool_add", "argument_before_name"],
+    )
+    def test_streaming_one_chunk_pre_v11(
+        self,
+        mistral_pre_v11_tool_parser,
+        mistral_pre_v11_tokenizer,
+        model_output,
+        expected_tool_calls,
+        expected_content,
+    ):
+        """Test pre-v11 streaming with all tokens in one chunk.
+
+        When all tokens arrive at once, we still produce streaming-style
+        output with multiple DeltaToolCall objects. We need to aggregate
+        these to verify the final result.
+        """
+        if isinstance(mistral_pre_v11_tokenizer, MistralTokenizer):
+            all_token_ids = mistral_pre_v11_tokenizer.encode(model_output)
+        else:
+            all_token_ids = mistral_pre_v11_tokenizer.encode(
+                model_output, add_special_tokens=False
+            )
+
+        all_token_ids = fix_tool_call_tokenization(
+            all_token_ids, mistral_pre_v11_tool_parser, mistral_pre_v11_tokenizer
+        )
+
+        delta_message = mistral_pre_v11_tool_parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text=model_output,
+            delta_text=model_output,
+            previous_token_ids=[],
+            current_token_ids=all_token_ids,
+            delta_token_ids=all_token_ids,
+            request=None,
+        )
+
+        assert isinstance(delta_message, DeltaMessage)
+
+        # Aggregate streaming deltas into final tool calls
+        # Each tool call starts with a name delta, followed by argument deltas
+        tool_call_data: dict[int, dict] = {}  # index -> {id, name, arguments}
+
+        for tc in delta_message.tool_calls or []:
+            idx = tc.index
+            if idx not in tool_call_data:
+                tool_call_data[idx] = {"id": None, "name": "", "arguments": ""}
+
+            if tc.id:
+                tool_call_data[idx]["id"] = tc.id
+
+            func = tc.function
+            func_name = getattr(func, 'name', None) or (func.get('name') if isinstance(func, dict) else None)
+            func_args = getattr(func, 'arguments', None) or (func.get('arguments') if isinstance(func, dict) else None)
+
+            if func_name:
+                tool_call_data[idx]["name"] = func_name
+            if func_args:
+                tool_call_data[idx]["arguments"] += func_args
+
+        # Verify we got the expected number of tool calls
+        assert len(tool_call_data) == len(expected_tool_calls), (
+            f"Expected {len(expected_tool_calls)} tool calls, got {len(tool_call_data)}"
+        )
+
+        # Verify each tool call
+        for i, expected in enumerate(expected_tool_calls):
+            actual = tool_call_data[i]
+            assert actual["name"] == expected.function.name, (
+                f"Expected name '{expected.function.name}', got '{actual['name']}'"
+            )
+            assert actual["arguments"] == expected.function.arguments, (
+                f"Expected args '{expected.function.arguments}', got '{actual['arguments']}'"
+            )
+            assert actual["id"] is not None and len(actual["id"]) == 9
+
+        # Content handling
+        if delta_message.content is None:
+            assert expected_content == ""
+        else:
+            assert delta_message.content == expected_content
+
+
+# =============================================================================
+# Edge case tests
+# =============================================================================
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_tool_call_id_format(self, mistral_tool_parser):
+        """Verify generated tool call IDs are valid."""
+        from vllm.entrypoints.openai.tool_parsers.mistral_tool_parser import (
+            MistralToolCall,
+        )
+
+        for _ in range(100):
+            tool_id = MistralToolCall.generate_random_id()
+            assert len(tool_id) == 9
+            assert tool_id.isalnum()
+            assert MistralToolCall.is_valid_id(tool_id)
+
+    def test_invalid_tool_id_validation(self):
+        """Test tool ID validation."""
+        from vllm.entrypoints.openai.tool_parsers.mistral_tool_parser import (
+            MistralToolCall,
+        )
+
+        assert not MistralToolCall.is_valid_id("")
+        assert not MistralToolCall.is_valid_id("12345678")  # Too short
+        assert not MistralToolCall.is_valid_id("1234567890")  # Too long
+        assert not MistralToolCall.is_valid_id("abc-def-g")  # Contains hyphen
+
+    def test_empty_model_output(self, mistral_tool_parser):
+        """Test handling of empty output."""
+        result = mistral_tool_parser.extract_tool_calls("", request=None)
+        assert not result.tools_called
+        assert result.tool_calls == []
+        assert result.content == ""
+
+    def test_malformed_json(self, mistral_pre_v11_tool_parser):
+        """Test handling of malformed JSON in tool calls."""
+        # Missing closing brace
+        model_output = '[TOOL_CALLS][{"name": "add", "arguments":{"a": 3'
+        result = mistral_pre_v11_tool_parser.extract_tool_calls(
+            model_output, request=None
+        )
+        # Should fail gracefully
+        assert not result.tools_called
+
+
+class TestTokenBasedDetection:
+    """Test that token-based detection works correctly."""
+
+    def test_bot_token_id_exists(self, mistral_tool_parser):
+        """Verify bot token ID is properly set."""
+        assert mistral_tool_parser.bot_token_id is not None
+        assert isinstance(mistral_tool_parser.bot_token_id, int)
+
+    def test_streaming_uses_token_ids(self, mistral_tool_parser, mistral_tokenizer):
+        """Test that streaming correctly uses token IDs for detection."""
+        # Content without tool call
+        content_text = "Hello, how can I help you?"
+        content_tokens = mistral_tokenizer.encode(content_text, add_special_tokens=False)
+
+        delta_message = mistral_tool_parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text=content_text,
+            delta_text=content_text,
+            previous_token_ids=[],
+            current_token_ids=content_tokens,
+            delta_token_ids=content_tokens,
+            request=None,
+        )
+
+        assert delta_message is not None
+        assert delta_message.content == content_text
+        assert not delta_message.tool_calls

--- a/tests/tool_use/test_mistral_tool_parser.py
+++ b/tests/tool_use/test_mistral_tool_parser.py
@@ -610,6 +610,12 @@ class TestStreamingOneChunk:
             )
             assert actual["id"] is not None and len(actual["id"]) == 9
 
+        # Verify content before tool calls is preserved
+        actual_content = delta_message.content or ""
+        assert actual_content == expected_content, (
+            f"Expected content '{expected_content}', got '{actual_content}'"
+        )
+
 
 # =============================================================================
 # Edge case tests

--- a/vllm/entrypoints/openai/tool_parsers/mistral_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/mistral_tool_parser.py
@@ -131,9 +131,7 @@ class MistralToolParser(ToolParser):
             pass
 
         # Regex for non-streaming parsing: name{args}
-        self.fn_name_regex = re.compile(
-            r"([a-zA-Z0-9_-]+)(\{[\s\S]*?\}+)", re.DOTALL
-        )
+        self.fn_name_regex = re.compile(r"([a-zA-Z0-9_-]+)(\{[\s\S]*?\}+)", re.DOTALL)
 
         # Streaming state
         self._streaming_state = StreamingState.CONTENT
@@ -275,9 +273,7 @@ class MistralToolParser(ToolParser):
         else:
             return tool_result
 
-    def _stream_tool_calls(
-        self, delta_token_ids: Sequence[int]
-    ) -> DeltaMessage | None:
+    def _stream_tool_calls(self, delta_token_ids: Sequence[int]) -> DeltaMessage | None:
         """
         Stream tool calls using token-based parsing.
 
@@ -364,9 +360,9 @@ class MistralToolParser(ToolParser):
                 delta_tool_calls.append(
                     DeltaToolCall(
                         index=self._current_tool_index,
-                        function=DeltaFunctionCall(
-                            arguments=token_str
-                        ).model_dump(exclude_none=True),
+                        function=DeltaFunctionCall(arguments=token_str).model_dump(
+                            exclude_none=True
+                        ),
                     )
                 )
 

--- a/vllm/entrypoints/openai/tool_parsers/mistral_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/mistral_tool_parser.py
@@ -44,6 +44,16 @@ logger = init_logger(__name__)
 ALPHANUMERIC = ascii_letters + digits
 
 
+def _escape_json_control_chars(s: str) -> str:
+    """Escape control characters that would break JSON serialization.
+
+    Models sometimes emit raw control characters (literal newlines, tabs, etc.)
+    inside JSON strings. These must be escaped for valid JSON output.
+    Already-escaped sequences (like the two-char '\\n') are left untouched.
+    """
+    return s.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+
+
 class MistralToolCall(ToolCall):
     id: str = Field(default_factory=lambda: MistralToolCall.generate_random_id())
 
@@ -172,7 +182,7 @@ class MistralToolParser(ToolParser):
                 matches = self.fn_name_regex.findall(segment)
                 for match in matches:
                     fn_name = match[0]
-                    fn_args = match[1]
+                    fn_args = _escape_json_control_chars(match[1])
                     tool_calls.append(
                         MistralToolCall(
                             type="function",

--- a/vllm/entrypoints/openai/tool_parsers/mistral_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/mistral_tool_parser.py
@@ -162,8 +162,8 @@ class MistralToolParser(ToolParser):
 
         try:
             # Get content before tool calls
-            content = model_output.split(self.bot_token)[0]
-            content = content if content.strip() else None
+            content_str = model_output.split(self.bot_token)[0]
+            content: str | None = content_str if content_str.strip() else None
 
             # Parse tool calls from each segment after [TOOL_CALLS]
             function_call_arr = []
@@ -246,6 +246,7 @@ class MistralToolParser(ToolParser):
         from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 
         # Find where [TOOL_CALLS] appears in this delta
+        assert self.bot_token_id is not None  # Validated in __init__
         try:
             bot_idx = list(delta_token_ids).index(self.bot_token_id)
         except ValueError:

--- a/vllm/entrypoints/openai/tool_parsers/mistral_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/mistral_tool_parser.py
@@ -1,12 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
-Mistral tool call parser supporting both streaming and non-streaming modes.
+Mistral tool call parser for v11+ models.
 
-This implementation:
-1. Non-streaming: Uses string/regex-based parsing (text is already decoded)
-2. Streaming: Uses token-based parsing for v11+ (token IDs are atomic)
-3. Supports all tokenizer versions (v2-v13)
+This implementation uses token-based parsing for streaming, leveraging the
+atomic nature of special token IDs ([TOOL_CALLS], [ARGS], [CALL_ID]) to
+reliably detect tool call boundaries.
+
+Supported models: Mistral-Small-3.1+, Ministral-3+, and other v11+ models.
+
+Note: Pre-v11 models (Mistral-7B-Instruct-v0.1/v0.2/v0.3) are not supported.
+These older models have limited tool calling capabilities and require complex
+text-based parsing with partial JSON handling. Users should upgrade to v11+
+models for reliable tool calling support.
 """
 
 import json
@@ -15,9 +21,7 @@ from enum import Enum, auto
 from random import choices
 from string import ascii_letters, digits
 
-import partial_json_parser
 import regex as re
-from partial_json_parser.core.options import Allow
 from pydantic import Field
 
 from vllm.entrypoints.openai.protocol import (
@@ -58,28 +62,42 @@ class StreamingState(Enum):
     """Streaming state for tool call parsing."""
 
     CONTENT = auto()  # Before any [TOOL_CALLS] token
-    PARSING_TOOL_NAME = auto()  # After [TOOL_CALLS], parsing function name (v11+)
+    PARSING_TOOL_NAME = auto()  # After [TOOL_CALLS], parsing function name
     PARSING_TOOL_ARGS = auto()  # Parsing JSON arguments
     COMPLETE = auto()  # All tools parsed
 
 
 class MistralToolParser(ToolParser):
     """
-    Tool call parser for Mistral models.
+    Tool call parser for Mistral v11+ models.
 
-    Supports two formats:
-    - Pre-v11: [TOOL_CALLS][{"name": "...", "arguments": {...}}, ...]
-    - V11+: [TOOL_CALLS]name[ARGS]{...} or [TOOL_CALLS]name[CALL_ID]id[ARGS]{...}
+    Supports the v11+ format: [TOOL_CALLS]name[ARGS]{...}
+    Optionally with call ID: [TOOL_CALLS]name[CALL_ID]id[ARGS]{...}
+
+    This parser requires MistralTokenizer (tokenizer_mode=mistral) and
+    models using tokenizer version 11 or higher.
     """
 
     def __init__(self, tokenizer: TokenizerLike):
         super().__init__(tokenizer)
 
-        self._use_mistral_tokenizer = isinstance(self.model_tokenizer, MistralTokenizer)
+        if not isinstance(self.model_tokenizer, MistralTokenizer):
+            raise RuntimeError(
+                "MistralToolParser requires MistralTokenizer. "
+                "Please use tokenizer_mode='mistral' in your vLLM configuration. "
+                "Note: Only v11+ Mistral models are supported for tool calling."
+            )
 
-        if not self._use_mistral_tokenizer:
-            logger.info(
-                "Non-Mistral tokenizer detected when using a Mistral model..."
+        self._mistral_base_tokenizer = self.model_tokenizer.tokenizer
+        self._version = self.model_tokenizer.version
+
+        if self._version < 11:
+            raise RuntimeError(
+                f"MistralToolParser requires tokenizer version 11 or higher, "
+                f"but got version {self._version}. Pre-v11 models "
+                "(Mistral-7B-Instruct-v0.1/v0.2/v0.3) are not supported for "
+                "tool calling. Please use a v11+ model such as "
+                "Mistral-Small-3.1 or Ministral-3."
             )
 
         # Get bot token info
@@ -88,41 +106,34 @@ class MistralToolParser(ToolParser):
 
         if self.bot_token_id is None:
             raise RuntimeError(
-                "Mistral Tool Parser could not locate the tool call token in "
-                "the tokenizer!"
+                "Mistral Tool Parser could not locate the [TOOL_CALLS] token "
+                "in the tokenizer!"
             )
 
-        # For MistralTokenizer, get additional info for v11+ parsing
-        self._args_token_id: int | None = None
+        # Get control tokens for v11+ format
+        try:
+            self._args_token_id = self._mistral_base_tokenizer.get_control_token(
+                "[ARGS]"
+            )
+        except Exception:
+            raise RuntimeError(
+                "Mistral Tool Parser could not locate the [ARGS] token. "
+                "This token is required for v11+ tool call parsing."
+            )
+
         self._call_id_token_id: int | None = None
-        self._version: int = 3  # Default to pre-v11
+        try:
+            self._call_id_token_id = self._mistral_base_tokenizer.get_control_token(
+                "[CALL_ID]"
+            )
+        except Exception:
+            # [CALL_ID] is optional - some models may not have it
+            pass
 
-        if self._use_mistral_tokenizer:
-            assert isinstance(self.model_tokenizer, MistralTokenizer)
-            self._mistral_base_tokenizer = self.model_tokenizer.tokenizer
-            self._version = self.model_tokenizer.version
-
-            # Get control tokens for v11+ format
-            if self._version >= 11:
-                try:
-                    self._args_token_id = self._mistral_base_tokenizer.get_control_token(
-                        "[ARGS]"
-                    )
-                except Exception:
-                    pass
-                try:
-                    self._call_id_token_id = (
-                        self._mistral_base_tokenizer.get_control_token("[CALL_ID]")
-                    )
-                except Exception:
-                    pass
-
-        # Regex patterns
-        self.tool_call_regex = re.compile(r"\[{.*}\]", re.DOTALL)
-        # V11+ format: name{args} where name is alphanumeric with underscores/hyphens
+        # Regex for non-streaming parsing: name{args}
         self.fn_name_regex = re.compile(
             r"([a-zA-Z0-9_-]+)(\{[\s\S]*?\}+)", re.DOTALL
-        ) if self._is_v11_plus() else None
+        )
 
         # Streaming state
         self._streaming_state = StreamingState.CONTENT
@@ -130,30 +141,10 @@ class MistralToolParser(ToolParser):
         self._current_tool_id: str | None = None
         self._current_tool_name: str = ""
         self._current_tool_args: str = ""
-        self._accumulated_tokens: list[int] = []
         self._brace_depth = 0
 
         # For compatibility with serving_chat.py's finish_reason detection
         self.prev_tool_call_arr: list[dict] = []
-
-    def adjust_request(self, request: ChatCompletionRequest) -> ChatCompletionRequest:
-        request = super().adjust_request(request)
-        if (
-            not self._use_mistral_tokenizer
-            and request.tools
-            and request.tool_choice != "none"
-        ):
-            # Do not skip special tokens when using chat template
-            # with Mistral parser as TOOL_CALL token is needed
-            # for tool detection.
-            # Note: we don't want skip_special_tokens=False
-            # with MistralTokenizer as it is incompatible
-            request.skip_special_tokens = False
-        return request
-
-    def _is_v11_plus(self) -> bool:
-        """Check if using v11+ tokenizer format."""
-        return self._use_mistral_tokenizer and self._version >= 11
 
     def extract_tool_calls(
         self,
@@ -163,7 +154,7 @@ class MistralToolParser(ToolParser):
         """
         Extract tool calls from a complete model response.
 
-        Uses string-based parsing since model_output is already decoded text.
+        Parses the v11+ format: [TOOL_CALLS]name{args}[TOOL_CALLS]name{args}...
         """
         # Fast path: no tool call token present
         if self.bot_token not in model_output:
@@ -176,15 +167,19 @@ class MistralToolParser(ToolParser):
             content = model_output.split(self.bot_token)[0]
             content = content if content.strip() else None
 
-            # Remove bot tokens and parse tool calls
-            tool_content = model_output.replace(self.bot_token, "").strip()
+            # Parse tool calls from each segment after [TOOL_CALLS]
+            function_call_arr = []
+            for segment in model_output.split(self.bot_token):
+                if not segment.strip():
+                    continue
 
-            if self._is_v11_plus():
-                # V11+ format: name{args} repeated for each tool call
-                function_call_arr = self._parse_v11_tool_calls(model_output)
-            else:
-                # Pre-v11 format: JSON array
-                function_call_arr = self._parse_pre_v11_tool_calls(tool_content)
+                matches = self.fn_name_regex.findall(segment)
+                for match in matches:
+                    fn_name = match[0]
+                    args = match[1]
+                    function_call_arr.append(
+                        {"name": fn_name, "arguments": json.loads(args)}
+                    )
 
             # Convert to MistralToolCall objects
             tool_calls: list[MistralToolCall] = [
@@ -214,36 +209,6 @@ class MistralToolParser(ToolParser):
                 content=model_output.replace(self.bot_token, "").strip(),
             )
 
-    def _parse_v11_tool_calls(self, model_output: str) -> list[dict]:
-        """Parse v11+ format: [TOOL_CALLS]name{args}[TOOL_CALLS]name{args}..."""
-        function_call_arr = []
-
-        # Split by [TOOL_CALLS] and process each segment
-        for segment in model_output.split(self.bot_token):
-            if not segment.strip():
-                continue
-
-            assert self.fn_name_regex is not None
-            matches = self.fn_name_regex.findall(segment)
-
-            for match in matches:
-                fn_name = match[0]
-                args = match[1]
-                function_call_arr.append(
-                    {"name": fn_name, "arguments": json.loads(args)}
-                )
-
-        return function_call_arr
-
-    def _parse_pre_v11_tool_calls(self, tool_content: str) -> list[dict]:
-        """Parse pre-v11 format: [{"name": "...", "arguments": {...}}, ...]"""
-        try:
-            return json.loads(tool_content)
-        except json.JSONDecodeError:
-            # Try regex extraction as fallback
-            raw_tool_call = self.tool_call_regex.findall(tool_content)[0]
-            return json.loads(raw_tool_call)
-
     def extract_tool_calls_streaming(
         self,
         previous_text: str,
@@ -255,36 +220,29 @@ class MistralToolParser(ToolParser):
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
         """
-        Extract tool calls from streaming output.
+        Extract tool calls from streaming output using token-based parsing.
 
-        For v11+ with MistralTokenizer, uses token-based parsing.
-        Otherwise, uses text-based partial JSON parsing.
+        Token IDs are atomic - they cannot be split across chunks - which
+        eliminates a whole class of parsing bugs that affect text-based parsing.
         """
         # If no tool call token seen yet, emit as content
         if self.bot_token_id not in current_token_ids:
             return DeltaMessage(content=delta_text)
 
-        # Accumulate tokens for parsing
-        self._accumulated_tokens.extend(delta_token_ids)
+        return self._stream_tool_calls(delta_token_ids)
 
-        # Route to appropriate streaming parser
-        if self._is_v11_plus():
-            return self._stream_v11_plus(delta_token_ids, delta_text)
-        else:
-            return self._stream_pre_v11(delta_text, current_text)
-
-    def _stream_v11_plus(
-        self, delta_token_ids: Sequence[int], delta_text: str
+    def _stream_tool_calls(
+        self, delta_token_ids: Sequence[int]
     ) -> DeltaMessage | None:
         """
-        Stream tool calls for v11+ format: [TOOL_CALLS]name[ARGS]{...}
+        Stream tool calls using token-based parsing.
 
-        Uses token-based parsing since token IDs are atomic.
+        Detects [TOOL_CALLS] and [ARGS] tokens to identify tool call boundaries,
+        then streams function names and arguments as they arrive.
         """
         from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 
         delta_tool_calls: list[DeltaToolCall] = []
-        content_delta: str | None = None
 
         for token_id in delta_token_ids:
             if token_id == self.bot_token_id:
@@ -326,8 +284,8 @@ class MistralToolParser(ToolParser):
                 pass
 
             elif self._streaming_state == StreamingState.CONTENT:
-                # Before any tool call - this shouldn't happen if bot_token_id is in current_token_ids
-                # but handle it gracefully
+                # Before any tool call - shouldn't happen if bot_token_id
+                # is in current_token_ids, but handle gracefully
                 pass
 
             elif self._streaming_state == StreamingState.PARSING_TOOL_NAME:
@@ -354,7 +312,9 @@ class MistralToolParser(ToolParser):
 
                 # Update streamed_args_for_tool for vLLM's finish handling
                 if self._current_tool_index < len(self.streamed_args_for_tool):
-                    self.streamed_args_for_tool[self._current_tool_index] = self._current_tool_args
+                    self.streamed_args_for_tool[self._current_tool_index] = (
+                        self._current_tool_args
+                    )
 
                 # Emit arguments delta
                 delta_tool_calls.append(
@@ -367,138 +327,6 @@ class MistralToolParser(ToolParser):
                 )
 
         # Build response
-        if delta_tool_calls:
-            return DeltaMessage(tool_calls=delta_tool_calls)
-
-        return None
-
-    def _stream_pre_v11(
-        self, delta_text: str, current_text: str
-    ) -> DeltaMessage | None:
-        """
-        Stream tool calls for pre-v11 format: [TOOL_CALLS][{...}, {...}]
-
-        Uses partial JSON parsing for structure, but streams raw text for arguments.
-        """
-        # Parse tool calls from text after [TOOL_CALLS]
-        if self.bot_token not in current_text:
-            return DeltaMessage(content=delta_text)
-
-        # Handle bot token in delta - but only if it's just the token arriving
-        # (not a one-chunk case where everything arrives at once)
-        if self.bot_token in delta_text:
-            if not self.prev_tool_call_arr:
-                self.prev_tool_call_arr = [{"arguments": {}}]
-            # Check if this is just the bot token arriving (not one-chunk)
-            parts = delta_text.split(self.bot_token)
-            content_before = parts[0]
-            content_after = parts[-1].strip() if len(parts) > 1 else ""
-
-            # If there's significant content after the bot token, this is a one-chunk case
-            # Continue processing instead of returning early
-            if content_before and not content_after:
-                return DeltaMessage(content=content_before)
-            elif not content_after:
-                # Just the bot token, nothing more - wait for more tokens
-                return None
-            # Otherwise fall through to process the full content
-
-        parsable = current_text.split(self.bot_token)[-1]
-
-        # Partial JSON parsing to detect tool call structure
-        flags = Allow.ALL if self._current_tool_name else Allow.ALL & ~Allow.STR
-        try:
-            tool_call_arr: list[dict] = partial_json_parser.loads(parsable, flags)
-        except Exception:
-            return None
-
-        if not tool_call_arr:
-            return None
-
-        delta_tool_calls: list[DeltaToolCall] = []
-
-        # Check if we've moved to a new tool
-        if len(tool_call_arr) > self._current_tool_index + 1:
-            self._current_tool_index = len(tool_call_arr) - 1
-            self._current_tool_name = ""
-            self._current_tool_args = ""
-            self._current_tool_id = MistralToolCall.generate_random_id()
-
-            # Initialize streamed_args_for_tool for this tool index
-            while len(self.streamed_args_for_tool) <= self._current_tool_index:
-                self.streamed_args_for_tool.append("")
-
-        current_tool = tool_call_arr[self._current_tool_index]
-
-        # Emit function name if available and not yet emitted
-        if "name" in current_tool and not self._current_tool_name:
-            self._current_tool_name = current_tool["name"]
-            delta_tool_calls.append(
-                DeltaToolCall(
-                    index=self._current_tool_index,
-                    type="function",
-                    id=self._current_tool_id,
-                    function=DeltaFunctionCall(
-                        name=self._current_tool_name
-                    ).model_dump(exclude_none=True),
-                )
-            )
-
-        # Emit arguments delta using raw text extraction
-        if "arguments" in current_tool and self._current_tool_name:
-            # Find the current tool's arguments in the parsable text.
-            # For multiple tools, we need to find the N-th "arguments" occurrence.
-            # Use findall to get all matches and pick the right one.
-            matches = list(re.finditer(
-                r'"arguments"\s*:\s*(\{)',
-                parsable
-            ))
-
-            if matches and len(matches) > self._current_tool_index:
-                # Get the start position for current tool's arguments
-                match = matches[self._current_tool_index]
-                args_start = match.start(1)  # Start of the '{'
-
-                # Extract from args_start to end, then trim to the arguments object
-                raw_args = parsable[args_start:]
-
-                # Trim trailing characters that aren't part of this tool's arguments.
-                # The raw_args may include `}}]` or `}, {...` for the next tool.
-                # We track brace depth to find where the arguments object ends.
-                brace_depth = 0
-                end_pos = len(raw_args)
-                for i, char in enumerate(raw_args):
-                    if char == '{':
-                        brace_depth += 1
-                    elif char == '}':
-                        brace_depth -= 1
-                        if brace_depth == 0:
-                            # Found the end of the arguments object
-                            end_pos = i + 1
-                            break
-
-                raw_args = raw_args[:end_pos]
-
-                # Find how much of this raw text is new
-                if len(raw_args) > len(self._current_tool_args):
-                    args_delta = raw_args[len(self._current_tool_args):]
-
-                    if args_delta:
-                        delta_tool_calls.append(
-                            DeltaToolCall(
-                                index=self._current_tool_index,
-                                function=DeltaFunctionCall(
-                                    arguments=args_delta
-                                ).model_dump(exclude_none=True),
-                            )
-                        )
-                    self._current_tool_args = raw_args
-
-                    # Update streamed_args_for_tool for vLLM's finish handling
-                    while len(self.streamed_args_for_tool) <= self._current_tool_index:
-                        self.streamed_args_for_tool.append("")
-                    self.streamed_args_for_tool[self._current_tool_index] = self._current_tool_args
-
         if delta_tool_calls:
             return DeltaMessage(tool_calls=delta_tool_calls)
 


### PR DESCRIPTION
## Purpose

Rewrite Mistral tool parser to use token-based parsing for v11+ models. Special tokens like `[TOOL_CALLS]` and `[ARGS]` have dedicated token IDs that are atomic - they can't be split across streaming chunks, which eliminates edge cases plaguing text-based parsing.

Drops pre-v11 support (Mistral-7B-Instruct-v0.1/v0.2/v0.3). These older models have weak tool calling and the text-based parsing is fragile. Users should upgrade to v11+ models.

Related to #19425 which tries to fix streaming issues while keeping pre-v11 support. This PR takes the opposite approach: drop pre-v11 and sidestep the parsing rabbit hole.

### Important

In the first commit of this PR, both pre-v11 and v11+ are supported and tested in the same manner as the 2nd commit (and yes I also tested them with tool calling on a GPU using curl and opencode). However, the tool calling capabilities of these older models are not super duper crazy, and thus I simplified the code in the 2nd commit.

This of course open to discussion.

## Test Plan

```bash
pytest tests/tool_use/test_mistral_tool_parser.py -v
```

Server test with Ministral-3-14B-Instruct-2512:

```bash
vllm serve mistralai/Ministral-3-14B-Instruct-2512 \
  --enable-auto-tool-choice \
  --tool-call-parser mistral
```

## Test Result

Local pytest: 17 passed, 1 xfailed (BPE tokenization edge case that doesn't occur in real inference)

Server integration on Ministral-3-14B-Instruct-2512:

- Single tool streaming/non-streaming: pass
- Multiple tools streaming/non-streaming: pass

## Additional note

I already shared the tool parser code and how I tested it on GPU: https://github.com/vllm-project/vllm/pull/19425#issuecomment-3611099986

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
