### PR TITLE
[CI] Speed up fusion tests

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -1064,7 +1064,7 @@ steps:
   - tests/compile/test_fusion_attn.py
   commands:
     - export VLLM_TEST_CLEAN_GPU_MEMORY=1
-    - pytest -v -s tests/compile/test_fusion_attn.py -k 'not Llama-4'
+    - pytest -v -s tests/compile/test_fusion_attn.py
 
 - label: Hopper Fusion Distributed E2E Tests (2xH100)  # 70min
   timeout_in_minutes: 70

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -1064,7 +1064,7 @@ steps:
   - tests/compile/test_fusion_attn.py
   commands:
     - export VLLM_TEST_CLEAN_GPU_MEMORY=1
-    - pytest -v -s tests/compile/test_fusion_attn.py
+    - pytest -v -s tests/compile/test_fusion_attn.py -k 'not Llama-4'
 
 - label: Hopper Fusion Distributed E2E Tests (2xH100)  # 70min
   timeout_in_minutes: 70

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -1064,6 +1064,7 @@ steps:
   - tests/compile/test_fusion_attn.py
   commands:
     - export VLLM_TEST_CLEAN_GPU_MEMORY=1
+    # skip Llama-4 since it does not fit on this device
     - pytest -v -s tests/compile/test_fusion_attn.py -k 'not Llama-4'
 
 - label: Hopper Fusion Distributed E2E Tests (2xH100)  # 70min

--- a/tests/compile/distributed/test_fusions_e2e.py
+++ b/tests/compile/distributed/test_fusions_e2e.py
@@ -13,9 +13,9 @@ from tests.compile.fusion_test_utils import (
     CUSTOM_OPS_FP8,
     CUSTOM_OPS_QUANT_RMS_NORM,
     CUSTOM_OPS_RMS_NORM,
-    MODELS,
-    MODELS_FP4,
-    MODELS_FP8,
+    DUMMY_MODELS,
+    DUMMY_MODELS_FP4,
+    DUMMY_MODELS_FP8,
     MODELS_GROUP_FP8,
     Matches,
     custom_ops_product,
@@ -37,11 +37,11 @@ from ...utils import flat_product, multi_gpu_test
     # Toggle RMSNorm and QuantFP8 for FP8 models
     list(
         flat_product(
-            MODELS_FP8, custom_ops_product(CUSTOM_OPS_FP8, CUSTOM_OPS_RMS_NORM)
+            DUMMY_MODELS_FP8, custom_ops_product(CUSTOM_OPS_FP8, CUSTOM_OPS_RMS_NORM)
         )
     )
     # Toggle RMSNorm for FP4 models and unquant models
-    + list(flat_product(MODELS_FP4 + MODELS, CUSTOM_OPS_RMS_NORM)),
+    + list(flat_product(DUMMY_MODELS_FP4 + DUMMY_MODELS, CUSTOM_OPS_RMS_NORM)),
 )
 @pytest.mark.parametrize("inductor_graph_partition", [True, False])
 @pytest.mark.skipif(
@@ -145,11 +145,11 @@ def test_tp2_attn_quant_allreduce_rmsnorm(
     # Toggle RMSNorm and QuantFP8 for FP8 models
     list(
         flat_product(
-            MODELS_FP8, custom_ops_product(CUSTOM_OPS_FP8, CUSTOM_OPS_RMS_NORM)
+            DUMMY_MODELS_FP8, custom_ops_product(CUSTOM_OPS_FP8, CUSTOM_OPS_RMS_NORM)
         )
     )
     # Toggle RMSNorm for FP4 models and unquant models
-    + list(flat_product(MODELS_FP4 + MODELS, CUSTOM_OPS_RMS_NORM)),
+    + list(flat_product(DUMMY_MODELS_FP4 + DUMMY_MODELS, CUSTOM_OPS_RMS_NORM)),
 )
 @pytest.mark.parametrize("inductor_graph_partition", [True, False])
 @pytest.mark.skipif(

--- a/tests/compile/distributed/test_fusions_e2e.py
+++ b/tests/compile/distributed/test_fusions_e2e.py
@@ -250,6 +250,8 @@ def test_tp2_attn_quant_async_tp(
 
     assert int(log_matches[0]) == matches.async_tp
     assert int(log_matches[1]) == matches.async_tp
+
+
 @pytest.mark.parametrize(
     "model_name, model_kwargs, backend, matches, custom_ops",
     # Test rms norm+group quant_fp8 fusion

--- a/tests/compile/distributed/test_fusions_e2e.py
+++ b/tests/compile/distributed/test_fusions_e2e.py
@@ -13,9 +13,9 @@ from tests.compile.fusion_test_utils import (
     CUSTOM_OPS_FP8,
     CUSTOM_OPS_QUANT_RMS_NORM,
     CUSTOM_OPS_RMS_NORM,
-    DUMMY_MODELS,
-    DUMMY_MODELS_FP4,
-    DUMMY_MODELS_FP8,
+    MODELS,
+    MODELS_FP4,
+    MODELS_FP8,
     MODELS_GROUP_FP8,
     Matches,
     custom_ops_product,
@@ -37,11 +37,11 @@ from ...utils import flat_product, multi_gpu_test
     # Toggle RMSNorm and QuantFP8 for FP8 models
     list(
         flat_product(
-            DUMMY_MODELS_FP8, custom_ops_product(CUSTOM_OPS_FP8, CUSTOM_OPS_RMS_NORM)
+            MODELS_FP8, custom_ops_product(CUSTOM_OPS_FP8, CUSTOM_OPS_RMS_NORM)
         )
     )
     # Toggle RMSNorm for FP4 models and unquant models
-    + list(flat_product(DUMMY_MODELS_FP4 + DUMMY_MODELS, CUSTOM_OPS_RMS_NORM)),
+    + list(flat_product(MODELS_FP4 + MODELS, CUSTOM_OPS_RMS_NORM)),
 )
 @pytest.mark.parametrize("inductor_graph_partition", [True, False])
 @pytest.mark.skipif(
@@ -145,11 +145,11 @@ def test_tp2_attn_quant_allreduce_rmsnorm(
     # Toggle RMSNorm and QuantFP8 for FP8 models
     list(
         flat_product(
-            DUMMY_MODELS_FP8, custom_ops_product(CUSTOM_OPS_FP8, CUSTOM_OPS_RMS_NORM)
+            MODELS_FP8, custom_ops_product(CUSTOM_OPS_FP8, CUSTOM_OPS_RMS_NORM)
         )
     )
     # Toggle RMSNorm for FP4 models and unquant models
-    + list(flat_product(DUMMY_MODELS_FP4 + DUMMY_MODELS, CUSTOM_OPS_RMS_NORM)),
+    + list(flat_product(MODELS_FP4 + MODELS, CUSTOM_OPS_RMS_NORM)),
 )
 @pytest.mark.parametrize("inductor_graph_partition", [True, False])
 @pytest.mark.skipif(

--- a/tests/compile/distributed/test_fusions_e2e.py
+++ b/tests/compile/distributed/test_fusions_e2e.py
@@ -250,8 +250,6 @@ def test_tp2_attn_quant_async_tp(
 
     assert int(log_matches[0]) == matches.async_tp
     assert int(log_matches[1]) == matches.async_tp
-
-
 @pytest.mark.parametrize(
     "model_name, model_kwargs, backend, matches, custom_ops",
     # Test rms norm+group quant_fp8 fusion

--- a/tests/compile/fusion_test_utils.py
+++ b/tests/compile/fusion_test_utils.py
@@ -44,13 +44,13 @@ class ModelBackendTestCase(NamedTuple):
 
 
 # E2E model test cases
-DUMMY_MODELS_FP8: list[ModelBackendTestCase] = []
-DUMMY_MODELS_FP4: list[ModelBackendTestCase] = []
-DUMMY_MODELS: list[ModelBackendTestCase] = []  # tp-only (unquantized)
+MODELS_FP8: list[ModelBackendTestCase] = []
+MODELS_FP4: list[ModelBackendTestCase] = []
+MODELS: list[ModelBackendTestCase] = []  # tp-only (unquantized)
 MODELS_GROUP_FP8: list[ModelBackendTestCase] = []
 
 if current_platform.is_cuda():
-    DUMMY_MODELS_FP8 = [
+    MODELS_FP8 = [
         ModelBackendTestCase(
             # Use smaller model for L40s in CI
             model_name="RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8",
@@ -90,7 +90,7 @@ if current_platform.is_cuda():
         ),
     ]
 
-    DUMMY_MODELS_FP4 = [
+    MODELS_FP4 = [
         ModelBackendTestCase(
             model_name="nvidia/Llama-3.1-8B-Instruct-FP4",
             model_kwargs=dict(
@@ -110,7 +110,7 @@ if current_platform.is_cuda():
     ]
 
     # TP only
-    DUMMY_MODELS = [
+    MODELS = [
         ModelBackendTestCase(
             model_name="meta-llama/Llama-3.1-8B-Instruct",
             model_kwargs=dict(
@@ -155,7 +155,7 @@ if current_platform.is_cuda():
     ]
 
 elif current_platform.is_rocm():
-    DUMMY_MODELS_FP8 = [
+    MODELS_FP8 = [
         ModelBackendTestCase(
             model_name="amd/Llama-3.1-8B-Instruct-FP8-KV",
             model_kwargs=dict(

--- a/tests/compile/fusion_test_utils.py
+++ b/tests/compile/fusion_test_utils.py
@@ -44,13 +44,13 @@ class ModelBackendTestCase(NamedTuple):
 
 
 # E2E model test cases
-MODELS_FP8: list[ModelBackendTestCase] = []
-MODELS_FP4: list[ModelBackendTestCase] = []
-MODELS: list[ModelBackendTestCase] = []  # tp-only (unquantized)
+DUMMY_MODELS_FP8: list[ModelBackendTestCase] = []
+DUMMY_MODELS_FP4: list[ModelBackendTestCase] = []
+DUMMY_MODELS: list[ModelBackendTestCase] = []  # tp-only (unquantized)
 MODELS_GROUP_FP8: list[ModelBackendTestCase] = []
 
 if current_platform.is_cuda():
-    MODELS_FP8 = [
+    DUMMY_MODELS_FP8 = [
         ModelBackendTestCase(
             # Use smaller model for L40s in CI
             model_name="RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8",
@@ -90,7 +90,7 @@ if current_platform.is_cuda():
         ),
     ]
 
-    MODELS_FP4 = [
+    DUMMY_MODELS_FP4 = [
         ModelBackendTestCase(
             model_name="nvidia/Llama-3.1-8B-Instruct-FP4",
             model_kwargs=dict(
@@ -110,7 +110,7 @@ if current_platform.is_cuda():
     ]
 
     # TP only
-    MODELS = [
+    DUMMY_MODELS = [
         ModelBackendTestCase(
             model_name="meta-llama/Llama-3.1-8B-Instruct",
             model_kwargs=dict(
@@ -155,7 +155,7 @@ if current_platform.is_cuda():
     ]
 
 elif current_platform.is_rocm():
-    MODELS_FP8 = [
+    DUMMY_MODELS_FP8 = [
         ModelBackendTestCase(
             model_name="amd/Llama-3.1-8B-Instruct-FP8-KV",
             model_kwargs=dict(

--- a/tests/compile/test_fusion.py
+++ b/tests/compile/test_fusion.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-
 import pytest
 import torch
 import logging
-import re
 from typing import Any
+
+import pytest
+import regex as re
+import torch
 
 from tests.compile.fusion_test_utils import (
     CUSTOM_OPS_QUANT_RMS_NORM,
@@ -14,10 +16,9 @@ from tests.compile.fusion_test_utils import (
     Matches,
     run_model,
 )
-
-import vllm.plugins
+from tests.utils import flat_product
 from vllm._aiter_ops import IS_AITER_FOUND, rocm_aiter_ops
-from vllm.config import CompilationConfig, CompilationMode, CUDAGraphMode, PassConfig
+from vllm.attention.backends.registry import AttentionBackendEnum
 from vllm.compilation.fusion import FUSED_OPS, FusedRMSQuantKey, RMSNormQuantFusionPass
 from vllm.compilation.fx_utils import find_op_nodes
 from vllm.compilation.matcher_utils import QUANT_OPS
@@ -26,6 +27,7 @@ from vllm.compilation.post_cleanup import PostCleanupPass
 from vllm.config import (
     CompilationConfig,
     CompilationMode,
+    CUDAGraphMode,
     ModelConfig,
     PassConfig,
     VllmConfig,
@@ -45,10 +47,9 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     cutlass_fp8_supported,
     maybe_create_device_identity,
 )
-from vllm.utils.torch_utils import is_torch_equal_or_newer
 from vllm.platforms import current_platform
-from vllm.attention.backends.registry import AttentionBackendEnum
 from vllm.utils.deep_gemm import is_deep_gemm_supported
+from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 from ..utils import override_cutlass_fp8_supported
 from .backend import TestBackend
@@ -411,6 +412,7 @@ def test_aiter_fusion_rmsnorm_quant(
         _run_fusion_test(
             model, fusion_pass, vllm_config, dtype, hidden_size, num_tokens
         )
+
 
 @pytest.mark.parametrize(
     "model_name, model_kwargs, backend, matches, custom_ops",

--- a/tests/compile/test_fusion.py
+++ b/tests/compile/test_fusion.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 import regex as re
 import torch
+from vllm.attention.backends.registry import AttentionBackendEnum
 
 import vllm.config
 from tests.compile.fusion_test_utils import (
@@ -18,7 +19,6 @@ from tests.compile.fusion_test_utils import (
 )
 from tests.utils import flat_product
 from vllm._aiter_ops import IS_AITER_FOUND, rocm_aiter_ops
-from vllm.attention.backends.registry import AttentionBackendEnum
 from vllm.compilation.fusion import FUSED_OPS, FusedRMSQuantKey, RMSNormQuantFusionPass
 from vllm.compilation.fx_utils import find_op_nodes
 from vllm.compilation.matcher_utils import QUANT_OPS

--- a/tests/compile/test_fusion.py
+++ b/tests/compile/test_fusion.py
@@ -1,23 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import logging
-from typing import Any
-
 import pytest
-import regex as re
 import torch
 
 import vllm.config
-from tests.compile.fusion_test_utils import (
-    CUSTOM_OPS_QUANT_RMS_NORM,
-    MODELS_GROUP_FP8,
-    Matches,
-    is_blackwell,
-    run_model,
-)
-from tests.utils import flat_product
-from tests.v1.attention.utils import AttentionBackendEnum
 from vllm._aiter_ops import IS_AITER_FOUND, rocm_aiter_ops
 from vllm.compilation.fusion import FUSED_OPS, FusedRMSQuantKey, RMSNormQuantFusionPass
 from vllm.compilation.fx_utils import find_op_nodes
@@ -27,7 +14,6 @@ from vllm.compilation.post_cleanup import PostCleanupPass
 from vllm.config import (
     CompilationConfig,
     CompilationMode,
-    CUDAGraphMode,
     ModelConfig,
     PassConfig,
     VllmConfig,
@@ -49,7 +35,6 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import is_deep_gemm_supported
-from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 from ..utils import override_cutlass_fp8_supported
 from .backend import TestBackend
@@ -412,69 +397,3 @@ def test_aiter_fusion_rmsnorm_quant(
         _run_fusion_test(
             model, fusion_pass, vllm_config, dtype, hidden_size, num_tokens
         )
-
-
-@pytest.mark.parametrize(
-    "model_name, model_kwargs, backend, matches, custom_ops",
-    # Test rms norm+group quant_fp8 fusion
-    list[tuple[Any, ...]](flat_product(MODELS_GROUP_FP8, CUSTOM_OPS_QUANT_RMS_NORM)),
-)
-@pytest.mark.parametrize("inductor_graph_partition", [True, False])
-# TODO: remove skip after we fix the fusion thoroughly
-@pytest.mark.skipif(is_blackwell(), reason="Temporarily disabled on Blackwell")
-def test_rms_group_quant(
-    model_name: str,
-    model_kwargs: dict[str, Any],
-    backend: AttentionBackendEnum,
-    matches: Matches,
-    custom_ops: str,
-    inductor_graph_partition: bool,
-    caplog_mp_spawn,
-    monkeypatch,
-):
-    if inductor_graph_partition and not is_torch_equal_or_newer("2.9.0.dev"):
-        pytest.skip("Inductor graph partition requires torch>=2.9")
-
-    custom_ops_list = custom_ops.split(",") if custom_ops else []
-
-    if inductor_graph_partition:
-        mode = CUDAGraphMode.FULL_AND_PIECEWISE
-        splitting_ops: list[str] | None = None
-    else:
-        mode = CUDAGraphMode.FULL_DECODE_ONLY
-        splitting_ops = []
-
-    # Disable, compile cache to make sure custom passes run.
-    # Otherwise, we can't verify fusion happened through the logs.
-    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
-
-    # To capture subprocess logs, we need to know whether spawn or fork is used.
-    # Force spawn as it is more general.
-    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
-
-    model_kwargs["attention_config"] = {"backend": backend.name}
-
-    compilation_config = CompilationConfig(
-        # Testing properties
-        custom_ops=custom_ops_list,
-        use_inductor_graph_partition=inductor_graph_partition,
-        cudagraph_mode=mode,
-        splitting_ops=splitting_ops,
-        # Common
-        mode=CompilationMode.VLLM_COMPILE,
-        pass_config=PassConfig(
-            fuse_norm_quant=True, fuse_act_quant=True, eliminate_noops=True
-        ),
-        # Inductor caches custom passes by default as well via uuid
-        inductor_compile_config={"force_disable_caches": True},
-    )
-
-    with caplog_mp_spawn(logging.DEBUG) as log_holder:
-        run_model(compilation_config, model_name, **model_kwargs)
-
-    log_matches = re.findall(
-        r"\[fusion.py:\d+] Replaced (\d+) patterns",
-        log_holder.text,
-    )
-    assert len(log_matches) == 1, log_holder.text
-    assert int(log_matches[0]) == matches.rms_quant_norm_fusion

--- a/tests/compile/test_fusion.py
+++ b/tests/compile/test_fusion.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+
 import pytest
 import torch
 
-import vllm.config
+import vllm.plugins
 from vllm._aiter_ops import IS_AITER_FOUND, rocm_aiter_ops
 from vllm.compilation.fusion import FUSED_OPS, FusedRMSQuantKey, RMSNormQuantFusionPass
 from vllm.compilation.fx_utils import find_op_nodes

--- a/tests/compile/test_fusion.py
+++ b/tests/compile/test_fusion.py
@@ -7,7 +7,6 @@ from typing import Any
 import pytest
 import regex as re
 import torch
-from vllm.attention.backends.registry import AttentionBackendEnum
 
 import vllm.config
 from tests.compile.fusion_test_utils import (
@@ -18,6 +17,7 @@ from tests.compile.fusion_test_utils import (
     run_model,
 )
 from tests.utils import flat_product
+from tests.v1.attention.utils import AttentionBackendEnum
 from vllm._aiter_ops import IS_AITER_FOUND, rocm_aiter_ops
 from vllm.compilation.fusion import FUSED_OPS, FusedRMSQuantKey, RMSNormQuantFusionPass
 from vllm.compilation.fx_utils import find_op_nodes

--- a/tests/compile/test_fusion_attn.py
+++ b/tests/compile/test_fusion_attn.py
@@ -11,8 +11,8 @@ import torch._dynamo
 from tests.compile.backend import LazyInitPass, TestBackend
 from tests.compile.fusion_test_utils import (
     CUSTOM_OPS_FP8,
-    DUMMY_MODELS_FP4,
-    DUMMY_MODELS_FP8,
+    MODELS_FP4,
+    MODELS_FP8,
     Matches,
     has_cuda_graph_wrapper_metadata,
     is_blackwell,
@@ -508,9 +508,9 @@ def test_attention_quant_pattern(
 @pytest.mark.parametrize(
     "model_name, model_kwargs, backend, matches, custom_ops",
     # Test attention+quant_fp8 fusion with custom and torch impls of QuantFP8
-    list(flat_product(DUMMY_MODELS_FP8, CUSTOM_OPS_FP8))
+    list(flat_product(MODELS_FP8, CUSTOM_OPS_FP8))
     # quant_fp4 only has the custom impl
-    + list(flat_product(DUMMY_MODELS_FP4, [""])),
+    + list(flat_product(MODELS_FP4, [""])),
 )
 @pytest.mark.parametrize(
     "inductor_graph_partition",

--- a/tests/compile/test_fusion_attn.py
+++ b/tests/compile/test_fusion_attn.py
@@ -11,8 +11,8 @@ import torch._dynamo
 from tests.compile.backend import LazyInitPass, TestBackend
 from tests.compile.fusion_test_utils import (
     CUSTOM_OPS_FP8,
-    MODELS_FP4,
-    MODELS_FP8,
+    DUMMY_MODELS_FP4,
+    DUMMY_MODELS_FP8,
     Matches,
     has_cuda_graph_wrapper_metadata,
     is_blackwell,
@@ -508,9 +508,9 @@ def test_attention_quant_pattern(
 @pytest.mark.parametrize(
     "model_name, model_kwargs, backend, matches, custom_ops",
     # Test attention+quant_fp8 fusion with custom and torch impls of QuantFP8
-    list(flat_product(MODELS_FP8, CUSTOM_OPS_FP8))
+    list(flat_product(DUMMY_MODELS_FP8, CUSTOM_OPS_FP8))
     # quant_fp4 only has the custom impl
-    + list(flat_product(MODELS_FP4, [""])),
+    + list(flat_product(DUMMY_MODELS_FP4, [""])),
 )
 @pytest.mark.parametrize(
     "inductor_graph_partition",


### PR DESCRIPTION
Speed-up fusion tests by trimming model size and using dummy weights

Based off: https://github.com/vllm-project/vllm/pull/32489 merge that first

Main
<img width="1402" height="77" alt="image" src="https://github.com/user-attachments/assets/4ff09227-b30e-428f-8bd8-3f9ca8c98d85" />

PR
<img width="1409" height="78" alt="image" src="https://github.com/user-attachments/assets/539d8add-ee6c-44ae-a283-f6bf5bc590a0" />
