### PR TITLE
[Frontend] Add --uvicorn-access-log-exclude-paths option

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -2142,6 +2142,7 @@ async def run_server_worker(
             # NOTE: When the 'disable_uvicorn_access_log' value is True,
             # no access log will be output.
             access_log=not args.disable_uvicorn_access_log,
+            access_log_exclude_paths=args.uvicorn_access_log_exclude_paths,
             timeout_keep_alive=envs.VLLM_HTTP_TIMEOUT_KEEP_ALIVE,
             ssl_keyfile=args.ssl_keyfile,
             ssl_certfile=args.ssl_certfile,

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -85,6 +85,10 @@ class FrontendArgs:
     """Log level for uvicorn."""
     disable_uvicorn_access_log: bool = False
     """Disable uvicorn access log."""
+    uvicorn_access_log_exclude_paths: list[str] = field(default_factory=lambda: [])
+    """Paths to exclude from uvicorn access log. For example, to exclude
+    /health and /metrics endpoints: --uvicorn-access-log-exclude-paths /health
+    --uvicorn-access-log-exclude-paths /metrics"""
     allow_credentials: bool = False
     """Allow credentials."""
     allowed_origins: list[str] = field(default_factory=lambda: ["*"])


### PR DESCRIPTION
## Summary
- Add new CLI option `--uvicorn-access-log-exclude-paths` to selectively exclude specific paths from uvicorn access logs
- This is useful for filtering out noisy endpoints like `/health` and `/metrics` that are frequently polled by monitoring systems
- Implements a `UvicornAccessLogFilter` class that filters log records based on the request path

## Usage Example
```bash
vllm serve model-name \
    --uvicorn-access-log-exclude-paths /metrics \
    --uvicorn-access-log-exclude-paths /health
```

## Test plan
- [x] Unit tested the `UvicornAccessLogFilter` class with various path patterns
- [x] Verified `/metrics` and `/health` paths are correctly filtered
- [x] Verified other paths like `/v1/chat/completions` pass through correctly
- [x] Verified pre-commit checks pass

Fixes #29023

Signed-off-by: GeoffreyWang1117 <173976389+GeoffreyWang1117@users.noreply.github.com>