### PR TITLE
[NIXL] Heterogeneous KV Layout and block_size - prefill NHD and nP > nD support

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -29,7 +29,10 @@ from vllm.distributed.kv_transfer.kv_connector.utils import (
     get_current_attn_backend,
     kv_postprocess_blksize_and_layout_on_receive,
     kv_postprocess_blksize_on_receive,
+    kv_postprocess_blksize_on_save,
+    kv_postprocess_layout_and_blksize_on_save,
     kv_postprocess_layout_on_receive,
+    kv_postprocess_layout_on_save,
     yield_req_data,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
@@ -250,6 +253,66 @@ class ReqMeta:
     remote: RemoteMeta | None = None
 
 
+def if_postprocess_kvcache_on_save(
+    vllm_config, current_block_size, current_kv_cache_layout
+):
+    assert vllm_config.kv_transfer_config.enable_permute_local_kv
+    if vllm_config.cache_config.enable_prefix_caching:
+        logger.warning_once(
+            "KV cache postprocess is not compatible with prefix caching."
+        )
+        return False, current_kv_cache_layout, current_block_size
+    postprocess_kv_caches_on_save = False
+    kv_cache_layout_on_save = "HND"
+    agreed_block_size = int(
+        vllm_config.kv_transfer_config.get_from_extra_config(
+            "agreed_block_size", current_block_size
+        )
+    )
+    # Only allow save to smaller block size (larger required additional allocation)
+    block_size_on_save = (
+        agreed_block_size
+        if agreed_block_size <= current_block_size
+        else current_block_size
+    )
+    if (
+        kv_cache_layout_on_save != current_kv_cache_layout
+        or block_size_on_save != current_block_size
+    ):
+        postprocess_kv_caches_on_save = True
+        logger.info(
+            "KV cache postprocess on save is enabled. "
+            "Local kv cache layout: %s -> %s, "
+            "block size: %d -> %d",
+            current_kv_cache_layout,
+            kv_cache_layout_on_save,
+            current_block_size,
+            block_size_on_save,
+        )
+    return postprocess_kv_caches_on_save, kv_cache_layout_on_save, block_size_on_save
+
+
+def get_mapped_blocks(block_ids, block_size_ratio, num_blocks):
+    """
+        Calculates the new set of block IDs by mapping every element
+        in the (potentially sparse) input array.
+        Example: block_ids=[0, 2], block_size_ratio=2
+    get_mapped_blocks    0     1     [2     3]     4     5
+            # remote is |h0-b0|h1-b0||h0-b1|h1-b1||h0-b1|h1-b1||
+            # local is  |h0-b0......||h1-b0......||h2-b0........
+    local_block_ids         0           [1]           2
+    """
+    if block_ids.size == 0:
+        return []
+
+    start_ids = block_ids * block_size_ratio
+    offsets = np.arange(block_size_ratio)
+    mapped_2d = start_ids[:, None] + offsets[None, :]
+    ret = mapped_2d.flatten().tolist()[:num_blocks]
+
+    return ret
+
+
 class NixlConnectorMetadata(KVConnectorMetadata):
     def __init__(self):
         self.reqs_to_recv: dict[ReqId, ReqMeta] = {}
@@ -460,6 +523,8 @@ class NixlConnector(KVConnectorBase_V1):
         assert isinstance(self._connector_metadata, NixlConnectorMetadata)
         if self.connector_worker.use_host_buffer and self.connector_worker.copy_blocks:
             self.connector_worker.save_kv_to_host(self._connector_metadata)
+        elif self.connector_worker.postprocess_kv_caches_on_save:
+            self.connector_worker.kv_caches_postprocess(self._connector_metadata)
 
     def shutdown(self):
         if self.connector_worker is not None:
@@ -487,6 +552,7 @@ class NixlConnectorScheduler:
     def __init__(self, vllm_config: VllmConfig, engine_id: str):
         self.vllm_config = vllm_config
         self.block_size = vllm_config.cache_config.block_size
+        self.kv_cache_layout = get_kv_cache_layout()
         self.engine_id: EngineId = engine_id
         self.side_channel_host = envs.VLLM_NIXL_SIDE_CHANNEL_HOST
         self.side_channel_port = (
@@ -501,6 +567,21 @@ class NixlConnectorScheduler:
                 vllm_config.kv_transfer_config.kv_buffer_device == "cpu"
             )
 
+        self.postprocess_kv_caches_on_save = False
+        self.kv_cache_layout_on_save = self.kv_cache_layout
+        self.block_size_on_save = self.block_size
+
+        # list of chunked prefill partials
+        self.partial_reqs: dict[ReqId, list] = {}
+
+        if vllm_config.kv_transfer_config.enable_permute_local_kv:
+            (
+                self.postprocess_kv_caches_on_save,
+                self.kv_cache_layout_on_save,
+                self.block_size_on_save,
+            ) = if_postprocess_kvcache_on_save(
+                self.vllm_config, self.block_size, self.kv_cache_layout
+            )
         logger.info("Initializing NIXL Scheduler %s", engine_id)
 
         # Background thread for handling new handshake requests.
@@ -655,7 +736,9 @@ class NixlConnectorScheduler:
 
         if params.get("do_remote_decode"):
             self._reqs_in_batch.add(request.request_id)
-        if self.use_host_buffer and params.get("do_remote_decode"):
+        if (self.use_host_buffer or self.postprocess_kv_caches_on_save) and params.get(
+            "do_remote_decode"
+        ):
             # NOTE: when accelerator is not directly supported by Nixl,
             # prefilled blocks need to be saved to host memory before transfer.
             self._reqs_need_save[request.request_id] = request
@@ -719,16 +802,27 @@ class NixlConnectorScheduler:
             req = req_to_save
 
             assert req.kv_transfer_params is not None
-            meta.add_new_req_to_save(
-                request_id=req_id,
-                local_block_ids=new_block_id_groups[0],
-                kv_transfer_params=req.kv_transfer_params,
-            )
+            block_ids = new_block_id_groups[0]
             assert scheduler_output.num_scheduled_tokens is not None
             num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
             is_partial = (
                 req.num_computed_tokens + num_scheduled_tokens
             ) < req.num_prompt_tokens
+            if self.postprocess_kv_caches_on_save:
+                new_block_ids = self.partial_reqs.get(req_id, [])
+                new_block_ids = new_block_ids + block_ids
+                self.partial_reqs[req_id] = new_block_ids
+                if is_partial:
+                    continue
+            else:
+                new_block_ids = block_ids
+            # set any chunked prefill as partial, except the last chunk
+            # only submit as new req when not partial
+            meta.add_new_req_to_save(
+                request_id=req_id,
+                local_block_ids=new_block_ids,
+                kv_transfer_params=req.kv_transfer_params,
+            )
             if not is_partial:
                 # For non-partial prefills, once new req_meta is scheduled, it
                 # can be removed from _reqs_need_save.
@@ -736,6 +830,7 @@ class NixlConnectorScheduler:
                 # _reqs_need_save until all blocks are scheduled with req_meta.
                 # Therefore, only pop if `not is_partial`.
                 self._reqs_need_save.pop(req_id)
+                self.partial_reqs.pop(req_id, None)
 
         meta.reqs_to_send = self._reqs_need_send
         meta.reqs_in_batch = self._reqs_in_batch
@@ -790,6 +885,8 @@ class NixlConnectorScheduler:
             self._reqs_not_processed.add(request.request_id)
             # Clear _reqs_need_save if a request is aborted as partial prefill.
             self._reqs_need_save.pop(request.request_id, None)
+            # Clear partial_reqs if a request is aborted as partial prefill.
+            self.partial_reqs.pop(request.request_id, None)
             return False, None
 
         # TODO: check whether block_ids actually ever be 0. If not we could
@@ -808,10 +905,23 @@ class NixlConnectorScheduler:
                 time.perf_counter() + envs.VLLM_NIXL_ABORT_REQUEST_TIMEOUT
             )
 
+        block_size_ratio = self.block_size // self.block_size_on_save
+        block_ids_on_save = block_ids
+        if block_size_ratio > 1:
+            num_blocks = math.ceil((request.num_tokens - 1) / self.block_size_on_save)
+            block_ids_on_save = get_mapped_blocks(
+                np.asarray(block_ids), block_size_ratio, num_blocks
+            )
+            logger.debug(
+                "request.num_tokens is %s, block_ids is %s, block_ids_on_save is %s",
+                request.num_tokens,
+                block_ids,
+                block_ids_on_save,
+            )
         return delay_free_blocks, dict(
             do_remote_prefill=True,
             do_remote_decode=False,
-            remote_block_ids=block_ids,
+            remote_block_ids=block_ids_on_save,
             remote_engine_id=self.engine_id,
             remote_request_id=request.request_id,
             remote_host=self.side_channel_host,
@@ -874,6 +984,7 @@ class NixlConnectorWorker:
         self.tp_group = get_tp_group()
         self.num_blocks = 0
         self.enable_permute_local_kv = False
+        self.postprocess_kv_caches_on_save = False
 
         # KV Caches and nixl tracking data.
         self.device_type = current_platform.device_type
@@ -990,6 +1101,16 @@ class NixlConnectorWorker:
         self.enforce_compat_hash = self.kv_transfer_config.get_from_extra_config(
             "enforce_handshake_compat", True
         )
+        self.kv_cache_layout_on_save = self.kv_cache_layout
+        self.block_size_on_save = self.block_size
+        if self.kv_transfer_config.enable_permute_local_kv:
+            (
+                self.postprocess_kv_caches_on_save,
+                self.kv_cache_layout_on_save,
+                self.block_size_on_save,
+            ) = if_postprocess_kvcache_on_save(
+                self.vllm_config, self.block_size, self.kv_cache_layout
+            )
 
         self._tp_size: dict[EngineId, int] = {self.engine_id: self.world_size}
         self._block_size: dict[EngineId, int] = {self.engine_id: self.block_size}
@@ -1314,6 +1435,7 @@ class NixlConnectorWorker:
         # Enable different block lengths for different layers when MLA is used.
         self.block_len_per_layer = list[int]()
         self.slot_size_per_layer = list[int]()  # HD bytes in kv terms
+        block_len_per_layer_on_save = list[int]()
         for layer_name, cache_or_caches in xfer_buffers.items():
             cache_list = cache_or_caches if split_k_and_v else [cache_or_caches]
 
@@ -1348,11 +1470,21 @@ class NixlConnectorWorker:
                     "All kv cache tensors must have the same number of blocks"
                 )
 
+                block_size_ratio_on_save = self.block_size // self.block_size_on_save
+
                 self.block_len_per_layer.append(
                     curr_tensor_size_bytes // self.num_blocks
                 )
                 self.slot_size_per_layer.append(
                     self.block_len_per_layer[-1] // self.block_size
+                )
+                block_len_per_layer_on_save.append(
+                    curr_tensor_size_bytes
+                    // self.num_blocks
+                    // block_size_ratio_on_save
+                )
+                num_blocks_on_save = (
+                    curr_tensor_size_bytes // block_len_per_layer_on_save[-1]
                 )
 
                 if not self.use_mla:
@@ -1400,9 +1532,10 @@ class NixlConnectorWorker:
 
         # Register local/src descr for NIXL xfer.
         self.seen_base_addresses = seen_base_addresses
-        self.src_xfer_handles_by_block_size[self.block_size], self.src_blocks_data = (
-            self.register_local_xfer_handler(self.block_size)
-        )
+        (
+            self.src_xfer_handles_by_block_size[self.block_size_on_save],
+            self.src_blocks_data,
+        ) = self.register_local_xfer_handler(self.block_size_on_save)
 
         # TODO(mgoin): Hybrid memory allocator is currently disabled for
         # models with local attention (Llama 4). Can remove this once enabled.
@@ -1432,12 +1565,12 @@ class NixlConnectorWorker:
             agent_metadata=self.nixl_wrapper.get_agent_metadata(),
             device_id=self.device_id,
             kv_caches_base_addr=self.kv_caches_base_addr[self.engine_id][self.tp_rank],
-            num_blocks=self.num_blocks,
-            block_lens=self.block_len_per_layer,
-            kv_cache_layout=self.kv_cache_layout
+            num_blocks=num_blocks_on_save,
+            block_lens=block_len_per_layer_on_save,
+            kv_cache_layout=self.kv_cache_layout_on_save
             if not self.use_host_buffer
             else self.host_buffer_kv_cache_layout,
-            block_size=self.block_size,
+            block_size=self.block_size_on_save,
         )
         # Wrap metadata in payload with hash for defensive decoding
         encoder = msgspec.msgpack.Encoder()
@@ -1470,7 +1603,9 @@ class NixlConnectorWorker:
                 self.get_backend_aware_kv_block_len(layer_idx=i) // block_size_ratio
             )
             block_len_per_layer = self.block_len_per_layer[i] // block_size_ratio
-            num_blocks = self.num_blocks * block_size_ratio
+            num_blocks = (
+                self.num_blocks * self.block_len_per_layer[i] // block_len_per_layer
+            )
             for block_id in range(num_blocks):
                 block_offset = block_id * block_len_per_layer
                 addr = base_addr + block_offset
@@ -1817,6 +1952,51 @@ class NixlConnectorWorker:
                 meta.local_physical_block_ids,
                 "d2h",
             )
+
+    def kv_caches_postprocess(self, metadata: NixlConnectorMetadata):
+        """Post-process the kv caches after receiving from remote.
+
+        This includes permuting the layout if needed and handling
+        block size mismatches.
+        """
+        block_ids_to_permute = []
+        for _, meta in metadata.reqs_to_save.items():
+            meta.local_physical_block_ids = self._logical_to_kernel_block_ids(
+                meta.local_block_ids
+            )
+            block_ids_to_permute.append(meta.local_physical_block_ids)
+        for block_ids in block_ids_to_permute:
+            self.post_process_device_kv_on_save(block_ids)
+
+    def post_process_device_kv_on_save(self, block_ids: list[int]):
+        """Transforms the local KV cache shape to target shape.
+
+        scenario 1. change KV layout from NHD to HND
+        scenario 2. change block_size to target block_size
+        scenario 3. change both layout and block_size
+        """
+
+        if len(block_ids) == 0:
+            return
+        target_block_size = self.block_size_on_save
+        split_k_and_v = self.kv_topo.split_k_and_v
+        sample_cache = list(self.device_kv_caches.values())[0][0]
+        indices = torch.tensor(block_ids, device=sample_cache.device)
+
+        for _, cache_or_caches in self.device_kv_caches.items():
+            cache_list = cache_or_caches if split_k_and_v else [cache_or_caches]
+            for cache in cache_list:
+                if (
+                    self.kv_cache_layout_on_save != self.kv_cache_layout
+                    and self.block_size_on_save != self.block_size
+                ):
+                    kv_postprocess_layout_and_blksize_on_save(
+                        cache, indices, target_block_size
+                    )
+                elif self.kv_cache_layout_on_save != self.kv_cache_layout:
+                    kv_postprocess_layout_on_save(cache, indices)
+                elif self.block_size_on_save != self.block_size:
+                    kv_postprocess_blksize_on_save(cache, indices, target_block_size)
 
     def post_process_device_kv_on_receive(
         self,
@@ -2183,22 +2363,20 @@ class NixlConnectorWorker:
         """
         block_size_ratio = self.kv_topo.block_size_ratio_from_engine_id(dst_engine_id)
         if block_size_ratio > 1:
-            local_block_ids = self.get_mapped_blocks(
-                np.asarray(local_block_ids), block_size_ratio
+            # NOTE:
+            # get_mapped_blocks will always expand block_ids for n times.
+            # ex:
+            # prefill block_ids with block_size as 4:
+            # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            # Local decode block_ids with block_size as 16: [1, 2, 3]
+            # expland ecode block_ids with get_mapped_blocks from [1, 2, 3] to
+            # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+            # Then we clip local to align with prefill
+            # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] to
+            # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            local_block_ids = get_mapped_blocks(
+                np.asarray(local_block_ids), block_size_ratio, len(remote_block_ids)
             )
-            if len(local_block_ids) > len(remote_block_ids):
-                # NOTE:
-                # get_mapped_blocks will always expand block_ids for n times.
-                # ex:
-                # prefill block_ids with block_size as 4:
-                # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-                # Local decode block_ids with block_size as 16: [1, 2, 3]
-                # expland ecode block_ids with get_mapped_blocks from [1, 2, 3] to
-                # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-                # Then we clip local to align with prefill
-                # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] to
-                # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-                local_block_ids = local_block_ids[: len(remote_block_ids)]
         # NOTE(rob): having the staging blocks be on the READER side is
         # not going to work well (since we will have to call rearrange tensors).
         # after we detect the txn is complete (which means we cannot make the
@@ -2330,25 +2508,6 @@ class NixlConnectorWorker:
             if handle is not None:
                 self.nixl_wrapper.release_xfer_handle(handle)
             self._failed_recv_reqs.add(request_id)
-
-    def get_mapped_blocks(self, block_ids, block_size_ratio):
-        """
-          Calculates the new set of block IDs by mapping every element
-          in the (potentially sparse) input array.
-          Example: block_ids=[0, 2], block_size_ratio=2
-        get_mapped_blocks    0     1     [2     3]     4     5
-              # remote is |h0-b0|h1-b0||h0-b1|h1-b1||h0-b1|h1-b1||
-              # local is  |h0-b0......||h1-b0......||h2-b0........
-        local_block_ids         0           [1]           2
-        """
-        if block_ids.size == 0:
-            return np.array([], dtype=np.int64)
-
-        start_ids = block_ids * block_size_ratio
-        offsets = np.arange(block_size_ratio)
-        mapped_2d = start_ids[:, None] + offsets[None, :]
-
-        return mapped_2d.flatten().astype(np.int64)
 
     def _get_block_descs_ids(
         self,


### PR DESCRIPTION
## Purpose

Proposal codes for #26744

This PR is to support non-host-buffer path Heterogeneous KV Layout and block_size - prefill NHD and nP > nD
Only support when prefix_cache is disabled

This PR includes two bug fix PR, pending on them merged firstly
https://github.com/vllm-project/vllm/pull/30420
https://github.com/vllm-project/vllm/pull/30419

## Test Plan

1P 1D with nP > nD + Prefill with NHD
```
DISABLE_PREFIX_CACHE=true AGREED_BLOCK_SIZE=16  PREFILL_KV_LAYOUT=NHD PREFILL_BLOCK_SIZE=64 DECODE_BLOCK_SIZE=16 bash tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
```
=> Accuracy passed Qwen3-0.6= ~0.41

P1D2 + prefill with NHD
```
DECODER_TP_SIZE=2 DISABLE_PREFIX_CACHE=true AGREED_BLOCK_SIZE=16  PREFILL_KV_LAYOUT=NHD PREFILL_BLOCK_SIZE=64 DECODE_BLOCK_SIZE=16 bash tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh
```
Accuracy passed Qwen3-0.6= ~0.41


## Design

This PR is to propose update KV_layout and block_size at prefill side after request complete prefill fwd

case 1, very naive case, the proposal can work properly
```
fwd_prefill => KV update(NHD to HND and blk_size = 16) 
=> send finish to decoder => decoder copy data correctly
```

Case 2, with chunked prefill

```
fwd partial prefill => temp save block_ids to nixl_connector_worker
=> second partial fwd => KV update(NHD to HND and blk_size = 16) 
=> send finish to decoder => decoder copy data correctly
```

## Changes proposed in this PR:
1. add new metadata `block_size_after_save` and `kv_layout_after_save` => If prefill is using different setting to decode, the `block_size_after_save` and `kv_layout_after_save` will use agreed block_size and 'HND' respectively.
2. This feature will only get enabled when prefix_cache is disabled, and `enable_permute_local_kv` is on.
3. Add a new `kv_caches_postprocess` function, and called at `wait_for_save`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

