### PR TITLE
[ROCm][Docker] Update pip and pip3 alternatives in rocm Dockerfile for Python 3.12

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -43,10 +43,10 @@ RUN apt-get update -y \
        python${PYTHON_VERSION}-lib2to3 python-is-python3  \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
     && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
-    && update-alternatives --install /usr/bin/pip pip /usr/local/lib/python3.12/dist-packages/pip 1 \
-    && update-alternatives --install /usr/bin/pip3 pip3 /usr/local/lib/python3.12/dist-packages/pip 1 \
-    && update-alternatives --set pip /usr/local/lib/python3.12/dist-packages/pip \
-    && update-alternatives --set pip3 /usr/local/lib/python3.12/dist-packages/pip \
+    && update-alternatives --install /usr/bin/pip pip /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pip 1 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pip 1 \
+    && update-alternatives --set pip /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pip \
+    && update-alternatives --set pip3 /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pip \
     && ln -sf /usr/bin/python${PYTHON_VERSION}-config /usr/bin/python3-config \
     && curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} \
     && python3 --version && python3 -m pip --version

--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -43,12 +43,12 @@ RUN apt-get update -y \
        python${PYTHON_VERSION}-lib2to3 python-is-python3  \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
     && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
+    && ln -sf /usr/bin/python${PYTHON_VERSION}-config /usr/bin/python3-config \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} \
     && update-alternatives --install /usr/bin/pip pip /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pip 1 \
     && update-alternatives --install /usr/bin/pip3 pip3 /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pip 1 \
     && update-alternatives --set pip /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pip \
     && update-alternatives --set pip3 /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pip \
-    && ln -sf /usr/bin/python${PYTHON_VERSION}-config /usr/bin/python3-config \
-    && curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} \
     && python3 --version && python3 -m pip --version
 
 RUN pip install -U packaging 'cmake<4' ninja wheel 'setuptools<80' pybind11 Cython

--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -43,6 +43,10 @@ RUN apt-get update -y \
        python${PYTHON_VERSION}-lib2to3 python-is-python3  \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 \
     && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
+    && update-alternatives --install /usr/bin/pip pip /usr/local/lib/python3.12/dist-packages/pip 1 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /usr/local/lib/python3.12/dist-packages/pip 1 \
+    && update-alternatives --set pip /usr/local/lib/python3.12/dist-packages/pip \
+    && update-alternatives --set pip3 /usr/local/lib/python3.12/dist-packages/pip \
     && ln -sf /usr/bin/python${PYTHON_VERSION}-config /usr/bin/python3-config \
     && curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} \
     && python3 --version && python3 -m pip --version

--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -45,10 +45,10 @@ RUN apt-get update -y \
     && update-alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
     && ln -sf /usr/bin/python${PYTHON_VERSION}-config /usr/bin/python3-config \
     && curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} \
-    && update-alternatives --install /usr/bin/pip pip /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pip 1 \
-    && update-alternatives --install /usr/bin/pip3 pip3 /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pip 1 \
-    && update-alternatives --set pip /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pip \
-    && update-alternatives --set pip3 /usr/local/lib/python${PYTHON_VERSION}/dist-packages/pip \
+    && update-alternatives --install /usr/bin/pip pip /usr/local/bin/pip${PYTHON_VERSION} 1 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /usr/local/bin/pip${PYTHON_VERSION} 1 \
+    && update-alternatives --set pip /usr/local/bin/pip${PYTHON_VERSION} \
+    && update-alternatives --set pip3 /usr/local/bin/pip${PYTHON_VERSION} \
     && python3 --version && python3 -m pip --version
 
 RUN pip install -U packaging 'cmake<4' ninja wheel 'setuptools<80' pybind11 Cython


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Only the Python alias was updated to `python3.12`, while `pip` and `pip3` still pointed to the base image’s Python 3.10. This caused mismatched environments during builds. The change ensures both `pip` and `pip3` are aligned with the updated Python version.
Because UV will be installed later, all vLLM release and development images do not have this issue. However, if someone uses the rocm_base image as a development image, they will encounter this problem.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

