### PR TITLE
Integration for Ray LLM with load_format=runai_streamer

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -784,7 +784,6 @@ class ModelConfig:
                 model, allow_pattern=["*.model", "*.py", "*.json"]
             )
             self.model_weights = model
-            self.model = object_storage_model.dir
 
             # If tokenizer is same as model, download to same directory
             if model == tokenizer:

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -784,7 +784,7 @@ class ModelConfig:
                 model, allow_pattern=["*.model", "*.py", "*.json"]
             )
             self.model_weights = model
-            self.model = model
+            self.model = object_storage_model.dir
 
             # If tokenizer is same as model, download to same directory
             if model == tokenizer:

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -784,6 +784,7 @@ class ModelConfig:
                 model, allow_pattern=["*.model", "*.py", "*.json"]
             )
             self.model_weights = model
+            self.model = model
 
             # If tokenizer is same as model, download to same directory
             if model == tokenizer:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1394,9 +1394,7 @@ class EngineArgs:
             )
 
         model_config = self.create_model_config()
-        # if streaming from cloud storage, do not overwrite self.model with local dir
-        if not (is_cloud_storage(self.model) and self.load_format=="runai_streamer"):
-            self.model = model_config.model
+        self.model = model_config.model
         self.tokenizer = model_config.tokenizer
 
         self._check_feature_supported(model_config)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1394,7 +1394,9 @@ class EngineArgs:
             )
 
         model_config = self.create_model_config()
-        self.model = model_config.model
+        # no need to overwrite model here for runai_streamer and cloud storage path.
+        if not (is_cloud_storage(self.model) and "runai_streamer" in self.load_format):
+            self.model = model_config.model
         self.tokenizer = model_config.tokenizer
 
         self._check_feature_supported(model_config)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1394,7 +1394,9 @@ class EngineArgs:
             )
 
         model_config = self.create_model_config()
-        self.model = model_config.model
+        # if streaming from cloud storage, do not overwrite self.model with local dir
+        if not (is_cloud_storage(self.model) and self.load_format=="runai_streamer"):
+            self.model = model_config.model
         self.tokenizer = model_config.tokenizer
 
         self._check_feature_supported(model_config)


### PR DESCRIPTION


<!-- markdownlint-disable -->
## Purpose
This PR makes it so that when a model is a s3 (or other cloud storage location) and we have runai_streamer turned on, we do not overwrite the self.model with a local directory which leads to failure of engine initialization since the local dir will not have the safe tensors.

## Test Plan
Run a simple ray job with ray data llm, passing in a s3 model path with runai_streamer turned on.

## Test Result
Runs as expected, no more failure.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

