### PR TITLE
[Bugfix] Improve DCP error message with backend hint

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5241,7 +5241,9 @@ class GPUModelRunner(
                     "DCP requires attention impls to return"
                     " the softmax lse for decode, but the impl "
                     f"{layer_impl.__class__.__name__} "
-                    "does not return the softmax lse for decode."
+                    "does not return the softmax lse for decode. "
+                    "Try setting VLLM_ATTENTION_BACKEND to a compatible "
+                    "backend such as FLASH_ATTN or FLASHINFER."
                 )
 
     def may_add_encoder_only_layers_to_kv_cache_config(self) -> None:


### PR DESCRIPTION
## Summary
- Add a helpful hint to the DCP error message suggesting users try setting `VLLM_ATTENTION_BACKEND` to a compatible backend
- Before: `AssertionError: DCP requires attention impls to return the softmax lse for decode, but the impl FlashInferImpl does not return the softmax lse for decode.`
- After: Same message + `Try setting VLLM_ATTENTION_BACKEND to a compatible backend such as FLASH_ATTN or FLASHINFER.`

## Test plan
- [x] Verified error message contains the new hint text
- [x] Verified pre-commit checks pass

Fixes #28407

Signed-off-by: GeoffreyWang1117 <173976389+GeoffreyWang1117@users.noreply.github.com>