### PR TITLE
[Bugfix][Model] Fix Afmoe rope_parameters issue

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -173,9 +173,7 @@ class _HfExamplesInfo:
 
 _TEXT_GENERATION_EXAMPLE_MODELS = {
     # [Decoder-only]
-    "AfmoeForCausalLM": _HfExamplesInfo(
-        "arcee-ai/Trinity-Nano-Preview",
-    ),
+    "AfmoeForCausalLM": _HfExamplesInfo("arcee-ai/Trinity-Nano-Preview"),
     "ApertusForCausalLM": _HfExamplesInfo("swiss-ai/Apertus-8B-Instruct-2509"),
     "AquilaModel": _HfExamplesInfo("BAAI/AquilaChat-7B", trust_remote_code=True),
     "AquilaForCausalLM": _HfExamplesInfo("BAAI/AquilaChat2-7B", trust_remote_code=True),

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -174,8 +174,7 @@ class _HfExamplesInfo:
 _TEXT_GENERATION_EXAMPLE_MODELS = {
     # [Decoder-only]
     "AfmoeForCausalLM": _HfExamplesInfo(
-        "arcee-ai/Trinity-Nano",
-        is_available_online=False,
+        "arcee-ai/Trinity-Nano-Preview",
     ),
     "ApertusForCausalLM": _HfExamplesInfo("swiss-ai/Apertus-8B-Instruct-2509"),
     "AquilaModel": _HfExamplesInfo("BAAI/AquilaChat-7B", trust_remote_code=True),

--- a/vllm/model_executor/models/afmoe.py
+++ b/vllm/model_executor/models/afmoe.py
@@ -239,11 +239,20 @@ class AfmoeAttention(nn.Module):
 
         # Only create rotary embeddings for local attention
         if self.is_local_attention:
+            # Handle Transformers v5 rope_parameters format (dict with layer types)
+            layer_type = config.layer_types[layer_idx]
+            if layer_type in config.rope_parameters:
+                # Transformers v5 rope config: use layer-specific rope_parameters
+                rope_parameters = config.rope_parameters[layer_type]
+            else:
+                # Transformers v4 rope config: use config.rope_parameters directly
+                rope_parameters = config.rope_parameters
+            
             self.rotary_emb = get_rope(
                 self.head_dim,
                 rotary_dim=self.head_dim,
                 max_position=max_position_embeddings,
-                rope_parameters=config["rope_parameters"],
+                rope_parameters=rope_parameters,
                 is_neox_style=True,
             )
         else:

--- a/vllm/model_executor/models/afmoe.py
+++ b/vllm/model_executor/models/afmoe.py
@@ -241,13 +241,14 @@ class AfmoeAttention(nn.Module):
         if self.is_local_attention:
             # Handle Transformers v5 rope_parameters format (dict with layer types)
             layer_type = config.layer_types[layer_idx]
-            if layer_type in config.rope_parameters:
+            rope_params = getattr(config, "rope_parameters", None)
+            if isinstance(rope_params, dict) and layer_type in rope_params:
                 # Transformers v5 rope config: use layer-specific rope_parameters
-                rope_parameters = config.rope_parameters[layer_type]
+                rope_parameters = rope_params[layer_type]
             else:
                 # Transformers v4 rope config: use config.rope_parameters directly
-                rope_parameters = config.rope_parameters
-            
+                rope_parameters = rope_params
+
             self.rotary_emb = get_rope(
                 self.head_dim,
                 rotary_dim=self.head_dim,

--- a/vllm/model_executor/models/afmoe.py
+++ b/vllm/model_executor/models/afmoe.py
@@ -239,16 +239,6 @@ class AfmoeAttention(nn.Module):
 
         # Only create rotary embeddings for local attention
         if self.is_local_attention:
-            # Handle Transformers v5 rope_parameters format (dict with layer types)
-            layer_type = config.layer_types[layer_idx]
-            rope_params = getattr(config, "rope_parameters", None)
-            if isinstance(rope_params, dict) and layer_type in rope_params:
-                # Transformers v5 rope config: use layer-specific rope_parameters
-                rope_parameters = rope_params[layer_type]
-            else:
-                # Transformers v4 rope config: use config.rope_parameters directly
-                rope_parameters = rope_params
-
             self.rotary_emb = get_rope(
                 self.head_dim,
                 rotary_dim=self.head_dim,

--- a/vllm/model_executor/models/afmoe.py
+++ b/vllm/model_executor/models/afmoe.py
@@ -253,7 +253,7 @@ class AfmoeAttention(nn.Module):
                 self.head_dim,
                 rotary_dim=self.head_dim,
                 max_position=max_position_embeddings,
-                rope_parameters=rope_parameters,
+                rope_parameters=config.rope_parameters,
                 is_neox_style=True,
             )
         else:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Without this, running the `AfmoeForCausalLM` architecture fails with 

```
vllm serve arcee-ai/trinity-mini
...
(EngineCore_DP0 pid=2901413)   File "/home/mgoin/code/vllm/vllm/model_executor/models/afmoe.py", line 246, in __init__
(EngineCore_DP0 pid=2901413)     rope_parameters=config["rope_parameters"],
(EngineCore_DP0 pid=2901413)                     ~~~~~~^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=2901413) TypeError: 'AfmoeConfig' object is not subscriptable
```

It seems this wasn't caught because the model was listed as `is_available_online=False` in the test registry

## Test Result

```
vllm serve arcee-ai/trinity-mini --async-scheduling

python tests/evals/gsm8k/gsm8k_eval.py 
Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/train.jsonl to /tmp/train.jsonl
Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl to /tmp/test.jsonl
Running GSM8K evaluation: 1319 questions, 5-shot
Evaluating: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:17<00:00, 73.51it/s]

Results:
Accuracy: 0.845
Invalid responses: 0.000
Total latency: 17.958 s
Questions per second: 73.451
Total output tokens: 127923
Output tokens per second: 7123.631
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

