### PR TITLE
[KV Connector][Metrics] Do not count local prefix cache hits in connector queries

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1042,7 +1042,7 @@ def _step_until_kv_transfer_finished(scheduler: Scheduler, req_ids: list[str]):
         prompt_logprobs_dict={},
         pooler_output=[],
     )
-    scheduler.update_from_output(output, EMPTY_OUTPUT)
+    initial_ecos = scheduler.update_from_output(output, EMPTY_OUTPUT)
 
     # Simulate KV transfer completion using KVConnectorOutput.finished_recving
     output = scheduler.schedule()
@@ -1061,6 +1061,8 @@ def _step_until_kv_transfer_finished(scheduler: Scheduler, req_ids: list[str]):
     scheduler.update_from_output(output, MODEL_RUNNER_OUTPUT)
     for req_id in req_ids:
         assert req_id in scheduler.finished_recving_kv_req_ids
+
+    return initial_ecos
 
 
 @pytest.mark.parametrize("is_async", [False, True])
@@ -1192,29 +1194,72 @@ def test_kv_connector_basic(is_async: bool):
 
 
 @pytest.mark.parametrize("is_async", [False, True])
-def test_external_prefix_cache_metrics(is_async: bool):
+@pytest.mark.parametrize("local_cache_hits", [False, True])
+def test_external_prefix_cache_metrics(is_async: bool, local_cache_hits: bool):
     """
     Verify connector prefix cache metrics are updated
     correctly when the scheduler processes requests with KV connector hits.
     """
 
+    BLOCK_SIZE = 16
+    if local_cache_hits:
+        NUM_MATCHED_NEW_TOKENS = BLOCK_SIZE * 2  # 32 tokens
+        NUM_LOCAL_HITS = NUM_MATCHED_NEW_TOKENS * 2  # 64 tokens
+        NUM_REQUESTS = 1
+        NUM_TOKENS = NUM_LOCAL_HITS * 2  # 128 tokens
+    else:
+        NUM_MATCHED_NEW_TOKENS = 4
+        NUM_LOCAL_HITS = 0
+        NUM_REQUESTS = 2
+        NUM_TOKENS = 8  # 8 tokens
+
     # Setup Scheduler.
-    NUM_MATCHED_NEW_TOKENS = 4
     scheduler = create_scheduler(
-        enable_prefix_caching=False,
+        enable_prefix_caching=local_cache_hits,
         use_kv_connector=mock_kv(
             matched_tokens=NUM_MATCHED_NEW_TOKENS, is_async=is_async
         ),
+        block_size=BLOCK_SIZE,
     )
 
-    # --- Prepare simple requests ---
-    NUM_REQUESTS = 2
-    NUM_TOKENS = 8
+    if local_cache_hits:
+        # First, establish local cache by running a request to completion
+        requests = create_requests(
+            num_requests=1,
+            num_tokens=NUM_LOCAL_HITS,
+            max_tokens=2,
+            block_size=BLOCK_SIZE,
+        )
+        req_ids = []
+        req_to_index = {}
+        for i, request in enumerate(requests):
+            scheduler.add_request(request)
+            req_ids.append(request.request_id)
+            req_to_index[request.request_id] = i
+
+        if is_async:
+            _step_until_kv_transfer_finished(scheduler, req_ids)
+
+        # Run first request to completion to establish local cache
+        output = scheduler.schedule()
+        MODEL_RUNNER_OUTPUT = ModelRunnerOutput(
+            req_ids=req_ids,
+            req_id_to_index=req_to_index,
+            sampled_token_ids=[[1000]] * len(req_ids),
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        )
+        _step_until_done(scheduler, output, MODEL_RUNNER_OUTPUT)
+        _ = scheduler.schedule()
+
+    # --- Prepare test requests ---
     MAX_TOKENS = 2
     requests = create_requests(
         num_requests=NUM_REQUESTS,
         num_tokens=NUM_TOKENS,
         max_tokens=MAX_TOKENS,
+        block_size=BLOCK_SIZE,
     )
     req_ids = []
     req_to_index = {}
@@ -1223,8 +1268,9 @@ def test_external_prefix_cache_metrics(is_async: bool):
         req_ids.append(request.request_id)
         req_to_index[request.request_id] = i
 
+    initial_ecos = None
     if is_async:
-        _step_until_kv_transfer_finished(scheduler, req_ids)
+        initial_ecos = _step_until_kv_transfer_finished(scheduler, req_ids)
 
     # --- Trigger scheduling and simulate model output ---
     output = scheduler.schedule()
@@ -1244,10 +1290,20 @@ def test_external_prefix_cache_metrics(is_async: bool):
     assert ecos is not None and len(ecos) > 0
     assert ecos[0].scheduler_stats is not None
 
+    if local_cache_hits:
+        # For async, local cache stats come from the first step
+        if initial_ecos:
+            local_stats = initial_ecos[0].scheduler_stats.prefix_cache_stats
+        else:
+            local_stats = ecos[0].scheduler_stats.prefix_cache_stats
+        assert local_stats is not None
+        assert local_stats.queries == NUM_TOKENS * NUM_REQUESTS
+        assert local_stats.hits == NUM_LOCAL_HITS * NUM_REQUESTS
+
     external_stats = ecos[0].scheduler_stats.connector_prefix_cache_stats
     assert external_stats is not None
 
-    assert external_stats.queries == NUM_TOKENS * NUM_REQUESTS
+    assert external_stats.queries == (NUM_TOKENS - NUM_LOCAL_HITS) * NUM_REQUESTS
     assert external_stats.hits == NUM_MATCHED_NEW_TOKENS * NUM_REQUESTS
     assert external_stats.requests == NUM_REQUESTS
     assert external_stats.preempted_requests == 0

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1300,7 +1300,10 @@ def test_external_prefix_cache_metrics(is_async: bool, local_cache_hits: bool):
         assert local_stats.queries == NUM_TOKENS * NUM_REQUESTS
         assert local_stats.hits == NUM_LOCAL_HITS * NUM_REQUESTS
 
-    external_stats = ecos[0].scheduler_stats.connector_prefix_cache_stats
+    if initial_ecos:
+        external_stats = initial_ecos[0].scheduler_stats.connector_prefix_cache_stats
+    else:
+        external_stats = ecos[0].scheduler_stats.connector_prefix_cache_stats
     assert external_stats is not None
 
     assert external_stats.queries == (NUM_TOKENS - NUM_LOCAL_HITS) * NUM_REQUESTS

--- a/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
+++ b/tests/v1/kv_connector/unit/test_invalid_blocks_correctness.py
@@ -164,18 +164,7 @@ def test_sync_recompute_blocks_not_freed_for_running_requests(
             "to recompute invalid portions."
         )
 
-    # 7. Connector prefix cache stats should not be recorded yet
-    # in SchedulerStats, but are recorded on the request
-    assert request.connector_prefix_cache_queries == num_prompt_tokens
-
-    # Reflect only successfully loaded blocks
-    expected_hits = invalid_block_idx * recompute_scheduler.block_size
-    assert request.connector_prefix_cache_hits == expected_hits, (
-        f"Request hits should be {expected_hits} (only valid blocks), "
-        f"got {request.connector_prefix_cache_hits}"
-    )
-
-    # Verify request can be rescheduled in next step
+    # 7. verify request can be rescheduled in next step
     scheduler_output_2 = recompute_scheduler.schedule()
 
     # request should appear in the new schedule to recompute invalid blocks
@@ -292,14 +281,16 @@ def test_sync_fail_invalid_blocks_evicted(fail_scheduler: Scheduler):
         f"(hash should be None), but hash is still {block.block_hash}"
     )
 
-    # Verify connector prefix cache stats - request failed, no stats recorded
+    # Verify connector prefix cache stats:
+    # - queries = num_prompt_tokens (total tokens not in local cache)
+    # - hits = num_external_computed_tokens (tokens loaded externally)
     assert engine_outputs.scheduler_stats is not None
     stats = engine_outputs.scheduler_stats
     assert stats.connector_prefix_cache_stats is not None
-    assert stats.connector_prefix_cache_stats.requests == 0, (
-        f"Failed requests should not contribute to connector stats, got"
-        f"{stats.connector_prefix_cache_stats} requests recorded"
-    )
+    conn_stats = stats.connector_prefix_cache_stats
+    assert conn_stats.requests == 1
+    assert conn_stats.queries == num_prompt_tokens
+    assert conn_stats.hits == num_external_computed_tokens
 
 
 def test_async_recompute_blocks_not_cached_when_invalid(
@@ -384,7 +375,9 @@ def test_async_recompute_blocks_not_cached_when_invalid(
     with patch.object(
         recompute_scheduler.kv_cache_manager, "evict_blocks", evict_blocks_spy
     ):
-        recompute_scheduler.update_from_output(scheduler_output, model_runner_output)
+        outputs = recompute_scheduler.update_from_output(
+            scheduler_output, model_runner_output
+        )
 
     # verify evict_blocks was NOT called (async blocks excluded from eviction)
     assert len(evict_blocks_calls) == 0, (
@@ -405,6 +398,19 @@ def test_async_recompute_blocks_not_cached_when_invalid(
         f"Async loading blocks shouldn't be cached or evicted. "
         f"Block {invalid_block_id} hash should be None but is {block.block_hash}"
     )
+
+    # Verify connector prefix cache stats:
+    # - queries = num_prompt_tokens (total tokens not in local cache)
+    # - hits = num_external_computed_tokens (tokens loaded externally)
+    assert len(outputs) == 1
+    engine_outputs = next(iter(outputs.values()))
+    assert engine_outputs.scheduler_stats is not None
+    stats = engine_outputs.scheduler_stats
+    assert stats.connector_prefix_cache_stats is not None
+    conn_stats = stats.connector_prefix_cache_stats
+    assert conn_stats.requests == 1
+    assert conn_stats.queries == num_prompt_tokens
+    assert conn_stats.hits == num_external_computed_tokens
 
     # now simulate async transfer completing
     model_runner_output_2 = create_model_runner_output(
@@ -441,7 +447,7 @@ def test_async_recompute_blocks_not_cached_when_invalid(
     ):
         # call schedule() again - this triggers _update_waiting_for_remote_kv()
         # which should call cache_blocks with the truncated value
-        scheduler_output_3 = recompute_scheduler.schedule()
+        recompute_scheduler.schedule()
 
     # verify cache_blocks was called with the truncated value
     assert len(cache_blocks_calls) == 1, (
@@ -472,27 +478,3 @@ def test_async_recompute_blocks_not_cached_when_invalid(
 
     # request should be in the running queue
     assert request in recompute_scheduler.running
-
-    # Execute the request to trigger stats recording
-    model_runner_output_3 = create_model_runner_output(
-        [request],
-        invalid_block_ids=None,  # no more invalid blocks
-        use_eos=False,
-    )
-
-    outputs = recompute_scheduler.update_from_output(
-        scheduler_output_3, model_runner_output_3
-    )
-
-    # Verify connector prefix cache stats:
-    # - queries = num_prompt_tokens (total tokens not in local cache)
-    # - hits = only valid tokens (truncated at invalid block boundary)
-    assert len(outputs) == 1
-    engine_outputs = next(iter(outputs.values()))
-    assert engine_outputs.scheduler_stats is not None
-    stats = engine_outputs.scheduler_stats
-    assert stats.connector_prefix_cache_stats is not None
-    conn_stats = stats.connector_prefix_cache_stats
-    assert conn_stats.requests == 1
-    assert conn_stats.queries == num_prompt_tokens
-    assert conn_stats.hits == expected_valid_tokens

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -110,7 +110,7 @@ class Scheduler(SchedulerInterface):
         # will have a corresponding KVConnector with Role=WORKER.
         # KV Connector pushes/pull of remote KVs for P/D and offloading.
         self.connector = None
-        self.connector_prefix_cache_stats: PrefixCacheStats | None = None
+        self.connector_prefix_cache_reset = False
         self.recompute_kv_load_failures = True
         if self.vllm_config.kv_transfer_config is not None:
             assert not self.is_encoder_decoder, (
@@ -121,8 +121,6 @@ class Scheduler(SchedulerInterface):
                 role=KVConnectorRole.SCHEDULER,
                 kv_cache_config=self.kv_cache_config,
             )
-            if self.log_stats:
-                self.connector_prefix_cache_stats = PrefixCacheStats()
             kv_load_failure_policy = (
                 self.vllm_config.kv_transfer_config.kv_load_failure_policy
             )
@@ -608,8 +606,13 @@ class Scheduler(SchedulerInterface):
                             skipped_waiting_requests.prepend_request(request)
                             continue
 
-                        request.num_external_computed_tokens = ext_tokens
                         num_external_computed_tokens = ext_tokens
+
+                        # Save the stats to be recorded once KV loaded and allocated
+                        request.connector_prefix_cache_queries = (
+                            request.num_tokens - num_new_local_computed_tokens
+                        )
+                        request.connector_prefix_cache_hits = ext_tokens
 
                     # Total computed tokens (local + external).
                     num_computed_tokens = (
@@ -736,8 +739,6 @@ class Scheduler(SchedulerInterface):
                     skipped_waiting_requests.prepend_request(request)
                     request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
                     continue
-
-                self._update_connector_prefix_cache_stats(request)
 
                 self.running.append(request)
                 if self.log_stats:
@@ -1237,6 +1238,7 @@ class Scheduler(SchedulerInterface):
             kv_stats = self.connector.get_kv_connector_stats()
             if kv_stats:
                 kv_connector_stats = kv_connector_stats.aggregate(kv_stats)
+        connector_prefix_cache_stats = PrefixCacheStats() if self.log_stats else None
 
         failed_kv_load_req_ids = None
         if kv_connector_output and kv_connector_output.invalid_block_ids:
@@ -1358,6 +1360,20 @@ class Scheduler(SchedulerInterface):
 
             # Get prompt logprobs for this request.
             prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
+
+            # Record external connector prefix cache stats
+            if (
+                connector_prefix_cache_stats
+                and request.connector_prefix_cache_queries > 0
+            ):
+                connector_prefix_cache_stats.record(
+                    num_tokens=request.connector_prefix_cache_queries,
+                    num_hits=request.connector_prefix_cache_hits,
+                    preempted=request.num_preemptions > 0,
+                )
+                request.connector_prefix_cache_queries = 0
+                request.connector_prefix_cache_hits = 0
+
             if (
                 new_token_ids
                 or pooler_output is not None
@@ -1453,7 +1469,11 @@ class Scheduler(SchedulerInterface):
 
         if (
             stats := self.make_stats(
-                spec_decoding_stats, kv_connector_stats, cudagraph_stats, perf_stats
+                spec_decoding_stats,
+                kv_connector_stats,
+                connector_prefix_cache_stats,
+                cudagraph_stats,
+                perf_stats,
             )
         ) is not None:
             # Return stats to only one of the front-ends.
@@ -1766,8 +1786,7 @@ class Scheduler(SchedulerInterface):
             return False
 
         if self.log_stats:
-            assert self.connector_prefix_cache_stats is not None
-            self.connector_prefix_cache_stats.reset = True
+            self.connector_prefix_cache_reset = True
 
         return True
 
@@ -1783,6 +1802,7 @@ class Scheduler(SchedulerInterface):
         self,
         spec_decoding_stats: SpecDecodingStats | None = None,
         kv_connector_stats: KVConnectorStats | None = None,
+        connector_prefix_cache_stats: PrefixCacheStats | None = None,
         cudagraph_stats: CUDAGraphStat | None = None,
         perf_stats: PerfStats | None = None,
     ) -> SchedulerStats | None:
@@ -1790,7 +1810,9 @@ class Scheduler(SchedulerInterface):
             return None
         prefix_cache_stats = self.kv_cache_manager.make_prefix_cache_stats()
         assert prefix_cache_stats is not None
-        connector_prefix_cache_stats = self._make_connector_prefix_cache_stats()
+        if connector_prefix_cache_stats and self.connector_prefix_cache_reset:
+            connector_prefix_cache_stats.reset = True
+            self.connector_prefix_cache_reset = False
         eviction_events = (
             self.kv_metrics_collector.drain_events()
             if self.kv_metrics_collector is not None
@@ -1850,23 +1872,6 @@ class Scheduler(SchedulerInterface):
     ########################################################################
     # KV Connector Related Methods
     ########################################################################
-
-    def _update_connector_prefix_cache_stats(self, request: Request) -> None:
-        if self.connector_prefix_cache_stats is None:
-            return
-
-        self.connector_prefix_cache_stats.record(
-            num_tokens=request.num_tokens,
-            num_hits=request.num_external_computed_tokens,
-            preempted=request.num_preemptions > 0,
-        )
-
-    def _make_connector_prefix_cache_stats(self) -> PrefixCacheStats | None:
-        if self.connector_prefix_cache_stats is None:
-            return None
-        stats = self.connector_prefix_cache_stats
-        self.connector_prefix_cache_stats = PrefixCacheStats()
-        return stats
 
     def get_kv_connector(self) -> KVConnectorBase_V1 | None:
         return self.connector
@@ -2065,7 +2070,8 @@ class Scheduler(SchedulerInterface):
                     req_num_computed_tokens - request.num_computed_tokens
                 )
                 total_affected_tokens += num_affected_tokens
-                request.num_external_computed_tokens -= num_affected_tokens
+                if request.connector_prefix_cache_hits:
+                    request.connector_prefix_cache_hits -= num_affected_tokens
                 # collect invalid block and all downstream dependent blocks
                 if evict_blocks:
                     blocks_to_evict.update(req_block_ids[idx:])

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -609,6 +609,7 @@ class Scheduler(SchedulerInterface):
                             skipped_waiting_requests.prepend_request(request)
                             continue
 
+                        request.num_external_computed_tokens = ext_tokens
                         num_external_computed_tokens = ext_tokens
 
                         connector_prefix_cache_queries = (
@@ -2063,6 +2064,7 @@ class Scheduler(SchedulerInterface):
                     req_num_computed_tokens - request.num_computed_tokens
                 )
                 total_affected_tokens += num_affected_tokens
+                request.num_external_computed_tokens -= num_affected_tokens
                 # collect invalid block and all downstream dependent blocks
                 if evict_blocks:
                     blocks_to_evict.update(req_block_ids[idx:])

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -154,6 +154,9 @@ class Request:
         # The number of times this request has been preempted by the scheduler.
         self.num_preemptions = 0
 
+        # The number of tokens that have been computed remotely.
+        self.num_external_computed_tokens = 0
+
         self.block_hashes: list[BlockHash] = []
         self.get_hash_new_full_blocks: Callable[[], list[BlockHash]] | None = None
         if block_hasher is not None:

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -154,10 +154,6 @@ class Request:
         # The number of times this request has been preempted by the scheduler.
         self.num_preemptions = 0
 
-        # Number of tokens queried and found in the external prefix cache
-        self.connector_prefix_cache_queries = 0
-        self.connector_prefix_cache_hits = 0
-
         self.block_hashes: list[BlockHash] = []
         self.get_hash_new_full_blocks: Callable[[], list[BlockHash]] | None = None
         if block_hasher is not None:

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -154,8 +154,9 @@ class Request:
         # The number of times this request has been preempted by the scheduler.
         self.num_preemptions = 0
 
-        # The number of tokens that have been computed remotely.
-        self.num_external_computed_tokens = 0
+        # Number of tokens queried and found in the external prefix cache
+        self.connector_prefix_cache_queries = 0
+        self.connector_prefix_cache_hits = 0
 
         self.block_hashes: list[BlockHash] = []
         self.get_hash_new_full_blocks: Callable[[], list[BlockHash]] | None = None


### PR DESCRIPTION
Somewhat related to #28585

The `vllm:external_prefix_cache_queries` metric was double-counting queries by recording the total prompt tokens instead of only the tokens actually queried from the KV connector.

Example scenario:
- Request with 1000 prompt tokens
- Local cache finds 600 tokens
- External cache finds 200 of the remaining 400 tokens
- Computed: 200 tokens

Metrics before this fix:
```
vllm:prefix_cache_queries: 1000
vllm:prefix_cache_hits: 600
vllm:external_prefix_cache_queries: 1000 # Double counting!
vllm:external_prefix_cache_hits: 200
```

We introduce a slight change in behavior - KV connector "hits" are counted, even if the load subsequently fails. Load failure metrics. Failed transfers can be captured by metrics like `vllm:nixl_num_failed_transfers` and the `vllm:prompt_tokens_by_source_total` in #33289 will arguably will offer better insight into the breakdown of where prompt KV was computed.