### PR TITLE
[gpt-oss] Fix harmony parser in streaming responses

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -734,6 +734,11 @@ class OpenAIServingChat(OpenAIServing):
                             delta_text += harmony_parser.last_content_delta or ""
                         cur_channel = harmony_parser.current_channel
                         cur_recipient = harmony_parser.current_recipient
+                        # handle the case where several tokens where generated at once
+                        # including the final token, leading to a delta in the text
+                        # but the current channel to be empty (start state)
+                        if not cur_channel and delta_text:
+                            cur_channel = "final"
                     else:
                         delta_text = output.text
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix missed final streaming tokens in speculative decoding (https://github.com/vllm-project/vllm/issues/30204)
## Test Plan
Rerun the reproducer after fix is implemented.
## Test Result
Final tokens are indeed returned as expected.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [*] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [*] The test plan, such as providing test command.
- [*] The test results, such as pasting the results comparison before and after, or e2e results
- [*] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [*] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

