### PR TITLE
[ROCm] Use aiter.topk_sigmoid in llama4

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1070,6 +1070,7 @@ class rocm_aiter_ops:
                 fake_impl=_rocm_aiter_rmsnorm_fused_dynamic_quant_fake,
                 dispatch_key=current_platform.dispatch_key,
             )
+
             direct_register_custom_op(
                 op_name="rocm_aiter_rmsnorm_fused_add_dynamic_quant",
                 op_func=_rocm_aiter_rmsnorm_fused_add_dynamic_quant_impl,
@@ -1115,6 +1116,7 @@ class rocm_aiter_ops:
                 fake_impl=_rocm_aiter_per_token_quant_fake,
                 dispatch_key=current_platform.dispatch_key,
             )
+
             if AITER_TOPK_SIGMOID_FOUND:
                 direct_register_custom_op(
                     op_name="rocm_aiter_topk_sigmoid",

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -52,7 +52,7 @@ def if_aiter_supported(func: Callable) -> Callable:
 
 
 def is_aiter_function_found(function_name: str) -> bool:
-    """Check if aiter module exists and has the specified function."""
+    """Returns True iff aiter module exists and has the specified symbol."""
     # First check if module exists
     if IS_AITER_FOUND:
         import aiter
@@ -61,6 +61,7 @@ def is_aiter_function_found(function_name: str) -> bool:
     return False
 
 
+# aiter.topk_sigmoid is in a relatively new version of aiter, so check for existence.
 AITER_TOPK_SIGMOID_FOUND = is_aiter_function_found("topk_sigmoid")
 
 
@@ -768,6 +769,12 @@ if AITER_TOPK_SIGMOID_FOUND:
     def _rocm_aiter_topk_sigmoid_impl(
         gating_output: torch.Tensor, topk: int
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Executes aiter's fused topk(dim=-1)+sigmoid+casting.
+
+        This operation avoids the limiting factor of kernel launch overhead on some AMD
+        hardware. See model_executors/models/utils.py:torch_topk_sigmoid_routing_func for the torch
+        version of this functionality.
+        """
         from aiter import topk_sigmoid
 
         tokens, _ = gating_output.shape

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -54,7 +54,7 @@ from .llama import LlamaForCausalLM, LlamaMLP, LlamaModel
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
-    dispatch_routing_function,
+    dispatch_topk_sigmoid_routing_func,
     extract_layer_index,
     is_pp_missing_parameter,
 )
@@ -70,7 +70,7 @@ class Llama4MoE(nn.Module):
         topk: int,
         renormalize: bool,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        return dispatch_routing_function()(gating_output, topk)
+        return dispatch_topk_sigmoid_routing_func()(gating_output, topk)
 
     def __init__(self, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -70,7 +70,9 @@ class Llama4MoE(nn.Module):
         topk: int,
         renormalize: bool,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        return dispatch_topk_sigmoid_routing_func()(gating_output, topk)
+        topk_sigmoid_func = dispatch_topk_sigmoid_routing_func()
+
+        return topk_sigmoid_func(gating_output, topk)
 
     def __init__(self, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import itertools
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Literal, Protocol, overload
 
@@ -11,6 +11,7 @@ import torch.nn as nn
 from torch.func import functional_call
 from transformers import PretrainedConfig
 
+from vllm._aiter_ops import AITER_TOPK_SIGMOID_FOUND, rocm_aiter_ops
 from vllm.config import VllmConfig
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
@@ -765,6 +766,28 @@ def fast_topk(
     else:
         # Use topk for efficiency with larger k values
         return torch.topk(values, topk, dim=dim)
+
+
+def torch_routing_func(
+    gating_output: torch.Tensor,
+    topk: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    router_scores, router_indices = fast_topk(gating_output, topk, dim=-1)
+    router_scores = torch.sigmoid(router_scores.float())
+    return (router_scores, router_indices.to(torch.int32))
+
+
+def dispatch_routing_function(
+    fallback_func: Callable[[torch.Tensor, int], tuple[torch.Tensor, torch.Tensor]]
+    | None = None,
+) -> Callable[[torch.Tensor, int], tuple[torch.Tensor, torch.Tensor]]:
+    if AITER_TOPK_SIGMOID_FOUND and rocm_aiter_ops.is_fused_moe_enabled():
+        return rocm_aiter_ops.topk_sigmoid
+    if fallback_func is not None:
+        return fallback_func
+
+    # torch implementation
+    return torch_routing_func
 
 
 # Chunk x along the num_tokens axis for sequence parallelism


### PR DESCRIPTION
This fuses a set of kernels that are bound by launch latency and is used whenever aiter is available.

Test Plan:
Server Launch:
`VLLM_ROCM_USE_AITER_MOE=1 VLLM_ROCM_USE_AITER=1 vllm serve ${MODEL}  --port ${PORT}   --swap-space 32  --max-model-len ${MAX_MODEL_LEN}    --tensor-parallel-size ${TP}   --max-num-seqs ${MAX_NUM_SEQS}   --gpu-memory-utilization 0.93 --kv-cache-dtype fp8   --max-num-batched-tokens ${MAX_NUM_BATCHED_TOKENS} --compilation-config "{\"custom_ops\": [\"-rms_norm\", \"-quant_fp8\", \"-silu_and_mul\"]  }"     --no-enable-prefix-caching     --async-scheduling`

Example benchmark command:
`vllm bench serve --model meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 --host localhost --dataset-name random --random-input-len 1024 --random-output-len 1024 --max-concurrency 4 --num-prompts 48 --ignore-eos`

Example correctness check:
`lm_eval   --model local-completions   --tasks gsm8k   --model_args base_url=http://0.0.0.0:${PORT}/v1/completions,model=meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8,tokenized_requests=False,tokenizer_backend=None,num_concurrent=128,timeout=120,max_retries=5`

Test Result (using mi325x8):

Throughput increase by about 4% and accuracy comparable/better.

Before:
```
============ Serving Benchmark Result ============
Successful requests:                     48
Failed requests:                         0
Maximum request concurrency:             4
Benchmark duration (s):                  117.04
Total input tokens:                      49104
Total generated tokens:                  49152
Request throughput (req/s):              0.41
Output token throughput (tok/s):         419.97
Peak output token throughput (tok/s):    436.00
Peak concurrent requests:                8.00
Total token throughput (tok/s):          839.53
---------------Time to First Token----------------
Mean TTFT (ms):                          130.65
Median TTFT (ms):                        119.85
P99 TTFT (ms):                           203.61
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.40
Median TPOT (ms):                        9.42
P99 TPOT (ms):                           9.48
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.41
Median ITL (ms):                         9.30
P99 ITL (ms):                            13.74
==================================================

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8961|±  |0.0084|
|     |       |strict-match    |     5|exact_match|↑  |0.8961|±  |0.0084|
```

After:
```
============ Serving Benchmark Result ============
Successful requests:                     48
Failed requests:                         0
Maximum request concurrency:             4
Benchmark duration (s):                  113.55
Total input tokens:                      49104
Total generated tokens:                  49152
Request throughput (req/s):              0.42
Output token throughput (tok/s):         432.87
Peak output token throughput (tok/s):    448.00
Peak concurrent requests:                8.00
Total token throughput (tok/s):          865.31
---------------Time to First Token----------------
Mean TTFT (ms):                          131.95
Median TTFT (ms):                        120.20
P99 TTFT (ms):                           197.02
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.12
Median TPOT (ms):                        9.12
P99 TPOT (ms):                           9.21
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.12
Median ITL (ms):                         9.02
P99 ITL (ms):                            13.55
==================================================

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8946|±  |0.0085|
|     |       |strict-match    |     5|exact_match|↑  |0.9007|±  |0.0082|
```