### PR TITLE
fix(gguf): Ensure Gemma2 configs have hidden_act for backward compatibility

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -484,6 +484,17 @@ class ModelConfig:
         )
 
         self.hf_config = hf_config
+
+        # Ensure Gemma2 configs have hidden_act for backward compatibility.
+        # GGUF configs may only have hidden_activation; model code expects both.
+        if (
+            hasattr(hf_config, "model_type")
+            and hf_config.model_type == "gemma2"
+            and not hasattr(hf_config, "hidden_act")
+            and hasattr(hf_config, "hidden_activation")
+        ):
+            hf_config.hidden_act = hf_config.hidden_activation
+
         if dict_overrides:
             self._apply_dict_overrides(hf_config, dict_overrides)
         self.hf_text_config = get_hf_text_config(self.hf_config)


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'Gemma2Config' object has no attribute 'hidden_act'` when loading Gemma2 GGUF models.

## Changes

- In `ModelConfig.__init__`, if model_type is "gemma2" and config has `hidden_activation` but not `hidden_act`, copy the value

## Root Cause

- Transformers' `Gemma2Config` only defines `hidden_activation`, not `hidden_act`
- vLLM's `gemma2.py` directly accesses `config.hidden_act` without fallback

## Testing

Tested with `bartowski/gemma-2-2b-it-GGUF` - model resolves architecture correctly.