### PR TITLE
[ROCm][CI] Add jiwer dependency for testing

### DIFF
--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -58,6 +58,7 @@ schemathesis==3.39.15
 
 # Evaluation and benchmarking
 lm-eval[api] @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@206b7722158f58c35b7ffcd53b035fdbdda5126d
+jiwer==4.0.0
 
 # Required for multiprocessed tests that use spawn method, Datasets and Evaluate Test
 multiprocess==0.70.16


### PR DESCRIPTION
To fix OpenAI API Correctness test group.

The jiwer package is missing in the test image.

`pytest -s entrypoints/openai/correctness/`

========== 2 passed, 10 warnings in 110.94s (0:01:50) ===========
