### PR TITLE
[CI] Reduce Flakiness For test_spec_decode.py::test_suffix_decoding_acceptance

### DIFF
--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -191,7 +191,7 @@ def test_suffix_decoding_acceptance(
     # Expect the acceptance rate to improve.
     assert first_accept_rate < last_accept_rate
 
-    # Heuristic: expect at least 82.5% acceptance rate at the end.
+    # Heuristic: expect at least 80.0% acceptance rate at the end.
     assert last_accept_rate > 0.80
 
     del spec_llm

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -192,7 +192,7 @@ def test_suffix_decoding_acceptance(
     assert first_accept_rate < last_accept_rate
 
     # Heuristic: expect at least 82.5% acceptance rate at the end.
-    assert last_accept_rate > 0.825
+    assert last_accept_rate > 0.80
 
     del spec_llm
     torch.cuda.empty_cache()


### PR DESCRIPTION
<!-- markdownlint-disable -->
`v1/e2e/test_spec_decode.py::test_suffix_decoding_acceptance` has been a bit flaky, failing about 5.6% of the time for almost the same exact reason each time despite passing after a retry. The final acceptance threshold is currently `last_accept_rate > 0.825`. Here are some examples of recent failures in buildkite for this test:

[Build 42551](https://buildkite.com/vllm/ci/builds/42551/steps/canvas?jid=019b00d0-a270-4db3-81e1-f692c784f894#019b00d0-a270-4db3-81e1-f692c784f894):
`FAILED v1/e2e/test_spec_decode.py::test_suffix_decoding_acceptance - assert 0.8142514011208967 > 0.825`

[Build 42535](https://buildkite.com/vllm/ci/builds/42535/steps/canvas?jid=019b0084-a652-48dc-9e80-e966309082d1#019b0084-a652-48dc-9e80-e966309082d1)
`FAILED v1/e2e/test_spec_decode.py::test_suffix_decoding_acceptance - assert 0.8142514011208967 > 0.825`

[Build 42714](https://buildkite.com/vllm/ci/builds/42714/steps/canvas?jid=019b04df-647d-4aa0-9ea5-a919f55cf484):
`FAILED v1/e2e/test_spec_decode.py::test_suffix_decoding_acceptance - assert 0.8105515587529976 > 0.825`

I believe I looked through almost all of the failures from the past week and all of them were 0.81 or above. I think if we can just set  the threshold to 0.80, the success rate over the past week would have been 100%