### PR TITLE
fix(gguf): Disable bfloat16 for GGUF on blackwell device

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1176,16 +1176,6 @@ class EngineArgs:
         # gguf file needs a specific model loader
         if is_gguf(self.model):
             self.quantization = self.load_format = "gguf"
-            # GGUF dequantization kernels use half precision (fp16) internally.
-            # bfloat16 causes incorrect output on some architectures (e.g., Blackwell).
-            # Default to float16 for safety; explicit --dtype bfloat16 still allowed
-            # for users on hardware where it works.
-            if self.dtype == "auto":
-                self.dtype = "float16"
-                logger.info(
-                    "GGUF models default to float16 (dequant kernels use fp16 "
-                    "internally). Use --dtype bfloat16 to override if needed."
-                )
 
         if not envs.VLLM_ENABLE_V1_MULTIPROCESSING:
             logger.warning(

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1176,6 +1176,16 @@ class EngineArgs:
         # gguf file needs a specific model loader
         if is_gguf(self.model):
             self.quantization = self.load_format = "gguf"
+            # GGUF dequantization kernels use half precision (fp16) internally.
+            # bfloat16 causes incorrect output on some architectures (e.g., Blackwell).
+            # Default to float16 for safety; explicit --dtype bfloat16 still allowed
+            # for users on hardware where it works.
+            if self.dtype == "auto":
+                self.dtype = "float16"
+                logger.info(
+                    "GGUF models default to float16 (dequant kernels use fp16 "
+                    "internally). Use --dtype bfloat16 to override if needed."
+                )
 
         if not envs.VLLM_ENABLE_V1_MULTIPROCESSING:
             logger.warning(

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -54,10 +54,10 @@ class GGUFConfig(QuantizationConfig):
 
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
         # GGUF dequantization kernels use half precision (fp16) internally.
-        # bfloat16 has precision issues on SM 120+ devices (Blackwell).
-        if current_platform.has_device_capability(120):
+        # bfloat16 has precision issues on Blackwell (SM 10.0+) devices.
+        if current_platform.has_device_capability(100):
             logger.warning_once(
-                "GGUF has precision issues with bfloat16 on SM 120+ devices. "
+                "GGUF has precision issues with bfloat16 on Blackwell devices (SM 10.0+). "
                 "bfloat16 is unavailable for Blackwell devices."
             )
             return [torch.half, torch.float32]

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -54,12 +54,9 @@ class GGUFConfig(QuantizationConfig):
 
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
         # GGUF dequantization kernels use half precision (fp16) internally.
-        # bfloat16 has precision issues on Blackwell (SM 10.0+) devices.
+        # bfloat16 has precision issues on Blackwell devices.
         if current_platform.has_device_capability(100):
-            logger.warning_once(
-                "GGUF has precision issues with bfloat16 on Blackwell devices (SM 10.0+). "
-                "bfloat16 is unavailable for Blackwell devices."
-            )
+            logger.warning_once("GGUF has precision issues with bfloat16 on Blackwell.")
             return [torch.half, torch.float32]
         return [torch.half, torch.bfloat16, torch.float32]
 

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -52,6 +52,10 @@ class GGUFConfig(QuantizationConfig):
         return "gguf"
 
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
+        # GGUF dequantization kernels use half precision (fp16) internally.
+        # bfloat16 may cause incorrect output on some architectures (e.g., Blackwell)
+        # but is kept for users who explicitly request it on hardware where it works.
+        # See: arg_utils.py auto-defaults to float16 for GGUF when dtype="auto"
         return [torch.half, torch.bfloat16, torch.float32]
 
     @classmethod


### PR DESCRIPTION
## Summary

Fixes incorrect output from GGUF models on Blackwell (SM 120+) GPUs by defaulting to float16 dtype.

## Changes

- Default GGUF quantization to float16 (was auto-selecting bfloat16)
- Add warning when bfloat16 is explicitly requested on Blackwell

## Root Cause

bfloat16 causes precision issues with GGUF quantized weights on Blackwell architecture.

## Testing

Tested with multiple GGUF models on RTX 5090.