### PR TITLE
Fix AWQ MoE marlin check issue in marlin_utils.py for AMD backend

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -180,6 +180,7 @@ def check_marlin_supports_shape(
 
 def check_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
     from vllm.platform import current_platform
+
     if current_platform.is_rocm():
         return False
     output_size_per_partition = (
@@ -199,6 +200,7 @@ def check_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
 
 def check_moe_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
     from vllm.platform import current_platform
+
     if current_platform.is_rocm():
         return False
     hidden_size = layer.hidden_size

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -179,6 +179,9 @@ def check_marlin_supports_shape(
 
 
 def check_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
+    is_rocm = getattr(torch.version, "hip", None) is not None
+    if is_rocm:
+        return False
     output_size_per_partition = (
         getattr(layer, "output_size_per_partition", None) or layer.output_size
     )
@@ -195,6 +198,9 @@ def check_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
 
 
 def check_moe_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
+    is_rocm = getattr(torch.version, "hip", None) is not None
+    if is_rocm:
+        return False
     hidden_size = layer.hidden_size
     intermediate_size_per_partition = layer.intermediate_size_per_partition
     # apply_router_weight_on_input is not supported for moe marlin

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -179,8 +179,8 @@ def check_marlin_supports_shape(
 
 
 def check_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
-    is_rocm = getattr(torch.version, "hip", None) is not None
-    if is_rocm:
+    from vllm.platform import current_platform
+    if current_platform.is_rocm():
         return False
     output_size_per_partition = (
         getattr(layer, "output_size_per_partition", None) or layer.output_size
@@ -198,8 +198,8 @@ def check_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
 
 
 def check_moe_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
-    is_rocm = getattr(torch.version, "hip", None) is not None
-    if is_rocm:
+    from vllm.platform import current_platform
+    if current_platform.is_rocm():
         return False
     hidden_size = layer.hidden_size
     intermediate_size_per_partition = layer.intermediate_size_per_partition

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -179,8 +179,6 @@ def check_marlin_supports_shape(
 
 
 def check_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
-    from vllm.platform import current_platform
-
     if current_platform.is_rocm():
         return False
     output_size_per_partition = (
@@ -199,8 +197,6 @@ def check_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
 
 
 def check_moe_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
-    from vllm.platform import current_platform
-
     if current_platform.is_rocm():
         return False
     hidden_size = layer.hidden_size


### PR DESCRIPTION
### Summary
This PR disables Marlin support for AWQ dense and MoE layers when running on ROCm, preventing the runtime from calling the unavailable `awq_marlin_repack` operator.

### Problem
On ROCm builds, the `vllm._C` extension does not include the `awq_marlin_repack` operator.  
However, both `check_marlin_supports_layer` and `check_moe_marlin_supports_layer` may return `True` for AWQ layers on AMD GPUs.  
This incorrectly enables the Marlin execution path, which leads to:

This error prevents AWQ models — especially AWQ MoE models — from running on AMD GPUs

### Fix
- Detect ROCm by checking `torch.version.hip`.
- If running on ROCm, both `check_marlin_supports_layer` and `check_moe_marlin_supports_layer` now return `False` immediately.
- This forces AWQ dense and MoE layers on ROCm to fall back to the supported non-Marlin kernels.
- CUDA behavior remains unchanged; Marlin continues to be used when supported.

### Impact
- Resolves the `awq_marlin_repack` AttributeError on ROCm.
- Restores AWQ and AWQ-MoE model functionality on AMD hardware.
- No changes to CUDA behavior; no regression in performance or correctness on existing CUDA paths.
- No runtime overhead on ROCm since Marlin kernels were not available there.

### Test Plan
Validated AWQ and AWQ-MoE models on AMD MI300X; error no longer occurs.

### Additional Notes
- This is a minimal compatibility fix for ROCm.  
- Future Marlin support on ROCm can remove this condition as new kernels become available.
