### PR TITLE
[Bugfix] Skip missing parameters during GGUF Gemma2 weight loading

### DIFF
--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -365,6 +365,10 @@ class Gemma2Model(nn.Module):
                     continue
                 if is_pp_missing_parameter(name, self):
                     continue
+                # Skip parameters not in the model (e.g., GGUF quantization
+                # metadata like qweight_type for embeddings)
+                if name not in params_dict:
+                    continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)


### PR DESCRIPTION
## Summary
Skip parameters not present in the model during GGUF weight loading, fixing `KeyError: 'embed_tokens.qweight_type'` when loading GGUF Gemma2 models.

## Root Cause
The GGUF loader yields quantization metadata parameters (`qweight_type`) for all quantized tensors, including embeddings. However, `VocabParallelEmbedding` doesn't have these parameters, causing a KeyError during engine core initialization.

## Changes
- Add safety check in `Gemma2Model.load_weights()` to skip parameters not in `params_dict`
- Matches existing pattern in `llama.py` (lines 502-503)

## Testing
- Tested with GGUF Gemma2 models that previously failed with KeyError
- Model loads successfully and generates coherent output

🤖 Generated with [Claude Code](https://claude.com/claude-code)