### PR TITLE
[Bugfix] Fix the issue where DeepSeek v3.2 cannot use structured_output

### DIFF
--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -60,10 +60,7 @@ class XgrammarBackend(StructuredOutputBackend):
             # copy from xgr.TokenizerInfo.from_huggingface()
             # because we are using a custom tokenizer wrapper here.
             vocab_dict = self.tokenizer.get_vocab()
-            max_id = max(vocab_dict.values())
-            tokenizer_vocab_size = max(len(vocab_dict), max_id + 1)
-
-            vocab_size = self.vocab_size or tokenizer_vocab_size
+            vocab_size = self.vocab_size or self.tokenizer.max_token_id
             # maintain tokenizer's indexing
             encoded_vocab = [""] * vocab_size
             for token, idx in vocab_dict.items():

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -63,7 +63,7 @@ class XgrammarBackend(StructuredOutputBackend):
             max_id = max(vocab_dict.values())
             tokenizer_vocab_size = max(len(vocab_dict), max_id + 1)
 
-            vocab_size = self.vocab_size or tokenizer_vocab_size
+            vocab_size = self.tokenizer.vocab_size or tokenizer_vocab_size
             # maintain tokenizer's indexing
             encoded_vocab = [""] * vocab_size
             for token, idx in vocab_dict.items():

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -60,7 +60,8 @@ class XgrammarBackend(StructuredOutputBackend):
             # copy from xgr.TokenizerInfo.from_huggingface()
             # because we are using a custom tokenizer wrapper here.
             vocab_dict = self.tokenizer.get_vocab()
-            vocab_size = self.vocab_size or self.tokenizer.max_token_id
+            tokenizer_vocab_size = max(len(vocab_dict), self.tokenizer.max_token_id + 1)
+            vocab_size = self.vocab_size or tokenizer_vocab_size
             # maintain tokenizer's indexing
             encoded_vocab = [""] * vocab_size
             for token, idx in vocab_dict.items():

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -10,7 +10,7 @@ import torch
 import vllm.envs
 from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams
-from vllm.tokenizers import MistralTokenizer
+from vllm.tokenizers import DeepseekV32Tokenizer, MistralTokenizer
 from vllm.utils.import_utils import LazyLoader
 from vllm.v1.structured_output.backend_types import (
     StructuredOutputBackend,
@@ -55,6 +55,27 @@ class XgrammarBackend(StructuredOutputBackend):
                 vocab_size=self.vocab_size,
                 stop_token_ids=stop_token_ids,
                 add_prefix_space=True,
+            )
+        elif isinstance(self.tokenizer, DeepseekV32Tokenizer):
+            vocab_dict = self.tokenizer.get_vocab()
+            max_id = max(vocab_dict.values())
+            tokenizer_vocab_size = max(len(vocab_dict), max_id + 1)
+
+            vocab_size = self.vocab_size or tokenizer_vocab_size
+            # maintain tokenizer's indexing
+            encoded_vocab = [""] * vocab_size
+            for token, idx in vocab_dict.items():
+                if idx < vocab_size:
+                    encoded_vocab[idx] = token
+            stop_token_ids = [self.tokenizer.eos_token_id]
+            backend_str = self.tokenizer.tokenizer.backend_tokenizer.to_str()
+            metadata = xgr.TokenizerInfo._detect_metadata_from_hf(backend_str)
+            tokenizer_info = xgr.TokenizerInfo(
+                encoded_vocab=encoded_vocab,
+                vocab_type=metadata["vocab_type"],
+                vocab_size=vocab_size,
+                stop_token_ids=stop_token_ids,
+                add_prefix_space=metadata["add_prefix_space"],
             )
         else:
             tokenizer_info = xgr.TokenizerInfo.from_huggingface(

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -63,7 +63,7 @@ class XgrammarBackend(StructuredOutputBackend):
             max_id = max(vocab_dict.values())
             tokenizer_vocab_size = max(len(vocab_dict), max_id + 1)
 
-            vocab_size = self.tokenizer.vocab_size or tokenizer_vocab_size
+            vocab_size = self.vocab_size or tokenizer_vocab_size
             # maintain tokenizer's indexing
             encoded_vocab = [""] * vocab_size
             for token, idx in vocab_dict.items():

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -57,6 +57,8 @@ class XgrammarBackend(StructuredOutputBackend):
                 add_prefix_space=True,
             )
         elif isinstance(self.tokenizer, DeepseekV32Tokenizer):
+            # copy from xgr.TokenizerInfo.from_huggingface()
+            # because we are using a custom tokenizer wrapper here.
             vocab_dict = self.tokenizer.get_vocab()
             max_id = max(vocab_dict.values())
             tokenizer_vocab_size = max(len(vocab_dict), max_id + 1)


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/30311

## Purpose

Fix the issue where DeepSeek v3.2 cannot use structured_output

## Test Plan
```
VLLM_USE_DEEP_GEMM=0 VLLM_MOE_USE_DEEP_GEMM=0 vllm serve /mnt/data4/models/deepseek-ai/DeepSeek-V3___2 -tp 8 --tokenizer-mode deepseek_v32 --tool-call-parser deepseek_v32 --enable-auto-tool-choice --reasoning-parser deepseek_v3
...
(APIServer pid=2366252) INFO 12-10 12:19:33 [launcher.py:46] Route: /pooling, Methods: POST
(APIServer pid=2366252) INFO:     Started server process [2366252]
(APIServer pid=2366252) INFO:     Waiting for application startup.
(APIServer pid=2366252) INFO:     Application startup complete.
(APIServer pid=2366252) INFO:     127.0.0.1:60586 - "GET /v1/models HTTP/1.1" 200 OK
(APIServer pid=2366252) INFO 12-10 12:19:38 [chat_utils.py:574] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=2366252) INFO:     127.0.0.1:60586 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=2366252) INFO:     127.0.0.1:60600 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=2366252) INFO:     127.0.0.1:60618 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=2366252) INFO:     127.0.0.1:60610 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=2366252) INFO:     127.0.0.1:60606 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```
## Test Result
```
python examples/online_serving/structured_outputs/structured_outputs.py --reasoning


choice:
  Content: 'positive'


regex:
  Content: 'a.turing@enigma.com\n'


json:
  Content: '{\n  "brand": "Toyota",\n  "model": "Supra (Mark IV)",\n  "car_type": "TRUCK"\n}'


grammar:
  Content: 'SELECT col_1  from table_1  where col_1 = 1 '


structural_tag:
  Content: '<function=get_weather>{"city": "New York City"}</function>'

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

