### PR TITLE
[Bugfix] Fix DeepGEMM after #29546 

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -30,6 +30,7 @@ from vllm.model_executor.parameter import (
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.deep_gemm import (
+    DeepGemmQuantScaleFMT,
     fp8_gemm_nt,
     is_deep_gemm_e8m0_used,
     is_deep_gemm_supported,
@@ -269,7 +270,7 @@ class W8A8BlockFp8LinearOp:
         weight_scale: torch.Tensor,
     ) -> torch.Tensor:
         assert self.deepgemm_input_quant_op is not None
-        if self.use_deep_gemm_e8m0:
+        if DeepGemmQuantScaleFMT.from_oracle() == DeepGemmQuantScaleFMT.UE8M0:
             q_input, input_scale = per_token_group_quant_fp8_packed_for_deepgemm(
                 input_2d,
                 group_size=self.act_quant_group_shape.col,

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -269,7 +269,6 @@ class W8A8BlockFp8LinearOp:
         weight: torch.Tensor,
         weight_scale: torch.Tensor,
     ) -> torch.Tensor:
-        assert self.deepgemm_input_quant_op is not None
         if DeepGemmQuantScaleFMT.from_oracle() == DeepGemmQuantScaleFMT.UE8M0:
             q_input, input_scale = per_token_group_quant_fp8_packed_for_deepgemm(
                 input_2d,
@@ -277,6 +276,7 @@ class W8A8BlockFp8LinearOp:
                 use_ue8m0=True,
             )
         else:
+            assert self.deepgemm_input_quant_op is not None
             q_input, input_scale = self.deepgemm_input_quant_op(input_2d)
         output = torch.empty(
             (q_input.shape[0], weight.shape[0]),

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -269,11 +269,14 @@ class W8A8BlockFp8LinearOp:
         weight_scale: torch.Tensor,
     ) -> torch.Tensor:
         assert self.deepgemm_input_quant_op is not None
-        q_input, input_scale = per_token_group_quant_fp8_packed_for_deepgemm(
-            input_2d,
-            group_size=self.act_quant_group_shape.col,
-            use_ue8m0=self.use_deep_gemm_e8m0,
-        )
+        if self.use_deep_gemm_e8m0:
+            q_input, input_scale = per_token_group_quant_fp8_packed_for_deepgemm(
+                input_2d,
+                group_size=self.act_quant_group_shape.col,
+                use_ue8m0=True,
+            )
+        else:
+            q_input, input_scale = self.deepgemm_input_quant_op(input_2d)
         output = torch.empty(
             (q_input.shape[0], weight.shape[0]),
             dtype=torch.bfloat16,

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -272,7 +272,7 @@ class W8A8BlockFp8LinearOp:
         q_input, input_scale = per_token_group_quant_fp8_packed_for_deepgemm(
             input_2d,
             group_size=self.act_quant_group_shape.col,
-            use_ue8m0=True,
+            use_ue8m0=self.use_deep_gemm_e8m0,
         )
         output = torch.empty(
             (q_input.shape[0], weight.shape[0]),

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -399,6 +399,7 @@ def should_use_deepgemm_for_fp8_linear_for_nk(
 
 __all__ = [
     "calc_diff",
+    "DeepGemmQuantScaleFMT",
     "fp8_gemm_nt",
     "m_grouped_fp8_gemm_nt_contiguous",
     "fp8_m_grouped_gemm_nt_masked",


### PR DESCRIPTION
## Purpose
Fixed hopper incompatibility after #29546: `_run_deepgemm` method was changed to always use
  `per_token_group_quant_fp8_packed_for_deepgemm`, which produces packed int32 scales, and the format is only supported on Blackwell:
```

2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]     return self.w8a8_block_fp8_linear.apply(
-- | --
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/utils/fp8_utils.py", line 255, in apply
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]     output = self._run_deepgemm(input_2d, weight, weight_scale)
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/utils/fp8_utils.py", line 282, in _run_deepgemm
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]     torch.ops.vllm.fp8_gemm_nt_op(
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1255, in __call__
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]     return self._op(*args, **kwargs)
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]            ^^^^^^^^^^^^^^^^^^^^^^^^^
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/utils/fp8_utils.py", line 170, in _fp8_gemm_nt_op
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]     fp8_gemm_nt(
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]   File "/usr/local/lib/python3.12/dist-packages/vllm/utils/deep_gemm.py", line 186, in fp8_gemm_nt
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]     return _fp8_gemm_nt_impl(*args, disable_ue8m0_cast=not use_ue8m0, **kwargs)
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-12-08 07:48:29 UTC | (Worker_DP1_TP0_EP2 pid=918) ERROR 12-07 23:48:29 [multiproc_executor.py:822] RuntimeError: Assertion error (csrc/apis/../jit_kernels/impls/../heuristics/../../utils/layout.hpp:49): sfa_dtype == torch::kFloat and sfb_dtype == torch::kFloat
```

## Test Plan
Passed CI: https://buildkite.com/vllm/ci/builds/42493#019aff0f-8d6e-4499-907f-010fc5594fc7

