### PR TITLE
[Perf] Enable separate shared_experts stream only for CUDA

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -863,7 +863,8 @@ class FusedMoE(CustomOp):
         use_chunked_impl: bool,
     ) -> tuple[bool, torch.Tensor | None]:
         use_shared_experts_stream = (
-            has_separate_shared_experts
+            current_platform.is_cuda()
+            and has_separate_shared_experts
             and not use_chunked_impl
             and self.shared_experts_stream is not None
             and (


### PR DESCRIPTION
@gshtras (AMD) reported a performance regression with the MoE running shared_experts in a separate cuda stream. This PR limits the usage of the stream only for CUDA/NVIDIA. 