### PR TITLE
[Bugfix] Qwen 3 VL Embedding loading

### DIFF
--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -175,13 +175,14 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
             self.vllm_config = vllm_config
 
             # These are not used in pooling models
-            for attr in ("lm_head", "logits_processor"):
-                if hasattr(self, attr):
-                    delattr(self, attr)
-            if language_model := getattr(self, "language_model"):
+            objects_to_clean = [self]
+            if language_model := getattr(self, "language_model", None):
+                objects_to_clean.append(language_model)
+
+            for obj in objects_to_clean:
                 for attr in ("lm_head", "logits_processor"):
-                    if hasattr(language_model, attr):
-                        delattr(language_model, attr)
+                    if hasattr(obj, attr):
+                        delattr(obj, attr)
 
             # If the model already defines a pooler instance, don't overwrite it
             if not getattr(self, "pooler", None):

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -178,6 +178,10 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
             for attr in ("lm_head", "logits_processor"):
                 if hasattr(self, attr):
                     delattr(self, attr)
+            if language_model := getattr(self, "language_model"):
+                for attr in ("lm_head", "logits_processor"):
+                    if hasattr(language_model, attr):
+                        delattr(language_model, attr)
 
             # If the model already defines a pooler instance, don't overwrite it
             if not getattr(self, "pooler", None):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix #30271

## Test Plan

```
from vllm import LLM

model = LLM(
    model="Qwen/Qwen3-VL-8B-Instruct",
    runner="pooling",
    max_model_len=1024,
    trust_remote_code=True,
    limit_mm_per_prompt={"image": 1, "video": 0}
)

prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]

outputs = model.embed(prompts)

print("\nGenerated Outputs:\n" + "-" * 60)
for prompt, output in zip(prompts, outputs):
    embeds = output.outputs.embedding
    embeds_trimmed = (
        (str(embeds[:16])[:-1] + ", ...]") if len(embeds) > 16 else embeds
    )
    print(f"Prompt: {prompt!r} \nEmbeddings: {embeds_trimmed} (size={len(embeds)})")
    print("-" * 60)
```



## Test Result

without this pr

```
ValueError: Following weights were not initialized from checkpoint: {'language_model.lm_head.weight'}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

