### PR TITLE
[Core] Add token-level KV cache metrics to V1 engine

### DIFF
--- a/tests/v1/core/test_kv_cache_token_metrics.py
+++ b/tests/v1/core/test_kv_cache_token_metrics.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tests for token-level KV cache metrics in KVCacheManager.
+
+These tests verify the new token-level properties (total_tokens, free_tokens)
+added to KVCacheManager to complement the existing percentage-based usage metric.
+"""
+
+import pytest
+import torch
+
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.kv_cache_interface import KVCacheConfig, StandardAttentionSpec
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.fixture
+def basic_kv_config():
+    """Create a basic KV cache configuration for testing."""
+    return KVCacheConfig(
+        num_blocks=100,
+        kv_cache_groups=[
+            StandardAttentionSpec(
+                block_size=16,
+                num_kv_heads=4,
+                head_size=128,
+                dtype=torch.float16,
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def multi_group_kv_config():
+    """Create a multi-group KV cache configuration (hybrid model)."""
+    return KVCacheConfig(
+        num_blocks=120,
+        kv_cache_groups=[
+            StandardAttentionSpec(
+                block_size=16,
+                num_kv_heads=4,
+                head_size=128,
+                dtype=torch.float16,
+            ),
+            StandardAttentionSpec(
+                block_size=8,  # Different block size
+                num_kv_heads=2,
+                head_size=64,
+                dtype=torch.float16,
+            ),
+        ],
+    )
+
+
+def test_token_metrics_basic(basic_kv_config):
+    """Test basic token metrics calculation with single group."""
+    manager = KVCacheManager(
+        kv_cache_config=basic_kv_config,
+        max_model_len=1024,
+        hash_block_size=16,
+        enable_caching=True,
+    )
+
+    # Verify block_size
+    assert manager.block_size == 16
+
+    # Verify total_tokens
+    # Formula: (num_blocks - 1) / num_groups × block_size
+    #        = (100 - 1) / 1 × 16 = 1584
+    assert manager.total_tokens == (100 - 1) * 16
+
+    # Initially all tokens should be free
+    assert manager.free_tokens == manager.total_tokens
+
+    # Verify consistency
+    assert manager.total_tokens >= manager.free_tokens
+
+
+def test_token_metrics_multi_group(multi_group_kv_config):
+    """Test token metrics with multi-group configuration (hybrid model)."""
+    manager = KVCacheManager(
+        kv_cache_config=multi_group_kv_config,
+        max_model_len=1024,
+        hash_block_size=8,
+        enable_caching=True,
+    )
+
+    # Should use min block size across groups
+    assert manager.block_size == min(16, 8)
+
+    # Formula: (num_blocks - 1) / num_groups × block_size
+    #        = (120 - 1) / 2 × 8 = 59 × 8 = 472
+    expected_total = ((120 - 1) // 2) * 8
+    assert manager.total_tokens == expected_total
+
+    # free_tokens should also account for num_groups
+    assert manager.free_tokens <= manager.total_tokens
+
+
+def test_token_metrics_caching_disabled():
+    """Test that metrics return 0 when caching is disabled."""
+    kv_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_groups=[
+            StandardAttentionSpec(
+                block_size=16,
+                num_kv_heads=4,
+                head_size=128,
+                dtype=torch.float16,
+            )
+        ],
+    )
+
+    manager = KVCacheManager(
+        kv_cache_config=kv_config,
+        max_model_len=1024,
+        hash_block_size=16,
+        enable_caching=False,
+    )
+
+    # All metrics should return 0 when caching is disabled
+    assert manager.block_size == 0
+    assert manager.total_tokens == 0
+    assert manager.free_tokens == 0
+
+
+def test_token_metrics_null_block_accounting(basic_kv_config):
+    """Test that null_block is correctly excluded from total_tokens."""
+    manager = KVCacheManager(
+        kv_cache_config=basic_kv_config,
+        max_model_len=1024,
+        hash_block_size=16,
+        enable_caching=True,
+    )
+
+    # total_tokens should be (num_blocks - 1) to exclude null_block
+    # num_blocks = 100, so available blocks = 99
+    expected_total = 99 * 16  # 1584
+    assert manager.total_tokens == expected_total
+
+    # Verify this matches the block_pool accounting
+    # block_pool.get_usage() also subtracts 1 for null_block
+    block_pool = manager.block_pool
+    available_blocks = block_pool.num_gpu_blocks - 1
+    assert manager.total_tokens == available_blocks * manager.block_size
+
+
+def test_token_metrics_consistency_with_usage(basic_kv_config):
+    """Test that token metrics are consistent with percentage-based usage."""
+    manager = KVCacheManager(
+        kv_cache_config=basic_kv_config,
+        max_model_len=1024,
+        hash_block_size=16,
+        enable_caching=True,
+    )
+
+    # When cache is empty, usage should be 0
+    assert manager.usage == 0.0
+    assert manager.free_tokens == manager.total_tokens
+
+    # The relationship: usage = 1.0 - (free_tokens / total_tokens)
+    # should hold (within floating point precision)
+    if manager.total_tokens > 0:
+        calculated_usage = 1.0 - (manager.free_tokens / manager.total_tokens)
+        assert abs(manager.usage - calculated_usage) < 0.01
+
+
+def test_token_metrics_type_safety():
+    """Test that metrics always return int, never None."""
+    kv_config = KVCacheConfig(
+        num_blocks=50,
+        kv_cache_groups=[
+            StandardAttentionSpec(
+                block_size=8,
+                num_kv_heads=2,
+                head_size=64,
+                dtype=torch.float16,
+            )
+        ],
+    )
+
+    manager = KVCacheManager(
+        kv_cache_config=kv_config,
+        max_model_len=1024,
+        hash_block_size=8,
+        enable_caching=True,
+    )
+
+    # All metrics should be int, not None or Optional[int]
+    assert isinstance(manager.block_size, int)
+    assert isinstance(manager.total_tokens, int)
+    assert isinstance(manager.free_tokens, int)
+
+    # Even when caching is disabled
+    manager_disabled = KVCacheManager(
+        kv_cache_config=kv_config,
+        max_model_len=1024,
+        hash_block_size=8,
+        enable_caching=False,
+    )
+
+    assert isinstance(manager_disabled.block_size, int)
+    assert isinstance(manager_disabled.total_tokens, int)
+    assert isinstance(manager_disabled.free_tokens, int)
+    assert manager_disabled.block_size == 0
+    assert manager_disabled.total_tokens == 0
+    assert manager_disabled.free_tokens == 0

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1439,6 +1439,8 @@ class Scheduler(SchedulerInterface):
             num_running_reqs=len(self.running),
             num_waiting_reqs=len(self.waiting),
             kv_cache_usage=self.kv_cache_manager.usage,
+            kv_cache_total_tokens=self.kv_cache_manager.total_tokens,
+            kv_cache_free_tokens=self.kv_cache_manager.free_tokens,
             prefix_cache_stats=prefix_cache_stats,
             connector_prefix_cache_stats=connector_prefix_cache_stats,
             kv_cache_eviction_events=eviction_events,

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -300,6 +300,12 @@ class AggregatedLoggingStatLogger(LoggingStatLogger, AggregateStatLoggerBase):
             self.last_scheduler_stats.kv_cache_usage += (
                 last_scheduler_stats.kv_cache_usage
             )
+            self.last_scheduler_stats.kv_cache_total_tokens += (
+                last_scheduler_stats.kv_cache_total_tokens
+            )
+            self.last_scheduler_stats.kv_cache_free_tokens += (
+                last_scheduler_stats.kv_cache_free_tokens
+            )
         self.last_scheduler_stats.kv_cache_usage /= len(self.last_scheduler_stats_dict)
 
     def log(self):
@@ -451,6 +457,26 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         )
         self.gauge_kv_cache_usage = make_per_engine(
             gauge_kv_cache_usage, engine_indexes, model_name
+        )
+
+        gauge_kv_cache_total_tokens = self._gauge_cls(
+            name="vllm:kv_cache_total_tokens",
+            documentation="Total KV cache capacity in tokens.",
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_kv_cache_total_tokens = make_per_engine(
+            gauge_kv_cache_total_tokens, engine_indexes, model_name
+        )
+
+        gauge_kv_cache_free_tokens = self._gauge_cls(
+            name="vllm:kv_cache_free_tokens",
+            documentation="Number of available tokens in KV cache.",
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_kv_cache_free_tokens = make_per_engine(
+            gauge_kv_cache_free_tokens, engine_indexes, model_name
         )
 
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
@@ -994,6 +1020,12 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 scheduler_stats.num_waiting_reqs
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
+            self.gauge_kv_cache_total_tokens[engine_idx].set(
+                scheduler_stats.kv_cache_total_tokens
+            )
+            self.gauge_kv_cache_free_tokens[engine_idx].set(
+                scheduler_stats.kv_cache_free_tokens
+            )
 
             self.counter_prefix_cache_queries[engine_idx].inc(
                 scheduler_stats.prefix_cache_stats.queries

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -171,6 +171,8 @@ class SchedulerStats:
     current_wave: int = 0
 
     kv_cache_usage: float = 0.0
+    kv_cache_total_tokens: int = 0
+    kv_cache_free_tokens: int = 0
 
     prefix_cache_stats: PrefixCacheStats = field(default_factory=PrefixCacheStats)
     connector_prefix_cache_stats: PrefixCacheStats | None = None


### PR DESCRIPTION
# Add token-level KV cache metrics to V1 engine

## Summary

Adds absolute token count metrics (`total_tokens`, `free_tokens`) to complement the existing percentage-based `kv_cache_usage` metric in the V1 engine.

## Motivation

The current V1 engine only exposes `kv_cache_usage` as a percentage (0.0-1.0), which limits operational visibility:

- **Capacity planning**: Absolute counts ("28k tokens available") are more actionable than percentages ("35% free")
- **Cost accounting**: Token-based billing requires absolute metrics
- **Debugging**: Exact cache state helps diagnose allocation issues

## Changes

### Core Implementation

**vllm/v1/core/kv_cache_manager.py** (+61 lines)

- `block_size`: Property returning minimum block size across kv_cache_groups
- `total_tokens`: Total cache capacity accounting for null_block and multi-group models
- `free_tokens`: Available tokens with proper multi-group division

**vllm/v1/metrics/stats.py** (+2 lines)

- Added `kv_cache_total_tokens` and `kv_cache_free_tokens` fields

**vllm/v1/core/sched/scheduler.py** (+2 lines)

- Populate new metrics in `make_stats()`

### Metrics Export

**vllm/v1/metrics/loggers.py** (+32 lines)

- Prometheus gauges: `vllm:kv_cache_total_tokens`, `vllm:kv_cache_free_tokens`
- Aggregation support for Data Parallel deployments

### Testing

**tests/v1/core/test_kv_cache_token_metrics.py** (+230 lines)

- Single-group and multi-group model scenarios
- Cache disabled edge cases
- Null block accounting verification
- Type safety and consistency checks

## Design Decisions

**No `used_tokens` in core**: Following vLLM's pattern (see `BlockPool.get_usage()`), we store primitives (`total`, `free`) and let consumers derive usage: `used = total - free`. This ensures consistency and simplifies maintenance.

**Multi-group support**: Divides by `num_groups` to handle hybrid attention models correctly, preventing over-counting.

## Multi-Group Model Behavior

For hybrid attention models (e.g., Qwen with sliding window + full attention):

### Why Metrics May Differ

**Token Metrics (This PR):** Logical per-group capacity (application view)

- Uses `min(block_size)` across groups for conservative estimation
- Uses integer division (`// num_groups`) to ensure safe allocation guarantees
- Purpose: "How many tokens can I **safely** allocate?"

```python
# Example: 2 groups (16-token, 8-token blocks), 118 free blocks
block_size = min(16, 8) = 8  # Conservative
free_tokens = 118 // 2 * 8 = 472 tokens

# Worst-case actual distribution:
# Group 0: 58 blocks × 16 = 928 tokens
# Group 1: 60 blocks × 8  = 480 tokens
# Our report: 472 ≤ min(928, 480) ✅ Always safe
```

This matches vLLM's existing pattern in `_report_kv_cache_config()` ([[kv_cache_utils.py:1269-1273](https://github.com/vllm-project/vllm/blob/main/vllm/v1/core/kv_cache_utils.py#L1269-L1273)](https://github.com/vllm-project/vllm/blob/main/vllm/v1/core/kv_cache_utils.py#L1269-L1273)) for consistency with "GPU KV cache size" logged during initialization.

**Usage Metric (Existing):** Physical block pool utilization (hardware view)

- Formula: `1 - free_blocks / total_blocks`
- Purpose: "How full is my GPU memory?"
- Example: `usage = 1 - 118/119 = 0.84%`

### Why This Design Is Correct

Both metrics are accurate for their respective purposes:

- **Token metrics**: Provide allocation guarantees (never over-promise)
- **Usage metric**: Reflects hardware efficiency (physical blocks used)

The difference is intentional—they answer different questions. Using `min(block_size)` and integer division ensures applications never request more tokens than can be allocated.

### ⚠️ Important: Integer Division Side Effect

**Known Limitation:** Due to integer division, the relationship `usage ≈ 1 - free_tokens/total_tokens` does not hold for multi-group models.

Example of the discrepancy:

```python
# Scenario: 119 total blocks, 118 free, 2 groups
usage = (119-118)/119 ≈ 0.84%  # Physical block usage (hardware view)

# Token metrics with conservative integer division:
total_tokens = (119 // 2) * 8 = 59 * 8 = 472
free_tokens  = (118 // 2) * 8 = 59 * 8 = 472
calculated_usage = 1 - 472/472 = 0%  # Appears completely free!
```

This happens because `(a - b) // c ≠ a // c - b // c` in integer arithmetic. This discrepancy is intentional—we prioritize:

- **Safety**: Never over-promise allocatable tokens
- **Conservatism**: Always provide a lower bound (worst-case guarantee)

The token metrics answer "What can I safely allocate?" while usage answers "How full is my hardware?" These are fundamentally different questions. For single-group models (the common case), both metrics remain consistent and `usage ≈ 1 - free_tokens/total_tokens` holds true.

## Addresses PR #29836 Feedback

This PR supersedes #29836 (closed) and fixes all reported issues:

- ✅ **P1: AttributeError on block_size** (Codex Bot)  
  Implemented as `@property` instead of instance variable

- ✅ **P1: Incorrect block size** (Codex Bot)  
  Uses `kv_cache_spec.block_size`, not `hash_block_size`

- ✅ **High: Missing unit tests** (Gemini Code Assist)  
  Added comprehensive 230-line test suite

- ✅ **Improved accuracy**: Multi-group division prevents token over-counting

## Example

Before:

```
vllm:kv_cache_usage_perc{model_name="my-model",engine="0"} 0.65
```

After:

```
vllm:kv_cache_usage_perc{model_name="my-model",engine="0"} 0.65
vllm:kv_cache_total_tokens{model_name="my-model",engine="0"} 82304
vllm:kv_cache_free_tokens{model_name="my-model",engine="0"} 28857
```

Consumers can derive: `used_tokens = 82304 - 28857 = 53447`

## Backward Compatibility

- ✅ New fields have default values (0)
- ✅ No breaking API changes
- ✅ Existing monitoring dashboards continue to work

## Related Issues

- Supersedes: #29836
- Addresses: #12283, #26850
- Related: #14101

---

Signed-off-by: Minsung-commit [[dialstjd931203@gmail.com](mailto:dialstjd931203@gmail.com)](mailto:dialstjd931203@gmail.com)