### PR TITLE
[Bugfix] Fix ViT with FlashAttention on ROCm

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -464,7 +464,10 @@ class MultiHeadAttention(nn.Module):
         }
 
         self.fa_version = None
-        if self.attn_backend == AttentionBackendEnum.FLASH_ATTN:
+        if (
+            self.attn_backend == AttentionBackendEnum.FLASH_ATTN
+            and current_platform.is_cuda()
+        ):
             self.fa_version = get_flash_attn_version()
             assert self._flash_attn_varlen_func is not None
             self._flash_attn_varlen_func = functools.partial(


### PR DESCRIPTION
## Purpose
#30575 introduced a bug on AMD because AMD's `flash_attn_varlen_func` doesn't take the `fa_version` argument. This led to CI failures: https://buildkite.com/vllm/amd-ci/builds/1680/steps/canvas?sid=019b222d-cb50-495f-b5e2-3ba219617298

This PR is a fix for that failure.

## Test Plan
AMD CI: `mi325_1: V1 Test entrypoints`, specifically `v1/entrypoints/openai/test_completion_with_image_embeds.py::test_completions_with_image_embeds[dtype0-llava-hf/llava-1.5-7b-hf]`

## Test Result
Should pass in CI

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

