### PR TITLE
fix(gguf): GGUF model support fixes for Blackwell GPUs

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -494,6 +494,17 @@ class ModelConfig:
         )
 
         self.hf_config = hf_config
+
+        # Ensure Gemma2 configs have hidden_act for backward compatibility.
+        # GGUF configs may only have hidden_activation; model code expects both.
+        if (
+            hasattr(hf_config, "model_type")
+            and hf_config.model_type == "gemma2"
+            and not hasattr(hf_config, "hidden_act")
+            and hasattr(hf_config, "hidden_activation")
+        ):
+            hf_config.hidden_act = hf_config.hidden_activation
+
         if dict_overrides:
             self._apply_dict_overrides(hf_config, dict_overrides)
         self.hf_text_config = get_hf_text_config(self.hf_config)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -389,11 +389,41 @@ class VllmConfig:
                     )
             supported_dtypes = quant_config.get_supported_act_dtypes()
             if model_config.dtype not in supported_dtypes:
-                raise ValueError(
-                    f"{model_config.dtype} is not supported for quantization "
-                    f"method {model_config.quantization}. Supported dtypes: "
-                    f"{supported_dtypes}"
-                )
+                # Handle dtype conflict between model restrictions and
+                # quantization restrictions (e.g., Gemma3 GGUF on Blackwell
+                # where Gemma3 blocks float16 and GGUF blocks bfloat16)
+                from vllm.config.model import _is_valid_dtype
+
+                model_type = getattr(model_config.hf_config, "model_type", None)
+                compatible_dtypes = [
+                    d
+                    for d in supported_dtypes
+                    if model_type is None or _is_valid_dtype(model_type, d)
+                ]
+                if compatible_dtypes:
+                    # Prefer float16 > bfloat16 > float32 for performance
+                    import torch
+
+                    dtype_preference = [torch.float16, torch.bfloat16, torch.float32]
+                    for preferred in dtype_preference:
+                        if preferred in compatible_dtypes:
+                            logger.warning(
+                                "dtype=%s is not supported for quantization "
+                                "method %s with model type %s. "
+                                "Automatically selecting %s as compatible dtype.",
+                                model_config.dtype,
+                                model_config.quantization,
+                                model_type,
+                                preferred,
+                            )
+                            model_config.dtype = preferred
+                            break
+                else:
+                    raise ValueError(
+                        f"{model_config.dtype} is not supported for quantization "
+                        f"method {model_config.quantization}. Supported dtypes: "
+                        f"{supported_dtypes}"
+                    )
             quant_config.maybe_update_config(model_config.model)
             return quant_config
         return None

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -402,8 +402,6 @@ class VllmConfig:
                 ]
                 if compatible_dtypes:
                     # Prefer float16 > bfloat16 > float32 for performance
-                    import torch
-
                     dtype_preference = [torch.float16, torch.bfloat16, torch.float32]
                     for preferred in dtype_preference:
                         if preferred in compatible_dtypes:

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -64,13 +64,11 @@ def memory_fence():
     operation (~20ns) that guarantees:
     - All stores before the barrier are visible to other threads/processes
     - All loads after the barrier see the latest values
-
-    Reference: POSIX.1-2008 specifies that mutex operations synchronize memory.
     """
     # Lock acquire/release provides full memory barrier semantics.
-    # This flushes CPU store buffers and invalidates stale cache lines.
-    _memory_fence_lock.acquire()
-    _memory_fence_lock.release()
+    # Using context manager ensures lock release even on exceptions.
+    with _memory_fence_lock:
+        pass
 
 
 def to_bytes_big(value: int, size: int) -> bytes:

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -64,11 +64,13 @@ def memory_fence():
     operation (~20ns) that guarantees:
     - All stores before the barrier are visible to other threads/processes
     - All loads after the barrier see the latest values
+
+    Reference: POSIX.1-2008 specifies that mutex operations synchronize memory.
     """
     # Lock acquire/release provides full memory barrier semantics.
-    # Using context manager ensures lock release even on exceptions.
-    with _memory_fence_lock:
-        pass
+    # This flushes CPU store buffers and invalidates stale cache lines.
+    _memory_fence_lock.acquire()
+    _memory_fence_lock.release()
 
 
 def to_bytes_big(value: int, size: int) -> bytes:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1201,16 +1201,6 @@ class EngineArgs:
         # gguf file needs a specific model loader
         if is_gguf(self.model):
             self.quantization = self.load_format = "gguf"
-            # GGUF dequantization kernels use half precision (fp16) internally.
-            # bfloat16 causes incorrect output on some architectures (e.g., Blackwell).
-            # Default to float16 for safety; explicit --dtype bfloat16 still allowed
-            # for users on hardware where it works.
-            if self.dtype == "auto":
-                self.dtype = "float16"
-                logger.info(
-                    "GGUF models default to float16 (dequant kernels use fp16 "
-                    "internally). Use --dtype bfloat16 to override if needed."
-                )
 
         # NOTE(woosuk): In V1, we use separate processes for workers (unless
         # VLLM_ENABLE_V1_MULTIPROCESSING=0), so setting a seed here

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1201,6 +1201,16 @@ class EngineArgs:
         # gguf file needs a specific model loader
         if is_gguf(self.model):
             self.quantization = self.load_format = "gguf"
+            # GGUF dequantization kernels use half precision (fp16) internally.
+            # bfloat16 causes incorrect output on some architectures (e.g., Blackwell).
+            # Default to float16 for safety; explicit --dtype bfloat16 still allowed
+            # for users on hardware where it works.
+            if self.dtype == "auto":
+                self.dtype = "float16"
+                logger.info(
+                    "GGUF models default to float16 (dequant kernels use fp16 "
+                    "internally). Use --dtype bfloat16 to override if needed."
+                )
 
         # NOTE(woosuk): In V1, we use separate processes for workers (unless
         # VLLM_ENABLE_V1_MULTIPROCESSING=0), so setting a seed here

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -54,11 +54,11 @@ class GGUFConfig(QuantizationConfig):
 
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
         # GGUF dequantization kernels use half precision (fp16) internally.
-        # bfloat16 has precision issues on SM 120+ devices (Blackwell).
-        if current_platform.has_device_capability(120):
+        # bfloat16 has precision issues on SM 10.0+ devices (Blackwell).
+        if current_platform.has_device_capability(100):
             logger.warning_once(
-                "GGUF has precision issues with bfloat16 on SM 120+ devices. "
-                "bfloat16 is unavailable for Blackwell devices."
+                "GGUF has precision issues with bfloat16 on Blackwell (SM 10.0+). "
+                "bfloat16 is unavailable."
             )
             return [torch.half, torch.float32]
         return [torch.half, torch.bfloat16, torch.float32]

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -52,6 +52,10 @@ class GGUFConfig(QuantizationConfig):
         return "gguf"
 
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
+        # GGUF dequantization kernels use half precision (fp16) internally.
+        # bfloat16 may cause incorrect output on some architectures (e.g., Blackwell)
+        # but is kept for users who explicitly request it on hardware where it works.
+        # See: arg_utils.py auto-defaults to float16 for GGUF when dtype="auto"
         return [torch.half, torch.bfloat16, torch.float32]
 
     @classmethod

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -147,6 +147,11 @@ class GGUFModelLoader(BaseModelLoader):
                     )
                 )
 
+        # For models with tied word embeddings, lm_head.weight is initialized
+        # from embed_tokens and doesn't need to be mapped from GGUF file
+        if getattr(config, "tie_word_embeddings", False):
+            sideload_params.append(re.compile(r"lm_head\.weight"))
+
         arch = None
         for key, value in gguf.MODEL_ARCH_NAMES.items():
             if value == model_type:

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -267,6 +267,8 @@ class Gemma2Model(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.embed_tokens",
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -366,6 +366,10 @@ class Gemma2Model(nn.Module):
                     continue
                 if is_pp_missing_parameter(name, self):
                     continue
+                # Skip parameters not in the model (e.g., GGUF quantization
+                # metadata like qweight_type for embeddings)
+                if name not in params_dict:
+                    continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -49,6 +49,7 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateShapeCalculator,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
     VocabParallelEmbedding,
@@ -435,6 +436,7 @@ class NemotronHAttention(nn.Module):
         self,
         config: NemotronHConfig,
         layer_idx: int,
+        max_position_embeddings: int,
         model_config: ModelConfig | None = None,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
@@ -490,13 +492,25 @@ class NemotronHAttention(nn.Module):
             prefix=f"{prefix}.attn",
         )
 
+        # Rotary embeddings for positional encoding
+        self.max_position_embeddings = max_position_embeddings
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            rotary_dim=self.head_dim,
+            max_position=max_position_embeddings,
+            is_neox_style=True,
+            dtype=model_config.dtype if model_config else torch.get_default_dtype(),
+        )
+
     def forward(
         self,
+        positions: torch.Tensor,
         hidden_states: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)
         return output
@@ -518,9 +532,10 @@ class NemotronHAttentionDecoderLayer(nn.Module):
         self.mixer = NemotronHAttention(
             config,
             layer_idx,
-            model_config,
-            cache_config,
-            quant_config,
+            max_position_embeddings=config.max_position_embeddings,
+            model_config=model_config,
+            cache_config=cache_config,
+            quant_config=quant_config,
             prefix=f"{prefix}.mixer",
         )
 
@@ -539,7 +554,7 @@ class NemotronHAttentionDecoderLayer(nn.Module):
         else:
             hidden_states, residual = self.norm(hidden_states, residual)
 
-        hidden_states = self.mixer(hidden_states=hidden_states)
+        hidden_states = self.mixer(positions=positions, hidden_states=hidden_states)
         return hidden_states, residual
 
 
@@ -659,6 +674,10 @@ class NemotronHModel(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
+            # Skip rotary embeddings - they are computed dynamically
+            if "rotary_emb.inv_freq" in name:
+                continue
+
             if "scale" in name:
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)

--- a/vllm/tokenizers/hf.py
+++ b/vllm/tokenizers/hf.py
@@ -7,10 +7,14 @@ from typing import TYPE_CHECKING
 
 from transformers import AutoTokenizer
 
+from vllm.logger import init_logger
 from vllm.transformers_utils.config import get_sentence_transformer_tokenizer_config
+from vllm.transformers_utils.gguf_utils import extract_eos_token_id_from_gguf
 
 from .protocol import TokenizerLike
 from .registry import TokenizerRegistry
+
+logger = init_logger(__name__)
 
 if TYPE_CHECKING:
     from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
@@ -120,5 +124,23 @@ class HfTokenizer(TokenizerLike):
                 k: v.lower() for k, v in tokenizer.special_tokens_map.items()
             }
             tokenizer.add_special_tokens(special_tokens_map)
+
+        # Patch EOS token ID from GGUF metadata if available
+        # GGUF files may have a different EOS token ID than HF tokenizer config
+        # (e.g., Gemma uses <end_of_turn> ID 106 as EOS, but HF reports <eos> ID 1)
+        gguf_file = kwargs.get("gguf_file")
+        if gguf_file:
+            gguf_path = Path(path_or_repo_id) / gguf_file
+            gguf_eos_id = extract_eos_token_id_from_gguf(str(gguf_path))
+            if gguf_eos_id is not None:
+                hf_eos_id = tokenizer.eos_token_id
+                if hf_eos_id != gguf_eos_id:
+                    logger.info(
+                        "Patching tokenizer eos_token_id from %d to %d "
+                        "(using GGUF metadata)",
+                        hf_eos_id,
+                        gguf_eos_id,
+                    )
+                    tokenizer.eos_token_id = gguf_eos_id
 
         return get_cached_tokenizer(tokenizer)

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -260,6 +260,46 @@ def extract_softcap_from_gguf(model: str) -> dict[str, float]:
         return {}
 
 
+def extract_eos_token_id_from_gguf(model: str) -> int | None:
+    """Extract EOS token ID from GGUF metadata.
+
+    GGUF files store the EOS token ID in tokenizer.ggml.eos_token_id field.
+    This may differ from HuggingFace's tokenizer config (e.g., Gemma models
+    use <end_of_turn> token ID 106 as EOS in GGUF, but HF tokenizer reports
+    <eos> token ID 1).
+
+    Args:
+        model: Path to GGUF model file
+
+    Returns:
+        EOS token ID from GGUF metadata, or None if not found
+    """
+    if not model.endswith(".gguf"):
+        return None
+
+    try:
+        model_path = Path(model)
+        if not model_path.is_file():
+            return None
+
+        reader = gguf.GGUFReader(str(model_path))
+
+        eos_field = reader.get_field(Keys.Tokenizer.EOS_ID)
+        if eos_field is not None:
+            eos_token_id = int(eos_field.parts[-1][0])
+            logger.debug(
+                "Extracted eos_token_id=%d from GGUF metadata",
+                eos_token_id,
+            )
+            return eos_token_id
+
+        return None
+
+    except Exception as e:
+        logger.debug("Error extracting EOS token ID from GGUF: %s", e)
+        return None
+
+
 def maybe_patch_hf_config_from_gguf(
     model: str,
     hf_config: PretrainedConfig,


### PR DESCRIPTION
## Summary

This PR bundles several fixes for GGUF model support, particularly targeting Blackwell (RTX 5090, SM 120+) GPUs. These fixes address dtype compatibility, config extraction, tokenizer handling, and memory synchronization issues.

### Key Changes

**GGUF Dtype Compatibility (Blackwell)**:
- Auto-select compatible dtype for GGUF models on Blackwell GPUs
- Default GGUF to float16 while preserving bfloat16 option for compatible hardware
- Disable bfloat16 on Blackwell (SM 120+) via device capability check

**GGUF Config Extraction**:
- Extract HF config from GGUF metadata for repos without config.json
- Extract `attn_logit_softcapping` from GGUF metadata
- Use EOS token ID from GGUF metadata instead of HF tokenizer
- Ensure Gemma2 configs have `hidden_act` for backward compatibility

**Gemma2 GGUF Support**:
- Add `quant_config` to embedding layer for GGUF support
- Skip missing parameters during GGUF weight loading
- Skip `lm_head` mapping for models with tied word embeddings

**Memory & IPC Fixes**:
- Add memory barriers for cross-process shared memory visibility
- Lazy tokenizer init in StructuredOutputManager to prevent semaphore leak

**Model Fixes**:
- Add rotary positional embeddings to Nemotron-H attention layers

## Test plan

- [ ] Test GGUF models (gemma-3-1b-it, phi35-mini-gguf) on Blackwell GPU
- [ ] Verify dtype auto-detection works correctly
- [ ] Test Gemma2 GGUF models with tied embeddings
- [ ] Verify shared memory barriers don't cause regressions

## Related PRs

- #30090: Default GGUF to float16
- #30284: Tokenizer semaphore leak fix  
- #29819: Shared memory barriers

🤖 Generated with [Claude Code](https://claude.com/claude-code)