### PR TITLE
[BugFix] Fix unmap_and_release by tag not done correctly

### DIFF
--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -234,7 +234,7 @@ class CuMemAllocator:
                 cpu_ptr = cpu_backup_tensor.data_ptr()
                 libcudart.cudaMemcpy(cpu_ptr, ptr, size_in_bytes)
                 data.cpu_backup_tensor = cpu_backup_tensor
-            unmap_and_release(handle)
+                unmap_and_release(handle)
 
         logger.info(
             "CuMemAllocator: sleep freed %.2f GiB memory in total, of which "


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix bug in cumem where memory is not correctly unmapped by tag during unmap_and_release. The bug happens because the tag check is incorrectly placed, causing potential memory management issues.