### PR TITLE
let draft model follow target model's config_format

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -337,6 +337,7 @@ class SpeculativeConfig:
                     enforce_eager=self.target_model_config.enforce_eager,
                     max_logprobs=self.target_model_config.max_logprobs,
                     hf_overrides=SpeculativeConfig.hf_config_override,
+                    config_format=self.target_model_config.config_format,
                 )
 
                 # Automatically detect the method


### PR DESCRIPTION
Summary: internally we use a custom plugin to handle our customized config format, without this change, draft model config will be default to "auto", this has caused mismatches

Test Plan: CI

Differential Revision: D88501036


