### PR TITLE
[Deprecation] Deprecation `--convert reward`, use `--convert embed` instead.

### DIFF
--- a/docs/models/pooling_models.md
+++ b/docs/models/pooling_models.md
@@ -320,9 +320,10 @@ We are going to remove `softmax` and `activation` from `PoolingParams` in v0.15.
 
 ### as_reward_model
 
+!!! warning
+    We are going to remove `--convert reward` in v0.15, use `--convert embed` instead.
+
 Pooling models now default support all pooling, you can use it without any settings.
 
 - Extracting hidden states prefers using `token_embed` task.
 - Reward models prefers using `token_classify` task.
-
-We are going to remove `--convert reward` in v0.15, use `--convert embed` instead.

--- a/docs/models/pooling_models.md
+++ b/docs/models/pooling_models.md
@@ -324,3 +324,5 @@ Pooling models now default support all pooling, you can use it without any setti
 
 - Extracting hidden states prefers using `token_embed` task.
 - Reward models prefers using `token_classify` task.
+
+We are going to remove `--convert reward`, use `--convert embed` instead.

--- a/docs/models/pooling_models.md
+++ b/docs/models/pooling_models.md
@@ -316,7 +316,7 @@ We have split the `encode` task into two more specific token-wise tasks: `token_
 
 ### Remove softmax from PoolingParams
 
-We are going to remove `softmax` and `activation` from `PoolingParams`. Instead, use `use_activation`, since we allow `classify` and `token_classify` to use any activation function.
+We are going to remove `softmax` and `activation` from `PoolingParams` in v0.15. Instead, use `use_activation`, since we allow `classify` and `token_classify` to use any activation function.
 
 ### as_reward_model
 
@@ -325,4 +325,4 @@ Pooling models now default support all pooling, you can use it without any setti
 - Extracting hidden states prefers using `token_embed` task.
 - Reward models prefers using `token_classify` task.
 
-We are going to remove `--convert reward`, use `--convert embed` instead.
+We are going to remove `--convert reward` in v0.15, use `--convert embed` instead.

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -790,8 +790,8 @@ class ModelConfig:
     ) -> ConvertType:
         if convert == "reward":
             logger.warning(
-                "`--convert reward` is deprecated and will be removed in a future "
-                "version. Please use `--convert embed` instead."
+                "`--convert reward` is deprecated and will be removed in v0.15. "
+                "Please use `--convert embed` instead."
             )
             return "embed"
 

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -788,6 +788,13 @@ class ModelConfig:
         runner_type: RunnerType,
         convert: ConvertOption,
     ) -> ConvertType:
+        if convert == "reward":
+            logger.warning(
+                "`--convert reward` is deprecated and will be removed in a future "
+                "version. Please use `--convert embed` instead."
+            )
+            return "embed"
+
         if convert != "auto":
             return convert
 

--- a/vllm/config/pooler.py
+++ b/vllm/config/pooler.py
@@ -111,13 +111,15 @@ class PoolerConfig:
 def get_use_activation(o: object):
     if softmax := getattr(o, "softmax", None) is not None:
         logger.warning_once(
-            "softmax will be deprecated, please use use_activation instead."
+            "softmax will be deprecated and will be removed in v0.15. "
+            "Please use use_activation instead."
         )
         return softmax
 
     if activation := getattr(o, "activation", None) is not None:
         logger.warning_once(
-            "activation will be deprecated, please use use_activation instead."
+            "activation will be deprecated and will be removed in v0.15. "
+            "Please use use_activation instead."
         )
         return activation
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Follow #26686

We are going to remove `--convert reward` in v0.15, use `--convert embed` instead.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

