### PR TITLE
[Docs] Add FlashInfer environment variables to env_vars documentation

### DIFF
--- a/docs/configuration/env_vars.md
+++ b/docs/configuration/env_vars.md
@@ -7,6 +7,32 @@ vLLM uses the following environment variables to configure the system:
 
     All environment variables used by vLLM are prefixed with `VLLM_`. **Special care should be taken for Kubernetes users**: please do not name the service as `vllm`, otherwise environment variables set by Kubernetes might conflict with vLLM's environment variables, because [Kubernetes sets environment variables for each service with the capitalized service name as the prefix](https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables).
 
+## vLLM Environment Variables
+
 ```python
 --8<-- "vllm/envs.py:env-vars-definition"
 ```
+
+## Third-Party Environment Variables
+
+vLLM depends on several third-party libraries that have their own environment variables. These are not part of vLLM but can affect its behavior.
+
+### FlashInfer
+
+[FlashInfer](https://github.com/flashinfer-ai/flashinfer) is used for efficient attention and MoE kernels. It uses JIT compilation and caches compiled kernels. The following environment variables can be used to configure FlashInfer:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `FLASHINFER_WORKSPACE` | Base directory for FlashInfer workspace (JIT compilation files) | `~/.cache/flashinfer` |
+| `FLASHINFER_CACHE_DIR` | Directory for compiled kernel cache. Can be set separately from workspace | Same as `FLASHINFER_WORKSPACE` |
+| `FLASHINFER_JIT_THREADS` | Number of threads for JIT compilation | Number of CPU cores |
+| `FLASHINFER_CUBINS_REPOSITORY` | URL of the repository to download FlashInfer cubin files. Useful for restricted network environments | NVIDIA public repository |
+
+!!! tip "Containerized Deployments"
+    In containerized environments, you may want to:
+
+    - Set `FLASHINFER_WORKSPACE` to a persistent volume to avoid recompilation on container restart
+    - Pre-compile kernels during image build to reduce cold-start time
+    - Use `VLLM_HAS_FLASHINFER_CUBIN=1` if you've pre-downloaded cubin files
+
+For more details, see the [FlashInfer JIT documentation](https://github.com/flashinfer-ai/flashinfer/blob/main/flashinfer/jit/env.py).


### PR DESCRIPTION
## Summary

Users have reported confusion about undocumented FlashInfer environment variables that affect vLLM behavior. This PR adds documentation for third-party environment variables.

## Changes

- Added a new section "Third-Party Environment Variables" to `env_vars.md`
- Documented FlashInfer JIT compilation environment variables:
  - `FLASHINFER_WORKSPACE`: Base directory for JIT compilation files
  - `FLASHINFER_CACHE_DIR`: Directory for compiled kernel cache
  - `FLASHINFER_JIT_THREADS`: Number of threads for JIT compilation
- Added tips for containerized deployments:
  - Persist workspace to avoid recompilation
  - Pre-compile kernels during image build
  - Use `VLLM_HAS_FLASHINFER_CUBIN=1` for pre-downloaded cubins

## Test Plan

- [x] Documentation review
- [x] Markdown formatting verified

Fixes #26398