### PR TITLE
[Bugfix] fix streaming final output for non harmony

### DIFF
--- a/tests/entrypoints/openai/test_response_api_simple.py
+++ b/tests/entrypoints/openai/test_response_api_simple.py
@@ -87,3 +87,48 @@ async def test_reasoning_item(client: OpenAI, model_name: str):
     assert response.output[0].type == "reasoning"
     assert response.output[1].type == "message"
     assert type(response.output[1].content[0].text) is str
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_streaming_output_consistency(client: OpenAI, model_name: str):
+    """Test that streaming delta text matches the final response output_text.
+
+    This test verifies that when using streaming mode:
+    1. The concatenated text from all 'response.output_text.delta' events
+    2. Matches the 'output_text' in the final 'response.completed' event
+    """
+    response = await client.responses.create(
+        model=model_name,
+        input="Say hello in one sentence.",
+        stream=True,
+    )
+
+    events = []
+    async for event in response:
+        events.append(event)
+
+    assert len(events) > 0
+
+    # Concatenate all delta text from streaming events
+    streaming_text = "".join(
+        event.delta for event in events if event.type == "response.output_text.delta"
+    )
+
+    # Get the final response from the last event
+    response_completed_event = events[-1]
+    assert response_completed_event.type == "response.completed"
+    assert response_completed_event.response.status == "completed"
+
+    # Get output_text from the final response
+    final_output_text = response_completed_event.response.output_text
+
+    # Verify final response has output
+    assert len(response_completed_event.response.output) > 0
+
+    # Verify streaming text matches final output_text
+    assert streaming_text == final_output_text, (
+        f"Streaming text does not match final output_text.\n"
+        f"Streaming: {streaming_text!r}\n"
+        f"Final: {final_output_text!r}"
+    )

--- a/vllm/entrypoints/context.py
+++ b/vllm/entrypoints/context.py
@@ -2,11 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
 import contextlib
+import copy
 import json
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import AsyncExitStack
+from dataclasses import replace
 from typing import TYPE_CHECKING, Union
 
 from openai.types.responses.response_function_tool_call_output_item import (
@@ -163,6 +165,12 @@ class SimpleContext(ConversationContext):
 
     def __init__(self):
         self.last_output = None
+
+        # Accumulated final output for streaming mode
+        self._accumulated_text: str = ""
+        self._accumulated_token_ids: list[int] = []
+        self._accumulated_logprobs: list = []
+
         self.num_prompt_tokens = 0
         self.num_output_tokens = 0
         self.num_cached_tokens = 0
@@ -182,6 +190,13 @@ class SimpleContext(ConversationContext):
         self.num_cached_tokens = output.num_cached_tokens or 0
         self.num_output_tokens += len(output.outputs[0].token_ids or [])
 
+        # Accumulate text, token_ids, and logprobs for streaming mode
+        delta_output = output.outputs[0]
+        self._accumulated_text += delta_output.text
+        self._accumulated_token_ids.extend(delta_output.token_ids)
+        if delta_output.logprobs is not None:
+            self._accumulated_logprobs.extend(delta_output.logprobs)
+
         if len(self.input_messages) == 0:
             output_prompt = output.prompt or ""
             output_prompt_token_ids = output.prompt_token_ids or []
@@ -193,10 +208,25 @@ class SimpleContext(ConversationContext):
             )
         self.output_messages.append(
             ResponseRawMessageAndToken(
-                message=output.outputs[0].text,
-                tokens=output.outputs[0].token_ids,
+                message=delta_output.text,
+                tokens=delta_output.token_ids,
             )
         )
+
+    @property
+    def final_output(self) -> RequestOutput | None:
+        """Return the final output, with complete text/token_ids/logprobs."""
+        if self.last_output is not None and self.last_output.outputs:
+            assert isinstance(self.last_output, RequestOutput)
+            final_output = copy.copy(self.last_output)
+            # copy inner item to avoid modify last_output
+            final_output.outputs = [replace(item) for item in self.last_output.outputs]
+            final_output.outputs[0].text = self._accumulated_text
+            final_output.outputs[0].token_ids = tuple(self._accumulated_token_ids)
+            if self._accumulated_logprobs:
+                final_output.outputs[0].logprobs = self._accumulated_logprobs
+            return final_output
+        return self.last_output
 
     def append_tool_output(self, output) -> None:
         raise NotImplementedError("Should not be called.")

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -668,7 +668,8 @@ class OpenAIServingResponses(OpenAIServing):
             num_tool_output_tokens = 0
         else:
             assert isinstance(context, SimpleContext)
-            final_res = context.last_output
+            # Use final_output which has accumulated text/token_ids/logprobs
+            final_res = context.final_output
             assert final_res is not None
             assert len(final_res.outputs) == 1
             final_output = final_res.outputs[0]
@@ -1219,7 +1220,6 @@ class OpenAIServingResponses(OpenAIServing):
             reasoning_parser = self.reasoning_parser(tokenizer)
         previous_text = ""
         previous_token_ids: list[int] = []
-        previous_logprobs: list = []
         first_delta_sent = False
         previous_delta_messages: list[DeltaMessage] = []
         async for ctx in result_generator:
@@ -1243,8 +1243,6 @@ class OpenAIServingResponses(OpenAIServing):
                     )
                 previous_text += output.text
                 previous_token_ids += output.token_ids
-                if output.logprobs is not None:
-                    previous_logprobs.extend(output.logprobs)
                 if not delta_message:
                     continue
                 if not first_delta_sent:
@@ -1502,18 +1500,6 @@ class OpenAIServingResponses(OpenAIServing):
                         item=item,
                     )
                 )
-
-        # Update context.last_output with accumulated text, token_ids and logprobs
-        # so that responses_full_generator can build the correct final response
-        if (
-            isinstance(context, SimpleContext)
-            and context.last_output is not None
-            and context.last_output.outputs
-        ):
-            context.last_output.outputs[0].text = previous_text
-            context.last_output.outputs[0].token_ids = tuple(previous_token_ids)
-            if previous_logprobs:
-                context.last_output.outputs[0].logprobs = previous_logprobs
 
     async def _process_harmony_streaming_events(
         self,


### PR DESCRIPTION
# Summary

  Fixed a bug where the output field in response.completed event was empty when using streaming mode with non-Harmony
  models (e.g., Qwen), even though the streaming delta events contained correct content.

# Problem

  When using the Responses API with stream=True, the streaming events (response.output_text.delta) correctly returned
  text deltas, but the final response.completed event had an empty output array:
```json
  {
    "type": "response.completed",
    "response": {
      "output": [],  // Should contain the message with full text
      "status": "completed"
    }
  }
```

# Root Cause

  In _process_simple_streaming_events, each iteration overwrites context.last_output with only the latest incremental
  output (delta). When responses_full_generator builds the final response, it reads context.last_output.outputs[0].text
  which only contains the last token's text instead of the accumulated full text.

# Fix

  At the end of _process_simple_streaming_events, save the accumulated previous_text and previous_token_ids back to
  context.last_output:
```python
  # Update context.last_output with accumulated text and token_ids
  # so that responses_full_generator can build the correct final response
  if (
      isinstance(context, SimpleContext)
      and context.last_output is not None
      and context.last_output.outputs
  ):
      context.last_output.outputs[0].text = previous_text
      context.last_output.outputs[0].token_ids = tuple(previous_token_ids)
```

# Test Plan

- Added test_streaming_output_consistency unit test that verifies:
  - Concatenated text from all response.output_text.delta events
  - Matches output_text in the final response.completed event
- Manual testing with Qwen/Qwen2-0.5B-Instruct model confirmed the fix

# Files Changed

- vllm/entrypoints/openai/serving_responses.py - Bug fix
- tests/entrypoints/openai/test_response_api_simple.py - Added unit test


# Output of OpenAI online service

Here is an example of `response.completed` event returned by OpenAI online service.

```json
{
    "response": {
        "id": "resp_030536962d977d6300693664899c6081a09339d2c46647c497",
        "created_at": 1765172361.0,
        "error": null,
        "incomplete_details": null,
        "instructions": null,
        "metadata": {},
        "model": "gpt-5-nano-2025-08-07",
        "object": "response",
        "output": [
            {
                "id": "rs_030536962d977d63006936648a2a0081a090d433992e91abbd",
                "summary": [],
                "type": "reasoning",
                "content": null,
                "encrypted_content": null,
                "status": null
            },
            {
                "id": "msg_030536962d977d630069366490662481a0a2602372b2ec0ddc",
                "content": [
                    {
                        "annotations": [],
                        "text": "Ronald Reagan. He was the 40th president, serving from January 20, 1981 to January 20, 1989, so he was the president in 1986. Want more details about notable events from 1986?",
                        "type": "output_text",
                        "logprobs": []
                    }
                ],
                "role": "assistant",
                "status": "completed",
                "type": "message"
            }
        ],
        "parallel_tool_calls": true,
        "temperature": 1.0,
        "tool_choice": "auto",
        "tools": [],
        "top_p": 1.0,
        "background": false,
        "conversation": null,
        "max_output_tokens": null,
        "max_tool_calls": null,
        "previous_response_id": null,
        "prompt": null,
        "prompt_cache_key": null,
        "prompt_cache_retention": null,
        "reasoning": {
            "effort": "medium",
            "generate_summary": null,
            "summary": null
        },
        "safety_identifier": null,
        "service_tier": "default",
        "status": "completed",
        "text": {
            "format": {
                "type": "text"
            },
            "verbosity": "medium"
        },
        "top_logprobs": 0,
        "truncation": "disabled",
        "usage": {
            "input_tokens": 16,
            "input_tokens_details": {
                "cached_tokens": 0
            },
            "output_tokens": 569,
            "output_tokens_details": {
                "reasoning_tokens": 512
            },
            "total_tokens": 585
        },
        "user": null,
        "store": true
    },
    "sequence_number": 60,
    "type": "response.completed"
}
```