### PR TITLE
[CI/Build]Temporary workaround for test_default_mm_loras timeout

### DIFF
--- a/tests/lora/test_default_mm_loras.py
+++ b/tests/lora/test_default_mm_loras.py
@@ -13,6 +13,7 @@ from huggingface_hub import snapshot_download
 from vllm.lora.request import LoRARequest
 
 from ..conftest import AudioTestAssets, VllmRunner
+from ..utils import create_new_process_for_each_test
 
 MODEL_PATH = snapshot_download("microsoft/Phi-4-multimodal-instruct")
 AUDIO_LORA_PATH = os.path.join(MODEL_PATH, "speech-lora")
@@ -60,6 +61,7 @@ def run_test(vllm_runner, audio_assets, lora_request, expected_suffix, **kwargs)
         assert vllm_outputs_with_default_lora[-1][-1][-1].endswith(expected_suffix)
 
 
+@create_new_process_for_each_test()
 def test_active_default_mm_lora(
     vllm_runner: type[VllmRunner],
     audio_assets: AudioTestAssets,
@@ -74,6 +76,7 @@ def test_active_default_mm_lora(
     )
 
 
+@create_new_process_for_each_test()
 def test_inactive_default_mm_lora(
     vllm_runner: type[VllmRunner],
     audio_assets: AudioTestAssets,
@@ -89,6 +92,7 @@ def test_inactive_default_mm_lora(
     )
 
 
+@create_new_process_for_each_test()
 def test_default_mm_lora_succeeds_with_redundant_lora_request(
     vllm_runner: type[VllmRunner],
     audio_assets: AudioTestAssets,
@@ -103,6 +107,7 @@ def test_default_mm_lora_succeeds_with_redundant_lora_request(
     )
 
 
+@create_new_process_for_each_test()
 def test_default_mm_lora_fails_with_overridden_lora_request(
     vllm_runner: type[VllmRunner],
     audio_assets: AudioTestAssets,
@@ -118,6 +123,7 @@ def test_default_mm_lora_fails_with_overridden_lora_request(
     )
 
 
+@create_new_process_for_each_test()
 def test_default_mm_lora_does_not_expand_string_reqs(vllm_runner):
     class MockEngineException(Exception):
         pass


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
I'll investigate why this test times out in a subsequent PR
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

