### PR TITLE
[AMD][CI] Add ray[default] Dependency On ROCm To Pass v1/metrics/test_engine_logger_apis.py

### DIFF
--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -63,6 +63,9 @@ jiwer==4.0.0
 # Required for multiprocessed tests that use spawn method, Datasets and Evaluate Test
 multiprocess==0.70.16
 
+# Required for v1/metrics/test_engine_logger_apis.py
+ray[cgraph,default]>=2.48.0
+
 # Plugins test
 terratorch @ git+https://github.com/IBM/terratorch.git@07184fcf91a1324f831ff521dd238d97fe350e3e
 torchgeo==0.7.0

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -5,7 +5,7 @@ numba == 0.61.2 # Required for N-gram speculative decoding
 
 # Dependencies for AMD GPUs
 datasets
-ray[cgraph, default]>=2.48.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
+ray[cgraph]>=2.48.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
 peft
 pytest-asyncio
 tensorizer==2.10.1

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -5,7 +5,7 @@ numba == 0.61.2 # Required for N-gram speculative decoding
 
 # Dependencies for AMD GPUs
 datasets
-ray[cgraph]>=2.48.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
+ray[cgraph, default]>=2.48.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
 peft
 pytest-asyncio
 tensorizer==2.10.1


### PR DESCRIPTION
<!-- markdownlint-disable -->
https://github.com/vllm-project/vllm/pull/24267/files introduced `from ray import serve as ray_serve` into `‎vllm/v1/metrics/ray_wrappers.py`, which causes `v1/metrics/test_engine_logger_apis.py` to fail on ROCm since the aforementioned import fails. Here, we just add the necessary dependency for it to pass (this dependency already exists for the main `test.in`).