### PR TITLE
Multiple Hybrid KV Cache Coordinator

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -444,9 +444,7 @@ def test_prefill_hybrid_model():
     )
 
 
-@pytest.mark.parametrize(
-    "second_spec_type", ["sliding_window", "full_attention"]
-)
+@pytest.mark.parametrize("second_spec_type", ["sliding_window", "full_attention"])
 def test_prefill_hybrid_model_parametrized(second_spec_type: str):
     """
     Test prefix caching with hybrid model where second spec can be:

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -35,6 +35,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    MambaSpec,
     SlidingWindowSpec,
 )
 
@@ -101,8 +102,47 @@ def make_kv_cache_config(block_size: int, num_blocks: int) -> KVCacheConfig:
 
 
 def make_kv_cache_config_hybrid_model(
-    block_size: int, num_blocks: int
+    block_size: int, num_blocks: int, second_spec_type: str = "sliding_window"
 ) -> KVCacheConfig:
+    if second_spec_type == "sliding_window":
+        second_spec = SlidingWindowSpec(
+            block_size, 1, 1, torch.float32, sliding_window=2 * block_size
+        )
+    elif second_spec_type == "full_attention":
+        second_spec = FullAttentionSpec(block_size, 2, 1, torch.float32)
+
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer1"],
+                FullAttentionSpec(block_size, 1, 1, torch.float32),
+            ),
+            KVCacheGroupSpec(
+                ["layer2"],
+                second_spec,
+            ),
+            KVCacheGroupSpec(
+                ["layer3"],
+                second_spec,
+            ),
+        ],
+    )
+
+
+def make_kv_cache_config_three_types(
+    block_size: int, num_blocks: int, third_spec_type: str = "mamba"
+) -> KVCacheConfig:
+    if third_spec_type == "mamba":
+        third_spec = MambaSpec(block_size, 1, 1, torch.float32)
+    elif third_spec_type == "sliding_window":
+        third_spec = SlidingWindowSpec(
+            block_size, 1, 1, torch.float32, sliding_window=4 * block_size
+        )
+    elif third_spec_type == "full_attention":
+        third_spec = FullAttentionSpec(block_size, 2, 1, torch.float32)
+
     return KVCacheConfig(
         num_blocks=num_blocks,
         kv_cache_tensors=[],
@@ -119,9 +159,7 @@ def make_kv_cache_config_hybrid_model(
             ),
             KVCacheGroupSpec(
                 ["layer3"],
-                SlidingWindowSpec(
-                    block_size, 1, 1, torch.float32, sliding_window=2 * block_size
-                ),
+                third_spec,
             ),
         ],
     )
@@ -404,6 +442,170 @@ def test_prefill_hybrid_model():
         ],
         0,
     )
+
+
+@pytest.mark.parametrize(
+    "second_spec_type", ["sliding_window", "full_attention"]
+)
+def test_prefill_hybrid_model_parametrized(second_spec_type: str):
+    """
+    Test prefix caching with hybrid model where second spec can be:
+    - SlidingWindow (original behavior)
+    - Different FullAttentionSpec (tests multiple FullAttention types)
+    """
+    block_size = 16
+    manager = KVCacheManager(
+        make_kv_cache_config_hybrid_model(block_size, 21, second_spec_type),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    hash_fn = sha256
+
+    # Complete 3 blocks (48 tokens)
+    common_token_ids = [i for i in range(3) for _ in range(block_size)]
+    unique_token_ids = [3] * 7
+    all_token_ids = common_token_ids + unique_token_ids
+
+    req0 = make_request("0", all_token_ids, block_size, hash_fn)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+
+    assert len(req0.block_hashes) == 3
+    assert not computed_blocks.blocks[0]  # No cache hit initially
+    assert num_computed_tokens == 0
+
+    blocks = manager.allocate_slots(
+        req0, 55, len(computed_blocks.blocks[0]) * block_size, computed_blocks
+    )
+    assert blocks is not None
+    # Should have blocks for all 3 groups
+    assert len(blocks.get_block_ids()) == 3
+
+    # Cache hit test
+    req1 = make_request("1", common_token_ids + [4] * 5, block_size, hash_fn)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+
+    # Should hit cached blocks for all 3 groups
+    assert num_computed_tokens == 3 * block_size
+    assert len(computed_blocks.blocks) == 3
+
+    manager.free(req0)
+    manager.free(req1)
+
+
+@pytest.mark.parametrize(
+    "third_spec_type",
+    ["mamba", "sliding_window", "full_attention"],
+)
+def test_prefill_three_spec_types(third_spec_type: str):
+    """
+    Test prefix caching with 3 different KV cache spec types:
+    FullAttention + SlidingWindow + third type (Mamba, different SlidingWindow,
+    or different FullAttention)
+    """
+    block_size = 16
+    manager = KVCacheManager(
+        make_kv_cache_config_three_types(block_size, 31, third_spec_type),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    hash_fn = sha256
+
+    # Complete 3 blocks (48 tokens)
+    common_token_ids = [i for i in range(3) for _ in range(block_size)]
+    unique_token_ids = [3] * 7
+    all_token_ids = common_token_ids + unique_token_ids
+
+    req0 = make_request("0", all_token_ids, block_size, hash_fn)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+
+    assert len(req0.block_hashes) == 3
+    assert not computed_blocks.blocks[0]  # No cache hit initially
+    assert num_computed_tokens == 0
+
+    blocks = manager.allocate_slots(
+        req0, 55, len(computed_blocks.blocks[0]) * block_size, computed_blocks
+    )
+    assert blocks is not None
+    # Should have blocks for all 3 groups
+    assert len(blocks.get_block_ids()) == 3
+
+    # Cache hit test
+    req1 = make_request("1", common_token_ids + [4] * 5, block_size, hash_fn)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+
+    # Should hit cached blocks for all 3 groups
+    assert num_computed_tokens == 3 * block_size
+    assert len(computed_blocks.blocks) == 3
+
+    manager.free(req0)
+    manager.free(req1)
+
+
+def test_interleaved_group_ids():
+    """
+    Test that interleaved group IDs work correctly.
+    Groups 0, 2 are FullAttention; Groups 1, 3 are SlidingWindow
+    """
+    block_size = 16
+    kv_cache_config = KVCacheConfig(
+        num_blocks=50,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer0"],
+                FullAttentionSpec(block_size, 1, 1, torch.float32),
+            ),
+            KVCacheGroupSpec(
+                ["layer1"],
+                SlidingWindowSpec(
+                    block_size, 1, 1, torch.float32, sliding_window=2 * block_size
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer2"],
+                FullAttentionSpec(block_size, 1, 1, torch.float32),
+            ),
+            KVCacheGroupSpec(
+                ["layer3"],
+                SlidingWindowSpec(
+                    block_size, 1, 1, torch.float32, sliding_window=2 * block_size
+                ),
+            ),
+        ],
+    )
+
+    manager = KVCacheManager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    common_token_ids = [i for i in range(3) for _ in range(block_size)]
+    req0 = make_request("0", common_token_ids + [3] * 7, block_size, sha256)
+
+    computed_blocks, _ = manager.get_computed_blocks(req0)
+    blocks = manager.allocate_slots(
+        req0, 55, len(computed_blocks.blocks[0]) * block_size, computed_blocks
+    )
+
+    # Verify blocks are allocated for all 4 groups
+    assert blocks is not None
+    assert len(blocks.get_block_ids()) == 4
+
+    # Verify cache hit works
+    manager.free(req0)
+    req1 = make_request("1", common_token_ids + [4] * 5, block_size, sha256)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+
+    assert num_computed_tokens == 3 * block_size
+    assert len(computed_blocks.blocks) == 4
+
+    manager.free(req1)
 
 
 def test_prefill_plp():

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -507,15 +507,15 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 del group_hit_blocks[num_other_blocks:]
 
         group_ids_to_hit_blocks: dict[int, list[KVCacheBlock]] = {}
-        for group_id, hit_blocks in zip(
+        for group_id, group_hit_blocks in zip(
             self.full_attention_group_ids, hit_blocks_full_attn
         ):
-            group_ids_to_hit_blocks[group_id] = hit_blocks
+            group_ids_to_hit_blocks[group_id] = group_hit_blocks
         for (_, group_ids, _), hit_blocks_other in zip(
             self.other_specs_data, other_hit_blocks
         ):
-            for group_id, hit_blocks in zip(group_ids, hit_blocks_other):
-                group_ids_to_hit_blocks[group_id] = hit_blocks
+            for group_id, group_hit_blocks in zip(group_ids, hit_blocks_other):
+                group_ids_to_hit_blocks[group_id] = group_hit_blocks
 
         hit_blocks = tuple(
             group_ids_to_hit_blocks[group_id]

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -15,6 +15,7 @@ from vllm.v1.core.kv_cache_utils import (
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
     FullAttentionManager,
+    SingleTypeKVCacheManager,
     get_manager_for_kv_cache_spec,
 )
 from vllm.v1.kv_cache_interface import (
@@ -378,7 +379,9 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         full_attention_spec: FullAttentionSpec | None = None
         self.full_attention_group_ids: list[int] = []
 
-        other_specs_map: dict[KVCacheSpec, tuple[list[int], type]] = {}
+        other_specs_map: dict[
+            KVCacheSpec, tuple[list[int], type[SingleTypeKVCacheManager]]
+        ] = {}
         for i, g in enumerate(self.kv_cache_config.kv_cache_groups):
             if isinstance(g.kv_cache_spec, FullAttentionSpec):
                 if full_attention_spec is None:


### PR DESCRIPTION
## Purpose

The current `HybridKVCacheConnector` limits the KV cache specs to exactly two types, with one being full attention and the second non-full attention (sliding window, mamba, ...).

Some of the models released by NVIDIA have more than 2 types (with at least one full attention), like vGQA (different number of KV heads per layer)

Currently, we must disable prefix caching when running these models in vLLM. This PR enables automatic prefix caching for such models, by updating the `HybridKVCacheCoordinator`, such that it accepts at least one full attention KV cache spec, plus at least one other spec - which could be full attention as well, but must have a different spec - and similarly to how it is today, finds the shortest cache hit and returns it, but this time with multiple "other" KV cache specs. We also don't force an order between the different KV cache specs (all full attention together up front, for example).

## Test Plan

Current tests pass. Add new tests and parametrize existing ones, to accept more than 2 different KV cache specs.

## Test Result

All tests pass


## Performance:

Running the server on an H100 GPU with vllm serve nvidia/NVIDIA-Nemotron-Nano-9B-v2 --trust-remote-code, I got the following results.
GSM8K was ran with lm_eval --model local-completions --tasks gsm8k --model_args "model=nvidia/NVIDIA-Nemotron-Nano-9B-v2,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=4,max_retries=3,tokenized_requests=False" --cache_requests true --batch_size 256.
E2E with vllm bench serve --backend vllm --model nvidia/NVIDIA-Nemotron-Nano-9B-v2 --endpoint /v1/completions --dataset-name random --num-prompts 10.

Branch:
GSM8K:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6922|±  |0.0127|
|     |       |strict-match    |     5|exact_match|↑  |0.7293|±  |0.0122|
```
E2E:
```
============ Serving Benchmark Result ============
Successful requests:                     10
Failed requests:                         0
Benchmark duration (s):                  1.52
Total input tokens:                      10230
Total generated tokens:                  1280
Request throughput (req/s):              6.58
Output token throughput (tok/s):         842.86
Peak output token throughput (tok/s):    749.00
Peak concurrent requests:                10.00
Total Token throughput (tok/s):          7579.13
---------------Time to First Token----------------
Mean TTFT (ms):                          241.87
Median TTFT (ms):                        256.37
P99 TTFT (ms):                           290.43
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.98
Median TPOT (ms):                        9.87
P99 TPOT (ms):                           11.33
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.98
Median ITL (ms):                         9.65
P99 ITL (ms):                            10.11
==================================================
```
Main:
GSM8K:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6869|±  |0.0128|
|     |       |strict-match    |     5|exact_match|↑  |0.7255|±  |0.0123|
```
E2E:
```
============ Serving Benchmark Result ============
Successful requests:                     10
Failed requests:                         0
Benchmark duration (s):                  1.51
Total input tokens:                      10230
Total generated tokens:                  1280
Request throughput (req/s):              6.62
Output token throughput (tok/s):         847.47
Peak output token throughput (tok/s):    749.00
Peak concurrent requests:                10.00
Total Token throughput (tok/s):          7620.57
---------------Time to First Token----------------
Mean TTFT (ms):                          241.51
Median TTFT (ms):                        256.27
P99 TTFT (ms):                           290.44
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.92
Median TPOT (ms):                        9.81
P99 TPOT (ms):                           11.27
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.92
Median ITL (ms):                         9.60
P99 ITL (ms):                            10.03
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

