### PR TITLE
[Misc] Pass reasoning to deepseekV32 tokenizer

### DIFF
--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -1139,7 +1139,9 @@ class OpenAIServing:
                 conversation=conversation,
                 messages=messages,
                 model_config=model_config,
-                reasoning=request.reasoning,
+                reasoning=getattr(
+                    request, "reasoning", getattr(request, "reasoning_effort", None)
+                ),
                 **_chat_template_kwargs,
             )
         else:

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -1139,6 +1139,7 @@ class OpenAIServing:
                 conversation=conversation,
                 messages=messages,
                 model_config=model_config,
+                reasoning=request.reasoning,
                 **_chat_template_kwargs,
             )
         else:

--- a/vllm/tokenizers/deepseekv32.py
+++ b/vllm/tokenizers/deepseekv32.py
@@ -43,6 +43,10 @@ class DeepseekV32Tokenizer(HfTokenizer):
         thinking_mode = "thinking"
         if not thinking:
             thinking_mode = "chat"
+        reasoning = kwargs.get("reasoning")
+        if reasoning is not None:
+            thinking_mode = "thinking"
+
         conversation = kwargs.get("conversation", messages)
         messages = conversation.copy()
         drop_thinking = True


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Currently the thinking mode is passed by "chat_template_kwargs":{"thinking":true}} to the chatCompletion from client. In addition, this PR adds the capability to pass the reasoning field from responsesRequest to the deepseekV32 tokenizer thus when reasoning effort is set, we will be able to enable thinking. 

## Test Plan
Run local server, with/without setting reasoning_effort, checked responses.

## Test Result
When passed reasoning_effort, we do see \<think\> tag in the answer

 "We are asked: \"what's 1+1\". This is a simple arithmetic question. The answer is 2. However, the user might be testing if the model responds correctly to a trivial question. So we answer straightforwardly. \</think\> 1 + 1 = 2."

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

