### PR TITLE
[Core] Whisper enable `FULL_DECODE_ONLY` CudaGraph 

### DIFF
--- a/tests/models/multimodal/generation/test_whisper.py
+++ b/tests/models/multimodal/generation/test_whisper.py
@@ -102,6 +102,7 @@ def run_test(
         max_model_len=448,
         tensor_parallel_size=tensor_parallel_size,
         distributed_executor_backend=distributed_executor_backend,
+        enforce_eager=True,
     ) as vllm_model:
         llm = vllm_model.llm
 

--- a/tests/models/multimodal/generation/test_whisper.py
+++ b/tests/models/multimodal/generation/test_whisper.py
@@ -102,6 +102,7 @@ def run_test(
         max_model_len=448,
         tensor_parallel_size=tensor_parallel_size,
         distributed_executor_backend=distributed_executor_backend,
+        # TODO (NickLucche) figure out output differences with non-eager and re-enable
         enforce_eager=True,
     ) as vllm_model:
         llm = vllm_model.llm

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -666,17 +666,17 @@ class VllmConfig:
 
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)
-        if (
-            self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
-            and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
-        ):
-            logger.info(
-                "Cudagraph mode %s is not compatible with compilation mode %s."
-                "Overriding to NONE.",
-                self.compilation_config.cudagraph_mode,
-                self.compilation_config.mode,
-            )
-            self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+        # if (
+        #     self.compilation_config.cudagraph_mode != CUDAGraphMode.PIECEWISE OR FULL_AND_PIECEWISE
+        #     and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
+        # ):
+        #     logger.info(
+        #         "Cudagraph mode %s is not compatible with compilation mode %s."
+        #         "Overriding to NONE.",
+        #         self.compilation_config.cudagraph_mode,
+        #         self.compilation_config.mode,
+        #     )
+        #     self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 
         # async tp is built on top of sequence parallelism
         # and requires it to be enabled.
@@ -703,11 +703,12 @@ class VllmConfig:
                     )
                     self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
                 elif self.model_config.is_encoder_decoder:
-                    logger.warning_once(
-                        "Encoder-decoder models do not support full cudagraphs. "
-                        "Overriding cudagraph_mode to PIECEWISE."
-                    )
-                    self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+                    pass
+                    # logger.warning_once(
+                    #     "Encoder-decoder models do not support full cudagraphs. "
+                    #     "Overriding cudagraph_mode to PIECEWISE."
+                    # )
+                    # self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
             # disable cudagraph when enforce eager execution
             if self.model_config is not None and self.model_config.enforce_eager:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -666,9 +666,9 @@ class VllmConfig:
 
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)
+
         if (
-            self.compilation_config.cudagraph_mode
-            in (CUDAGraphMode.PIECEWISE, CUDAGraphMode.FULL_AND_PIECEWISE)
+            self.compilation_config.cudagraph_mode.requires_piecewise_compilation()
             and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
         ):
             logger.info(

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -666,17 +666,18 @@ class VllmConfig:
 
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)
-        # if (
-        #     self.compilation_config.cudagraph_mode != CUDAGraphMode.PIECEWISE OR FULL_AND_PIECEWISE
-        #     and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
-        # ):
-        #     logger.info(
-        #         "Cudagraph mode %s is not compatible with compilation mode %s."
-        #         "Overriding to NONE.",
-        #         self.compilation_config.cudagraph_mode,
-        #         self.compilation_config.mode,
-        #     )
-        #     self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+        if (
+            self.compilation_config.cudagraph_mode
+            in (CUDAGraphMode.PIECEWISE, CUDAGraphMode.FULL_AND_PIECEWISE)
+            and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
+        ):
+            logger.info(
+                "Cudagraph mode %s is not compatible with compilation mode %s."
+                "Overriding to NONE.",
+                self.compilation_config.cudagraph_mode,
+                self.compilation_config.mode,
+            )
+            self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 
         # async tp is built on top of sequence parallelism
         # and requires it to be enabled.
@@ -702,13 +703,19 @@ class VllmConfig:
                         "Overriding cudagraph_mode to PIECEWISE."
                     )
                     self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
-                elif self.model_config.is_encoder_decoder:
-                    pass
-                    # logger.warning_once(
-                    #     "Encoder-decoder models do not support full cudagraphs. "
-                    #     "Overriding cudagraph_mode to PIECEWISE."
-                    # )
-                    # self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+                elif (
+                    self.model_config.is_encoder_decoder
+                    and self.compilation_config.cudagraph_mode
+                    not in (CUDAGraphMode.NONE, CUDAGraphMode.FULL_DECODE_ONLY)
+                ):
+                    logger.info_once(
+                        "Encoder-decoder models do not support %s. "
+                        "Overriding cudagraph_mode to FULL_DECODE_ONLY.",
+                        self.compilation_config.cudagraph_mode.name,
+                    )
+                    self.compilation_config.cudagraph_mode = (
+                        CUDAGraphMode.FULL_DECODE_ONLY
+                    )
 
             # disable cudagraph when enforce eager execution
             if self.model_config is not None and self.model_config.enforce_eager:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -693,18 +693,18 @@ class VllmConfig:
 
         if current_platform.support_static_graph_mode():
             # if cudagraph_mode has full cudagraphs, we need to check support
-            if (
-                self.compilation_config.cudagraph_mode.has_full_cudagraphs()
-                and self.model_config is not None
-            ):
-                if self.model_config.pooler_config is not None:
+            if model_config := self.model_config:
+                if (
+                    self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+                    and model_config.pooler_config is not None
+                ):
                     logger.warning_once(
                         "Pooling models do not support full cudagraphs. "
                         "Overriding cudagraph_mode to PIECEWISE."
                     )
                     self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
                 elif (
-                    self.model_config.is_encoder_decoder
+                    model_config.is_encoder_decoder
                     and self.compilation_config.cudagraph_mode
                     not in (CUDAGraphMode.NONE, CUDAGraphMode.FULL_DECODE_ONLY)
                 ):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4463,7 +4463,6 @@ class GPUModelRunner(
                     self.encoder_cache["tmp"] = dict(enumerate(dummy_encoder_outputs))
 
         # Add `is_profile` here to pre-allocate communication buffers
-        # TORCH COMPILE FOR DECODE (step 1 onward)
         hidden_states, last_hidden_states = self._dummy_run(
             self.max_num_tokens, is_profile=True
         )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1267,6 +1267,8 @@ class GPUModelRunner(
         if not isinstance(kv_cache_spec, CrossAttentionSpec):
             return None, None
 
+        # Zero out buffer for padding requests that are not actually scheduled (CGs)
+        self.encoder_seq_lens.np[:num_reqs] = 0
         # Build encoder_seq_lens array mapping request indices to
         # encoder lengths for inputs scheduled in this batch
         for req_id in num_scheduled_tokens:


### PR DESCRIPTION
## Overview

Whisper currently only supports PIECEWISE cudagraph mode, but it does NOT support torch.compile, so in practice this results in running in eager mode (see profiler below, `cudagraphlaunch` query). 


<img width="1252" height="1063" alt="Pasted image 20251202144814" src="https://github.com/user-attachments/assets/d9ad0a81-18f8-4bc1-a50c-be03a57f49ee" />



This PR addresses another important performance limitation by adding support for cuda graph through the `FULL_DECODE_ONLY` mode.  
This guarantees that all decode steps after the first one will just replay the graph.
Mind that the first decode step is actually branching in flow due to `encoder_outputs` being present for populating the crossattn kv cache. Hence we only GC the steps that follow.

New profile(r) pic:
<img width="972" height="1064" alt="Pasted image 20251204180234" src="https://github.com/user-attachments/assets/1b2340cb-b6c3-4630-9fda-59ce198f0c53" />


Full explicit command:
```
vllm serve openai/whisper-large-v3-turbo --max-num-batched-tokens 32874 -cc.cudagraph_mode=FULL_DECODE_ONLY
```

New default:
```
vllm serve openai/whisper-large-v3-turbo
...
INFO 12-04 17:44:48 [vllm.py:704] Encoder-decoder models do not support FULL_AND_PIECEWISE. Overriding cudagraph_mode to FULL_DECODE_ONLY.
```

## Benchmark

Pre
```
================================================================================
RESULTS SUMMARY
================================================================================
Total samples: 50
Successful: 50
Failed: 0
Total time: 1.36s
Average latency: 0.88s
Throughput: 36.82 requests/s
```

Post 
```
================================================================================
RESULTS SUMMARY
================================================================================
Total samples: 50
Successful: 50
Failed: 0
Total time: 1.02s
Average latency: 0.61s
Throughput: 49.11 requests/s
```

cc @ProExpertProg @LucasWilkinson @robertgshaw2-redhat 