### PR TITLE
Add tip for `mypy` and `markdownlint` to the pre-commit comment

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -35,6 +35,20 @@ pull_request_rules:
 
         For future commits, `pre-commit` will run automatically on changed files before each commit.
 
+        > [!TIP]
+        > <details>
+        > <summary>Is <code>mypy</code> or <code>markdownlint</code> failing?</summary>
+        > </br>
+        > <code>mypy</code> and <code>markdownlint</code> are run differently in CI. If the failure is related to either of these checks, please use the following commands to run them locally:
+        >
+        > ```bash
+        > # For mypy (substitute "3.10" with the failing version if needed)
+        > pre-commit run --hook-stage manual mypy-3.10
+        > # For markdownlint
+        > pre-commit run --hook-stage manual markdownlint
+        > ```
+        > </details>
+
 - name: comment-dco-failure
   description: Comment on PR when DCO check fails
   conditions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -38,7 +38,7 @@ pull_request_rules:
         > [!TIP]
         > <details>
         > <summary>Is <code>mypy</code> or <code>markdownlint</code> failing?</summary>
-        > </br>
+        > <br/>
         > <code>mypy</code> and <code>markdownlint</code> are run differently in CI. If the failure is related to either of these checks, please use the following commands to run them locally:
         >
         > ```bash


### PR DESCRIPTION
Should help reduce this comment spamming when authors are trying to fix `mypy` and `markdownlint` failures.

Folded:

<img width="286" height="99" alt="image" src="https://github.com/user-attachments/assets/05b78248-0e08-43fb-a172-b890f0efc108" />

Unfolded:

<img width="821" height="268" alt="image" src="https://github.com/user-attachments/assets/67816474-bbc1-4832-b682-b046fb51f819" />
