### PR TITLE
[Bugfix] Qwen3-next with  --hf-overrides \{\"num_hidden_layers\":8\} 

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -1089,9 +1089,9 @@ class Qwen3NextModel(nn.Module):
                     if is_pp_missing_parameter(name, self):
                         continue
                     # Skip loading extra bias for GPTQ models.
-                    if (
-                        name.endswith(".bias") or name.endswith("_bias")
-                    ) and name not in params_dict:
+                    if name.endswith(".bias") or name.endswith("_bias"):
+                        continue
+                    if name not in params_dict:
                         continue
                     param = params_dict[name]
                     weight_loader = param.weight_loader
@@ -1108,6 +1108,11 @@ class Qwen3NextModel(nn.Module):
                     if name.endswith(".bias") and name not in params_dict:
                         continue
                     if is_pp_missing_parameter(name, self):
+                        continue
+                    if name not in params_dict:
+                        logger.warning_once(
+                            f"Parameter {name} not found in params_dict, skip loading"
+                        )
                         continue
                     param = params_dict[name]
                     weight_loader = getattr(

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -1089,7 +1089,9 @@ class Qwen3NextModel(nn.Module):
                     if is_pp_missing_parameter(name, self):
                         continue
                     # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") or name.endswith("_bias"):
+                    if (
+                        name.endswith(".bias") or name.endswith("_bias")
+                    ) and name not in params_dict:
                         continue
                     if name not in params_dict:
                         continue


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

I'm testing qwen3 next with `vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct --hf-overrides \{\"num_hidden_layers\":8\} --enforce-eager` to fit in one gpu card. But I get this error:
```
(EngineCore_DP0 pid=4063290) ERROR 12-10 15:15:56 [core.py:867]   File "**/vllm/vllm/model_executor/models/qwen3_next.py", line 1096, in load_weights
(EngineCore_DP0 pid=4063290) ERROR 12-10 15:15:56 [core.py:867]     param = params_dict[name]
(EngineCore_DP0 pid=4063290) ERROR 12-10 15:15:56 [core.py:867]             ~~~~~~~~~~~^^^^^^
(EngineCore_DP0 pid=4063290) ERROR 12-10 15:15:56 [core.py:867] KeyError: 'layers.45.mlp.experts.w2_weight'
```

This PR fix it by skipping the unexist layers

## Test Plan
```
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct --hf-overrides \{\"num_hidden_layers\":8\} --enforce-eager
```
## Test Result
Can run, with output like:
```
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.35.mlp.experts.w2_weight not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.input_layernorm.weight not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.linear_attn.A_log not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.linear_attn.conv1d.weight not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.linear_attn.dt_bias not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.linear_attn.in_proj_ba.weight not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.linear_attn.in_proj_qkvz.weight not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.linear_attn.norm.weight not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.linear_attn.out_proj.weight not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.mlp.experts.w13_weight not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.mlp.gate.weight not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.mlp.shared_expert.down_proj.weight not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.mlp.shared_expert.gate_gate_up_proj.weight not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.mlp.shared_expert.gate_up_proj.weight not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.mlp.shared_expert_gate.weight not found in params_dict, skip loading
(EngineCore_DP0 pid=4057748) WARNING 12-10 15:14:50 [qwen3_next.py:1113] Parameter layers.36.post_attention_layernorm.weight not found in params_dict, skip loading
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

