### PR TITLE
fix(gguf): Extract attn_logit_softcapping from GGUF metadata

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -470,6 +470,17 @@ class ModelConfig:
         )
 
         self.hf_config = hf_config
+
+        # Ensure Gemma2 configs have hidden_act for backward compatibility.
+        # GGUF configs may only have hidden_activation; model code expects both.
+        if (
+            hasattr(hf_config, "model_type")
+            and hf_config.model_type == "gemma2"
+            and not hasattr(hf_config, "hidden_act")
+            and hasattr(hf_config, "hidden_activation")
+        ):
+            hf_config.hidden_act = hf_config.hidden_activation
+
         if dict_overrides:
             self._apply_dict_overrides(hf_config, dict_overrides)
         self.hf_text_config = get_hf_text_config(self.hf_config)

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -54,9 +54,12 @@ class GGUFConfig(QuantizationConfig):
 
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
         # GGUF dequantization kernels use half precision (fp16) internally.
-        # bfloat16 has precision issues on Blackwell devices.
+        # bfloat16 has precision issues on SM 10.0+ devices (Blackwell).
         if current_platform.has_device_capability(100):
-            logger.warning_once("GGUF has precision issues with bfloat16 on Blackwell.")
+            logger.warning_once(
+                "GGUF has precision issues with bfloat16 on Blackwell (SM 10.0+). "
+                "bfloat16 is unavailable."
+            )
             return [torch.half, torch.float32]
         return [torch.half, torch.bfloat16, torch.float32]
 

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -147,6 +147,11 @@ class GGUFModelLoader(BaseModelLoader):
                     )
                 )
 
+        # For models with tied word embeddings, lm_head.weight is initialized
+        # from embed_tokens and doesn't need to be mapped from GGUF file
+        if getattr(config, "tie_word_embeddings", False):
+            sideload_params.append(re.compile(r"lm_head\.weight"))
+
         arch = None
         for key, value in gguf.MODEL_ARCH_NAMES.items():
             if value == model_type:

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -365,6 +365,10 @@ class Gemma2Model(nn.Module):
                     continue
                 if is_pp_missing_parameter(name, self):
                     continue
+                # Skip parameters not in the model (e.g., GGUF quantization
+                # metadata like qweight_type for embeddings)
+                if name not in params_dict:
+                    continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -266,6 +266,8 @@ class Gemma2Model(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -199,6 +199,67 @@ def extract_vision_config_from_gguf(mmproj_path: str) -> "SiglipVisionConfig | N
     return config
 
 
+def extract_softcap_from_gguf(model: str) -> dict[str, float]:
+    """Extract attention and final logit softcap values from GGUF metadata.
+
+    Reads softcap parameters from GGUF metadata using arch-specific keys.
+    These parameters are critical for models like Gemma2 where attention
+    logit softcapping prevents numerical instability.
+
+    Args:
+        model: Path to GGUF model file
+
+    Returns:
+        Dictionary with 'attn_logit_softcapping' and/or 'final_logit_softcapping'
+        keys if found in GGUF metadata, empty dict otherwise
+    """
+    if not model.endswith(".gguf"):
+        return {}
+
+    try:
+        model_path = Path(model)
+        if not model_path.is_file():
+            return {}
+
+        reader = gguf.GGUFReader(str(model_path))
+
+        # Get architecture name to build arch-specific keys
+        arch_field = reader.get_field(Keys.General.ARCHITECTURE)
+        if arch_field is None:
+            logger.debug("No architecture field found in GGUF metadata")
+            return {}
+
+        arch = bytes(arch_field.parts[-1]).decode("utf-8")
+
+        result = {}
+
+        # Extract attention logit softcapping
+        attn_key = Keys.LLM.ATTN_LOGIT_SOFTCAPPING.format(arch=arch)
+        attn_field = reader.get_field(attn_key)
+        if attn_field is not None:
+            result["attn_logit_softcapping"] = float(attn_field.parts[-1])
+            logger.info(
+                "Extracted attn_logit_softcapping=%.2f from GGUF metadata",
+                result["attn_logit_softcapping"],
+            )
+
+        # Extract final logit softcapping
+        final_key = Keys.LLM.FINAL_LOGIT_SOFTCAPPING.format(arch=arch)
+        final_field = reader.get_field(final_key)
+        if final_field is not None:
+            result["final_logit_softcapping"] = float(final_field.parts[-1])
+            logger.info(
+                "Extracted final_logit_softcapping=%.2f from GGUF metadata",
+                result["final_logit_softcapping"],
+            )
+
+        return result
+
+    except Exception as e:
+        logger.warning("Error extracting softcap from GGUF '%s': %s", model, e)
+        return {}
+
+
 def maybe_patch_hf_config_from_gguf(
     model: str,
     hf_config: PretrainedConfig,
@@ -207,7 +268,8 @@ def maybe_patch_hf_config_from_gguf(
 
     Applies GGUF-specific patches to HuggingFace config:
     1. For multimodal models: patches architecture and vision config
-    2. For all GGUF models: overrides vocab_size from embedding tensor
+    2. For models with softcap (e.g., Gemma2): patches attention/logit softcapping
+    3. For all GGUF models: overrides vocab_size from embedding tensor
 
     This ensures compatibility with GGUF models that have extended
     vocabularies (e.g., Unsloth) where the GGUF file contains more
@@ -235,6 +297,15 @@ def maybe_patch_hf_config_from_gguf(
                 architectures=["Gemma3ForConditionalGeneration"],
             )
             hf_config = new_hf_config
+
+    # Patch softcap parameters from GGUF metadata
+    # Critical for models like Gemma2 where attention softcapping
+    # prevents numerical instability and ensures correct output
+    softcap_params = extract_softcap_from_gguf(model)
+    if "attn_logit_softcapping" in softcap_params:
+        hf_config.attn_logit_softcapping = softcap_params["attn_logit_softcapping"]
+    if "final_logit_softcapping" in softcap_params:
+        hf_config.final_logit_softcapping = softcap_params["final_logit_softcapping"]
 
     return hf_config
 

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -95,13 +95,13 @@ def detect_gguf_multimodal(model: str) -> Path | None:
     Returns:
         Path to mmproj file if found, None otherwise
     """
-    if not model.endswith(".gguf"):
+    # Use magic bytes detection instead of file extension heuristic
+    # HuggingFace blob paths don't have .gguf extension
+    if not check_gguf_file(model):
         return None
 
     try:
         model_path = Path(model)
-        if not model_path.is_file():
-            return None
 
         model_dir = model_path.parent
         mmproj_patterns = ["mmproj.gguf", "mmproj-*.gguf", "*mmproj*.gguf"]
@@ -213,13 +213,13 @@ def extract_softcap_from_gguf(model: str) -> dict[str, float]:
         Dictionary with 'attn_logit_softcapping' and/or 'final_logit_softcapping'
         keys if found in GGUF metadata, empty dict otherwise
     """
-    if not model.endswith(".gguf"):
+    # Use magic bytes detection instead of file extension heuristic
+    # HuggingFace blob paths don't have .gguf extension
+    if not check_gguf_file(model):
         return {}
 
     try:
         model_path = Path(model)
-        if not model_path.is_file():
-            return {}
 
         reader = gguf.GGUFReader(str(model_path))
 


### PR DESCRIPTION
## Summary
Fixes garbage output from Gemma2 GGUF models by extracting the `attn_logit_softcapping` parameter from GGUF metadata and patching it onto the HuggingFace config.

## Root Cause
GGUF models store softcap in metadata with arch-specific keys (e.g., `gemma2.attn_logit_softcapping`), but this wasn't being extracted and applied to the HF config. Without softcap, the V1 FlashAttention backend uses `softcap=0` (disabled), causing numerical instability and garbage output.

The attention backends ALREADY support softcap correctly - this fix is in the GGUF config mapping layer, not the attention kernels.

## Changes
- Add `extract_softcap_from_gguf()` to read softcap from GGUF metadata
- Update `maybe_patch_hf_config_from_gguf()` to apply softcap values
- Support both `attn_logit_softcapping` and `final_logit_softcapping`

## Testing
Tested with: `google/gemma-2-2b-it:Q4_K_M` - produces coherent output instead of garbage

## Related
This is part of a series of GGUF fixes for Blackwell (SM 120+) compatibility.