### PR TITLE
[Bug] Fix attention_backend arg string parsing

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1649,7 +1649,13 @@ class EngineArgs:
                     "attention_backend and attention_config.backend "
                     "are mutually exclusive"
                 )
-            attention_config.backend = self.attention_backend
+            # Convert string to enum if needed (CLI parsing returns a string)
+            if isinstance(self.attention_backend, str):
+                attention_config.backend = AttentionBackendEnum[
+                    self.attention_backend.upper()
+                ]
+            else:
+                attention_config.backend = self.attention_backend
 
         load_config = self.create_load_config()
 


### PR DESCRIPTION

## Purpose

The issue was that `attention_backend` (a string from CLI parsing) is directly assigned to `attention_config.backend`, but the code expects an `AttentionBackendEnum` object 

`vllm serve mgoin/Qwen3-0.6B-NVFP4 --attention-backend flashinfer`

Before
```
(EngineCore_DP0 pid=36719)   File "/home/mgoin/code/vllm/vllm/attention/selector.py", line 46, in get_attn_backend
(EngineCore_DP0 pid=36719)     return _cached_get_attn_backend(
(EngineCore_DP0 pid=36719)            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=36719)   File "/home/mgoin/code/vllm/vllm/attention/selector.py", line 75, in _cached_get_attn_backend
(EngineCore_DP0 pid=36719)     attention_cls = current_platform.get_attn_backend_cls(
(EngineCore_DP0 pid=36719)                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=36719)   File "/home/mgoin/code/vllm/vllm/platforms/cuda.py", line 343, in get_attn_backend_cls
(EngineCore_DP0 pid=36719)     backend_class = selected_backend.get_class()
(EngineCore_DP0 pid=36719)                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=36719) AttributeError: 'str' object has no attribute 'get_class'
```

After
```
(EngineCore_DP0 pid=41625) INFO 12-11 23:30:56 [cuda.py:364] Using AttentionBackendEnum.FLASHINFER backend.
```

cc @MatthewBonanni 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

