### PR TITLE
[Bugfix] Use PIECEWISE cudagraph with gpt-oss on Ampere

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -701,6 +701,16 @@ class VllmConfig:
                             "Overriding cudagraph_mode to PIECEWISE."
                         )
                         self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+                    elif (
+                        self.model_config.hf_config.model_type == "gpt_oss"
+                        and not current_platform.has_device_capability(90)
+                    ):
+                        logger.warning_once(
+                            "gpt_oss models do not support full cudagraphs on "
+                            "Ampere or earlier GPUs. "
+                            "Overriding cudagraph_mode to PIECEWISE."
+                        )
+                        self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
             # disable cudagraph when enforce eager execution
             if self.model_config is not None and self.model_config.enforce_eager:


### PR DESCRIPTION
## Purpose

Multiple user reports have come in about repeated, infinite generations by gpt-oss models on Ampere hardware. After reproducing this on Ampere hardware, I was able to workaround it by downgrading to PIECEWISE cudagraphs. FULL and FULL_AND_PIECEWISE can reliably reproduce infinite generation on the 2nd and later requests.

The check here to downgrade only triggers for gpt-oss models on Ampere or older CUDA GPUs. This matches where I was able to reproduce the issue and with what appears to be the largest number of user reports.

There could potentially be problems on more MoE models or with a slightly larger range of GPUs, but thought it best to make the most targeted fix for now just to get these models working reliably again on Ampere GPUs. It's probably worth auditing the entirety of the kernels in use here to ensure they are compatible with full cudagraphs, but for now I'm proposing a tactical solution as that investigation will take longer.

Users report that gpt-oss models on vLLM 0.10.2 worked well on Ampere GPUs, which is further evidence that this is related to us moving to FULL_AND_PIECEWISE cudagraphs by default with vLLM v0.11.0 that negatively impacted this hardware.

This potentially fixes:
- #29998 (user reported manually specifying PIECEWISE cudagraph successfully worked around the issue)
- #26480

## Test Plan

I primarily tested this manually with the curl reproducer shown in #29998. 

Specifically, from an Ampere (2x A5500 in my case) GPU:
```
vllm serve openai/gpt-oss-20b \
  --tool-call-parser openai \
  --enable-auto-tool-choice \
  --reasoning_parser openai_gptoss \
  --tensor-parallel-size 2
```

Send this request twice in a row exactly as-is:
```
curl -X POST http://localhost:8000/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "openai/gpt-oss-20b",
    "stream": false,
    "messages": [
      {
        "role": "system",
        "content": "Be a helpful assistant."
      },
      {
        "role": "user",
        "content": "Hi"
      },
      {
        "role": "assistant",
        "content": "How can I help you?"
      },
      {
        "role": "user",
        "content": "Do you like Monty Python?"
      }
    ],
    "tools": [
      {
        "type": "function",
        "function": {
          "name": "CHANGE-NAME-BEFORE-SENDING",
          "description": "Use this tool if you need to extract information from a website.",
          "parameters": {
            "type": "object",
            "properties": {
              "url": {
                "type": "string",
                "description": "The URL to search or extract information from."
              }
            },
            "required": ["url"]
          }
        }
      }
    ]
  }'
```

## Test Result

Before my change, the 2nd curl request would always hang and in the vLLM logs we'd see an infinite generation. The tokens being infinitely generated was always the token id `0`.

After my change, the 2nd (and multiple subsequent) curl requests complete without issue.

