### PR TITLE
[CI/Test] Fix FP8 per-tensor quant test reference scale shape

### DIFF
--- a/tests/kernels/quant_utils.py
+++ b/tests/kernels/quant_utils.py
@@ -103,7 +103,7 @@ def ref_dynamic_per_tensor_fp8_quant(
         .clamp(fp8_traits_min, fp8_traits_max)
         .to(FP8_DTYPE)
     )
-    return ref_out, ref_scale.view((1, 1))
+    return ref_out, ref_scale.view(1)
 
 
 def native_w8a8_block_matmul(


### PR DESCRIPTION
## Summary

Fixes `test_dynamic_per_tensor_fp8_quant` that was broken by [#30257](https://github.com/vllm-project/vllm/pull/30257). (CI failure: https://buildkite.com/organizations/vllm/pipelines/ci/builds/42664/jobs/019b03c9-8e5a-4fb8-baec-7ba031141cbf/log)

## Issue

https://github.com/vllm-project/vllm/pull/30257 changed `ops.scaled_fp8_quant` to return scale with shape `[1]` instead of `[1, 1]`. However, the test's reference function `ref_dynamic_per_tensor_fp8_quant` was not updated to match, causing all `test_dynamic_per_tensor_fp8_quant` tests to fail with:

```
AssertionError: The values for attribute 'shape' do not match: torch.Size([1, 1]) != torch.Size([1]).
```

## Fix

Updated `ref_dynamic_per_tensor_fp8_quant` in [`tests/kernels/quant_utils.py`](https://github.com/vllm-project/vllm/blob/main/tests/kernels/quant_utils.py) to return scale with shape `[1]` instead of `[1, 1]`, matching the new behavior of the ops implementation.

## Testing

```bash
pytest tests/kernels/quantization/test_fp8_quant.py -v
# 109 passed
```