### PR TITLE
Fix difference in last hidden_states between vLLM and Transformers for Qwen3VLForConditionalGeneration

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1285,7 +1285,7 @@ class Qwen3VLForConditionalGeneration(
             self.deepstack_input_embeds = None
         self.visual_dim = config.vision_config.out_hidden_size
         self.multiscale_dim = self.visual_dim * self.deepstack_num_level
-        self.return_pre_norm_hidden_states = False
+        self.return_pre_norm_hidden_states = True
 
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
         self.language_model.model.aux_hidden_state_layers = layers


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
To solve this issue from me: https://github.com/vllm-project/vllm/issues/30193


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue ([#30193](https://github.com/vllm-project/vllm/issues/30193))".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

