### PR TITLE
[Bugfix][Async] fix update_async_output_token_ids for async + spec

### DIFF
--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -949,9 +949,11 @@ class InputBatch:
             if sampled_token_ids is None:
                 assert self.async_copy_ready_event is not None
                 self.async_copy_ready_event.synchronize()
-                sampled_token_ids = self.sampled_token_ids_cpu.squeeze(-1).tolist()
+                sampled_token_ids = self.sampled_token_ids_cpu.tolist()
             # Replace placeholder token id with actual sampled id.
-            req_output_token_ids[-1] = sampled_token_ids[prev_index]
+            req_output_token_ids[-len(sampled_token_ids[prev_index]) :] = (
+                sampled_token_ids[prev_index]
+            )
 
     @property
     def num_reqs(self) -> int:

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -950,10 +950,9 @@ class InputBatch:
                 assert self.async_copy_ready_event is not None
                 self.async_copy_ready_event.synchronize()
                 sampled_token_ids = self.sampled_token_ids_cpu.tolist()
-            # Replace placeholder token id with actual sampled id.
-            req_output_token_ids[-len(sampled_token_ids[prev_index]) :] = (
-                sampled_token_ids[prev_index]
-            )
+            # Replace placeholder token id(s) with actual sampled id(s).
+            if sampled_ids := sampled_token_ids[prev_index]:
+                req_output_token_ids[-len(sampled_ids) :] = sampled_ids
 
     @property
     def num_reqs(self) -> int:


### PR DESCRIPTION

## Purpose

https://github.com/vllm-project/vllm/blob/6038b1b04b7ee1b716a75591040fd3ecaa596a3d/vllm/v1/worker/gpu_input_batch.py#L944-L954

In `update_async_output_token_ids`, we incorrectly replace **only the last placeholder token**  in `req_output_token_ids[-1]` with **sampled token** (`sampled_token_ids[prev_index]`). 

However, in spec decode:  
- `req_output_token_ids` is a 1D list (from the 2D `output_token_ids` linked to `req_state.output_token_ids`).  
- `sampled_token_ids[prev_index]` is a **full list of sampled tokens** for the request accept, not a single token.  


The GPU runner extends `output_token_ids` with `num_accepted` placeholders (e.g., `[-1, -1, ...]`), so we must replace **all placeholders** with the **entire list** of sampled tokens from the prior step.  

The current assignment `req_output_token_ids[-1] = sampled_token_ids[prev_index]` is incorrect—it inserts a list into a single position, leading to malformed output_token_ids (e.g., nested lists) and leaves some placeholders unreplaced. This PR fixes that issue.

