### PR TITLE
[main][BugFix] Fixed an accuracy bug of Qwen3-next-MTP when batched inferring

### DIFF
--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -211,7 +211,7 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 spec_token_masks = torch.repeat_interleave(
                     spec_sequence_masks, query_lens
                 )
-                index = torch.argsort(spec_token_masks)
+                index = torch.argsort(spec_token_masks, stable=True)
                 num_non_spec_tokens = num_prefill_tokens + num_decode_tokens
                 non_spec_token_indx = index[:num_non_spec_tokens]
                 spec_token_indx = index[num_non_spec_tokens:]


### PR DESCRIPTION
…nferring

<!-- markdownlint-disable -->

## Purpose

To solve a bug in Qwen3-Next-MTP which produces a lot of redundant tokens when batched inferring. It is descibed in https://github.com/vllm-project/vllm/issues/30631.

We found this bug in `vllm-ascend`, which is described in https://github.com/vllm-project/vllm-ascend/issues/4930.

We solve it for `vllm-ascend` in https://github.com/vllm-project/vllm-ascend/pull/4932.

FIX https://github.com/vllm-project/vllm/issues/30631
## Test Plan

We use the same environment described in https://github.com/vllm-project/vllm/issues/30631.

Run codes below.

```python
    prompts = [
        "Hello, my name is", 
        "The president of the United States is",
        "The capital of France is", 
        "The future of AI is"
    ]

    sampling_params = SamplingParams(temperature=0.0, top_p=0.95, top_k=40, max_tokens=20)
    llm = LLM(model="/home/model/Qwen3-Next-80B-A3B-Instruct",
              tensor_parallel_size=4,
              enforce_eager=True,
              distributed_executor_backend="mp",
              gpu_memory_utilization=0.7,
              speculative_config={
                  "method": "qwen3_next_mtp",
                  "num_speculative_tokens": 1,
              },
              max_model_len=4096, 
              enable_prefix_caching=False)

    outputs = llm.generate(prompts, sampling_params)
    for output in outputs:
        prompt = output.prompt
        generated_text = output.outputs[0].text
        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```

## Test Result

Before we modified, the outputs are:

```text
Prompt: 'Hello, my name is', Generated text: ' [Your Name], and I am a 20-year-old student from [Your Country]. I'
Prompt: 'The president of the United States is', Generated text: ' 2024 is the president of the United States of America. The president of the United'
Prompt: 'The capital of France is', Generated text: ' the of capital isThe the of capital isThe the of capital isThe the of capital of capital'
Prompt: 'The future of AI is', Generated text: ' the future of the world is in the hands of the people of the world. The future of the'
```

The third conversation has a lot of redundant tokens.

After we modified, the outputs are:

```text
Prompt: 'Hello, my name is', Generated text: ' [Your Name], and I am a 20-year-old student from [Your Country]. I'
Prompt: 'The president of the United States is', Generated text: ' the head of state and head of government of the United States, directing the executive branch of the federal'
Prompt: 'The capital of France is', Generated text: ' Paris. The capital of Germany is Berlin. The capital of Italy is Rome. The capital of Spain'
Prompt: 'The future of AI is', Generated text: ' not just about technology—it’s about people. As AI becomes more integrated into our daily lives, the'
```

We can see the third conversation has no more redundant tokens.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

