### PR TITLE
[Bugfix]: Fix glm46 awq marlin moe wna16 compatibility

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -895,6 +895,46 @@ def get_moe_configs(
     return None
 
 
+def _ensure_block_size_k_divisible(
+    size_k: int, block_size_k: int, group_size: int
+) -> int:
+    """Ensure block_size_k is a divisor of size_k and divisible by group_size.
+
+    This ensures BLOCK_SIZE_K compatibility with MoeWNA16 CUDA kernel which
+    requires size_k % BLOCK_SIZE_K == 0 and BLOCK_SIZE_K % group_size == 0.
+
+    Args:
+        size_k: The size_k dimension that must be divisible by result.
+        block_size_k: Preferred block size (will be adjusted if needed).
+        group_size: The result must be divisible by this.
+
+    Returns:
+        A valid BLOCK_SIZE_K that divides size_k and is divisible by group_size.
+    """
+    # Fast path: already valid
+    if size_k % block_size_k == 0:
+        return block_size_k
+
+    # Find largest divisor <= block_size_k, stepping by group_size
+    # Round down to nearest group_size multiple
+    start = (min(block_size_k, 512) // group_size) * group_size
+    for candidate in range(start, 0, -group_size):
+        if size_k % candidate == 0:
+            return candidate
+
+    # Fallback: search from 512 down to group_size
+    for candidate in range(512, group_size - 1, -group_size):
+        if size_k % candidate == 0:
+            return candidate
+
+    # Last resort: use group_size if it divides size_k
+    if size_k % group_size == 0:
+        return group_size
+
+    # This should not happen with correct group_size, but ensure divisibility
+    return size_k
+
+
 def get_moe_wna16_block_config(
     config: dict[str, int],
     use_moe_wna16_cuda: bool,
@@ -959,6 +999,9 @@ def get_moe_wna16_block_config(
             # Not sure why, maybe it force the CUDA SM process only one block
             # at the same time.
             block_size_n = 1024
+
+        # Ensure BLOCK_SIZE_K is a divisor of size_k for CUDA kernel compatibility
+        block_size_k = _ensure_block_size_k_divisible(size_k, block_size_k, group_size)
 
         return {"BLOCK_SIZE_N": block_size_n, "BLOCK_SIZE_K": block_size_k}
 

--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -211,7 +211,11 @@ class AWQMarlinConfig(QuantizationConfig):
                     f"Layer '{prefix}' is not supported by AWQMoeMarlin. "
                     "Falling back to Moe WNA16 kernels."
                 )
-                return MoeWNA16Config.from_config(self.full_config).get_quant_method(
+                # Convert awq_marlin to awq for MoeWNA16 compatibility
+                moe_wna16_config = self.full_config.copy()
+                if moe_wna16_config.get("quant_method") == "awq_marlin":
+                    moe_wna16_config["quant_method"] = "awq"
+                return MoeWNA16Config.from_config(moe_wna16_config).get_quant_method(
                     layer, prefix
                 )
             moe_quant_method = AWQMarlinMoEMethod(self, layer.moe_config)

--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -211,11 +211,7 @@ class AWQMarlinConfig(QuantizationConfig):
                     f"Layer '{prefix}' is not supported by AWQMoeMarlin. "
                     "Falling back to Moe WNA16 kernels."
                 )
-                # Convert awq_marlin to awq for MoeWNA16 compatibility
-                moe_wna16_config = self.full_config.copy()
-                if moe_wna16_config.get("quant_method") == "awq_marlin":
-                    moe_wna16_config["quant_method"] = "awq"
-                return MoeWNA16Config.from_config(moe_wna16_config).get_quant_method(
+                return MoeWNA16Config.from_config(self.full_config).get_quant_method(
                     layer, prefix
                 )
             moe_quant_method = AWQMarlinMoEMethod(self, layer.moe_config)

--- a/vllm/model_executor/layers/quantization/moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/moe_wna16.py
@@ -468,7 +468,8 @@ class MoeWNA16Method(FusedMoEMethodBase):
             shard_size = layer.intermediate_size_per_partition
 
             # convert gptq and awq weight to a standard format
-            if layer.quant_config.linear_quant_method == "awq":
+            # awq_marlin uses the same weight format as awq
+            if layer.quant_config.linear_quant_method in ("awq", "awq_marlin"):
                 assert layer.quant_config.weight_bits == 4
                 if "weight" in weight_name:
                     loaded_weight = convert_awq_tensor(loaded_weight, "qweight")

--- a/vllm/model_executor/layers/quantization/moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/moe_wna16.py
@@ -60,7 +60,7 @@ class MoeWNA16Config(QuantizationConfig):
 
         if self.linear_quant_method == "gptq":
             self.use_marlin = GPTQMarlinConfig.is_gptq_marlin_compatible(full_config)
-        elif self.linear_quant_method == "awq":
+        elif self.linear_quant_method in ("awq", "awq_marlin"):
             capability_tuple = current_platform.get_device_capability()
             device_capability = (
                 -1 if capability_tuple is None else capability_tuple.to_int()
@@ -107,7 +107,7 @@ class MoeWNA16Config(QuantizationConfig):
         if linear_quant_method == "gptq":
             has_zp = not cls.get_from_keys(config, ["sym"])
             modules_to_not_convert = []
-        elif linear_quant_method == "awq":
+        elif linear_quant_method in ("awq", "awq_marlin"):
             has_zp = cls.get_from_keys(config, ["zero_point"])
             modules_to_not_convert = cls.get_from_keys_or(
                 config, ["modules_to_not_convert"], None
@@ -184,7 +184,7 @@ class MoeWNA16Config(QuantizationConfig):
                     return GPTQConfig.from_config(self.full_config).get_quant_method(
                         layer, prefix
                     )
-            elif self.linear_quant_method == "awq":
+            elif self.linear_quant_method in ("awq", "awq_marlin"):
                 if self.use_marlin and check_marlin_supports_layer(
                     layer, self.group_size
                 ):


### PR DESCRIPTION
## Purpose
Fixes two issues preventing GLM-4.6-AWQ from loading in vLLM:
1AWQ Marlin fallback compatibility: When AWQ Marlin doesn't support a MoE layer and falls back to MoeWNA16, it fails because MoeWNA16Config.from_config() only accepts quant_method as "awq" or "gptq", not "awq_marlin".
2 BLOCK_SIZE_K divisibility check: The MoeWNA16 CUDA kernel requires size_k % BLOCK_SIZE_K == 0, but the computed BLOCK_SIZE_K may not satisfy this, causing a runtime error.

Currently, the main branch ([541a2ef](https://github.com/baonudesifeizhai/vllm/commit/541a2ef892720489f770569417bc1bc4436dbb21)
 ·)cannot start GLM-4.6-AWQ models due to these issues. After these fixes, the model loads successfully and produces normal conversational output without garbled text.


## Test Plan
 vllm serve \
    QuantTrio/GLM-4.6-AWQ \
    --served-model-name glm46 \
    --enable-auto-tool-choice \
    --tool-call-parser glm45 \
    --reasoning-parser glm45 \
    --swap-space 16 \
    --max-num-seqs 32 \
    --max-model-len 8192 \
    --gpu-memory-utilization 0.9 \
    --tensor-parallel-size 8 \
    --trust-remote-code \
    --host 0.0.0.0 \
    --port 8000
## Test Result
<img width="1148" height="590" alt="image" src="https://github.com/user-attachments/assets/bb8db0e8-0921-4db4-9c42-6c94a8b80b93" />
<img width="1201" height="770" alt="image" src="https://github.com/user-attachments/assets/a0719f63-f14f-4219-b5e2-c7681ab226d4" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

