### PR TITLE
[Misc][Quantization] Clarify the intent of GGUF `FusedMoE` weight materialization

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1200,10 +1200,14 @@ class FusedMoE(CustomOp):
         if full_load:
             shard_dim += 1
 
-        # Materialize GGUF UninitializedParameter
+        # Materialize GGUF UninitializedParameter accounting merged weights
         if is_gguf_weight and isinstance(param, UninitializedParameter):
+            # To materialize a tensor, we must have full shape including
+            # number of experts, making this portion to require `full_load`.
+            assert full_load
             final_shape = list(loaded_weight.shape)
-            if shard_id in ["w1", "w3"]:
+            # w1 and w3 are merged per expert.
+            if shard_id in {"w1", "w3"}:
                 final_shape[1] *= 2
             final_shape[shard_dim] = final_shape[shard_dim] // self.tp_size
             param.materialize(final_shape, dtype=loaded_weight.dtype)


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

This is a refactoring PR with no functional changes (unless the GGUF file is broken).

In the process of `FusedMoE` weight data materialization from GGUF files, there is a magic number and some intents are not clear enough.

This commit clarifies some of them:

1.  GGUF (currently) requires 3D tensor(s) (i.e. `full_load`) for `FusedMoE` layer weights.
2.  `w1` and `w3` are merged per expert, i.e. the next dimension after the expert ID is to be doubled to store both `w1` and `w3`.
    *   Expert ID is the first dimension (as in the code right after the `if is_gguf_weight...` block).
    *   That means, the second dimension's size (`final_shape[1]`) should be doubled for `w1` and `w3`, improving the clarity.

... and makes some minor adjustments.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
