### PR TITLE
Cast inputs_embeds to model dtype if necessary

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2747,6 +2747,13 @@ class GPUModelRunner(
         Returns:
             Model output tensor
         """
+        # This check is needed because in some environments
+        # (e.g. Docker with specific models),
+        # inputs_embeds validation might fail
+        # if dtypes don't strictly match.
+        if inputs_embeds is not None and inputs_embeds.dtype != self.dtype:
+            inputs_embeds = inputs_embeds.to(self.dtype)
+
         return self.model(
             input_ids=input_ids,
             positions=positions,
@@ -4195,7 +4202,7 @@ class GPUModelRunner(
                     ubatch_slices=ubatch_slices_padded,
                 ),
             ):
-                outputs = self.model(
+                outputs = self._model_forward(
                     input_ids=input_ids,
                     positions=positions,
                     intermediate_tensors=intermediate_tensors,


### PR DESCRIPTION
## Purpose

Ensure inputs_embeds are cast to the correct dtype. This should help with #29349 and <details><summary>`RuntimeError: expected mat1 and mat2 to have the same dtype, but got: float != c10::Half`</summary>

```
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843] EngineCore failed to start.
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843] Traceback (most recent call last):
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 834, in run_engine_core
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     engine_core = EngineCoreProc(*args, **kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 610, in __init__
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     super().__init__(
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 109, in __init__
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 235, in _initialize_kv_caches
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     available_gpu_memory = self.model_executor.determine_available_memory()
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/abstract.py", line 126, in determine_available_memory
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return self.collective_rpc("determine_available_memory")
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/uniproc_executor.py", line 75, in collective_rpc
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     result = run_method(self.driver_worker, method, args, kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/serial_utils.py", line 479, in run_method
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return func(*args, **kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return func(*args, **kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 324, in determine_available_memory
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     self.model_runner.profile_run()
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 4357, in profile_run
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     hidden_states, last_hidden_states = self._dummy_run(
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]                                         ^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return func(*args, **kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 4071, in _dummy_run
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     outputs = self.model(
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]               ^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/apertus.py", line 552, in forward
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     model_output = self.model(
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]                    ^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/decorators.py", line 360, in __call__
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return self.forward(*args, **kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/apertus.py", line 395, in forward
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     hidden_states, residual = layer(positions, hidden_states, residual)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/apertus.py", line 313, in forward
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     hidden_states = self.mlp(hidden_states)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]                     ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/apertus.py", line 110, in forward
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     x, _ = self.down_proj(x)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/linear.py", line 1405, in forward
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     output_parallel = self.quant_method.apply(self, input_parallel, bias_)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/linear.py", line 240, in apply
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return dispatch_unquantized_gemm()(layer, x, layer.weight, bias)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/utils.py", line 105, in default_unquantized_gemm
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return torch.nn.functional.linear(x, weight, bias)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/parameter.py", line 126, in __torch_function__
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]     return super().__torch_function__(func, types, args, kwargs)
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=160) ERROR 12-13 22:37:33 [core.py:843] RuntimeError: expected mat1 and mat2 to have the same dtype, but got: float != c10::Half
```

</details>

## Test Plan

WIP

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

