### PR TITLE
[BugFix] Fix minimax m2 model rope_parameters

### DIFF
--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -199,6 +199,9 @@ class MiniMaxM2Attention(nn.Module):
             prefix=f"{prefix}.o_proj",
         )
 
+        if rope_parameters is not None:
+            rope_parameters["partial_rotary_factor"] = 1.0
+
         self.rotary_emb = get_rope(
             self.head_dim,
             rotary_dim=rotary_dim,


### PR DESCRIPTION

Currently Minimax-M2 output is garbled, and i found this issue was introduced by #29966.

This PR might be a trick solution, while i checked `https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/configuration_minimax_m2.py` that `partial_rotary_factor` should be `0.5`. However, m2 need to set `1.0` to work. It makes me confused.

cc @hmellor

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

