### PR TITLE
[Bugfix] Improve DCP error hint in cp_utils

### DIFF
--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -31,7 +31,9 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "DCP requires attention impls to return"
                     " the softmax lse for decode, but the impl "
                     f"{layer_impl.__class__.__name__} "
-                    "does not return the softmax lse for decode."
+                    "does not return the softmax lse for decode. "
+                    "Try using --attention-backend to set a compatible "
+                    "backend such as FLASH_ATTN or FLASHINFER."
                 )
 
             if pcp_size > 1:


### PR DESCRIPTION
**This PR is a follow-up to [PR #30174](https://github.com/vllm-project/vllm/pull/30174) and applies the same improvement to the current DCP code path in `vllm/v1/worker/cp_utils.py`.**

## Purpose
Improve the error message in `vllm/v1/worker/cp_utils.py` when Distributed Context Parallelism (DCP) encounters an incompatible attention backend. The enhanced error message now provides actionable guidance by suggesting compatible backends.

This change helps users quickly resolve configuration issues by providing clear guidance on how to fix the problem.

## Test Plan
1. The change only modifies an error message string, no functional code changes
2. Pre-commit checks (ruff, mypy, typos) all passed
3. Existing tests should continue to pass as no behavior is changed

## Test Result
<img width="1142" height="496" alt="image" src="https://github.com/user-attachments/assets/a4c7b29e-6807-4581-92dc-6efe06f4b042" />

Fixes #28407

Signed-off-by: Jack Liu <jacklau9515@gmail.com>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
