### PR TITLE
[Optimization] Pad the number of tokens to a multiple of 4 to improve FP8 performance

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3087,10 +3087,6 @@ class GPUModelRunner(
             record_function_or_nullcontext("gpu_model_runner: forward"),
             self.maybe_get_kv_connector_output(scheduler_output) as kv_connector_output,
         ):
-            # logger.info("Number of input tokens: %d", num_input_tokens)
-            # logger.info("Positions size: %s", None if positions is None else positions.size())
-            # logger.info("Input id size: %s", None if input_ids is None else input_ids.size())
-            # logger.info("Input embeds size: %s", None if inputs_embeds is None else inputs_embeds.size())
             model_output = self._model_forward(
                 input_ids=input_ids,
                 positions=positions,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4,6 +4,7 @@
 import functools
 import gc
 import itertools
+import math
 import time
 from collections import defaultdict
 from collections.abc import Iterator, Sequence
@@ -2776,7 +2777,11 @@ class GPUModelRunner(
         torch.Tensor | None,
         CUDAGraphStat | None,
     ]:
-        num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
+        if self.model_config.quantization == "fp8":
+            # FP8 GEMM kernels generally perform better when M is a multiple of 4.
+            # TODO: Better huristics for FP8/SP/DP combinations.
+            num_tokens_padded = round_up(num_tokens, 4)
+        num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens_padded)
         uniform_decode = (
             (
                 (max_num_scheduled_tokens == self.uniform_decode_query_len)
@@ -3050,9 +3055,6 @@ class GPUModelRunner(
                     )
                 )
 
-            if self.model_config.quantization == "fp8":
-                # FP8 GEMM kernels generally perform better when M is a multiple of 4.
-                num_tokens_padded = round_up(num_tokens_padded, 4)
             (
                 input_ids,
                 inputs_embeds,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4,7 +4,6 @@
 import functools
 import gc
 import itertools
-import math
 import time
 from collections import defaultdict
 from collections.abc import Iterator, Sequence

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3050,6 +3050,9 @@ class GPUModelRunner(
                     )
                 )
 
+            if self.model_config.quantization == "fp8":
+                # FP8 GEMM kernels generally perform better when M is a multiple of 4.
+                num_tokens_padded = round_up(num_tokens_padded, 4)
             (
                 input_ids,
                 inputs_embeds,
@@ -3084,6 +3087,10 @@ class GPUModelRunner(
             record_function_or_nullcontext("gpu_model_runner: forward"),
             self.maybe_get_kv_connector_output(scheduler_output) as kv_connector_output,
         ):
+            # logger.info("Number of input tokens: %d", num_input_tokens)
+            # logger.info("Positions size: %s", None if positions is None else positions.size())
+            # logger.info("Input id size: %s", None if input_ids is None else input_ids.size())
+            # logger.info("Input embeds size: %s", None if inputs_embeds is None else inputs_embeds.size())
             model_output = self._model_forward(
                 input_ids=input_ids,
                 positions=positions,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2776,10 +2776,11 @@ class GPUModelRunner(
         torch.Tensor | None,
         CUDAGraphStat | None,
     ]:
+        num_tokens_padded = num_tokens
         if self.model_config.quantization == "fp8":
             # FP8 GEMM kernels generally perform better when M is a multiple of 4.
             # TODO: Better huristics for FP8/SP/DP combinations.
-            num_tokens_padded = round_up(num_tokens, 4)
+            num_tokens_padded = round_up(num_tokens_padded, 4)
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens_padded)
         uniform_decode = (
             (


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Pad the number of tokens to a multiple of 4 to improve FP8 serving performance by up to 25% end-to-end.

## Test Plan
- End-to-End serving benchmark
`vllm serve` and `vllm bench serve --backend vllm --dataset-name sharegpt --dataset-path ./ShareGPT_V3_unfiltered_cleaned_split.json  --base-url http://localhost:8000  --endpoint /v1/completions --model
[model] --tokenizer [model] --num-prompts 2000 --max-concurrency 100`

- GEMM benchmark: 
`python3 benchmarks/kernels/deepgemm/benchmark_fp8_block_dense_gemm.py` with shape modifications

## Test Result
- End-to-End serving benchmark

| GPU | model | Total Token throughput (tok/s) Before | Total Token throughput (tok/s) After | Speedup |
| -- | -- | -- | -- | -- |
| B200 | Qwen/Qwen3-8B-FP8 | 15455.37 | 17350.65 | 10.9% |
| B200 | Qwen/Qwen3-32B-FP8 | 6350.89 | 8016.02 | 26.2% |
| H200 | Qwen/Qwen3-8B-FP8 | 15810.43 | 16136.04 | 2.0% |
| H200 | Qwen/Qwen3-32B-FP8 | 6049.23 | 6161.02 | 1.8% |

- GEMM benchmark (B200)

FP8 GEMM kernels generally perform better when M is a multiple of 4.

| m    | n     | k     | Time DeepGEMM (μs) | TFLOPS DeepGEMM | GB/s DeepGEMM | Time vLLM CUTLASS (μs) | TFLOPS vLLM CUTLASS | GB/s vLLM CUTLASS |
|------|-------|-------|--------------------|------------------|---------------|----------------|-------------|-----------|
| 63   | 24576 | 1536  | 103.1              | 46.1             | 397.2         | 20.5           | 232.3       | 1999.9    |
| 64   | 24576 | 1536  | 63.8               | 75.7             | 642.2         | 19.1           | 253.0       | 2146.2    |
| 127  | 24576 | 1536  | 103.4              | 92.7             | 427.3         | 31.6           | 303.5       | 1398.8    |
| 128  | 24576 | 1536  | 63.8               | 151.4            | 693.2         | 18.5           | 521.6       | 2387.7    |
| 4095 | 24576 | 1536  | 168.5              | 1835.3           | 1456.3        | 778.0          | 397.4       | 315.3     |
| 4096 | 24576 | 1536  | 161.0              | 1921.3           | 1524.4        | 204.3          | 1513.9      | 1201.2    |

H200 GEMM benchmark requires m to be a multiple of 4.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

