### PR TITLE
[Feature]: OpenTelemetry Metrics Support

### DIFF
--- a/tests/config/test_observability_config.py
+++ b/tests/config/test_observability_config.py
@@ -32,10 +32,10 @@ class TestObservabilityConfig:
             },
         ):
             # Force reload to pick up the mocked imports
-            import vllm.v1.metrics.opentelemetry_metrics
-
             # Reload the module to simulate missing imports
             import importlib
+
+            import vllm.v1.metrics.opentelemetry_metrics
 
             importlib.reload(vllm.v1.metrics.opentelemetry_metrics)
 

--- a/tests/config/test_observability_config.py
+++ b/tests/config/test_observability_config.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm.config import ObservabilityConfig
+
+
+@pytest.mark.cpu_test
+class TestObservabilityConfig:
+    """Test ObservabilityConfig validation."""
+
+    def test_default_config(self):
+        """Test that default config is valid."""
+        config = ObservabilityConfig()
+        assert config.disable_prometheus_metrics is False
+        assert config.enable_otel_metrics is False
+        assert config.otlp_traces_endpoint is None
+
+    def test_enable_otel_without_package_raises_error(self):
+        """Test that enabling otel_metrics without the package raises error."""
+        # Mock the opentelemetry imports to fail
+        with patch.dict(
+            sys.modules,
+            {
+                "opentelemetry": None,
+                "opentelemetry.metrics": None,
+                "opentelemetry.exporter.otlp.proto.grpc.metric_exporter": None,
+            },
+        ):
+            # Force reload to pick up the mocked imports
+            import vllm.v1.metrics.opentelemetry_metrics
+
+            # Reload the module to simulate missing imports
+            import importlib
+
+            importlib.reload(vllm.v1.metrics.opentelemetry_metrics)
+
+            with pytest.raises(ValueError) as exc_info:
+                ObservabilityConfig(enable_otel_metrics=True)
+
+            assert "OpenTelemetry Metrics SDK is not available" in str(exc_info.value)
+            assert "pip install" in str(exc_info.value)
+
+    def test_enable_otel_with_package_succeeds(self):
+        """Test that enabling otel_metrics with the package succeeds."""
+        # Mock the opentelemetry package as available
+        mock_metrics = MagicMock()
+        mock_exporter = MagicMock()
+        mock_sdk = MagicMock()
+        mock_resource = MagicMock()
+
+        with patch.dict(
+            sys.modules,
+            {
+                "opentelemetry": MagicMock(),
+                "opentelemetry.metrics": mock_metrics,
+                "opentelemetry.exporter.otlp.proto.grpc.metric_exporter": mock_exporter,
+                "opentelemetry.sdk.metrics": mock_sdk,
+                "opentelemetry.sdk.metrics.export": MagicMock(),
+                "opentelemetry.sdk.resources": mock_resource,
+            },
+        ):
+            # Force reload to pick up the mocked imports
+            import importlib
+
+            import vllm.v1.metrics.opentelemetry_metrics
+
+            importlib.reload(vllm.v1.metrics.opentelemetry_metrics)
+
+            # Should not raise
+            config = ObservabilityConfig(enable_otel_metrics=True)
+            assert config.enable_otel_metrics is True
+
+    def test_disable_prometheus_without_otel_raises_error(self):
+        """Test that disabling Prometheus without enabling OTel raises error."""
+        with pytest.raises(ValueError) as exc_info:
+            ObservabilityConfig(
+                disable_prometheus_metrics=True, enable_otel_metrics=False
+            )
+
+        assert "Cannot disable Prometheus metrics" in str(exc_info.value)
+        assert "--enable-otel-metrics" in str(exc_info.value)
+
+    def test_disable_prometheus_with_otel_succeeds(self):
+        """Test that disabling Prometheus with OTel enabled succeeds."""
+        # Mock the opentelemetry package as available
+        with patch.dict(
+            sys.modules,
+            {
+                "opentelemetry": MagicMock(),
+                "opentelemetry.metrics": MagicMock(),
+                "opentelemetry.exporter.otlp.proto.grpc.metric_exporter": MagicMock(),
+                "opentelemetry.sdk.metrics": MagicMock(),
+                "opentelemetry.sdk.metrics.export": MagicMock(),
+                "opentelemetry.sdk.resources": MagicMock(),
+            },
+        ):
+            # Force reload to pick up the mocked imports
+            import importlib
+
+            import vllm.v1.metrics.opentelemetry_metrics
+
+            importlib.reload(vllm.v1.metrics.opentelemetry_metrics)
+
+            # Should not raise
+            config = ObservabilityConfig(
+                disable_prometheus_metrics=True, enable_otel_metrics=True
+            )
+            assert config.disable_prometheus_metrics is True
+            assert config.enable_otel_metrics is True
+
+    def test_both_prometheus_and_otel_enabled_succeeds(self):
+        """Test that having both Prometheus and OTel enabled succeeds."""
+        # Mock the opentelemetry package as available
+        with patch.dict(
+            sys.modules,
+            {
+                "opentelemetry": MagicMock(),
+                "opentelemetry.metrics": MagicMock(),
+                "opentelemetry.exporter.otlp.proto.grpc.metric_exporter": MagicMock(),
+                "opentelemetry.sdk.metrics": MagicMock(),
+                "opentelemetry.sdk.metrics.export": MagicMock(),
+                "opentelemetry.sdk.resources": MagicMock(),
+            },
+        ):
+            # Force reload to pick up the mocked imports
+            import importlib
+
+            import vllm.v1.metrics.opentelemetry_metrics
+
+            importlib.reload(vllm.v1.metrics.opentelemetry_metrics)
+
+            # Both enabled should work fine
+            config = ObservabilityConfig(
+                disable_prometheus_metrics=False, enable_otel_metrics=True
+            )
+            assert config.disable_prometheus_metrics is False
+            assert config.enable_otel_metrics is True
+
+    def test_tracing_validation_requires_endpoint(self):
+        """Test that detailed tracing requires OTLP endpoint."""
+        with pytest.raises(ValueError) as exc_info:
+            ObservabilityConfig(
+                collect_detailed_traces=["model"], otlp_traces_endpoint=None
+            )
+
+        assert "collect_detailed_traces requires" in str(exc_info.value)
+        assert "--otlp-traces-endpoint" in str(exc_info.value)
+
+    def test_tracing_with_endpoint_succeeds(self):
+        """Test that detailed tracing with endpoint succeeds."""
+        config = ObservabilityConfig(
+            collect_detailed_traces=["model"],
+            otlp_traces_endpoint="http://localhost:4317",
+        )
+        assert config.collect_detailed_traces == ["model"]
+        assert config.otlp_traces_endpoint == "http://localhost:4317"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/v1/metrics/test_opentelemetry_metrics.py
+++ b/tests/v1/metrics/test_opentelemetry_metrics.py
@@ -42,6 +42,9 @@ def mock_vllm_config():
 
     cache_config = Mock(spec=CacheConfig)
     cache_config.num_gpu_blocks = 1000
+    cache_config.metrics_info = Mock(
+        return_value={"num_gpu_blocks": 1000, "block_size": 16}
+    )
 
     scheduler_config = Mock(spec=SchedulerConfig)
 
@@ -52,6 +55,7 @@ def mock_vllm_config():
     config.cache_config = cache_config
     config.scheduler_config = scheduler_config
     config.observability_config = observability_config
+    config.lora_config = None
 
     return config
 
@@ -84,7 +88,7 @@ def mock_otel_imports():
         ),
         patch("vllm.v1.metrics.opentelemetry_metrics.metrics.set_meter_provider"),
         patch(
-            "vllm.v1.metrics.opentelemetry_metrics.OTLPMetricExporter",
+            "opentelemetry.exporter.otlp.proto.grpc.metric_exporter.OTLPMetricExporter",
             return_value=mock_exporter,
         ),
         patch(

--- a/tests/v1/metrics/test_opentelemetry_metrics.py
+++ b/tests/v1/metrics/test_opentelemetry_metrics.py
@@ -95,9 +95,7 @@ def mock_otel_imports():
             "vllm.v1.metrics.opentelemetry_metrics.MeterProvider",
             return_value=mock_meter_provider,
         ),
-        patch(
-            "vllm.v1.metrics.opentelemetry_metrics.Resource", create=mock_resource
-        ),
+        patch("vllm.v1.metrics.opentelemetry_metrics.Resource", create=mock_resource),
         patch(
             "vllm.v1.metrics.opentelemetry_metrics.is_otel_metrics_available",
             return_value=True,

--- a/tests/v1/metrics/test_opentelemetry_metrics.py
+++ b/tests/v1/metrics/test_opentelemetry_metrics.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+from dataclasses import dataclass
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from vllm.config import (
+    CacheConfig,
+    ModelConfig,
+    ObservabilityConfig,
+    SchedulerConfig,
+    VllmConfig,
+)
+from vllm.v1.metrics.stats import (
+    FinishedRequestStats,
+    IterationStats,
+    PrefixCacheStats,
+    SchedulerStats,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+@dataclass
+class MockFinishReason:
+    """Mock finish reason for testing."""
+
+    name: str = "completed"
+
+    def __str__(self):
+        return self.name
+
+
+@pytest.fixture
+def mock_vllm_config():
+    """Create a mock VllmConfig for testing."""
+    model_config = Mock(spec=ModelConfig)
+    model_config.served_model_name = "test-model"
+
+    cache_config = Mock(spec=CacheConfig)
+    cache_config.num_gpu_blocks = 1000
+
+    scheduler_config = Mock(spec=SchedulerConfig)
+
+    observability_config = ObservabilityConfig()
+
+    config = Mock(spec=VllmConfig)
+    config.model_config = model_config
+    config.cache_config = cache_config
+    config.scheduler_config = scheduler_config
+    config.observability_config = observability_config
+
+    return config
+
+
+@pytest.fixture(autouse=True)
+def mock_otel_imports():
+    """Mock OpenTelemetry imports for all tests."""
+    # Mock the OpenTelemetry modules
+    mock_meter = MagicMock()
+    mock_meter_provider = MagicMock()
+    mock_exporter = MagicMock()
+    mock_reader = MagicMock()
+    mock_resource = MagicMock()
+
+    # Create mock instruments
+    mock_counter = MagicMock()
+    mock_gauge = MagicMock()
+    mock_histogram = MagicMock()
+
+    mock_meter.create_counter.return_value = mock_counter
+    mock_meter.create_observable_gauge.return_value = mock_gauge
+    mock_meter.create_histogram.return_value = mock_histogram
+
+    mock_resource.create.return_value = mock_resource
+
+    patches = [
+        patch(
+            "vllm.v1.metrics.opentelemetry_metrics.metrics.get_meter",
+            return_value=mock_meter,
+        ),
+        patch("vllm.v1.metrics.opentelemetry_metrics.metrics.set_meter_provider"),
+        patch(
+            "vllm.v1.metrics.opentelemetry_metrics.OTLPMetricExporter",
+            return_value=mock_exporter,
+        ),
+        patch(
+            "vllm.v1.metrics.opentelemetry_metrics.PeriodicExportingMetricReader",
+            return_value=mock_reader,
+        ),
+        patch(
+            "vllm.v1.metrics.opentelemetry_metrics.MeterProvider",
+            return_value=mock_meter_provider,
+        ),
+        patch(
+            "vllm.v1.metrics.opentelemetry_metrics.Resource", create=mock_resource
+        ),
+        patch(
+            "vllm.v1.metrics.opentelemetry_metrics.is_otel_metrics_available",
+            return_value=True,
+        ),
+    ]
+
+    for p in patches:
+        p.start()
+
+    yield {
+        "meter": mock_meter,
+        "meter_provider": mock_meter_provider,
+        "exporter": mock_exporter,
+        "reader": mock_reader,
+        "resource": mock_resource,
+        "counter": mock_counter,
+        "gauge": mock_gauge,
+        "histogram": mock_histogram,
+    }
+
+    for p in patches:
+        p.stop()
+
+
+class TestOpenTelemetryMetricsLogger:
+    """Test OpenTelemetryMetricsLogger."""
+
+    def test_initialization_default_config(self, mock_vllm_config, mock_otel_imports):
+        """Test logger initialization with default configuration."""
+        from vllm.v1.metrics.opentelemetry_metrics import OpenTelemetryMetricsLogger
+
+        logger = OpenTelemetryMetricsLogger(
+            vllm_config=mock_vllm_config, engine_indexes=[0]
+        )
+
+        # Verify meter was created
+        assert logger.meter is not None
+        assert logger.engine_indexes == [0]
+        assert logger.common_attributes["model_name"] == "test-model"
+
+        # Verify instruments were created
+        assert mock_otel_imports["meter"].create_counter.called
+        assert mock_otel_imports["meter"].create_observable_gauge.called
+        assert mock_otel_imports["meter"].create_histogram.called
+
+    def test_initialization_with_custom_endpoint(
+        self, mock_vllm_config, mock_otel_imports
+    ):
+        """Test logger initialization with custom OTLP endpoint."""
+        from vllm.v1.metrics.opentelemetry_metrics import OpenTelemetryMetricsLogger
+
+        custom_endpoint = "http://custom-collector:4317"
+        with patch.dict(
+            os.environ,
+            {"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": custom_endpoint},
+        ):
+            logger = OpenTelemetryMetricsLogger(
+                vllm_config=mock_vllm_config, engine_indexes=[0, 1]
+            )
+
+            assert logger.engine_indexes == [0, 1]
+            # Logger should be created successfully
+            assert logger is not None
+
+    def test_initialization_without_otel_raises_error(self, mock_vllm_config):
+        """Test that initialization without OpenTelemetry raises error."""
+        from vllm.v1.metrics.opentelemetry_metrics import OpenTelemetryMetricsLogger
+
+        with patch(
+            "vllm.v1.metrics.opentelemetry_metrics.is_otel_metrics_available",
+            return_value=False,
+        ):
+            with pytest.raises(ValueError) as exc_info:
+                OpenTelemetryMetricsLogger(
+                    vllm_config=mock_vllm_config, engine_indexes=[0]
+                )
+
+            assert "OpenTelemetry Metrics SDK is not available" in str(exc_info.value)
+
+    def test_record_scheduler_stats(self, mock_vllm_config, mock_otel_imports):
+        """Test recording scheduler stats."""
+        from vllm.v1.metrics.opentelemetry_metrics import OpenTelemetryMetricsLogger
+
+        logger = OpenTelemetryMetricsLogger(
+            vllm_config=mock_vllm_config, engine_indexes=[0]
+        )
+
+        # Create scheduler stats
+        prefix_cache_stats = PrefixCacheStats(queries=100, hits=80)
+        scheduler_stats = SchedulerStats(
+            num_running_reqs=5,
+            num_waiting_reqs=3,
+            kv_cache_usage=0.75,
+            prefix_cache_stats=prefix_cache_stats,
+        )
+
+        # Record stats
+        logger.record(
+            scheduler_stats=scheduler_stats,
+            iteration_stats=None,
+            mm_cache_stats=None,
+            engine_idx=0,
+        )
+
+        # Verify prefix cache stats were recorded
+        assert logger.counter_prefix_cache_queries.add.called
+        assert logger.counter_prefix_cache_hits.add.called
+
+        # Check that the scheduler stats were stored for gauge callbacks
+        assert 0 in logger._latest_scheduler_stats
+        assert logger._latest_scheduler_stats[0] == scheduler_stats
+
+    def test_record_iteration_stats(self, mock_vllm_config, mock_otel_imports):
+        """Test recording iteration stats."""
+        from vllm.v1.metrics.opentelemetry_metrics import OpenTelemetryMetricsLogger
+
+        logger = OpenTelemetryMetricsLogger(
+            vllm_config=mock_vllm_config, engine_indexes=[0]
+        )
+
+        # Create iteration stats
+        iteration_stats = IterationStats()
+        iteration_stats.num_prompt_tokens = 50
+        iteration_stats.num_generation_tokens = 100
+        iteration_stats.num_preempted_reqs = 2
+        iteration_stats.time_to_first_tokens_iter = [0.1, 0.2, 0.15]
+        iteration_stats.inter_token_latencies_iter = [0.01, 0.02, 0.015]
+
+        # Record stats
+        logger.record(
+            scheduler_stats=None,
+            iteration_stats=iteration_stats,
+            mm_cache_stats=None,
+            engine_idx=0,
+        )
+
+        # Verify counters were called
+        assert logger.counter_prompt_tokens.add.called
+        assert logger.counter_generation_tokens.add.called
+        assert logger.counter_num_preempted_reqs.add.called
+
+        # Verify histograms were recorded (at least once each)
+        assert logger.histogram_time_to_first_token.record.call_count >= 1
+        assert logger.histogram_inter_token_latency.record.call_count >= 1
+
+    def test_record_finished_requests(self, mock_vllm_config, mock_otel_imports):
+        """Test recording finished request stats."""
+        from vllm.v1.metrics.opentelemetry_metrics import OpenTelemetryMetricsLogger
+
+        logger = OpenTelemetryMetricsLogger(
+            vllm_config=mock_vllm_config, engine_indexes=[0]
+        )
+
+        # Create finished request stats
+        finished_request = FinishedRequestStats(
+            finish_reason=MockFinishReason("completed"),
+            e2e_latency=1.5,
+            num_prompt_tokens=50,
+            num_generation_tokens=100,
+            queued_time=0.1,
+            inference_time=1.4,
+        )
+
+        iteration_stats = IterationStats()
+        iteration_stats.finished_requests = [finished_request]
+
+        # Record stats
+        logger.record(
+            scheduler_stats=None,
+            iteration_stats=iteration_stats,
+            mm_cache_stats=None,
+            engine_idx=0,
+        )
+
+        # Verify request success counter was called
+        assert logger.counter_request_success.add.called
+
+        # Verify latency histograms were recorded
+        assert logger.histogram_e2e_time_request.record.called
+        assert logger.histogram_queue_time_request.record.called
+        assert logger.histogram_inference_time_request.record.called
+
+    def test_gauge_callbacks(self, mock_vllm_config, mock_otel_imports):
+        """Test observable gauge callbacks."""
+        from vllm.v1.metrics.opentelemetry_metrics import OpenTelemetryMetricsLogger
+
+        logger = OpenTelemetryMetricsLogger(
+            vllm_config=mock_vllm_config, engine_indexes=[0, 1]
+        )
+
+        # Create scheduler stats for multiple engines
+        scheduler_stats_0 = SchedulerStats(
+            num_running_reqs=5, num_waiting_reqs=3, kv_cache_usage=0.75
+        )
+        scheduler_stats_1 = SchedulerStats(
+            num_running_reqs=8, num_waiting_reqs=2, kv_cache_usage=0.60
+        )
+
+        logger._latest_scheduler_stats[0] = scheduler_stats_0
+        logger._latest_scheduler_stats[1] = scheduler_stats_1
+
+        # Test running requests callback
+        observations = logger._observe_running_requests(None)
+        assert len(observations) == 2
+
+        # Test waiting requests callback
+        observations = logger._observe_waiting_requests(None)
+        assert len(observations) == 2
+
+        # Test KV cache usage callback
+        observations = logger._observe_kv_cache_usage(None)
+        assert len(observations) == 2
+
+    def test_log_engine_initialized(self, mock_vllm_config, mock_otel_imports):
+        """Test engine initialization logging."""
+        from vllm.v1.metrics.opentelemetry_metrics import OpenTelemetryMetricsLogger
+
+        logger = OpenTelemetryMetricsLogger(
+            vllm_config=mock_vllm_config, engine_indexes=[0]
+        )
+
+        # Should not raise
+        logger.log_engine_initialized()
+
+    def test_multiple_engines(self, mock_vllm_config, mock_otel_imports):
+        """Test recording metrics for multiple engines."""
+        from vllm.v1.metrics.opentelemetry_metrics import OpenTelemetryMetricsLogger
+
+        logger = OpenTelemetryMetricsLogger(
+            vllm_config=mock_vllm_config, engine_indexes=[0, 1, 2]
+        )
+
+        # Create stats for different engines
+        for engine_idx in [0, 1, 2]:
+            scheduler_stats = SchedulerStats(
+                num_running_reqs=engine_idx + 1,
+                num_waiting_reqs=engine_idx,
+                kv_cache_usage=0.5 + engine_idx * 0.1,
+            )
+
+            iteration_stats = IterationStats()
+            iteration_stats.num_prompt_tokens = 10 * (engine_idx + 1)
+            iteration_stats.num_generation_tokens = 20 * (engine_idx + 1)
+
+            logger.record(
+                scheduler_stats=scheduler_stats,
+                iteration_stats=iteration_stats,
+                mm_cache_stats=None,
+                engine_idx=engine_idx,
+            )
+
+        # Verify all engines' stats were stored
+        assert len(logger._latest_scheduler_stats) == 3
+        assert all(idx in logger._latest_scheduler_stats for idx in [0, 1, 2])
+
+    def test_custom_service_name(self, mock_vllm_config, mock_otel_imports):
+        """Test custom service name configuration."""
+        from vllm.v1.metrics.opentelemetry_metrics import OpenTelemetryMetricsLogger
+
+        custom_service_name = "my-vllm-service"
+        with patch.dict(
+            os.environ,
+            {"OTEL_SERVICE_NAME": custom_service_name},
+        ):
+            logger = OpenTelemetryMetricsLogger(
+                vllm_config=mock_vllm_config, engine_indexes=[0]
+            )
+
+            # Logger should be created successfully
+            assert logger is not None
+
+    def test_custom_export_interval(self, mock_vllm_config, mock_otel_imports):
+        """Test custom export interval configuration."""
+        from vllm.v1.metrics.opentelemetry_metrics import OpenTelemetryMetricsLogger
+
+        custom_interval = "30000"  # 30 seconds
+        with patch.dict(
+            os.environ,
+            {"OTEL_METRIC_EXPORT_INTERVAL": custom_interval},
+        ):
+            logger = OpenTelemetryMetricsLogger(
+                vllm_config=mock_vllm_config, engine_indexes=[0]
+            )
+
+            # Logger should be created successfully
+            assert logger is not None
+
+
+class TestIsOtelMetricsAvailable:
+    """Test is_otel_metrics_available function."""
+
+    def test_function_exists_and_returns_bool(self):
+        """Test that is_otel_metrics_available exists and returns a boolean."""
+        from vllm.v1.metrics.opentelemetry_metrics import is_otel_metrics_available
+
+        result = is_otel_metrics_available()
+        assert isinstance(result, bool)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -154,7 +154,7 @@ class ObservabilityConfig:
                 raise ValueError(
                     "OpenTelemetry Metrics SDK is not available. Unable to enable "
                     "'enable_otel_metrics'. Install with: "
-                    "pip install opentelemetry-exporter-otlp-proto-grpc\n"
+                    "pip install opentelemetry-sdk\n"
                     f"Original error:\n{otel_import_error_traceback}"
                 )
         return value

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -163,6 +163,7 @@ class SupportsHash(Protocol):
     def compute_hash(self) -> str: ...
 
 
+@runtime_checkable
 class SupportsMetricsInfo(Protocol):
     def metrics_info(self) -> dict[str, str]: ...
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -511,6 +511,8 @@ class EngineArgs:
     show_hidden_metrics_for_version: str | None = (
         ObservabilityConfig.show_hidden_metrics_for_version
     )
+    disable_prometheus_metrics: bool = ObservabilityConfig.disable_prometheus_metrics
+    enable_otel_metrics: bool = ObservabilityConfig.enable_otel_metrics
     otlp_traces_endpoint: str | None = ObservabilityConfig.otlp_traces_endpoint
     collect_detailed_traces: list[DetailedTraceModules] | None = (
         ObservabilityConfig.collect_detailed_traces
@@ -1047,6 +1049,13 @@ class EngineArgs:
         observability_group.add_argument(
             "--enable-layerwise-nvtx-tracing",
             **observability_kwargs["enable_layerwise_nvtx_tracing"],
+        )
+        observability_group.add_argument(
+            "--disable-prometheus-metrics",
+            **observability_kwargs["disable_prometheus_metrics"],
+        )
+        observability_group.add_argument(
+            "--enable-otel-metrics", **observability_kwargs["enable_otel_metrics"]
         )
 
         # Scheduler arguments
@@ -1727,7 +1736,13 @@ class EngineArgs:
             )
 
         observability_config = ObservabilityConfig(
+<<<<<<< HEAD
             show_hidden_metrics_for_version=self.show_hidden_metrics_for_version,
+=======
+            show_hidden_metrics_for_version=(self.show_hidden_metrics_for_version),
+            disable_prometheus_metrics=self.disable_prometheus_metrics,
+            enable_otel_metrics=self.enable_otel_metrics,
+>>>>>>> 3143cebda (implement otel metrics)
             otlp_traces_endpoint=self.otlp_traces_endpoint,
             collect_detailed_traces=self.collect_detailed_traces,
             kv_cache_metrics=self.kv_cache_metrics,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1736,13 +1736,9 @@ class EngineArgs:
             )
 
         observability_config = ObservabilityConfig(
-<<<<<<< HEAD
             show_hidden_metrics_for_version=self.show_hidden_metrics_for_version,
-=======
-            show_hidden_metrics_for_version=(self.show_hidden_metrics_for_version),
             disable_prometheus_metrics=self.disable_prometheus_metrics,
             enable_otel_metrics=self.enable_otel_metrics,
->>>>>>> 3143cebda (implement otel metrics)
             otlp_traces_endpoint=self.otlp_traces_endpoint,
             collect_detailed_traces=self.collect_detailed_traces,
             kv_cache_metrics=self.kv_cache_metrics,

--- a/vllm/v1/metrics/opentelemetry_metrics.py
+++ b/vllm/v1/metrics/opentelemetry_metrics.py
@@ -1,0 +1,346 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+OpenTelemetry Metrics Logger for vLLM.
+
+This module provides push-based metrics export to OpenTelemetry collectors,
+as an alternative to the pull-based Prometheus metrics.
+"""
+
+import os
+
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.v1.metrics.loggers import AggregateStatLoggerBase
+from vllm.v1.metrics.stats import (
+    IterationStats,
+    MultiModalCacheStats,
+    SchedulerStats,
+)
+
+logger = init_logger(__name__)
+
+_is_otel_available = False
+otel_import_error_traceback: str | None = None
+
+try:
+    from opentelemetry import metrics
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+        OTLPMetricExporter,
+    )
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+    from opentelemetry.sdk.resources import Resource
+
+    _is_otel_available = True
+except ImportError:
+    import traceback
+
+    otel_import_error_traceback = traceback.format_exc()
+
+
+def is_otel_metrics_available() -> bool:
+    """Check if OpenTelemetry metrics SDK is available."""
+    return _is_otel_available
+
+
+class OpenTelemetryMetricsLogger(AggregateStatLoggerBase):
+    """
+    OpenTelemetry-based metrics logger that pushes metrics to OTEL collectors.
+
+    This logger uses the OpenTelemetry Metrics SDK to push metrics directly
+    to an OTLP endpoint, eliminating the need for external scrapers.
+
+    Configuration via environment variables:
+        - OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: OTLP endpoint for metrics
+          (default: http://localhost:4317)
+        - OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: Protocol (grpc or http/protobuf)
+          (default: grpc)
+        - OTEL_METRIC_EXPORT_INTERVAL: Export interval in milliseconds
+          (default: 60000)
+        - OTEL_SERVICE_NAME: Service name for metrics
+          (default: vllm)
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        engine_indexes: list[int] | None = None,
+    ):
+        if not is_otel_metrics_available():
+            raise ValueError(
+                "OpenTelemetry Metrics SDK is not available. "
+                "Install with: pip install opentelemetry-exporter-otlp-proto-grpc\n"
+                f"Original error:\n{otel_import_error_traceback}"
+            )
+
+        if engine_indexes is None:
+            engine_indexes = [0]
+
+        self.engine_indexes = engine_indexes
+        self.vllm_config = vllm_config
+
+        # Get configuration from environment
+        endpoint = os.getenv(
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+            "http://localhost:4317",
+        )
+        protocol = os.getenv("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "grpc")
+        export_interval_millis = int(os.getenv("OTEL_METRIC_EXPORT_INTERVAL", "60000"))
+        service_name = os.getenv("OTEL_SERVICE_NAME", "vllm")
+
+        logger.info(
+            "Initializing OpenTelemetry metrics exporter: "
+            "endpoint=%s, protocol=%s, export_interval=%dms, service=%s",
+            endpoint,
+            protocol,
+            export_interval_millis,
+            service_name,
+        )
+
+        # Create OTLP exporter
+        if protocol == "grpc":
+            exporter = OTLPMetricExporter(endpoint=endpoint)
+        elif protocol == "http/protobuf":
+            from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+                OTLPMetricExporter as HTTPMetricExporter,
+            )
+
+            exporter = HTTPMetricExporter(endpoint=endpoint)
+        else:
+            raise ValueError(f"Unsupported OTLP protocol: {protocol}")
+
+        # Create periodic reader with configured export interval
+        reader = PeriodicExportingMetricReader(
+            exporter,
+            export_interval_millis=export_interval_millis,
+        )
+
+        # Create resource with service name and model info
+        resource = Resource.create(
+            {
+                "service.name": service_name,
+                "vllm.model": vllm_config.model_config.served_model_name,
+                "vllm.version": "1.0.0",  # TODO: Import from vllm.version
+            }
+        )
+
+        # Set up meter provider
+        meter_provider = MeterProvider(resource=resource, metric_readers=[reader])
+        metrics.set_meter_provider(meter_provider)
+
+        # Get meter for creating instruments
+        self.meter = metrics.get_meter("vllm.metrics")
+
+        # Common labels/attributes
+        model_name = vllm_config.model_config.served_model_name
+        self.common_attributes = {"model_name": model_name}
+
+        # Create metric instruments (similar to Prometheus metrics)
+        self._create_instruments()
+
+        logger.info("OpenTelemetry metrics logger initialized successfully")
+
+    def _create_instruments(self):
+        """Create OpenTelemetry metric instruments."""
+
+        # Scheduler state gauges (ObservableGauge for async observation)
+        self.gauge_scheduler_running = self.meter.create_observable_gauge(
+            name="vllm.num_requests_running",
+            description="Number of requests in model execution batches",
+            callbacks=[self._observe_running_requests],
+        )
+
+        self.gauge_scheduler_waiting = self.meter.create_observable_gauge(
+            name="vllm.num_requests_waiting",
+            description="Number of requests waiting to be processed",
+            callbacks=[self._observe_waiting_requests],
+        )
+
+        # KV cache usage
+        self.gauge_kv_cache_usage = self.meter.create_observable_gauge(
+            name="vllm.kv_cache_usage_perc",
+            description="KV-cache usage (1 = 100%)",
+            callbacks=[self._observe_kv_cache_usage],
+        )
+
+        # Counters for tokens and requests
+        self.counter_prompt_tokens = self.meter.create_counter(
+            name="vllm.prompt_tokens",
+            description="Number of prefill tokens processed",
+            unit="tokens",
+        )
+
+        self.counter_generation_tokens = self.meter.create_counter(
+            name="vllm.generation_tokens",
+            description="Number of generation tokens processed",
+            unit="tokens",
+        )
+
+        self.counter_request_success = self.meter.create_counter(
+            name="vllm.request_success",
+            description="Count of successfully processed requests",
+            unit="requests",
+        )
+
+        self.counter_num_preempted_reqs = self.meter.create_counter(
+            name="vllm.num_preemptions",
+            description="Cumulative number of preemptions",
+            unit="preemptions",
+        )
+
+        # Prefix cache metrics
+        self.counter_prefix_cache_queries = self.meter.create_counter(
+            name="vllm.prefix_cache_queries",
+            description="Prefix cache queries (number of queried tokens)",
+            unit="tokens",
+        )
+
+        self.counter_prefix_cache_hits = self.meter.create_counter(
+            name="vllm.prefix_cache_hits",
+            description="Prefix cache hits (number of cached tokens)",
+            unit="tokens",
+        )
+
+        # Histograms for latencies
+        self.histogram_time_to_first_token = self.meter.create_histogram(
+            name="vllm.time_to_first_token_seconds",
+            description="Time to first token in seconds",
+            unit="s",
+        )
+
+        self.histogram_inter_token_latency = self.meter.create_histogram(
+            name="vllm.inter_token_latency_seconds",
+            description="Inter-token latency in seconds",
+            unit="s",
+        )
+
+        self.histogram_e2e_time_request = self.meter.create_histogram(
+            name="vllm.e2e_request_latency_seconds",
+            description="End-to-end request latency in seconds",
+            unit="s",
+        )
+
+        self.histogram_queue_time_request = self.meter.create_histogram(
+            name="vllm.request_queue_time_seconds",
+            description="Time spent in WAITING phase",
+            unit="s",
+        )
+
+        self.histogram_inference_time_request = self.meter.create_histogram(
+            name="vllm.request_inference_time_seconds",
+            description="Time spent in RUNNING phase",
+            unit="s",
+        )
+
+        # Store latest scheduler stats for observable gauges
+        self._latest_scheduler_stats: dict[int, SchedulerStats] = {}
+
+    def record(
+        self,
+        scheduler_stats: SchedulerStats | None,
+        iteration_stats: IterationStats | None,
+        mm_cache_stats: MultiModalCacheStats | None = None,
+        engine_idx: int = 0,
+    ):
+        """Record metrics from scheduler and iteration stats."""
+
+        # Store scheduler stats for gauge observations
+        if scheduler_stats is not None:
+            self._latest_scheduler_stats[engine_idx] = scheduler_stats
+
+            # Record prefix cache metrics
+            self.counter_prefix_cache_queries.add(
+                scheduler_stats.prefix_cache_stats.queries,
+                attributes={**self.common_attributes, "engine": str(engine_idx)},
+            )
+            self.counter_prefix_cache_hits.add(
+                scheduler_stats.prefix_cache_stats.hits,
+                attributes={**self.common_attributes, "engine": str(engine_idx)},
+            )
+
+        if iteration_stats is None:
+            return
+
+        attrs = {**self.common_attributes, "engine": str(engine_idx)}
+
+        # Record token counters
+        self.counter_prompt_tokens.add(
+            iteration_stats.num_prompt_tokens, attributes=attrs
+        )
+        self.counter_generation_tokens.add(
+            iteration_stats.num_generation_tokens, attributes=attrs
+        )
+
+        # Record preemptions
+        self.counter_num_preempted_reqs.add(
+            iteration_stats.num_preempted_reqs, attributes=attrs
+        )
+
+        # Record latency histograms
+        for ttft in iteration_stats.time_to_first_tokens_iter:
+            self.histogram_time_to_first_token.record(ttft, attributes=attrs)
+
+        for itl in iteration_stats.inter_token_latencies_iter:
+            self.histogram_inter_token_latency.record(itl, attributes=attrs)
+
+        # Record finished request metrics
+        for finished_request in iteration_stats.finished_requests:
+            finish_attrs = {
+                **attrs,
+                "finished_reason": str(finished_request.finish_reason),
+            }
+
+            self.counter_request_success.add(1, attributes=finish_attrs)
+            self.histogram_e2e_time_request.record(
+                finished_request.e2e_latency, attributes=attrs
+            )
+            self.histogram_queue_time_request.record(
+                finished_request.queued_time, attributes=attrs
+            )
+            self.histogram_inference_time_request.record(
+                finished_request.inference_time, attributes=attrs
+            )
+
+    def _observe_running_requests(
+        self, options: "metrics.CallbackOptions"
+    ) -> list["metrics.Observation"]:
+        """Callback for running requests gauge."""
+        observations = []
+        for engine_idx, stats in self._latest_scheduler_stats.items():
+            attrs = {**self.common_attributes, "engine": str(engine_idx)}
+            observations.append(
+                metrics.Observation(stats.num_running_reqs, attributes=attrs)
+            )
+        return observations
+
+    def _observe_waiting_requests(
+        self, options: "metrics.CallbackOptions"
+    ) -> list["metrics.Observation"]:
+        """Callback for waiting requests gauge."""
+        observations = []
+        for engine_idx, stats in self._latest_scheduler_stats.items():
+            attrs = {**self.common_attributes, "engine": str(engine_idx)}
+            observations.append(
+                metrics.Observation(stats.num_waiting_reqs, attributes=attrs)
+            )
+        return observations
+
+    def _observe_kv_cache_usage(
+        self, options: "metrics.CallbackOptions"
+    ) -> list["metrics.Observation"]:
+        """Callback for KV cache usage gauge."""
+        observations = []
+        for engine_idx, stats in self._latest_scheduler_stats.items():
+            attrs = {**self.common_attributes, "engine": str(engine_idx)}
+            observations.append(
+                metrics.Observation(stats.kv_cache_usage, attributes=attrs)
+            )
+        return observations
+
+    def log_engine_initialized(self):
+        """Log that the engine has been initialized."""
+        logger.info(
+            "OpenTelemetry metrics logger: Engine initialized with %d GPU blocks",
+            self.vllm_config.cache_config.num_gpu_blocks or 0,
+        )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Implements feature request https://github.com/vllm-project/vllm/issues/30252.

## Test Plan
Added tests.

Simple manual test:
* Run OTel Collector in background
docker-compose.yaml:
```
services:
  otel-collector:
    image: otel/opentelemetry-collector:latest
    container_name: vllm-otel-collector
    command: ["--config=/etc/otel-collector-config.yaml"]
    volumes:
      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
    ports:
      - "4317:4317"   # OTLP gRPC receiver
      - "4318:4318"   # OTLP HTTP receiver
      - "8888:8888"   # Prometheus metrics exposed by the collector
      - "8889:8889"   # Prometheus exporter metrics
      - "13133:13133" # Health check extension
    restart: unless-stopped
```
otel-collector-config.yaml:
```
receivers:
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4317
      http:
        endpoint: 0.0.0.0:4318

processors:
  batch:
    timeout: 10s
    send_batch_size: 1024

exporters:
  # Log metrics to console for debugging
  debug:
    verbosity: detailed
    sampling_initial: 5
    sampling_thereafter: 200

  # Export metrics in Prometheus format
  prometheus:
    endpoint: "0.0.0.0:8889"
    namespace: vllm

  # Alternative: Export to Prometheus Remote Write
  # prometheusremotewrite:
  #   endpoint: "http://prometheus:9090/api/v1/write"

extensions:
  health_check:
    endpoint: 0.0.0.0:13133
  pprof:
    endpoint: 0.0.0.0:1777
  zpages:
    endpoint: 0.0.0.0:55679

service:
  extensions: [health_check, pprof, zpages]
  pipelines:
    metrics:
      receivers: [otlp]
      processors: [batch]
      exporters: [debug, prometheus]

```
* Start serving vLLM with enabled OTel metrics support
```
python -m vllm.entrypoints.openai.api_server --model facebook/opt-125m --enable-otel-metrics --port 8080
```
* Do a vLLM prompt request
```
curl -s http://localhost:8080/v1/completions \
    -H "Content-Type: application/json" \
    -d '{
      "model": "facebook/opt-125m",
      "prompt": "San Francisco is a",
      "max_tokens": 10
    }'
```
* Check whether metric exist in both vLLM /metric endpoint and OTel Collector
vLLM /metrics endpoint
```
curl -s http://localhost:8080/metrics | grep "kv_cache_usage_perc"
# HELP vllm:kv_cache_usage_perc KV-cache usage. 1 means 100 percent usage.
# TYPE vllm:kv_cache_usage_perc gauge
vllm:kv_cache_usage_perc{engine="0",model_name="facebook/opt-125m"} 0.0
```
OTel Collector
```
curl -s http://localhost:8889/metrics | grep "kv_cache_usage_perc"
# HELP vllm_vllm_kv_cache_usage_perc KV-cache usage (1 = 100%)
# TYPE vllm_vllm_kv_cache_usage_perc gauge
vllm_vllm_kv_cache_usage_perc{engine="0",job="vllm",model_name="facebook/opt-125m",otel_scope_name="vllm.metrics",otel_scope_schema_url="",otel_scope_version=""} 0
```

## Test Result
Metric exist on vLLM /metrics endpoint and in OTel Collector.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

