### PR TITLE
Fix incorrect dimension in reduce_scatter

### DIFF
--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -179,7 +179,7 @@ class DeviceCommunicatorBase:
 
         # Note: This will produce an incorrect answer if we don't make
         # the input_tensor contiguous. Possible bug in reduce_scatter_tensor?
-        input_tensor = input_.movedim(0, dim).contiguous()
+        input_tensor = input_.movedim(dim, 0).contiguous()
 
         assert input_tensor.shape[0] % world_size == 0
         chunk_size = input_tensor.shape[0] // world_size

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -183,7 +183,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
 
         # Note: This will produce an incorrect answer if we don't make
         # the input_tensor contiguous. Possible bug in reduce_scatter_tensor?
-        input_tensor = input_.movedim(0, dim).contiguous()
+        input_tensor = input_.movedim(dim, 0).contiguous()
 
         assert input_tensor.shape[0] % world_size == 0
         chunk_size = input_tensor.shape[0] // world_size
@@ -210,7 +210,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
 
         # Note: This will produce an incorrect answer if we don't make
         # the input_tensor contiguous. Possible bug in reduce_scatter_tensor?
-        input_tensor = input_.movedim(0, dim).contiguous()
+        input_tensor = input_.movedim(dim, 0).contiguous()
 
         if sizes is not None:
             assert len(sizes) == world_size


### PR DESCRIPTION
## Purpose

Fixes #30546

This PR fixes a bug in the `reduce_scatter` function where the input tensor's dimensions were being permuted incorrectly.

**The issue:**
The code previously used `input_.movedim(0, dim)`.
* This moves the 0-th dimension to `dim`.
* However, `torch.distributed.reduce_scatter_tensor` expects the dimension to be reduced (the target `dim`) to be at the front (index 0).

**The fix:**
Changed to `input_.movedim(dim, 0)`. This correctly moves the target `dim` to the 0-th position. This is also the strict mathematical inverse of `output_tensor.movedim(0, dim)` which is called at the end of the function.

## Test Plan

**1. Logic Verification (Symmetry):**
I verified the correctness by checking the function's exit logic. The function ends with `return output_tensor.movedim(0, dim)`. Therefore, the input preparation must be the inverse operation: `movedim(dim, 0)`.

**2. Gap Analysis of Existing Tests:**
I investigated why this bug was not caught by CI.
The existing test case `reduce_scatter_test_worker` in `vllm/tests/distributed/test_comm_ops.py` is insufficient because:
* It tests on **1D tensors** (shape `[8]`).
* It explicitly passes **`dim=0`**.

In this specific scenario (`dim=0`), the incorrect code `movedim(0, dim)` becomes `movedim(0, 0)`, which is an identity operation (no-op). This masked the bug for higher-dimensional tensors where `dim >= 2`.

**3. Verification:**
Since this is a clear logical error masking as a no-op in current tests, I rely on the logical proof and existing CI to ensure no regression.

## Test Result

- **Logic Check**: Confirmed that `movedim(dim, 0)` is the correct pre-processing step for `reduce_scatter_tensor`.
- **CI**: Waiting for GitHub Actions to pass.
