### PR TITLE
Fix 500 /tokenize errors and 400 v1/chat/completions errors when using truncate_prompt_tokens and sending /tokenize and v1/chat/completions requests under high concurrency

### DIFF
--- a/tests/entrypoints/openai/test_serving_engine.py
+++ b/tests/entrypoints/openai/test_serving_engine.py
@@ -25,6 +25,7 @@ def serving() -> OpenAIServing:
     models.model_config = model_config
     models.input_processor = Mock()
     models.io_processor = Mock()
+    models.async_tokenizer_pool = {}
 
     serving = OpenAIServing(
         engine_client=engine_client,

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -286,7 +286,7 @@ class OpenAIServing:
             apply_mistral_chat_template, executor=self._tokenizer_executor
         )
 
-        self._async_tokenizer_pool: dict[TokenizerLike, AsyncMicrobatchTokenizer] = {}
+        self._async_tokenizer_pool = models.async_tokenizer_pool
         self.log_error_stack = log_error_stack
 
         self.input_processor = self.models.input_processor

--- a/vllm/entrypoints/openai/serving_models.py
+++ b/vllm/entrypoints/openai/serving_models.py
@@ -19,6 +19,8 @@ from vllm.entrypoints.openai.protocol import (
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.lora.resolver import LoRAResolver, LoRAResolverRegistry
+from vllm.tokenizers import TokenizerLike
+from vllm.utils.async_utils import AsyncMicrobatchTokenizer
 from vllm.utils.counter import AtomicCounter
 
 logger = init_logger(__name__)
@@ -73,6 +75,8 @@ class OpenAIServingModels:
         self.io_processor = self.engine_client.io_processor
         self.model_config = self.engine_client.model_config
         self.max_model_len = self.model_config.max_model_len
+
+        self.async_tokenizer_pool: dict[TokenizerLike, AsyncMicrobatchTokenizer] = {}
 
     async def init_static_loras(self):
         """Loads all static LoRA modules.


### PR DESCRIPTION
- When sending /tokenize and /v1/chat/completions (with truncate_prompt_tokens) we can randomly get the following errors:

```
"POST /v1/chat/completions HTTP/1.1" 400 Bad Request (caused by RuntimeError: Already borrowed at self._tokenizer.enable_truncation)

and

"POST /tokenize HTTP/1.1" 500 Internal Server Error
```

- This is caused by each endpoint using the same huggingface tokenizer, when /v1/chat/completions tries to change the tokenizer’s truncation state while the /tokenize endpoint is using it, we get the "RuntimeError: Already borrowed" error. This PR fixes this by using a shared tokenizer pool between /tokenize and /v1/chat/completions