### PR TITLE
[Model] Add video input support for transformers modeling backend

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -23,8 +23,6 @@ Currently, the Transformers modeling backend works for the following:
 - Architectures: encoder-only, decoder-only, mixture-of-experts
 - Attention types: full attention and/or sliding attention
 
-_*Vision-language models currently accept only image inputs. Support for video inputs will be added in a future release._
-
 If the Transformers model implementation follows all the steps in [writing a custom model](#writing-custom-models) then, when used with the Transformers modeling backend, it will be compatible with the following features of vLLM:
 
 - All the features listed in the [compatibility matrix](../features/README.md#feature-x-feature)

--- a/vllm/multimodal/parse.py
+++ b/vllm/multimodal/parse.py
@@ -280,7 +280,7 @@ class VideoProcessorItems(ProcessorBatchItems[HfVideoItem]):
         if isinstance(image, PILImage.Image):
             return ImageSize(*image.size)
         if isinstance(image, (np.ndarray, torch.Tensor)):
-            _, h, w = image.shape
+            w, h, _ = image.shape
             return ImageSize(w, h)
 
         assert_never(image)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1118,7 +1118,18 @@ class GPUModelRunner(
         assert mm_budget is not None
 
         dummy_modality = mm_budget.get_modality_with_max_tokens()
-        return self._get_mm_dummy_batch(dummy_modality, num_seqs)
+
+        # TBD:
+        # The mm_dummy_batch below is only retrieved when
+        # supports_multimodal_raw_input_only is True.
+        # Currently, only the transform modeling backend and terratorch have
+        # supports_multimodal_raw_input_only as True.
+        # When testing the transform modeling backend, it was found that
+        # if num_seqs (usually the default 256) is passed in here,
+        # an OOM error occurs.
+        # It needs to be confirmed what value should be passed in here,
+        # for now it is fixed to 1.
+        return self._get_mm_dummy_batch(dummy_modality, 1)
 
     def _get_cumsum_and_arange(
         self,


### PR DESCRIPTION
I am a developer from Cybercore. We are developing a multimodal model named Leum and plan to deploy it using the vLLM transformers modeling backend. We noticed that the current implementation does not support video input, which is a necessary feature for our model. This pull request introduces the required changes to enable video input processing.

Key changes:
- Extended multimodal classes (`MultiModalProcessingInfo`, `MultiModalProcessor`, `MultiModalMixin`) to handle video-specific logic, including token calculation, dummy data generation, and embedding.
- Corrected the frame size extraction for video frames in `vllm/multimodal/parse.py`.
- Updated documentation to reflect video support.
- Fixed a potential OOM issue in the dummy batch generator for multimodal models.

Thank you for considering our contribution!

---

Edits from maintainers.

Merge after:

- [ ] https://github.com/huggingface/transformers/pull/42919