### PR TITLE
[ROCm][CI] Skip multi-GPU speculative decoding tests when insufficient GPUs available

### DIFF
--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -16,6 +16,16 @@ from vllm.platforms import current_platform
 MTP_SIMILARITY_RATE = 0.8
 
 
+def _skip_if_insufficient_gpus_for_tp(tp_size: int):
+    """Skip test if available GPUs < tp_size on ROCm."""
+    if current_platform.is_rocm():
+        available_gpus = torch.cuda.device_count()
+        if available_gpus < tp_size:
+            pytest.skip(
+                f"Test requires {tp_size} GPUs, but only {available_gpus} available"
+            )
+
+
 def get_test_prompts(mm_enabled: bool):
     prompt_types = ["repeat", "sentence"]
     if mm_enabled:
@@ -455,12 +465,7 @@ def test_eagle_correctness(
                 m.setenv("VLLM_ROCM_USE_AITER", "1")
 
         method, model_name, spec_model_name, tp_size = model_setup
-        if current_platform.is_rocm() and tp_size > 1:
-            available_gpus = torch.cuda.device_count()
-            if available_gpus < tp_size:
-                pytest.skip(
-                    f"Test requires {tp_size} GPUs, but only {available_gpus} available"
-                )
+        _skip_if_insufficient_gpus_for_tp(tp_size)
 
         max_model_len = 2048
         max_num_batched_tokens = 128 if enable_chunked_prefill else max_model_len
@@ -532,12 +537,7 @@ def test_mtp_correctness(
         m.setenv("VLLM_MLA_DISABLE", "1")
 
         method, model_name, tp_size = model_setup
-        if current_platform.is_rocm() and tp_size > 1:
-            available_gpus = torch.cuda.device_count()
-            if available_gpus < tp_size:
-                pytest.skip(
-                    f"Test requires {tp_size} GPUs, but only {available_gpus} available"
-                )
+        _skip_if_insufficient_gpus_for_tp(tp_size)
 
         ref_llm = LLM(
             model=model_name,

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -455,6 +455,13 @@ def test_eagle_correctness(
                 m.setenv("VLLM_ROCM_USE_AITER", "1")
 
         method, model_name, spec_model_name, tp_size = model_setup
+        if current_platform.is_rocm() and tp_size > 1:
+            available_gpus = torch.cuda.device_count()
+            if available_gpus < tp_size:
+                pytest.skip(
+                    f"Test requires {tp_size} GPUs, but only {available_gpus} available"
+                )
+
         max_model_len = 2048
         max_num_batched_tokens = 128 if enable_chunked_prefill else max_model_len
 
@@ -525,6 +532,12 @@ def test_mtp_correctness(
         m.setenv("VLLM_MLA_DISABLE", "1")
 
         method, model_name, tp_size = model_setup
+        if current_platform.is_rocm() and tp_size > 1:
+            available_gpus = torch.cuda.device_count()
+            if available_gpus < tp_size:
+                pytest.skip(
+                    f"Test requires {tp_size} GPUs, but only {available_gpus} available"
+                )
 
         ref_llm = LLM(
             model=model_name,


### PR DESCRIPTION
This PR adds GPU availability checks to the speculative decoding tests to skip multi-GPU tests on ROCm when the required number of GPUs is not available.

Changes:
- Add skip logic to `test_eagle_correctness` for multi-GPU tests (tp_size > 1)
- Add skip logic to `test_mtp_correctness` for multi-GPU tests (tp_size > 1)

This prevents test failures when running on ROCm systems with fewer GPUs than required by certain test configurations (e.g., Llama-4-Scout tests requiring 4 GPUs).