### PR TITLE
fix(gemma2): Add quant_config to embedding layer for GGUF support

### DIFF
--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -266,6 +266,8 @@ class Gemma2Model(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,


### PR DESCRIPTION
## Summary
- Adds `quant_config` parameter to `VocabParallelEmbedding` in Gemma2 model
- Enables proper GGUF quantized embedding handling

## Problem
Gemma2 GGUF models produce **garbage output** despite loading successfully:
```
Input: "Say hello in 5 words"
Output: " GHFW側から ThinkmariKeywords!");\rJahre Iliad幺个人..."
```

## Root Cause
Without `quant_config`, `VocabParallelEmbedding` uses `UnquantizedEmbeddingMethod` which calls `F.embedding()` directly on quantized bytes, interpreting them as float values.

This is the **exact same bug** that was fixed for DeepSeek in commit `aa375dca9` ("#12836 - Missing quant_config in deepseek embedding layer").

## The Fix
```diff
 self.embed_tokens = VocabParallelEmbedding(
     config.vocab_size,
     config.hidden_size,
+    quant_config=quant_config,
+    prefix=f"{prefix}.embed_tokens",
 )
```

## Comparison
| Model | quant_config Passed? | GGUF Works? |
|-------|---------------------|-------------|
| Gemma2 | ❌ NO (before fix) | ❌ Garbage |
| Gemma3 | ✅ YES | ✅ Works |
| Llama | ✅ YES | ✅ Works |
| DeepSeek | ✅ YES (after #12836) | ✅ Works |

## Affected Models
All Gemma2 GGUF variants:
- gemma-2-2b-it-GGUF
- gemma-2-9b-GGUF  
- gemma-2-27b-GGUF

## Test Plan
- [ ] Gemma2 GGUF model loads without errors
- [ ] Inference produces coherent output (not garbage)
- [ ] Compare output quality with Gemma3 GGUF or safetensors Gemma2

🤖 Generated with [Claude Code](https://claude.com/claude-code)