### PR TITLE
Add `moe_align_block_size_no_permute` for small batch size with large num_expert

### DIFF
--- a/csrc/moe/moe_align_sum_kernels.cu
+++ b/csrc/moe/moe_align_sum_kernels.cu
@@ -312,21 +312,16 @@ __global__ void moe_align_block_size_small_batch_expert_kernel(
 template <typename scalar_t>
 __global__ void moe_align_block_size_no_permute(
     const scalar_t* __restrict__ topk_ids,
-    int32_t* __restrict__ sorted_token_ids, 
-    int32_t* __restrict__ expert_ids,
-    int32_t* __restrict__ total_tokens_post_pad, 
-    int32_t num_experts,
-    int32_t block_size,
-    size_t numel, 
-    int32_t max_num_tokens_padded) {
-
+    int32_t* __restrict__ sorted_token_ids, int32_t* __restrict__ expert_ids,
+    int32_t* __restrict__ total_tokens_post_pad, int32_t num_experts,
+    int32_t block_size, size_t numel, int32_t max_num_tokens_padded) {
   const size_t tid = threadIdx.x;
   const size_t stride = blockDim.x;
 
   for (size_t it = tid; it < max_num_tokens_padded; it += stride) {
     sorted_token_ids[it] = numel;
   }
-  
+
   if (tid == 0) {
     *total_tokens_post_pad = numel * block_size;
   }
@@ -381,16 +376,14 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
 
         if (no_permute_mode) {
           const int32_t threads = 256;
-          auto no_permute_kernel = vllm::moe::moe_align_block_size_no_permute<scalar_t>;
+          auto no_permute_kernel =
+              vllm::moe::moe_align_block_size_no_permute<scalar_t>;
           no_permute_kernel<<<1, threads, 0, stream>>>(
               topk_ids.data_ptr<scalar_t>(),
               sorted_token_ids.data_ptr<int32_t>(),
               experts_ids.data_ptr<int32_t>(),
-              num_tokens_post_pad.data_ptr<int32_t>(), 
-              num_experts,
-              block_size,
-              topk_ids.numel(),
-              sorted_token_ids.size(0));
+              num_tokens_post_pad.data_ptr<int32_t>(), num_experts, block_size,
+              topk_ids.numel(), sorted_token_ids.size(0));
         } else if (small_batch_expert_mode) {
           const int32_t threads = max((int32_t)num_experts, WARP_SIZE);
           const int32_t shared_mem_size =

--- a/csrc/moe/moe_align_sum_kernels.cu
+++ b/csrc/moe/moe_align_sum_kernels.cu
@@ -370,7 +370,10 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
   VLLM_DISPATCH_INTEGRAL_AND_UNSIGNED_TYPES(
       topk_ids.scalar_type(), "moe_align_block_size_kernel", [&] {
         // calc needed amount of shared mem for `cumsum` tensors
-        bool no_permute_mode = (topk_ids.numel() * 4 <= num_experts) && !has_expert_map;
+        constexpr int NO_PERMUTE_MODE_EXPERT_FACTOR = 4;
+        bool no_permute_mode =
+            (topk_ids.numel() * NO_PERMUTE_MODE_EXPERT_FACTOR <= num_experts) &&
+            !has_expert_map;
         bool small_batch_expert_mode =
             (topk_ids.numel() < 1024) && (num_experts <= 64);
 

--- a/csrc/moe/moe_align_sum_kernels.cu
+++ b/csrc/moe/moe_align_sum_kernels.cu
@@ -370,7 +370,7 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
   VLLM_DISPATCH_INTEGRAL_AND_UNSIGNED_TYPES(
       topk_ids.scalar_type(), "moe_align_block_size_kernel", [&] {
         // calc needed amount of shared mem for `cumsum` tensors
-        bool no_permute_mode = (topk_ids.numel() * 4 <= num_experts);
+        bool no_permute_mode = (topk_ids.numel() * 4 <= num_experts) && !has_expert_map;
         bool small_batch_expert_mode =
             (topk_ids.numel() < 1024) && (num_experts <= 64);
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
This PR enhances the fused MoE implementation by adding `moe_align_block_size_no_permute` kernel. It introduces a small-batch fallback path designed for models with large numbers of experts, where the regular kernel becomes inefficient. For these regimes, the new path provides a speed-up by reducing unnecessary data movement and improving kernel efficiency for low-token workloads.
## Test Result

### Benchmark: Llama-4-Maverick-17B-128E (TP = 8)

Command:
```bash
python3 benchmarks/kernels/benchmark_moe.py \
  --model meta-llama/Llama-4-Maverick-17B-128E-Instruct \
  --tp-size 8
```

Results:
| M  | with permute (µs) | without permute (µs) | speed-up |
|----|-------------------|-----------------------|----------|
| 1  | 33.14             | 29.56                 | **-12.11%** |
| 2  | 36.05             | 32.73                 | **-10.14%** |
| 4  | 49.42             | 46.22                | **-6.92%** |
| 8  | 76.77             | 73.2                 | **-4.88%**  |
| 16 | 136.29           | 132.32                | **-3.00%**  |
| 24 | 183.81            | 178.01                | **-3.26%**  |
| 32 | 234.63            | 228.54                | **-2.66%**  |
| 48 | 309.59            | 309.73                | 0.05%    |
| 64 | 382.59            | 382.68                | 0.02%    |
| 96 | 513.39            | 512.00                | -0.27%   |

### Benchmark: DeepSeek-R1 (TP = 8)

Command:
```bash
python3 benchmarks/kernels/benchmark_moe.py \
  --model deepseek-ai/DeepSeek-R1 \
  --tp-size 8
```

Results:
| M  | with permute (µs) | without permute (µs) | speed-up |
|----|-------------------|-----------------------|----------|
| 1  | 70.69             | 65.53                 | **-6.25%**  |
| 2  | 83.58            | 80.34                 | **-4.03%** |
| 4  | 112.80            | 110.32                | **-2.25%** |
| 8  | 171.68            | 172.13                | 0.2%          |
| 16 | 338.09            | 338.50                | 0.12%       |

### Benchmark: Qwen3-Coder-480B-A35B-Instruct-FP8 (TP = 8)

Command:
```bash
python3 benchmarks/kernels/benchmark_moe.py \
  --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 \
  --tp-size 8
```

Results
| M  | with permute (µs) | without permute (µs) | speed-up |
|----|-------------------|-----------------------|----------|
| 1  | 69.76            | 66.06                 | **-5.60%**  |
| 2  | 85.90            | 82.24                 | **-4.45%** |
| 4  | 116.18            | 114.19                | **-1.74%** |
| 8  | 176.28            |176.36                 | 0.004%  |
| 16 | 340.01            | 343.42                | -0.01%     |

### Benchmark: GPT-OSS-120B (TP = 4)

Command:
```bash
python3 benchmarks/kernels/benchmark_moe.py \
  --model openai/gpt-oss-120b \
  --tp-size 4
```

Results:
| M  | with permute (µs) | without permute (µs) | speed-up |
|----|-------------------|-----------------------|----------|
| 1  | 49.55             | 46.41                 | **-6.77%** |
| 2  | 68.18             | 65.01                 | **-4.88%**  |
| 4  | 120.50            | 118.2                | **-1.95%**  |
| 8  | 227.08            | 227.45                | 0.16%       |
| 16 | 322.53            | 322.60                | 0.02%       |



Accuracy:
Pass pytest:
```
pytest tests/kernels/moe/test_moe.py::test_fused_moe
```

---

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

