### PR TITLE
[CI/Build][AMD] Skip test_cutlass_w4a8_moe tests on ROCm sine they require cutlass_pack_scale_fp8

### DIFF
--- a/tests/kernels/quantization/test_cutlass_w4a8_moe.py
+++ b/tests/kernels/quantization/test_cutlass_w4a8_moe.py
@@ -18,7 +18,9 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 from vllm.scalar_type import ScalarType, scalar_types
 
-IS_SUPPORTED_BY_GPU = current_platform.get_device_capability()[0] >= 9
+IS_CUDA = current_platform.is_cuda()
+IS_CAPABLE = current_platform.get_device_capability()[0] >= 9
+IS_SUPPORTED_BY_GPU = IS_CUDA and IS_CAPABLE
 
 
 def to_fp8(tensor: torch.Tensor) -> torch.Tensor:

--- a/tests/kernels/quantization/test_cutlass_w4a8_moe.py
+++ b/tests/kernels/quantization/test_cutlass_w4a8_moe.py
@@ -18,9 +18,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 from vllm.scalar_type import ScalarType, scalar_types
 
-IS_CUDA = current_platform.is_cuda()
-IS_CAPABLE = current_platform.get_device_capability()[0] >= 9
-IS_SUPPORTED_BY_GPU = IS_CUDA and IS_CAPABLE
+IS_SUPPORTED_BY_GPU = current_platform.is_cuda() and current_platform.get_device_capability()[0] >= 9
 
 
 def to_fp8(tensor: torch.Tensor) -> torch.Tensor:

--- a/tests/kernels/quantization/test_cutlass_w4a8_moe.py
+++ b/tests/kernels/quantization/test_cutlass_w4a8_moe.py
@@ -18,7 +18,9 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 from vllm.scalar_type import ScalarType, scalar_types
 
-IS_SUPPORTED_BY_GPU = current_platform.is_cuda() and current_platform.get_device_capability()[0] >= 9
+IS_SUPPORTED_BY_GPU = (
+    current_platform.is_cuda() and current_platform.get_device_capability()[0] >= 9
+)
 
 
 def to_fp8(tensor: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
This PR skips tests in `test_cutlass_w4a8_moe.py` since they require `cutlass_pack_scale_fp8 `and ROCm doesn't have it.
