### PR TITLE
[Bugfix] Update get_processor_data to use get_all method

### DIFF
--- a/vllm/multimodal/parse.py
+++ b/vllm/multimodal/parse.py
@@ -120,7 +120,7 @@ class ProcessorBatchItems(ModalityDataItems[Sequence[_T], _T]):
         return self.data[index]
 
     def get_processor_data(self) -> Mapping[str, object]:
-        return {f"{self.modality}s": self.data}
+        return {f"{self.modality}s": self.get_all()}
 
     def get_passthrough_data(self) -> Mapping[str, object]:
         return {}


### PR DESCRIPTION
update ProcessorBatchItems.get_processor_data() to respect get() implementation [specifically use of _unwrap()] to ensure that processors get media items instead of MediaWithBytes objects.


## Purpose

The purpose of this PR is to fix issues observed with zai-org/GLM-4.6V-Flash for processing images (transformers 5.0.0rc1) that result in 400 Bad Request even for properly formatted inputs.  (See issue #30584)

FIX #30584

## Test Plan

TBD

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

