### PR TITLE
[bugfix][quantization] Fix fp8 per_tensor scale shape

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1638,7 +1638,7 @@ def scaled_fp8_quant(
                 output, input, scale, scale_ub
             )
         else:
-            scale = torch.empty((1, 1), device=input.device, dtype=torch.float32)
+            scale = torch.empty(1, device=input.device, dtype=torch.float32)
             torch.ops._C.dynamic_scaled_fp8_quant(output, input, scale)
     else:
         assert scale.numel() == 1, f"{scale.shape}"


### PR DESCRIPTION
For fp8 quantization, the [scale.dim()=2 ](https://github.com/vllm-project/vllm/blob/main/vllm/_custom_ops.py#L1729)returned by pertensor's input quantization causes errors during inference.
The occurrence of this issue is also related to the judgment conditions of pertoken. https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/quantization/utils/w8a8_utils.py#L477 



Script to Reproduce the Error
```
# SPDX-License-Identifier: Apache-2.0

from vllm import LLM, SamplingParams

import argparse
prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]
sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument("--dtype", type=str, default="auto", choices=["auto", "float16", "bfloat16", "float32"], help="Data type for model weights and computation.")
    args = parser.parse_args()
    llm = LLM(model="/mnt/Qwen/Qwen1.5-0.5B",  dtype=args.dtype, tensor_parallel_size=1, enforce_eager=True, quantization="fp8")

    outputs = llm.generate(prompts, sampling_params)
    for output in outputs:
        prompt = output.prompt
        generated_text = output.outputs[0].text
        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```