### PR TITLE
Add more docs for regex

### DIFF
--- a/docs/features/structured_outputs.md
+++ b/docs/features/structured_outputs.md
@@ -61,7 +61,7 @@ Now let´s see an example for each of the cases, starting with the `choice`, as 
     print(completion.choices[0].message.content)
     ```
 
-The next example shows how to use the 'regex'. The supported regex syntax depends on the structured output backend. For example, 'xgrammar', 'guidance', and 'outlines' use Rust-style regex, while 'lm-format-enforcer' uses Python's 're' module. The idea is to generate an email address, given a simple regex template:
+The next example shows how to use the `regex`. The supported regex syntax depends on the structured output backend. For example, `xgrammar`, `guidance`, and `outlines` use Rust-style regex, while `lm-format-enforcer` uses Python's `re` module. The idea is to generate an email address, given a simple regex template:
 
 ??? code
 

--- a/docs/features/structured_outputs.md
+++ b/docs/features/structured_outputs.md
@@ -61,7 +61,7 @@ Now let´s see an example for each of the cases, starting with the `choice`, as 
     print(completion.choices[0].message.content)
     ```
 
-The next example shows how to use the `regex`. The idea is to generate an email address, given a simple regex template:
+The next example shows how to use the `regex`. The regex pattern should follow rust style. The idea is to generate an email address, given a simple regex template:
 
 ??? code
 

--- a/docs/features/structured_outputs.md
+++ b/docs/features/structured_outputs.md
@@ -61,7 +61,7 @@ Now let´s see an example for each of the cases, starting with the `choice`, as 
     print(completion.choices[0].message.content)
     ```
 
-The next example shows how to use the `regex`. The regex pattern should follow rust style. The idea is to generate an email address, given a simple regex template:
+The next example shows how to use the 'regex'. The supported regex syntax depends on the structured output backend. For example, 'xgrammar', 'guidance', and 'outlines' use Rust-style regex, while 'lm-format-enforcer' uses Python's 're' module. The idea is to generate an email address, given a simple regex template:
 
 ??? code
 


### PR DESCRIPTION
## Purpose

rust style regex is a bit different from python regex. For example, `^(?!abc)` is not supported in rust regex.
```
error: look-around, including look-ahead and look-behind, is not supported
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

