### PR TITLE
[ROCm] Fix broken import in platform attention backend dispatching

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -403,7 +403,22 @@ class RocmPlatform(Platform):
                 compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
         if cache_config and cache_config.block_size is None:
-            cache_config.block_size = 16
+            if (
+                os.environ.get("VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION")
+                and os.environ.get("VLLM_ROCM_USE_AITER")
+                # NOTE: This block has been deprecated
+                # or get_env_variable_attn_backend()
+                # == AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN
+                # TODO: monitor https://github.com/vllm-project/vllm/pull/30396
+                # to see how we can transition to the new way of selecting
+                # attention backends
+            ):
+                cache_config.block_size = 64
+                logger.warning(
+                    "[ROCM_AITER_UNIFIED_ATTN]: Setting kv cache block size to 64."
+                )
+            else:
+                cache_config.block_size = 16
 
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm.v1.worker.gpu_worker.Worker"

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -404,8 +404,7 @@ class RocmPlatform(Platform):
 
         if cache_config and cache_config.block_size is None:
             if (
-                os.environ.get("VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION")
-                and os.environ.get("VLLM_ROCM_USE_AITER")
+                envs.VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION and envs.VLLM_ROCM_USE_AITER
                 # NOTE: This block has been deprecated
                 # or get_env_variable_attn_backend()
                 # == AttentionBackendEnum.ROCM_AITER_UNIFIED_ATTN


### PR DESCRIPTION
## Summary
Removes broken dependency on `get_env_variable_attn_backend` from `vllm.attention.selector` in ROCm platform configuration.

## Problem
The import `from vllm.attention.selector import get_env_variable_attn_backend` was causing failures on ROCm. This was used to check for `ROCM_AITER_UNIFIED_ATTN` backend selection when setting KV cache block size.

## Fix
Deprecate the `get_env_variable_attn_backend` check and rely on environment variables (`VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION`, `VLLM_ROCM_USE_AITER`) directly for block size configuration.

Tracking upstream PR https://github.com/vllm-project/vllm/pull/30396 for the proper way to handle attention backend selection going forward.

## Testing
Verified ROCm platform initializes correctly without import errors.