### PR TITLE
Support GPU tensors in tensor_data() to enable GPU-accelerated multimodal preprocessing

### DIFF
--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -405,10 +405,16 @@ def tensor_data(tensor: torch.Tensor) -> memoryview:
     """Get the raw data of a tensor as a uint8 memoryview, useful for
     serializing and hashing.
 
+    Note:
+        The `.cpu()` call is necessary to handle GPU tensors, as PyTorch's
+        `.numpy()` method only works on CPU tensors. This involves a
+        device-to-memory (device2mem) transfer for GPU tensors. For tensors
+        already on CPU, `.cpu()` is a no-op.
+
     Args:
-        tensor: The input tensor.
+        tensor: The input tensor (can be on CPU or GPU).
 
     Returns:
         A memoryview of the tensor data as uint8.
     """
-    return tensor.flatten().contiguous().view(torch.uint8).numpy().data
+    return tensor.flatten().contiguous().view(torch.uint8).cpu().numpy().data


### PR DESCRIPTION
## Purpose

Add support for GPU tensors in the `tensor_data` function, enabling proper functionality of GPU-accelerated multimodal preprocessing.

### Background

In our practical deployment, we enabled GPU-accelerated multimodal preprocessing by utilizing the following configurations, thereby moving tasks such as image and video preprocessing to the GPU. This significantly reduces CPU overhead in high-concurrency scenarios:

- CLI argument: `--mm-processor-kwargs '{"device": "cuda"}'`
- Model config: Setting `"device": "cuda"` in `preprocessor_config.json`

However, the current implementation of the `tensor_data()` function in `vllm/v1/utils.py` fails to handle tensors residing on the GPU, causing errors when GPU preprocessing is enabled.

### Problem

The `tensor_data()` function is used for tensor serialization and hashing, particularly in multimodal input processing. The current implementation directly calls `.numpy()` on tensors:

```python
return tensor.flatten().contiguous().view(torch.uint8).numpy().data
```

This fails for GPU tensors because PyTorch's `.numpy()` method only supports CPU tensors, raising:
```
 TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

### Solution

Add `.cpu()` call before `.numpy()` to handle both CPU and GPU tensors:
```python
return tensor.flatten().contiguous().view(torch.uint8).cpu().numpy().data
```

**Performance Impact:**
- CPU tensors: `.cpu()` is a no-op, no performance impact
- GPU tensors: Necessary device-to-memory transfer (same as what would be needed anyway for serialization)

This change is critical for multimodal models when GPU preprocessing is enabled, as tensors may reside on GPU devices.

## Test Plan

### Unit Tests
```python
import torch
from vllm.v1.utils import tensor_data

def test_tensor_data_cpu():
    tensor = torch.randn(10, 20)
    result = tensor_data(tensor)
    assert isinstance(result, memoryview)
    assert len(result) == tensor.numel() * tensor.element_size()
    print("CPU tensor test passed")

def test_tensor_data_gpu():
    if not torch.cuda.is_available():
        print("GPU not available, skipping GPU test")
        return
    tensor = torch.randn(10, 20).cuda()
    result = tensor_data(tensor)
    assert isinstance(result, memoryview)
    assert len(result) == tensor.numel() * tensor.element_size()
    print("GPU tensor test passed")

def test_tensor_data_various_dtypes():
    dtypes = [torch.float32, torch.float16, torch.int32, torch.int64]
    for dtype in dtypes:
        tensor = torch.randn(5, 5).to(dtype)
        result = tensor_data(tensor)
        assert isinstance(result, memoryview)
    print("Various dtypes test passed")

# Run tests
test_tensor_data_cpu()
test_tensor_data_gpu()
test_tensor_data_various_dtypes()
```

### Integration Test

Test with actual multimodal preprocessing using GPU device:

```bash

# Start vLLM with GPU preprocessing
vllm serve <multimodal-model> \
  --mm-processor-kwargs '{"device": "cuda"}'
  
# Send multimodal inference request
# Should not raise TypeError during tensor serialization
```

## Test Result

### Before Fix
- CPU tensors: Works correctly
- GPU tensors: `TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.`
- Impact: GPU-accelerated preprocessing cannot be used

### After Fix
- CPU tensors: Works correctly (no performance regression)
- GPU tensors: Works correctly with automatic device-to-memory transfer
- Impact: GPU-accelerated preprocessing fully functional

**Test Output:**
```
CPU tensor test passed
GPU tensor test passed
Various dtypes test passed
```

### Affected Code Paths

The `tensor_data()` function is called in:
1. `vllm/v1/serial_utils.py` - Tensor encoding for serialization
2. `vllm/v1/core/kv_cache_utils.py` - Block prompt embeddings hashing
3. Various test files - Unit testing

All these code paths now work correctly with GPU tensors when GPU preprocessing is enabled.

## Documentation Updates

Updated docstring in `vllm/v1/utils.py:tensor_data()` to clarify:
- Function now supports both CPU and GPU tensors
- Device-to-memory transfer behavior for GPU tensors
- No-op behavior for CPU tensors

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
