### PR TITLE
Fix gigachat3 parser + update tests

### DIFF
--- a/tests/entrypoints/openai/tool_parsers/test_gigachat3_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_gigachat3_tool_parser.py
@@ -13,7 +13,6 @@ from vllm.entrypoints.openai.engine.protocol import FunctionCall
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers import ToolParser, ToolParserManager
 
-
 MSG_SEP_TOKEN = "<|message_sep|>\n\n"
 ROLE_SEP_TOKEN = "<|role_sep|>\n"
 EOS_TOKEN = "</s>"
@@ -45,7 +44,9 @@ PARAMETERLESS_FUNCTION_JSON = json.dumps(
     },
     ensure_ascii=False,
 )
-PARAMETERLESS_FUNCTION_OUTPUT = f"{MSG_SEP_TOKEN}{TOOL_HEADER}{PARAMETERLESS_FUNCTION_JSON}"
+PARAMETERLESS_FUNCTION_OUTPUT = (
+    f"{MSG_SEP_TOKEN}{TOOL_HEADER}{PARAMETERLESS_FUNCTION_JSON}"
+)
 PARAMETERLESS_FUNCTION_CALL = FunctionCall(
     name="manage_user_memory",
     arguments=json.dumps({}, ensure_ascii=False),
@@ -82,11 +83,7 @@ MIXED_OUTPUT = f"{CONTENT_TEXT}{SIMPLE_FUNCTION_OUTPUT}"
 
 @pytest.fixture(name="gigachat_tokenizer")
 def fixture_gigachat_tokenizer(default_tokenizer: TokenizerLike):
-    default_tokenizer.add_tokens([
-        MSG_SEP_TOKEN, 
-        ROLE_SEP_TOKEN,
-        EOS_TOKEN
-    ])
+    default_tokenizer.add_tokens([MSG_SEP_TOKEN, ROLE_SEP_TOKEN, EOS_TOKEN])
     return default_tokenizer
 
 
@@ -220,7 +217,7 @@ def test_streaming_tool_call_with_large_steps(gigachat_tokenizer: TokenizerLike)
         TOOL_HEADER,
         COMPLEX_FUNCTION_JSON[:40],
         COMPLEX_FUNCTION_JSON[40:-1],
-        COMPLEX_FUNCTION_JSON[-1]
+        COMPLEX_FUNCTION_JSON[-1],
     ]
     reconstructor = run_tool_extraction_streaming(
         tool_parser,

--- a/vllm/tool_parsers/gigachat3_tool_parser.py
+++ b/vllm/tool_parsers/gigachat3_tool_parser.py
@@ -30,7 +30,7 @@ REGEX_FUNCTION_CALL = re.compile(
 )
 
 REGEX_CONTENT_PATTERN = re.compile(
-    r"^(.*?)<\|message_sep\|>", 
+    r"^(.*?)<\|message_sep\|>",
     re.DOTALL,
 )
 
@@ -43,6 +43,7 @@ ARGS_REGEX = re.compile(
     r'"arguments"\s*:\s*(.*)',
     re.DOTALL,
 )
+
 
 class GigaChat3ToolParser(ToolParser):
     def __init__(self, tokenizer: TokenizerLike):
@@ -68,12 +69,16 @@ class GigaChat3ToolParser(ToolParser):
         function_call = None
         content = None
         if model_output.rstrip().endswith("</s>"):
-            model_output = model_output[:model_output.rfind("</s>")]
+            model_output = model_output[: model_output.rfind("</s>")]
         m_func = REGEX_FUNCTION_CALL.search(model_output)
         if m_func:
             try:
                 function_call = json.loads(m_func.group(1), strict=False)
-                if isinstance(function_call, dict) and "name" in function_call and "arguments" in function_call:
+                if (
+                    isinstance(function_call, dict)
+                    and "name" in function_call
+                    and "arguments" in function_call
+                ):
                     if not isinstance(function_call["arguments"], dict):
                         function_call = None
                 else:
@@ -157,7 +162,7 @@ class GigaChat3ToolParser(ToolParser):
         if args_match:
             cur_args = args_match.group(1).strip()
             if cur_args.endswith("</s>"):
-                cur_args = cur_args[:-len("</s>")]
+                cur_args = cur_args[: -len("</s>")]
             if cur_args.endswith("}"):  # last '}' end of json
                 try:
                     candidate = cur_args[:-1].strip()
@@ -191,7 +196,7 @@ class GigaChat3ToolParser(ToolParser):
         if not prev_args:
             delta_args = cur_args
         elif cur_args.startswith(prev_args):
-            delta_args = cur_args[len(prev_args):]
+            delta_args = cur_args[len(prev_args) :]
         else:
             return None
         if not delta_args:


### PR DESCRIPTION

## Purpose
This PR fix a tool parser for parsing the function calls made by the Gigachat 3 models.
Current parsing doesnt use special tokens for tool detection.
Models can generate only one function call with text using this format:
```
{text}<|message_sep|>\n\nfunction call<|role_sep|>\n{json}
``` 
Where `<|message_sep|>\n\n` and `<|role_sep|>\n` are special tokens.

## Test Plan
This PR also fix and adds tests for Gigachat 3 parser.

## Test Result
```
pytest tests/entrypoints/openai/tool_parsers/test_gigachat3_tool_parser.py
```
Output:
```
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.12.3, pytest-9.0.1, pluggy-1.6.0
configfile: pyproject.toml
plugins: anyio-4.11.0
collected 13 items                                                                                                                                                                      

tests/entrypoints/openai/tool_parsers/test_gigachat3_tool_parser.py .............                                                                                                 [100%]

================================================================================== 13 passed in 11.48s ==================================================================================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
