### PR TITLE
[responsesAPI][6] Fix multi turn MCP tokenization

### DIFF
--- a/vllm/entrypoints/constants.py
+++ b/vllm/entrypoints/constants.py
@@ -8,3 +8,5 @@ Shared constants for vLLM entrypoints.
 # These constants help mitigate header abuse attacks
 H11_MAX_INCOMPLETE_EVENT_SIZE_DEFAULT = 4194304  # 4 MB
 H11_MAX_HEADER_COUNT_DEFAULT = 256
+
+MCP_PREFIX = "mcp_"

--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -303,7 +303,7 @@ class ParsableContext(ConversationContext):
         result_str = result.content[0].text
 
         message = ResponseFunctionToolCallOutputItem(
-            id=f"fco_{random_uuid()}",
+            id=f"mcpo_{random_uuid()}",
             type="function_call_output",
             call_id=f"call_{random_uuid()}",
             output=result_str,
@@ -385,6 +385,9 @@ class ParsableContext(ConversationContext):
         if not self.parser.response_messages:
             return []
         last_msg = self.parser.response_messages[-1]
+        # HACK: change this to a mcp_ function call
+        last_msg.id = f"mcp_{random_uuid()}"
+        self.parser.response_messages[-1] = last_msg
         if last_msg.name == "code_interpreter":
             return await self.call_python_tool(self._tool_sessions["python"], last_msg)
         elif last_msg.name == "web_search_preview":

--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -19,6 +19,7 @@ from vllm import envs
 from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
 )
+from vllm.entrypoints.constants import MCP_PREFIX
 from vllm.entrypoints.openai.parser.harmony_utils import (
     get_encoding,
     get_streamable_parser_for_assistant,
@@ -385,8 +386,8 @@ class ParsableContext(ConversationContext):
         if not self.parser.response_messages:
             return []
         last_msg = self.parser.response_messages[-1]
-        # HACK: change this to a mcp_ function call
-        last_msg.id = f"mcp_{random_uuid()}"
+        # change this to a mcp_ function call
+        last_msg.id = f"{MCP_PREFIX}{random_uuid()}"
         self.parser.response_messages[-1] = last_msg
         if last_msg.name == "code_interpreter":
             return await self.call_python_tool(self._tool_sessions["python"], last_msg)

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -1150,6 +1150,8 @@ class OpenAIServing:
             )
 
         mm_data = await mm_data_future
+        # TODO: can strip out the </think>\n\n[e~[\n]~b]ai\n\n<minimax:tool_call>
+        # to become </think>\n\n\n<minimax:tool_call>
 
         # tool parsing is done only if a tool_parser has been set and if
         # tool_choice is not "none" (if tool_choice is "none" but a tool_parser
@@ -1339,6 +1341,7 @@ class OpenAIServing:
                 )
                 engine_prompt = engine_prompts[0]
                 request_prompt = request_prompts[0]
+                prompt_text, _, _ = self._get_prompt_components(request_prompt)
 
             # Update the sampling params.
             sampling_params.max_tokens = self.max_model_len - len(

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -1150,8 +1150,6 @@ class OpenAIServing:
             )
 
         mm_data = await mm_data_future
-        # TODO: can strip out the </think>\n\n[e~[\n]~b]ai\n\n<minimax:tool_call>
-        # to become </think>\n\n\n<minimax:tool_call>
 
         # tool parsing is done only if a tool_parser has been set and if
         # tool_choice is not "none" (if tool_choice is "none" but a tool_parser

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -310,6 +310,9 @@ class OpenAIServingResponses(OpenAIServing):
         | ResponsesResponse
         | ErrorResponse
     ):
+        import fbvscode
+
+        fbvscode.set_trace()
         error_check_ret = await self._check_model(request)
         if error_check_ret is not None:
             logger.error("Error with model %s", error_check_ret)

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -310,9 +310,6 @@ class OpenAIServingResponses(OpenAIServing):
         | ResponsesResponse
         | ErrorResponse
     ):
-        import fbvscode
-
-        fbvscode.set_trace()
         error_check_ret = await self._check_model(request)
         if error_check_ret is not None:
             logger.error("Error with model %s", error_check_ret)

--- a/vllm/entrypoints/responses_utils.py
+++ b/vllm/entrypoints/responses_utils.py
@@ -136,7 +136,7 @@ def _maybe_combine_reasoning_and_tool_call(
 def construct_chat_messages_with_tool_call(
     input_messages: list[ResponseInputOutputItem],
 ) -> list[ChatCompletionMessageParam]:
-    """This function wraps construct_chat_message_with_tool_call
+    """This function wraps _construct_single_message_from_response_item
     Because some chatMessages come from multiple response items
     for example a reasoning item and a MCP tool call are two response items
     but are one chat message
@@ -147,12 +147,12 @@ def construct_chat_messages_with_tool_call(
         if maybe_combined_message is not None:
             messages[-1] = maybe_combined_message
         else:
-            messages.append(construct_chat_message_with_tool_call(item))
+            messages.append(_construct_single_message_from_response_item(item))
 
     return messages
 
 
-def construct_chat_message_with_tool_call(
+def _construct_single_message_from_response_item(
     item: ResponseInputOutputItem,
 ) -> ChatCompletionMessageParam:
     if isinstance(item, ResponseFunctionToolCall):


### PR DESCRIPTION

## Purpose

As we are enabling MCP for non harmony models #30115, this PR addresses a previous shortcoming where we use a responsesParser, and the construct_input_messages maintains a 1:1 mapping between response items and chatCompletion inputs which become model sentences. However in reality the model sentence can have both a tool call and reasoning (https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/chat_template.jinja#L105). Essentially, we change the following:

```
</think>\n\n[e~[\n]~b]ai\n\n<minimax:tool_call> # before
</think>\n\n\n<minimax:tool_call> # after this PR
```

## Test Plan

added unit tests

```
 CUDA_VISIBLE_DEVICES=4,5,6,7 VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT=1 vllm serve MiniMaxAI/MiniMax-M2   --tensor-parallel-size 4   --tool-call-parser minimax_m2   --reasoning-parser minimax_m2    --enable-auto-tool-choice --trust-remote-code  --tool-server=localhost:8081/container,localhost:8081/browser,localhost:8081/python
 ./vllm/fb/scripts/gptoss/run_mcp_server.sh
```

```
 curl -X POST "http://localhost:8000/v1/responses"   -H "Content-Type: application/json"   -H "Authorization: Bearer dummy-api-key"   -d '{
        "model": "MiniMaxAI/MiniMax-M2",
        "input": "Multiply 64548*15151 using the python tool.",
        "tools": [
          {
            "type": "mcp",
            "server_label": "code_interpreter",
            "headers": {"test": "test"},
            "server_url": "IGNORED"
          }
        ]
      }'
```

## Test Result

<details>
<summary>Detailed Test Result </summary>

Turn 1
```
']~!b[]~b]system\nYou are a helpful assistant.\n\n# Tools\nYou may call one or more tools to assist with the user query.\nHere are the tools available in JSONSchema format:\n\n<tools>\n<tool>{"server_label": "code_interpreter", "type": "mcp", "allowed_tools": null, "authorization": null, "connector_id": null, "headers": {"test": "test"}, "require_approval": null, "server_description": null, "server_url": "IGNORED"}</tool>\n</tools>\n\nWhen making tool calls, use XML format to invoke tools and pass parameters:\n\n<minimax:tool_call>\n<invoke name="tool-name-1">\n<parameter name="param-key-1">param-value-1</parameter>\n<parameter name="param-key-2">param-value-2</parameter>\n...\n</invoke>\n</minimax:tool_call>[e~[\n]~b]user\nMultiply 64548*15151 using the python tool.[e~[\n]~b]ai\n<think>\n'
```

Turn 1 output
```
'Okay, the user wants me to multiply two numbers, 64548 and 15151, using a Python tool. Looking at my available tools, I see I have a `code_interpreter` which allows me to execute Python code. This is perfect for performing the multiplication. I\'ll use the `code_interpreter` tool with the multiplication expression.\n</think>\n\n\n<minimax:tool_call>\n<invoke name="code_interpreter">\n<parameter name="code">64548 * 15151</parameter>\n</invoke>\n</minimax:tool_call>'
```

Turn 2 before PR
Note the existence of `</think>\n\n[e~[\n]~b]ai\n\n<minimax:tool_call>`

```
']~!b[]~b]system\nYou are a helpful assistant.\n\n# Tools\nYou may call one or more tools to assist with the user query.\nHere are the tools available in JSONSchema format:\n\n<tools>\n<tool>{"server_label": "code_interpreter", "type": "mcp", "allowed_tools": null, "authorization": null, "connector_id": null, "headers": {"test": "test"}, "require_approval": null, "server_description": null, "server_url": "IGNORED"}</tool>\n</tools>\n\nWhen making tool calls, use XML format to invoke tools and pass parameters:\n\n<minimax:tool_call>\n<invoke name="tool-name-1">\n<parameter name="param-key-1">param-value-1</parameter>\n<parameter name="param-key-2">param-value-2</parameter>\n...\n</invoke>\n</minimax:tool_call>[e~[\n]~b]user\nMultiply 64548*15151 using the python tool.[e~[\n]~b]ai\n<think>\nOkay, the user wants me to multiply two numbers, 64548 and 15151, using a Python tool. Looking at my available tools, I see I have a `code_interpreter` which allows me to execute Python code. This is perfect for performing the multiplication. I\'ll use the `code_interpreter` tool with the multiplication expression.\n\n</think>\n\n[e~[\n]~b]ai\n\n<minimax:tool_call>\n<invoke name="code_interpreter">\n<parameter name="code">64548 * 15151</parameter>\n</invoke>\n</minimax:tool_call>[e~[\n]~b]tool\n<response>977966748\n\n</response>[e~[\n]~b]ai\n<think>\n'
```

Turn 2 after PR
```
']~!b[]~b]system\nYou are a helpful assistant.\n\n# Tools\nYou may call one or more tools to assist with the user query.\nHere are the tools available in JSONSchema format:\n\n<tools>\n<tool>{"server_label": "code_interpreter", "type": "mcp", "allowed_tools": null, "authorization": null, "connector_id": null, "headers": {"test": "test"}, "require_approval": null, "server_description": null, "server_url": "IGNORED"}</tool>\n</tools>\n\nWhen making tool calls, use XML format to invoke tools and pass parameters:\n\n<minimax:tool_call>\n<invoke name="tool-name-1">\n<parameter name="param-key-1">param-value-1</parameter>\n<parameter name="param-key-2">param-value-2</parameter>\n...\n</invoke>\n</minimax:tool_call>[e~[\n]~b]user\nMultiply 64548*15151 using the python tool.[e~[\n]~b]ai\n<think>\nOkay, the user wants me to multiply two numbers, 64548 and 15151, using a Python tool. Looking at my available tools, I see I have a `code_interpreter` which allows me to execute Python code. This is perfect for performing the multiplication. I\'ll use the `code_interpreter` tool with the multiplication expression.\n\n</think>\n\n\n<minimax:tool_call>\n<invoke name="code_interpreter">\n<parameter name="code">64548 * 15151</parameter>\n</invoke>\n</minimax:tool_call>[e~[\n]~b]tool\n<response>977966748\n\n</response>[e~[\n]~b]ai\n<think>\n'
```

Turn 2 output
```
"Okay, I see that I've just used the code_interpreter tool to calculate the product of 64548 and 15151. Let me look at the result that was returned.\n\nThe tool executed the multiplication and returned the value 977966748. This is the product of the two numbers that the user asked me to calculate. I should verify if this makes sense mathematically:\n\n64548 * 15151 = ?\n\nHmm, multiplying these large numbers manually would be time-consuming and error-prone, which is exactly why using the Python tool was the right approach. The tool has calculated it directly, and I should trust that result since Python handles integer arithmetic accurately.\n\nLet me think about whether I should provide any additional context or explanation. The user simply asked for the multiplication result, not the steps or any verification. Since the calculation was straightforward, there's not much more to explain. I could mention that I used Python to calculate it, but that's already evident from how I handled the request.\n\nThe result 977966748 appears to be a valid integer that could be the product of these two numbers. It looks reasonable given the magnitude of the inputs - 64548 is about 64.5 thousand and 15151 is about 15.15 thousand, so their product should be somewhere in the hundreds of millions range, which matches what we got.\n\nI think the best approach is to simply state the answer clearly and concisely. If the user wants to verify this result or needs more complex calculations with these numbers, they can always ask in a follow-up question.\n</think>\n\nThe product of 64548 and 15151 is 977966748."
```

</details>

