### PR TITLE
fix(nemotron_h): Add missing rotary positional embeddings to attention layers

### DIFF
--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -49,6 +49,7 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateShapeCalculator,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -435,6 +436,7 @@ class NemotronHAttention(nn.Module):
         self,
         config: NemotronHConfig,
         layer_idx: int,
+        max_position_embeddings: int,
         model_config: ModelConfig | None = None,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
@@ -490,13 +492,25 @@ class NemotronHAttention(nn.Module):
             prefix=f"{prefix}.attn",
         )
 
+        # Rotary embeddings for positional encoding
+        self.max_position_embeddings = max_position_embeddings
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=max_position_embeddings,
+            is_neox_style=True,
+            dtype=torch.get_default_dtype(),
+        )
+
     def forward(
         self,
+        positions: torch.Tensor,
         hidden_states: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
         return output
@@ -518,9 +532,10 @@ class NemotronHAttentionDecoderLayer(nn.Module):
         self.mixer = NemotronHAttention(
             config,
             layer_idx,
-            model_config,
-            cache_config,
-            quant_config,
+            max_position_embeddings=config.max_position_embeddings,
+            model_config=model_config,
+            cache_config=cache_config,
+            quant_config=quant_config,
             prefix=f"{prefix}.mixer",
         )
 
@@ -539,7 +554,7 @@ class NemotronHAttentionDecoderLayer(nn.Module):
         else:
             hidden_states, residual = self.norm(hidden_states, residual)
 
-        hidden_states = self.mixer(hidden_states=hidden_states)
+        hidden_states = self.mixer(positions=positions, hidden_states=hidden_states)
         return hidden_states, residual
 
 
@@ -659,6 +674,10 @@ class NemotronHModel(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
+            # Skip rotary embeddings - they are computed dynamically
+            if "rotary_emb.inv_freq" in name:
+                continue
+
             if "scale" in name:
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)


### PR DESCRIPTION
## Summary

Fixes inference failure for `nvidia/NVIDIA-Nemotron-Nano-9B-v2` and similar nemotron_h architecture models.

## Problem

The `NemotronHAttention` class was missing rotary positional embeddings (RoPE), causing token generation to fail despite successful model loading.

Without RoPE, attention layers operate without positional information, producing corrupted attention scores and preventing coherent token generation.

## Root Cause

- `NemotronHAttention.__init__()` had no `rotary_emb` initialization
- `forward()` did not accept positions parameter or apply RoPE to Q, K
- `NemotronHAttentionDecoderLayer.forward()` did not pass positions to mixer

## Changes

1. Imports `get_rope` from `vllm.model_executor.layers.rotary_embedding`
2. Adds `rotary_emb` initialization in `NemotronHAttention.__init__()`
3. Updates `forward()` to accept positions and apply `q, k = rotary_emb(positions, q, k)`
4. Updates `NemotronHAttentionDecoderLayer` to pass positions to mixer
5. Adds `rotary_emb.inv_freq` filter in `load_weights` to skip computed weights

## Testing

Tested with `nvidia/NVIDIA-Nemotron-Nano-9B-v2` - model now generates coherent output.