### PR TITLE
[Bugfix] Skip generation config fallback for GGUF to prevent multi-process hang

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -954,6 +954,13 @@ def try_get_generation_config(
     revision: str | None = None,
     config_format: str | ConfigFormat = "auto",
 ) -> GenerationConfig | None:
+    # GGUF files don't have generation_config.json - their config is embedded
+    # in the file header. Skip all filesystem lookups to avoid re-reading the
+    # memory-mapped file, which can hang in multi-process scenarios when the
+    # EngineCore process already has the file mapped.
+    if is_gguf(model):
+        return None
+
     try:
         return GenerationConfig.from_pretrained(
             model,


### PR DESCRIPTION
## Summary

Fix a hang that occurs when loading GGUF models in multi-process mode (V1 engine with separate EngineCore and APIServer processes).

## Root Cause

When loading GGUF models, `try_get_generation_config()` attempts to load `generation_config.json`. When this file doesn't exist (GGUF files embed config in the file header, they don't have separate `generation_config.json`), the function falls back to `get_config()` which re-reads the GGUF file via memory-mapped I/O.

In multi-process scenarios:
1. EngineCore process loads the model, memory-mapping the GGUF file → **succeeds**
2. APIServer process calls `get_diff_sampling_param()` → `try_get_generation_config()` → `get_config()` → `AutoConfig.from_pretrained()` → `GGUFReader` → **hangs**

The hang occurs because both processes try to memory-map the same file concurrently.

## Fix

Skip the `get_config()` fallback for GGUF files since:
1. GGUF files don't have `generation_config.json` anyway
2. The config is already embedded in the GGUF header and loaded during model init
3. This avoids the memory-map contention that causes the hang

## Testing

Before fix:
```
$ python -m vllm.entrypoints.openai.api_server --model bartowski/Llama-3.2-3B-Instruct-GGUF --enforce-eager
# Hangs indefinitely after "Model loading took 3.26 GiB memory and 13.6 seconds"
```

After fix:
```
$ python -m vllm.entrypoints.openai.api_server --model bartowski/Llama-3.2-3B-Instruct-GGUF --enforce-eager
# Successfully starts: "Starting vLLM API server 0 on http://127.0.0.1:8000"
```

## Why This Bug May Not Be Widely Reported

The bug manifests under specific conditions:

1. **V1 engine** (default since vLLM 0.11+) - Uses separate EngineCore and APIServer processes
2. **Local GGUF file path** - Direct path to `.gguf` blob, not a HuggingFace repo ID like `repo/model:Q4_K_M`
3. **No generation_config.json** - Standard for GGUF files since config is embedded in the header

Most users either:
- Use safetensors/HF models (have `generation_config.json`, no fallback triggered)
- Use the `repo_id:quant_type` syntax which resolves differently
- Were on V0 engine (single process, no contention)

I hit this running benchmarks against locally-cached GGUF files via their blob paths with the V1 engine.

## Change

4 lines added (including comment) in `vllm/transformers_utils/config.py`:
```python
if is_gguf(model):
    return None
```
