### PR TITLE
[Bugfix] Fix missing first token in tool calls during reasoning-to-tool transition

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -964,21 +964,9 @@ class OpenAIServingChat(OpenAIServing):
                         assert reasoning_end_arr is not None
                         output_token_ids = as_list(output.token_ids)
                         if not reasoning_end_arr[i]:
-                            delta_message = (
-                                reasoning_parser.extract_reasoning_streaming(
-                                    previous_text,
-                                    current_text,
-                                    delta_text,
-                                    previous_token_ids,
-                                    current_token_ids,
-                                    output_token_ids,
-                                )
-                            )
                             # When encountering think end id in prompt_token_ids
                             # i.e {"enable_thinking": False},
                             # set reasoning status to end.
-                            # Remove the text and token ids related
-                            # to 'reasoning'.
                             if (
                                 res.prompt_token_ids
                                 and reasoning_parser.is_reasoning_end(
@@ -987,30 +975,38 @@ class OpenAIServingChat(OpenAIServing):
                             ):
                                 reasoning_end_arr[i] = True
                                 current_token_ids = output_token_ids
-                                if delta_message and delta_message.content:
-                                    current_text = delta_message.content
-                                    delta_message.content = None
-                                else:
-                                    current_text = ""
-                            # When encountering think end id in delta_token_ids,
-                            # set reasoning status to end.
-                            # Remove the text and token ids related
-                            # to 'reasoning'.
-                            if reasoning_parser.is_reasoning_end(output_token_ids):
-                                reasoning_end_arr[i] = True
-                                current_token_ids = (
-                                    reasoning_parser.extract_content_ids(
-                                        output_token_ids
+                                # Don't update current_text, keep it as is from delta
+                            else:
+                                delta_message = (
+                                    reasoning_parser.extract_reasoning_streaming(
+                                        previous_text,
+                                        current_text,
+                                        delta_text,
+                                        previous_token_ids,
+                                        current_token_ids,
+                                        output_token_ids,
                                     )
                                 )
-                                if delta_message and delta_message.content:
-                                    current_text = delta_message.content
-                                    delta_message.content = None
-                                else:
-                                    current_text = ""
+
+                                # When encountering think end id in delta_token_ids,
+                                # set reasoning status to end.
+                                # Remove the text and token ids related
+                                # to 'reasoning'.
+                                if reasoning_parser.is_reasoning_end(output_token_ids):
+                                    reasoning_end_arr[i] = True
+                                    current_token_ids = (
+                                        reasoning_parser.extract_content_ids(
+                                            output_token_ids
+                                        )
+                                    )
+                                    if delta_message and delta_message.content:
+                                        current_text = delta_message.content
+                                        delta_message.content = None
+                                    else:
+                                        current_text = ""
 
                         # handle tool calls only after reasoning is done,
-                        else:
+                        if reasoning_end_arr[i]:
                             delta_token_ids = output_token_ids
                             # First time to tool call,
                             # add the remaining text and token ids


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR refactors the streaming logic in the generation handler to fix an issue where the first token of a tool call could be dropped or set to `None` during the transition from `Reasoning` to `Tool Calling`.

### The Problem
Previously, the logic used a mutually exclusive `if-else` structure:

```
if not reasoning_end_arr[i]:
    # Handle reasoning...
    if is_end: reasoning_end_arr[i] = True
else:
    # Handle tool calls...
```
In streaming scenarios, if the "Reasoning End" token (e.g., `</think>`) appeared in the current iteration, the `reasoning_end_arr` flag was set to `True`, but the else block was skipped for that iteration. This resulted in the immediate next token being generated by the engine but dropped from the streaming response.

### Evidence (Log Analysis)
The following SSE logs demonstrate the issue before the fix. Observe the second chunk: the model generated the token **"Ap"** (visible in `logprobs`), but the `delta.content` was set to null. The next chunk continues with **"ologies"**. Result: The user receives **"ologies"** instead of **"Apologies"**.

```
// 1. Initial chunk
data: {"id": "...", "choices": [{"delta": {"role": "assistant", "content": "", "reasoning_content": null}}]}

// 2. THE BUG: Transition happens here.
// 'token' is "Ap" (logprob exists), but 'delta.content' is null.
data: {"id": "...", "choices": [{"delta": {"content": null, "reasoning_content": null}, "logprobs": {"content": [{"token": "Ap", "logprob": -8.55, ...}]}}]}

// 3. Next chunk continues, missing the start.
data: {"id": "...", "choices": [{"delta": {"content": "ologies", "reasoning_content": null}, "logprobs": {"content": [{"token": "ologies", "logprob": -0.0008, ...}]}}]}
```

### The Fix
The logic is now changed to sequential `if` statements:

- Sequential Processing: After checking/processing reasoning, the code immediately checks `if reasoning_end_arr[i]:`. This ensures that if reasoning finishes in the current step, the `tool_parser` is immediately invoked to process the remaining tokens in the same iteration.

- Optimization: The check for `prompt_token_ids` (disabling reasoning via prompt) is moved before the expensive `extract_reasoning_streaming call`, avoiding unnecessary processing when thinking is disabled.

## Test Plan

Just directly test tool-call + reasoning case, such as
```
'{
  "model": "deepseek-ai/DeepSeek-V3.2",
  "stream": true,
  "stream_options": {
    "include_usage": true
  },
  "messages": [
    {
      "role": "user",
      "content": "What is the weather like in Boston in fahrenheit?"
    }
  ],
  "max_tokens": 65536,
  "temperature": 1,
  "top_p": 1,
  "frequency_penalty": 0,
  "presence_penalty": 0,
  "seed": null,
  "min_p": 0,
  "repetition_penalty": 1,
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "get_current_weather",
        "description": "Get the current weather in a given location",
        "strict": true,
        "parameters": {
          "type": "object",
          "properties": {
            "location": {
              "type": "string",
              "description": "The city and state, e.g. San Francisco, CA"
            },
            "unit": {
              "type": "string",
              "enum": [
                "celsius",
                "fahrenheit"
              ]
            }
          },
          "additionalProperties": false,
          "required": [
            "location",
            "unit"
          ]
        }
      }
    }
  ]
}'
```

## Test Result

The first token is generated normally, without setting to `None` or just dropped.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

