### PR TITLE
[Core] Add repetitive token detection for hallucination prevention

### DIFF
--- a/tests/v1/core/test_repetition_detection.py
+++ b/tests/v1/core/test_repetition_detection.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for repetition detection in scheduler utilities."""
+
+import pytest
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.utils import check_repetition, check_stop
+from vllm.v1.request import Request, RequestStatus
+
+pytestmark = pytest.mark.cpu_test
+
+# Use a consistent EOS token ID for tests
+EOS_TOKEN_ID = 2
+
+
+class TestCheckRepetition:
+    """Tests for the check_repetition function."""
+
+    def test_disabled_when_max_consecutive_repeats_zero(self):
+        """Repetition detection should be disabled when max_consecutive_repeats=0."""
+        output_token_ids = [1, 1, 1, 1, 1]  # 5 consecutive identical tokens
+        assert check_repetition(output_token_ids, max_consecutive_repeats=0) is False
+
+    def test_disabled_when_max_consecutive_repeats_negative(self):
+        """Repetition detection should be disabled for negative values."""
+        output_token_ids = [1, 1, 1, 1, 1]
+        assert check_repetition(output_token_ids, max_consecutive_repeats=-1) is False
+
+    def test_not_enough_tokens(self):
+        """Should return False when there aren't enough tokens."""
+        output_token_ids = [1, 1]  # Only 2 tokens
+        assert check_repetition(output_token_ids, max_consecutive_repeats=3) is False
+
+    def test_no_repetition_different_tokens(self):
+        """Should return False when tokens are different."""
+        output_token_ids = [1, 2, 3, 4, 5]
+        assert check_repetition(output_token_ids, max_consecutive_repeats=3) is False
+
+    def test_no_repetition_last_two_differ(self):
+        """O(1) fast path: should return False immediately if last 2 tokens differ."""
+        output_token_ids = [1, 1, 1, 1, 2]  # Last token is different
+        assert check_repetition(output_token_ids, max_consecutive_repeats=3) is False
+
+    def test_detect_exact_consecutive_repeats(self):
+        """Should detect exactly N consecutive identical tokens."""
+        output_token_ids = [1, 2, 3, 3, 3]  # 3 consecutive 3s
+        assert check_repetition(output_token_ids, max_consecutive_repeats=3) is True
+
+    def test_detect_more_than_threshold_repeats(self):
+        """Should detect when there are more than N consecutive repeats."""
+        output_token_ids = [1, 2, 3, 3, 3, 3, 3]  # 5 consecutive 3s
+        assert check_repetition(output_token_ids, max_consecutive_repeats=3) is True
+
+    def test_partial_match_not_enough(self):
+        """Should return False when consecutive count is less than threshold."""
+        output_token_ids = [1, 2, 3, 3]  # Only 2 consecutive 3s
+        assert check_repetition(output_token_ids, max_consecutive_repeats=3) is False
+
+    def test_repetition_at_end_only(self):
+        """Should only check repetition at the end of the sequence."""
+        output_token_ids = [1, 1, 1, 2, 3, 4]  # Repetition at start, not end
+        assert check_repetition(output_token_ids, max_consecutive_repeats=3) is False
+
+    def test_large_consecutive_threshold(self):
+        """Should work with large consecutive repeat thresholds (performance test)."""
+        # Create 100 identical tokens
+        output_token_ids = [42] * 100
+        assert check_repetition(output_token_ids, max_consecutive_repeats=100) is True
+        assert check_repetition(output_token_ids, max_consecutive_repeats=101) is False
+
+    def test_single_token_repetition(self):
+        """Should handle edge case of single token threshold.
+
+        max_consecutive_repeats=1 is normalized to 2 since a single token
+        cannot be considered repetition. This means it behaves the same as
+        max_consecutive_repeats=2.
+        """
+        # With max_consecutive_repeats=1, it's normalized to 2
+        # So we need at least 2 identical tokens
+        output_token_ids = [1, 2, 3]
+        assert check_repetition(output_token_ids, max_consecutive_repeats=1) is False
+
+        # When last 2 tokens match, max_consecutive_repeats=1 (normalized to 2)
+        # should trigger
+        output_token_ids_same = [1, 2, 2]
+        assert (
+            check_repetition(output_token_ids_same, max_consecutive_repeats=1) is True
+        )
+
+    def test_single_token_list_with_max_1(self):
+        """Should handle single token list without IndexError.
+
+        This is a regression test for the IndexError that occurred when
+        max_consecutive_repeats=1 and output_token_ids had only one token.
+        """
+        output_token_ids = [42]  # Single token
+        # Should not raise IndexError, should return False
+        assert check_repetition(output_token_ids, max_consecutive_repeats=1) is False
+
+    def test_empty_token_list(self):
+        """Should handle empty token list gracefully."""
+        output_token_ids: list[int] = []
+        assert check_repetition(output_token_ids, max_consecutive_repeats=3) is False
+
+
+class TestCheckStopWithRepetition:
+    """Tests for check_stop function with repetition detection."""
+
+    def _create_request(
+        self,
+        max_consecutive_repeats: int = 0,
+        max_tokens: int = 100,
+        ignore_eos: bool = True,
+    ) -> Request:
+        """Helper to create a test request."""
+        sampling_params = SamplingParams(
+            ignore_eos=ignore_eos,
+            max_tokens=max_tokens,
+            max_consecutive_repeats=max_consecutive_repeats,
+        )
+        return Request(
+            request_id="test-request",
+            prompt_token_ids=[0, 1, 2],
+            sampling_params=sampling_params,
+            pooling_params=None,
+            eos_token_id=EOS_TOKEN_ID,
+        )
+
+    def test_no_stop_when_repetition_detection_disabled(self):
+        """Should not stop for repetition when max_consecutive_repeats=0."""
+        request = self._create_request(max_consecutive_repeats=0)
+        # Add repetitive tokens
+        request.append_output_token_ids([5, 5, 5, 5, 5])
+
+        result = check_stop(request, max_model_len=1000)
+        assert result is False
+
+    def test_stop_on_repetition_detection(self):
+        """Should stop when repetitive pattern detected."""
+        request = self._create_request(max_consecutive_repeats=4)
+        # Add 4 consecutive identical tokens
+        request.append_output_token_ids([5, 5, 5, 5])
+
+        result = check_stop(request, max_model_len=1000)
+        assert result is True
+        assert request.status == RequestStatus.FINISHED_REPETITION
+        assert request.stop_reason == "repetition_detected"
+
+    def test_no_stop_below_threshold(self):
+        """Should not stop when consecutive count below threshold."""
+        request = self._create_request(max_consecutive_repeats=4)
+        # Add only 3 consecutive identical tokens
+        request.append_output_token_ids([5, 5, 5])
+
+        result = check_stop(request, max_model_len=1000)
+        assert result is False
+
+    def test_eos_takes_precedence_over_repetition(self):
+        """EOS token should stop before repetition check."""
+        request = self._create_request(max_consecutive_repeats=4, ignore_eos=False)
+        # Add tokens ending with EOS
+        request.append_output_token_ids([5, 5, 5, EOS_TOKEN_ID])
+
+        result = check_stop(request, max_model_len=1000)
+        assert result is True
+        assert request.status == RequestStatus.FINISHED_STOPPED
+        # Stop reason should not be repetition since EOS was hit first
+
+    def test_length_cap_takes_precedence(self):
+        """Length cap should stop before repetition check."""
+        request = self._create_request(max_consecutive_repeats=10, max_tokens=3)
+        # Add 3 tokens (hitting max_tokens)
+        request.append_output_token_ids([5, 5, 5])
+
+        result = check_stop(request, max_model_len=1000)
+        assert result is True
+        assert request.status == RequestStatus.FINISHED_LENGTH_CAPPED
+
+    def test_model_len_cap_takes_precedence(self):
+        """Model length cap should stop before repetition check."""
+        request = self._create_request(max_consecutive_repeats=10, max_tokens=100)
+        # 3 prompt tokens + 3 output = 6 total, max_model_len = 6
+        request.append_output_token_ids([5, 5, 5])
+
+        result = check_stop(request, max_model_len=6)
+        assert result is True
+        assert request.status == RequestStatus.FINISHED_LENGTH_CAPPED
+
+
+class TestRepetitionDetectionPerformance:
+    """Performance-related tests for repetition detection."""
+
+    def test_fast_path_no_repetition(self):
+        """Verify fast path is taken when last two tokens differ."""
+        # This should be O(1) - just one comparison
+        # Last token differs from second-last
+        output_token_ids = list(range(1000)) + [999]
+        # Should return immediately without iterating
+        assert check_repetition(output_token_ids, max_consecutive_repeats=100) is False
+
+    def test_handles_large_threshold_efficiently(self):
+        """Should handle large thresholds without excessive iteration."""
+        # Create sequence where repetition starts but doesn't continue
+        output_token_ids = [1] * 50 + [2, 2]  # Only 2 consecutive 2s at end
+        # Even with large threshold, should exit early
+        assert check_repetition(output_token_ids, max_consecutive_repeats=100) is False

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -608,9 +608,17 @@ class ChatCompletionRequest(OpenAIBaseModel):
     spaces_between_special_tokens: bool = True
     truncate_prompt_tokens: Annotated[int, Field(ge=-1)] | None = None
     prompt_logprobs: int | None = None
+    max_consecutive_repeats: int = Field(
+        default=0,
+        description=(
+            "Stop generation if N consecutive identical tokens are detected. "
+            "Set to 0 to disable. Typical values: 3-5. "
+            "This helps detect repetitive output patterns (hallucination)."
+        ),
+    )
     allowed_token_ids: list[int] | None = None
     bad_words: list[str] = Field(default_factory=list)
-    # --8<-- [end:chat-completion-sampling-params]
+    # Hallucination detection parameter
 
     # --8<-- [start:chat-completion-extra-params]
     echo: bool = Field(
@@ -878,6 +886,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone
+            max_consecutive_repeats=self.max_consecutive_repeats,
         )
 
     @model_validator(mode="before")
@@ -1090,6 +1099,14 @@ class CompletionRequest(OpenAIBaseModel):
     truncate_prompt_tokens: Annotated[int, Field(ge=-1)] | None = None
     allowed_token_ids: list[int] | None = None
     prompt_logprobs: int | None = None
+    max_consecutive_repeats: int = Field(
+        default=0,
+        description=(
+            "Stop generation if N consecutive identical tokens are detected. "
+            "Set to 0 to disable. Typical values: 3-5. "
+            "This helps detect repetitive output patterns (hallucination)."
+        ),
+    )
     # --8<-- [end:completion-sampling-params]
 
     # --8<-- [start:completion-extra-params]
@@ -1319,6 +1336,7 @@ class CompletionRequest(OpenAIBaseModel):
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone
+            max_consecutive_repeats=self.max_consecutive_repeats,
         )
 
     @model_validator(mode="before")

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -244,6 +244,12 @@ class SamplingParams(
     generated token can complete the sequence."""
     _bad_words_token_ids: list[list[int]] | None = None
 
+    # Hallucination detection parameters
+    max_consecutive_repeats: int = 0
+    """Stop generation if N consecutive identical tokens are detected.
+    Set to 0 to disable. Typical values: 3-5.
+    This helps detect repetitive output patterns (hallucination)."""
+
     skip_reading_prefix_cache: bool | None = None
 
     @staticmethod
@@ -277,6 +283,7 @@ class SamplingParams(
         allowed_token_ids: list[int] | None = None,
         extra_args: dict[str, Any] | None = None,
         skip_clone: bool = False,
+        max_consecutive_repeats: int = 0,
     ) -> "SamplingParams":
         if logit_bias is not None:
             # Convert token_id to integer
@@ -318,6 +325,7 @@ class SamplingParams(
             allowed_token_ids=allowed_token_ids,
             extra_args=extra_args,
             skip_clone=skip_clone,
+            max_consecutive_repeats=max_consecutive_repeats,
         )
 
     def __post_init__(self) -> None:

--- a/vllm/v1/core/sched/utils.py
+++ b/vllm/v1/core/sched/utils.py
@@ -37,8 +37,62 @@ def remove_all(lst: list, items_to_remove: set) -> list:
     return [item for item in lst if item not in items_to_remove]
 
 
-def check_stop(request: Request, max_model_len: int) -> bool:
+def check_repetition(
+    output_token_ids: list[int],
+    max_consecutive_repeats: int = 0,
+) -> bool:
+    """Detect repetitive token patterns indicating potential hallucination.
+
+    This function checks for consecutive identical tokens: if the same token
+    appears N times in a row, it indicates the model may be stuck in a loop.
+
+    Performance: O(1) in the common case (no repetition). Only performs the
+    full check when the last two tokens are identical, which is the only case
+    where a long consecutive run could exist.
+
+    Args:
+        output_token_ids: List of generated output token IDs
+        max_consecutive_repeats: Stop if N consecutive identical tokens detected.
+            Set to 0 to disable this check. Typical values: 3-5
+
+    Returns:
+        True if repetitive pattern detected (hallucination), False otherwise
+    """
+    # A single token is not a repetition. For max_consecutive_repeats=1,
+    # the behavior is the same as 2 (detects two identical tokens).
+    if max_consecutive_repeats == 1:
+        max_consecutive_repeats = 2
+
+    num_tokens = len(output_token_ids)
+
+    # Early exit: need at least max_consecutive_repeats tokens
+    if max_consecutive_repeats <= 0 or num_tokens < max_consecutive_repeats:
+        return False
+
+    # O(1) fast path: if last two tokens differ, no consecutive run exists
+    last_token = output_token_ids[-1]
+    if output_token_ids[-2] != last_token:
+        return False
+
+    # Only reach here if last two tokens are identical.
+    # Now count backwards to see if we have max_consecutive_repeats in a row.
+    for i in range(3, max_consecutive_repeats + 1):
+        if output_token_ids[-i] != last_token:
+            return False
+
+    # If we reached here, it means we have max_consecutive_repeats identical tokens.
+    return True
+
+
+def check_stop(
+    request: Request, max_model_len: int, pooler_output: torch.Tensor | None = None
+) -> bool:
     assert not request.pooling_params
+    if request.pooling_params:
+        if pooler_output is not None:
+            request.status = RequestStatus.FINISHED_STOPPED
+            return True
+        return False
 
     sampling_params = request.sampling_params
     assert sampling_params is not None
@@ -61,4 +115,16 @@ def check_stop(request: Request, max_model_len: int) -> bool:
     ):
         request.status = RequestStatus.FINISHED_LENGTH_CAPPED
         return True
+
+    # Check for repetitive token patterns (hallucination detection)
+    max_consecutive = getattr(sampling_params, "max_consecutive_repeats", 0)
+
+    if max_consecutive > 0 and check_repetition(
+        list(request.output_token_ids),
+        max_consecutive_repeats=max_consecutive,
+    ):
+        request.status = RequestStatus.FINISHED_REPETITION
+        request.stop_reason = "repetition_detected"
+        return True
+
     return False

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -19,12 +19,12 @@ from vllm.v1.serial_utils import UtilityResult
 
 # These are possible values of RequestOutput.finish_reason,
 # so form part of the external API.
-FINISH_REASON_STRINGS = ("stop", "length", "abort", "error")
+FINISH_REASON_STRINGS = ("stop", "length", "abort", "error", "repetition")
 
 
 class FinishReason(enum.IntEnum):
     """
-    Reason a request finished - stop, length, abort, or error.
+    Reason a request finished - stop, length, abort, error, or repetition.
 
     Int rather than Str for more compact serialization.
 
@@ -33,6 +33,7 @@ class FinishReason(enum.IntEnum):
     abort - aborted by client
     error - retryable request-level internal error (e.g., KV load failure).
             Invariant: always converted to 500 Internal Server Error.
+    repetition - repetitive token pattern detected (hallucination)
 
     """
 
@@ -40,6 +41,7 @@ class FinishReason(enum.IntEnum):
     LENGTH = 1
     ABORT = 2
     ERROR = 3
+    REPETITION = 4
 
     def __str__(self):
         return FINISH_REASON_STRINGS[self.value]

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -255,6 +255,7 @@ class RequestStatus(enum.IntEnum):
     FINISHED_ABORTED = enum.auto()
     FINISHED_IGNORED = enum.auto()
     FINISHED_ERROR = enum.auto()
+    FINISHED_REPETITION = enum.auto()
 
     def __str__(self):
         return self.name
@@ -278,4 +279,5 @@ _FINISHED_REASON_MAP = {
     RequestStatus.FINISHED_ABORTED: FinishReason.ABORT,
     RequestStatus.FINISHED_IGNORED: FinishReason.LENGTH,
     RequestStatus.FINISHED_ERROR: FinishReason.ERROR,
+    RequestStatus.FINISHED_REPETITION: FinishReason.REPETITION,
 }


### PR DESCRIPTION
This PR adds a new feature to detect and stop generation when repetitive token patterns are detected, which is a common indicator of model hallucination.

## Changes

1. Added  parameter to :
   - Set to 0 (default) to disable
   - Set to N to stop generation when N consecutive identical tokens are detected

2. Added  status and :
   - New request status for when repetition detection triggers
   - New finish reason exposed in API responses

3. Implemented O(1) fast-path repetition detection in :
   - Only performs full check when last two tokens are identical
   - Avoids performance impact in common case (no repetition)

4. Added comprehensive unit tests covering:
   - Edge cases (empty list, disabled detection, thresholds)
   - Integration with check_stop()
   - Performance characteristics

## Usage

```python
from vllm import SamplingParams

# Enable repetition detection with threshold of 4
params = SamplingParams(
    max_consecutive_repeats=4,  # Stop if 4+ identical tokens in a row
    max_tokens=1000,
)
```

## Motivation

Some multimodal models (e.g., Qwen3 VL) can get stuck outputting repetitive tokens, which wastes compute and produces unusable output. This feature allows early termination of such requests.
