### PR TITLE
[Bugfix] Fix compressed-tensors models failing to load with transformers backend

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -136,10 +136,10 @@ class CompressedTensorsConfig(QuantizationConfig):
             return target
 
         def _apply_dict(d: dict) -> dict:
-            return {k: v for t, v in d.items() if (k := _map_target(t))}
+            return {k: v for t, v in d.items() if (k := _map_target(t)) is not None}
 
         def _apply_list(lst: list) -> list:
-            return [t for x in lst if (t := _map_target(x))]
+            return [t for x in lst if (t := _map_target(x)) is not None]
 
         self.target_scheme_map = _apply_dict(self.target_scheme_map)
         self.ignore = _apply_list(self.ignore)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -116,16 +116,37 @@ class CompressedTensorsConfig(QuantizationConfig):
         return "compressed-tensors"
 
     def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):
-        self.target_scheme_map = hf_to_vllm_mapper.apply_dict(self.target_scheme_map)
-        self.ignore = hf_to_vllm_mapper.apply_list(self.ignore)
-        self.sparsity_scheme_map = hf_to_vllm_mapper.apply_dict(
-            self.sparsity_scheme_map
-        )
-        self.sparsity_ignore_list = hf_to_vllm_mapper.apply_list(
-            self.sparsity_ignore_list
-        )
+        """
+        Transform layer paths in config targets to match vLLM's naming.
+
+        The WeightsMapper is designed for weight paths, but some backends
+        (e.g. transformers) use broad prefix mappings like "" -> "model."
+        which would incorrectly transform non-path targets.
+
+        compressed-tensors targets can be:
+        - Layer paths: "layers.0.self_attn.q_proj" -> transformed
+        - Module class names: "Linear" -> preserved (no ".")
+        - Regex patterns: "re:.*proj" -> preserved (starts with "re:")
+        """
+
+        def _map_target(target: str) -> str | None:
+            is_layer_path = "." in target and not target.startswith("re:")
+            if is_layer_path:
+                return hf_to_vllm_mapper._map_name(target)
+            return target
+
+        def _apply_dict(d: dict) -> dict:
+            return {k: v for t, v in d.items() if (k := _map_target(t))}
+
+        def _apply_list(lst: list) -> list:
+            return [t for x in lst if (t := _map_target(x))]
+
+        self.target_scheme_map = _apply_dict(self.target_scheme_map)
+        self.ignore = _apply_list(self.ignore)
+        self.sparsity_scheme_map = _apply_dict(self.sparsity_scheme_map)
+        self.sparsity_ignore_list = _apply_list(self.sparsity_ignore_list)
         if self.kv_cache_scheme is not None:
-            self.kv_cache_scheme = hf_to_vllm_mapper.apply_dict(self.kv_cache_scheme)
+            self.kv_cache_scheme = _apply_dict(self.kv_cache_scheme)
 
     def get_quant_method(
         self,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The transformers backend's `WeightsMapper` uses a broad prefix mapping (`"" -> "model."`) to transform weight paths. This mapper is also applied to quantization config targets via `apply_vllm_mapper`. However, compressed-tensors targets can be module class names (e.g., `"Linear"`) or regex patterns (e.g., `"re:.*proj"`), not just layer paths.

When `"Linear"` is transformed to `"model.Linear"`, the target matching fails because the module class name check looks for `"Linear"` in `"model.Linear"` (substring match), which fails.

The fix filters which targets get transformed: only layer paths (containing `.` and not starting with `re:`) are mapped. Class names and regex patterns are preserved.

## Test Plan

```bash
# Previously failing, now passing - compressed-tensors with transformers backend
vllm serve RedHatAI/Qwen3-0.6B-FP8-BLOCK --model-impl transformers

# Verify native backend still works
vllm serve RedHatAI/Qwen3-0.6B-FP8-BLOCK

# Verify fp8 (non-compressed-tensors) still works with transformers
vllm serve Qwen/Qwen3-0.6B-FP8 --model-impl transformers
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

