### PR TITLE
[Doc] Add instructions for building docker image on GB300 with CUDA13

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -82,7 +82,7 @@ DOCKER_BUILDKIT=1 docker build . \
 
 ## Building for Arm64/aarch64
 
-A docker container can be built for aarch64 systems such as the Nvidia Grace-Hopper. At time of this writing, this should be considered **experimental**. Using the flag `--platform "linux/arm64"` will attempt to build for arm64.
+A docker container can be built for aarch64 systems such as the Nvidia Grace-Hopper and Grace-Blackwell. At time of this writing, this should be considered **experimental**. Using the flag `--platform "linux/arm64"` will attempt to build for arm64.
 
 !!! note
     Multiple modules must be compiled, so this process can take a while. Recommend using `--build-arg max_jobs=` & `--build-arg nvcc_threads=`
@@ -102,6 +102,26 @@ A docker container can be built for aarch64 systems such as the Nvidia Grace-Hop
     --build-arg nvcc_threads=2 \
     --build-arg torch_cuda_arch_list="9.0 10.0+PTX" \
     --build-arg RUN_WHEEL_CHECK=false
+    ```
+
+For (G)B300, we recommend to use CUDA13.
+
+??? console "Command"
+
+    ```bash
+    DOCKER_BUILDKIT=1 docker build \
+    --build-arg CUDA_VERSION=13.0.1 \
+    --build-arg BUILD_BASE_IMAGE=nvidia/cuda:13.0.1-devel-ubuntu22.04 \
+    --build-arg max_jobs=256 \
+    --build-arg nvcc_threads=2 \
+    --build-arg RUN_WHEEL_CHECK=false \
+    --build-arg FLASHINFER_AOT_COMPILE=true \
+    --build-arg torch_cuda_arch_list='9.0 10.0+PTX' \
+    --platform "linux/arm64" \
+    --tag vllm/vllm-gb300-openai:latest  \
+    --target vllm-openai \
+    -f docker/Dockerfile \
+    .
     ```
 
 !!! note

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -104,7 +104,7 @@ A docker container can be built for aarch64 systems such as the Nvidia Grace-Hop
     --build-arg RUN_WHEEL_CHECK=false
     ```
 
-For (G)B300, we recommend to use CUDA13.
+For (G)B300, we recommend using CUDA 13, as shown in the following command.
 
 ??? console "Command"
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -115,7 +115,6 @@ For (G)B300, we recommend using CUDA 13, as shown in the following command.
     --build-arg max_jobs=256 \
     --build-arg nvcc_threads=2 \
     --build-arg RUN_WHEEL_CHECK=false \
-    --build-arg FLASHINFER_AOT_COMPILE=true \
     --build-arg torch_cuda_arch_list='9.0 10.0+PTX' \
     --platform "linux/arm64" \
     --tag vllm/vllm-gb300-openai:latest  \

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -82,7 +82,7 @@ DOCKER_BUILDKIT=1 docker build . \
 
 ## Building for Arm64/aarch64
 
-A docker container can be built for aarch64 systems such as the Nvidia Grace-Hopper and Grace-Blackwell. At time of this writing, this should be considered **experimental**. Using the flag `--platform "linux/arm64"` will attempt to build for arm64.
+A docker container can be built for aarch64 systems such as the Nvidia Grace-Hopper and Grace-Blackwell. Using the flag `--platform "linux/arm64"` will build for arm64.
 
 !!! note
     Multiple modules must be compiled, so this process can take a while. Recommend using `--build-arg max_jobs=` & `--build-arg nvcc_threads=`

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -117,7 +117,7 @@ For (G)B300, we recommend using CUDA 13, as shown in the following command.
     --build-arg RUN_WHEEL_CHECK=false \
     --build-arg torch_cuda_arch_list='9.0 10.0+PTX' \
     --platform "linux/arm64" \
-    --tag vllm/vllm-gb300-openai:latest  \
+    --tag vllm/vllm-gb300-openai:latest \
     --target vllm-openai \
     -f docker/Dockerfile \
     .


### PR DESCRIPTION
## Purpose

Currently, we recommend to use CUDA 13 for GB300. Therefore update the docker building instructions in doc.

cc @wangshangsam @tlrmchlsmth 

## Test Plan

Have tried run the command to build docker image. 

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

