### PR TITLE
[Optimization]: Add fused router for GPTOSS

### DIFF
--- a/tests/kernels/moe/test_gpt_oss_triton_kernels.py
+++ b/tests/kernels/moe/test_gpt_oss_triton_kernels.py
@@ -204,7 +204,10 @@ class GPTOSS120BModelConfig:
     rope_parameters_factor: float = 32.0
     rope_ntk_alpha: float = 1.0
     rope_ntk_beta: float = 32.0
+
+
 ModelConfig = GPTOSS120BModelConfig
+
 
 @dataclass
 class GPTOSS20BModelConfig:
@@ -223,6 +226,7 @@ class GPTOSS20BModelConfig:
     rope_parameters_factor: float = 32.0
     rope_ntk_alpha: float = 1.0
     rope_ntk_beta: float = 32.0
+
 
 def swiglu(x, alpha: float = 1.702, limit: float = 1.0):
     # Note we add an extra bias of 1 to the linear layer
@@ -285,9 +289,11 @@ class Case:
         ]
     ],
 )
-@pytest.mark.parametrize("num_token", [2])
+@pytest.mark.parametrize("num_token", [2, 128])
 @pytest.mark.parametrize("tp", [1, 2, 4, 8])
-@pytest.mark.parametrize("GPTOSSModelConfig", [GPTOSS120BModelConfig, GPTOSS20BModelConfig])
+@pytest.mark.parametrize(
+    "GPTOSSModelConfig", [GPTOSS120BModelConfig, GPTOSS20BModelConfig]
+)
 def test_equiv(num_token, a_dtype, w_dtype, tp, GPTOSSModelConfig):
     from triton_kernels.tensor_details import layout
 

--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -24,7 +24,7 @@ if has_triton_kernels():
     try:
         import triton_kernels.swiglu
         from triton_kernels.matmul_ogs import FnSpecs, FusedActivation, matmul_ogs
-        from triton_kernels.routing import RoutingData, routing, routing_from_bitmatrix
+        from triton_kernels.routing import RoutingData, routing_from_bitmatrix
         from triton_kernels.tensor import Bitmatrix
     except (AttributeError, ImportError) as e:
         logger.error(
@@ -74,6 +74,135 @@ def pack_bitmatrix(
         tl.store(bitmatrix_ptrs, y, mask=offsets_m[:, None] < n_rows)
 
 
+@triton.autotune(
+    configs=[
+        triton.Config({"ROWS_PER_PID": r}, num_warps=num_warps, num_stages=num_stages)
+        for r in [1, 2, 4, 8, 16, 32]
+        for num_warps in [1, 2, 4, 8, 16]
+        for num_stages in [1, 2, 3]
+    ],
+    key=["N", "topk"],
+    cache_results=True,
+)
+@triton.jit
+def _topk_softmax_kernel(
+    logits_ptr,
+    weights_ptr,
+    indices_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    topk: tl.constexpr,
+    stride_lm,
+    stride_ln,
+    stride_wm,
+    stride_wk,
+    stride_im,
+    stride_ik,
+    RENORM: tl.constexpr,
+    ROWS_PER_PID: tl.constexpr,
+    num_stages: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_programs = tl.num_programs(0)
+
+    offs_n = tl.arange(0, N)
+    offs_k = tl.arange(0, topk)
+
+    # impl topk<=2 and RENORM specialization by tl.constexpr,
+    # same as constexpr if in C++17
+
+    rows = tl.arange(0, ROWS_PER_PID)
+    for row_idx in tl.range(
+        pid * ROWS_PER_PID,
+        M,
+        num_programs * ROWS_PER_PID,
+        num_stages,
+        warp_specialize=True,
+    ):
+        topk_vals = tl.full([ROWS_PER_PID, topk], float("-inf"), dtype=tl.float32)
+        topk_idxs = tl.zeros([ROWS_PER_PID, topk], dtype=tl.int32)
+        row_indices = row_idx + rows  # [ROWS_PER_POD,]
+        row_mask = row_indices < M
+
+        # broadcast to [ROWS_PER_PID, BLOCKN]
+        ptr_off = (
+            logits_ptr + row_indices[:, None] * stride_lm + offs_n[None, :] * stride_ln
+        )
+        logits = tl.load(ptr_off, mask=row_mask[:, None], other=float("-inf"))
+
+        if not RENORM:
+            logits = tl.softmax(logits, dim=1, keep_dims=True)
+
+        # XXX: may use topk from triton_kernels
+        for k in tl.static_range(topk):
+            cur_max = tl.max(logits, axis=1, keep_dims=True)  # [ROWS_PER_PID, 1]
+            cur_idx = tl.argmax(logits, axis=1, keep_dims=True)
+
+            k_mask = offs_k == k
+            topk_vals = tl.where(
+                k_mask, cur_max, topk_vals
+            )  # [ROWS_PER PID, 1], [ROWS_PER PID, topkpadded]
+            topk_idxs = tl.where(k_mask, cur_idx, topk_idxs)
+
+            mask_selected = cur_idx == offs_n[None, :]  # [ROWSPERPID,1] [1,BLOCKN]
+            logits = tl.where(mask_selected, float("-inf"), logits)
+
+        if RENORM:
+            topk_vals = tl.softmax(topk_vals, dim=1, keep_dims=True)
+
+        # WB
+        tl.store(
+            weights_ptr
+            + row_indices[:, None] * stride_wm  # [ROWSPERPID,1]
+            + offs_k[None, :] * stride_wk,  # [1, topkpadded]
+            topk_vals,
+            mask=row_mask[:, None],
+        )
+        tl.store(
+            indices_ptr
+            + row_indices[:, None] * stride_im
+            + offs_k[None, :] * stride_ik,
+            topk_idxs,
+            mask=row_mask[:, None],
+        )
+
+
+def fused_topk_softmax(
+    router_logits: torch.Tensor,
+    topk: int,
+    renormalize: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    M, N = router_logits.shape  # num_tokens, num_experts
+    weights = torch.empty(
+        (M, topk), device=router_logits.device, dtype=router_logits.dtype
+    )
+    indices = torch.empty((M, topk), device=router_logits.device, dtype=torch.int32)
+
+    BLOCK_N = triton.next_power_of_2(N)  # num_padded_experts
+    topk_padded = triton.next_power_of_2(topk)
+    assert (BLOCK_N == N) and (topk_padded == topk)
+
+    grid = lambda META: (triton.cdiv(M, META["ROWS_PER_PID"]),)
+
+    _topk_softmax_kernel[grid](
+        logits_ptr=router_logits,
+        weights_ptr=weights,
+        indices_ptr=indices,
+        M=M,
+        N=N,
+        topk=topk,
+        stride_lm=router_logits.stride(0),
+        stride_ln=router_logits.stride(1),
+        stride_wm=weights.stride(0),
+        stride_wk=weights.stride(1),
+        stride_im=indices.stride(0),
+        stride_ik=indices.stride(1),
+        RENORM=renormalize,
+    )
+
+    return weights, indices
+
+
 def triton_kernel_moe_forward(
     hidden_states: torch.Tensor,
     w1,  # Tensor or triton_kernels.Tensor
@@ -87,8 +216,9 @@ def triton_kernel_moe_forward(
     global_num_experts: int = -1,
     expert_map: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    routing_data, gather_idx, scatter_idx = routing(
-        gating_output, topk, sm_first=not renormalize
+    topk_weights, topk_indices = fused_topk_softmax(gating_output, topk, renormalize)
+    routing_data, gather_idx, scatter_idx = make_routing_data(
+        topk_indices, topk_weights, num_local_experts=gating_output.shape[-1]
     )
 
     output = torch.empty_like(hidden_states)
@@ -445,7 +575,6 @@ class UnfusedOAITritonExperts(BaseOAITritonExperts):
     ):
         if self.quant_config is None:
             self.quant_config = FUSED_MOE_UNQUANTIZED_CONFIG
-
         if expert_map is not None:
             topk_ids = expert_map[topk_ids]
 

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -377,7 +377,7 @@ class FusedMoEPermuteExpertsUnpermute(ABC):
         """
         quant_config: Quantization parameters for this experts instance.
         """
-        self.quant_config = quant_config
+        self.quant_config: FusedMoEQuantConfig = quant_config
 
     @property
     @abstractmethod

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -377,7 +377,7 @@ class FusedMoEPermuteExpertsUnpermute(ABC):
         """
         quant_config: Quantization parameters for this experts instance.
         """
-        self.quant_config: FusedMoEQuantConfig = quant_config
+        self.quant_config = quant_config
 
     @property
     @abstractmethod


### PR DESCRIPTION
<details>
<summary> output collect_env </summary>

```
Collecting environment information...
==============================
        System Info
==============================
OS                           : Ubuntu 24.04.3 LTS (x86_64)
GCC version                  : (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
Clang version                : Could not collect
CMake version                : version 3.28.3
Libc version                 : glibc-2.39

==============================
       PyTorch Info
==============================
PyTorch version              : 2.9.0+cu128
Is debug build               : False
CUDA used to build PyTorch   : 12.8
ROCM used to build PyTorch   : N/A

==============================
      Python Environment
==============================
Python version               : 3.12.11 | packaged by conda-forge | (main, Jun  4 2025, 14:45:31) [GCC 13.3.0] (64-bit runtime)
Python platform              : Linux-5.15.0-139-generic-x86_64-with-glibc2.39

==============================
       CUDA / GPU Info
==============================
Is CUDA available            : True
CUDA runtime version         : 12.8.93
CUDA_MODULE_LOADING set to   : 
GPU models and configuration : GPU 0: NVIDIA H100 NVL
Nvidia driver version        : 570.133.20
cuDNN version                : Probably one of the following:
/usr/lib/x86_64-linux-gnu/libcudnn.so.9.8.0
/usr/lib/x86_64-linux-gnu/libcudnn_adv.so.9.8.0
/usr/lib/x86_64-linux-gnu/libcudnn_cnn.so.9.8.0
/usr/lib/x86_64-linux-gnu/libcudnn_engines_precompiled.so.9.8.0
/usr/lib/x86_64-linux-gnu/libcudnn_engines_runtime_compiled.so.9.8.0
/usr/lib/x86_64-linux-gnu/libcudnn_graph.so.9.8.0
/usr/lib/x86_64-linux-gnu/libcudnn_heuristic.so.9.8.0
/usr/lib/x86_64-linux-gnu/libcudnn_ops.so.9.8.0
HIP runtime version          : N/A
MIOpen runtime version       : N/A
Is XNNPACK available         : True

==============================
          CPU Info
==============================
Architecture:                         x86_64
CPU op-mode(s):                       32-bit, 64-bit
Address sizes:                        52 bits physical, 57 bits virtual
Byte Order:                           Little Endian
CPU(s):                               224
On-line CPU(s) list:                  0-223
Vendor ID:                            AuthenticAMD
Model name:                           AMD EPYC 9534 64-Core Processor
CPU family:                           25
Model:                                17
Thread(s) per core:                   2
Core(s) per socket:                   56
Socket(s):                            2
Stepping:                             1
Frequency boost:                      enabled
CPU(s) scaling MHz:                   42%
CPU max MHz:                          3718.0659
CPU min MHz:                          1500.0000
BogoMIPS:                             4900.17
Flags:                                fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 invpcid_single hw_pstate ssbd mba ibrs ibpb stibp ibrs_enhanced vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local avx512_bf16 clzero irperf xsaveerptr rdpru wbnoinvd amd_ppin cppc arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif v_spec_ctrl avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq la57 rdpid overflow_recov succor smca fsrm flush_l1d
Virtualization:                       AMD-V
L1d cache:                            3.5 MiB (112 instances)
L1i cache:                            3.5 MiB (112 instances)
L2 cache:                             112 MiB (112 instances)
L3 cache:                             512 MiB (16 instances)
NUMA node(s):                         2
NUMA node0 CPU(s):                    0-55,112-167
NUMA node1 CPU(s):                    56-111,168-223
Vulnerability Gather data sampling:   Not affected
Vulnerability Itlb multihit:          Not affected
Vulnerability L1tf:                   Not affected
Vulnerability Mds:                    Not affected
Vulnerability Meltdown:               Not affected
Vulnerability Mmio stale data:        Not affected
Vulnerability Reg file data sampling: Not affected
Vulnerability Retbleed:               Not affected
Vulnerability Spec rstack overflow:   Mitigation; safe RET
Vulnerability Spec store bypass:      Mitigation; Speculative Store Bypass disabled via prctl and seccomp
Vulnerability Spectre v1:             Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:             Mitigation; Enhanced / Automatic IBRS; IBPB conditional; STIBP always-on; RSB filling; PBRSB-eIBRS Not affected; BHI Not affected
Vulnerability Srbds:                  Not affected
Vulnerability Tsx async abort:        Not affected

==============================
Versions of relevant libraries
==============================
[pip3] flashinfer-python==0.5.3
[pip3] numpy==2.2.6
[pip3] nvidia-cublas-cu12==12.8.4.1
[pip3] nvidia-cuda-cupti-cu12==12.8.90
[pip3] nvidia-cuda-nvrtc-cu12==12.8.93
[pip3] nvidia-cuda-runtime-cu12==12.8.90
[pip3] nvidia-cudnn-cu12==9.10.2.21
[pip3] nvidia-cudnn-frontend==1.16.0
[pip3] nvidia-cufft-cu12==11.3.3.83
[pip3] nvidia-cufile-cu12==1.13.1.3
[pip3] nvidia-curand-cu12==10.3.9.90
[pip3] nvidia-cusolver-cu12==11.7.3.90
[pip3] nvidia-cusparse-cu12==12.5.8.93
[pip3] nvidia-cusparselt-cu12==0.7.1
[pip3] nvidia-cutlass-dsl==4.3.3
[pip3] nvidia-ml-py==13.590.44
[pip3] nvidia-nccl-cu12==2.27.5
[pip3] nvidia-nvjitlink-cu12==12.8.93
[pip3] nvidia-nvshmem-cu12==3.3.20
[pip3] nvidia-nvtx-cu12==12.8.90
[pip3] pyzmq==27.1.0
[pip3] torch==2.9.0
[pip3] torchaudio==2.9.0
[pip3] torchvision==0.24.0
[pip3] transformers==4.57.3
[pip3] triton==3.5.0
[conda] pyzmq                     27.1.0                   pypi_0    pypi

==============================
         vLLM Info
==============================
ROCM Version                 : Could not collect
vLLM Version                 : 0.1.dev12080+g1166c31cc (git sha: 1166c31cc)
vLLM Build Flags:
  CUDA Archs: Not Set; ROCm: Disabled
GPU Topology:
  	^[[4mGPU0	CPU Affinity	NUMA Affinity	GPU NUMA ID^[[0m
GPU0	 X 	56-111,168-223	1		N/A

Legend:

  X    = Self
  SYS  = Connection traversing PCIe as well as the SMP interconnect between NUMA nodes (e.g., QPI/UPI)
  NODE = Connection traversing PCIe as well as the interconnect between PCIe Host Bridges within a NUMA node
  PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
  PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
  PIX  = Connection traversing at most a single PCIe bridge
  NV#  = Connection traversing a bonded set of # NVLinks

==============================
     Environment Variables
==============================
NVIDIA_VISIBLE_DEVICES=D.a4217d1e48cb438419d5e86d7370c70fe6461bc4198287fa753236a5abe0bf99/gpu=5
NVIDIA_REQUIRE_CUDA=cuda>=12.8 brand=unknown,driver>=470,driver<471 brand=grid,driver>=470,driver<471 brand=tesla,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=quadro,driver>=470,driver<471 brand=quadrortx,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471 brand=vapps,driver>=470,driver<471 brand=vpc,driver>=470,driver<471 brand=vcs,driver>=470,driver<471 brand=vws,driver>=470,driver<471 brand=cloudgaming,driver>=470,driver<471 brand=unknown,driver>=535,driver<536 brand=grid,driver>=535,driver<536 brand=tesla,driver>=535,driver<536 brand=nvidia,driver>=535,driver<536 brand=quadro,driver>=535,driver<536 brand=quadrortx,driver>=535,driver<536 brand=nvidiartx,driver>=535,driver<536 brand=vapps,driver>=535,driver<536 brand=vpc,driver>=535,driver<536 brand=vcs,driver>=535,driver<536 brand=vws,driver>=535,driver<536 brand=cloudgaming,driver>=535,driver<536 brand=unknown,driver>=550,driver<551 brand=grid,driver>=550,driver<551 brand=tesla,driver>=550,driver<551 brand=nvidia,driver>=550,driver<551 brand=quadro,driver>=550,driver<551 brand=quadrortx,driver>=550,driver<551 brand=nvidiartx,driver>=550,driver<551 brand=vapps,driver>=550,driver<551 brand=vpc,driver>=550,driver<551 brand=vcs,driver>=550,driver<551 brand=vws,driver>=550,driver<551 brand=cloudgaming,driver>=550,driver<551 brand=unknown,driver>=560,driver<561 brand=grid,driver>=560,driver<561 brand=tesla,driver>=560,driver<561 brand=nvidia,driver>=560,driver<561 brand=quadro,driver>=560,driver<561 brand=quadrortx,driver>=560,driver<561 brand=nvidiartx,driver>=560,driver<561 brand=vapps,driver>=560,driver<561 brand=vpc,driver>=560,driver<561 brand=vcs,driver>=560,driver<561 brand=vws,driver>=560,driver<561 brand=cloudgaming,driver>=560,driver<561 brand=unknown,driver>=565,driver<566 brand=grid,driver>=565,driver<566 brand=tesla,driver>=565,driver<566 brand=nvidia,driver>=565,driver<566 brand=quadro,driver>=565,driver<566 brand=quadrortx,driver>=565,driver<566 brand=nvidiartx,driver>=565,driver<566 brand=vapps,driver>=565,driver<566 brand=vpc,driver>=565,driver<566 brand=vcs,driver>=565,driver<566 brand=vws,driver>=565,driver<566 brand=cloudgaming,driver>=565,driver<566
NCCL_VERSION=2.25.1-1
NVIDIA_DRIVER_CAPABILITIES=all
NVIDIA_PRODUCT_NAME=CUDA
CUDA_VERSION=12.8.1
LD_LIBRARY_PATH=/usr/local/cuda/lib64
PYTORCH_NVML_BASED_CUDA_CHECK=1
TORCHINDUCTOR_COMPILE_THREADS=1
TORCHINDUCTOR_CACHE_DIR=/tmp/torchinductor_root
VLLM_WORKER_MULTIPROC_METHOD=spawn

```

</details>

## Purpose
Resolves: #28986
Add fused routing, including topk,softmax,sub_bitmatrix_rows, two combined_routing*

Only consider GPTOSS model's num_experts and topk

## Test Plan
Add GPTOSS20B config to existed unittest

## Test Result
<details>
<summary> unittest output </summary>

```
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS120BModelConfig-1-2-bf16-mx4] PASSED                                                                                                                                                                          [  5%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS120BModelConfig-1-128-bf16-mx4] PASSED                                                                                                                                                                        [ 11%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS120BModelConfig-2-2-bf16-mx4] PASSED                                                                                                                                                                          [ 17%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS120BModelConfig-2-128-bf16-mx4] PASSED                                                                                                                                                                        [ 23%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS120BModelConfig-4-2-bf16-mx4] PASSED                                                                                                                                                                          [ 29%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS120BModelConfig-4-128-bf16-mx4] PASSED                                                                                                                                                                        [ 35%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS120BModelConfig-8-2-bf16-mx4] PASSED                                                                                                                                                                          [ 41%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS120BModelConfig-8-128-bf16-mx4] PASSED                                                                                                                                                                        [ 47%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS20BModelConfig-1-2-bf16-mx4] PASSED                                                                                                                                                                           [ 52%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS20BModelConfig-1-128-bf16-mx4] PASSED                                                                                                                                                                         [ 58%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS20BModelConfig-2-2-bf16-mx4] PASSED                                                                                                                                                                           [ 64%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS20BModelConfig-2-128-bf16-mx4] PASSED                                                                                                                                                                         [ 70%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS20BModelConfig-4-2-bf16-mx4] PASSED                                                                                                                                                                           [ 76%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS20BModelConfig-4-128-bf16-mx4] PASSED                                                                                                                                                                         [ 82%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS20BModelConfig-8-2-bf16-mx4] PASSED                                                                                                                                                                           [ 88%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_equiv[GPTOSS20BModelConfig-8-128-bf16-mx4] PASSED                                                                                                                                                                         [ 94%]
tests/kernels/moe/test_gpt_oss_triton_kernels.py::test_unit_shuffle PASSED                                                                                                                                                                                                       [100%]
```

</details>
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

