### PR TITLE
fix(gguf): Use EOS token ID from GGUF metadata instead of HF tokenizer

### DIFF
--- a/vllm/tokenizers/hf.py
+++ b/vllm/tokenizers/hf.py
@@ -79,6 +79,9 @@ class CachedHfTokenizer(TokenizerLike):
         download_dir: str | None = None,
         **kwargs,
     ) -> HfTokenizer:
+        # Save gguf_file before AutoTokenizer.from_pretrained() pops it from kwargs
+        gguf_file = kwargs.get("gguf_file")
+
         try:
             tokenizer = AutoTokenizer.from_pretrained(
                 path_or_repo_id,
@@ -123,7 +126,8 @@ class CachedHfTokenizer(TokenizerLike):
         # Patch EOS token ID from GGUF metadata if available
         # GGUF files may have a different EOS token ID than HF tokenizer config
         # (e.g., Gemma uses <end_of_turn> ID 106 as EOS, but HF reports <eos> ID 1)
-        gguf_file = kwargs.get("gguf_file")
+        # Note: gguf_file was saved above before
+        # AutoTokenizer.from_pretrained() popped it
         if gguf_file:
             gguf_path = Path(path_or_repo_id) / gguf_file
             gguf_eos_id = extract_eos_token_id_from_gguf(str(gguf_path))

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -234,9 +234,9 @@ def extract_eos_token_id_from_gguf(model: str) -> int | None:
     Returns:
         EOS token ID from GGUF metadata, or None if not found
     """
-    if not model.endswith(".gguf"):
-        return None
-
+    # Note: We don't check for .gguf extension here because HuggingFace Hub
+    # stores GGUF files as blob hashes without extensions. The caller is
+    # responsible for ensuring this is a valid GGUF file (via check_gguf_file).
     try:
         model_path = Path(model)
         if not model_path.is_file():


### PR DESCRIPTION
## Summary

GGUF files store the correct EOS token ID in `tokenizer.ggml.eos_token_id` metadata. However, vLLM was using the HuggingFace tokenizer's `eos_token_id`, which can differ from the GGUF value.

This causes generation to not stop properly for models like Gemma 3, where:
- GGUF metadata specifies EOS token ID 106 (`<end_of_turn>`)
- HF tokenizer reports EOS token ID 1 (`<eos>`)

The model generates `<end_of_turn>` to signal completion, but vLLM waits for token ID 1 which never comes, resulting in repeated EOS tokens until `max_tokens` is reached.

**Example output before fix:**
```
Response: Hello! I'm doing well, thank you!<end_of_turn><end_of_turn><end_of_turn>...(repeats until max_tokens)
```

## Changes

- Add `extract_eos_token_id_from_gguf()` in `gguf_utils.py` to read EOS from GGUF metadata
- Patch `tokenizer.eos_token_id` in `hf.py` when loading GGUF tokenizers
- Log when EOS token ID is patched for debugging

## Testing

- Tested with `unsloth/gemma-3-12b-it-GGUF` model
- Verified GGUF EOS token ID (106) is extracted correctly
- Generation now stops properly at `<end_of_turn>` token

## Notes

This is a common issue with GGUF models that use different EOS tokens than the base HuggingFace tokenizer. The fix ensures vLLM uses the authoritative EOS token ID from the GGUF file itself.