### PR TITLE
fix#30092 Kimi-Linear model loading failure with missing indexer_rotary_emb

### DIFF
--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -24,9 +24,9 @@ class MLAModules:
     q_b_proj: torch.nn.Module | None
     q_proj: torch.nn.Module | None
     indexer: torch.nn.Module | None
-    indexer_rotary_emb: torch.nn.Module | None
     is_sparse: bool
     topk_indices_buffer: torch.Tensor | None
+    indexer_rotary_emb: torch.nn.Module | None = None
 
 
 @CustomOp.register("multi_head_latent_attention")

--- a/vllm/model_executor/models/kimi_linear.py
+++ b/vllm/model_executor/models/kimi_linear.py
@@ -255,6 +255,7 @@ class KimiMLAAttention(nn.Module):
             q_b_proj=None,
             q_proj=self.q_proj,
             indexer=None,
+            indexer_rotary_emb=None,
             is_sparse=False,
             topk_indices_buffer=None,
         )

--- a/vllm/model_executor/models/kimi_linear.py
+++ b/vllm/model_executor/models/kimi_linear.py
@@ -255,7 +255,6 @@ class KimiMLAAttention(nn.Module):
             q_b_proj=None,
             q_proj=self.q_proj,
             indexer=None,
-            indexer_rotary_emb=None,
             is_sparse=False,
             topk_indices_buffer=None,
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
fix #30092 
## Test Plan
vllm serve moonshotai/Kimi-Linear-48B-A3B-Instruct \
  --port 8000 \
  --tensor-parallel-size 8 \
  --max-model-len 1048576 \
  --trust-remote-code \
  --gpu-memory-utilization 0.95  
## Test Result
<img width="1363" height="319" alt="image" src="https://github.com/user-attachments/assets/d4b8e5a8-ab70-45a4-a537-906f02e748d7" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

