### PR TITLE
Make the `httpx` logger less annoying when Transformers v5 is installed

### DIFF
--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -229,6 +229,11 @@ def suppress_logging(level: int = logging.INFO) -> Generator[None, Any, None]:
 # guaranteed by the Python GIL.
 _configure_vllm_root_logger()
 
+# Transformers uses httpx to access the Hugging Face Hub. httpx is quite verbose,
+# so we set its logging level to WARNING when vLLM's logging level is INFO.
+if envs.VLLM_LOGGING_LEVEL == "INFO":
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
 logger = init_logger(__name__)
 
 


### PR DESCRIPTION
Transfor ers v5 uses `httpx` to access the Hugging Face Hub. When its logger is set to `INFO`, the logging output is quite verbose.

This PR sets `httpx`'s logging level to `WARNING` when vLLM's logging level is default (`INFO`) so that:

- The default log level is less spammy
- When users specify non-default logging levels, `httpx` will follow