### PR TITLE
Generalize pooling model support with multi-task, multi-layer, multi-label classification that can be pooled from both hidden states and LM head's logits.

### DIFF
--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -162,6 +162,7 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
 
     class ModelForPooling(orig_cls, VllmModelForPooling):
         is_pooling_model = True
+        should_load_lm_head: bool = False
 
         def __init__(
             self,
@@ -174,10 +175,23 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
 
             self.vllm_config = vllm_config
 
-            # These are not used in pooling models
-            for attr in ("lm_head", "logits_processor"):
-                if hasattr(self, attr):
-                    delattr(self, attr)
+            mtml_config = getattr(
+                self.vllm_config.model_config.hf_config,
+                "multi_task_classification_config",
+                None,
+            )
+
+            if mtml_config and any(
+                c.get("apply_to_logits", False) for c in mtml_config.values()
+            ):
+                # We want to keep lm_head for compute_logits (ONLY when one of
+                # the MTML classification heads pools from lm_head logits).
+                self.should_load_lm_head = True
+            else:
+                # These are not used in pooling models
+                for attr in ("lm_head", "logits_processor"):
+                    if hasattr(self, attr):
+                        delattr(self, attr)
 
             # If the model already defines a pooler instance, don't overwrite it
             if not getattr(self, "pooler", None):
@@ -192,6 +206,9 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
             load_lm_head: bool = False,
         ):
             # TODO: Support uninitialized params tracking
+
+            if self.should_load_lm_head:
+                load_lm_head = True
 
             # For most pooling models: We have deleted this attribute, so don't load it.
             # For converting an LLM into a seq cls model, we need the lm_head.
@@ -274,9 +291,13 @@ def as_seq_cls_model(cls: _T) -> _T:
     hidden state corresponding to the last token.
 
     Note:
-        We assume that the classification head is a single linear layer
-        stored as the attribute `score` of the top-level model;
-        please implement your own model if this is not the case.
+        If `multi_task_classification_config` is not present in the model's HF
+        config, we assume that the classification head is a single linear layer
+        stored as the attribute `score` of the top-level model.
+
+        If `multi_task_classification_config` is present, `cls` is adapted with
+        multi-task multi-layer classification heads, as documented in
+        `_MultiTaskClassification`.
     """
     # Avoid modifying existing classification models
     if is_pooling_model(cls):
@@ -299,30 +320,63 @@ def as_seq_cls_model(cls: _T) -> _T:
             text_config = vllm_config.model_config.hf_config.get_text_config()
             model_config = vllm_config.model_config
             quant_config = vllm_config.quant_config
-
-            self.score = ReplicatedLinear(
-                model_config.get_hidden_size(),
-                text_config.num_labels,
-                bias=False,
-                params_dtype=vllm_config.model_config.head_dtype,
-                quant_config=quant_config,
-                return_bias=False,
-                prefix=maybe_prefix(prefix, "score"),
+            multi_task_classification_config = getattr(
+                model_config.hf_config, "multi_task_classification_config", None
             )
+
+            if not multi_task_classification_config:
+                self.score = ReplicatedLinear(
+                    model_config.get_hidden_size(),
+                    text_config.num_labels,
+                    bias=False,
+                    params_dtype=vllm_config.model_config.head_dtype,
+                    quant_config=quant_config,
+                    return_bias=False,
+                    prefix=maybe_prefix(prefix, "score"),
+                )
+            else:
+                if getattr(model_config.hf_config, "head_dtype", None) != "model":
+                    # defer head dtype conversion at the end
+                    model_config.hf_config.head_dtype = "model"
+                    head_dtype = model_config.head_dtype
+                else:
+                    head_dtype = model_config.dtype
+
+                self.score = _MultiTaskClassification(
+                    multi_task_classification_config,
+                    model_config,
+                    quant_config,
+                    compute_logits=self.compute_logits,
+                    head_dtype=head_dtype,
+                    prefix=prefix,
+                )
 
             pooler_config = vllm_config.model_config.pooler_config
             assert pooler_config is not None
 
+            from vllm.model_executor.layers.pooler import PoolerIdentity
+
+            def get_act_fn(fallback):
+                if multi_task_classification_config:
+                    # disable act_fn in Pooler, as we already included
+                    # activation function as part of the multi-task
+                    # classification tower.
+                    return PoolerIdentity()
+                else:
+                    return fallback
+
             self.pooler = DispatchPooler(
                 {
                     "token_classify": Pooler.for_token_classify(
-                        pooler_config, classifier=self.score
+                        pooler_config, classifier=self.score, act_fn=get_act_fn(None)
                     ),
                     "classify": Pooler.for_classify(
-                        pooler_config, classifier=self.score, act_fn="classify"
+                        pooler_config,
+                        classifier=self.score,
+                        act_fn=get_act_fn("classify"),
                     ),
                     "score": Pooler.for_classify(
-                        pooler_config, classifier=self.score, act_fn="score"
+                        pooler_config, classifier=self.score, act_fn=get_act_fn("score")
                     ),
                 }
             )
@@ -503,3 +557,226 @@ def seq_cls_model_loader(model, weights: Iterable[tuple[str, torch.Tensor]]):
     method = getattr(text_config, "method", None)
     assert method in SEQ_CLS_LOAD_METHODS, f"method {method} not supported"
     return SEQ_CLS_LOAD_METHODS[method](model, weights)
+
+
+class _MultiTaskClassification(nn.ModuleDict):
+    """\
+    Enables pooling models to support multi-task multi-layer multi-label
+    sequence classification head.
+
+    Supports the following features, all of which can be customized via config:
+
+    - multiple classification tasks
+    - each task supports multiple linear layers
+    - each task pools either hidden states or language model's LM head
+    - each task outputs to sigmoid/softmax activation via `PoolerClassify`
+
+    CONFIGURATION
+    =============
+
+    This classification head is enabled and configured via hf config key:
+    `multi_task_classification_config`. It is a dict mapping task names to the
+    task's classification head config:
+
+        "multi_task_classification_config": {
+            "task_1": {
+                "out_dims": [ h_1, h_2, ..., h_k ],
+                "apply_to_logits": true                 # optional
+            },
+            "task_2": { ... }
+        }
+
+    where h_1, h_2, ..., h_k corresponds to the output dimension of each linear
+    layers. The input dimension of the first layer is model's hidden_size or
+    lm_head vocab_size, depending on `apply_to_logits`. The last dimension h_k
+    is the num of labels for this task.
+
+    The `apply_to_logits` boolean flag is optional. When it is true (default to
+    false), the pooled hidden state first goes through LM head to obtain logits
+    before applying the multi-task classification towers.
+
+    OUTPUT
+    ======
+
+    The output of each request is a tensor of shape (num_tasks, max_num_labels),
+    representing the probabilities/scores of each label of each task. We allow
+    tasks to have different number of labels, in which case, the output tensor is
+    padded to the task with max number of labels.
+
+    E.g., for the above example, an output would be
+
+        [[ 0.7, 0.3, -inf ]     task_1 scores (with padding)
+         [ 0.3, 0.6, 0.1  ]]    task_2 scores
+
+    EXAMPLE
+    =======
+
+    To pool the last token's hidden state into a two-task multi-layer
+    classification tower with softmax, specify the following engine args:
+
+    >>> from vllm import LLM
+    ... from vllm.config.pooler import PoolerConfig
+    ... llm = LLM(
+    ...     model="Qwen/Qwen3-0.6B",
+    ...     convert="classify",
+    ...     runner="pooling",
+    ...     pooler_config=PoolerConfig(pooling_type="LAST"),
+    ...     load_format="dummy",
+    ...     hf_overrides={
+    ...         "multi_task_classification_config": {
+    ...             "task_1": {
+    ...                 "out_dims": [64, 64, 2],
+    ...             },
+    ...             "task_2": {
+    ...                 "out_dims": [16, 3],
+    ...             },
+    ...         }
+    ...     },
+    ... )
+    ... llm.encode(
+    ...     "the ultimate question of life the universe and everything is 42",
+    ...     pooling_task="classify",
+    ... )
+
+    The `multi_task_classification_config` config can also (and preferrably) be
+    specified in the model's HF config.
+
+    In above example, two classification tasks were setup, each can potentially
+    have different MLP layers and dimensions.
+
+                 task_1
+
+         ┌───────────────────┐
+         │       softmax     │
+         └─────────▲─────────┘
+                   │                           task_2
+                   │
+         ┌─────────┴─────────┐          ┌───────────────────┐
+         │ 64 x 2 (labels)   │          │       softmax     │
+         └─────────▲─────────┘          └──────────▲────────┘
+                   │                               │
+                   │                               │
+         ┌─────────┴─────────┐          ┌──────────┴────────┐
+         │      64 x 64      │          │ 16 x 3 (labels)   │
+         └─────────▲─────────┘          └──────────▲────────┘
+                   │                               │
+                   │                               │
+         ┌─────────┴─────────┐          ┌──────────┴────────┐
+         │   in_size x 64    │          │    in_size x 16   │
+         └───────────────────┘          └───────────────────┘
+                   ▲                               ▲
+                   │                               │
+                   └───────────────┬───────────────┘
+                                   │
+                         pooled hidden states (hidden_size)
+                         or LM head logits (vocab_size)
+
+
+    This corresponds to the following model arch:
+
+        (score): Tasks(
+          (task_1): Sequential(
+            (0): ReplicatedLinear(in_features=2048, output_features=64, bias=False)
+            (1): ReplicatedLinear(in_features=64, output_features=64, bias=False)
+            (2): ReplicatedLinear(in_features=64, output_features=2, bias=False)
+            (3): PoolerClassify()
+          )
+          (task_2): Sequential(
+            (0): ReplicatedLinear(in_features=2048, output_features=16, bias=False)
+            (1): ReplicatedLinear(in_features=16, output_features=3, bias=False)
+            (2): PoolerClassify()
+          )
+        )
+
+
+    The corresponding weights hierarchy:
+
+        score.task_1.0.weight...................torch.Size([64, 2048])
+        score.task_1.1.weight...................torch.Size([64, 64])
+        score.task_1.2.weight...................torch.Size([2, 64])
+        score.task_2.0.weight...................torch.Size([16, 2048])
+        score.task_2.1.weight...................torch.Size([3, 16])
+    """
+    def __init__(
+        self,
+        multi_task_classification_config,
+        model_config,
+        quant_config,
+        compute_logits=None,
+        head_dtype=torch.dtype,
+        prefix: str = "",
+    ):
+        self.compute_logits = compute_logits
+
+        class _Lambda(nn.Module):
+            def __init__(self, func):
+                super().__init__()
+                self.func = func
+
+            def forward(self, x):
+                return self.func(x)
+
+        def create_classification_head(task_config) -> nn.Module:
+            from vllm.model_executor.layers.linear import ReplicatedLinear
+            from .utils import maybe_prefix
+            apply_to_logits = task_config.get("apply_to_logits", False)
+            in_dim = (
+                model_config.get_vocab_size()
+                if apply_to_logits
+                else model_config.get_hidden_size()
+            )
+            layers = []
+            for i, out_dim in enumerate(task_config["out_dims"]):
+                layers.append(
+                    ReplicatedLinear(
+                        in_dim,
+                        out_dim,
+                        bias=False,
+                        params_dtype=model_config.head_dtype,
+                        quant_config=quant_config,
+                        return_bias=False,
+                        prefix=maybe_prefix(prefix, f"score_{i}"),
+                    ),
+                )
+                in_dim = out_dim
+
+            if apply_to_logits:
+                layers = [_Lambda(compute_logits), *layers]
+
+            from vllm.model_executor.layers.pooler import PoolerClassify
+
+            layers.append(PoolerClassify(static_num_labels=False))
+            layers.append(_Lambda(lambda inp: inp.to(head_dtype)))
+            return nn.Sequential(*layers)
+
+        tasks = {
+            task_name: create_classification_head(task_config)
+            for task_name, task_config in multi_task_classification_config.items()
+        }
+
+        max_num_labels = max(
+            c["out_dims"][-1]
+            for c in multi_task_classification_config.values()
+        )
+
+        self.task_pads = {
+            task: max_num_labels - config["out_dims"][-1]
+            for task, config in multi_task_classification_config.items()
+        }
+
+        super().__init__(tasks)
+
+    def forward(self, hidden_state):
+        res = {
+            k: nn.functional.pad(
+                v(hidden_state),
+                # pad last dimension (labels) to max_num_labels
+                (0, self.task_pads[k]),
+                value=-torch.inf,  # -inf to signify padded positions
+            )
+            for k, v in self.items()
+        }
+
+        # for both BxL and L shaped tensors, stack along the L dimension
+        # B: batch dimension, L: label dimension
+        return torch.stack(tuple(res.values()), dim=-2)

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -162,6 +162,7 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
 
     class ModelForPooling(orig_cls, VllmModelForPooling):
         is_pooling_model = True
+        should_load_lm_head: bool = False
 
         def __init__(
             self,
@@ -174,10 +175,23 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
 
             self.vllm_config = vllm_config
 
-            # These are not used in pooling models
-            for attr in ("lm_head", "logits_processor"):
-                if hasattr(self, attr):
-                    delattr(self, attr)
+            mtml_config = getattr(
+                self.vllm_config.model_config.hf_config,
+                "multi_task_classification_config",
+                None,
+            )
+
+            if mtml_config and any(
+                c.get("apply_to_logits", False) for c in mtml_config.values()
+            ):
+                # We want to keep lm_head for compute_logits (ONLY when one of
+                # the MTML classification heads pools from lm_head logits).
+                self.should_load_lm_head = True
+            else:
+                # These are not used in pooling models
+                for attr in ("lm_head", "logits_processor"):
+                    if hasattr(self, attr):
+                        delattr(self, attr)
 
             # If the model already defines a pooler instance, don't overwrite it
             if not getattr(self, "pooler", None):
@@ -192,6 +206,9 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
             load_lm_head: bool = False,
         ):
             # TODO: Support uninitialized params tracking
+
+            if self.should_load_lm_head:
+                load_lm_head = True
 
             # For most pooling models: We have deleted this attribute, so don't load it.
             # For converting an LLM into a seq cls model, we need the lm_head.
@@ -274,9 +291,13 @@ def as_seq_cls_model(cls: _T) -> _T:
     hidden state corresponding to the last token.
 
     Note:
-        We assume that the classification head is a single linear layer
-        stored as the attribute `score` of the top-level model;
-        please implement your own model if this is not the case.
+        If `multi_task_classification_config` is not present in the model's HF
+        config, we assume that the classification head is a single linear layer
+        stored as the attribute `score` of the top-level model.
+
+        If `multi_task_classification_config` is present, `cls` is adapted with
+        multi-task multi-layer classification heads, as documented in
+        `_MultiTaskClassification`.
     """
     # Avoid modifying existing classification models
     if is_pooling_model(cls):
@@ -299,30 +320,63 @@ def as_seq_cls_model(cls: _T) -> _T:
             text_config = vllm_config.model_config.hf_config.get_text_config()
             model_config = vllm_config.model_config
             quant_config = vllm_config.quant_config
-
-            self.score = ReplicatedLinear(
-                model_config.get_hidden_size(),
-                text_config.num_labels,
-                bias=False,
-                params_dtype=vllm_config.model_config.head_dtype,
-                quant_config=quant_config,
-                return_bias=False,
-                prefix=maybe_prefix(prefix, "score"),
+            multi_task_classification_config = getattr(
+                model_config.hf_config, "multi_task_classification_config", None
             )
+
+            if not multi_task_classification_config:
+                self.score = ReplicatedLinear(
+                    model_config.get_hidden_size(),
+                    text_config.num_labels,
+                    bias=False,
+                    params_dtype=vllm_config.model_config.head_dtype,
+                    quant_config=quant_config,
+                    return_bias=False,
+                    prefix=maybe_prefix(prefix, "score"),
+                )
+            else:
+                if getattr(model_config.hf_config, "head_dtype", None) != "model":
+                    # defer head dtype conversion at the end
+                    model_config.hf_config.head_dtype = "model"
+                    head_dtype = model_config.head_dtype
+                else:
+                    head_dtype = model_config.dtype
+
+                self.score = _MultiTaskClassification(
+                    multi_task_classification_config,
+                    model_config,
+                    quant_config,
+                    compute_logits=self.compute_logits,
+                    head_dtype=head_dtype,
+                    prefix=prefix,
+                )
 
             pooler_config = vllm_config.model_config.pooler_config
             assert pooler_config is not None
 
+            from vllm.model_executor.layers.pooler import PoolerIdentity
+
+            def get_act_fn(fallback):
+                if multi_task_classification_config:
+                    # disable act_fn in Pooler, as we already included
+                    # activation function as part of the multi-task
+                    # classification tower.
+                    return PoolerIdentity()
+                else:
+                    return fallback
+
             self.pooler = DispatchPooler(
                 {
                     "token_classify": Pooler.for_token_classify(
-                        pooler_config, classifier=self.score
+                        pooler_config, classifier=self.score, act_fn=get_act_fn(None)
                     ),
                     "classify": Pooler.for_classify(
-                        pooler_config, classifier=self.score, act_fn="classify"
+                        pooler_config,
+                        classifier=self.score,
+                        act_fn=get_act_fn("classify"),
                     ),
                     "score": Pooler.for_classify(
-                        pooler_config, classifier=self.score, act_fn="score"
+                        pooler_config, classifier=self.score, act_fn=get_act_fn("score")
                     ),
                 }
             )
@@ -503,3 +557,228 @@ def seq_cls_model_loader(model, weights: Iterable[tuple[str, torch.Tensor]]):
     method = getattr(text_config, "method", None)
     assert method in SEQ_CLS_LOAD_METHODS, f"method {method} not supported"
     return SEQ_CLS_LOAD_METHODS[method](model, weights)
+
+
+class _MultiTaskClassification(nn.ModuleDict):
+    """\
+    Enables pooling models to support multi-task multi-layer multi-label
+    sequence classification head.
+
+    Supports the following features, all of which can be customized via config:
+
+    - multiple classification tasks
+    - each task supports multiple linear layers
+    - each task pools either hidden states or language model's LM head
+    - each task outputs to sigmoid/softmax activation via `PoolerClassify`
+
+    CONFIGURATION
+    =============
+
+    This classification head is enabled and configured via hf config key:
+    `multi_task_classification_config`. It is a dict mapping task names to the
+    task's classification head config:
+
+        "multi_task_classification_config": {
+            "task_1": {
+                "out_dims": [ h_1, h_2, ..., h_k ],
+                "apply_to_logits": true                 # optional
+            },
+            "task_2": { ... }
+        }
+
+    where h_1, h_2, ..., h_k corresponds to the output dimension of each linear
+    layers. The input dimension of the first layer is model's hidden_size or
+    lm_head vocab_size, depending on `apply_to_logits`. The last dimension h_k
+    is the num of labels for this task.
+
+    The `apply_to_logits` boolean flag is optional. When it is true (default to
+    false), the pooled hidden state first goes through LM head to obtain logits
+    before applying the multi-task classification towers.
+
+    OUTPUT
+    ======
+
+    The output of each request is a tensor of shape (num_tasks, max_num_labels),
+    representing the probabilities/scores of each label of each task. We allow
+    tasks to have different number of labels, in which case, the output tensor is
+    padded to the task with max number of labels.
+
+    E.g., for the above example, an output would be
+
+        [[ 0.7, 0.3, -inf ]     task_1 scores (with padding)
+         [ 0.3, 0.6, 0.1  ]]    task_2 scores
+
+    EXAMPLE
+    =======
+
+    To pool the last token's hidden state into a two-task multi-layer
+    classification tower with softmax, specify the following engine args:
+
+    >>> from vllm import LLM
+    ... from vllm.config.pooler import PoolerConfig
+    ... llm = LLM(
+    ...     model="Qwen/Qwen3-0.6B",
+    ...     convert="classify",
+    ...     runner="pooling",
+    ...     pooler_config=PoolerConfig(pooling_type="LAST"),
+    ...     load_format="dummy",
+    ...     hf_overrides={
+    ...         "multi_task_classification_config": {
+    ...             "task_1": {
+    ...                 "out_dims": [64, 64, 2],
+    ...             },
+    ...             "task_2": {
+    ...                 "out_dims": [16, 3],
+    ...             },
+    ...         }
+    ...     },
+    ... )
+    ... llm.encode(
+    ...     "the ultimate question of life the universe and everything is 42",
+    ...     pooling_task="classify",
+    ... )
+
+    The `multi_task_classification_config` config can also (and preferrably) be
+    specified in the model's HF config.
+
+    In above example, two classification tasks were setup, each can potentially
+    have different MLP layers and dimensions.
+
+                 task_1
+
+         ┌───────────────────┐
+         │       softmax     │
+         └─────────▲─────────┘
+                   │                           task_2
+                   │
+         ┌─────────┴─────────┐          ┌───────────────────┐
+         │ 64 x 2 (labels)   │          │       softmax     │
+         └─────────▲─────────┘          └──────────▲────────┘
+                   │                               │
+                   │                               │
+         ┌─────────┴─────────┐          ┌──────────┴────────┐
+         │      64 x 64      │          │ 16 x 3 (labels)   │
+         └─────────▲─────────┘          └──────────▲────────┘
+                   │                               │
+                   │                               │
+         ┌─────────┴─────────┐          ┌──────────┴────────┐
+         │   in_size x 64    │          │    in_size x 16   │
+         └───────────────────┘          └───────────────────┘
+                   ▲                               ▲
+                   │                               │
+                   └───────────────┬───────────────┘
+                                   │
+                         pooled hidden states (hidden_size)
+                         or LM head logits (vocab_size)
+
+
+    This corresponds to the following model arch:
+
+        (score): Tasks(
+          (task_1): Sequential(
+            (0): ReplicatedLinear(in_features=2048, output_features=64, bias=False)
+            (1): ReplicatedLinear(in_features=64, output_features=64, bias=False)
+            (2): ReplicatedLinear(in_features=64, output_features=2, bias=False)
+            (3): PoolerClassify()
+          )
+          (task_2): Sequential(
+            (0): ReplicatedLinear(in_features=2048, output_features=16, bias=False)
+            (1): ReplicatedLinear(in_features=16, output_features=3, bias=False)
+            (2): PoolerClassify()
+          )
+        )
+
+
+    The corresponding weights hierarchy:
+
+        score.task_1.0.weight...................torch.Size([64, 2048])
+        score.task_1.1.weight...................torch.Size([64, 64])
+        score.task_1.2.weight...................torch.Size([2, 64])
+        score.task_2.0.weight...................torch.Size([16, 2048])
+        score.task_2.1.weight...................torch.Size([3, 16])
+    """
+
+    def __init__(
+        self,
+        multi_task_classification_config,
+        model_config,
+        quant_config,
+        compute_logits=None,
+        head_dtype=torch.dtype,
+        prefix: str = "",
+    ):
+        self.compute_logits = compute_logits
+
+        class _Lambda(nn.Module):
+            def __init__(self, func):
+                super().__init__()
+                self.func = func
+
+            def forward(self, x):
+                return self.func(x)
+
+        def create_classification_head(task_config) -> nn.Module:
+            from vllm.model_executor.layers.linear import ReplicatedLinear
+
+            from .utils import maybe_prefix
+
+            apply_to_logits = task_config.get("apply_to_logits", False)
+            in_dim = (
+                model_config.get_vocab_size()
+                if apply_to_logits
+                else model_config.get_hidden_size()
+            )
+            layers = []
+            for i, out_dim in enumerate(task_config["out_dims"]):
+                layers.append(
+                    ReplicatedLinear(
+                        in_dim,
+                        out_dim,
+                        bias=False,
+                        params_dtype=model_config.head_dtype,
+                        quant_config=quant_config,
+                        return_bias=False,
+                        prefix=maybe_prefix(prefix, f"score_{i}"),
+                    ),
+                )
+                in_dim = out_dim
+
+            if apply_to_logits:
+                layers = [_Lambda(compute_logits), *layers]
+
+            from vllm.model_executor.layers.pooler import PoolerClassify
+
+            layers.append(PoolerClassify(static_num_labels=False))
+            layers.append(_Lambda(lambda inp: inp.to(head_dtype)))
+            return nn.Sequential(*layers)
+
+        tasks = {
+            task_name: create_classification_head(task_config)
+            for task_name, task_config in multi_task_classification_config.items()
+        }
+
+        max_num_labels = max(
+            c["out_dims"][-1] for c in multi_task_classification_config.values()
+        )
+
+        self.task_pads = {
+            task: max_num_labels - config["out_dims"][-1]
+            for task, config in multi_task_classification_config.items()
+        }
+
+        super().__init__(tasks)
+
+    def forward(self, hidden_state):
+        res = {
+            k: nn.functional.pad(
+                v(hidden_state),
+                # pad last dimension (labels) to max_num_labels
+                (0, self.task_pads[k]),
+                value=-torch.inf,  # -inf to signify padded positions
+            )
+            for k, v in self.items()
+        }
+
+        # for both BxL and L shaped tensors, stack along the L dimension
+        # B: batch dimension, L: label dimension
+        return torch.stack(tuple(res.values()), dim=-2)


### PR DESCRIPTION
Summary:

Currently vLLM [pooling model conversion][1] only supports single-task, single-layer classifiers. This change adds support for multi-task multi-layer multi-label sequence classification head.

Supports the following features, all of which can be customized via config:

- multiple classification tasks
- each task supports multiple linear layers
- each task pools either hidden states or language model's LM head
- each task outputs to sigmoid/softmax activation via `PoolerClassify`

CONFIGURATION
=============

This classification head is enabled and configured via hf config key: `multi_task_classification_config`. It is a dict mapping task names to the task's classification head config:

    "multi_task_classification_config": {
        "task_1": {
            "out_dims": [ h_1, h_2, ..., h_k ],
            "apply_to_logits": true                 # optional
        },
        "task_2": { ... }
    }

where h_1, h_2, ..., h_k corresponds to the output dimension of each linear layers. The input dimension of the first layer is model's hidden_size or lm_head vocab_size, depending on `apply_to_logits`. The last dimension h_k is the num of labels for this task.

The `apply_to_logits` boolean flag is optional. When it is true (default to false), the pooled hidden state first goes through LM head to obtain logits before applying the multi-task classification towers.

OUTPUT
======

The output of each request is a tensor of shape (num_tasks, max_num_labels), representing the probabilities/scores of each label of each task. We allow tasks to have different number of labels, in which case, the output tensor is padded to the task with max number of labels.

E.g., for the above example, an output would be

    [[ 0.7, 0.3, -inf ]     task_1 scores (with padding)
     [ 0.3, 0.6, 0.1  ]]    task_2 scores

EXAMPLE
=======

To pool the last token's hidden state into a two-task multi-layer classification tower with softmax, specify the following engine args:

```python
>>> from vllm import LLM
... from vllm.config.pooler import PoolerConfig
... llm = LLM(
...     model="Qwen/Qwen3-0.6B",
...     convert="classify",
...     runner="pooling",
...     pooler_config=PoolerConfig(pooling_type="LAST"),
...     load_format="dummy",
...     hf_overrides={
...         "multi_task_classification_config": {
...             "task_1": {
...                 "out_dims": [64, 64, 2],
...             },
...             "task_2": {
...                 "out_dims": [16, 3],
...             },
...         }
...     },
... )
... llm.encode(
...     "the ultimate question of life the universe and everything is 42",
...     pooling_task="classify",
... )
```

The `multi_task_classification_config` config can also (and preferrably) be specified in the model's HF config.

In above example, two classification tasks were setup, each can potentially have different MLP layers and dimensions.

             task_1

     ┌───────────────────┐
     │       softmax     │
     └─────────▲─────────┘
               │                           task_2
               │
     ┌─────────┴─────────┐          ┌───────────────────┐
     │ 64 x 2 (labels)   │          │       softmax     │
     └─────────▲─────────┘          └──────────▲────────┘
               │                               │
               │                               │
     ┌─────────┴─────────┐          ┌──────────┴────────┐
     │      64 x 64      │          │ 16 x 3 (labels)   │
     └─────────▲─────────┘          └──────────▲────────┘
               │                               │
               │                               │
     ┌─────────┴─────────┐          ┌──────────┴────────┐
     │   in_size x 64    │          │    in_size x 16   │
     └───────────────────┘          └───────────────────┘
               ▲                               ▲
               │                               │
               └───────────────┬───────────────┘
                               │
                     pooled hidden states (hidden_size)
                     or LM head logits (vocab_size)

This corresponds to the following model arch:

    (score): Tasks(
      (task_1): Sequential(
        (0): ReplicatedLinear(in_features=2048, output_features=64, bias=False)
        (1): ReplicatedLinear(in_features=64, output_features=64, bias=False)
        (2): ReplicatedLinear(in_features=64, output_features=2, bias=False)
        (3): PoolerClassify()
      )
      (task_2): Sequential(
        (0): ReplicatedLinear(in_features=2048, output_features=16, bias=False)
        (1): ReplicatedLinear(in_features=16, output_features=3, bias=False)
        (2): PoolerClassify()
      )
    )

The corresponding weights hierarchy:

    score.task_1.0.weight...................torch.Size([64, 2048])
    score.task_1.1.weight...................torch.Size([64, 64])
    score.task_1.2.weight...................torch.Size([2, 64])
    score.task_2.0.weight...................torch.Size([16, 2048])
    score.task_2.1.weight...................torch.Size([3, 16])

<!-- markdownlint-disable -->

## Purpose
This PR generalizes vLLM's pooling model with multi-task, multi-layer, multi-label classification that can be pooled from both hidden states and LM head's logits.

## Test Plan

```python
from vllm import LLM
from vllm.config.pooler import PoolerConfig
llm = LLM(
    model="Qwen/Qwen3-0.6B",
    convert="classify",
    runner="pooling",
    pooler_config=PoolerConfig(pooling_type="LAST"),
    load_format="dummy",
    hf_overrides={
        "multi_task_classification_config": {
            "task_1": {
                "out_dims": [64, 64, 2],
            },
            "task_2": {
                "out_dims": [16, 3],
            },
        }
    },
)
llm.encode(
    "the ultimate question of life the universe and everything is 42",
    pooling_task="classify",
)
```

## Test Result

```
INFO 12-08 23:42:05 [utils.py:253] non-default args: {'runner': 'pooling', 'convert': 'classify', 'load_format': 'dummy', 'seed': None, 'disable_log_stats': True, 'hf_overrides': {'multi_task_classification_config': {'task_1': {'out_dims': [64, 64, 2]}, 'task_2': {'out_dims': [16, 3]}}}, 'pooler_config': PoolerConfig(pooling_type='LAST', normalize=None, dimensions=None, enable_chunked_processing=None, max_embed_len=None, softmax=None, activation=None, use_activation=None, logit_bias=None, step_tag_id=None, returned_token_ids=None)}
WARNING 12-08 23:42:06 [arg_utils.py:1206] `seed=None` is equivalent to `seed=0` in V1 Engine. You will no longer be allowed to pass `None` in v0.13.
INFO 12-08 23:42:06 [model.py:629] Resolved architecture: Qwen3ForCausalLM
INFO 12-08 23:42:06 [model.py:1755] Using max model len 40960
INFO 12-08 23:42:06 [scheduler.py:228] Chunked prefill is enabled with max_num_batched_tokens=16384.
WARNING 12-08 23:42:06 [vllm.py:695] Pooling models do not support full cudagraphs. Overriding cudagraph_mode to PIECEWISE.
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:06 [core.py:93] Initializing a V1 LLM engine (v0.1.dev12072+g58d5b3f51) with config: model='Qwen/Qwen3-0.6B', speculative_config=None, tokenizer='Qwen/Qwen3-0.6B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=40960, download_dir=None, load_format=dummy, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False), seed=0, served_model_name=Qwen/Qwen3-0.6B, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=PoolerConfig(pooling_type='LAST', normalize=None, dimensions=None, enable_chunked_processing=None, max_embed_len=None, softmax=None, activation=None, use_activation=None, logit_bias=None, step_tag_id=None, returned_token_ids=None), compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [16384], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.PIECEWISE: 1>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False}, 'local_cache_dir': None}
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:07 [parallel_state.py:1411] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:08 [gpu_model_runner.py:3544] Starting to load model Qwen/Qwen3-0.6B...
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:08 [cuda.py:412] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION']
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:09 [gpu_model_runner.py:3626] Model loading took 1.1203 GiB memory and 0.218614 seconds
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:14 [backends.py:676] Dynamo bytecode transform time: 4.40 s
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:17 [backends.py:243] Cache the graph of compile range (1, 16384) for later use
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:19 [backends.py:260] Compiling a graph for compile range (1, 16384) takes 1.86 s
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:19 [monitor.py:34] torch.compile takes 6.26 s in total
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:21 [gpu_worker.py:364] Available KV cache memory: 83.80 GiB
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:21 [kv_cache_utils.py:1287] GPU KV cache size: 784,560 tokens
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:21 [kv_cache_utils.py:1292] Maximum concurrency for 40,960 tokens per request: 19.15x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 51/51 [00:01<00:00, 30.00it/s]
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:24 [gpu_model_runner.py:4548] Graph capturing finished in 3 secs, took 0.38 GiB
(EngineCore_DP0 pid=2966363) INFO 12-08 23:42:25 [core.py:256] init engine (profile, create kv cache, warmup model) took 15.08 seconds
INFO 12-08 23:42:26 [llm.py:343] Supported tasks: ['token_classify', 'classify']
Adding requests: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 137.17it/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 94.41it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]
Out[2]:
[PoolingRequestOutput(request_id='0', outputs=PoolingOutput(data=tensor([[0.5000, 0.5000,   -inf],
         [0.3340, 0.3340, 0.3340]], dtype=torch.bfloat16)), prompt_token_ids=[1782, 16724, 3405, 315, 2272, 279, 15494, 323, 4297, 374, 220, 19, 17], num_cached_tokens=0, finished=True)]


```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

