### PR TITLE
[Bugfix] Drop empty tool_calls lists to keep assistant replies in chat template

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1629,12 +1629,17 @@ def _postprocess_messages(messages: list[ConversationMessage]) -> None:
     # so, for messages that have tool_calls, parse the string (which we get
     # from openAI format) to dict
     for message in messages:
-        if (
-            message["role"] == "assistant"
-            and "tool_calls" in message
-            and isinstance(message["tool_calls"], list)
-        ):
-            for item in message["tool_calls"]:
+        if message["role"] == "assistant" and "tool_calls" in message:
+            tool_calls = message.get("tool_calls")
+            if not isinstance(tool_calls, list):
+                continue
+
+            if len(tool_calls) == 0:
+                # Drop empty tool_calls to keep templates on the normal assistant path.
+                message.pop("tool_calls", None)
+                continue
+
+            for item in tool_calls:
                 # if arguments is None or empty string, set to {}
                 if content := item["function"].get("arguments"):
                     if not isinstance(content, (dict, list)):


### PR DESCRIPTION
## Purpose
### Summary

- Fixes chat postprocessing to drop empty assistant `tool_calls` lists.
- Ensures chat templates correctly identify these messages as text responses rather than tool calls, preventing assistant content from being omitted.
- Leaves non-empty tool calls unchanged while continuing to normalize their arguments.

### Problem

- When using `gpt-oss` via the vllm serve Chat API, `model_response.choices[0].message.model_dump(exclude_none=True)` includes `tool_calls=[]`.
- If this empty list is passed back into the next payload’s messages, the chat template incorrectly routes logic to the tool-call branch. Consequently, the assistant's text content is dropped/ignored. (See the Testing section for details).

### Fix

- Modified `_postprocess_messages` in `vllm/entrypoints/chat_utils.py` to remove empty assistant `tool_calls` before argument normalization.
- This ensures the chat template treats the message as standard assistant content, while valid tool calls still undergo argument parsing/normalization.


## Test Plan
### Test code
```
from openai import OpenAI
import json
import urllib

MODEL_ID = "openai/gpt-oss-20b"
client = OpenAI(base_url="http://localhost:8000/v1", api_key=MODEL_ID, timeout=1800)
DETOK_BASE = "http://localhost:8000/detokenize"

def vllm_openai_tokenizer_request(payload):
    url = DETOK_BASE
    headers = {
        "Content-Type": "application/json",
        "Authorization": f"Bearer {MODEL_ID}"
    }
    data = json.dumps(payload).encode("utf-8")
    req = urllib.request.Request(url, data=data, headers=headers)
    with urllib.request.urlopen(req, timeout=30) as resp:
        return json.loads(resp.read().decode("utf-8"))

def vllm_openai_detokenize_token_ids(token_ids):
        payload = {
            "model": MODEL_ID,
            "tokens": token_ids 
        }
        response = vllm_openai_tokenizer_request(payload)
        return response["prompt"]

messages_without_empty_tool_calls = [
    {'role': 'user', 'content': 'Calculate 1+1'},
    {'content': '2', 'role': 'assistant', 'reasoning': 'The user asks: "Calculate 1+1". The answer is 2.'},
    {'role': 'user', 'content': 'What did I ask you to do previously?'},
]

messages_with_empty_tool_calls = [
    {'role': 'user', 'content': 'Calculate 1+1'},
    {'tool_calls': [], 'content': '2', 'role': 'assistant', 'reasoning': 'The user asks: "Calculate 1+1". The answer is 2.'},
    {'role': 'user', 'content': 'What did I ask you to do previously?'},
]

payload_with_empty_tool_calls = {
    "model": MODEL_ID,
    "messages": messages_with_empty_tool_calls,
    "max_tokens": 512,
    "temperature": 0.2,
    "extra_body": {"return_token_ids": True},
}

payload_without_empty_tool_calls = {
    "model": MODEL_ID,
    "messages": messages_without_empty_tool_calls,
    "max_tokens": 512,
    "temperature": 0.2,
    "extra_body": {"return_token_ids": True},
}

response = client.chat.completions.create(**payload_without_empty_tool_calls)
prompt_tokens = response.prompt_token_ids
prompt_without_empty_tool_calls = vllm_openai_detokenize_token_ids(prompt_tokens)
print("Detokenized prompt without empty tool calls:")
print(prompt_without_empty_tool_calls)

response = client.chat.completions.create(**payload_with_empty_tool_calls)
prompt_tokens = response.prompt_token_ids
prompt_with_empty_tool_calls = vllm_openai_detokenize_token_ids(prompt_tokens)
print("\nDetokenized prompt with empty tool calls:")
print(prompt_with_empty_tool_calls)

print("\nAre the prompts identical?", prompt_without_empty_tool_calls == prompt_with_empty_tool_calls)
```

### vllm serve command
```
vllm serve \
  --model "openai/gpt-oss-20b" \
  --api-key "openai/gpt-oss-20b" \
  --gpu-memory-utilization 0.8 \
  --reasoning-parser openai_gptoss \
  --tool-call-parser openai \
  --enable-auto-tool-choice
```

## Test Result
### Before fix
```
Detokenized prompt without empty tool calls:
<|start|>system<|message|>You are ChatGPT, a large language model trained by OpenAI.
Knowledge cutoff: 2024-06
Current date: 2025-12-14

Reasoning: medium

# Valid channels: analysis, final. Channel must be included for every message.<|end|><|start|>developer<|message|><|end|><|start|>user<|message|>Calculate 1+1<|end|><|start|>assistant<|message|>2<|end|><|start|>user<|message|>What did I ask you to do previously?<|end|><|start|>assistant

Detokenized prompt with empty tool calls:
<|start|>system<|message|>You are ChatGPT, a large language model trained by OpenAI.
Knowledge cutoff: 2024-06
Current date: 2025-12-14

Reasoning: medium

# Valid channels: analysis, final. Channel must be included for every message.<|end|><|start|>developer<|message|><|end|><|start|>user<|message|>Calculate 1+1<|end|><|start|>user<|message|>What did I ask you to do previously?<|end|><|start|>assistant

Are the prompts identical? False
```

### After fix
```
Detokenized prompt without empty tool calls:
<|start|>system<|message|>You are ChatGPT, a large language model trained by OpenAI.
Knowledge cutoff: 2024-06
Current date: 2025-12-14

Reasoning: medium

# Valid channels: analysis, final. Channel must be included for every message.<|end|><|start|>developer<|message|><|end|><|start|>user<|message|>Calculate 1+1<|end|><|start|>assistant<|channel|>final<|message|>2<|end|><|start|>user<|message|>What did I ask you to do previously?<|end|><|start|>assistant

Detokenized prompt with empty tool calls:
<|start|>system<|message|>You are ChatGPT, a large language model trained by OpenAI.
Knowledge cutoff: 2024-06
Current date: 2025-12-14

Reasoning: medium

# Valid channels: analysis, final. Channel must be included for every message.<|end|><|start|>developer<|message|><|end|><|start|>user<|message|>Calculate 1+1<|end|><|start|>assistant<|channel|>final<|message|>2<|end|><|start|>user<|message|>What did I ask you to do previously?<|end|><|start|>assistant

Are the prompts identical? True
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

