### PR TITLE
[CI/Build] Only install DeepEP kernels on CUDA version 12.8+

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -283,7 +283,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         ${PPLX_COMMIT_HASH:+--pplx-ref "$PPLX_COMMIT_HASH"} \
         ${DEEPEP_COMMIT_HASH:+--deepep-ref "$DEEPEP_COMMIT_HASH"} \
         ${NVSHMEM_VER:+--nvshmem-ver "$NVSHMEM_VER"} && \
-    find /tmp/ep_kernels_workspace/nvshmem -name '*.a' -delete
+    if [ -d "/tmp/ep_kernels_workspace/nvshmem" ]; then find /tmp/ep_kernels_workspace/nvshmem -name '*.a' -delete; fi
+
 #################### EXTENSIONS BUILD IMAGE ####################
 
 #################### WHEEL BUILD IMAGE ####################
@@ -546,8 +547,12 @@ ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 # Install EP kernels wheels (pplx-kernels and DeepEP) that have been built in the `build` stage
 RUN --mount=type=bind,from=build,src=/tmp/ep_kernels_workspace/dist,target=/vllm-workspace/ep_kernels/dist \
     --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system ep_kernels/dist/*.whl --verbose \
-        --extra-index-url ${PYTORCH_CUDA_INDEX_BASE_URL}/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')
+    sh -c 'if ls ep_kernels/dist/*.whl >/dev/null 2>&1; then \
+              uv pip install --system ep_kernels/dist/*.whl --verbose \
+                --extra-index-url ${PYTORCH_CUDA_INDEX_BASE_URL}/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.'); \
+           else \
+              echo "No DeepEP wheels to install; skipping."; \
+           fi'
 
 # CUDA image changed from /usr/local/nvidia to /usr/local/cuda in 12.8 but will
 # return to /usr/local/nvidia in 13.0 to allow container providers to mount drivers

--- a/tools/ep_kernels/install_python_libraries.sh
+++ b/tools/ep_kernels/install_python_libraries.sh
@@ -84,6 +84,24 @@ mkdir -p "$WHEEL_DIR"
 
 pushd "$WORKSPACE"
 
+# Auto-detect CUDA version if not provided
+if [ -z "$CUDA_VERSION" ]; then
+    CUDA_VERSION=$(${CUDA_HOME}/bin/nvcc --version | grep "release" | sed -n 's/.*release \([0-9]\+\.[0-9]\+\).*/\1/p')
+    echo "Auto-detected CUDA version: $CUDA_VERSION"
+fi
+
+# Extract major and minor version numbers
+CUDA_MAJOR="${CUDA_VERSION%%.*}"
+CUDA_MINOR="${CUDA_VERSION#${CUDA_MAJOR}.}"
+CUDA_MINOR="${CUDA_MINOR%%.*}"
+echo "CUDA version: $CUDA_VERSION (major: $CUDA_MAJOR, minor: $CUDA_MINOR)"
+
+# Check CUDA version requirement
+if [ "$CUDA_MAJOR" -lt 12 ] || { [ "$CUDA_MAJOR" -eq 12 ] && [ "$CUDA_MINOR" -lt 8 ]; }; then
+    echo "Skipping DeepEP build/installation (requires CUDA 12.8+ but got ${CUDA_VERSION})"
+    exit 0
+fi
+
 # install dependencies if not installed
 if [ -z "$VIRTUAL_ENV" ]; then
   uv pip install --system cmake torch ninja


### PR DESCRIPTION



## Purpose

DeepEP kernels are built for sm_90a and sm_100a, and sm_100a is only supported since CUDA version 12.8, thus disabling the installation of DeepEP kernels on older CUDA versions

## Test Plan

```
DOCKER_BUILDKIT=1 docker build --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=0 --build-arg CUDA_VERSION=12.6.3 --target vllm-openai --progress plain -f docker/Dockerfile .
```

## Test Result

N/A, takes too long to run.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Implements CUDA-aware DeepEP handling and safer installs.
> 
> - Adds `tools/ep_kernels/install_python_libraries.sh` with CUDA auto-detection, strict version gating (require >=12.8 for DeepEP), NVSHMEM version validation, and a CUDA 13 include patch for DeepEP; builds `pplx-kernels` and `DeepEP` as wheels or installs into env
> - In `docker/Dockerfile`, wraps EP wheel installation in a conditional so the step is skipped when no wheels are produced; also guards NVSHMEM static library cleanup with a directory-existence check
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee279ad0500df93ed609968dfdd84c0c5652fb5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
