### PR TITLE
[CI] Fix Flaky test_eagle_max_len Test

### DIFF
--- a/tests/v1/spec_decode/test_max_len.py
+++ b/tests/v1/spec_decode/test_max_len.py
@@ -82,7 +82,7 @@ def test_eagle_max_len(
                 len(o.prompt_token_ids)
                 < 80
                 < len(o.prompt_token_ids) + len(o.outputs[0].token_ids)
-                < 200
+                <= 200
             ), (
                 "This test is only meaningful if the output "
                 "is longer than the eagle max length"


### PR DESCRIPTION
<!-- markdownlint-disable -->
After https://github.com/vllm-project/vllm/pull/29916 was merged, which fixed the original failure in `tests/v1/spec_decode/test_max_len.py`, we are now noticing that the test is flaky on ROCm. Roughly 15% of the time, I am seeing this when running `pytest -v -s v1/spec_decode/test_max_len.py::test_eagle_max_len[ROCM_AITER_FA-3]`:

```
AssertionError: This test is only meaningful if the output is longer than the eagle max length
...
=========================== short test summary info ============================
FAILED v1/spec_decode/test_max_len.py::test_eagle_max_len[ROCM_AITER_FA-3] - ...
======================== 1 failed, 6 warnings in 27.39s ========================
```

This occurs when `len(o.prompt_token_ids) + len(o.outputs[0].token_ids) = 200` (the failure mode that I observed multiple times was `len(o.prompt_token_ids) = 50` and `len(o.outputs[0].token_ids) = 150`, which seems to be a valid case that was mistakenly not accounted for). After changing the condition to `len(o.prompt_token_ids) + len(o.outputs[0].token_ids) <= 200`, the test passed 50 times in a row locally. Further, I captured an example of the previously failing case where `len(o.prompt_token_ids) = 50` and `len(o.outputs[0].token_ids) = 150`, and the test passed the final correctness assertion `o.outputs[0].text == "a b c d e " * 15`, showing that it is a valid case and the root cause of the flakiness has been addressed.

Now, I am consistently seeing the following when running the whole test_max_len suite `pytest -v -s v1/spec_decode/test_max_len.py`:
```
======================================================= 9 passed, 6 warnings in 170.14s (0:02:50) ====================================================================
```

