### PR TITLE
fix(nemotron_h): Add missing rotary positional embeddings to attention layers

### DIFF
--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -54,6 +54,7 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateShapeCalculator,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -432,6 +433,7 @@ class NemotronHAttention(nn.Module):
         self,
         config: NemotronHConfig,
         layer_idx: int,
+        max_position_embeddings: int,
         model_config: ModelConfig | None = None,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
@@ -492,13 +494,25 @@ class NemotronHAttention(nn.Module):
             per_layer_sliding_window=sliding_window,
         )
 
+        # Rotary embeddings for positional encoding
+        self.max_position_embeddings = max_position_embeddings
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=max_position_embeddings,
+            is_neox_style=True,
+            dtype=torch.get_default_dtype(),
+        )
+
     def forward(
         self,
+        positions: torch.Tensor,
         hidden_states: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
         return output
@@ -524,9 +538,10 @@ class NemotronHAttentionDecoderLayer(nn.Module):
         self.mixer = NemotronHAttention(
             layer_config,
             layer_idx,
-            model_config,
-            cache_config,
-            quant_config,
+            max_position_embeddings=config.max_position_embeddings,
+            model_config=model_config,
+            cache_config=cache_config,
+            quant_config=quant_config,
             prefix=f"{prefix}.mixer",
         )
 
@@ -545,7 +560,7 @@ class NemotronHAttentionDecoderLayer(nn.Module):
         else:
             hidden_states, residual = self.norm(hidden_states, residual)
 
-        hidden_states = self.mixer(hidden_states=hidden_states)
+        hidden_states = self.mixer(positions=positions, hidden_states=hidden_states)
         return hidden_states, residual
 
 
@@ -701,6 +716,10 @@ class NemotronHModel(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
+            # Skip rotary embeddings - they are computed dynamically
+            if "rotary_emb.inv_freq" in name:
+                continue
+
             if "scale" in name or "zero_point" in name:
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -498,7 +498,6 @@ class NemotronHAttention(nn.Module):
         self.max_position_embeddings = max_position_embeddings
         self.rotary_emb = get_rope(
             head_size=self.head_dim,
-            rotary_dim=self.head_dim,
             max_position=max_position_embeddings,
             is_neox_style=True,
             dtype=model_config.dtype if model_config else torch.get_default_dtype(),

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -501,7 +501,7 @@ class NemotronHAttention(nn.Module):
             rotary_dim=self.head_dim,
             max_position=max_position_embeddings,
             is_neox_style=True,
-            dtype=torch.get_default_dtype(),
+            dtype=model_config.dtype if model_config else torch.get_default_dtype(),
         )
 
     def forward(


### PR DESCRIPTION
## Summary

Fixes inference failure for `nvidia/NVIDIA-Nemotron-Nano-9B-v2` and similar nemotron_h architecture models.

## Problem

The `NemotronHAttention` class was missing rotary positional embeddings (RoPE), causing corrupted attention scores.

## Changes

1. Add `rotary_emb` initialization in `NemotronHAttention.__init__()`
2. Update `forward()` to accept positions and apply RoPE
3. Update `NemotronHAttentionDecoderLayer` to pass positions to mixer

## Testing

Tested with `nvidia/NVIDIA-Nemotron-Nano-9B-v2` - model generates coherent output.