### PR TITLE
[fix] Fix qwen3_coder tool call per parameter streaming

### DIFF
--- a/tests/tool_use/test_qwen3coder_tool_parser.py
+++ b/tests/tool_use/test_qwen3coder_tool_parser.py
@@ -906,7 +906,8 @@ TX
         if chunk.tool_calls and chunk.tool_calls[0].function.arguments:
             arg_chunks.append(chunk.tool_calls[0].function.arguments)
 
-    # Arguments should be streamed incrementally and strings should be streamed per parameter
+    # Arguments should be streamed incrementally
+    # and strings should be streamed per parameter
     assert len(arg_chunks) == 9
 
     # Concatenated arguments should form valid JSON

--- a/tests/tool_use/test_qwen3coder_tool_parser.py
+++ b/tests/tool_use/test_qwen3coder_tool_parser.py
@@ -849,12 +849,70 @@ TX
             arg_chunks.append(chunk.tool_calls[0].function.arguments)
 
     # Arguments should be streamed incrementally
-    assert len(arg_chunks) > 1
+    assert len(arg_chunks) == 7
 
     # Concatenated arguments should form valid JSON
     full_args = "".join(arg_chunks)
     parsed_args = json.loads(full_args)
     assert parsed_args["city"] == "Dallas"
+    assert parsed_args["state"] == "TX"
+
+
+def test_extract_tool_calls_streaming_strings_incremental(
+    qwen3_tool_parser_parametrized, qwen3_tokenizer, sample_tools
+):
+    """Test that streaming is truly incremental"""
+    model_output = """I'll check the weather.<tool_call>
+<function=get_current_weather>
+<parameter=city>
+Dallas Dallas Dallas
+</parameter>
+<parameter=state>
+TX
+</parameter>
+</function>
+</tool_call>"""
+
+    request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
+
+    chunks = []
+    for delta_message in stream_delta_message_generator(
+        qwen3_tool_parser_parametrized, qwen3_tokenizer, model_output, request
+    ):
+        chunks.append(delta_message)
+
+    # Should have multiple chunks
+    assert len(chunks) > 3
+
+    # First chunk(s) should be content
+    assert chunks[0].content is not None
+    assert chunks[0].tool_calls is None or chunks[0].tool_calls == []
+
+    # Should have a chunk with tool header (id, name, type)
+    header_found = False
+    for chunk in chunks:
+        if chunk.tool_calls and chunk.tool_calls[0].id:
+            header_found = True
+            assert chunk.tool_calls[0].function.name == "get_current_weather"
+            assert chunk.tool_calls[0].type == "function"
+            # Empty initially
+            assert chunk.tool_calls[0].function.arguments == ""
+            break
+    assert header_found
+
+    # Should have chunks with incremental arguments
+    arg_chunks = []
+    for chunk in chunks:
+        if chunk.tool_calls and chunk.tool_calls[0].function.arguments:
+            arg_chunks.append(chunk.tool_calls[0].function.arguments)
+
+    # Arguments should be streamed incrementally and strings should be streamed per parameter
+    assert len(arg_chunks) == 9
+
+    # Concatenated arguments should form valid JSON
+    full_args = "".join(arg_chunks)
+    parsed_args = json.loads(full_args)
+    assert parsed_args["city"] == "Dallas Dallas Dallas"
     assert parsed_args["state"] == "TX"
 
 

--- a/vllm/entrypoints/openai/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/qwen3coder_tool_parser.py
@@ -703,7 +703,8 @@ class Qwen3CoderToolParser(ToolParser):
 
                 return False
 
-            # while streaming strings, the parser needs to watch for prefix and end tags.
+            # while streaming, the parser needs to watch for prefix and end tags
+            # that may be upcoming to avoid sending them as chunks.
             if (
                 ends_with_prefix_of(value_text, self.parameter_prefix)
                 or ends_with_prefix_of(value_text, self.parameter_end_token)

--- a/vllm/entrypoints/openai/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/qwen3coder_tool_parser.py
@@ -649,9 +649,7 @@ class Qwen3CoderToolParser(ToolParser):
         # Get parameter configuration for type conversion and string checking
         param_config = self._get_arguments_config(
             self.current_function_name or "",
-            self.streaming_request.tools
-            if self.streaming_request
-            else None,
+            self.streaming_request.tools if self.streaming_request else None,
         )
 
         # handle strings via streaming.
@@ -749,18 +747,12 @@ class Qwen3CoderToolParser(ToolParser):
 
         # Build JSON fragment based on the converted type
         # Use json.dumps to properly serialize the value
-        serialized_value = json.dumps(
-            converted_value, ensure_ascii=False
-        )
+        serialized_value = json.dumps(converted_value, ensure_ascii=False)
 
         if self.param_count == 0:
-            json_fragment = (
-                f'"{self.current_param_name}": {serialized_value}'
-            )
+            json_fragment = f'"{self.current_param_name}": {serialized_value}'
         else:
-            json_fragment = (
-                f', "{self.current_param_name}": {serialized_value}'
-            )
+            json_fragment = f', "{self.current_param_name}": {serialized_value}'
 
         self.param_count += 1
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix https://github.com/vllm-project/vllm/issues/30439

## Test Plan

Update the tests to check for per string token streaming in qwen 3 coder tool parser.

## Test Result
ests/tool_use/test_qwen3coder_tool_parser.py ....................                                                                                                                                  [100%]

============================================================================================ warnings summary =============================================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

vllm/entrypoints/openai/parser/responses_parser.py:19
  /root/chat/vllm-distributed/vllm/vllm/entrypoints/openai/parser/responses_parser.py:19: DeprecationWarning: `vllm.transformers_utils.tokenizer.AnyTokenizer` has been moved to `vllm.tokenizers.TokenizerLike`. The old name will be removed in v0.14.
    from vllm.transformers_utils.tokenizer import AnyTokenizer

vllm/entrypoints/context.py:44
  /root/chat/vllm-distributed/vllm/vllm/entrypoints/context.py:44: DeprecationWarning: `vllm.transformers_utils.tokenizer.AnyTokenizer` has been moved to `vllm.tokenizers.TokenizerLike`. The old name will be removed in v0.14.
    from vllm.transformers_utils.tokenizer import AnyTokenizer

vllm/entrypoints/openai/serving_engine.py:52
  /root/chat/vllm-distributed/vllm/vllm/entrypoints/openai/serving_engine.py:52: DeprecationWarning: `vllm.transformers_utils.tokenizer.AnyTokenizer` has been moved to `vllm.tokenizers.TokenizerLike`. The old name will be removed in v0.14.
    from vllm.transformers_utils.tokenizer import AnyTokenizer

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================== 20 passed, 5 warnings in 5.99s ====================================================================================

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".  
- [x] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

