### PR TITLE
feat(api): Eager chat template warmup to eliminate first-request latency

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1082,6 +1082,9 @@ async def init_app_state(
         if "generate" in supported_tasks
         else None
     )
+    # Warm up chat template processing to avoid first-request latency
+    if state.openai_serving_chat is not None:
+        await state.openai_serving_chat.warmup()
     state.openai_serving_completion = (
         OpenAIServingCompletion(
             engine_client,

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -72,55 +72,6 @@ def kernel_warmup(worker: "Worker"):
             create_mixed_batch=True,
         )
 
-    # Attention backend warmup (non-FlashInfer too).
-    #
-    # NOTE: The default startup "profile run" intentionally avoids building
-    # attention metadata unless running FULL CUDA graphs, which can leave
-    # attention kernels/backends (e.g. FlashAttention/Triton) uninitialized.
-    # That shows up as a slow first real request due to JIT/autotune work.
-    #
-    # Here we force a small attention-inclusive dummy run so the attention path
-    # is exercised during startup across backends.
-    if (
-        (not worker.model_runner.is_pooling_model)
-        and worker.model_runner.attn_groups
-        and (not worker.model_config.is_encoder_decoder)
-    ):
-        try:
-            max_batched_tokens = worker.scheduler_config.max_num_batched_tokens
-            max_num_seqs = worker.scheduler_config.max_num_seqs
-            uniform_decode_query_len = getattr(
-                worker.model_runner, "uniform_decode_query_len", 1
-            )
-
-            # 1) Mixed prefill+decode warmup (covers both paths, low cost).
-            mixed_tokens = min(16, max_batched_tokens)
-            if mixed_tokens > 0:
-                worker.model_runner._dummy_run(
-                    num_tokens=mixed_tokens,
-                    skip_eplb=True,
-                    is_profile=True,
-                    force_attention=True,
-                    create_mixed_batch=True,
-                )
-
-            # 2) Uniform decode warmup (hits decode-specialized attention paths).
-            # Keep it small to avoid extra startup latency.
-            q = max(1, int(uniform_decode_query_len))
-            num_reqs = min(16, max_num_seqs, max_batched_tokens // q)
-            decode_tokens = q * num_reqs
-            if decode_tokens > 0:
-                worker.model_runner._dummy_run(
-                    num_tokens=decode_tokens,
-                    skip_eplb=True,
-                    is_profile=True,
-                    force_attention=True,
-                    uniform_decode=True,
-                )
-        except Exception:
-            # Best-effort: warmup should never block engine startup.
-            logger.exception("Attention backend warmup failed; continuing startup.")
-
 
 def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     """

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -72,6 +72,55 @@ def kernel_warmup(worker: "Worker"):
             create_mixed_batch=True,
         )
 
+    # Attention backend warmup (non-FlashInfer too).
+    #
+    # NOTE: The default startup "profile run" intentionally avoids building
+    # attention metadata unless running FULL CUDA graphs, which can leave
+    # attention kernels/backends (e.g. FlashAttention/Triton) uninitialized.
+    # That shows up as a slow first real request due to JIT/autotune work.
+    #
+    # Here we force a small attention-inclusive dummy run so the attention path
+    # is exercised during startup across backends.
+    if (
+        (not worker.model_runner.is_pooling_model)
+        and worker.model_runner.attn_groups
+        and (not worker.model_config.is_encoder_decoder)
+    ):
+        try:
+            max_batched_tokens = worker.scheduler_config.max_num_batched_tokens
+            max_num_seqs = worker.scheduler_config.max_num_seqs
+            uniform_decode_query_len = getattr(
+                worker.model_runner, "uniform_decode_query_len", 1
+            )
+
+            # 1) Mixed prefill+decode warmup (covers both paths, low cost).
+            mixed_tokens = min(16, max_batched_tokens)
+            if mixed_tokens > 0:
+                worker.model_runner._dummy_run(
+                    num_tokens=mixed_tokens,
+                    skip_eplb=True,
+                    is_profile=True,
+                    force_attention=True,
+                    create_mixed_batch=True,
+                )
+
+            # 2) Uniform decode warmup (hits decode-specialized attention paths).
+            # Keep it small to avoid extra startup latency.
+            q = max(1, int(uniform_decode_query_len))
+            num_reqs = min(16, max_num_seqs, max_batched_tokens // q)
+            decode_tokens = q * num_reqs
+            if decode_tokens > 0:
+                worker.model_runner._dummy_run(
+                    num_tokens=decode_tokens,
+                    skip_eplb=True,
+                    is_profile=True,
+                    force_attention=True,
+                    uniform_decode=True,
+                )
+        except Exception:
+            # Best-effort: warmup should never block engine startup.
+            logger.exception("Attention backend warmup failed; continuing startup.")
+
 
 def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     """


### PR DESCRIPTION
## Summary
Adds automatic warmup of chat template processing during server initialization to eliminate the significant latency penalty on the first chat completion request.

## Problem
When a vLLM server starts, the first chat completion request experiences much higher latency than subsequent requests. This is caused by lazy initialization of:

1. **Chat template content format auto-detection** — Analyzes the Jinja2 template structure
2. **Jinja2 template compilation** — Compiles the chat template on first use  
3. **Tokenizer chat initialization** — First-time setup of tokenizer for chat formatting

This creates problems in production:
- Load balancers may timeout on the first request
- Users experience inconsistent response times
- The `/health` endpoint reports healthy before the server is truly "warm"

## Solution
Add a `warmup()` method to `OpenAIServingChat` that runs during `init_app_state()`, **before** the server starts accepting requests:

```python
async def warmup(self) -> None:
    # Get tokenizer and create minimal dummy request
    tokenizer = await self.engine_client.get_tokenizer()
    dummy_request = ChatCompletionRequest(
        messages=[{"role": "user", "content": "warmup"}],
        model=None,
        max_completion_tokens=1,
    )
    # Trigger template compilation
    await self._preprocess_chat(dummy_request, tokenizer, ...)
```

**Key design decisions:**
- Reuses existing `_preprocess_chat()` rather than duplicating logic
- Handles exceptions gracefully (logs warning with full traceback, doesn't fail startup)
- Logs timing for observability
- Runs before `/health` reports healthy

## Changes
- `vllm/entrypoints/openai/serving_chat.py` — Added `warmup()` method (+49 lines)
- `vllm/entrypoints/openai/api_server.py` — Call warmup in `init_app_state()` (+3 lines)

---

## Verification

Tested on **Qwen/Qwen3-4B** on **NVIDIA H100** with **vllm/vllm-openai:v0.12.0**.

*Note: Actual timings vary based on model, hardware, and configuration.*

**Before (without warmup):**
| Request | Latency |
|---------|---------|
| 1st chat completion | ~1050ms |
| 2nd chat completion | ~170ms |

**After (with warmup):**
| Request | Latency |
|---------|---------|
| 1st chat completion | ~170ms |
| 2nd chat completion | ~170ms |

Server logs now show warmup during initialization:
```
INFO: Warming up chat template processing...
INFO: Detected the chat template content format to be 'string'...
INFO: Chat template warmup completed in ~850ms
```

The warmup cost is moved from the first user request to server startup, ensuring consistent response times from the first request onward.
