### PR TITLE
[Deepseek] Fix OOM during DeepSeek R1 startup

### DIFF
--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -205,6 +205,10 @@ class ForwardContext:
 
     ubatch_slices: UBatchSlices | None = None
 
+    # set dynamically for each forward pass
+    # True during memory profiling, False otherwise
+    is_memory_profile: bool = False
+
     def __post_init__(self):
         assert self.cudagraph_runtime_mode.valid_runtime_modes(), (
             f"Invalid cudagraph runtime mode: {self.cudagraph_runtime_mode}"
@@ -235,6 +239,7 @@ def create_forward_context(
     cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
     batch_descriptor: BatchDescriptor | None = None,
     ubatch_slices: UBatchSlices | None = None,
+    is_memory_profile: bool = False,
 ):
     return ForwardContext(
         no_compile_layers=vllm_config.compilation_config.static_forward_context,
@@ -244,6 +249,7 @@ def create_forward_context(
         cudagraph_runtime_mode=cudagraph_runtime_mode,
         batch_descriptor=batch_descriptor,
         ubatch_slices=ubatch_slices,
+        is_memory_profile=is_memory_profile,
     )
 
 
@@ -272,6 +278,7 @@ def set_forward_context(
     cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
     batch_descriptor: BatchDescriptor | None = None,
     ubatch_slices: UBatchSlices | None = None,
+    is_memory_profile: bool = False,
 ):
     """A context manager that stores the current forward context,
     can be attention metadata, etc.
@@ -317,6 +324,7 @@ def set_forward_context(
         cudagraph_runtime_mode,
         batch_descriptor,
         ubatch_slices,
+        is_memory_profile,
     )
 
     try:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4125,6 +4125,7 @@ class GPUModelRunner(
                     cudagraph_runtime_mode=cudagraph_runtime_mode,
                     batch_descriptor=batch_desc,
                     ubatch_slices=ubatch_slices_padded,
+                    is_memory_profile=is_profile,
                 ),
             ):
                 outputs = self.model(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Starting up DeepSeek R1 DP8/EP on 8xH200 currently OOMs at the default `--gpu-memory-utilization` (0.9). This PR prevents an unnecessary 4 GiB allocation during the post-CG-capture dummy run, allowing it to start up without having to reduce `--gpu-memory-utilization`. It still OOMs when prompted, though, so while this improves the situation and reflects the original intent of the code, it doesn't solve the problem.

## Test Plan
```
vllm serve deepseek-ai/DeepSeek-R1 -dp 8 --enable-expert-parallel
```

## Test Result
main: OOM during server startup

PR branch: no longer OOMs during startup

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
