### PR TITLE
[Misc] Move `disable_nccl_for_dp_synchronization` init logic into `VllmConfig`

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -586,6 +586,15 @@ class VllmConfig:
             else:
                 self.scheduler_config.async_scheduling = True
 
+        if (
+            self.scheduler_config.async_scheduling
+            and not self.parallel_config.disable_nccl_for_dp_synchronization
+        ):
+            logger.info(
+                "Disabling NCCL for DP synchronization when using async scheduling."
+            )
+            self.parallel_config.disable_nccl_for_dp_synchronization = True
+
         from vllm.platforms import current_platform
 
         if (

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1602,12 +1602,6 @@ class EngineArgs:
             model_config.skip_tokenizer_init = True
             logger.info("Skipping tokenizer initialization for tokens-only mode.")
 
-        if self.async_scheduling and not self.disable_nccl_for_dp_synchronization:
-            logger.info(
-                "Disabling NCCL for DP synchronization when using async scheduling."
-            )
-            self.disable_nccl_for_dp_synchronization = True
-
         parallel_config = ParallelConfig(
             pipeline_parallel_size=self.pipeline_parallel_size,
             tensor_parallel_size=self.tensor_parallel_size,


### PR DESCRIPTION
Follow-on from https://github.com/vllm-project/vllm/pull/29311, I realized that this check / implicit update should be done in `VllmConfig.__post_init__` for consistency with similar logic and so that it runs after implicit async scheduler enabling/disabling is done.

This also means it will behave as intended if initializing with a `VllmConfig` object directly rather than from command line args.