### PR TITLE
[Misc] Fix circular import in vllm.transformers_utils.config

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -25,7 +25,6 @@ from transformers.models.auto.tokenization_auto import get_tokenizer_config
 from transformers.utils import CONFIG_NAME as HF_CONFIG_NAME
 
 from vllm import envs
-from vllm.config.utils import getattr_iter
 from vllm.logger import init_logger
 from vllm.transformers_utils.utils import parse_safetensors_file_metadata
 
@@ -305,6 +304,8 @@ def set_default_rope_theta(config: PretrainedConfig, default_theta: float) -> No
 
 def patch_rope_parameters(config: PretrainedConfig) -> None:
     """Provide backwards compatibility for RoPE."""
+    from vllm.config.utils import getattr_iter
+
     rope_theta_names = ("rope_theta", "rotary_emb_base")
     rope_theta = getattr_iter(config, rope_theta_names, None)
     if Version(version("transformers")) < Version("5.0.0.dev0"):


### PR DESCRIPTION
Summary:
Fixes circular import error introduced by upstream vLLM PR #29966 which added a module-level import that creates a circular dependency chain which causes the following errors:
```
cannot import name 'ConfigFormat' from partially initialized module
```

This circular import happens because:
```
  vllm/transformers_utils/config.py
    → imports from vllm.config.utils
    → requires vllm/config/__init__.py to execute first (Python package rule)
    → which imports from vllm.config.model
    → which imports from vllm.transformers_utils.config
    → DEADLOCK: transformers_utils/config can't finish initializing!
```

Test Plan:
- The tests with following errors now pass: "cannot import name 'ConfigFormat' from partially initialized module"

Differential Revision: D88549243
