### PR TITLE
[CI/Build] Update batch invariant test trigger

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -350,7 +350,8 @@ steps:
   timeout_in_minutes: 25
   gpu: h100
   source_file_dependencies:
-    - vllm/
+    - vllm/v1/attention
+    - vllm/model_executor/layers
     - tests/v1/determinism/
   commands:
     - export VLLM_WORKER_MULTIPROC_METHOD=spawn


### PR DESCRIPTION
## Purpose
Test trigger for batch invariant test is bit too general with `vllm/`, so that PRs like https://github.com/vllm-project/vllm/pull/30005 will trigger the test.
This PR narrows the trigger to `vllm/v1/attention`  + `vllm/model_executor/layers`
## Test Plan
CI
