### PR TITLE
[LoRA]  Reduce the loading time of MoE LoRA

### DIFF
--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -115,7 +115,7 @@ class LoRAModel:
         weights_mapper: WeightsMapper | None = None,
     ) -> "LoRAModel":
         """Create a LoRAModel from a dictionary of tensors."""
-        pin_memory = str(device) == "cpu" and is_pin_memory_available()
+
         loras: dict[str, LoRALayerWeights] = {}
         for tensor_name, tensor in tensors.items():
             if is_base_embeddding_weights(tensor_name):
@@ -139,14 +139,8 @@ class LoRAModel:
                         f" with the base model's vocabulary size({model_vocab_size})."
                     )
                 loras[module_name].lora_a = tensor.to(device=device, dtype=dtype)
-                if pin_memory:
-                    loras[module_name].lora_a = loras[module_name].lora_a.pin_memory()
             else:
                 loras[module_name].lora_b = tensor.to(device=device, dtype=dtype)
-
-                if pin_memory:
-                    loras[module_name].lora_b = loras[module_name].lora_b.pin_memory()
-
         return cls(lora_model_id, peft_helper.r, loras)
 
     @classmethod
@@ -741,6 +735,22 @@ class LoRAModelManager:
 
         for lora in lora_model.loras.values():
             lora.optimize()
+        device = (
+            lora.lora_a[0].device
+            if isinstance(lora.lora_a, list)
+            else lora.lora_a.device
+        )
+        pin_memory = str(device) == "cpu" and is_pin_memory_available()
+        if pin_memory:
+            for lora in lora_model.loras.values():
+                if isinstance(lora.lora_a, list):
+                    for index in range(len(lora.lora_a)):
+                        lora.lora_a[index] = lora.lora_a[index].pin_memory()
+                        lora.lora_b[index] = lora.lora_b[index].pin_memory()
+                else:
+                    lora.lora_a = lora.lora_a.pin_memory()
+                    lora.lora_b = lora.lora_b.pin_memory()
+        pass
 
     def _get_lora_layer_weights(
         self, lora_model: LoRAModel, module_name: str

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -735,7 +735,9 @@ class LoRAModelManager:
 
         for lora in lora_model.loras.values():
             lora.optimize()
-
+            
+        lora = next(iter(lora_model.loras.values()), None)
+        assert lora is not None
         device = (
             lora.lora_a[0].device
             if isinstance(lora.lora_a, list)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Follows up on https://github.com/vllm-project/vllm/pull/29322

Merging all LoRA weights before executing `pin_memory` related logic can greatly reduce the overhead caused by pin memory

Reduces disk loading time for LoRA weights by ~2x

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

