### PR TITLE
[Core] Whisper support `torch.compile`

### DIFF
--- a/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
@@ -156,7 +156,9 @@ def test_wer_correctness(
     model_name, dataset_repo, expected_wer, n_examples=-1, max_concurrent_request=None
 ):
     # TODO refactor to use `ASRDataset`
-    with RemoteOpenAIServer(model_name, ["--enforce-eager"]) as remote_server:
+    with RemoteOpenAIServer(
+        model_name, ["--enforce-eager"], max_wait_seconds=480
+    ) as remote_server:
         dataset = load_hf_dataset(dataset_repo)
 
         if not max_concurrent_request:

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -207,6 +207,9 @@ class ForwardContext:
 
     ubatch_slices: UBatchSlices | None = None
 
+    # If True, bypass the compiled model call, e.g. by using .forward() directly
+    skip_compiled: bool = False
+
     additional_kwargs: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
@@ -240,6 +243,7 @@ def create_forward_context(
     batch_descriptor: BatchDescriptor | None = None,
     ubatch_slices: UBatchSlices | None = None,
     additional_kwargs: dict[str, Any] | None = None,
+    skip_compiled: bool = False,
 ):
     return ForwardContext(
         no_compile_layers=vllm_config.compilation_config.static_forward_context,
@@ -249,6 +253,7 @@ def create_forward_context(
         cudagraph_runtime_mode=cudagraph_runtime_mode,
         batch_descriptor=batch_descriptor,
         ubatch_slices=ubatch_slices,
+        skip_compiled=skip_compiled,
         additional_kwargs=additional_kwargs or {},
     )
 
@@ -278,6 +283,7 @@ def set_forward_context(
     cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
     batch_descriptor: BatchDescriptor | None = None,
     ubatch_slices: UBatchSlices | None = None,
+    skip_compiled: bool = False,
 ):
     """A context manager that stores the current forward context,
     can be attention metadata, etc.
@@ -336,6 +342,7 @@ def set_forward_context(
         batch_descriptor,
         ubatch_slices,
         additional_kwargs,
+        skip_compiled,
     )
 
     try:

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -22,6 +22,7 @@ from vllm.attention.layer import Attention
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, SpeechToTextConfig, VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
+from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.inputs.data import PromptType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import get_act_fn

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -19,9 +19,9 @@ from transformers import (
 from transformers.models.whisper.modeling_whisper import sinusoids
 
 from vllm.attention.layer import Attention
+from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, ModelConfig, SpeechToTextConfig, VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
-from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.inputs.data import PromptType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import get_act_fn
@@ -561,6 +561,7 @@ class WhisperEncoder(nn.Module):
         return self.forward_layers(hidden_states)
 
 
+@support_torch_compile(dynamic_arg_dims={"input_ids": 0, "positions": -1})
 class WhisperDecoder(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2896,7 +2896,6 @@ class GPUModelRunner(
         positions: torch.Tensor | None = None,
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
-        force_eager: bool = False,
         **model_kwargs: dict[str, Any],
     ) -> Any:
         """Helper method to call the model forward pass.
@@ -2915,17 +2914,6 @@ class GPUModelRunner(
         Returns:
             Model output tensor
         """
-
-        if force_eager:
-            # Run un-compiled forward pass.
-            return self.model.forward(
-                input_ids=input_ids,
-                positions=positions,
-                intermediate_tensors=intermediate_tensors,
-                inputs_embeds=inputs_embeds,
-                **model_kwargs,
-            )
-
         return self.model(
             input_ids=input_ids,
             positions=positions,
@@ -3298,6 +3286,7 @@ class GPUModelRunner(
                 cudagraph_runtime_mode=cudagraph_mode,
                 batch_descriptor=batch_desc,
                 ubatch_slices=ubatch_slices_padded,
+                skip_compiled=has_encoder_input,
             ),
             record_function_or_nullcontext("gpu_model_runner: forward"),
             self.maybe_get_kv_connector_output(scheduler_output) as kv_connector_output,
@@ -3307,7 +3296,6 @@ class GPUModelRunner(
                 positions=positions,
                 intermediate_tensors=intermediate_tensors,
                 inputs_embeds=inputs_embeds,
-                force_eager=has_encoder_input,
                 **model_kwargs,
             )
 


### PR DESCRIPTION
This PR is yet another Whisper performance optimization, adding support for torch.compile during *decoding step*.
It follows a very similar approach to https://github.com/vllm-project/vllm/pull/30072 (and should also land after that to ensure best defaults) in which only the 2nd decoder steps onward are compiled.
This is due to the fact that step0 in enc-dec models computes and caches crossattn KVs, requiring encoder_output as additional input and hence generating a different graph from the other steps.

Updated profiling:
<img width="972" height="1039" alt="image" src="https://github.com/user-attachments/assets/a53734e1-9d1d-4fe7-b36b-cc851a535a1b" />



## Considerations

I've attempted to add the "2nd decoder step" selection logic directly in the model runner (`_model_forward`).   
I am aware that `_model_forward` is currently used by OOT runners (https://github.com/vllm-project/vllm/pull/25084), although no "official" runner interface contract is maintained to ensure compatibility (unlike connectors to name one), which makes maintaining these kinds of methods without breaking external usage quite hairy.
As this change may affect those runners I am also pinging @patrick-toulme .

Happy to change to a less invasive logic if we find a cleaner way to do it @LucasWilkinson . 
Other options are adding the flag to attn_metadata and then retrieving the metadata from the support_torch_compile wrapper OR hacking the WhisperDecoder `__call__` (definitely not nice).

UPDATE: 
Following @ProExpertProg suggestion, I've moved to implementing the alternative option in which the `skip_compiled` logic is generically handled inside the compile decorator.
So no change to `_model_forward` is actually needed.

Related PRs https://github.com/vllm-project/vllm/pull/29421 https://github.com/vllm-project/vllm/pull/30072

### Test with

Compilation is enabled by default:
```
vllm serve openai/whisper-large-v3-turbo
```

cc @DarkLight1337  @robertgshaw2-redhat 