### PR TITLE
[BUGFIX]DeepSeek V3.2 on B200 fails with "CUTLASS_MLA is not valid... Reason: ['sparse not supported']"

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -197,6 +197,13 @@ class CudaPlatformBase(Platform):
                     # Blackwell with sparse attention => Don't force any backend.
                     # Let automatic selection choose a sparse-compatible backend.
                     # This prevents forcing CUTLASS_MLA which doesn't support sparse.
+                    # Also set block size to 64 for FLASHMLA_SPARSE compatibility.
+                    if cache_config.block_size != 64:
+                        cache_config.block_size = 64
+                        logger.info(
+                            "Forcing kv cache block size to 64 for sparse attention "
+                            "on Blackwell GPU."
+                        )
                     logger.info(
                         "Sparse attention detected on Blackwell GPU. "
                         "Using automatic backend selection to choose a "

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -87,8 +87,8 @@ class FlashMLASparseBackend(AttentionBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
-        # Support Hopper (9), Ampere/Hopper (10), and Blackwell (100)
-        return capability.major in [9, 10, 100]
+        # Support Hopper (9.x) and Blackwell (10.x)
+        return capability.major in [9, 10]
 
     @staticmethod
     def get_kv_cache_shape(

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -87,7 +87,8 @@ class FlashMLASparseBackend(AttentionBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
-        return capability.major in [9, 10]
+        # Support Hopper (9), Ampere/Hopper (10), and Blackwell (100)
+        return capability.major in [9, 10, 100]
 
     @staticmethod
     def get_kv_cache_shape(


### PR DESCRIPTION
LEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
see: https://github.com/vllm-project/vllm/issues/30214

This PR fixes a bug where vLLM fails to start when deploying DeepSeek-V3.2-Exp (or any model requiring sparse attention) on NVIDIA B200 (Blackwell, compute capability 100) GPUs.

**Root Cause:**
1. The backend selection logic in `platforms/cuda.py` was forcing `CUTLASS_MLA` backend for Blackwell GPUs even when sparse attention was required. However, `CUTLASS_MLA` does not support sparse attention, causing a validation error: `ValueError: Selected backend AttentionBackendEnum.CUTLASS_MLA is not valid for this configuration. Reason: ['sparse not supported']`.

2. The `FLASHMLA_SPARSE` backend (the only MLA backend that supports sparse attention) only declared support for compute capabilities 9 and 10, but not 100 (Blackwell), even though the implementation already had Blackwell-specific code paths.

**Changes:**
- **`vllm/platforms/cuda.py`**: 
  - Added explicit handling for the "Blackwell + sparse attention" case. When sparse attention is detected on Blackwell GPUs, the code no longer forces `CUTLASS_MLA` and instead lets the automatic backend selection mechanism choose a sparse-compatible backend.
  - **Fixed block size issue**: When sparse attention is detected on Blackwell, the block size is now explicitly set to 64 (required by `FLASHMLA_SPARSE`) to prevent `ValueError("No common block size for 16.")` errors.

- **`vllm/v1/attention/backends/mla/flashmla_sparse.py`**: 
  - Updated `supports_compute_capability()` to correctly support Blackwell GPUs. Blackwell has compute capability 10.x (major=10), so the check correctly uses `capability.major in [9, 10]` to support both Hopper (9.x) and Blackwell (10.x).
  - Fixed comment to accurately reflect that Ampere is 8.x (not 10.x) and clarified that the check supports Hopper (9.x) and Blackwell (10.x).

**Related Issues:**
This fixes the issue where users cannot deploy DeepSeek-V3.2-Exp on B200 GPUs using the nightly build of vLLM.

## Test Plan

### Test Environment
- Hardware: NVIDIA B200 GPUs (Blackwell, compute capability 100)
- Model: `deepseek-ai/DeepSeek-V3.2-Exp`
- vLLM: Nightly build

### Test Command
```bash
vllm serve deepseek-ai/DeepSeek-V3.2-Exp \
    -dp 8 \
    --enable-expert-parallel \
    --served-model-name deepseek-v32 \
    --host 0.0.0.0 \
    --port 1544 \
    --max-num-seqs 256 \
    --gpu-memory-utilization 0.95 \
    --trust-remote-code
```

### Expected Behavior
1. **Before fix**: Server fails to start with error:
   ```
   ValueError: Selected backend AttentionBackendEnum.CUTLASS_MLA is not valid for this configuration. Reason: ['sparse not supported']
   ```

2. **After fix**: 
   - Server starts successfully
   - Logs show: `"Sparse attention detected on Blackwell GPU. Using automatic backend selection to choose a sparse-compatible backend."`
   - Backend selection automatically chooses `FLASHMLA_SPARSE`
   - Model loads and serves requests correctly

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

