### PR TITLE
[Optimization]: Add fused router for GPTOSS

### DIFF
--- a/vllm/model_executor/layers/fused_moe/bitonic_sort.py
+++ b/vllm/model_executor/layers/fused_moe/bitonic_sort.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from vllm.triton_utils import tl, triton
+
+"""
+warp-level bitonic sort using PTX inline asm.
+
+this module implements a 32-element bitonic sort that runs entirely within
+a single warp using counterpart of shfl_sync function like in CUDA C,
+avoiding shared memory overhead.
+
+bitonic sort overview:
+    bitonic sort is a parallel sorting algorithm that works in two phases:
+    1. build phase: construct a "bitonic sequence" where the first half is
+       ascending and the second half is descending (or vice versa).
+    2. merge phase: recursively merge bitonic sequences into sorted order.
+
+    for 32 elements, this requires:
+    - build phase: 10 compare-exchange steps (length_pair = 2,4,8,16)
+    - merge phase: 5 compare-exchange steps (stride = 16,8,4,2,1)
+    - total: 15 warp shuffle operations
+
+references:
+    - https://en.wikipedia.org/wiki/Bitonic_sorter
+    - https://www.geeksforgeeks.org/dsa/bitonic-sort/
+
+PTX register types:
+    we declare registers as .f32/.s32. sub-word types (8/16-bit)
+    are held in 32-bit registers when loaded, stored, or converted.
+    see: https://docs.nvidia.com/cuda/parallel-thread-execution/index.html?highlight=shfl#restricted-use-of-sub-word-sizes
+"""
+
+
+@triton.jit
+def bitonic_compare_exchange_descending(
+    val, idx, stride: tl.constexpr, log2_length_pair: tl.constexpr
+):
+    """
+    bitonic compare_exchange for building bitonic sequences (descending order).
+
+    this function performs one step of bitonic sequence construction. within
+    each "length_pair" group, adjacent pairs alternate between ascending and
+    descending order to form bitonic sequences.
+
+    args:
+        val: values to sort
+        idx: corresponding indices to track original positions
+        stride: distance between elements to compare (power of 2)
+        log2_length_pair: log2 of the current subsequence length being processed.
+            Used to determine sort direction (ascending/descending) for each group.
+
+    example (length_pair=4, stride=2):
+        before: [3, 1, 4, 2, 8, 6, 7, 5]
+        groups: [3, 1, 4, 2] [8, 6, 7, 5]
+                 ↓ desc      ↓ asc
+        after:  [4, 2, 3, 1] [7, 5, 8, 6]
+
+    PTX implementation:
+        1. shfl.sync.bfly: save partner lane's value or index in own register
+            by mode=XOR(bfly)
+        2. determine group: (lane >> log2_length_pair) & 1 gives alternating
+            (0 or 1, imply mean or odd) groups
+        3. determine position: left ((lane & stride) == 0) or right
+        4. compare and conditionally swap based on position and group.
+        we only do swap if such cases:
+            a, left < right in mean group;
+            b, left > right in odd group.
+    """
+
+    new_val, new_idx = tl.inline_asm_elementwise(
+        asm="""
+        {
+            // counterpart elems registers
+            .reg .f32 %partner_val;
+            .reg .s32 %partner_idx;
+            .reg .u32 %lane_id;
+            .reg .u32 %is_left;
+            .reg .pred %p_left, %p_swap;
+            .reg .u32 %group_id;
+            .reg .pred %group_id_mask;
+            
+            // save partner's regs
+            shfl.sync.bfly.b32 %partner_val, $2, $4, 0x1f, 0xffffffff;
+            shfl.sync.bfly.b32 %partner_idx, $3, $4, 0x1f, 0xffffffff;
+            
+            // we can't directly use special register %laneid in many insts.
+            mov.u32 %lane_id, %laneid;
+            
+            // assign elems in length_pair to a group id, and .pred reg 
+            // indicates mean or odd.
+            shr.u32 %group_id, %lane_id, $5;
+            and.b32 %group_id, %group_id, 1;
+            setp.eq.u32 %group_id_mask, %group_id, 1;
+            
+            // recognize if left or right in each lengthpair
+            and.b32 %is_left, %lane_id, $4;
+            setp.eq.u32 %p_left, %is_left, 0;
+            
+            // compare partner_val > val? if so, swap.
+            setp.gt.f32 %p_swap, %partner_val, $2;
+
+            // XNOR: left and swap -> swap, right and not swap -> swap.    
+            xor.pred %p_swap, %p_swap, %p_left;
+            not.pred %p_swap, %p_swap;
+            xor.pred %p_swap, %p_swap, %group_id_mask;
+            
+            selp.f32 $0, %partner_val, $2, %p_swap;
+            selp.b32 $1, %partner_idx, $3, %p_swap;
+        }
+        """,
+        constraints="=f,=r,f,r,n,n",
+        args=[val, idx, stride, log2_length_pair],
+        dtype=(tl.float32, tl.int32),
+        is_pure=True,
+        pack=1,
+        # declaring pack=1 indicates each thread proceed 1 element at a time.
+        # along this way, to ensure warp proceed 32 elements.
+    )
+    return new_val, new_idx
+
+
+@triton.jit
+def bitonic_compare_across_part_descending(val, idx, stride: tl.constexpr):
+    """
+    bitonic merge step: compare_exchange for final merging (descending order).
+
+    args:
+        val: values to sort
+        idx: corresponding indices
+        stride: distance between elements to compare
+
+    behavior:
+        compare values within pairs constructed by stride.
+        this pushes larger values toward lower lane indices (descending order).
+    """
+    new_val, new_idx = tl.inline_asm_elementwise(
+        asm="""{
+            .reg .f32 %partner_val;
+            .reg .s32 %partner_idx;
+            .reg .u32 %is_left;
+            .reg .pred  %p_left;
+            .reg .pred %p_swap;
+            .reg .u32 %lane_id;
+            // $2 val, $3 idx, $4 stride;
+            
+            // save partner's register
+            shfl.sync.bfly.b32 %partner_val, $2, $4, 0x1f, 0xffffffff;
+            shfl.sync.bfly.b32 %partner_idx, $3, $4, 0x1f, 0xffffffff;
+
+            // determine left or right in each pair
+            mov.u32 %lane_id, %laneid;
+            and.b32 %is_left, %lane_id, $4;
+            setp.eq.u32 %p_left, %is_left, 0;
+
+            // use XNOR here.
+            // if partner's value > my value, predicate swap.
+            // if (predicate swap && left) || (!(predicate swap) && right), swap.
+            setp.gt.f32 %p_swap, %partner_val, $2;
+            xor.pred %p_swap, %p_swap, %p_left;
+            not.pred %p_swap, %p_swap;
+
+            selp.f32 $0, %partner_val, $2, %p_swap;
+            selp.b32 $1, %partner_idx, $3, %p_swap;
+        }""",
+        constraints="=f,=r,f,r,n",
+        args=[val, idx, stride],
+        dtype=(tl.float32, tl.int32),
+        is_pure=True,
+        pack=1,
+    )
+    return new_val, new_idx
+
+
+@triton.jit
+def bitonic_sort_warp_size_descending(val, idx):
+    """
+    Refer to https://www.geeksforgeeks.org/dsa/bitonic-sort/ to understand bitonic sort,
+    or a more formal reference: https://en.wikipedia.org/wiki/Bitonic_sorter.
+    We build bitonic sequence at first, then proceed merge step.
+    """
+    # build phase
+    # length_pair = 2, log2(2) = 1
+    val, idx = bitonic_compare_exchange_descending(val, idx, 1, 1)
+
+    # length_pair = 4, log2(4) = 2
+    val, idx = bitonic_compare_exchange_descending(val, idx, 2, 2)
+    val, idx = bitonic_compare_exchange_descending(val, idx, 1, 2)
+
+    # length_pair = 8, log2(8) = 3
+    val, idx = bitonic_compare_exchange_descending(val, idx, 4, 3)
+    val, idx = bitonic_compare_exchange_descending(val, idx, 2, 3)
+    val, idx = bitonic_compare_exchange_descending(val, idx, 1, 3)
+
+    # length_pair = 16, log2(16) = 4
+    val, idx = bitonic_compare_exchange_descending(val, idx, 8, 4)
+    val, idx = bitonic_compare_exchange_descending(val, idx, 4, 4)
+    val, idx = bitonic_compare_exchange_descending(val, idx, 2, 4)
+    val, idx = bitonic_compare_exchange_descending(val, idx, 1, 4)
+
+    # merge phase
+    # length_pair = 32, log2(32) = 5
+    val, idx = bitonic_compare_across_part_descending(val, idx, 16)
+    val, idx = bitonic_compare_across_part_descending(val, idx, 8)
+    val, idx = bitonic_compare_across_part_descending(val, idx, 4)
+    val, idx = bitonic_compare_across_part_descending(val, idx, 2)
+    val, idx = bitonic_compare_across_part_descending(val, idx, 1)
+
+    return val, idx
+
+
+"""
+wrapper function used in unittest or other purpose.
+"""
+
+
+@triton.jit
+def bitonic_compare_exchange_descending_wrapper(
+    val_ptr,
+    idx_ptr,
+    new_val_ptr,
+    new_idx_ptr,
+    stride: tl.constexpr,
+    log2_length_pair: tl.constexpr,
+):
+    offs = tl.arange(0, 32)
+    val = tl.load(val_ptr + offs)
+    idx = tl.load(idx_ptr + offs)
+    new_val, new_idx = bitonic_compare_exchange_descending(
+        val, idx, stride, log2_length_pair
+    )
+    tl.store(new_val_ptr + offs, new_val)
+    tl.store(new_idx_ptr + offs, new_idx)
+
+
+@triton.jit
+def bitonic_sort_warp_size_descending_wrapper(
+    val_ptr, idx_ptr, new_val_ptr, new_idx_ptr
+):
+    offs = tl.arange(0, 32)
+    val = tl.load(val_ptr + offs)
+    idx = tl.load(idx_ptr + offs)
+    new_val, new_idx = bitonic_sort_warp_size_descending(val, idx)
+    tl.store(new_val_ptr + offs, new_val)
+    tl.store(new_idx_ptr + offs, new_idx)

--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
 from vllm.model_executor.layers.fused_moe.utils import _resize_cache
 from vllm.triton_utils import tl, triton
 from vllm.utils.import_utils import has_triton_kernels
+from .bitonic_sort import bitonic_sort_warp_size_descending
 
 logger = init_logger(__name__)
 
@@ -73,6 +74,257 @@ def pack_bitmatrix(
         bitmatrix_ptrs = bitmatrix + offsets_m[:, None] * bm_cols + offs[None, :]
         tl.store(bitmatrix_ptrs, y, mask=offsets_m[:, None] < n_rows)
 
+@triton.autotune(
+    configs=[
+        triton.Config({"ROWS_PER_PID": r}, num_warps=num_warps, num_stages=num_stages)
+        for r in [1, 2, 4, 8, 16, 32]
+        for num_warps in [1, 2, 4, 8, 16]
+        for num_stages in [1, 2, 3]
+    ],
+    key=["N", "topk"],
+    cache_results=True,
+)
+@triton.jit
+def _topk_softmax_kernel(
+    logits_ptr,
+    weights_ptr,
+    indices_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    topk: tl.constexpr,
+    stride_lm,
+    stride_ln,
+    stride_wm,
+    stride_wk,
+    stride_im,
+    stride_ik,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    topk_padded: tl.constexpr,
+    RENORM: tl.constexpr,
+    ROWS_PER_PID: tl.constexpr,
+    num_stages: tl.constexpr,
+    USE_BITONIC: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_programs = tl.num_programs(0)
+
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, topk_padded)
+    mask_n = offs_n < N
+    store_mask = offs_k < topk
+    warp_size: tl.constexpr = 32
+
+    # impl topk<=2 and RENORM specialization by tl.constexpr,
+    # same as constexpr if in C++17
+    if topk == 1:
+        for row_idx in tl.range(pid, M, num_programs, num_stages, warp_specialize=True):
+            if BLOCK_N != N:
+                logits = tl.load(
+                    logits_ptr + row_idx * stride_lm + offs_n * stride_ln,
+                    mask=mask_n,
+                    other=float("-inf"),
+                )
+            else:
+                logits = tl.load(
+                    logits_ptr + row_idx * stride_lm + offs_n * stride_ln,
+                )
+
+            if not RENORM:
+                row_sub_max = logits - tl.max(logits, axis=0)
+                numerator = tl.exp(row_sub_max)
+                denominator = tl.sum(numerator, axis=0)
+                logits = numerator / denominator
+
+            cur_max = 1 if RENORM else tl.max(logits, axis=0)
+            cur_idx = tl.argmax(logits, axis=0)
+
+            tl.store(weights_ptr + row_idx * stride_wm + 0 * stride_wk, cur_max)
+            tl.store(indices_ptr + row_idx * stride_im + 0 * stride_ik, cur_idx)
+
+    elif topk == 2:
+        for row_idx in tl.range(pid, M, num_programs, num_stages, warp_specialize=True):
+            if BLOCK_N != N:
+                logits = tl.load(
+                    logits_ptr + row_idx * stride_lm + offs_n * stride_ln,
+                    mask=mask_n,
+                    other=float("-inf"),
+                )
+            else:
+                logits = tl.load(
+                    logits_ptr + row_idx * stride_lm + offs_n * stride_ln,
+                )
+
+            if not RENORM:
+                row_sub_max = logits - tl.max(logits, axis=0)
+                numerator = tl.exp(row_sub_max)
+                denominator = tl.sum(numerator, axis=0)
+                logits = numerator / denominator
+
+            val0 = tl.max(logits, axis=0)
+            idx0 = tl.argmax(logits, axis=0)
+            logits = tl.where(offs_n == idx0, float("-inf"), logits)
+            val1 = tl.max(logits, axis=0)
+            idx1 = tl.argmax(logits, axis=0)
+
+            if RENORM:
+                max_val = tl.maximum(val0, val1)
+                exp0 = tl.exp(val0 - max_val)
+                exp1 = tl.exp(val1 - max_val)
+                val0 = exp0 / (exp0 + exp1)
+                val1 = exp1 / (exp0 + exp1)
+
+            tl.store(weights_ptr + row_idx * stride_wm, val0)
+            tl.store(indices_ptr + row_idx * stride_im, idx0)
+            tl.store(weights_ptr + row_idx * stride_wm + 1 * stride_wk, val1)
+            tl.store(indices_ptr + row_idx * stride_im + 1 * stride_ik, idx1)
+
+    else:
+        rows = tl.arange(0, ROWS_PER_PID)
+        for row_idx in tl.range(
+            pid * ROWS_PER_PID,
+            M,
+            num_programs * ROWS_PER_PID,
+            num_stages,
+            warp_specialize=True,
+        ):
+            topk_vals = tl.full(
+                [ROWS_PER_PID, topk_padded], float("-inf"), dtype=tl.float32
+            )
+            topk_idxs = tl.zeros([ROWS_PER_PID, topk_padded], dtype=tl.int32)
+            row_indices = row_idx + rows  # [ROWS_PER_POD,]
+            row_mask = row_indices < M
+
+            # broadcast to [ROWS_PER_PID, BLOCKN]
+            ptr_off = (
+                logits_ptr
+                + row_indices[:, None] * stride_lm
+                + offs_n[None, :] * stride_ln
+            )
+            logits = tl.load(ptr_off)
+
+            if not RENORM:
+                logits = tl.softmax(logits, dim=1, keep_dims=True)
+
+            if N == BLOCK_N and warp_size == N:
+                # TODO(ijpq): we should enable this sort when N <= warp_size,
+                # but need align tensor's layout with warp.
+                # leverage PTX to sort warp_size experts to bypass sharedmemory
+                idx = tl.arange(0, warp_size)[None, :]
+                idxs = tl.broadcast_to(idx, (ROWS_PER_PID, warp_size))
+                sorted_val, sorted_idx = bitonic_sort_warp_size_descending(
+                    val=logits, idx=idxs
+                )  # [ROWS_PER_PID, 32]
+                tl.static_assert(sorted_val.shape == (ROWS_PER_PID, warp_size))
+            else:
+                # XXX: may use topk from triton_kernels
+                for k in tl.static_range(topk):
+                    cur_max = tl.max(
+                        logits, axis=1, keep_dims=True
+                    )  # [ROWS_PER_PID, 1]
+                    cur_idx = tl.argmax(logits, axis=1, keep_dims=True)
+
+                    k_mask = offs_k == k
+                    topk_vals = tl.where(
+                        k_mask, cur_max, topk_vals
+                    )  # [ROWS_PER PID, 1], [ROWS_PER PID, topkpadded]
+                    topk_idxs = tl.where(k_mask, cur_idx, topk_idxs)
+
+                    mask_selected = (
+                        cur_idx == offs_n[None, :]
+                    )  # [ROWSPERPID,1] [1,BLOCKN]
+                    logits = tl.where(mask_selected, float("-inf"), logits)
+
+            if RENORM:
+                if USE_BITONIC:
+                    topk_col_mask = (
+                        tl.arange(0, warp_size)[None, :] < topk
+                    )  # [1, warp_size]
+                    masked_val = tl.where(topk_col_mask, sorted_val, float("-inf"))
+                    masked_val = tl.softmax(masked_val, dim=1)
+                    sorted_val = tl.where(
+                        topk_col_mask, masked_val, sorted_val
+                    )
+                else:
+                    topk_vals = topk_vals - tl.max(
+                        topk_vals, axis=1, keep_dims=True
+                    )  # [ROWSPERPID, topkpadded] - [ROWSPERPID,1]
+                    numerator = tl.exp(topk_vals)
+                    denominator = tl.sum(
+                        numerator, axis=1, keep_dims=True
+                    )  # [ROWSPERPID,1]
+                    topk_vals = numerator / denominator  # [ROWSPERPID,topkpadded]
+
+            # WB
+            if USE_BITONIC:
+                offs_warp_size = tl.arange(0, warp_size)
+                store_col_mask = offs_warp_size < topk
+                tl.store(
+                    weights_ptr
+                    + row_indices[:, None] * stride_wm
+                    + offs_warp_size[None, :] * stride_wk,
+                    sorted_val,
+                    mask=row_mask[:, None] & store_col_mask[None, :],
+                )
+                tl.store(
+                    indices_ptr
+                    + row_indices[:, None] * stride_im
+                    + offs_warp_size[None, :] * stride_ik,
+                    sorted_idx,
+                    mask=row_mask[:, None] & store_col_mask[None, :],
+                )
+            else:
+                tl.store(
+                    weights_ptr
+                    + row_indices[:, None] * stride_wm  # [ROWSPERPID,1]
+                    + offs_k[None, :] * stride_wk,  # [1, topkpadded]
+                    topk_vals,
+                )
+                tl.store(
+                    indices_ptr
+                    + row_indices[:, None] * stride_im
+                    + offs_k[None, :] * stride_ik,
+                    topk_idxs,
+                )
+               
+
+def fused_topk_softmax(
+    router_logits: torch.Tensor,
+    topk: int,
+    renormalize: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    M, N = router_logits.shape  # num_tokens, num_experts
+    weights = torch.empty((M, topk), device=router_logits.device, dtype=router_logits.dtype)
+    indices = torch.empty((M, topk), device=router_logits.device, dtype=torch.int32)
+
+    BLOCK_N = triton.next_power_of_2(N)  # num_padded_experts
+    topk_padded = triton.next_power_of_2(topk)
+    BLOCK_M = triton.next_power_of_2(M)
+    warp_size = 32
+
+    grid = lambda META: (triton.cdiv(M, META["ROWS_PER_PID"]),)
+
+    _topk_softmax_kernel[grid](
+        logits_ptr=router_logits,
+        weights_ptr=weights,
+        indices_ptr=indices,
+        M=M,
+        N=N,
+        topk=topk,
+        stride_lm=router_logits.stride(0),
+        stride_ln=router_logits.stride(1),
+        stride_wm=weights.stride(0),
+        stride_wk=weights.stride(1),
+        stride_im=indices.stride(0),
+        stride_ik=indices.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        topk_padded=topk_padded,
+        RENORM=renormalize,
+        USE_BITONIC=False
+    )
+
+    return weights, indices
 
 def triton_kernel_moe_forward(
     hidden_states: torch.Tensor,
@@ -87,9 +339,8 @@ def triton_kernel_moe_forward(
     global_num_experts: int = -1,
     expert_map: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    routing_data, gather_idx, scatter_idx = routing(
-        gating_output, topk, sm_first=not renormalize
-    )
+    topk_weights, topk_indices = fused_topk_softmax(gating_output, topk, renormalize)
+    routing_data, gather_idx, scatter_idx = make_routing_data(topk_indices, topk_weights, num_local_experts=gating_output.shape[-1])
 
     output = torch.empty_like(hidden_states)
 


### PR DESCRIPTION
## Discuss
I think we should fuse routing data's generating process into routing, like original triton's routing
## Purpose
Fuse routing for GPTOSS model. 
## Test Plan

- [x] Use existed moe_forward unittest
- [ ] Add unittest for bitonic_sort, if we reach agreement on using inline PTX.
- [ ] Latency perf 
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

