### PR TITLE
[ROCm][Bugfix] Add MLACommonMetadata to allowed attention types for speculative decoding

### DIFF
--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -180,15 +180,9 @@ class EagleProposer:
                 rocm_types.append(AiterFlashAttentionMetadata)
 
             # TRITON_MLA backend support for MLA models (e.g., DeepSeek)
-            try:
-                from vllm.v1.attention.backends.mla.common import MLACommonMetadata
+            from vllm.v1.attention.backends.mla.common import MLACommonMetadata
 
-                rocm_types.append(MLACommonMetadata)
-            except ImportError:
-                logger.debug(
-                    "Could not import MLACommonMetadata. MLA backend "
-                    "for speculative decoding will be unavailable."
-                )
+            rocm_types.append(MLACommonMetadata)
 
             self.allowed_attn_types = tuple(rocm_types)
 

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -178,6 +178,15 @@ class EagleProposer:
                 )
 
                 rocm_types.append(AiterFlashAttentionMetadata)
+
+            # TRITON_MLA backend support for MLA models (e.g., DeepSeek)
+            try:
+                from vllm.v1.attention.backends.mla.common import MLACommonMetadata
+
+                rocm_types.append(MLACommonMetadata)
+            except ImportError:
+                pass
+
             self.allowed_attn_types = tuple(rocm_types)
 
         # Parse the speculative token tree.

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -185,7 +185,10 @@ class EagleProposer:
 
                 rocm_types.append(MLACommonMetadata)
             except ImportError:
-                pass
+                logger.debug(
+                    "Could not import MLACommonMetadata. MLA backend "
+                    "for speculative decoding will be unavailable."
+                )
 
             self.allowed_attn_types = tuple(rocm_types)
 


### PR DESCRIPTION
## Summary
Adds `MLACommonMetadata` to the allowed attention types for ROCm in the EAGLE speculative decoding proposer.

## Problem
When using MLA on ROCm (e.g., DeepSeek) and speculative decoding with `num_speculative_tokens > 1`, the following error occurs:
```
ValueError: Unsupported attention metadata type for speculative decoding with num_speculative_tokens > 1: <class 'vllm.v1.attention.backends.mla.common.MLACommonMetadata'>. Supported types are: (<class 'vllm.v1.attention.backends.triton_attn.TritonAttentionMetadata'>, <class 'vllm.v1.attention.backends.flash_attn.FlashAttentionMetadata'>, <class 'vllm.v1.attention.backends.rocm_aiter_fa.AiterFlashAttentionMetadata'>)
```

This PR fixes this issue, originally triggered in `tests/v1/e2e/test_async_spec_decode.py::test_no_sync_with_spec_decode[eagle-mla-deepseek]`