### PR TITLE
[BugFix][DeepSeek-V3.2] Fix backend selection logic for Blackwell

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -182,8 +182,8 @@ class CudaPlatformBase(Platform):
 
             if vllm_config.attention_config.backend is None:
                 # Default case
-                if cls.is_device_capability(100):
-                    # Blackwell => Force CutlassMLA.
+                if cls.is_device_capability(100) and not use_sparse:
+                    # Blackwell => Force CutlassMLA (unless sparse, i.e. DSv3.2).
                     use_cutlass_mla = True
                     # Set the backend in AttentionConfig so it's used during
                     # backend selection


### PR DESCRIPTION
Fix
```
ValueError: Selected backend AttentionBackendEnum.CUTLASS_MLA is not valid for this configuration. Reason: ['kv_cache_dtype not supported', 'sparse not supported']
```

When running
```
vllm serve deepseek-ai/DeepSeek-V3.2 
```

on 8xB200