### PR TITLE
[gpt-oss] Add model_identity to system message retrieval for harmony chat template

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1761,7 +1761,7 @@ class OpenAIServingChat(OpenAIServing):
         assert not self.supports_browsing
         assert not self.supports_code_interpreter
         sys_msg = get_system_message(
-            model_identity=request.chat_template_kwargs.get("model_identity", None),
+            model_identity=(request.chat_template_kwargs or {}).get("model_identity"),
             reasoning_effort=request.reasoning_effort,
             browser_description=None,
             python_description=None,

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1761,6 +1761,7 @@ class OpenAIServingChat(OpenAIServing):
         assert not self.supports_browsing
         assert not self.supports_code_interpreter
         sys_msg = get_system_message(
+            model_identity=request.chat_template_kwargs.get("model_identity", None),
             reasoning_effort=request.reasoning_effort,
             browser_description=None,
             python_description=None,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
When using GPT-OSS, `model_identity` passed in from `chat_template_kwargs` is not being used to adjust model's identity. This PR is to pass the `model_identity` from chat/completion to the system message formatter.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

