### PR TITLE
lazy load vllm.utils.serial_utils import tensor2base64 to avoid break. 

### DIFF
--- a/vllm/multimodal/audio.py
+++ b/vllm/multimodal/audio.py
@@ -11,7 +11,6 @@ import pybase64
 import torch
 
 from vllm.utils.import_utils import PlaceholderModule
-from vllm.utils.serial_utils import tensor2base64
 
 from .base import MediaIO
 
@@ -136,4 +135,6 @@ class AudioEmbeddingMediaIO(MediaIO[torch.Tensor]):
         return torch.load(filepath, weights_only=True)
 
     def encode_base64(self, media: torch.Tensor) -> str:
+        from vllm.utils.serial_utils import tensor2base64
+
         return tensor2base64(media)


### PR DESCRIPTION
## Purpose
Fix the vllm on tpu loading issue. 

After the PR https://github.com/vllm-project/vllm/pull/29970/, vllm on tpu is blocked at loading by 

```
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843] EngineCore failed to start.
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843] Traceback (most recent call last):
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "/workspace/vllm/vllm/v1/engine/core.py", line 834, in run_engine_core
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]     engine_core = EngineCoreProc(*args, **kwargs)
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "/workspace/vllm/vllm/v1/engine/core.py", line 610, in __init__
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]     super().__init__(
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "/workspace/vllm/vllm/v1/engine/core.py", line 102, in __init__
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]     self.model_executor = executor_class(vllm_config)
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "/workspace/vllm/vllm/v1/executor/abstract.py", line 101, in __init__
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]     self._init_executor()
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "/workspace/vllm/vllm/v1/executor/uniproc_executor.py", line 46, in _init_executor
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]     self.driver_worker.init_worker(all_kwargs=[kwargs])
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "/workspace/vllm/vllm/v1/worker/worker_base.py", line 255, in init_worker
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]     worker_class = resolve_obj_by_qualname(
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]                    ^^^^^^^^^^^^^^^^^^^^^^^^
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "/workspace/vllm/vllm/utils/import_utils.py", line 122, in resolve_obj_by_qualname
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]     module = importlib.import_module(module_name)
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "/usr/local/lib/python3.12/importlib/__init__.py", line 90, in import_module
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]     return _bootstrap._gcd_import(name[level:], package, level)
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "<frozen importlib._bootstrap_external>", line 999, in exec_module
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]   File "/workspace/vllm/vllm/v1/worker/tpu_worker.py", line 41, in <module>
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843]     import torch_xla.core.xla_model as xm
^[[0;36m(EngineCore_DP0 pid=309)^[[0;0m ERROR 12-04 07:44:22 [core.py:843] ModuleNotFoundError: No module named 'torch_xla'
```
Lazy loading `vllm.utils.serial_utils import` can address it.

## Test Plan
1. wait for ci/cd test.

2. manually load vllm tpu with 
```
vllm serve \
  --model=Qwen/Qwen2.5-7B-Instruct   \
  --download_dir /mnt/disks/persist \
  --tensor-parallel-size=1   \
  --swap-space=16   \
  --enable-chunked-prefill   \
  --max-model-len=128
```

with the fix, it can loaded.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

