### PR TITLE
[Bugfix] Fix fp8 DeepGemm compilation issues

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -281,7 +281,7 @@ class W8A8BlockFp8LinearOp:
             )
         else:
             assert self.deepgemm_input_quant_op is not None
-        q_input, input_scale = self.deepgemm_input_quant_op(input_2d)
+            q_input, input_scale = self.deepgemm_input_quant_op(input_2d)
         output = torch.empty(
             (q_input.shape[0], weight.shape[0]),
             dtype=torch.bfloat16,

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -33,12 +33,18 @@ class DeepGemmQuantScaleFMT(Enum):
     UE8M0 = 2
 
     @staticmethod
-    def from_oracle() -> "DeepGemmQuantScaleFMT":
-        if not is_deep_gemm_e8m0_used():
+    def from_oracle(
+        use_ue8m0: bool | None = None, is_blackwell: bool | None = None
+    ) -> "DeepGemmQuantScaleFMT":
+        if use_ue8m0 is None:
+            use_ue8m0 = is_deep_gemm_e8m0_used()
+        if is_blackwell is None:
+            is_blackwell = current_platform.is_device_capability(100)
+        if not use_ue8m0:
             return DeepGemmQuantScaleFMT.FLOAT32
         return (
             DeepGemmQuantScaleFMT.UE8M0
-            if current_platform.is_device_capability(100)
+            if is_blackwell
             else DeepGemmQuantScaleFMT.FLOAT32_CEIL_UE8M0
         )
 

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -33,18 +33,12 @@ class DeepGemmQuantScaleFMT(Enum):
     UE8M0 = 2
 
     @staticmethod
-    def from_oracle(
-        use_ue8m0: bool | None = None, is_blackwell: bool | None = None
-    ) -> "DeepGemmQuantScaleFMT":
-        if use_ue8m0 is None:
-            use_ue8m0 = is_deep_gemm_e8m0_used()
-        if is_blackwell is None:
-            is_blackwell = current_platform.is_device_capability(100)
-        if not use_ue8m0:
+    def from_oracle() -> "DeepGemmQuantScaleFMT":
+        if not is_deep_gemm_e8m0_used():
             return DeepGemmQuantScaleFMT.FLOAT32
         return (
             DeepGemmQuantScaleFMT.UE8M0
-            if is_blackwell
+            if current_platform.is_device_capability(100)
             else DeepGemmQuantScaleFMT.FLOAT32_CEIL_UE8M0
         )
 


### PR DESCRIPTION
`is_deep_gemm_e8m0_used()` and `current_platform.is_device_capability()` are not compatible with Dynamo, causing failed compilations. This PR intends to fix this problem.

### Testing
Run inference on `Qwen/Qwen3-30B-A3B-FP8` (one of the models affected) with `VLLM_USE_DEEP_GEMM=1`.