### PR TITLE
[Fix] Add default rope theta for qwen1 model

### DIFF
--- a/vllm/model_executor/models/qwen.py
+++ b/vllm/model_executor/models/qwen.py
@@ -36,6 +36,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.config import set_default_rope_theta
 
 from .interfaces import SupportsLoRA, SupportsPP
 from .utils import (
@@ -149,6 +150,7 @@ class QWenBlock(nn.Module):
         prefix: str = "",
     ):
         super().__init__()
+        set_default_rope_theta(config, default_theta=10000)
         self.ln_1 = RMSNorm(config.hidden_size, eps=config.layer_norm_epsilon)
 
         self.attn = QWenAttention(


### PR DESCRIPTION
Need to set default rope theta for qwen1 model.

error: 

<img width="985" height="525" alt="image" src="https://github.com/user-attachments/assets/34fa3dc0-9df8-4dc0-b8b3-987f5a6643d9" />

Qwen1 config:
<img width="600" height="716" alt="image" src="https://github.com/user-attachments/assets/e0f1fe47-df81-490b-a4f5-e322092c4c0e" />


## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

