### PR TITLE
[BugFix] Fix minimax m2 model partial_rotary_factor

### DIFF
--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -200,13 +200,14 @@ class MiniMaxM2Attention(nn.Module):
             prefix=f"{prefix}.o_proj",
         )
 
+        final_rotary_dim = rotary_dim
         # https://github.com/vllm-project/vllm/pull/30384
         if hasattr(config, "partial_rotary_factor"):
-            rotary_dim = self.head_dim
+            final_rotary_dim = self.head_dim
 
         self.rotary_emb = get_rope(
             self.head_dim,
-            rotary_dim=rotary_dim,
+            rotary_dim=final_rotary_dim,
             max_position=max_position_embeddings,
             rope_parameters=rope_parameters,
         )


### PR DESCRIPTION

## Purpose

In #30384, I fixed an inference issue with MiniMax-M2, but this caused some community-contributed quantized models to fail(#30445), some of which were forked before I added `partial_rotary_factor`. This update provides compatibility with those community-contributed quantized models.

## Test Plan

```bash
lm_eval --model local-completions \
  --model_args base_url=http://localhost:10086/v1/completions,tokenizer=/model,model=/model \
  --tasks gsm8k_cot  \
  --batch_size 128 \
  --num_fewshot 5
```

## Test Result

```bash
local-completions (base_url=http://localhost:10086/v1/completions,tokenizer=/model,model=/model), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: 128
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     5|exact_match|↑  |0.9227|±  |0.0074|
|         |       |strict-match    |     5|exact_match|↑  |0.9105|±  |0.0079|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

