### PR TITLE
chores: adjust the attn register param order

### DIFF
--- a/vllm/attention/backends/registry.py
+++ b/vllm/attention/backends/registry.py
@@ -201,8 +201,8 @@ _MAMBA_ATTN_OVERRIDES: dict[MambaAttentionBackendEnum, str] = {}
 
 def register_backend(
     backend: AttentionBackendEnum | MambaAttentionBackendEnum,
-    is_mamba: bool = False,
     class_path: str | None = None,
+    is_mamba: bool = False,
 ) -> Callable[[type], type]:
     """Register or override a backend implementation.
 


### PR DESCRIPTION

## Purpose
This is a follow-up to [#26487](https://github.com/vllm-project/vllm/pull/26487).

It accidently change the order of attention registry default parameter, which caused the failure in normal registry and crashed all the workflow of our plugins tests (the vllm-metax).

For not adding `class_path =` everywhere in the registry code in non-mamba cases ( and I think that's the most common situation) , it is needed to exchange the order of the default parameter. 

## Test Plan
By plugin
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

