### PR TITLE
[Bug] add sm100f check for trtllm-gen flashinfer attention and moe

### DIFF
--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -254,6 +254,16 @@ def has_nvidia_artifactory() -> bool:
 
 
 @functools.cache
+def is_sm90_supported() -> bool:
+    return current_platform.is_device_capability(90)
+
+
+@functools.cache
+def is_sm100f_supported() -> bool:
+    return any(current_platform.is_device_capability(cap) for cap in [100, 103])
+
+
+@functools.cache
 def supports_trtllm_attention() -> bool:
     """
     TRTLLM attention is supported if the platform is SM100,

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -220,7 +220,7 @@ from vllm.model_executor.layers.linear import (
     UnquantizedLinearMethod,
 )
 from vllm.platforms import current_platform
-from vllm.utils.flashinfer import has_nvidia_artifactory
+from vllm.utils.flashinfer import has_nvidia_artifactory, is_sm100f_supported
 from vllm.utils.math_utils import cdiv, round_down
 from vllm.v1.attention.backends.utils import (
     AttentionMetadataBuilder,
@@ -446,7 +446,7 @@ def use_flashinfer_prefill() -> bool:
         and flashinfer_available
         and not vllm_config.attention_config.use_cudnn_prefill
         and not vllm_config.attention_config.use_trtllm_ragged_deepseek_prefill
-        and current_platform.is_device_capability(100)
+        and is_sm100f_supported()
     )
 
 
@@ -457,7 +457,7 @@ def use_cudnn_prefill() -> bool:
     return (
         flashinfer_available
         and vllm_config.attention_config.use_cudnn_prefill
-        and current_platform.is_device_capability(100)
+        and is_sm100f_supported()
         and has_nvidia_artifactory()
     )
 
@@ -470,7 +470,7 @@ def use_trtllm_ragged_deepseek_prefill() -> bool:
     return (
         flashinfer_available
         and vllm_config.attention_config.use_trtllm_ragged_deepseek_prefill
-        and current_platform.is_device_capability(100)
+        and is_sm100f_supported()
     )
 
 

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -457,7 +457,7 @@ def use_cudnn_prefill() -> bool:
     return (
         flashinfer_available
         and vllm_config.attention_config.use_cudnn_prefill
-        and is_sm100f_supported()
+        and current_platform.is_device_capability(100)
         and has_nvidia_artifactory()
     )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

On GB300, Vllm doesn't select flashinfer attention/mla/moe despite the environment is set. Update the ISA version check to include sm103.

## Test Plan

Tested on 4xGB300, DEP4.

`lm-eval --model local-completions --tasks gsm8k --model_args model=nvidia/DeepSeek-R1-0528-FP4,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=64,max_retries=3,tokenized_requests=False --num_fewshot 20`

## Test Result

- `VLLM_USE_FLASHINFER_MOE_FP4=1`

  ```
  |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
  |-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
  |gsm8k|      3|flexible-extract|    20|exact_match|_  |0.9553|_  |0.0057|
  |     |       |strict-match    |    20|exact_match|_  |0.9545|_  |0.0057|
  ```

- `VLLM_USE_FLASHINFER_MOE_FP4=1`, `VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL=1`

  ```
  |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
  |-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
  |gsm8k|      3|flexible-extract|    20|exact_match|_  |0.9530|_  |0.0058|
  |     |       |strict-match    |    20|exact_match|_  |0.9522|_  |0.0059|
  ```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

