### PR TITLE
[Bug Fix] Fix Kimi-Linear model initialization crash due to missing 'indexer_rotary_emb' arg

### DIFF
--- a/vllm/model_executor/models/kimi_linear.py
+++ b/vllm/model_executor/models/kimi_linear.py
@@ -248,6 +248,7 @@ class KimiMLAAttention(nn.Module):
             kv_a_layernorm=self.kv_a_layernorm,
             kv_b_proj=self.kv_b_proj,
             rotary_emb=None,
+            indexer_rotary_emb=None,
             o_proj=self.o_proj,
             fused_qkv_a_proj=None,
             kv_a_proj_with_mqa=self.kv_a_proj_with_mqa,


### PR DESCRIPTION
## Bug Fix

### Description
This PR fixes a regression in `vllm/model_executor/models/kimi_linear.py` where the initialization of `MLAModules` was missing the required `indexer_rotary_emb` argument. This caused the engine to crash immediately upon loading the `moonshotai/Kimi-Linear-48B-A3B-Instruct` model.

### Issue
The `MLAModules` class signature was recently updated to require `indexer_rotary_emb`, but the Kimi model definition was not updated to reflect this change.

**Error Log:**
> TypeError: MLAModules.__init__() missing 1 required positional argument: 'indexer_rotary_emb'

### Fix
Added `indexer_rotary_emb=None` to the `MLAModules` initialization call in `kimi_linear.py`.

### Verification
- Tested locally with `moonshotai/Kimi-Linear-48B-A3B-Instruct`.
- Verified that the server starts up successfully and the error is resolved.