### PR TITLE
[Kernel] Guard all NVFP4 op registrations in torch bindings

### DIFF
--- a/csrc/quantization/fp4/nvfp4_blockwise_moe_kernel.cu
+++ b/csrc/quantization/fp4/nvfp4_blockwise_moe_kernel.cu
@@ -357,9 +357,6 @@ void run_fp4_blockwise_scaled_group_mm_sm100(
   TORCH_CHECK(status == cutlass::Status::kSuccess, "Failed to run GEMM");
 }
 
-// SM120 FP4 MoE requires TMA support for float_e2m1_t (CUDA 12.7+)
-#if defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120 && \
-    defined(CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B)
 void run_fp4_blockwise_scaled_group_mm_sm120(
     torch::Tensor& output, const torch::Tensor& a, const torch::Tensor& b,
     const torch::Tensor& a_blockscale, const torch::Tensor& b_blockscales,
@@ -533,7 +530,6 @@ void run_fp4_blockwise_scaled_group_mm_sm120(
   status = gemm_op.run(args, workspace.data_ptr(), stream);
   TORCH_CHECK(status == cutlass::Status::kSuccess, "Failed to run GEMM");
 }
-#endif  // ENABLE_NVFP4_SM120 && CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B
 
 template <typename OutType>
 void run_fp4_blockwise_scaled_group_mm(
@@ -543,8 +539,7 @@ void run_fp4_blockwise_scaled_group_mm(
     const torch::Tensor& expert_offsets, const torch::Tensor& sf_offsets, int M,
     int N, int K) {
   int32_t version_num = get_sm_version_num();
-#if defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120 && \
-    defined(CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B)
+#if defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120
   if (version_num >= 120 && version_num < 130) {
     run_fp4_blockwise_scaled_group_mm_sm120(
         output, a, b, a_blockscale, b_blockscales, alphas, problem_sizes,
@@ -623,8 +618,7 @@ void cutlass_fp4_group_mm(
         output, a, b, a_blockscale, b_blockscales, alphas, problem_sizes,
         expert_offsets, sf_offsets, M, N, K);
   } else {
-  #if defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120 && \
-      defined(CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B)
+  #if defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120
     int32_t version_num = get_sm_version_num();
     if (version_num >= 120 && version_num < 130) {
       TORCH_CHECK_NOT_IMPLEMENTED(

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -542,12 +542,12 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "Tensor input, Tensor input_global_scale, Tensor input_offset_by_experts,"
       "Tensor output_scale_offset_by_experts) -> ()");
   ops.impl("scaled_fp4_experts_quant", torch::kCUDA, &scaled_fp4_experts_quant);
+#endif
 
   // Check if cutlass_scaled_mm_fp4 is supported for CUDA devices
   // of the given capability
   ops.def("cutlass_scaled_mm_supports_fp4(int cuda_device_capability) -> bool");
   ops.impl("cutlass_scaled_mm_supports_fp4", &cutlass_scaled_mm_supports_fp4);
-#endif
 #endif
 
   // Quantized GEMM for GPTQ.

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -385,7 +385,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   ops.def("ggml_moe_get_block_size", &ggml_moe_get_block_size);
 
-#if VLLM_USE_NVFP4
+#ifndef USE_ROCM
+  #if VLLM_USE_NVFP4
   // CUTLASS nvfp4 block scaled GEMM
   ops.def(
       "cutlass_scaled_fp4_mm(Tensor! out, Tensor a, Tensor b,"
@@ -405,8 +406,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "cutlass_fp4_group_mm(Tensor! out, Tensor a, Tensor b,"
       " Tensor a_blockscale, Tensor b_blockscales, Tensor alphas,"
       " Tensor problem_sizes, Tensor expert_offsets, Tensor sf_offsets) -> ()");
-  // conditionally compiled so impl registration is in source file
-#endif
+    // conditionally compiled so impl registration is in source file
+  #endif
 
   // CUTLASS w8a8 GEMM, supporting symmetric per-tensor or per-row/column
   // quantization, as well as bias
@@ -529,7 +530,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "-> int");
   // conditionally compiled so impl in source file
 
-#if VLLM_USE_NVFP4
+  #if VLLM_USE_NVFP4
   // Compute NVFP4 block quantized tensor.
   ops.def(
       "scaled_fp4_quant(Tensor! output, Tensor input,"
@@ -542,7 +543,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "Tensor input, Tensor input_global_scale, Tensor input_offset_by_experts,"
       "Tensor output_scale_offset_by_experts) -> ()");
   ops.impl("scaled_fp4_experts_quant", torch::kCUDA, &scaled_fp4_experts_quant);
-#endif
+  #endif
 
   // Check if cutlass_scaled_mm_fp4 is supported for CUDA devices
   // of the given capability

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -6,9 +6,9 @@
 #include <torch/library.h>
 #include <torch/version.h>
 
-#if !defined(USE_ROCM) &&                                     \
-    (((defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100)) || \
-     ((defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120)))
+#if !defined(USE_ROCM) &&                                   \
+    ((defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100) || \
+     (defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120))
   #define VLLM_USE_NVFP4 1
 #else
   #define VLLM_USE_NVFP4 0
@@ -117,9 +117,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "silu_and_mul_quant(Tensor! result, Tensor input, Tensor scale) -> ()");
   ops.impl("silu_and_mul_quant", torch::kCUDA, &silu_and_mul_quant);
 
-#if !defined(USE_ROCM) &&                                   \
-    ((defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100) || \
-     (defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120))
+#if VLLM_USE_NVFP4
   ops.def(
       "silu_and_mul_nvfp4_quant(Tensor! result, Tensor! result_block_scale, "
       "Tensor input, Tensor input_global_scale) -> ()");

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -83,7 +83,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    Tensor suffix_output,"
       "    Tensor suffix_lse) -> ()");
   ops.impl("merge_attn_states", torch::kCUDA, &merge_attn_states);
-#if VLLM_USE_NVFP4
+#ifndef USE_ROCM
   ops.def(
       "convert_vertical_slash_indexes("
       "   Tensor! block_count, Tensor! block_offset, "

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -386,6 +386,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("ggml_moe_get_block_size", &ggml_moe_get_block_size);
 
 #ifndef USE_ROCM
+
   #if VLLM_USE_NVFP4
   // CUTLASS nvfp4 block scaled GEMM
   ops.def(
@@ -394,13 +395,6 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "                      Tensor alpha) -> ()");
   ops.impl("cutlass_scaled_fp4_mm", torch::kCUDA, &cutlass_scaled_fp4_mm);
 
-  // cutlass blockwise scaledgroup GEMM
-  ops.def(
-      "cutlass_blockwise_scaled_grouped_mm(Tensor! output, Tensor a, Tensor b, "
-      "Tensor scales_a, Tensor scales_b, "
-      "Tensor problem_sizes, Tensor expert_offsets) -> ()");
-  // conditionally compiled so impl registration is in source file
-
   // cutlass nvfp4 block scaled group GEMM
   ops.def(
       "cutlass_fp4_group_mm(Tensor! out, Tensor a, Tensor b,"
@@ -408,6 +402,13 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       " Tensor problem_sizes, Tensor expert_offsets, Tensor sf_offsets) -> ()");
     // conditionally compiled so impl registration is in source file
   #endif
+
+  // cutlass blockwise scaledgroup GEMM
+  ops.def(
+      "cutlass_blockwise_scaled_grouped_mm(Tensor! output, Tensor a, Tensor b, "
+      "Tensor scales_a, Tensor scales_b, "
+      "Tensor problem_sizes, Tensor expert_offsets) -> ()");
+  // conditionally compiled so impl registration is in source file
 
   // CUTLASS w8a8 GEMM, supporting symmetric per-tensor or per-row/column
   // quantization, as well as bias

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -109,7 +109,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "silu_and_mul_quant(Tensor! result, Tensor input, Tensor scale) -> ()");
   ops.impl("silu_and_mul_quant", torch::kCUDA, &silu_and_mul_quant);
 
-#ifndef USE_ROCM
+#if !defined(USE_ROCM) &&                                   \
+    ((defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100) || \
+     (defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120))
   ops.def(
       "silu_and_mul_nvfp4_quant(Tensor! result, Tensor! result_block_scale, "
       "Tensor input, Tensor input_global_scale) -> ()");
@@ -378,6 +380,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("ggml_moe_get_block_size", &ggml_moe_get_block_size);
 
 #ifndef USE_ROCM
+  #if (defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100) || \
+      (defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120)
   // CUTLASS nvfp4 block scaled GEMM
   ops.def(
       "cutlass_scaled_fp4_mm(Tensor! out, Tensor a, Tensor b,"
@@ -397,7 +401,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "cutlass_fp4_group_mm(Tensor! out, Tensor a, Tensor b,"
       " Tensor a_blockscale, Tensor b_blockscales, Tensor alphas,"
       " Tensor problem_sizes, Tensor expert_offsets, Tensor sf_offsets) -> ()");
-  // conditionally compiled so impl registration is in source file
+    // conditionally compiled so impl registration is in source file
+  #endif
 
   // CUTLASS w8a8 GEMM, supporting symmetric per-tensor or per-row/column
   // quantization, as well as bias
@@ -520,6 +525,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "-> int");
   // conditionally compiled so impl in source file
 
+  #if (defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100) || \
+      (defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120)
   // Compute NVFP4 block quantized tensor.
   ops.def(
       "scaled_fp4_quant(Tensor! output, Tensor input,"
@@ -537,6 +544,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   // of the given capability
   ops.def("cutlass_scaled_mm_supports_fp4(int cuda_device_capability) -> bool");
   ops.impl("cutlass_scaled_mm_supports_fp4", &cutlass_scaled_mm_supports_fp4);
+  #endif
 #endif
 
   // Quantized GEMM for GPTQ.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
We are getting a lot of internal build errors after https://github.com/vllm-project/vllm/pull/29242.
We don't include fp4 source files for non blackwell build so adding these guards in torch bindings.

## Test Plan
Build it and CI

## Test Result
It now compiles on our end.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

