### PR TITLE
[Bugfix] Fail instead of ignoring when CompilationConfig gets invalid args

### DIFF
--- a/tests/benchmarks/test_param_sweep.py
+++ b/tests/benchmarks/test_param_sweep.py
@@ -23,14 +23,6 @@ class TestParameterSweepItem:
                 {"compilation_config.use_inductor_graph_partition": True},
                 "--compilation-config.use_inductor_graph_partition=true",
             ),
-            (
-                {"compilation_config.use_inductor": False},
-                "--compilation-config.use_inductor=false",
-            ),
-            (
-                {"compilation_config.use_inductor": True},
-                "--compilation-config.use_inductor=true",
-            ),
         ],
     )
     def test_nested_boolean_params(self, input_dict, expected):

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -8,7 +8,7 @@ from dataclasses import field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
-from pydantic import Field, TypeAdapter, field_validator
+from pydantic import ConfigDict, Field, TypeAdapter, field_validator
 from pydantic.dataclasses import dataclass
 
 import vllm.envs as envs
@@ -96,7 +96,7 @@ class CUDAGraphMode(enum.Enum):
 
 
 @config
-@dataclass
+@dataclass(config=ConfigDict(extra="forbid"))
 class PassConfig:
     """Configuration for custom Inductor passes.
 
@@ -251,7 +251,7 @@ class DynamicShapesType(str, enum.Enum):
 
 
 @config
-@dataclass
+@dataclass(config=ConfigDict(extra="forbid"))
 class DynamicShapesConfig:
     """Configuration to control/debug torch compile dynamic shapes."""
 
@@ -290,7 +290,7 @@ class DynamicShapesConfig:
 
 
 @config
-@dataclass
+@dataclass(config=ConfigDict(extra="forbid"))
 class CompilationConfig:
     """Configuration for compilation.
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

I noticed this when trying to run with an old flag of `-cc.use_inductor=False` where I saw that my arg was completely ignored:
```
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 --port 9000 --tensor-parallel-size 1 --max-model-len 50k --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}' -cc.use_inductor=false
(APIServer pid=3033517) INFO 12-15 12:44:29 [api_server.py:1351] vLLM API server version 0.11.2.dev695+g5c213d289
(APIServer pid=3033517) INFO 12-15 12:44:29 [utils.py:253] non-default args: {'model_tag': 'Qwen/Qwen3-Next-80B-A3B-Instruct-FP8', 'port': 9000, 'model': 'Qwen/Qwen3-Next-80B-A3B-Instruct-FP8', 'max_model_len': 50000, 'speculative_config': {'method': 'qwen3_next_mtp', 'num_speculative_tokens': 2}}
```

Now when I run the same command, I see a usage failure as expected:
```
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 --port 9000 --tensor-parallel-size 1 --max-model-len 50k --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}' -cc.use_inductor=false
usage: vllm serve [model_tag] [options]
vllm serve: error: argument --compilation-config/-cc: 1 validation error for CompilationConfig
use_inductor
  Unexpected keyword argument [type=unexpected_keyword_argument, input_value=False, input_type=bool]
    For further information visit https://errors.pydantic.dev/2.12/v/unexpected_keyword_argument
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

