### PR TITLE
Support TP which is not divded for NVFP4 kernels (flashinfer-cutlass) by adding dynamic padding

### DIFF
--- a/csrc/quantization/fp4/nvfp4_quant_kernels.cu
+++ b/csrc/quantization/fp4/nvfp4_quant_kernels.cu
@@ -35,11 +35,10 @@ template <typename Int>
 __host__ __device__ inline Int round_up(Int x, Int y) {
   static_assert(std::is_integral_v<Int>,
                 "round_up argument must be integral type");
-  return (x + y - 1) / y * y;
+  return ((x + y - 1) / y) * y;
 }
 
-
-// // Use UE4M3 by default.
+// Use UE4M3 by default.
 template <class Type, bool UE8M0_SF = false>
 __global__ void __launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))
     cvt_fp16_to_fp4(int32_t numRows, int32_t numCols, Type const* in,
@@ -51,128 +50,65 @@ __global__ void __launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))
                 "Vec size is not matched.");
 
   int sf_m = round_up<int>(numRows, 128);
-  int sf_n_unpadded = numCols / CVT_FP4_SF_VEC_SIZE; // 29 // 4 = 7 - 1=  6
-  int sf_n_int = round_up<int>(sf_n_unpadded, 4) / 4; // 8
-  for (int row = numRows + blockIdx.x; row < sf_m; row += gridDim.x) {
-    // Each thread writes 4 uint32_t elements.
-    for (int col = sf_n_unpadded + threadIdx.x * 4; col < sf_n_int;
-         col += blockDim.x * 4) {
-      SFout[row * sf_n_int + col] = 0x00;
-    }
-  }
+  
+  // Columns (SFs) are packed in blocks of 4.
+  int sf_n_unpadded = numCols / CVT_FP4_SF_VEC_SIZE;
+  int sf_n_int = round_up<int>(sf_n_unpadded, 4) / 4;
+  
+  // Total columns to iterate (includes padding columns)
+  int num_padded_cols = sf_n_int * 4 * CVT_FP4_SF_VEC_SIZE; 
 
-  // Get the global scaling factor, which will be applied to the SF.
-  // Note SFScale is the same as next GEMM's alpha, which is
-  // (448.f / (Alpha_A / 6.f)).
+  // Get the global scaling factor
   float const global_scale = SFScale == nullptr ? 1.0f : SFScale[0];
 
-  // Input tensor row/col loops.
-  for (int rowIdx = blockIdx.x; rowIdx < numRows; rowIdx += gridDim.x) {
-    for (int colIdx = threadIdx.x; colIdx < numCols / CVT_FP4_ELTS_PER_THREAD;
-         colIdx += blockDim.x) {
-      int64_t inOffset = rowIdx * (numCols / CVT_FP4_ELTS_PER_THREAD) + colIdx;
-      PackedVec in_vec = reinterpret_cast<PackedVec const*>(in)[inOffset];
-      // Get the output tensor offset.
-      // Same as inOffset because 8 elements are packed into one uint32_t.
-      int64_t outOffset = inOffset;
-      auto& out_pos = out[outOffset];
 
+  // 2. Unified Loop: Iterate over PADDED rows and PADDED columns
+  // This ensures we visit every single scale factor address to initialize it.
+  for (int rowIdx = blockIdx.x; rowIdx < sf_m; rowIdx += gridDim.x) {
+    for (int colIdx = threadIdx.x; colIdx < num_padded_cols / CVT_FP4_ELTS_PER_THREAD;
+         colIdx += blockDim.x) {
+      
+      // Calculate logical element index
+      int elem_idx = colIdx * CVT_FP4_ELTS_PER_THREAD;
+      
+      PackedVec in_vec;
+
+      // 3. Handle Padding (Vertical OR Horizontal)
+      // If we are outside valid rows OR outside valid columns -> Use Zeros
+      if (rowIdx >= numRows || elem_idx >= numCols) {
+          // Padding Zone: Fake input as zeros. 
+          // This results in a Scale Factor of 0.0, safely zeroing the output SF.
+          memset(&in_vec, 0, sizeof(PackedVec));
+
+      } else {
+          // Valid Region: Load actual data
+          // Calculate input offset based on original stride
+          int64_t inOffset = rowIdx * (numCols / CVT_FP4_ELTS_PER_THREAD) + colIdx;
+          in_vec = reinterpret_cast<PackedVec const*>(in)[inOffset];
+      }
+
+      // 4. Calculate Swizzled Scale Factor Address
+      // This works for valid AND padding regions to find the correct SF location
       auto sf_out =
           cvt_quant_to_fp4_get_sf_out_offset<uint32_t,
                                              CVT_FP4_NUM_THREADS_PER_SF>(
-              rowIdx, colIdx, numCols, SFout);
+              rowIdx, colIdx, num_padded_cols, SFout);
 
-      out_pos =
-          cvt_warp_fp16_to_fp4<Type, UE8M0_SF>(in_vec, global_scale, sf_out);
+      // 5. Quantize
+      // - Valid input -> Real scale
+      // - Zero input -> Zero scale (Correctly handles padding initialization)
+      // This function handles the intra-block bit packing safely.
+      auto out_val = cvt_warp_fp16_to_fp4<Type, UE8M0_SF>(in_vec, global_scale, sf_out);
+      
+      // 6. Write Output Tensor (Only if strictly within valid bounds)
+      // We do NOT write output for padding because the 'out' tensor is not padded.
+      if (rowIdx < numRows && elem_idx < numCols) {
+          int64_t inOffset = rowIdx * (numCols / CVT_FP4_ELTS_PER_THREAD) + colIdx;
+          out[inOffset] = out_val;
+      }
     }
   }
 }
-
-
-
-
-
-// // Use UE4M3 by default.
-// template <class Type, bool UE8M0_SF = false>
-// __global__ void __launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))
-//     cvt_fp16_to_fp4(int32_t numRows, int32_t numCols, Type const* in,
-//                     float const* SFScale, uint32_t* out, uint32_t* SFout) {
-//   using PackedVec = PackedVec<Type>;
-//   static constexpr int CVT_FP4_NUM_THREADS_PER_SF =
-//       (CVT_FP4_SF_VEC_SIZE / CVT_FP4_ELTS_PER_THREAD);
-//   static_assert(sizeof(PackedVec) == sizeof(Type) * CVT_FP4_ELTS_PER_THREAD,
-//                 "Vec size is not matched.");
-
-//   int sf_m = round_up<int>(numRows, 128);
-//   int sf_n_unpadded = numCols / CVT_FP4_SF_VEC_SIZE;
-//   int sf_n_int = round_up<int>(sf_n_unpadded, 4) / 4;
-
-//   // Get the global scaling factor, which will be applied to the SF.
-//   // Note SFScale is the same as next GEMM's alpha, which is
-//   // (448.f / (Alpha_A / 6.f)).
-//   float const global_scale = SFScale == nullptr ? 1.0f : SFScale[0];
-
-//   // Calculate padded columns to ensure we cover the full tail block of SFs.
-//   // Each SF covers 16 elements. A block covers 4 SFs = 64 elements.
-//   int num_padded_cols = sf_n_int * 4 * CVT_FP4_SF_VEC_SIZE; 
-//   int numColThreads = numCols / CVT_FP4_ELTS_PER_THREAD;
-//   int numPaddedColThreads = num_padded_cols / CVT_FP4_ELTS_PER_THREAD;
-
-//   // Main loop: Process ALL rows and columns (including padding) like TensorRT-LLM
-//   // This ensures we zero scale factors at their correct swizzled addresses
-//   for (int rowIdx = blockIdx.x; rowIdx < sf_m; rowIdx += gridDim.x) {
-//     for (int colIdx = threadIdx.x; colIdx < numPaddedColThreads; colIdx += blockDim.x) {
-//       // Get the swizzled SF pointer - works for BOTH valid and padding regions
-//       auto sf_out =
-//           cvt_quant_to_fp4_get_sf_out_offset<uint32_t,
-//                                              CVT_FP4_NUM_THREADS_PER_SF>(
-//               rowIdx, colIdx, num_padded_cols, SFout);
-
-//       // Check if we're in padding region (either row or column)
-//       bool is_padding_region = (rowIdx >= numRows) || (colIdx >= numColThreads);
-      
-//       // DEBUG LOG
-//       if (blockIdx.x == 0 && threadIdx.x == 0) {
-//           // Log only the first few iterations or boundary conditions to avoid spam
-//           // Log boundary of valid/padding
-//           if (colIdx == numColThreads || colIdx == numColThreads - 1 || 
-//               (rowIdx == numRows || rowIdx == numRows - 1)) {
-//               printf("[FP4_DEBUG] row=%d, col=%d, is_padding=%d, sf_out_ptr=%p\n", 
-//                      rowIdx, colIdx, is_padding_region, sf_out);
-//           }
-//       }
-
-//       if (is_padding_region) {
-//           // Zero the scale factor for padding (like TRT-LLM lines 830-836)
-//           // This is CRITICAL - must use swizzled address from sf_out, not linear indexing!
-//           if (sf_out != nullptr) {
-//               *sf_out = 0x00;
-//               // DEBUG LOG
-//               if (blockIdx.x == 0 && threadIdx.x == 0 && rowIdx < numRows + 2) {
-//                   printf("[FP4_DEBUG] ZEROING Padding: row=%d, col=%d at %p\n", rowIdx, colIdx, sf_out);
-//               }
-//           }
-//           // Note: We do NOT write to the FP4 output buffer for padding regions
-//           // because the output buffer is allocated with original dimensions (m, n//2)
-//       } else {
-//           // Valid region - load input and quantize
-//           int64_t inOffset = rowIdx * numColThreads + colIdx;
-//           PackedVec in_vec = reinterpret_cast<PackedVec const*>(in)[inOffset];
-          
-//           // Perform conversion (writes scale to sf_out) and get FP4 output
-//           auto out_val = cvt_warp_fp16_to_fp4<Type, UE8M0_SF>(in_vec, global_scale, sf_out);
-          
-//           // Write FP4 output using UNPADDED stride (buffer has original dimensions)
-//           out[inOffset] = out_val;
-          
-//           // DEBUG LOG
-//           if (blockIdx.x == 0 && threadIdx.x == 0 && rowIdx == 0 && colIdx > numColThreads - 5) {
-//                printf("[FP4_DEBUG] Writing VALID: row=%d, col=%d, inOffset=%ld\n", rowIdx, colIdx, inOffset);
-//           }
-//       }
-//     }
-//   }
-// }
 
 template <typename T>
 void invokeFP4Quantization(int m, int n, T const* input, float const* SFScale,
@@ -185,6 +121,7 @@ void invokeFP4Quantization(int m, int n, T const* input, float const* SFScale,
   int const numBlocksPerSM =
       vllm_runtime_blocks_per_sm(static_cast<int>(block.x));
   dim3 grid(std::min(int(m), multiProcessorCount * numBlocksPerSM));
+
 
   // Launch the cvt kernel.
   if (useUE8M0) {

--- a/csrc/quantization/fp4/nvfp4_quant_kernels.cu
+++ b/csrc/quantization/fp4/nvfp4_quant_kernels.cu
@@ -40,6 +40,59 @@ __host__ __device__ inline Int round_up(Int x, Int y) {
 
 
 // // Use UE4M3 by default.
+template <class Type, bool UE8M0_SF = false>
+__global__ void __launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))
+    cvt_fp16_to_fp4(int32_t numRows, int32_t numCols, Type const* in,
+                    float const* SFScale, uint32_t* out, uint32_t* SFout) {
+  using PackedVec = PackedVec<Type>;
+  static constexpr int CVT_FP4_NUM_THREADS_PER_SF =
+      (CVT_FP4_SF_VEC_SIZE / CVT_FP4_ELTS_PER_THREAD);
+  static_assert(sizeof(PackedVec) == sizeof(Type) * CVT_FP4_ELTS_PER_THREAD,
+                "Vec size is not matched.");
+
+  int sf_m = round_up<int>(numRows, 128);
+  int sf_n_unpadded = numCols / CVT_FP4_SF_VEC_SIZE; // 29 // 4 = 7 - 1=  6
+  int sf_n_int = round_up<int>(sf_n_unpadded, 4) / 4; // 8
+  for (int row = numRows + blockIdx.x; row < sf_m; row += gridDim.x) {
+    // Each thread writes 4 uint32_t elements.
+    for (int col = sf_n_unpadded + threadIdx.x * 4; col < sf_n_int;
+         col += blockDim.x * 4) {
+      SFout[row * sf_n_int + col] = 0x00;
+    }
+  }
+
+  // Get the global scaling factor, which will be applied to the SF.
+  // Note SFScale is the same as next GEMM's alpha, which is
+  // (448.f / (Alpha_A / 6.f)).
+  float const global_scale = SFScale == nullptr ? 1.0f : SFScale[0];
+
+  // Input tensor row/col loops.
+  for (int rowIdx = blockIdx.x; rowIdx < numRows; rowIdx += gridDim.x) {
+    for (int colIdx = threadIdx.x; colIdx < numCols / CVT_FP4_ELTS_PER_THREAD;
+         colIdx += blockDim.x) {
+      int64_t inOffset = rowIdx * (numCols / CVT_FP4_ELTS_PER_THREAD) + colIdx;
+      PackedVec in_vec = reinterpret_cast<PackedVec const*>(in)[inOffset];
+      // Get the output tensor offset.
+      // Same as inOffset because 8 elements are packed into one uint32_t.
+      int64_t outOffset = inOffset;
+      auto& out_pos = out[outOffset];
+
+      auto sf_out =
+          cvt_quant_to_fp4_get_sf_out_offset<uint32_t,
+                                             CVT_FP4_NUM_THREADS_PER_SF>(
+              rowIdx, colIdx, numCols, SFout);
+
+      out_pos =
+          cvt_warp_fp16_to_fp4<Type, UE8M0_SF>(in_vec, global_scale, sf_out);
+    }
+  }
+}
+
+
+
+
+
+// // Use UE4M3 by default.
 // template <class Type, bool UE8M0_SF = false>
 // __global__ void __launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))
 //     cvt_fp16_to_fp4(int32_t numRows, int32_t numCols, Type const* in,
@@ -53,126 +106,73 @@ __host__ __device__ inline Int round_up(Int x, Int y) {
 //   int sf_m = round_up<int>(numRows, 128);
 //   int sf_n_unpadded = numCols / CVT_FP4_SF_VEC_SIZE;
 //   int sf_n_int = round_up<int>(sf_n_unpadded, 4) / 4;
-//   for (int row = numRows + blockIdx.x; row < sf_m; row += gridDim.x) {
-//     // Each thread writes 4 uint32_t elements.
-//     for (int col = sf_n_unpadded + threadIdx.x * 4; col < sf_n_int;
-//          col += blockDim.x * 4) {
-//       SFout[row * sf_n_int + col] = 0x00;
-//     }
-//   }
 
 //   // Get the global scaling factor, which will be applied to the SF.
 //   // Note SFScale is the same as next GEMM's alpha, which is
 //   // (448.f / (Alpha_A / 6.f)).
 //   float const global_scale = SFScale == nullptr ? 1.0f : SFScale[0];
 
-//   // Input tensor row/col loops.
-//   for (int rowIdx = blockIdx.x; rowIdx < numRows; rowIdx += gridDim.x) {
-//     for (int colIdx = threadIdx.x; colIdx < numCols / CVT_FP4_ELTS_PER_THREAD;
-//          colIdx += blockDim.x) {
-//       int64_t inOffset = rowIdx * (numCols / CVT_FP4_ELTS_PER_THREAD) + colIdx;
-//       PackedVec in_vec = reinterpret_cast<PackedVec const*>(in)[inOffset];
-//       // Get the output tensor offset.
-//       // Same as inOffset because 8 elements are packed into one uint32_t.
-//       int64_t outOffset = inOffset;
-//       auto& out_pos = out[outOffset];
+//   // Calculate padded columns to ensure we cover the full tail block of SFs.
+//   // Each SF covers 16 elements. A block covers 4 SFs = 64 elements.
+//   int num_padded_cols = sf_n_int * 4 * CVT_FP4_SF_VEC_SIZE; 
+//   int numColThreads = numCols / CVT_FP4_ELTS_PER_THREAD;
+//   int numPaddedColThreads = num_padded_cols / CVT_FP4_ELTS_PER_THREAD;
 
+//   // Main loop: Process ALL rows and columns (including padding) like TensorRT-LLM
+//   // This ensures we zero scale factors at their correct swizzled addresses
+//   for (int rowIdx = blockIdx.x; rowIdx < sf_m; rowIdx += gridDim.x) {
+//     for (int colIdx = threadIdx.x; colIdx < numPaddedColThreads; colIdx += blockDim.x) {
+//       // Get the swizzled SF pointer - works for BOTH valid and padding regions
 //       auto sf_out =
 //           cvt_quant_to_fp4_get_sf_out_offset<uint32_t,
 //                                              CVT_FP4_NUM_THREADS_PER_SF>(
-//               rowIdx, colIdx, numCols, SFout);
+//               rowIdx, colIdx, num_padded_cols, SFout);
 
-//       out_pos =
-//           cvt_warp_fp16_to_fp4<Type, UE8M0_SF>(in_vec, global_scale, sf_out);
+//       // Check if we're in padding region (either row or column)
+//       bool is_padding_region = (rowIdx >= numRows) || (colIdx >= numColThreads);
+      
+//       // DEBUG LOG
+//       if (blockIdx.x == 0 && threadIdx.x == 0) {
+//           // Log only the first few iterations or boundary conditions to avoid spam
+//           // Log boundary of valid/padding
+//           if (colIdx == numColThreads || colIdx == numColThreads - 1 || 
+//               (rowIdx == numRows || rowIdx == numRows - 1)) {
+//               printf("[FP4_DEBUG] row=%d, col=%d, is_padding=%d, sf_out_ptr=%p\n", 
+//                      rowIdx, colIdx, is_padding_region, sf_out);
+//           }
+//       }
+
+//       if (is_padding_region) {
+//           // Zero the scale factor for padding (like TRT-LLM lines 830-836)
+//           // This is CRITICAL - must use swizzled address from sf_out, not linear indexing!
+//           if (sf_out != nullptr) {
+//               *sf_out = 0x00;
+//               // DEBUG LOG
+//               if (blockIdx.x == 0 && threadIdx.x == 0 && rowIdx < numRows + 2) {
+//                   printf("[FP4_DEBUG] ZEROING Padding: row=%d, col=%d at %p\n", rowIdx, colIdx, sf_out);
+//               }
+//           }
+//           // Note: We do NOT write to the FP4 output buffer for padding regions
+//           // because the output buffer is allocated with original dimensions (m, n//2)
+//       } else {
+//           // Valid region - load input and quantize
+//           int64_t inOffset = rowIdx * numColThreads + colIdx;
+//           PackedVec in_vec = reinterpret_cast<PackedVec const*>(in)[inOffset];
+          
+//           // Perform conversion (writes scale to sf_out) and get FP4 output
+//           auto out_val = cvt_warp_fp16_to_fp4<Type, UE8M0_SF>(in_vec, global_scale, sf_out);
+          
+//           // Write FP4 output using UNPADDED stride (buffer has original dimensions)
+//           out[inOffset] = out_val;
+          
+//           // DEBUG LOG
+//           if (blockIdx.x == 0 && threadIdx.x == 0 && rowIdx == 0 && colIdx > numColThreads - 5) {
+//                printf("[FP4_DEBUG] Writing VALID: row=%d, col=%d, inOffset=%ld\n", rowIdx, colIdx, inOffset);
+//           }
+//       }
 //     }
 //   }
 // }
-
-
-
-
-
-// Use UE4M3 by default.
-template <class Type, bool UE8M0_SF = false>
-__global__ void __launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))
-    cvt_fp16_to_fp4(int32_t numRows, int32_t numCols, Type const* in,
-                    float const* SFScale, uint32_t* out, uint32_t* SFout) {
-  using PackedVec = PackedVec<Type>;
-  static constexpr int CVT_FP4_NUM_THREADS_PER_SF =
-      (CVT_FP4_SF_VEC_SIZE / CVT_FP4_ELTS_PER_THREAD);
-  static_assert(sizeof(PackedVec) == sizeof(Type) * CVT_FP4_ELTS_PER_THREAD,
-                "Vec size is not matched.");
-
-  int sf_m = round_up<int>(numRows, 128);
-  int sf_n_unpadded = numCols / CVT_FP4_SF_VEC_SIZE;
-  int sf_n_int = round_up<int>(sf_n_unpadded, 4) / 4;
-
-  // Get the global scaling factor, which will be applied to the SF.
-  // Note SFScale is the same as next GEMM's alpha, which is
-  // (448.f / (Alpha_A / 6.f)).
-  float const global_scale = SFScale == nullptr ? 1.0f : SFScale[0];
-
-  // Calculate padded columns to ensure we cover the full tail block of SFs.
-  // Each SF covers 16 elements. A block covers 4 SFs = 64 elements.
-  int num_padded_cols = sf_n_int * 4 * CVT_FP4_SF_VEC_SIZE; 
-  int numColThreads = numCols / CVT_FP4_ELTS_PER_THREAD;
-  int numPaddedColThreads = num_padded_cols / CVT_FP4_ELTS_PER_THREAD;
-
-  // Main loop: Process ALL rows and columns (including padding) like TensorRT-LLM
-  // This ensures we zero scale factors at their correct swizzled addresses
-  for (int rowIdx = blockIdx.x; rowIdx < sf_m; rowIdx += gridDim.x) {
-    for (int colIdx = threadIdx.x; colIdx < numPaddedColThreads; colIdx += blockDim.x) {
-      // Get the swizzled SF pointer - works for BOTH valid and padding regions
-      auto sf_out =
-          cvt_quant_to_fp4_get_sf_out_offset<uint32_t,
-                                             CVT_FP4_NUM_THREADS_PER_SF>(
-              rowIdx, colIdx, num_padded_cols, SFout);
-
-      // Check if we're in padding region (either row or column)
-      bool is_padding_region = (rowIdx >= numRows) || (colIdx >= numColThreads);
-      
-      // DEBUG LOG
-      if (blockIdx.x == 0 && threadIdx.x == 0) {
-          // Log only the first few iterations or boundary conditions to avoid spam
-          // Log boundary of valid/padding
-          if (colIdx == numColThreads || colIdx == numColThreads - 1 || 
-              (rowIdx == numRows || rowIdx == numRows - 1)) {
-              printf("[FP4_DEBUG] row=%d, col=%d, is_padding=%d, sf_out_ptr=%p\n", 
-                     rowIdx, colIdx, is_padding_region, sf_out);
-          }
-      }
-
-      if (is_padding_region) {
-          // Zero the scale factor for padding (like TRT-LLM lines 830-836)
-          // This is CRITICAL - must use swizzled address from sf_out, not linear indexing!
-          if (sf_out != nullptr) {
-              *sf_out = 0x00;
-              // DEBUG LOG
-              if (blockIdx.x == 0 && threadIdx.x == 0 && rowIdx < numRows + 2) {
-                  printf("[FP4_DEBUG] ZEROING Padding: row=%d, col=%d at %p\n", rowIdx, colIdx, sf_out);
-              }
-          }
-          // Note: We do NOT write to the FP4 output buffer for padding regions
-          // because the output buffer is allocated with original dimensions (m, n//2)
-      } else {
-          // Valid region - load input and quantize
-          int64_t inOffset = rowIdx * numColThreads + colIdx;
-          PackedVec in_vec = reinterpret_cast<PackedVec const*>(in)[inOffset];
-          
-          // Perform conversion (writes scale to sf_out) and get FP4 output
-          auto out_val = cvt_warp_fp16_to_fp4<Type, UE8M0_SF>(in_vec, global_scale, sf_out);
-          
-          // Write FP4 output using UNPADDED stride (buffer has original dimensions)
-          out[inOffset] = out_val;
-          
-          // DEBUG LOG
-          if (blockIdx.x == 0 && threadIdx.x == 0 && rowIdx == 0 && colIdx > numColThreads - 5) {
-               printf("[FP4_DEBUG] Writing VALID: row=%d, col=%d, inOffset=%ld\n", rowIdx, colIdx, inOffset);
-          }
-      }
-    }
-  }
-}
 
 template <typename T>
 void invokeFP4Quantization(int m, int n, T const* input, float const* SFScale,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1590,7 +1590,7 @@ def scaled_fp4_quant(
     scale_n = n // block_size
     rounded_n = round_up(scale_n, 4)
     # Use torch.empty for performance - kernel zeros padding at swizzled addresses
-    output_scale = torch.zeros(
+    output_scale = torch.empty(
         (rounded_m, rounded_n // 4), device=device, dtype=torch.int32
     )
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1589,7 +1589,7 @@ def scaled_fp4_quant(
     rounded_m = round_up(m, 128)
     scale_n = n // block_size
     rounded_n = round_up(scale_n, 4)
-    output_scale = torch.empty(
+    output_scale = torch.zeros(
         (rounded_m, rounded_n // 4), device=device, dtype=torch.int32
     )
 
@@ -1642,7 +1642,7 @@ def scaled_fp4_experts_quant(
     output = torch.empty(
         m_numtopk, k // 2, device=input_tensor.device, dtype=torch.uint8
     )
-    output_scales = torch.empty(
+    output_scales = torch.zeros(
         MAX_TOKENS_PER_EXPERT * topk,
         padded_k,
         dtype=torch.int32,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1589,7 +1589,6 @@ def scaled_fp4_quant(
     rounded_m = round_up(m, 128)
     scale_n = n // block_size
     rounded_n = round_up(scale_n, 4)
-    # Use torch.empty for performance - kernel zeros padding at swizzled addresses
     output_scale = torch.empty(
         (rounded_m, rounded_n // 4), device=device, dtype=torch.int32
     )

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1642,7 +1642,7 @@ def scaled_fp4_experts_quant(
     output = torch.empty(
         m_numtopk, k // 2, device=input_tensor.device, dtype=torch.uint8
     )
-    output_scales = torch.zeros(
+    output_scales = torch.empty(
         MAX_TOKENS_PER_EXPERT * topk,
         padded_k,
         dtype=torch.int32,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1589,7 +1589,7 @@ def scaled_fp4_quant(
     rounded_m = round_up(m, 128)
     scale_n = n // block_size
     rounded_n = round_up(scale_n, 4)
-    output_scale = torch.zeros(
+    output_scale = torch.empty(
         (rounded_m, rounded_n // 4), device=device, dtype=torch.int32
     )
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1589,7 +1589,8 @@ def scaled_fp4_quant(
     rounded_m = round_up(m, 128)
     scale_n = n // block_size
     rounded_n = round_up(scale_n, 4)
-    output_scale = torch.empty(
+    # Use torch.empty for performance - kernel zeros padding at swizzled addresses
+    output_scale = torch.zeros(
         (rounded_m, rounded_n // 4), device=device, dtype=torch.int32
     )
 

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1217,9 +1217,6 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
         # x_blockscale is implicitly padded/rounded by the kernel to satisfy alignment
         x_fp4, x_blockscale = scaled_fp4_quant(x, layer.input_scale_inv)
 
-        # actual_batch_size = x_fp4.shape[0]
-        # x_blockscale = x_blockscale[:actual_batch_size, :].contiguous()
-
         # validate dtypes of quantized input, input block scale,
         # weight and weight_blockscale
         assert x_fp4.dtype == torch.uint8

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1237,7 +1237,6 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
 
         if bias is not None:
             out = out + bias
-
         return out.view(*output_shape)
 
 

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1193,11 +1193,6 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
             pad_k_bytes = getattr(layer, "execution_padding_k_bytes", 0)
             output_shape = [x.shape[0], layer.output_size_per_partition]
 
-            logger.info(
-                f"[FP4_DEBUG] Pre-Pad: x_fp4={x_fp4.shape}, "
-                f"x_blockscale={x_blockscale.shape}, pad_k_bytes={pad_k_bytes}"
-            )
-
             x_fp4 = torch.nn.functional.pad(x_fp4, (0, pad_k_bytes)).contiguous()
 
             # If we pad x_fp4 so we maybe need to add pad x_block scale as well
@@ -1213,18 +1208,10 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
 
             if original_scale_blocks < required_scale_blocks:
                 pad_scales = required_scale_blocks - original_scale_blocks
-                logger.info(
-                    f"[FP4_DEBUG] Padding Scales: original={original_scale_blocks}, "
-                    f"required={required_scale_blocks}, pad={pad_scales}"
-                )
                 x_blockscale = torch.nn.functional.pad(
                     x_blockscale, (0, pad_scales), value=0.0
                 ).contiguous()
 
-            logger.info(
-                f"[FP4_DEBUG] Final: x_fp4={x_fp4.shape}, "
-                f"x_blockscale={x_blockscale.shape}"
-            )
 
             mm_args = (
                 x_fp4,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1117,14 +1117,13 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
             # Pad weight to match swizzled scale dimensions
             if weight_scale_rows_padded != weight_current_rows:
                 pad_rows = weight_scale_rows_padded - weight_current_rows
-                assert pad_rows >= 0, (
+                assert pad_rows > 0, (
                     f"Weight scale rows ({weight_scale_rows_padded}) < "
                     f"weight rows ({weight_current_rows})."
                 )
-                if pad_rows > 0:
-                    weight = torch.nn.functional.pad(
-                        weight, (0, 0, 0, pad_rows)
-                    ).contiguous()
+                weight = torch.nn.functional.pad(
+                    weight, (0, 0, 0, pad_rows)
+                ).contiguous()
 
             # Calculate the number of k blocks padded to satisfy alignment
             # constraints for the weight
@@ -1133,7 +1132,6 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
             num_k_blocks_padded = swizzled_weight_scale.shape[1]
             k_bytes_padded = (num_k_blocks_padded * group_size) // 2
             k_bytes_orig = weight.shape[1]
-
 
             if k_bytes_padded != k_bytes_orig:
                 pad_bytes = k_bytes_padded - k_bytes_orig
@@ -1211,7 +1209,6 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
                 x_blockscale = torch.nn.functional.pad(
                     x_blockscale, (0, pad_scales), value=0.0
                 ).contiguous()
-
 
             mm_args = (
                 x_fp4,


### PR DESCRIPTION
## The Issues

**Unaligned TP Shapes**: TP4 splits resulted in misaligned dimensions (e.g., 464) incompatible with block size (16) and hardware tile constraints.

**Uninitialized Scale Memory**: `scaled_fp4_quant` uses `torch.empty` for scales with padded sizes (128-row × 4-column alignment). Padding regions contained garbage (NaNs).

**Kernel OOB Reads**: MatMul kernels read scales for padded input blocks, propagating NaNs from uninitialized memory into results.

## The Fix

### Weight & Activation Preprocessing (`modelopt.py`)
- Detect misalignment and pad weights/activations with zeros
- Pad `x_blockscale` with `0.0` for padded input regions

### Scale Initialization - Kernel Optimization (`nvfp4_quant_kernels.cu`)
**Previous approach**: Used `torch.zeros()` in Python (simple but adds forward pass overhead)

**New approach**: Keep `torch.empty()` for performance, initialize padding in-kernel:
1. Iterate over **full padded dimensions** (128-row alignment, 64-column alignment), not just valid input
2. Detect padding via `rowIdx >= numRows || elem_idx >= numCols`
3. Feed zero vectors to `cvt_warp_fp16_to_fp4()` for padding regions → produces zero scales
4. Write scales to all swizzled addresses (including padding), output only for valid regions

**Result**: Eliminates `torch.zeros()` overhead while ensuring complete memory initialization through the quantization algorithm itself.

### Example (TP4)
- Input: `[..., 464]` (29 blocks) → Padded to 480 (30 blocks) + 128 rows
- **Before**: Scale[29] uninitialized → NaN → crash
- **After**: Kernel processes block 29 with zeros → writes `0.0` to Scale[29] → valid output

---