### PR TITLE
Ensure minimum frames for GLM 4.6V compatibility

### DIFF
--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -1257,6 +1257,7 @@ class Glm4vDummyInputsBuilder(BaseDummyInputsBuilder[Glm4vProcessingInfo]):
                     )
                 height = min(height, overrides.height)
 
+        num_frames = max(num_frames, 2)  # GLM 4.6V requires 2 frames
         video = np.full((num_frames, width, height, 3), 255, dtype=np.uint8)
         video_items = []
         for i in range(num_videos):


### PR DESCRIPTION
Fix for startup video generation of 1 frame that causes issue with GLM 4.6V-FP8: ` (EngineCore_DP0 pid=1037) INFO 12-08 23:30:53 [core.py:93] Initializing a V1 LLM engine (v0.12.0) with config: model='zai-org/GLM-4.6V-FP8', speculative_config=None, tokenizer='zai-org/GLM-4.6V-FP8', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=8192, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=compressed-tensors, enforce_eager=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01), seed=0, served_model_name=zai-org/GLM-4.6V-FP8, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer'], 'compile_mm_encoder': False, 'compile_sizes': [], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>}, 'local_cache_dir': None} (EngineCore_DP0 pid=1037) [2025-12-08 23:30:53] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/zai-org/GLM-4.6V-FP8/tree/main?recursive=true&expand=false "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:53] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/tokenizer_config.json "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:53] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/tokenizer_config.json "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:53] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/tokenizer.json "HTTP/1.1 302 Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:54] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/zai-org/GLM-4.6V-FP8/tree/main/additional_chat_templates?recursive=false&expand=false "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:54] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/zai-org/GLM-4.6V-FP8/tree/main?recursive=true&expand=false "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:54] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/zai-org/GLM-4.6V-FP8 "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:55] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/zai-org/GLM-4.6V-FP8/tree/main?recursive=true&expand=false "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) INFO 12-08 23:30:55 [parallel_state.py:1200] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://192.168.1.73:56699 backend=nccl (EngineCore_DP0 pid=1037) INFO 12-08 23:30:55 [parallel_state.py:1408] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0 (EngineCore_DP0 pid=1037) [2025-12-08 23:30:55] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/processor_config.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:55] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/preprocessor_config.json "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:55] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/preprocessor_config.json "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:55] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/processor_config.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:55] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/preprocessor_config.json "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:55] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/preprocessor_config.json "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:55] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/processor_config.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:56] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/preprocessor_config.json "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:56] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/preprocessor_config.json "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) Using a slow image processor as use_fast is unset and a slow processor was saved with this model. use_fast=True will be the default behavior in v4.52, even if the model was saved with a slow processor. This will result in minor differences in outputs. You'll still be able to use a slow processor with use_fast=False. (EngineCore_DP0 pid=1037) [2025-12-08 23:30:56] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/tokenizer_config.json "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:56] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/tokenizer_config.json "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:56] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/tokenizer.json "HTTP/1.1 302 Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:56] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/zai-org/GLM-4.6V-FP8/tree/main/additional_chat_templates?recursive=false&expand=false "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:56] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/zai-org/GLM-4.6V-FP8/tree/main?recursive=true&expand=false "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:56] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/zai-org/GLM-4.6V-FP8 "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:57] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/processor_config.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:57] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/video_preprocessor_config.json "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:57] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/video_preprocessor_config.json "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:57] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/preprocessor_config.json "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:57] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/preprocessor_config.json "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:57] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/zai-org/GLM-4.6V-FP8/tree/main/additional_chat_templates?recursive=false&expand=false "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:57] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/processor_config.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:57] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/chat_template.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:57] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/chat_template.jinja "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:57] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/chat_template.jinja "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:57] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/audio_tokenizer_config.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:58] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/processor_config.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:58] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/preprocessor_config.json "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:58] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/preprocessor_config.json "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:58] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/processor_config.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:58] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/preprocessor_config.json "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:58] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/preprocessor_config.json "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:58] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/processor_config.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:58] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/preprocessor_config.json "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:58] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/preprocessor_config.json "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:58] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/tokenizer_config.json "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:58] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/tokenizer_config.json "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:59] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/tokenizer.json "HTTP/1.1 302 Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:59] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/zai-org/GLM-4.6V-FP8/tree/main/additional_chat_templates?recursive=false&expand=false "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:59] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/zai-org/GLM-4.6V-FP8/tree/main?recursive=true&expand=false "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:30:59] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/zai-org/GLM-4.6V-FP8 "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:31:01] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/processor_config.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:31:01] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/video_preprocessor_config.json "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:31:01] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/video_preprocessor_config.json "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:31:01] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/preprocessor_config.json "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:31:01] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/preprocessor_config.json "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:31:01] INFO _client.py:1025: HTTP Request: GET https://huggingface.co/api/models/zai-org/GLM-4.6V-FP8/tree/main/additional_chat_templates?recursive=false&expand=false "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:31:01] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/processor_config.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:31:01] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/chat_template.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) [2025-12-08 23:31:01] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/chat_template.jinja "HTTP/1.1 307 Temporary Redirect" (EngineCore_DP0 pid=1037) [2025-12-08 23:31:01] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/zai-org/GLM-4.6V-FP8/51d11a82928689d2e94aed779f2926c5a5cb4dbe/chat_template.jinja "HTTP/1.1 200 OK" (EngineCore_DP0 pid=1037) [2025-12-08 23:31:02] INFO _client.py:1025: HTTP Request: HEAD https://huggingface.co/zai-org/GLM-4.6V-FP8/resolve/main/audio_tokenizer_config.json "HTTP/1.1 404 Not Found" (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] EngineCore failed to start. (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] Traceback (most recent call last): (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1115, in call_hf_processor (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] output = hf_processor(**data, **allowed_kwargs, return_tensors="pt") (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/transformers/models/glm46v/processing_glm46v.py", line 131, in __call__ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] videos_inputs = self.video_processor(videos=videos, **output_kwargs["videos_kwargs"]) (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/transformers/video_processing_utils.py", line 208, in __call__ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] return self.preprocess(videos, **kwargs) (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/transformers/video_processing_utils.py", line 399, in preprocess (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] preprocessed_videos = self._preprocess(videos=videos, **kwargs) (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/transformers/models/glm46v/video_processing_glm46v.py", line 206, in _preprocess (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] resized_height, resized_width = smart_resize( (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/transformers/models/glm46v/image_processing_glm46v.py", line 76, in smart_resize (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] raise ValueError(f"t:{num_frames} must be larger than temporal_factor:{temporal_factor}") (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ValueError: t:1 must be larger than temporal_factor:2 (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] The above exception was the direct cause of the following exception: (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] Traceback (most recent call last): (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/core.py", line 834, in run_engine_core (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] engine_core = EngineCoreProc(*args, **kwargs) (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/core.py", line 610, in __init__ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] super().__init__( (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/core.py", line 102, in __init__ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] self.model_executor = executor_class(vllm_config) (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/executor/abstract.py", line 101, in __init__ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] self._init_executor() (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/executor/uniproc_executor.py", line 47, in _init_executor (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] self.driver_worker.init_device() (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/worker/worker_base.py", line 326, in init_device (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] self.worker.init_device() # type: ignore (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/worker/gpu_worker.py", line 262, in init_device (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] self.model_runner = GPUModelRunner(self.vllm_config, self.device) (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/worker/gpu_model_runner.py", line 557, in __init__ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] MultiModalBudget( (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/worker/utils.py", line 42, in __init__ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] max_tokens_by_modality = mm_registry.get_max_tokens_per_item_by_modality( (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/registry.py", line 167, in get_max_tokens_per_item_by_modality (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] return profiler.get_mm_max_contiguous_tokens( (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/profiling.py", line 369, in get_mm_max_contiguous_tokens (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] return self._get_mm_max_tokens(seq_len, mm_counts, mm_embeddings_only=False) (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/profiling.py", line 351, in _get_mm_max_tokens (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] mm_inputs = self._get_dummy_mm_inputs(seq_len, mm_counts) (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/profiling.py", line 267, in _get_dummy_mm_inputs (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] return self.processor.apply( (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 2133, in apply (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ) = self._cached_apply_hf_processor( (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1915, in _cached_apply_hf_processor (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ) = self._apply_hf_processor_main( (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1652, in _apply_hf_processor_main (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] mm_processed_data = self._apply_hf_processor_mm_only( (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1610, in _apply_hf_processor_mm_only (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] _, mm_processed_data, _ = self._apply_hf_processor_text_mm( (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1537, in _apply_hf_processor_text_mm (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] processed_data = self._call_hf_processor( (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/model_executor/models/glm4_1v.py", line 1325, in _call_hf_processor (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] video_outputs = super()._call_hf_processor( (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1497, in _call_hf_processor (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] return self.info.ctx.call_hf_processor( (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1144, in call_hf_processor (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] raise ValueError(msg) from exc (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ValueError: Failed to apply Glm46VProcessor on data={'text': '<|begin_of_video|><|video|><|end_of_video|>', 'videos': [[array([[[[255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ..., (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255]], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [[255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ..., (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255]], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [[255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ..., (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255]], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ..., (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [[255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ..., (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255]], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [[255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ..., (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255]], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [[255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] ..., (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255], (EngineCore_DP0 pid=1037) ERROR 12-08 23:31:02 [core.py:843] [255, 255, 255]]]], shape=(1, 1708, 1708, 3), dtype=uint8)]], 'video_metadata': [[VideoMetadata(total_num_frames=1, fps=2.0, width=None, height=None, duration=0.5, video_backend='opencv', frames_indices=[0])]]} with kwargs={'do_sample_frames': False, 'truncation': False} (EngineCore_DP0 pid=1037) Process EngineCore_DP0: (EngineCore_DP0 pid=1037) Traceback (most recent call last): (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1115, in call_hf_processor (EngineCore_DP0 pid=1037) output = hf_processor(**data, **allowed_kwargs, return_tensors="pt") (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/transformers/models/glm46v/processing_glm46v.py", line 131, in __call__ (EngineCore_DP0 pid=1037) videos_inputs = self.video_processor(videos=videos, **output_kwargs["videos_kwargs"]) (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/transformers/video_processing_utils.py", line 208, in __call__ (EngineCore_DP0 pid=1037) return self.preprocess(videos, **kwargs) (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/transformers/video_processing_utils.py", line 399, in preprocess (EngineCore_DP0 pid=1037) preprocessed_videos = self._preprocess(videos=videos, **kwargs) (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/transformers/models/glm46v/video_processing_glm46v.py", line 206, in _preprocess (EngineCore_DP0 pid=1037) resized_height, resized_width = smart_resize( (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/transformers/models/glm46v/image_processing_glm46v.py", line 76, in smart_resize (EngineCore_DP0 pid=1037) raise ValueError(f"t:{num_frames} must be larger than temporal_factor:{temporal_factor}") (EngineCore_DP0 pid=1037) ValueError: t:1 must be larger than temporal_factor:2 (EngineCore_DP0 pid=1037) (EngineCore_DP0 pid=1037) The above exception was the direct cause of the following exception: (EngineCore_DP0 pid=1037) (EngineCore_DP0 pid=1037) Traceback (most recent call last): (EngineCore_DP0 pid=1037) File "/usr/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap (EngineCore_DP0 pid=1037) self.run() (EngineCore_DP0 pid=1037) File "/usr/lib/python3.11/multiprocessing/process.py", line 108, in run (EngineCore_DP0 pid=1037) self._target(*self._args, **self._kwargs) (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/core.py", line 847, in run_engine_core (EngineCore_DP0 pid=1037) raise e (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/core.py", line 834, in run_engine_core (EngineCore_DP0 pid=1037) engine_core = EngineCoreProc(*args, **kwargs) (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/core.py", line 610, in __init__ (EngineCore_DP0 pid=1037) super().__init__( (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/core.py", line 102, in __init__ (EngineCore_DP0 pid=1037) self.model_executor = executor_class(vllm_config) (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/executor/abstract.py", line 101, in __init__ (EngineCore_DP0 pid=1037) self._init_executor() (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/executor/uniproc_executor.py", line 47, in _init_executor (EngineCore_DP0 pid=1037) self.driver_worker.init_device() (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/worker/worker_base.py", line 326, in init_device (EngineCore_DP0 pid=1037) self.worker.init_device() # type: ignore (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/worker/gpu_worker.py", line 262, in init_device (EngineCore_DP0 pid=1037) self.model_runner = GPUModelRunner(self.vllm_config, self.device) (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/worker/gpu_model_runner.py", line 557, in __init__ (EngineCore_DP0 pid=1037) MultiModalBudget( (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/worker/utils.py", line 42, in __init__ (EngineCore_DP0 pid=1037) max_tokens_by_modality = mm_registry.get_max_tokens_per_item_by_modality( (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/registry.py", line 167, in get_max_tokens_per_item_by_modality (EngineCore_DP0 pid=1037) return profiler.get_mm_max_contiguous_tokens( (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/profiling.py", line 369, in get_mm_max_contiguous_tokens (EngineCore_DP0 pid=1037) return self._get_mm_max_tokens(seq_len, mm_counts, mm_embeddings_only=False) (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/profiling.py", line 351, in _get_mm_max_tokens (EngineCore_DP0 pid=1037) mm_inputs = self._get_dummy_mm_inputs(seq_len, mm_counts) (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/profiling.py", line 267, in _get_dummy_mm_inputs (EngineCore_DP0 pid=1037) return self.processor.apply( (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 2133, in apply (EngineCore_DP0 pid=1037) ) = self._cached_apply_hf_processor( (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1915, in _cached_apply_hf_processor (EngineCore_DP0 pid=1037) ) = self._apply_hf_processor_main( (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1652, in _apply_hf_processor_main (EngineCore_DP0 pid=1037) mm_processed_data = self._apply_hf_processor_mm_only( (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1610, in _apply_hf_processor_mm_only (EngineCore_DP0 pid=1037) _, mm_processed_data, _ = self._apply_hf_processor_text_mm( (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1537, in _apply_hf_processor_text_mm (EngineCore_DP0 pid=1037) processed_data = self._call_hf_processor( (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/model_executor/models/glm4_1v.py", line 1325, in _call_hf_processor (EngineCore_DP0 pid=1037) video_outputs = super()._call_hf_processor( (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1497, in _call_hf_processor (EngineCore_DP0 pid=1037) return self.info.ctx.call_hf_processor( (EngineCore_DP0 pid=1037) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (EngineCore_DP0 pid=1037) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/multimodal/processing.py", line 1144, in call_hf_processor (EngineCore_DP0 pid=1037) raise ValueError(msg) from exc (EngineCore_DP0 pid=1037) ValueError: Failed to apply Glm46VProcessor on data={'text': '<|begin_of_video|><|video|><|end_of_video|>', 'videos': [[array([[[[255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) ..., (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255]], (EngineCore_DP0 pid=1037) (EngineCore_DP0 pid=1037) [[255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) ..., (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255]], (EngineCore_DP0 pid=1037) (EngineCore_DP0 pid=1037) [[255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) ..., (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255]], (EngineCore_DP0 pid=1037) (EngineCore_DP0 pid=1037) ..., (EngineCore_DP0 pid=1037) (EngineCore_DP0 pid=1037) [[255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) ..., (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255]], (EngineCore_DP0 pid=1037) (EngineCore_DP0 pid=1037) [[255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) ..., (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255]], (EngineCore_DP0 pid=1037) (EngineCore_DP0 pid=1037) [[255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) ..., (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255], (EngineCore_DP0 pid=1037) [255, 255, 255]]]], shape=(1, 1708, 1708, 3), dtype=uint8)]], 'video_metadata': [[VideoMetadata(total_num_frames=1, fps=2.0, width=None, height=None, duration=0.5, video_backend='opencv', frames_indices=[0])]]} with kwargs={'do_sample_frames': False, 'truncation': False} [rank0]:[W1208 23:31:03.632647966 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator()) (APIServer pid=999) Traceback (most recent call last): (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/bin/vllm", line 8, in <module> (APIServer pid=999) sys.exit(main()) (APIServer pid=999) ^^^^^^ (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/entrypoints/cli/main.py", line 73, in main (APIServer pid=999) args.dispatch_function(args) (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/entrypoints/cli/serve.py", line 60, in cmd (APIServer pid=999) uvloop.run(run_server(args)) (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/uvloop/__init__.py", line 92, in run (APIServer pid=999) return runner.run(wrapper()) (APIServer pid=999) ^^^^^^^^^^^^^^^^^^^^^ (APIServer pid=999) File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run (APIServer pid=999) return self._loop.run_until_complete(task) (APIServer pid=999) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (APIServer pid=999) File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/uvloop/__init__.py", line 48, in wrapper (APIServer pid=999) return await main (APIServer pid=999) ^^^^^^^^^^ (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 1819, in run_server (APIServer pid=999) await run_server_worker(listen_address, sock, args, **uvicorn_kwargs) (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 1838, in run_server_worker (APIServer pid=999) async with build_async_engine_client( (APIServer pid=999) File "/usr/lib/python3.11/contextlib.py", line 204, in __aenter__ (APIServer pid=999) return await anext(self.gen) (APIServer pid=999) ^^^^^^^^^^^^^^^^^^^^^ (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 183, in build_async_engine_client (APIServer pid=999) async with build_async_engine_client_from_engine_args( (APIServer pid=999) File "/usr/lib/python3.11/contextlib.py", line 204, in __aenter__ (APIServer pid=999) return await anext(self.gen) (APIServer pid=999) ^^^^^^^^^^^^^^^^^^^^^ (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 224, in build_async_engine_client_from_engine_args (APIServer pid=999) async_llm = AsyncLLM.from_vllm_config( (APIServer pid=999) ^^^^^^^^^^^^^^^^^^^^^^^^^^ (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 223, in from_vllm_config (APIServer pid=999) return cls( (APIServer pid=999) ^^^^ (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/async_llm.py", line 134, in __init__ (APIServer pid=999) self.engine_core = EngineCoreClient.make_async_mp_client( (APIServer pid=999) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 121, in make_async_mp_client (APIServer pid=999) return AsyncMPClient(*client_args) (APIServer pid=999) ^^^^^^^^^^^^^^^^^^^^^^^^^^^ (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 810, in __init__ (APIServer pid=999) super().__init__( (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/core_client.py", line 471, in __init__ (APIServer pid=999) with launch_core_engines(vllm_config, executor_class, log_stats) as ( (APIServer pid=999) File "/usr/lib/python3.11/contextlib.py", line 144, in __exit__ (APIServer pid=999) next(self.gen) (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/utils.py", line 903, in launch_core_engines (APIServer pid=999) wait_for_engine_startup( (APIServer pid=999) File "/root/.local/share/virtualenvs/root-BuDEOXnJ/lib/python3.11/site-packages/vllm/v1/engine/utils.py", line 960, in wait_for_engine_startup (APIServer pid=999) raise RuntimeError( (APIServer pid=999) RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {} root@vllm-glm4:~#`

<!-- markdownlint-disable -->

## Purpose
Fix issue of GLM 4.6V crash on video generation of 1 frame and memory profiling

## Test Plan
Run the vllm serve command
## Test Result
Successful Model output
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [ X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

