### PR TITLE
[BugFix] Fix `AttributeError: 'MergedColumnParallelLinear' object has no attribute 'weight_scale'`

### DIFF
--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -89,7 +89,7 @@ def _extract_data_from_linear_base_module(
     assert m.quant_method.quant_config is not None
 
     w = m.weight
-    ws = m.weight_scale
+    ws = m.weight_scale_inv if hasattr(m, "weight_scale_inv") else m.weight_scale
     quant_block_size = m.quant_method.quant_config.weight_block_size
 
     assert isinstance(w, torch.Tensor)


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/30267 introduced a 
```
AttributeError: 'MergedColumnParallelLinear' object has no attribute 'weight_scale'
```
failure in `tests/quantization/test_blackwell_moe.py::test_deepseek_fp8_block_moe_deep_gemm` in [Blackwell Quantized MoE Test](https://buildkite.com/vllm/ci/builds/42801/steps/canvas?sid=019b0710-6222-4b38-94f5-0c2b8659bb5a))

FIX https://github.com/vllm-project/vllm/pull/28480#issuecomment-3637303720