### PR TITLE
[MISC]: change NIXL compatibility hash logging level to debug

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -189,7 +189,7 @@ def compute_nixl_compatibility_hash(
     }
 
     compat_hash = hash_factors(factors)
-    logger.info(
+    logger.debug(
         "NIXL compatibility hash: %s (model=%s, dtype=%s, num_kv_heads=%d, "
         "cache_dtype=%s, attn_backend=%s)",
         compat_hash,


### PR DESCRIPTION
Change NIXL compatibility hash logging from info to debug

## Purpose

issue: #30137 

## Test Plan

No. Just a miscellany log level change

Fixes #30137 

