### PR TITLE
[Feature]: Prometheus Metrics Abstraction

### DIFF
--- a/tests/v1/metrics/test_ray_metrics.py
+++ b/tests/v1/metrics/test_ray_metrics.py
@@ -7,7 +7,8 @@ import ray
 from vllm.config.model import ModelDType
 from vllm.sampling_params import SamplingParams
 from vllm.v1.engine.async_llm import AsyncEngineArgs, AsyncLLM
-from vllm.v1.metrics.ray_wrappers import RayPrometheusMetric, RayPrometheusStatLogger
+from vllm.v1.metrics.backends.ray_backend import _get_sanitized_opentelemetry_name
+from vllm.v1.metrics.ray_wrappers import RayPrometheusStatLogger
 
 MODELS = [
     "distilbert/distilgpt2",
@@ -57,40 +58,27 @@ def test_sanitized_opentelemetry_name():
 
     # Only a-z, A-Z, 0-9, _, test valid characters are preserved
     valid_name = "valid_metric_123_abcDEF"
-    assert (
-        RayPrometheusMetric._get_sanitized_opentelemetry_name(valid_name) == valid_name
-    )
+    assert _get_sanitized_opentelemetry_name(valid_name) == valid_name
 
     # Test dash, dot, are replaced
     name_with_dash_dot = "metric-name.test"
     expected = "metric_name_test"
-    assert (
-        RayPrometheusMetric._get_sanitized_opentelemetry_name(name_with_dash_dot)
-        == expected
-    )
+    assert _get_sanitized_opentelemetry_name(name_with_dash_dot) == expected
 
     # Test colon is replaced with underscore
     name_with_colon = "metric:name"
     expected = "metric_name"
-    assert (
-        RayPrometheusMetric._get_sanitized_opentelemetry_name(name_with_colon)
-        == expected
-    )
+    assert _get_sanitized_opentelemetry_name(name_with_colon) == expected
 
     # Test multiple invalid characters are replaced
     name_with_invalid = "metric:name@with#special%chars"
     expected = "metric_name_with_special_chars"
-    assert (
-        RayPrometheusMetric._get_sanitized_opentelemetry_name(name_with_invalid)
-        == expected
-    )
+    assert _get_sanitized_opentelemetry_name(name_with_invalid) == expected
 
     # Test mixed valid and invalid characters
     complex_name = "vllm:engine_stats/time.latency_ms-99p"
     expected = "vllm_engine_stats_time_latency_ms_99p"
-    assert (
-        RayPrometheusMetric._get_sanitized_opentelemetry_name(complex_name) == expected
-    )
+    assert _get_sanitized_opentelemetry_name(complex_name) == expected
 
     # Test empty string
-    assert RayPrometheusMetric._get_sanitized_opentelemetry_name("") == ""
+    assert _get_sanitized_opentelemetry_name("") == ""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -56,12 +56,11 @@ if TYPE_CHECKING:
     from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
         KVConnectorPromMetrics,
         KVConnectorStats,
-        PromMetric,
-        PromMetricT,
     )
     from vllm.forward_context import ForwardContext
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.metrics.backends import MetricBackend
     from vllm.v1.request import Request
 
 # s_tensor_list, d_tensor_list, s_indices, d_indices, direction
@@ -581,9 +580,9 @@ class KVConnectorBase_V1(ABC):
     def build_prom_metrics(
         cls,
         vllm_config: "VllmConfig",
-        metric_types: dict[type["PromMetric"], type["PromMetricT"]],
+        backend: "MetricBackend",
         labelnames: list[str],
-        per_engine_labelvalues: dict[int, list[object]],
+        per_engine_labelvalues: dict[int, list[str]],
     ) -> "KVConnectorPromMetrics | None":
         """
         Create a KVConnectorPromMetrics subclass which should register

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -40,13 +40,12 @@ if TYPE_CHECKING:
     from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
         KVConnectorPromMetrics,
         KVConnectorStats,
-        PromMetric,
-        PromMetricT,
     )
     from vllm.forward_context import ForwardContext
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.core.kv_cache_utils import BlockHash
     from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.metrics.backends import MetricBackend
     from vllm.v1.request import Request
 
 logger = lmcache_init_logger(__name__)
@@ -834,9 +833,9 @@ class LMCacheMPConnector(KVConnectorBase_V1):
     def build_prom_metrics(
         cls,
         vllm_config: "VllmConfig",
-        metric_types: dict[type["PromMetric"], type["PromMetricT"]],
+        backend: "MetricBackend",
         labelnames: list[str],
-        per_engine_labelvalues: dict[int, list[object]],
+        per_engine_labelvalues: dict[int, list[str]],
     ) -> "KVConnectorPromMetrics | None":
         """
         Create a KVConnectorPromMetrics subclass which should register

--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -122,21 +122,21 @@ class KVConnectorPromMetrics:
         vllm_config: VllmConfig,
         backend: MetricBackend,
         labelnames: list[str],
-        per_engine_labelvalues: dict[int, list[object]],
+        per_engine_labelvalues: dict[int, list[str]],
     ):
         self._kv_transfer_config = vllm_config.kv_transfer_config
         self._backend = backend
         self._labelnames = labelnames
         self.per_engine_labelvalues = per_engine_labelvalues
 
-    def make_per_engine(self, metric: PromMetric) -> dict[int, PromMetric]:
+    def make_per_engine(self, metric: PromMetricT) -> dict[int, PromMetricT]:
         """
         Create a per-engine child of a prometheus_client.Metric with
         the appropriate labels set. The parent metric must be created
         using the labelnames list.
         """
         return {
-            idx: metric.labels(*labelvalues)
+            idx: metric.labels(*labelvalues)  # type: ignore[return-value,misc]
             for idx, labelvalues in self.per_engine_labelvalues.items()
         }
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -3,13 +3,18 @@
 from dataclasses import dataclass, field
 from typing import Any, TypeAlias, TypeVar
 
-from prometheus_client import Counter, Gauge, Histogram
-
 from vllm.config import KVTransferConfig, VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
 from vllm.logger import init_logger
+from vllm.v1.metrics.backends import (
+    AbstractCounter,
+    AbstractGauge,
+    AbstractHistogram,
+    MetricBackend,
+    PrometheusBackend,
+)
 
-PromMetric: TypeAlias = Gauge | Counter | Histogram
+PromMetric: TypeAlias = AbstractGauge | AbstractCounter | AbstractHistogram
 PromMetricT = TypeVar("PromMetricT", bound=PromMetric)
 
 logger = init_logger(__name__)
@@ -115,14 +120,12 @@ class KVConnectorPromMetrics:
     def __init__(
         self,
         vllm_config: VllmConfig,
-        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        backend: MetricBackend,
         labelnames: list[str],
         per_engine_labelvalues: dict[int, list[object]],
     ):
         self._kv_transfer_config = vllm_config.kv_transfer_config
-        self._gauge_cls = metric_types[Gauge]
-        self._counter_cls = metric_types[Counter]
-        self._histogram_cls = metric_types[Histogram]
+        self._backend = backend
         self._labelnames = labelnames
         self.per_engine_labelvalues = per_engine_labelvalues
 
@@ -154,28 +157,24 @@ class KVConnectorPrometheus:
     KVConnectorBase.build_prom_metrics().
     """
 
-    _gauge_cls = Gauge
-    _counter_cls = Counter
-    _histogram_cls = Histogram
-
     def __init__(
         self,
         vllm_config: VllmConfig,
         labelnames: list[str],
-        per_engine_labelvalues: dict[int, list[object]],
+        per_engine_labelvalues: dict[int, list[str]],
+        backend: MetricBackend | None = None,
     ):
         self.prom_metrics: KVConnectorPromMetrics | None = None
         kv_transfer_config = vllm_config.kv_transfer_config
+
+        # Use provided backend or default to Prometheus
+        backend = backend if backend is not None else PrometheusBackend()
+
         if kv_transfer_config and kv_transfer_config.kv_connector:
             connector_cls = KVConnectorFactory.get_connector_class(kv_transfer_config)
-            metric_types = {
-                Gauge: self._gauge_cls,
-                Counter: self._counter_cls,
-                Histogram: self._histogram_cls,
-            }
             self.prom_metrics = connector_cls.build_prom_metrics(
                 vllm_config,
-                metric_types,
+                backend,
                 labelnames,
                 per_engine_labelvalues,
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -2756,15 +2756,15 @@ class NixlPromMetrics(KVConnectorPromMetrics):
             self.make_per_engine(counter_nixl_num_failed_notifications)
         )  # type: ignore[assignment]
 
-        counter_nixl_num_kv_expired_reqs = self._counter_cls(
+        counter_nixl_num_kv_expired_reqs = self._backend.create_counter(
             name="vllm:nixl_num_kv_expired_reqs",
             documentation="Number of requests that had their KV expire. "
             "NOTE: This metric is tracked on the P instance.",
             labelnames=labelnames,
         )
-        self.counter_nixl_num_kv_expired_reqs = self.make_per_engine(
-            counter_nixl_num_kv_expired_reqs
-        )
+        self.counter_nixl_num_kv_expired_reqs: dict[int, AbstractCounter] = (
+            self.make_per_engine(counter_nixl_num_kv_expired_reqs)
+        )  # type: ignore[assignment]
 
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
         for prom_obj, list_item_key in zip(

--- a/vllm/v1/metrics/backends/__init__.py
+++ b/vllm/v1/metrics/backends/__init__.py
@@ -4,7 +4,7 @@
 """Metrics backend abstraction layer.
 
 This module provides a unified interface for metrics collection that supports
-multiple backend implementations (Prometheus, OpenTelemetry, etc.).
+multiple backend implementations (Prometheus, OpenTelemetry, Ray, etc.).
 
 The abstraction allows metrics to be defined once and exported to different
 backends without code duplication.
@@ -19,6 +19,14 @@ from vllm.v1.metrics.backends.abstract import (
 from vllm.v1.metrics.backends.otel_backend import OTELBackend
 from vllm.v1.metrics.backends.prometheus_backend import PrometheusBackend
 
+try:
+    from vllm.v1.metrics.backends.ray_backend import RayBackend
+
+    RAY_AVAILABLE = True
+except ImportError:
+    RayBackend = None  # type: ignore[assignment,misc]
+    RAY_AVAILABLE = False
+
 __all__ = [
     "MetricBackend",
     "AbstractCounter",
@@ -26,4 +34,5 @@ __all__ = [
     "AbstractHistogram",
     "PrometheusBackend",
     "OTELBackend",
+    "RayBackend",
 ]

--- a/vllm/v1/metrics/backends/__init__.py
+++ b/vllm/v1/metrics/backends/__init__.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Metrics backend abstraction layer.
+
+This module provides a unified interface for metrics collection that supports
+multiple backend implementations (Prometheus, OpenTelemetry, etc.).
+
+The abstraction allows metrics to be defined once and exported to different
+backends without code duplication.
+"""
+
+from vllm.v1.metrics.backends.abstract import (
+    AbstractCounter,
+    AbstractGauge,
+    AbstractHistogram,
+    MetricBackend,
+)
+from vllm.v1.metrics.backends.otel_backend import OTELBackend
+from vllm.v1.metrics.backends.prometheus_backend import PrometheusBackend
+
+__all__ = [
+    "MetricBackend",
+    "AbstractCounter",
+    "AbstractGauge",
+    "AbstractHistogram",
+    "PrometheusBackend",
+    "OTELBackend",
+]

--- a/vllm/v1/metrics/backends/abstract.py
+++ b/vllm/v1/metrics/backends/abstract.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Abstract base classes for metrics backend implementations.
+
+This module defines the interface that all metrics backends must implement.
+It provides abstract classes for different metric types (Counter, Gauge, Histogram)
+and a MetricBackend factory interface.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class AbstractMetric(ABC):
+    """Base class for all metric types."""
+
+    def __init__(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ):
+        """Initialize a metric.
+
+        Args:
+            name: Metric name (e.g., "vllm:num_requests_running")
+            documentation: Human-readable description of the metric
+            labelnames: List of label names for dimensional metrics
+            **kwargs: Backend-specific parameters (e.g., multiprocess_mode)
+        """
+        self.name = name
+        self.documentation = documentation
+        self.labelnames = labelnames or []
+        self.extra_params = kwargs
+
+    @abstractmethod
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "AbstractMetric":
+        """Create a labeled instance of this metric.
+
+        Args:
+            *labelvalues: Label values in the same order as labelnames
+            **labelkwargs: Label values as keyword arguments
+
+        Returns:
+            A new metric instance with the specified labels
+        """
+        pass
+
+
+class AbstractCounter(AbstractMetric):
+    """Abstract counter metric (monotonically increasing value)."""
+
+    @abstractmethod
+    def inc(self, amount: float = 1.0) -> None:
+        """Increment the counter.
+
+        Args:
+            amount: Amount to increment by (default: 1.0)
+        """
+        pass
+
+
+class AbstractGauge(AbstractMetric):
+    """Abstract gauge metric (value that can go up or down)."""
+
+    @abstractmethod
+    def set(self, value: float) -> None:
+        """Set the gauge to a specific value.
+
+        Args:
+            value: The value to set
+        """
+        pass
+
+    @abstractmethod
+    def inc(self, amount: float = 1.0) -> None:
+        """Increment the gauge.
+
+        Args:
+            amount: Amount to increment by (default: 1.0)
+        """
+        pass
+
+    @abstractmethod
+    def dec(self, amount: float = 1.0) -> None:
+        """Decrement the gauge.
+
+        Args:
+            amount: Amount to decrement by (default: 1.0)
+        """
+        pass
+
+
+class AbstractHistogram(AbstractMetric):
+    """Abstract histogram metric (bucketed observations)."""
+
+    @abstractmethod
+    def observe(self, amount: float) -> None:
+        """Observe a value.
+
+        Args:
+            amount: The value to observe
+        """
+        pass
+
+
+class MetricBackend(ABC):
+    """Abstract factory for creating metrics.
+
+    Each backend (Prometheus, OpenTelemetry, etc.) implements this interface
+    to provide backend-specific metric instances.
+    """
+
+    @abstractmethod
+    def create_counter(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ) -> AbstractCounter:
+        """Create a counter metric.
+
+        Args:
+            name: Metric name
+            documentation: Human-readable description
+            labelnames: List of label names
+            **kwargs: Backend-specific parameters
+
+        Returns:
+            A counter metric instance
+        """
+        pass
+
+    @abstractmethod
+    def create_gauge(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ) -> AbstractGauge:
+        """Create a gauge metric.
+
+        Args:
+            name: Metric name
+            documentation: Human-readable description
+            labelnames: List of label names
+            **kwargs: Backend-specific parameters
+
+        Returns:
+            A gauge metric instance
+        """
+        pass
+
+    @abstractmethod
+    def create_histogram(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        buckets: list[float] | None = None,
+        **kwargs: Any,
+    ) -> AbstractHistogram:
+        """Create a histogram metric.
+
+        Args:
+            name: Metric name
+            documentation: Human-readable description
+            labelnames: List of label names
+            buckets: Histogram buckets (backend-specific default if None)
+            **kwargs: Backend-specific parameters
+
+        Returns:
+            A histogram metric instance
+        """
+        pass

--- a/vllm/v1/metrics/backends/otel_backend.py
+++ b/vllm/v1/metrics/backends/otel_backend.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""OpenTelemetry implementation of the metrics backend (PROTOTYPE).
+
+This module provides a prototype OpenTelemetry implementation of the metrics
+abstraction layer. This is a placeholder for future full OTEL support.
+
+Note: This is a prototype implementation and is not yet fully functional.
+Full OTEL support will be added in a future PR.
+"""
+
+from typing import Any
+
+from vllm.logger import init_logger
+from vllm.v1.metrics.backends.abstract import (
+    AbstractCounter,
+    AbstractGauge,
+    AbstractHistogram,
+    MetricBackend,
+)
+
+logger = init_logger(__name__)
+
+
+class OTELCounter(AbstractCounter):
+    """OpenTelemetry counter implementation (PROTOTYPE).
+
+    This is a placeholder implementation that logs metric operations.
+    Full OTEL integration will be added in a future PR.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(name, documentation, labelnames, **kwargs)
+        self._labels: dict[str, str] = {}
+        self._value: float = 0.0
+        logger.debug("OTEL Counter created: %s - %s", name, documentation)
+
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "OTELCounter":
+        """Create a labeled instance of this counter."""
+        labeled_counter = OTELCounter.__new__(OTELCounter)
+        labeled_counter.name = self.name
+        labeled_counter.documentation = self.documentation
+        labeled_counter.labelnames = self.labelnames
+        labeled_counter.extra_params = self.extra_params
+        labeled_counter._value = 0.0
+
+        # Build labels dict
+        labeled_counter._labels = {}
+        for i, value in enumerate(labelvalues):
+            if i < len(self.labelnames):
+                labeled_counter._labels[self.labelnames[i]] = value
+        labeled_counter._labels.update(labelkwargs)
+
+        return labeled_counter
+
+    def inc(self, amount: float = 1.0) -> None:
+        """Increment the counter.
+
+        Note: This is a placeholder implementation.
+        """
+        self._value += amount
+        # TODO: Implement actual OTEL counter increment
+        # This would use opentelemetry.metrics.Counter.add()
+
+
+class OTELGauge(AbstractGauge):
+    """OpenTelemetry gauge implementation (PROTOTYPE).
+
+    This is a placeholder implementation that logs metric operations.
+    Full OTEL integration will be added in a future PR.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(name, documentation, labelnames, **kwargs)
+        self._labels: dict[str, str] = {}
+        self._value: float = 0.0
+        logger.debug("OTEL Gauge created: %s - %s", name, documentation)
+
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "OTELGauge":
+        """Create a labeled instance of this gauge."""
+        labeled_gauge = OTELGauge.__new__(OTELGauge)
+        labeled_gauge.name = self.name
+        labeled_gauge.documentation = self.documentation
+        labeled_gauge.labelnames = self.labelnames
+        labeled_gauge.extra_params = self.extra_params
+        labeled_gauge._value = 0.0
+
+        # Build labels dict
+        labeled_gauge._labels = {}
+        for i, value in enumerate(labelvalues):
+            if i < len(self.labelnames):
+                labeled_gauge._labels[self.labelnames[i]] = value
+        labeled_gauge._labels.update(labelkwargs)
+
+        return labeled_gauge
+
+    def set(self, value: float) -> None:
+        """Set the gauge to a specific value.
+
+        Note: This is a placeholder implementation.
+        """
+        self._value = value
+        # TODO: Implement actual OTEL gauge set
+        # This would use opentelemetry.metrics.ObservableGauge callback
+
+    def inc(self, amount: float = 1.0) -> None:
+        """Increment the gauge.
+
+        Note: This is a placeholder implementation.
+        """
+        self._value += amount
+        # TODO: Implement actual OTEL gauge increment
+
+    def dec(self, amount: float = 1.0) -> None:
+        """Decrement the gauge.
+
+        Note: This is a placeholder implementation.
+        """
+        self._value -= amount
+        # TODO: Implement actual OTEL gauge decrement
+
+
+class OTELHistogram(AbstractHistogram):
+    """OpenTelemetry histogram implementation (PROTOTYPE).
+
+    This is a placeholder implementation that logs metric operations.
+    Full OTEL integration will be added in a future PR.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        buckets: list[float] | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(name, documentation, labelnames, **kwargs)
+        self._labels: dict[str, str] = {}
+        self._buckets = buckets
+        logger.debug("OTEL Histogram created: %s - %s", name, documentation)
+
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "OTELHistogram":
+        """Create a labeled instance of this histogram."""
+        labeled_histogram = OTELHistogram.__new__(OTELHistogram)
+        labeled_histogram.name = self.name
+        labeled_histogram.documentation = self.documentation
+        labeled_histogram.labelnames = self.labelnames
+        labeled_histogram.extra_params = self.extra_params
+        labeled_histogram._buckets = self._buckets
+
+        # Build labels dict
+        labeled_histogram._labels = {}
+        for i, value in enumerate(labelvalues):
+            if i < len(self.labelnames):
+                labeled_histogram._labels[self.labelnames[i]] = value
+        labeled_histogram._labels.update(labelkwargs)
+
+        return labeled_histogram
+
+    def observe(self, amount: float) -> None:
+        """Observe a value.
+
+        Note: This is a placeholder implementation.
+        """
+        # TODO: Implement actual OTEL histogram observation
+        # This would use opentelemetry.metrics.Histogram.record()
+        pass
+
+
+class OTELBackend(MetricBackend):
+    """OpenTelemetry implementation of the metric backend factory (PROTOTYPE).
+
+    This is a placeholder implementation for testing the abstraction layer.
+    Full OTEL support will be added in a future PR.
+
+    To use this backend:
+        backend = OTELBackend()
+        counter = backend.create_counter("my_counter", "Counter description")
+    """
+
+    def __init__(self):
+        """Initialize the OTEL backend.
+
+        Note: Full initialization with MeterProvider will be added in future PR.
+        """
+        logger.info(
+            "Initializing OTEL metrics backend (PROTOTYPE). "
+            "Full OTEL support coming in future PR."
+        )
+        # TODO: Initialize OpenTelemetry MeterProvider
+        # from opentelemetry import metrics
+        # from opentelemetry.sdk.metrics import MeterProvider
+        # self.meter_provider = MeterProvider()
+        # self.meter = self.meter_provider.get_meter("vllm")
+
+    def create_counter(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ) -> OTELCounter:
+        """Create an OTEL counter metric."""
+        return OTELCounter(name, documentation, labelnames, **kwargs)
+
+    def create_gauge(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ) -> OTELGauge:
+        """Create an OTEL gauge metric."""
+        return OTELGauge(name, documentation, labelnames, **kwargs)
+
+    def create_histogram(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        buckets: list[float] | None = None,
+        **kwargs: Any,
+    ) -> OTELHistogram:
+        """Create an OTEL histogram metric."""
+        return OTELHistogram(name, documentation, labelnames, buckets, **kwargs)

--- a/vllm/v1/metrics/backends/prometheus_backend.py
+++ b/vllm/v1/metrics/backends/prometheus_backend.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Prometheus implementation of the metrics backend.
+
+This module provides a Prometheus-specific implementation of the metrics
+abstraction layer, wrapping prometheus_client metrics.
+"""
+
+from typing import Any
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from vllm.v1.metrics.backends.abstract import (
+    AbstractCounter,
+    AbstractGauge,
+    AbstractHistogram,
+    MetricBackend,
+)
+
+
+class PrometheusCounter(AbstractCounter):
+    """Prometheus counter implementation."""
+
+    def __init__(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(name, documentation, labelnames, **kwargs)
+        self._counter = Counter(
+            name=name,
+            documentation=documentation,
+            labelnames=labelnames or [],
+            **kwargs,
+        )
+
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "PrometheusCounter":
+        """Create a labeled instance of this counter."""
+        labeled_counter = PrometheusCounter.__new__(PrometheusCounter)
+        labeled_counter.name = self.name
+        labeled_counter.documentation = self.documentation
+        labeled_counter.labelnames = self.labelnames
+        labeled_counter.extra_params = self.extra_params
+        labeled_counter._counter = self._counter.labels(*labelvalues, **labelkwargs)
+        return labeled_counter
+
+    def inc(self, amount: float = 1.0) -> None:
+        """Increment the counter."""
+        self._counter.inc(amount)
+
+
+class PrometheusGauge(AbstractGauge):
+    """Prometheus gauge implementation."""
+
+    def __init__(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(name, documentation, labelnames, **kwargs)
+        self._gauge = Gauge(
+            name=name,
+            documentation=documentation,
+            labelnames=labelnames or [],
+            **kwargs,
+        )
+
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "PrometheusGauge":
+        """Create a labeled instance of this gauge."""
+        labeled_gauge = PrometheusGauge.__new__(PrometheusGauge)
+        labeled_gauge.name = self.name
+        labeled_gauge.documentation = self.documentation
+        labeled_gauge.labelnames = self.labelnames
+        labeled_gauge.extra_params = self.extra_params
+        labeled_gauge._gauge = self._gauge.labels(*labelvalues, **labelkwargs)
+        return labeled_gauge
+
+    def set(self, value: float) -> None:
+        """Set the gauge to a specific value."""
+        self._gauge.set(value)
+
+    def inc(self, amount: float = 1.0) -> None:
+        """Increment the gauge."""
+        self._gauge.inc(amount)
+
+    def dec(self, amount: float = 1.0) -> None:
+        """Decrement the gauge."""
+        self._gauge.dec(amount)
+
+
+class PrometheusHistogram(AbstractHistogram):
+    """Prometheus histogram implementation."""
+
+    def __init__(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        buckets: list[float] | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(name, documentation, labelnames, **kwargs)
+        # If buckets are provided, add them to kwargs
+        if buckets is not None:
+            kwargs["buckets"] = buckets
+        self._histogram = Histogram(
+            name=name,
+            documentation=documentation,
+            labelnames=labelnames or [],
+            **kwargs,
+        )
+
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "PrometheusHistogram":
+        """Create a labeled instance of this histogram."""
+        labeled_histogram = PrometheusHistogram.__new__(PrometheusHistogram)
+        labeled_histogram.name = self.name
+        labeled_histogram.documentation = self.documentation
+        labeled_histogram.labelnames = self.labelnames
+        labeled_histogram.extra_params = self.extra_params
+        labeled_histogram._histogram = self._histogram.labels(
+            *labelvalues, **labelkwargs
+        )
+        return labeled_histogram
+
+    def observe(self, amount: float) -> None:
+        """Observe a value."""
+        self._histogram.observe(amount)
+
+
+class PrometheusBackend(MetricBackend):
+    """Prometheus implementation of the metric backend factory."""
+
+    def create_counter(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ) -> PrometheusCounter:
+        """Create a Prometheus counter metric."""
+        return PrometheusCounter(name, documentation, labelnames, **kwargs)
+
+    def create_gauge(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ) -> PrometheusGauge:
+        """Create a Prometheus gauge metric."""
+        return PrometheusGauge(name, documentation, labelnames, **kwargs)
+
+    def create_histogram(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        buckets: list[float] | None = None,
+        **kwargs: Any,
+    ) -> PrometheusHistogram:
+        """Create a Prometheus histogram metric."""
+        return PrometheusHistogram(name, documentation, labelnames, buckets, **kwargs)

--- a/vllm/v1/metrics/backends/ray_backend.py
+++ b/vllm/v1/metrics/backends/ray_backend.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Ray metrics implementation of the metrics backend.
+
+This module provides a Ray-specific implementation of the metrics
+abstraction layer, wrapping Ray's util.metrics library.
+"""
+
+from typing import Any
+
+try:
+    from ray.util import metrics as ray_metrics
+    from ray.util.metrics import Metric
+
+    RAY_AVAILABLE = True
+except ImportError:
+    ray_metrics = None
+    Metric = None  # type: ignore[misc,assignment]
+    RAY_AVAILABLE = False
+
+import regex as re
+
+try:
+    from ray import serve as ray_serve
+except ImportError:
+    ray_serve = None
+
+from vllm.v1.metrics.backends.abstract import (
+    AbstractCounter,
+    AbstractGauge,
+    AbstractHistogram,
+    MetricBackend,
+)
+
+
+def _get_replica_id() -> str | None:
+    """Get the current Ray Serve replica ID, or None if not in a Serve context."""
+    if ray_serve is None:
+        return None
+    try:
+        return ray_serve.get_replica_context().replica_id.unique_id
+    except ray_serve.exceptions.RayServeException:
+        return None
+
+
+def _get_sanitized_opentelemetry_name(name: str) -> str:
+    """
+    For compatibility with Ray + OpenTelemetry, the metric name must be
+    sanitized. In particular, this replaces disallowed character (e.g., ':')
+    with '_' in the metric name.
+    Allowed characters: a-z, A-Z, 0-9, _
+
+    # ruff: noqa: E501
+    Ref: https://github.com/open-telemetry/opentelemetry-cpp/blob/main/sdk/src/metrics/instrument_metadata_validator.cc#L22-L23
+    Ref: https://github.com/ray-project/ray/blob/master/src/ray/stats/metric.cc#L107
+    """
+    return re.sub(r"[^a-zA-Z0-9_]", "_", name)
+
+
+def _get_tag_keys(labelnames: list[str] | None) -> tuple[str, ...]:
+    """Get tag keys for Ray metrics, adding ReplicaId."""
+    labels = list(labelnames) if labelnames else []
+    labels.append("ReplicaId")
+    return tuple(labels)
+
+
+class RayCounter(AbstractCounter):
+    """Ray counter implementation."""
+
+    def __init__(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ):
+        if not RAY_AVAILABLE:
+            raise ImportError("Ray is not installed. Cannot use RayCounter.")
+
+        super().__init__(name, documentation, labelnames, **kwargs)
+
+        tag_keys = _get_tag_keys(labelnames)
+        name = _get_sanitized_opentelemetry_name(name)
+
+        self._counter: Metric = ray_metrics.Counter(
+            name=name, description=documentation, tag_keys=tag_keys
+        )
+
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "RayCounter":
+        """Create a labeled instance of this counter."""
+        labeled_counter = RayCounter.__new__(RayCounter)
+        labeled_counter.name = self.name
+        labeled_counter.documentation = self.documentation
+        labeled_counter.labelnames = self.labelnames
+        labeled_counter.extra_params = self.extra_params
+        labeled_counter._counter = self._counter
+
+        # Apply labels
+        if labelvalues:
+            # -1 because ReplicaId was added automatically
+            expected = len(self._counter._tag_keys) - 1
+            if len(labelvalues) != expected:
+                raise ValueError(
+                    "Number of labels must match the number of tag keys. "
+                    f"Expected {expected}, got {len(labelvalues)}"
+                )
+            labelkwargs.update(zip(self._counter._tag_keys, labelvalues))
+
+        labelkwargs["ReplicaId"] = _get_replica_id() or ""
+
+        if labelkwargs:
+            for k, v in labelkwargs.items():
+                if not isinstance(v, str):
+                    labelkwargs[k] = str(v)
+            labeled_counter._counter.set_default_tags(labelkwargs)
+
+        return labeled_counter
+
+    def inc(self, amount: float = 1.0) -> None:
+        """Increment the counter."""
+        if amount == 0:
+            return
+        self._counter.inc(amount)
+
+
+class RayGauge(AbstractGauge):
+    """Ray gauge implementation."""
+
+    def __init__(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ):
+        if not RAY_AVAILABLE:
+            raise ImportError("Ray is not installed. Cannot use RayGauge.")
+
+        # All Ray metrics are keyed by WorkerId, so multiprocess modes like
+        # "mostrecent", "all", "sum" do not apply. This logic can be manually
+        # implemented at the observability layer (Prometheus/Grafana).
+        # Remove multiprocess_mode from kwargs if present
+        kwargs.pop("multiprocess_mode", None)
+
+        super().__init__(name, documentation, labelnames, **kwargs)
+
+        tag_keys = _get_tag_keys(labelnames)
+        name = _get_sanitized_opentelemetry_name(name)
+
+        self._gauge: Metric = ray_metrics.Gauge(
+            name=name, description=documentation, tag_keys=tag_keys
+        )
+
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "RayGauge":
+        """Create a labeled instance of this gauge."""
+        labeled_gauge = RayGauge.__new__(RayGauge)
+        labeled_gauge.name = self.name
+        labeled_gauge.documentation = self.documentation
+        labeled_gauge.labelnames = self.labelnames
+        labeled_gauge.extra_params = self.extra_params
+        labeled_gauge._gauge = self._gauge
+
+        # Apply labels
+        if labelvalues:
+            # -1 because ReplicaId was added automatically
+            expected = len(self._gauge._tag_keys) - 1
+            if len(labelvalues) != expected:
+                raise ValueError(
+                    "Number of labels must match the number of tag keys. "
+                    f"Expected {expected}, got {len(labelvalues)}"
+                )
+            labelkwargs.update(zip(self._gauge._tag_keys, labelvalues))
+
+        labelkwargs["ReplicaId"] = _get_replica_id() or ""
+
+        if labelkwargs:
+            for k, v in labelkwargs.items():
+                if not isinstance(v, str):
+                    labelkwargs[k] = str(v)
+            labeled_gauge._gauge.set_default_tags(labelkwargs)
+
+        return labeled_gauge
+
+    def set(self, value: float) -> None:
+        """Set the gauge to a specific value."""
+        self._gauge.set(value)
+
+    def inc(self, amount: float = 1.0) -> None:
+        """Increment the gauge."""
+        self._gauge.inc(amount)
+
+    def dec(self, amount: float = 1.0) -> None:
+        """Decrement the gauge."""
+        self._gauge.dec(amount)
+
+
+class RayHistogram(AbstractHistogram):
+    """Ray histogram implementation."""
+
+    def __init__(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        buckets: list[float] | None = None,
+        **kwargs: Any,
+    ):
+        if not RAY_AVAILABLE:
+            raise ImportError("Ray is not installed. Cannot use RayHistogram.")
+
+        super().__init__(name, documentation, labelnames, **kwargs)
+
+        tag_keys = _get_tag_keys(labelnames)
+        name = _get_sanitized_opentelemetry_name(name)
+        boundaries = buckets if buckets else []
+
+        self._histogram: Metric = ray_metrics.Histogram(
+            name=name,
+            description=documentation,
+            tag_keys=tag_keys,
+            boundaries=boundaries,
+        )
+
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "RayHistogram":
+        """Create a labeled instance of this histogram."""
+        labeled_histogram = RayHistogram.__new__(RayHistogram)
+        labeled_histogram.name = self.name
+        labeled_histogram.documentation = self.documentation
+        labeled_histogram.labelnames = self.labelnames
+        labeled_histogram.extra_params = self.extra_params
+        labeled_histogram._histogram = self._histogram
+
+        # Apply labels
+        if labelvalues:
+            # -1 because ReplicaId was added automatically
+            expected = len(self._histogram._tag_keys) - 1
+            if len(labelvalues) != expected:
+                raise ValueError(
+                    "Number of labels must match the number of tag keys. "
+                    f"Expected {expected}, got {len(labelvalues)}"
+                )
+            labelkwargs.update(zip(self._histogram._tag_keys, labelvalues))
+
+        labelkwargs["ReplicaId"] = _get_replica_id() or ""
+
+        if labelkwargs:
+            for k, v in labelkwargs.items():
+                if not isinstance(v, str):
+                    labelkwargs[k] = str(v)
+            labeled_histogram._histogram.set_default_tags(labelkwargs)
+
+        return labeled_histogram
+
+    def observe(self, amount: float) -> None:
+        """Observe a value."""
+        self._histogram.observe(amount)
+
+
+class RayBackend(MetricBackend):
+    """Ray implementation of the metric backend factory."""
+
+    def __init__(self):
+        if not RAY_AVAILABLE:
+            raise ImportError(
+                "Ray is not installed. Cannot use RayBackend. "
+                "Please install Ray with: pip install ray"
+            )
+
+    def create_counter(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ) -> RayCounter:
+        """Create a Ray counter metric."""
+        return RayCounter(name, documentation, labelnames, **kwargs)
+
+    def create_gauge(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        **kwargs: Any,
+    ) -> RayGauge:
+        """Create a Ray gauge metric."""
+        return RayGauge(name, documentation, labelnames, **kwargs)
+
+    def create_histogram(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: list[str] | None = None,
+        buckets: list[float] | None = None,
+        **kwargs: Any,
+    ) -> RayHistogram:
+        """Create a Ray histogram metric."""
+        return RayHistogram(name, documentation, labelnames, buckets, **kwargs)

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -10,6 +10,7 @@ from typing import TypeAlias, TypeVar
 import vllm.envs as envs
 from vllm.compilation.cuda_graph import CUDAGraphLogging
 from vllm.config import SupportsMetricsInfo, VllmConfig
+from vllm.config.model import get_served_model_name
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
     KVConnectorLogging,
     KVConnectorPrometheus,
@@ -420,7 +421,9 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         )
 
         labelnames = ["model_name", "engine"]
-        model_name = vllm_config.model_config.served_model_name
+        model_name = get_served_model_name(
+            vllm_config.model_config.model, vllm_config.model_config.served_model_name
+        )
         max_model_len = vllm_config.model_config.max_model_len
 
         per_engine_labelvalues: dict[int, list[str]] = {

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -431,10 +431,13 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         }
 
         self.spec_decoding_prom = self._spec_decoding_cls(
-            vllm_config.speculative_config, labelnames, per_engine_labelvalues
+            vllm_config.speculative_config,
+            labelnames,
+            per_engine_labelvalues,
+            backend=self.backend,
         )
         self.kv_connector_prom = self._kv_connector_cls(
-            vllm_config, labelnames, per_engine_labelvalues
+            vllm_config, labelnames, per_engine_labelvalues, backend=self.backend
         )
         self.perf_metrics_prom = self._perf_metrics_cls(
             vllm_config, labelnames, per_engine_labelvalues

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -423,7 +423,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         model_name = vllm_config.model_config.served_model_name
         max_model_len = vllm_config.model_config.max_model_len
 
-        per_engine_labelvalues: dict[int, list[object]] = {
+        per_engine_labelvalues: dict[int, list[str]] = {
             idx: [model_name, str(idx)] for idx in engine_indexes
         }
 

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1209,7 +1209,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                     self.labelname_waiting_lora_adapters: waiting_lora_adapters,
                     self.labelname_max_lora: self.max_lora,
                 }
-                self.gauge_lora_info.labels(**lora_info_labels).set_to_current_time()  # type: ignore[attr-defined]
+                self.gauge_lora_info.labels(**lora_info_labels).set(time.time())  # type: ignore[attr-defined]
 
         if mm_cache_stats is not None:
             self.counter_mm_cache_queries[engine_idx].inc(mm_cache_stats.queries)

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -670,7 +670,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         self.counter_prompt_tokens_by_source: dict[str, dict[int, AbstractCounter]] = {}
         for source in PromptTokenStats.ALL_SOURCES:
             self.counter_prompt_tokens_by_source[source] = {
-                idx: counter_prompt_tokens_by_source.labels(
+                idx: counter_prompt_tokens_by_source.labels(  # type: ignore[misc]
                     model_name, str(idx), source
                 )
                 for idx in engine_indexes

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1134,7 +1134,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             name=name,
             documentation=documentation,
             multiprocess_mode="mostrecent",
-            labelnames=metrics_info.keys(),
+            labelnames=list(metrics_info.keys()),
         )
         for engine_index in self.engine_indexes:
             metrics_info = config_obj.metrics_info()
@@ -1210,7 +1210,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 lora_info_labels = {
                     self.labelname_running_lora_adapters: running_lora_adapters,
                     self.labelname_waiting_lora_adapters: waiting_lora_adapters,
-                    self.labelname_max_lora: self.max_lora,
+                    self.labelname_max_lora: str(self.max_lora),
                 }
                 self.gauge_lora_info.labels(**lora_info_labels).set(time.time())  # type: ignore[attr-defined]
 

--- a/vllm/v1/metrics/perf.py
+++ b/vllm/v1/metrics/perf.py
@@ -1257,7 +1257,7 @@ class PerfMetricsProm:
         self,
         vllm_config: VllmConfig,
         labelnames: list[str],
-        per_engine_labelvalues: dict[int, list[object]],
+        per_engine_labelvalues: dict[int, list[str]],
     ):
         counter_flops = self._counter_cls(
             name="vllm:estimated_flops_per_gpu_total",
@@ -1306,7 +1306,7 @@ class PerfMetricsProm:
 
 
 def make_per_engine(
-    counter: prometheus_client.Counter, per_engine_labelvalues: dict[int, list[object]]
+    counter: prometheus_client.Counter, per_engine_labelvalues: dict[int, list[str]]
 ):
     """Create a counter for each label value."""
     return {

--- a/vllm/v1/metrics/ray_wrappers.py
+++ b/vllm/v1/metrics/ray_wrappers.py
@@ -64,8 +64,6 @@ class RayPerfMetricsProm(PerfMetricsProm):
     uses Ray's util.metrics library.
     """
 
-    _counter_cls = RayCounterWrapper
-
 
 class RayPrometheusStatLogger(PrometheusStatLogger):
     """RayPrometheusStatLogger uses Ray metrics instead of Prometheus.

--- a/vllm/v1/metrics/ray_wrappers.py
+++ b/vllm/v1/metrics/ray_wrappers.py
@@ -1,161 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import time
 
+"""Ray-specific implementations of metrics loggers.
+
+This module provides Ray-compatible wrappers for vLLM's metrics logging
+infrastructure, using Ray's util.metrics library instead of Prometheus directly.
+"""
+
+from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorPrometheus
+from vllm.v1.metrics.backends.ray_backend import RayBackend
 from vllm.v1.metrics.loggers import PrometheusStatLogger
 from vllm.v1.metrics.perf import PerfMetricsProm
 from vllm.v1.spec_decode.metrics import SpecDecodingProm
-
-try:
-    from ray import serve as ray_serve
-    from ray.util import metrics as ray_metrics
-    from ray.util.metrics import Metric
-except ImportError:
-    ray_metrics = None
-    ray_serve = None
-import regex as re
-
-
-def _get_replica_id() -> str | None:
-    """Get the current Ray Serve replica ID, or None if not in a Serve context."""
-    if ray_serve is None:
-        return None
-    try:
-        return ray_serve.get_replica_context().replica_id.unique_id
-    except ray_serve.exceptions.RayServeException:
-        return None
-
-
-class RayPrometheusMetric:
-    def __init__(self):
-        if ray_metrics is None:
-            raise ImportError("RayPrometheusMetric requires Ray to be installed.")
-        self.metric: Metric = None
-
-    @staticmethod
-    def _get_tag_keys(labelnames: list[str] | None) -> tuple[str, ...]:
-        labels = list(labelnames) if labelnames else []
-        labels.append("ReplicaId")
-        return tuple(labels)
-
-    def labels(self, *labels, **labelskwargs):
-        if labels:
-            # -1 because ReplicaId was added automatically
-            expected = len(self.metric._tag_keys) - 1
-            if len(labels) != expected:
-                raise ValueError(
-                    "Number of labels must match the number of tag keys. "
-                    f"Expected {expected}, got {len(labels)}"
-                )
-            labelskwargs.update(zip(self.metric._tag_keys, labels))
-
-        labelskwargs["ReplicaId"] = _get_replica_id() or ""
-
-        if labelskwargs:
-            for k, v in labelskwargs.items():
-                if not isinstance(v, str):
-                    labelskwargs[k] = str(v)
-            self.metric.set_default_tags(labelskwargs)
-        return self
-
-    @staticmethod
-    def _get_sanitized_opentelemetry_name(name: str) -> str:
-        """
-        For compatibility with Ray + OpenTelemetry, the metric name must be
-        sanitized. In particular, this replaces disallowed character (e.g., ':')
-        with '_' in the metric name.
-        Allowed characters: a-z, A-Z, 0-9, _
-
-        # ruff: noqa: E501
-        Ref: https://github.com/open-telemetry/opentelemetry-cpp/blob/main/sdk/src/metrics/instrument_metadata_validator.cc#L22-L23
-        Ref: https://github.com/ray-project/ray/blob/master/src/ray/stats/metric.cc#L107
-        """
-
-        return re.sub(r"[^a-zA-Z0-9_]", "_", name)
-
-
-class RayGaugeWrapper(RayPrometheusMetric):
-    """Wraps around ray.util.metrics.Gauge to provide same API as
-    prometheus_client.Gauge"""
-
-    def __init__(
-        self,
-        name: str,
-        documentation: str | None = "",
-        labelnames: list[str] | None = None,
-        multiprocess_mode: str | None = "",
-    ):
-        # All Ray metrics are keyed by WorkerId, so multiprocess modes like
-        # "mostrecent", "all", "sum" do not apply. This logic can be manually
-        # implemented at the observability layer (Prometheus/Grafana).
-        del multiprocess_mode
-
-        tag_keys = self._get_tag_keys(labelnames)
-        name = self._get_sanitized_opentelemetry_name(name)
-
-        self.metric = ray_metrics.Gauge(
-            name=name,
-            description=documentation,
-            tag_keys=tag_keys,
-        )
-
-    def set(self, value: int | float):
-        return self.metric.set(value)
-
-    def set_to_current_time(self):
-        # ray metrics doesn't have set_to_current time, https://docs.ray.io/en/latest/_modules/ray/util/metrics.html
-        return self.metric.set(time.time())
-
-
-class RayCounterWrapper(RayPrometheusMetric):
-    """Wraps around ray.util.metrics.Counter to provide same API as
-    prometheus_client.Counter"""
-
-    def __init__(
-        self,
-        name: str,
-        documentation: str | None = "",
-        labelnames: list[str] | None = None,
-    ):
-        tag_keys = self._get_tag_keys(labelnames)
-        name = self._get_sanitized_opentelemetry_name(name)
-        self.metric = ray_metrics.Counter(
-            name=name,
-            description=documentation,
-            tag_keys=tag_keys,
-        )
-
-    def inc(self, value: int | float = 1.0):
-        if value == 0:
-            return
-        return self.metric.inc(value)
-
-
-class RayHistogramWrapper(RayPrometheusMetric):
-    """Wraps around ray.util.metrics.Histogram to provide same API as
-    prometheus_client.Histogram"""
-
-    def __init__(
-        self,
-        name: str,
-        documentation: str | None = "",
-        labelnames: list[str] | None = None,
-        buckets: list[float] | None = None,
-    ):
-        tag_keys = self._get_tag_keys(labelnames)
-        name = self._get_sanitized_opentelemetry_name(name)
-
-        boundaries = buckets if buckets else []
-        self.metric = ray_metrics.Histogram(
-            name=name,
-            description=documentation,
-            tag_keys=tag_keys,
-            boundaries=boundaries,
-        )
-
-    def observe(self, value: int | float):
-        return self.metric.observe(value)
 
 
 class RaySpecDecodingProm(SpecDecodingProm):
@@ -165,7 +22,18 @@ class RaySpecDecodingProm(SpecDecodingProm):
     util.metrics library.
     """
 
-    _counter_cls = RayCounterWrapper
+    def __init__(
+        self,
+        speculative_config,
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[str]],
+        backend=None,
+    ):
+        # Use RayBackend if no backend is provided
+        backend = backend if backend is not None else RayBackend()
+        super().__init__(
+            speculative_config, labelnames, per_engine_labelvalues, backend=backend
+        )
 
 
 class RayKVConnectorPrometheus(KVConnectorPrometheus):
@@ -175,9 +43,18 @@ class RayKVConnectorPrometheus(KVConnectorPrometheus):
     uses Ray's util.metrics library.
     """
 
-    _gauge_cls = RayGaugeWrapper
-    _counter_cls = RayCounterWrapper
-    _histogram_cls = RayHistogramWrapper
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[str]],
+        backend=None,
+    ):
+        # Use RayBackend if no backend is provided
+        backend = backend if backend is not None else RayBackend()
+        super().__init__(
+            vllm_config, labelnames, per_engine_labelvalues, backend=backend
+        )
 
 
 class RayPerfMetricsProm(PerfMetricsProm):
@@ -191,16 +68,27 @@ class RayPerfMetricsProm(PerfMetricsProm):
 
 
 class RayPrometheusStatLogger(PrometheusStatLogger):
-    """RayPrometheusStatLogger uses Ray metrics instead."""
+    """RayPrometheusStatLogger uses Ray metrics instead of Prometheus.
 
-    _gauge_cls = RayGaugeWrapper
-    _counter_cls = RayCounterWrapper
-    _histogram_cls = RayHistogramWrapper
+    This logger uses a RayBackend to create Ray metrics instead of
+    Prometheus metrics, enabling integration with Ray's metrics system.
+    """
+
     _spec_decoding_cls = RaySpecDecodingProm
     _kv_connector_cls = RayKVConnectorPrometheus
     _perf_metrics_cls = RayPerfMetricsProm
 
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        engine_indexes: list[int] | None = None,
+        backend=None,
+    ):
+        # Use RayBackend if no backend is provided
+        backend = backend if backend is not None else RayBackend()
+        super().__init__(vllm_config, engine_indexes, backend=backend)
+
     @staticmethod
     def _unregister_vllm_metrics():
-        # No-op on purpose
+        # No-op on purpose - Ray handles its own metric lifecycle
         pass

--- a/vllm/v1/spec_decode/metrics.py
+++ b/vllm/v1/spec_decode/metrics.py
@@ -198,7 +198,7 @@ class SpecDecodingProm:
         self.counter_spec_decode_num_accepted_tokens_per_pos: dict[
             int, list[AbstractCounter]
         ] = {
-            idx: [base_counter.labels(*lv, str(pos)) for pos in range(num_spec_tokens)]
+            idx: [base_counter.labels(*lv, str(pos)) for pos in range(num_spec_tokens)]  # type: ignore[misc]
             for idx, lv in per_engine_labelvalues.items()
         }
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -757,6 +757,7 @@ class Worker(WorkerBase):
                 elif self.profiler_config.profiler == "cuda":
                     self.profiler = CudaProfilerWrapper(self.profiler_config)
                     logger.debug("Starting CUDA profiler")
+                assert self.profiler is not None
                 self.profiler.start()
             else:
                 # Profiler already initialized. Restart profiling but keep


### PR DESCRIPTION
## Purpose
Implemented feature https://github.com/vllm-project/vllm/issues/30394

Why is this change important:
* OTEL is becoming "the standard" in production environments as observability framework
* It is not only related to metrics but logs and traces as well which would create unified tool for all of those
* It would allow to operate VLLM in production with more confidance identifying issues raised by metrics based alerting more quickly

## Test Plan
Added tests.

## Test Result
All metrics test pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit f8a2b42c9e6d78690da5b31cca1726d859e2c55c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces a backend-agnostic metrics layer and migrates existing metrics to it.
> 
> - Adds `vllm.v1.metrics.backends` with `MetricBackend` + abstract metric types and implementations: `PrometheusBackend` (default) and prototype `OTELBackend`
> - Refactors `PrometheusStatLogger`, KV connector metrics (`KVConnectorPrometheus`, `KVConnectorPromMetrics`, `NixlPromMetrics`, multi-connector), and speculative decoding metrics to create metrics via backend (`create_counter/gauge/histogram`) instead of `prometheus_client`
> - Updates method signatures and types (e.g., `build_prom_metrics(backend, ...)`, `per_engine_labelvalues: dict[int, list[str]]`), adjusts bucket types to float, and uses `get_served_model_name` for labels
> - Keeps deprecated metrics behind `show_hidden_metrics`; no functional changes to metric semantics beyond backend indirection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 767dcd4fdceea9a3deed5823c35a1ca57d602f5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces a backend-agnostic metrics abstraction and migrates metrics to it.
> 
> - Adds `vllm.v1.metrics.backends` with `MetricBackend` and abstract metric types; implements `PrometheusBackend` (default), `RayBackend` (with name sanitization), and prototype `OTELBackend`
> - Refactors `PrometheusStatLogger`, speculative decoding metrics, and KV connector metrics (`KVConnectorPrometheus`, `KVConnectorPromMetrics`, `NixlPromMetrics`, multi-connector) to create metrics via backend (`create_counter/gauge/histogram`) and accept `backend` in constructors
> - Updates APIs/types: `build_prom_metrics(vllm_config, backend, labelnames, per_engine_labelvalues)`, `per_engine_labelvalues: dict[int, list[str]]`, histogram buckets now `float`, and uses `get_served_model_name` for labels
> - Replaces Ray-specific wrappers to use the new backend (`RayPrometheusStatLogger`, `RayKVConnectorPrometheus`, `RaySpecDecodingProm`); adds tests for Ray metric name sanitization and smoke test for Ray stat logger
> - Keeps deprecated metrics behind `show_hidden_metrics`; no semantic changes to metric values aside from backend indirection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55e85d21e3ed61d932709189a65e4fc8b3e4dd46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
