### PR TITLE
[Fix] Update lazing loading of video loader backend

### DIFF
--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -283,8 +283,15 @@ class VideoMediaIO(MediaIO[tuple[npt.NDArray, dict[str, Any]]]):
         # They can be passed to the underlying
         # media loaders (e.g. custom implementations)
         # for flexible control.
+
+        # Allow per-request override of video backend via kwargs.
+        # This enables users to specify a different backend than the
+        # global VLLM_VIDEO_LOADER_BACKEND env var, e.g.:
+        #   --media-io-kwargs '{"video": {"video_backend": "torchcodec"}}'
+        video_loader_backend = (
+            kwargs.pop("video_backend", None) or envs.VLLM_VIDEO_LOADER_BACKEND
+        )
         self.kwargs = kwargs
-        video_loader_backend = envs.VLLM_VIDEO_LOADER_BACKEND
         self.video_loader = VIDEO_LOADER_REGISTRY.load(video_loader_backend)
 
     def load_bytes(self, data: bytes) -> tuple[npt.NDArray, dict[str, Any]]:


### PR DESCRIPTION
## Purpose

The goal of this diff is to allow having a lazy late decision of the video backend to load; Until now if mutiple plugins decide to override the envs then there is a conflict

## Test Plan

pytest tests/multimodal/test_video.py

## Test Result

================================================================================== 11 passed, 7 warnings in 8.88s ====================================================================================


