### PR TITLE
[ROCm] Guard group quant RMS norm fusion patterns

### DIFF
--- a/vllm/compilation/fusion.py
+++ b/vllm/compilation/fusion.py
@@ -490,23 +490,25 @@ class RMSNormQuantFusionPass(VllmPatternMatcherPass):
         # as the latter is a subset of the former in torch ops
         for epsilon in [1e-5, 1e-6]:
             # Fuse fused_add_rms_norm + fp8 group quant
-            FusedAddRMSNormGroupQuantPattern(
-                epsilon, FP8_DTYPE, group_shape=GroupShape(1, 128)
-            ).register(self.patterns)
+            # Only register group quant patterns on CUDA where the C++ op exists
+            if current_platform.is_cuda():
+                FusedAddRMSNormGroupQuantPattern(
+                    epsilon, FP8_DTYPE, group_shape=GroupShape(1, 128)
+                ).register(self.patterns)
 
-            # Fuse rms_norm + fp8 group quant
-            RMSNormGroupQuantPattern(
-                epsilon, FP8_DTYPE, group_shape=GroupShape(1, 128)
-            ).register(self.patterns)
+                # Fuse rms_norm + fp8 group quant
+                RMSNormGroupQuantPattern(
+                    epsilon, FP8_DTYPE, group_shape=GroupShape(1, 128)
+                ).register(self.patterns)
 
-            FusedAddRMSNormGroupQuantPattern(
-                epsilon, FP8_DTYPE, group_shape=GroupShape(1, 64)
-            ).register(self.patterns)
+                FusedAddRMSNormGroupQuantPattern(
+                    epsilon, FP8_DTYPE, group_shape=GroupShape(1, 64)
+                ).register(self.patterns)
 
-            # Fuse rms_norm + fp8 group quant
-            RMSNormGroupQuantPattern(
-                epsilon, FP8_DTYPE, group_shape=GroupShape(1, 64)
-            ).register(self.patterns)
+                # Fuse rms_norm + fp8 group quant
+                RMSNormGroupQuantPattern(
+                    epsilon, FP8_DTYPE, group_shape=GroupShape(1, 64)
+                ).register(self.patterns)
 
             # Fuse fused_add_rms_norm + static fp8 quant
             FusedAddRMSNormStaticQuantPattern(epsilon, FP8_DTYPE).register(


### PR DESCRIPTION
Summary:
Fix AMD compilation failure for DeepSeek models introduced in https://github.com/vllm-project/vllm/pull/27883.

The issue was that RMSNormQuantFusionPass unconditionally creates
FusedAddRMSNormGroupQuantPattern and RMSNormGroupQuantPattern for
group quantization (GroupShape 64 and 128), but the underlying C++
operation per_token_group_fp8_quant is only available on CUDA
(wrapped in #ifndef USE_ROCM in torch_bindings.cpp).

On AMD platforms, this caused an assertion failure:
```
AssertionError: unsupported quantization scheme QuantKey(f8e4m3fnuz,scale(f32,dynamic,GroupShape(row=1, col=128)),symmetric)
```

The fix guards the creation of group quant patterns with
current_platform.is_cuda(), matching the guard used for registering
these keys in QUANT_OPS.

Test Plan:
Ran e2e correctness/perf tests for DeepSeek on AMD. Will paste results after it's completed.
Perf
```
Ran 40/40 requests in 48.11s
Success rate:        100.00%
QPS:                 0.83
Avg latency:         4.566s
Avg TTFT (client):   553.11ms
P50 TTFT (client):   551.61ms
P99 TTFT (client):   569.35ms
Avg TTIT (client):   40.13ms
P50 TTIT (client):   40.78ms
P99 TTIT (client):   41.43ms
Avg TTFT (server):   825.17ms
Avg TTIT (server):   36.83ms
Avg prefill len:     5823.10 tokens
P50 prefill len:     5824.00 tokens
P99 prefill len:     5886.00 tokens
Avg decode len:      100.00 tokens
P50 decode len:      100.00 tokens
P99 decode len:      100.00 tokens
Peak TPGS: 9.875
```

Correctness
```
[2025-12-07 22:38:16,439] [rank 0] [INFO] Evaluation results on task gsm8k.8_shot.1_gen: em: 0.980000 | f1: 0.980000 | em_maj1@1: 0.980000 | f1_maj1@1: 0.980000
```

Will also wait for external CI

Differential Revision:
D88608586
