### PR TITLE
[docker] Only install flashinfer-jit-cache on CUDA 12.8+

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -595,8 +595,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 #   SM120/SM121 (RTX 50 / DGX Spark) via flashinfer#2738
 ARG FLASHINFER_VERSION=0.6.7
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \
-        --extra-index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.') \
+    CUDA_MAJOR="${CUDA_VERSION%%.*}" CUDA_MINOR="${CUDA_VERSION#${CUDA_MAJOR}.}" CUDA_MINOR="${CUDA_MINOR%%.*}"; \
+    && if [ "$CUDA_MAJOR" -lt 12 ] || { [ "$CUDA_MAJOR" -eq 12 ] && [ "$CUDA_MINOR" -lt 8 ]; }; then \
+      echo "Skipping flashinfer-jit-cache installation (requires CUDA 12.8+ but got ${CUDA_VERSION})"; \
+    else \
+      uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \
+        --extra-index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.'); \
+    fi \
     && flashinfer show-config
 
 # Pre-download FlashInfer TRTLLM BMM headers for air-gapped environments.


### PR DESCRIPTION

## Purpose

Docker build currently fails with CUDA 12.6, due to failing to install flashinfer-jit-cache, as the wheels are only available for CUDA 12.8+, see https://flashinfer.ai/whl/

## Test Plan
```
DOCKER_BUILDKIT=1 docker build --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=0 --build-arg CUDA_VERSION=12.6.3 --target vllm-openai --progress plain -f docker/Dockerfile .
```
Or run this script testing only the snippet
```shell
for CUDA_VERSION in 12.6.3 12.9.1; do
  echo "Testing running snippet using CUDA version ${CUDA_VERSION}"
  echo "----------------------"
  CUDA_MAJOR="${CUDA_VERSION%%.*}" CUDA_MINOR="${CUDA_VERSION#${CUDA_MAJOR}.}" CUDA_MINOR="${CUDA_MINOR%%.*}"; \
  echo uv pip install --system flashinfer-cubin==0.5.3 \
  && if [ "$CUDA_MAJOR" -lt 12 ] || { [ "$CUDA_MAJOR" -eq 12 ] && [ "$CUDA_MINOR" -lt 8 ]; }; then \
    echo "Skipping flashinfer-jit-cache installation (requires CUDA 12.8+ but got ${CUDA_VERSION})"; \
  else \
    echo uv pip install --system flashinfer-jit-cache==0.5.3 \
      --extra-index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.'); \
  fi \
  && echo flashinfer show-config
  echo "----------------------"
done
```

## Test Result

```
Testing running snippet using CUDA version 12.6.3
----------------------
uv pip install --system flashinfer-cubin==0.5.3
Skipping flashinfer-jit-cache installation (requires CUDA 12.8+ but got 12.6.3)
flashinfer show-config
----------------------
Testing running snippet using CUDA version 12.9.1
----------------------
uv pip install --system flashinfer-cubin==0.5.3
uv pip install --system flashinfer-jit-cache==0.5.3 --extra-index-url https://flashinfer.ai/whl/cu129
flashinfer show-config
----------------------
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

