### PR TITLE
[CI/Build][AMD] Skip marlin, machete, and hadacore tests since these require _C functions not defined for ROCm

### DIFF
--- a/tests/kernels/quantization/test_hadacore.py
+++ b/tests/kernels/quantization/test_hadacore.py
@@ -8,6 +8,7 @@ import torch
 from compressed_tensors.transform import deterministic_hadamard_matrix
 
 from vllm import _custom_ops as ops
+from vllm.platforms import current_platform
 
 if current_platform.is_rocm():
     pytest.skip(

--- a/tests/kernels/quantization/test_hadacore.py
+++ b/tests/kernels/quantization/test_hadacore.py
@@ -9,6 +9,12 @@ from compressed_tensors.transform import deterministic_hadamard_matrix
 
 from vllm import _custom_ops as ops
 
+if current_platform.is_rocm():
+    pytest.skip(
+        "These tests require hadacore_transform, not supported on ROCm.",
+        allow_module_level=True,
+    )
+
 
 @pytest.mark.parametrize("batch_size", [1, 32])
 @pytest.mark.parametrize("hidden_dim", [2**n for n in range(10)])

--- a/tests/kernels/quantization/test_machete_mm.py
+++ b/tests/kernels/quantization/test_machete_mm.py
@@ -23,6 +23,10 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 from vllm.scalar_type import ScalarType, scalar_types
 
+if current_platform.is_rocm():
+    pytest.skip("These tests require machete_prepack_B, not supported on ROCm.",
+            allow_module_level = True)
+
 CUDA_DEVICES = [f"cuda:{i}" for i in range(1 if torch.cuda.device_count() == 1 else 2)]
 
 # TODO: in future PR refactor this and `is_quant_method_supported` in the kernel

--- a/tests/kernels/quantization/test_machete_mm.py
+++ b/tests/kernels/quantization/test_machete_mm.py
@@ -24,8 +24,10 @@ from vllm.platforms import current_platform
 from vllm.scalar_type import ScalarType, scalar_types
 
 if current_platform.is_rocm():
-    pytest.skip("These tests require machete_prepack_B, not supported on ROCm.",
-            allow_module_level = True)
+    pytest.skip(
+        "These tests require machete_prepack_B, not supported on ROCm.",
+        allow_module_level=True,
+    )
 
 CUDA_DEVICES = [f"cuda:{i}" for i in range(1 if torch.cuda.device_count() == 1 else 2)]
 

--- a/tests/kernels/quantization/test_marlin_gemm.py
+++ b/tests/kernels/quantization/test_marlin_gemm.py
@@ -622,7 +622,8 @@ def test_gptq_marlin_24_gemm(k_chunk, n_chunk, quant_type, group_size, mnk_facto
 
     assert max_diff < 0.04
 
-
+@pytest.mark.skipif(current_platform.is_rocm(),
+                    reason="This test requires gptq_marlin_repack is not defined for ROCm")
 @pytest.mark.skipif(
     not is_quant_method_supported("gptq_marlin"),
     reason="Marlin is not supported on this GPU type.",

--- a/tests/kernels/quantization/test_marlin_gemm.py
+++ b/tests/kernels/quantization/test_marlin_gemm.py
@@ -56,6 +56,12 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 
+if current_platform.is_rocm():
+    pytest.skip("These tests require gptq_marlin_repack,"
+            "marlin_int4_fp8_preprocess, gptq_marlin_24_gemm,"
+            "or gptq_marlin_gemm which are not supported on ROCm.",
+            allow_module_level = True)
+
 ACT_ORDER_OPTS = [False, True]
 K_FULL_OPTS = [False, True]
 USE_ATOMIC_ADD_OPTS = [False, True]
@@ -622,8 +628,6 @@ def test_gptq_marlin_24_gemm(k_chunk, n_chunk, quant_type, group_size, mnk_facto
 
     assert max_diff < 0.04
 
-@pytest.mark.skipif(current_platform.is_rocm(),
-                    reason="This test requires gptq_marlin_repack is not defined for ROCm")
 @pytest.mark.skipif(
     not is_quant_method_supported("gptq_marlin"),
     reason="Marlin is not supported on this GPU type.",

--- a/tests/kernels/quantization/test_marlin_gemm.py
+++ b/tests/kernels/quantization/test_marlin_gemm.py
@@ -57,10 +57,12 @@ from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 
 if current_platform.is_rocm():
-    pytest.skip("These tests require gptq_marlin_repack,"
-            "marlin_int4_fp8_preprocess, gptq_marlin_24_gemm,"
-            "or gptq_marlin_gemm which are not supported on ROCm.",
-            allow_module_level = True)
+    pytest.skip(
+        "These tests require gptq_marlin_repack,"
+        "marlin_int4_fp8_preprocess, gptq_marlin_24_gemm,"
+        "or gptq_marlin_gemm which are not supported on ROCm.",
+        allow_module_level=True,
+    )
 
 ACT_ORDER_OPTS = [False, True]
 K_FULL_OPTS = [False, True]
@@ -627,6 +629,7 @@ def test_gptq_marlin_24_gemm(k_chunk, n_chunk, quant_type, group_size, mnk_facto
     max_diff = compute_max_diff(output, output_ref)
 
     assert max_diff < 0.04
+
 
 @pytest.mark.skipif(
     not is_quant_method_supported("gptq_marlin"),


### PR DESCRIPTION
This PR skips the marlin, machete, and hadacore tests since these require _C functions that are not defined for ROCm.  The functions are `marlin_int4_fp8_preprocess`, `gptq_marlin_24_gemm`, `gptq_marlin_gemm` , `machete_prepack_B`, and 'hadacore_transform'.