### PR TITLE
Filter safetensors files to download if .safetensors.index.json exists

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -23,6 +23,7 @@ import torch
 from huggingface_hub import HfFileSystem, hf_hub_download, snapshot_download
 from safetensors.torch import load, load_file, safe_open, save_file
 from tqdm.auto import tqdm
+from transformers.utils import SAFE_WEIGHTS_INDEX_NAME
 
 from vllm import envs
 from vllm.config import ModelConfig
@@ -451,11 +452,11 @@ def download_weights_from_hf(
             # If downloading safetensors and an index file exists, use the
             # specific file names from the index to avoid downloading
             # unnecessary files (e.g., from subdirectories like "original/").
-            index_file = f"{model_name_or_path}/model.safetensors.index.json"
+            index_file = f"{model_name_or_path}/{SAFE_WEIGHTS_INDEX_NAME}"
             if "*.safetensors" in allow_patterns and index_file in file_list:
                 index_path = hf_hub_download(
                     repo_id=model_name_or_path,
-                    filename="model.safetensors.index.json",
+                    filename=SAFE_WEIGHTS_INDEX_NAME,
                     cache_dir=cache_dir,
                     revision=revision,
                 )


### PR DESCRIPTION

## Purpose

I noticed when running `vllm serve openai/gpt-oss-20b` on a new machine that it not only downloaded the base model files, but also included the `original/` directory that I assumed was picked up because it has files ending in `*.safetensors`

```
model-00000-of-00002.safetensors: 100%|██████████████████████████████████████████████████████████████████████████| 4.79G/4.79G [06:24<00:00, 12.5MB/s]
model-00001-of-00002.safetensors: 100%|██████████████████████████████████████████████████████████████████████████| 4.80G/4.80G [06:10<00:00, 13.0MB/s]
model-00002-of-00002.safetensors: 100%|██████████████████████████████████████████████████████████████████████████| 4.17G/4.17G [05:03<00:00, 13.7MB/s]
original/model.safetensors:  76%|█████████████████████████████████████████████████████████████                   | 10.5G/13.8G [14:48<04:34, 11.8MB/s]
```

Since the model has a [`model.safetensors.index.json`](https://huggingface.co/openai/gpt-oss-20b/blob/main/model.safetensors.index.json), I think we should use this to filter the glob if we can find one

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

