### PR TITLE
Fix compilation tests find commands

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -486,7 +486,7 @@ steps:
   # they do not suffer from https://github.com/vllm-project/vllm/issues/28965
   # However, find does not normally propagate error codes, so we combine it with xargs
   # (using -0 for proper path handling)
-  - "find compile/fullgraph -maxdepth 1 -name 'test_*.py' -not -name 'test_full_graph.py' -print0 | xargs -0 -n1 -I{} pytest -s -v '{}''
+  - "find compile/fullgraph -maxdepth 1 -name 'test_*.py' -not -name 'test_full_graph.py' -print0 | xargs -0 -n1 -I{} pytest -s -v '{}'"
 
 - label: PyTorch Fullgraph Test # 27min
   timeout_in_minutes: 40

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -468,7 +468,11 @@ steps:
   # tests covered elsewhere.
   # Use `find` to launch multiple instances of pytest so that
   # they do not suffer from https://github.com/vllm-project/vllm/issues/28965
-  - "find compile/ -maxdepth 1 -name 'test_*.py' -exec pytest -s -v {} \\\\;"
+  # However, find does not normally propagate error codes, so we combine it with xargs
+  # (using -0 for proper path handling)
+  - >
+    find compile/ -maxdepth 1 -name 'test_*.py' -print0 |
+    xargs -0 -n1 -I{} pytest -s -v "{}"
 
 - label: PyTorch Fullgraph Smoke Test # 15min
   timeout_in_minutes: 30
@@ -482,7 +486,11 @@ steps:
   # as it is a heavy test that is covered in other steps.
   # Use `find` to launch multiple instances of pytest so that
   # they do not suffer from https://github.com/vllm-project/vllm/issues/28965
-  - "find compile/fullgraph/ -name 'test_*.py' -not -name 'test_full_graph.py' -exec pytest -s -v {} \\\\;"
+  # However, find does not normally propagate error codes, so we combine it with xargs
+  # (using -0 for proper path handling)
+  - >
+    find compile/fullgraph -maxdepth 1 -name 'test_*.py' -not -name 'test_full_graph.py' -print0 |
+    xargs -0 -n1 -I{} pytest -s -v "{}"
 
 - label: PyTorch Fullgraph Test # 27min
   timeout_in_minutes: 40

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -470,7 +470,7 @@ steps:
   # they do not suffer from https://github.com/vllm-project/vllm/issues/28965
   # However, find does not normally propagate error codes, so we combine it with xargs
   # (using -0 for proper path handling)
-  - >
+  - |
     find compile/ -maxdepth 1 -name 'test_*.py' -print0 |
     xargs -0 -n1 -I{} pytest -s -v "{}"
 
@@ -488,7 +488,7 @@ steps:
   # they do not suffer from https://github.com/vllm-project/vllm/issues/28965
   # However, find does not normally propagate error codes, so we combine it with xargs
   # (using -0 for proper path handling)
-  - >
+  - |
     find compile/fullgraph -maxdepth 1 -name 'test_*.py' -not -name 'test_full_graph.py' -print0 |
     xargs -0 -n1 -I{} pytest -s -v "{}"
 

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -470,9 +470,7 @@ steps:
   # they do not suffer from https://github.com/vllm-project/vllm/issues/28965
   # However, find does not normally propagate error codes, so we combine it with xargs
   # (using -0 for proper path handling)
-  - |
-    find compile/ -maxdepth 1 -name 'test_*.py' -print0 |
-    xargs -0 -n1 -I{} pytest -s -v "{}"
+  - "find compile/ -maxdepth 1 -name 'test_*.py' -print0 | xargs -0 -n1 -I{} pytest -s -v '{}'"
 
 - label: PyTorch Fullgraph Smoke Test # 15min
   timeout_in_minutes: 30
@@ -488,9 +486,7 @@ steps:
   # they do not suffer from https://github.com/vllm-project/vllm/issues/28965
   # However, find does not normally propagate error codes, so we combine it with xargs
   # (using -0 for proper path handling)
-  - |
-    find compile/fullgraph -maxdepth 1 -name 'test_*.py' -not -name 'test_full_graph.py' -print0 |
-    xargs -0 -n1 -I{} pytest -s -v "{}"
+  - "find compile/fullgraph -maxdepth 1 -name 'test_*.py' -not -name 'test_full_graph.py' -print0 | xargs -0 -n1 -I{} pytest -s -v '{}''
 
 - label: PyTorch Fullgraph Test # 27min
   timeout_in_minutes: 40


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Compilation tests were using the `find` command, which does not propagate errors, so the CI passes even when tests fail.

## Test Plan
CI (first commit should fail)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

