### PR TITLE
[Bug][KVConnector][Metrics] Remove a vacuous assertion breaking external-launcher

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -7,7 +7,6 @@ from prometheus_client import Counter, Gauge, Histogram
 
 from vllm.config import KVTransferConfig, VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
-from vllm.distributed.kv_transfer.kv_transfer_state import has_kv_transfer_group
 from vllm.logger import init_logger
 
 PromMetric: TypeAlias = Gauge | Counter | Histogram
@@ -53,8 +52,6 @@ class KVConnectorStats:
 
 class KVConnectorLogging:
     def __init__(self, kv_transfer_config: KVTransferConfig | None):
-        # This should be called on frontend process.
-        assert not has_kv_transfer_group()
         # Instantiate the connector's stats class.
         if kv_transfer_config and kv_transfer_config.kv_connector:
             self.connector_cls = KVConnectorFactory.get_connector_class(


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
Remove a vacuous assertion that breaks external-launcher mode, which is essential to RL on DP use cases.

### Why is this assertion vacuous?
It checks the field _KV_CONNECTOR_AGENT that spans [only in Worker](https://github.com/vllm-project/vllm/blob/1e6b115300b8b3629d10e69db0933246fe3253af/vllm/distributed/kv_transfer/kv_transfer_state.py#L67-L71).
But this check is at Scheduler, so serves no purpose at all.

### Why it breaks?
Under external-launcher mode, Engine is created per GPU rank, with one Scheduler and one Worker **within the same process**.

## Test Plan
Existed tests.
The change is a no-op for non external-launcher cases.

## Test Result
No new breakages.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>


