### PR TITLE
[Bugfix] Cache added_vocab to avoid per-token overhead

### DIFF
--- a/vllm/tokenizers/deepseekv32.py
+++ b/vllm/tokenizers/deepseekv32.py
@@ -17,6 +17,8 @@ class DeepseekV32Tokenizer(HfTokenizer):
         self.name_or_path = (
             tokenizer.name_or_path if hasattr(tokenizer, "name_or_path") else ""
         )
+        self._added_vocab = self.tokenizer.get_added_vocab()
+        self._added_vocab_size = len(self._added_vocab)
 
     @classmethod
     def from_pretrained(
@@ -98,7 +100,7 @@ class DeepseekV32Tokenizer(HfTokenizer):
 
     def __len__(self) -> int:
         # </think> is an added token in DeepseekV32 tokenizer
-        return self.vocab_size + len(self.get_added_vocab())
+        return self.vocab_size + self._added_vocab_size
 
     def __call__(
         self,
@@ -120,7 +122,7 @@ class DeepseekV32Tokenizer(HfTokenizer):
         return self.tokenizer.get_vocab()
 
     def get_added_vocab(self) -> dict[str, int]:
-        return self.tokenizer.get_added_vocab()
+        return self._added_vocab
 
     def encode(
         self,

--- a/vllm/tokenizers/deepseekv32.py
+++ b/vllm/tokenizers/deepseekv32.py
@@ -122,7 +122,7 @@ class DeepseekV32Tokenizer(HfTokenizer):
         return self.tokenizer.get_vocab()
 
     def get_added_vocab(self) -> dict[str, int]:
-        return self._added_vocab
+        return self._added_vocab.copy()
 
     def encode(
         self,


### PR DESCRIPTION
## Purpose
FIX https://github.com/vllm-project/vllm/issues/30343
When serving DeepSeek-V3.2 in tokenizer-mode, main thread is busy in detokenization.

`detokenize_incrementally` runs on every generated token and checks `len(tokenizer)`, which invokes `DeepseekV32Tokenizer.__len__`.

```
143:161:vllm/tokenizers/detokenizer_utils.py
    ...

    new_token_id = all_input_ids[-1]
    # Hot path: executed once per generated token.
    if 0 <= new_token_id < len(tokenizer):  # calls tokenizer.__len__ each token
        new_tokens = tokenizer.convert_ids_to_tokens(
            [new_token_id], skip_special_tokens=skip_special_tokens
        )
        if isinstance(new_tokens, str):
            new_tokens = [new_tokens]
    else:
        new_tokens = [""]

    ...
```

`__len__` used to call `get_added_vocab()` on each invocation; for fast tokenizers this rebuilds/consults the native `added_tokens_decoder` (shows up as `BTreeMap::insert`), executed once per token on the GIL-holding main thread.

```
14:125:vllm/tokenizers/deepseekv32.py
class DeepseekV32Tokenizer(HfTokenizer):
    def __init__(self, tokenizer: TokenizerLike):
        self.tokenizer = tokenizer

    def __len__(self) -> int:
        # </think> is an added token in DeepseekV32 tokenizer
        return self.vocab_size + len(self.get_added_vocab())

    def get_added_vocab(self) -> dict[str, int]:
        return self._added_vocab
```

Result: per-token detokenization triggers expensive native work, starving the event loop and causing `/health` and other HTTP endpoints to hang.

<img width="1568" height="1410" alt="image" src="https://github.com/user-attachments/assets/343e18a6-ad4b-468d-99fc-5d1b03319cfb" />


This PR cache added vocab at tokenizer init and reuse: In `vllm/tokenizers/deepseekv32.py`, prefetch `self._added_vocab = tokenizer.get_added_vocab() and self._added_vocab_size = len(...)` once. `__len__` returns `vocab_size + _added_vocab_size`; `get_added_vocab()` returns the cached dict.

This removes per-token repeated `get_added_vocab()` calls.  

In my view, in a serve setting the model and tokenizer vocab stay unchanged after load, so caching the added vocab is safe. If I’m wrong, please let me know—I’ll keep revising until it’s correct.

## Test Plan

Command:
`vllm serve /path/to/DeepSeek-V3.2-Speciale --served-model-name dsv3p2-dp8 --max-model-len 163840 --max-num-seqs 256 --enable-chunked-prefill --data-parallel-size 8 --enable-expert-parallel --gpu-memory-utilization 0.9 --tool-call-parser deepseek_v32 --reasoning-parser deepseek_v3 --enable-auto-tool-choice --tokenizer-mode deepseek_v32`

## Test Result

We can observe that the API server’s CPU utilization has returned to normal levels instead of remaining persistently high.

# #
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

