### PR TITLE
[Bugfix][Frontend] Prevent IndexError in MiniMax M2 tool parser during streaming extraction

### DIFF
--- a/tests/tool_use/test_minimax_m2_tool_parser.py
+++ b/tests/tool_use/test_minimax_m2_tool_parser.py
@@ -5,7 +5,7 @@ import json
 
 import pytest
 
-from vllm.entrypoints.openai.tool_parsers.minimax_m2_tool_parser import (
+from vllm.tool_parsers.minimax_m2_tool_parser import (
     MinimaxM2ToolParser,
 )
 

--- a/tests/tool_use/test_minimax_m2_tool_parser.py
+++ b/tests/tool_use/test_minimax_m2_tool_parser.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.entrypoints.openai.tool_parsers.minimax_m2_tool_parser import (
+    MinimaxM2ToolParser,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+class FakeTokenizer:
+    """Minimal fake tokenizer that exposes the attributes used by the
+    parser: a truthy model_tokenizer marker and a vocab mapping for the
+    special tokens.
+    """
+
+    def __init__(self):
+        self.model_tokenizer = True
+        # The parser will look up start/end tokens by their literal strings
+        self.vocab = {
+            "<minimax:tool_call>": 1,
+            "</minimax:tool_call>": 2,
+        }
+
+
+@pytest.fixture
+def minimax_m2_tool_parser():
+    return MinimaxM2ToolParser(FakeTokenizer())
+
+
+def test_extract_tool_calls_streaming_incremental(minimax_m2_tool_parser):
+    """Simulate incremental streaming of a <minimax:tool_call> and ensure
+    no IndexError is raised and fragments are returned as expected.
+    """
+    parser = minimax_m2_tool_parser
+
+    # Reset parser streaming state to ensure a fresh start
+    parser._reset_streaming_state()
+
+    stages = [
+        # header with invoke start
+        '<minimax:tool_call><invoke name="get_weather">',
+        # parameter appears
+        '<parameter name="city">Seattle</parameter>',
+        # close invoke and tool_call
+        "</invoke></minimax:tool_call>",
+    ]
+
+    previous = ""
+    saw_name = False
+    saw_param = False
+    saw_close = False
+
+    for i, current in enumerate(stages):
+        delta = current[len(previous) :]
+
+        # Call the streaming extractor; it must not raise IndexError
+        result = None
+        try:
+            result = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current if current is not None else "",
+                delta_text=delta,
+                previous_token_ids=[],
+                current_token_ids=[],
+                delta_token_ids=[],
+                request=None,
+            )
+        except Exception as e:
+            pytest.fail(f"extract_tool_calls_streaming raised an exception: {e}")
+
+        # Inspect returned DeltaMessage (if any) for expected fragments
+        if result is not None and hasattr(result, "tool_calls") and result.tool_calls:
+            tc = result.tool_calls[0]
+            # Stage 0: header should include function name
+            if i == 0:
+                assert tc.function is not None and tc.function.name == "get_weather"
+                saw_name = True
+            # Stage 1: parameter fragment should include the parameter name/value
+            if i == 1:
+                assert (
+                    tc.function is not None
+                    and tc.function.arguments == '{"city":"Seattle"}'
+                )
+                saw_param = True
+            # Stage 2: closing brace/fragment expected
+            if i == 2:
+                # Parser returns closing '}' fragment when finishing
+                assert tc.function is not None and tc.function.arguments == "}"
+                saw_close = True
+
+        previous = current
+
+    assert saw_name, "Expected function name to be sent during streaming"
+    assert saw_param, "Expected parameter fragment to be sent during streaming"
+    assert saw_close, "Expected tool call close fragment to be sent"
+
+
+def test_streaming_minimax_m2_multiple_invokes(minimax_m2_tool_parser):
+    """Comprehensive streaming test that simulates the MiniMax M2
+    tool_call output containing two <invoke> blocks. Verifies the parser
+    does not raise, emits header/param fragments, and populates
+    prev_tool_call_arr with parsed JSON arguments at completion.
+    """
+    parser = minimax_m2_tool_parser
+
+    # Reset streaming state
+    parser._reset_streaming_state()
+
+    full = (
+        "<minimax:tool_call>\n"
+        '<invoke name="search_web">\n'
+        '<parameter name="query_tag">["technology", "events"]</parameter>\n'
+        '<parameter name="query_list">["\\"OpenAI\\" \\"latest\\" \\"release\\""]\n'
+        "</parameter>\n"
+        "</invoke>\n"
+        '<invoke name="search_web">\n'
+        '<parameter name="query_tag">["technology", "events"]</parameter>\n'
+        '<parameter name="query_list">["\\"Gemini\\" \\"latest\\" \\"release\\""]\n'
+        "</parameter>\n"
+        "</invoke>\n"
+        "</minimax:tool_call>"
+    )
+
+    # Stream in reasonable chunks to simulate real streaming
+    chunks = []
+    # split by lines to produce streaming-like deltas
+    for line in full.split("\n"):
+        chunks.append(line + "\n")
+
+    previous = ""
+    headers_seen = 0
+
+    for chunk in chunks:
+        current = previous + chunk
+        delta = chunk
+        try:
+            res = parser.extract_tool_calls_streaming(
+                previous_text=previous,
+                current_text=current,
+                delta_text=delta,
+                previous_token_ids=[],
+                current_token_ids=[],
+                delta_token_ids=[],
+                request=None,
+            )
+        except Exception as e:
+            pytest.fail(f"extract_tool_calls_streaming raised an exception: {e}")
+
+        # Count header messages (function name present)
+        if res is not None and hasattr(res, "tool_calls") and res.tool_calls:
+            for tc in res.tool_calls:
+                if tc.function and getattr(tc.function, "name", None):
+                    headers_seen += 1
+
+        previous = current
+
+    # After streaming all chunks, parser.prev_tool_call_arr should contain
+    # two completed tool calls with parsed argument JSON strings.
+    assert len(parser.prev_tool_call_arr) == 2, (
+        f"Expected 2 completed tool calls, got {len(parser.prev_tool_call_arr)}"
+    )
+
+    import json
+
+    for entry in parser.prev_tool_call_arr:
+        assert entry["name"] == "search_web"
+        assert "arguments" in entry
+        args = json.loads(entry["arguments"])
+        # query_tag should be a list
+        assert isinstance(args.get("query_tag"), list)
+        assert args["query_tag"] == ["technology", "events"]
+        assert isinstance(args.get("query_list"), list)
+        joined = args["query_list"][0]
+        assert ("OpenAI" in joined) or ("Gemini" in joined)
+
+    # Ensure we observed at least two headers (one per invoke)
+    assert headers_seen >= 2, f"Expected at least 2 header events, saw {headers_seen}"

--- a/tests/tool_use/test_minimax_m2_tool_parser.py
+++ b/tests/tool_use/test_minimax_m2_tool_parser.py
@@ -24,6 +24,9 @@ class FakeTokenizer:
             "</minimax:tool_call>": 2,
         }
 
+    def get_vocab(self):
+        return self.vocab
+
 
 @pytest.fixture
 def minimax_m2_tool_parser():
@@ -31,150 +34,78 @@ def minimax_m2_tool_parser():
 
 
 def test_extract_tool_calls_streaming_incremental(minimax_m2_tool_parser):
-    """Simulate incremental streaming of a <minimax:tool_call> and ensure
-    no IndexError is raised and fragments are returned as expected.
-    """
     parser = minimax_m2_tool_parser
-
-    # Reset parser streaming state to ensure a fresh start
     parser._reset_streaming_state()
-
-    stages = [
-        # header with invoke start
-        '<minimax:tool_call><invoke name="get_weather">',
-        # parameter appears
-        '<parameter name="city">Seattle</parameter>',
-        # close invoke and tool_call
+    chunks = [
+        "<minimax:tool_call>",
+        '<invoke name="get_weather">',
+        '<parameter name="city">',
+        "Seattle</parameter>",
         "</invoke></minimax:tool_call>",
     ]
-
     previous = ""
-    saw_name = False
-    saw_param = False
-    saw_close = False
-
-    for i, current in enumerate(stages):
-        delta = current[len(previous) :]
-
-        # Call the streaming extractor; it must not raise IndexError
-        result = None
-        try:
-            result = parser.extract_tool_calls_streaming(
-                previous_text=previous,
-                current_text=current if current is not None else "",
-                delta_text=delta,
-                previous_token_ids=[],
-                current_token_ids=[],
-                delta_token_ids=[],
-                request=None,
-            )
-        except Exception as e:
-            pytest.fail(f"extract_tool_calls_streaming raised an exception: {e}")
-
-        # Inspect returned DeltaMessage (if any) for expected fragments
-        if result is not None and hasattr(result, "tool_calls") and result.tool_calls:
-            tc = result.tool_calls[0]
-            # Stage 0: header should include function name
-            if i == 0:
-                assert tc.function is not None and tc.function.name == "get_weather"
-                saw_name = True
-            # Stage 1: parameter fragment should include the parameter name/value
-            if i == 1:
-                assert (
-                    tc.function is not None
-                    and tc.function.arguments == '{"city":"Seattle"}'
-                )
-                saw_param = True
-            # Stage 2: closing brace/fragment expected
-            if i == 2:
-                # Parser returns closing '}' fragment when finishing
-                assert tc.function is not None and tc.function.arguments == "}"
-                saw_close = True
-
-        previous = current
-
-    assert saw_name, "Expected function name to be sent during streaming"
-    assert saw_param, "Expected parameter fragment to be sent during streaming"
-    assert saw_close, "Expected tool call close fragment to be sent"
-
-
-def test_streaming_minimax_m2_multiple_invokes(minimax_m2_tool_parser):
-    """Comprehensive streaming test that simulates the MiniMax M2
-    tool_call output containing two <invoke> blocks. Verifies the parser
-    does not raise, emits header/param fragments, and populates
-    prev_tool_call_arr with parsed JSON arguments at completion.
-    """
-    parser = minimax_m2_tool_parser
-
-    # Reset streaming state
-    parser._reset_streaming_state()
-
-    full = (
-        "<minimax:tool_call>\n"
-        '<invoke name="search_web">\n'
-        '<parameter name="query_tag">["technology", "events"]</parameter>\n'
-        '<parameter name="query_list">["\\"OpenAI\\" \\"latest\\" \\"release\\""]\n'
-        "</parameter>\n"
-        "</invoke>\n"
-        '<invoke name="search_web">\n'
-        '<parameter name="query_tag">["technology", "events"]</parameter>\n'
-        '<parameter name="query_list">["\\"Gemini\\" \\"latest\\" \\"release\\""]\n'
-        "</parameter>\n"
-        "</invoke>\n"
-        "</minimax:tool_call>"
-    )
-
-    # Stream in reasonable chunks to simulate real streaming
-    chunks = []
-    # split by lines to produce streaming-like deltas
-    for line in full.split("\n"):
-        chunks.append(line + "\n")
-
-    previous = ""
-    headers_seen = 0
-
     for chunk in chunks:
         current = previous + chunk
         delta = chunk
-        try:
-            res = parser.extract_tool_calls_streaming(
-                previous_text=previous,
-                current_text=current,
-                delta_text=delta,
-                previous_token_ids=[],
-                current_token_ids=[],
-                delta_token_ids=[],
-                request=None,
-            )
-        except Exception as e:
-            pytest.fail(f"extract_tool_calls_streaming raised an exception: {e}")
-
-        # Count header messages (function name present)
-        if res is not None and hasattr(res, "tool_calls") and res.tool_calls:
-            for tc in res.tool_calls:
-                if tc.function and getattr(tc.function, "name", None):
-                    headers_seen += 1
-
+        parser.extract_tool_calls_streaming(
+            previous_text=previous,
+            current_text=current,
+            delta_text=delta,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=None,
+        )
         previous = current
 
-    # After streaming all chunks, parser.prev_tool_call_arr should contain
-    # two completed tool calls with parsed argument JSON strings.
-    assert len(parser.prev_tool_call_arr) == 2, (
-        f"Expected 2 completed tool calls, got {len(parser.prev_tool_call_arr)}"
-    )
-
+    assert len(parser.prev_tool_call_arr) == 1
+    entry = parser.prev_tool_call_arr[0]
     import json
 
-    for entry in parser.prev_tool_call_arr:
-        assert entry["name"] == "search_web"
-        assert "arguments" in entry
-        args = json.loads(entry["arguments"])
-        # query_tag should be a list
-        assert isinstance(args.get("query_tag"), list)
-        assert args["query_tag"] == ["technology", "events"]
-        assert isinstance(args.get("query_list"), list)
-        joined = args["query_list"][0]
-        assert ("OpenAI" in joined) or ("Gemini" in joined)
+    assert entry["name"] == "get_weather"
+    args = json.loads(entry["arguments"])
+    assert args["city"] == "Seattle"
 
-    # Ensure we observed at least two headers (one per invoke)
-    assert headers_seen >= 2, f"Expected at least 2 header events, saw {headers_seen}"
+
+def test_streaming_minimax_m2_multiple_invokes(minimax_m2_tool_parser):
+    parser = minimax_m2_tool_parser
+    parser._reset_streaming_state()
+
+    chunks = [
+        "<minimax:tool_call>",
+        '<invoke name="search_web">',
+        '<parameter name="query_tag">',
+        '["technology", "events"]</parameter>',
+        '<parameter name="query_list">',
+        '["OpenAI", "latest", "release"]</parameter>',
+        "</invoke>",
+        '<invoke name="search_web">',
+        '<parameter name="query_tag">',
+        '["technology", "events"]</parameter>',
+        '<parameter name="query_list">',
+        '["Gemini", "latest", "release"]</parameter>',
+        "</invoke>",
+        "</minimax:tool_call>",
+    ]
+    previous = ""
+    for chunk in chunks:
+        current = previous + chunk
+        delta = chunk
+        parser.extract_tool_calls_streaming(
+            previous_text=previous,
+            current_text=current,
+            delta_text=delta,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=None,
+        )
+        previous = current
+
+    assert len(parser.prev_tool_call_arr) == 2
+
+    for entry, expect_model in zip(parser.prev_tool_call_arr, ["OpenAI", "Gemini"]):
+        assert entry["name"] == "search_web"
+        args = entry["arguments"]
+        assert "technology" in args and "events" in args
+        assert expect_model in args

--- a/vllm/tool_parsers/minimax_m2_tool_parser.py
+++ b/vllm/tool_parsers/minimax_m2_tool_parser.py
@@ -423,7 +423,7 @@ class MinimaxM2ToolParser(ToolParser):
                         self.prev_tool_call_arr.append(
                             {
                                 "name": self.current_function_name,
-                                "arguments": "{}",  # Placeholder, will be updated later
+                                "arguments": {},  # Placeholder, will be updated later
                             }
                         )
                         # Initialize streamed_args_for_tool for this tool call
@@ -501,7 +501,7 @@ class MinimaxM2ToolParser(ToolParser):
                                 args = parsed_tool.function.arguments
                                 self.prev_tool_call_arr[self.current_tool_index][
                                     "arguments"
-                                ] = args
+                                ] = json.loads(args)
                         except Exception:
                             pass  # Ignore parsing errors during streaming
 

--- a/vllm/tool_parsers/minimax_m2_tool_parser.py
+++ b/vllm/tool_parsers/minimax_m2_tool_parser.py
@@ -122,6 +122,8 @@ class MinimaxM2ToolParser(ToolParser):
         self.streaming_request = None
         # Clear previous tool call history to avoid state pollution
         self.prev_tool_call_arr.clear()
+        # Reset streamed args tracking
+        self.streamed_args_for_tool.clear()
 
     def _extract_name(self, name_str: str) -> str:
         """Extract name from quoted string."""
@@ -424,6 +426,9 @@ class MinimaxM2ToolParser(ToolParser):
                                 "arguments": "{}",  # Placeholder, will be updated later
                             }
                         )
+                        # Initialize streamed_args_for_tool for this tool call
+                        if len(self.streamed_args_for_tool) <= self.current_tool_index:
+                            self.streamed_args_for_tool.append("")
 
                     # Send header with function info
                     return DeltaMessage(
@@ -445,6 +450,9 @@ class MinimaxM2ToolParser(ToolParser):
             # Send opening brace if not sent yet
             if self.in_function and not self.json_started:
                 self.json_started = True
+                # Update streamed_args_for_tool for opening brace
+                if self.current_tool_index < len(self.streamed_args_for_tool):
+                    self.streamed_args_for_tool[self.current_tool_index] += "{"
                 return DeltaMessage(
                     tool_calls=[
                         DeltaToolCall(
@@ -505,7 +513,9 @@ class MinimaxM2ToolParser(ToolParser):
                             )
                         ]
                     )
-
+                    # Update streamed_args_for_tool for closing brace
+                    if self.current_tool_index < len(self.streamed_args_for_tool):
+                        self.streamed_args_for_tool[self.current_tool_index] += "}"
                     # Reset state for next tool
                     self.json_closed = True
                     self.in_function = False
@@ -630,7 +640,11 @@ class MinimaxM2ToolParser(ToolParser):
                             )
 
                         self.param_count += 1
-
+                        # Update streamed_args_for_tool for this tool call
+                        if self.current_tool_index < len(self.streamed_args_for_tool):
+                            self.streamed_args_for_tool[self.current_tool_index] += (
+                                json_fragment
+                            )
                         return DeltaMessage(
                             tool_calls=[
                                 DeltaToolCall(


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/30554.

Prevent IndexError in MiniMax M2 tool parser during streaming extraction. 
Add args str to streamed_args_for_tool field.