### PR TITLE
[DCP][Bugfix][CI] Fix accuracy issue of DCP when using FLASH_ATTN_MLA

### DIFF
--- a/tests/distributed/test_context_parallel.py
+++ b/tests/distributed/test_context_parallel.py
@@ -123,8 +123,11 @@ class CPTestSettings:
 
 CP_TEXT_GENERATION_MODELS = {
     "deepseek-ai/DeepSeek-V2-Lite-Chat": [
+        CPTestSettings.detailed(dcp_multipliers=[1]),
         CPTestSettings.detailed(
-            dcp_multipliers=[0.5, 1], cp_kv_cache_interleave_size=64
+            dcp_multipliers=[0.5],
+            cp_kv_cache_interleave_size=64,
+            attn_backend="FLASHMLA",
         ),
     ],
     "Qwen/Qwen2.5-1.5B-Instruct": [

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -105,13 +105,14 @@ class FlashAttnMLAMetadataBuilder(MLACommonMetadataBuilder[FlashAttnMLAMetadata]
         vllm_config: VllmConfig,
         device: torch.device,
     ):
+        interleave_size = vllm_config.parallel_config.cp_kv_cache_interleave_size
         super().__init__(
             kv_cache_spec,
             layer_names,
             vllm_config,
             device,
             FlashAttnMLAMetadata,
-            supports_dcp_with_varlen=True,
+            supports_dcp_with_varlen=(interleave_size == 1),
         )
         self.max_num_splits = 0  # No upper bound on the number of splits.
         self.fa_aot_schedule = get_flash_attn_version() == 3


### PR DESCRIPTION
## Purpose
https://github.com/vllm-project/vllm/pull/25049 add MTP support for DCP with FA3, but this only works when cp_kv_cache_interleave_size=1.

For FA3 backend, we should check `cp_kv_cache_interleave_size` and set `supports_dcp_with_varlen` accordingly.

## Test Plan
```shell
vllm serve deepseek-ai/DeepSeek-V2-Lite-Chat/ --gpu-memory-utilization 0.9 --tensor-parallel-size 4 --decode-context-parallel-size 4 --cp-kv-cache-interleave-size 64
```

```shell
python ./tests/evals/gsm8k/gsm8k_eval.py
```
## Test Result

- Main
```text
Running GSM8K evaluation: 1319 questions, 5-shot
Evaluating: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:40<00:00, 32.62it/s]

Results:
Accuracy: 0.028
Invalid responses: 0.007
Total latency: 40.447 s
Questions per second: 32.611
Total output tokens: 189017
Output tokens per second: 4673.216
```

- This PR
```text
Running GSM8K evaluation: 1319 questions, 5-shot
Evaluating: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:45<00:00, 28.81it/s]

Results:
Accuracy: 0.639
Invalid responses: 0.002
Total latency: 45.794 s
Questions per second: 28.803
Total output tokens: 161057
Output tokens per second: 3516.982
```

cc @LucasWilkinson @minosfuture @pisceskkk 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
