### PR TITLE
[CI] Speed up sequence parallel tests 

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -1064,7 +1064,7 @@ steps:
   - tests/compile/test_fusion_attn.py
   commands:
     - export VLLM_TEST_CLEAN_GPU_MEMORY=1
-    - pytest -v -s tests/compile/test_fusion_attn.py -k 'not Llama-4'
+    - pytest -v -s tests/compile/test_fusion_attn.py
 
 - label: Hopper Fusion Distributed E2E Tests (2xH100)  # 70min
   timeout_in_minutes: 70

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -1064,7 +1064,7 @@ steps:
   - tests/compile/test_fusion_attn.py
   commands:
     - export VLLM_TEST_CLEAN_GPU_MEMORY=1
-    - pytest -v -s tests/compile/test_fusion_attn.py
+    - pytest -v -s tests/compile/test_fusion_attn.py -k 'not Llama-4'
 
 - label: Hopper Fusion Distributed E2E Tests (2xH100)  # 70min
   timeout_in_minutes: 70

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -1064,6 +1064,7 @@ steps:
   - tests/compile/test_fusion_attn.py
   commands:
     - export VLLM_TEST_CLEAN_GPU_MEMORY=1
+    # skip Llama-4 since it does not fit on this device
     - pytest -v -s tests/compile/test_fusion_attn.py -k 'not Llama-4'
 
 - label: Hopper Fusion Distributed E2E Tests (2xH100)  # 70min

--- a/tests/compile/test_fusion.py
+++ b/tests/compile/test_fusion.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-
 import pytest
 import torch
 import logging
-import re
 from typing import Any
+
+import pytest
+import regex as re
+import torch
 
 from tests.compile.fusion_test_utils import (
     CUSTOM_OPS_QUANT_RMS_NORM,
@@ -14,10 +16,9 @@ from tests.compile.fusion_test_utils import (
     Matches,
     run_model,
 )
-
-import vllm.plugins
+from tests.utils import flat_product
 from vllm._aiter_ops import IS_AITER_FOUND, rocm_aiter_ops
-from vllm.config import CompilationConfig, CompilationMode, CUDAGraphMode, PassConfig
+from vllm.attention.backends.registry import AttentionBackendEnum
 from vllm.compilation.fusion import FUSED_OPS, FusedRMSQuantKey, RMSNormQuantFusionPass
 from vllm.compilation.fx_utils import find_op_nodes
 from vllm.compilation.matcher_utils import QUANT_OPS
@@ -26,6 +27,7 @@ from vllm.compilation.post_cleanup import PostCleanupPass
 from vllm.config import (
     CompilationConfig,
     CompilationMode,
+    CUDAGraphMode,
     ModelConfig,
     PassConfig,
     VllmConfig,
@@ -45,10 +47,9 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     cutlass_fp8_supported,
     maybe_create_device_identity,
 )
-from vllm.utils.torch_utils import is_torch_equal_or_newer
 from vllm.platforms import current_platform
-from vllm.attention.backends.registry import AttentionBackendEnum
 from vllm.utils.deep_gemm import is_deep_gemm_supported
+from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 from ..utils import override_cutlass_fp8_supported
 from .backend import TestBackend
@@ -411,6 +412,7 @@ def test_aiter_fusion_rmsnorm_quant(
         _run_fusion_test(
             model, fusion_pass, vllm_config, dtype, hidden_size, num_tokens
         )
+
 
 @pytest.mark.parametrize(
     "model_name, model_kwargs, backend, matches, custom_ops",

--- a/tests/compile/test_fusion.py
+++ b/tests/compile/test_fusion.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 import regex as re
 import torch
+from vllm.attention.backends.registry import AttentionBackendEnum
 
 import vllm.config
 from tests.compile.fusion_test_utils import (
@@ -18,7 +19,6 @@ from tests.compile.fusion_test_utils import (
 )
 from tests.utils import flat_product
 from vllm._aiter_ops import IS_AITER_FOUND, rocm_aiter_ops
-from vllm.attention.backends.registry import AttentionBackendEnum
 from vllm.compilation.fusion import FUSED_OPS, FusedRMSQuantKey, RMSNormQuantFusionPass
 from vllm.compilation.fx_utils import find_op_nodes
 from vllm.compilation.matcher_utils import QUANT_OPS

--- a/tests/compile/test_fusion.py
+++ b/tests/compile/test_fusion.py
@@ -1,23 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import logging
-from typing import Any
-
 import pytest
-import regex as re
 import torch
 
 import vllm.config
-from tests.compile.fusion_test_utils import (
-    CUSTOM_OPS_QUANT_RMS_NORM,
-    MODELS_GROUP_FP8,
-    Matches,
-    is_blackwell,
-    run_model,
-)
-from tests.utils import flat_product
-from tests.v1.attention.utils import AttentionBackendEnum
 from vllm._aiter_ops import IS_AITER_FOUND, rocm_aiter_ops
 from vllm.compilation.fusion import FUSED_OPS, FusedRMSQuantKey, RMSNormQuantFusionPass
 from vllm.compilation.fx_utils import find_op_nodes
@@ -27,7 +14,6 @@ from vllm.compilation.post_cleanup import PostCleanupPass
 from vllm.config import (
     CompilationConfig,
     CompilationMode,
-    CUDAGraphMode,
     ModelConfig,
     PassConfig,
     VllmConfig,
@@ -49,7 +35,6 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import is_deep_gemm_supported
-from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 from ..utils import override_cutlass_fp8_supported
 from .backend import TestBackend
@@ -412,69 +397,3 @@ def test_aiter_fusion_rmsnorm_quant(
         _run_fusion_test(
             model, fusion_pass, vllm_config, dtype, hidden_size, num_tokens
         )
-
-
-@pytest.mark.parametrize(
-    "model_name, model_kwargs, backend, matches, custom_ops",
-    # Test rms norm+group quant_fp8 fusion
-    list[tuple[Any, ...]](flat_product(MODELS_GROUP_FP8, CUSTOM_OPS_QUANT_RMS_NORM)),
-)
-@pytest.mark.parametrize("inductor_graph_partition", [True, False])
-# TODO: remove skip after we fix the fusion thoroughly
-@pytest.mark.skipif(is_blackwell(), reason="Temporarily disabled on Blackwell")
-def test_rms_group_quant(
-    model_name: str,
-    model_kwargs: dict[str, Any],
-    backend: AttentionBackendEnum,
-    matches: Matches,
-    custom_ops: str,
-    inductor_graph_partition: bool,
-    caplog_mp_spawn,
-    monkeypatch,
-):
-    if inductor_graph_partition and not is_torch_equal_or_newer("2.9.0.dev"):
-        pytest.skip("Inductor graph partition requires torch>=2.9")
-
-    custom_ops_list = custom_ops.split(",") if custom_ops else []
-
-    if inductor_graph_partition:
-        mode = CUDAGraphMode.FULL_AND_PIECEWISE
-        splitting_ops: list[str] | None = None
-    else:
-        mode = CUDAGraphMode.FULL_DECODE_ONLY
-        splitting_ops = []
-
-    # Disable, compile cache to make sure custom passes run.
-    # Otherwise, we can't verify fusion happened through the logs.
-    monkeypatch.setenv("VLLM_DISABLE_COMPILE_CACHE", "1")
-
-    # To capture subprocess logs, we need to know whether spawn or fork is used.
-    # Force spawn as it is more general.
-    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
-
-    model_kwargs["attention_config"] = {"backend": backend.name}
-
-    compilation_config = CompilationConfig(
-        # Testing properties
-        custom_ops=custom_ops_list,
-        use_inductor_graph_partition=inductor_graph_partition,
-        cudagraph_mode=mode,
-        splitting_ops=splitting_ops,
-        # Common
-        mode=CompilationMode.VLLM_COMPILE,
-        pass_config=PassConfig(
-            fuse_norm_quant=True, fuse_act_quant=True, eliminate_noops=True
-        ),
-        # Inductor caches custom passes by default as well via uuid
-        inductor_compile_config={"force_disable_caches": True},
-    )
-
-    with caplog_mp_spawn(logging.DEBUG) as log_holder:
-        run_model(compilation_config, model_name, **model_kwargs)
-
-    log_matches = re.findall(
-        r"\[fusion.py:\d+] Replaced (\d+) patterns",
-        log_holder.text,
-    )
-    assert len(log_matches) == 1, log_holder.text
-    assert int(log_matches[0]) == matches.rms_quant_norm_fusion

--- a/tests/compile/test_fusion.py
+++ b/tests/compile/test_fusion.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+
 import pytest
 import torch
 
-import vllm.config
+import vllm.plugins
 from vllm._aiter_ops import IS_AITER_FOUND, rocm_aiter_ops
 from vllm.compilation.fusion import FUSED_OPS, FusedRMSQuantKey, RMSNormQuantFusionPass
 from vllm.compilation.fx_utils import find_op_nodes

--- a/tests/compile/test_fusion.py
+++ b/tests/compile/test_fusion.py
@@ -7,7 +7,6 @@ from typing import Any
 import pytest
 import regex as re
 import torch
-from vllm.attention.backends.registry import AttentionBackendEnum
 
 import vllm.config
 from tests.compile.fusion_test_utils import (
@@ -18,6 +17,7 @@ from tests.compile.fusion_test_utils import (
     run_model,
 )
 from tests.utils import flat_product
+from tests.v1.attention.utils import AttentionBackendEnum
 from vllm._aiter_ops import IS_AITER_FOUND, rocm_aiter_ops
 from vllm.compilation.fusion import FUSED_OPS, FusedRMSQuantKey, RMSNormQuantFusionPass
 from vllm.compilation.fx_utils import find_op_nodes

--- a/tests/distributed/test_sequence_parallel.py
+++ b/tests/distributed/test_sequence_parallel.py
@@ -11,22 +11,33 @@ WARNING: This test runs in both single-node (4 GPUs) and multi-node
 import json
 import os
 from dataclasses import dataclass
-from typing import Literal, NamedTuple
+from typing import NamedTuple
 
 import pytest
 
+from tests.evals.gsm8k.gsm8k_eval import evaluate_gsm8k
+from tests.utils import RemoteOpenAIServer, create_new_process_for_each_test
 from vllm.config.compilation import CompilationMode
 from vllm.config.model import RunnerOption
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
 from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 from ..models.registry import HF_EXAMPLE_MODELS
-from ..utils import compare_two_settings, create_new_process_for_each_test
 
 logger = init_logger("test_sequence_parallel")
 
 VLLM_MULTI_NODE = os.getenv("VLLM_MULTI_NODE", "0") == "1"
+
+# min accuracy for each model
+# Baseline TP=1 (no SP): 72.66%, with SP: ~71%, threshold with 2% buffer
+SP_TEST_MODELS = {
+    # .buildkite/lm-eval-harness/configs/Meta-Llama-3-8B-Instruct.yaml
+    "meta-llama/Meta-Llama-3-8B-Instruct": 0.70,
+}
+
+# GSM8K eval configuration
+NUM_QUESTIONS = 256  # Fast eval for CI
+NUM_SHOTS = 5  # Few-shot examples
 
 
 class ParallelSetup(NamedTuple):
@@ -40,7 +51,6 @@ class ParallelSetup(NamedTuple):
 
 class SPTestOptions(NamedTuple):
     multi_node_only: bool
-    load_format: str | None = None
 
 
 @dataclass
@@ -55,13 +65,15 @@ class SPTestSettings:
         *,
         tp_base: int = 2,
         pp_base: int = 1,
+        pp_multipliers: list[int] | None = None,
         multi_node_only: bool = False,
         runner: RunnerOption = "auto",
-        load_format: str | None = None,
     ):
         parallel_setups = []
+        if pp_multipliers is None:
+            pp_multipliers = [1, 2]
         for eager_mode_val in [False, True]:
-            for pp_multiplier in [1, 2]:
+            for pp_multiplier in pp_multipliers:
                 for chunked_prefill_val in [False, True]:
                     parallel_setups.append(
                         ParallelSetup(
@@ -77,71 +89,7 @@ class SPTestSettings:
             parallel_setups=parallel_setups,
             distributed_backends=["mp", "ray"],
             runner=runner,
-            test_options=SPTestOptions(
-                multi_node_only=multi_node_only, load_format=load_format
-            ),
-        )
-
-    @staticmethod
-    def fast(
-        *,
-        tp_base: int = 2,
-        pp_base: int = 1,
-        runner: RunnerOption = "auto",
-        multi_node_only: bool = False,
-        load_format: str | None = None,
-    ):
-        parallel_setups = []
-        for eager_mode_val in [False, True]:
-            for pp_multiplier in [1, 2]:
-                for chunked_prefill_val in [False, True]:
-                    parallel_setups.append(
-                        ParallelSetup(
-                            tp_size=tp_base,
-                            pp_size=pp_multiplier * pp_base,
-                            fuse_norm_quant=False,
-                            fuse_act_quant=False,
-                            eager_mode=eager_mode_val,
-                            chunked_prefill=chunked_prefill_val,
-                        )
-                    )
-        return SPTestSettings(
-            parallel_setups=parallel_setups,
-            distributed_backends=["mp", "ray"],
-            runner=runner,
-            test_options=SPTestOptions(
-                multi_node_only=multi_node_only, load_format=load_format
-            ),
-        )
-
-    @staticmethod
-    def fp8_quant(
-        *,
-        tp_base: int = 2,
-        pp_base: int = 1,
-        runner: RunnerOption = "auto",
-        multi_node_only: bool = False,
-        load_format: str | None = None,
-    ):
-        parallel_setups = []
-        for fusion_val in [False, True]:
-            parallel_setups.append(
-                ParallelSetup(
-                    tp_size=tp_base,
-                    pp_size=pp_base,
-                    fuse_norm_quant=fusion_val,
-                    fuse_act_quant=fusion_val,
-                    eager_mode=True,
-                    chunked_prefill=False,
-                )
-            )
-        return SPTestSettings(
-            parallel_setups=parallel_setups,
-            distributed_backends=["mp", "ray"],
-            runner=runner,
-            test_options=SPTestOptions(
-                multi_node_only=multi_node_only, load_format=load_format
-            ),
+            test_options=SPTestOptions(multi_node_only=multi_node_only),
         )
 
     def iter_params(self, model_id: str):
@@ -158,7 +106,7 @@ class SPTestSettings:
                 )
 
 
-def _compare_sp(
+def _test_sp_gsm8k(
     model_id: str,
     parallel_setup: ParallelSetup,
     distributed_backend: str,
@@ -167,9 +115,6 @@ def _compare_sp(
     num_gpus_available: int,
     use_inductor_graph_partition: bool,
     fuse_gemm_comms: bool,
-    *,
-    method: Literal["generate", "encode"],
-    is_multimodal: bool,
 ):
     (
         tp_size,
@@ -180,7 +125,7 @@ def _compare_sp(
         chunked_prefill,
     ) = parallel_setup
 
-    multi_node_only, load_format = test_options
+    (multi_node_only,) = test_options
 
     model_info = HF_EXAMPLE_MODELS.find_hf_info(model_id)
     model_info.check_transformers_version(on_fail="skip")
@@ -188,24 +133,6 @@ def _compare_sp(
     trust_remote_code = model_info.trust_remote_code
     tokenizer_mode = model_info.tokenizer_mode
     hf_overrides = model_info.hf_overrides
-    require_embed_inputs = model_info.require_embed_inputs
-
-    if load_format == "dummy":
-        # Avoid OOM
-        text_overrides = {
-            "num_hidden_layers": 4,
-            "hidden_size": 512,
-            "intermediate_size": 800,
-            "num_attention_heads": 4,
-            "num_key_value_heads": 1,
-        }
-
-        if is_multimodal:
-            hf_overrides.update({"text_config": text_overrides})
-        else:
-            hf_overrides.update(text_overrides)
-    else:
-        model_info.check_available_online(on_fail="skip")
 
     if num_gpus_available < tp_size * pp_size:
         pytest.skip(f"Need at least {tp_size} x {pp_size} GPUs")
@@ -217,37 +144,27 @@ def _compare_sp(
     if multi_node_only and not VLLM_MULTI_NODE:
         pytest.skip("Not in multi-node setting")
 
-    common_args = [
+    server_args = [
         # use half precision for speed and memory savings in CI environment
         "--dtype",
-        "float16",
+        "bfloat16",
         "--max-model-len",
-        "2048",
+        "4096",
         "--max-num-seqs",
-        "8",
+        "64",
     ]
     if chunked_prefill:
-        common_args.append("--enable-chunked-prefill")
+        server_args.append("--enable-chunked-prefill")
     if eager_mode:
-        common_args.append("--enforce-eager")
+        server_args.append("--enforce-eager")
     if runner != "auto":
-        common_args.extend(["--runner", runner])
+        server_args.extend(["--runner", runner])
     if trust_remote_code:
-        common_args.append("--trust-remote-code")
+        server_args.append("--trust-remote-code")
     if tokenizer_mode:
-        common_args.extend(["--tokenizer-mode", tokenizer_mode])
-    if load_format:
-        common_args.extend(["--load-format", load_format])
+        server_args.extend(["--tokenizer-mode", tokenizer_mode])
     if hf_overrides:
-        common_args.extend(["--hf-overrides", json.dumps(hf_overrides)])
-    if require_embed_inputs:
-        common_args.extend(
-            [
-                "--skip-tokenizer-init",
-                "--enable-prompt-embeds",
-                "--enable-mm-embeds",
-            ]
-        )
+        server_args.extend(["--hf-overrides", json.dumps(hf_overrides)])
 
     compilation_config = {
         "mode": CompilationMode.VLLM_COMPILE,
@@ -262,41 +179,41 @@ def _compare_sp(
         "use_inductor_graph_partition": use_inductor_graph_partition,
     }
 
-    tp_sp_args = [
-        *common_args,
-        "--tensor-parallel-size",
-        str(tp_size),
-        "--pipeline-parallel-size",
-        str(pp_size),
-        "--distributed-executor-backend",
-        distributed_backend,
-        "--compilation_config",
-        json.dumps(compilation_config),
-    ]
+    server_args.extend(
+        [
+            "--tensor-parallel-size",
+            str(tp_size),
+            "--pipeline-parallel-size",
+            str(pp_size),
+            "--distributed-executor-backend",
+            distributed_backend,
+            "--compilation_config",
+            json.dumps(compilation_config),
+        ]
+    )
 
-    tp_args = [
-        *common_args,
-        "--tensor-parallel-size",
-        str(tp_size),
-        "--distributed-executor-backend",
-        "mp",
-    ]
+    with RemoteOpenAIServer(
+        model_id,
+        server_args,
+        max_wait_seconds=720,
+    ) as remote_server:
+        host = f"http://{remote_server.host}"
+        port = remote_server.port
 
-    compare_two_settings(model_id, tp_sp_args, tp_args, method=method)
+        # Run GSM8K evaluation
+        results = evaluate_gsm8k(
+            num_questions=NUM_QUESTIONS,
+            num_shots=NUM_SHOTS,
+            host=host,
+            port=port,
+        )
 
-
-SP_TEXT_GENERATION_MODELS = {
-    # [Decoder-only]
-    "hmellor/tiny-random-LlamaForCausalLM": SPTestSettings.fast(),
-    "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8": SPTestSettings.fp8_quant(),
-}
-
-SP_TEST_MODELS = [
-    # TODO support other models
-    # [LANGUAGE GENERATION]
-    "hmellor/tiny-random-LlamaForCausalLM",
-    "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8",
-]
+        # Validate accuracy is reasonable
+        accuracy = results["accuracy"]
+        min_accuracy = SP_TEST_MODELS[model_id]
+        assert accuracy >= min_accuracy, (
+            f"TP+SP accuracy too low: {accuracy:.3f} < {min_accuracy:.3f}"
+        )
 
 
 @pytest.mark.parametrize(
@@ -308,10 +225,9 @@ SP_TEST_MODELS = [
         "test_options",
     ),
     [
-        params
-        for model_id, settings in SP_TEXT_GENERATION_MODELS.items()
-        for params in settings.iter_params(model_id)
-        if model_id in SP_TEST_MODELS
+        param
+        for model_id in SP_TEST_MODELS
+        for param in SPTestSettings.detailed().iter_params(model_id)
     ],
 )
 @pytest.mark.parametrize("use_inductor_graph_partition", [True, False])
@@ -330,15 +246,7 @@ def test_tp_sp_generation(
     if use_inductor_graph_partition and not is_torch_equal_or_newer("2.9.0.dev"):
         pytest.skip("inductor graph partition is only available in PyTorch 2.9+")
 
-    # Skip FP8 SP-only test on sm89 (compute capability 8.9)
-    if (
-        "fp8" in model_id.lower()
-        and current_platform.get_device_capability() < (9, 0)
-        and (not fuse_gemm_comms)
-    ):
-        pytest.skip("FP8 reduction support begins with sm90 capable devices.")
-
-    _compare_sp(
+    _test_sp_gsm8k(
         model_id,
         parallel_setup,
         distributed_backend,
@@ -347,6 +255,4 @@ def test_tp_sp_generation(
         num_gpus_available,
         use_inductor_graph_partition,
         fuse_gemm_comms=fuse_gemm_comms,
-        method="generate",
-        is_multimodal=False,
     )


### PR DESCRIPTION
Convert the sequence parallel test to a gsm8k smoke test to avoid having to spin up the server twice every test

Based off: https://github.com/vllm-project/vllm/pull/32489 merge that first

Main / https://github.com/vllm-project/vllm/pull/30499

<img width="1062" height="39" alt="image" src="https://github.com/user-attachments/assets/cd50512b-ca80-4e32-9c25-e165fbc8905c" />

PR

<img width="1057" height="43" alt="image" src="https://github.com/user-attachments/assets/f5c8bffb-9ff5-4e43-929f-66c3429e6924" />
