### PR TITLE
[Bugfix] Fix ScalarType NanRepr enum comparisons

### DIFF
--- a/tests/test_scalartype.py
+++ b/tests/test_scalartype.py
@@ -41,3 +41,13 @@ def test_scalar_type_min_max(type_tuple):
     print(t, min, max, t.min(), t.max())
     assert min == t.min(), f"min: {min} != {t.min()}"
     assert max == t.max(), f"max: {max} != {t.max()}"
+
+
+def test_scalar_type_nan_repr_helpers():
+    # IEEE-754 types should be identified as IEEE-754 and should not carry
+    # extra non-standard flags in their string representations.
+    assert scalar_types.float16_e8m7.is_ieee_754()
+    assert str(scalar_types.float16_e8m7) == "float16_e8m7"
+
+    # Types created with NanRepr.NONE should report no NaNs.
+    assert not scalar_types.float4_e2m1f.has_nans()

--- a/vllm/scalar_type.py
+++ b/vllm/scalar_type.py
@@ -206,14 +206,14 @@ class ScalarType:
         return not self._finite_values_only
 
     def has_nans(self) -> bool:
-        return self.nan_repr != NanRepr.NONE.value
+        return self.nan_repr != NanRepr.NONE
 
     def is_ieee_754(self) -> bool:
         """
         If the type is a floating point type that follows IEEE 754
         conventions
         """
-        return self.nan_repr == NanRepr.IEEE_754.value and not self._finite_values_only
+        return self.nan_repr == NanRepr.IEEE_754 and not self._finite_values_only
 
     def __str__(self) -> str:
         """


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix incorrect `NanRepr` comparisons in `vllm.scalar_type.ScalarType` (`Enum` vs `.value` int), which caused helper methods like `is_ieee_754()`/`has_nans()` to return wrong values and polluted IEEE-754 type string names (e.g. `float16_e8m7n`).

## Test Plan
- Run unit tests for ScalarType:

```bash
pytest -q tests/test_scalartype.py
```

- Run formatting/lint hooks on modified files:

```bash
pre-commit run --files vllm/scalar_type.py tests/test_scalartype.py
```

## Test Result
- `pytest -q tests/test_scalartype.py`: **PASS** (13 passed)
- `pre-commit run --files vllm/scalar_type.py tests/test_scalartype.py`: **PASS**
- Verified behavior change:
  - Before: `scalar_types.float16_e8m7.is_ieee_754()` was `False`, `str(...)` produced `float16_e8m7n`
  - After: `scalar_types.float16_e8m7.is_ieee_754()` is `True`, `str(...)` is `float16_e8m7`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

