### PR TITLE
[CI/Build] Fix broken mm processor test Mistral-3-large

### DIFF
--- a/tests/models/multimodal/processing/test_tensor_schema.py
+++ b/tests/models/multimodal/processing/test_tensor_schema.py
@@ -36,6 +36,7 @@ from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.utils.collection_utils import is_list_of
 from vllm.utils.torch_utils import set_default_torch_dtype
 
+from ....utils import create_new_process_for_each_test
 from ...registry import HF_EXAMPLE_MODELS
 from ...utils import dummy_hf_overrides
 from .test_common import get_model_ids_to_test, get_text_token_prompts
@@ -166,6 +167,7 @@ def initialize_dummy_model(
     cleanup_dist_env_and_memory()
 
 
+@create_new_process_for_each_test()
 @pytest.mark.parametrize("model_id", get_model_ids_to_test())
 def test_model_tensor_schema(model_id: str):
     model_info = HF_EXAMPLE_MODELS.find_hf_info(model_id)

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -774,7 +774,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     "PixtralForConditionalGeneration": _HfExamplesInfo(
         "mistralai/Pixtral-12B-2409",
         extras={
-            "mistral-large-3-nvfp4": "mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4",  # noqa: E501
+            "mistral-large-3": "mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4",
             "ministral-3": "mistralai/Ministral-3-3B-Instruct-2512",
         },
         tokenizer_mode="mistral",

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -774,7 +774,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     "PixtralForConditionalGeneration": _HfExamplesInfo(
         "mistralai/Pixtral-12B-2409",
         extras={
-            "mistral-large-3": "mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4",
+            "mistral-large-3-nvfp4": "mistralai/Mistral-Large-3-675B-Instruct-2512-NVFP4",  # noqa: E501
             "ministral-3": "mistralai/Ministral-3-3B-Instruct-2512",
         },
         tokenizer_mode="mistral",


### PR DESCRIPTION

## Purpose
- Fix https://github.com/vllm-project/vllm/pull/30514#issuecomment-3648951039
- Skip nvfp4 mistral-3-large in mm processor test. This should be fine because we're still testing ministral-3 and pixtral sharing same architecture.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

