### PR TITLE
[ROCm][CI] Increase the memory threshold for test_deep_sleep_fp8_kvcache

### DIFF
--- a/tests/basic_correctness/test_cumem.py
+++ b/tests/basic_correctness/test_cumem.py
@@ -260,13 +260,23 @@ def test_deep_sleep_fp8_kvcache():
     llm.sleep(level=2)
 
     used_bytes = current_platform.get_current_memory_usage() - used_bytes_baseline
-    assert used_bytes < 3 * GiB_bytes
+
+    # Rocm uses more memory for CudaGraphs, so we add 2 GiB more for the threshold
+    mem_threshold_after_sleep = (
+        (3 + 2) * GiB_bytes if current_platform.is_rocm() else 3 * GiB_bytes
+    )
+    assert used_bytes < mem_threshold_after_sleep
 
     llm.wake_up(tags=["weights"])
     llm.collective_rpc("reload_weights")
 
     used_bytes = current_platform.get_current_memory_usage() - used_bytes_baseline
-    assert used_bytes < 4 * GiB_bytes
+
+    # Rocm uses more memory for CudaGraphs, so we add 2 GiB more for the threshold
+    mem_threshold_after_wake_up = (
+        (4 + 2) * GiB_bytes if current_platform.is_rocm() else 4 * GiB_bytes
+    )
+    assert used_bytes < mem_threshold_after_wake_up
 
     # now allocate kv cache and cuda graph memory
     llm.wake_up(tags=["kv_cache"])

--- a/tests/basic_correctness/test_cumem.py
+++ b/tests/basic_correctness/test_cumem.py
@@ -262,20 +262,15 @@ def test_deep_sleep_fp8_kvcache():
     used_bytes = current_platform.get_current_memory_usage() - used_bytes_baseline
 
     # Rocm uses more memory for CudaGraphs, so we add 2 GiB more for the threshold
-    mem_threshold_after_sleep = (
-        (3 + 2) * GiB_bytes if current_platform.is_rocm() else 3 * GiB_bytes
-    )
+    rocm_extra_mem_bytes = 2 * GiB_bytes if current_platform.is_rocm() else 0
+    mem_threshold_after_sleep = 3 * GiB_bytes + rocm_extra_mem_bytes
     assert used_bytes < mem_threshold_after_sleep
 
     llm.wake_up(tags=["weights"])
     llm.collective_rpc("reload_weights")
 
     used_bytes = current_platform.get_current_memory_usage() - used_bytes_baseline
-
-    # Rocm uses more memory for CudaGraphs, so we add 2 GiB more for the threshold
-    mem_threshold_after_wake_up = (
-        (4 + 2) * GiB_bytes if current_platform.is_rocm() else 4 * GiB_bytes
-    )
+    mem_threshold_after_wake_up = 4 * GiB_bytes + rocm_extra_mem_bytes
     assert used_bytes < mem_threshold_after_wake_up
 
     # now allocate kv cache and cuda graph memory


### PR DESCRIPTION
Rocm fails on this unit test, because of the memory usage for CudaGraph of model Qwen/Qwen2-0.5B is higher than Nvidia, i.e., 2.79GB vs 0.75GB.

So this PR uses higher memory threshold that fails this unit test for ROCm.

`pytest -sv basic_correctness/test_cumem.py`

====== 8 passed, 5 warnings in 74.20s (0:01:14) ======