### PR TITLE
[BugFix] Add embed_input_ids method to make QWenLMHeadModel a vllm model

### DIFF
--- a/vllm/model_executor/models/qwen.py
+++ b/vllm/model_executor/models/qwen.py
@@ -281,6 +281,9 @@ class QWenBaseModel(nn.Module):
             self.transformer.make_empty_intermediate_tensors
         )
 
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.transformer.wte(input_ids)
+
     def compute_logits(
         self,
         hidden_states: torch.Tensor,
@@ -348,9 +351,6 @@ class QWenLMHeadModel(QWenBaseModel, SupportsPP, SupportsLoRA):
             )
 
         super().__init__(vllm_config=vllm_config, prefix=prefix)
-
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.transformer.wte(input_ids)
 
     def forward(
         self,

--- a/vllm/model_executor/models/qwen.py
+++ b/vllm/model_executor/models/qwen.py
@@ -349,6 +349,9 @@ class QWenLMHeadModel(QWenBaseModel, SupportsPP, SupportsLoRA):
 
         super().__init__(vllm_config=vllm_config, prefix=prefix)
 
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.transformer.wte(input_ids)
+
     def forward(
         self,
         input_ids: torch.Tensor,


### PR DESCRIPTION
bug:
<img width="3408" height="206" alt="image" src="https://github.com/user-attachments/assets/1e80f05d-cb26-41ac-bdf2-5ed3450f7228" />

