### PR TITLE
[CustomOp] Support object-level enable for CustomOp

### DIFF
--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -40,8 +40,8 @@ class CustomOp(nn.Module):
 
     def __init__(self, enforce_enable: bool = False):
         super().__init__()
-        self._forward_method = self.dispatch_forward()
         self._enforce_enable = enforce_enable
+        self._forward_method = self.dispatch_forward()
 
     def forward(self, *args, **kwargs):
         return self._forward_method(*args, **kwargs)


### PR DESCRIPTION
## Purpose

Add `enforce_enable` param to CustomOp to control whether enable a CustomOp at object-level. This is useful to enable some device-specific kernels in ViT models when enabling graph mode. By default, it will still follow the `compilation_config` to determine whether enable itself.

This is can resolve the issue in https://github.com/vllm-project/vllm/pull/29873#issuecomment-3636102452.

Like:

```python
class XxxVisionAttention:

    def __init__(...):
        apply_rotary_emb = ApplyRotaryEmb(enforce_enable=True)
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

