### PR TITLE
[Misc][LLaMa4] Compile LLaMa Vision Encoder

### DIFF
--- a/tests/compile/fullgraph/test_multimodal_compile.py
+++ b/tests/compile/fullgraph/test_multimodal_compile.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import pytest
-import torch
 
 from vllm.compilation.counter import compilation_counter
 from vllm.config import VllmConfig
@@ -75,11 +74,9 @@ def test_qwen2_5_vl_no_vit_compilation(vllm_runner, monkeypatch):
 
 
 # forked needed to workaround https://github.com/vllm-project/vllm/issues/21073
+# Requires Cuda and 8 gpus as well
 @pytest.mark.forked
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="Skip if not cuda")
-@pytest.mark.skipif(
-    torch.cuda.device_count() < 8, reason="Need at least 8 GPUs to run the test."
-)
+@pytest.mark.skip(reason="Skipping due to CI resource constraints")
 def test_mllama4_vit_compilation(vllm_runner, monkeypatch):
     """Test that Mllama4 vision submodules are compiled.
 
@@ -89,8 +86,6 @@ def test_mllama4_vit_compilation(vllm_runner, monkeypatch):
 
     However since we are using TP=8, we compilation_counter will not
     work properly so we will just check the run succeeds rn
-
-    TODO: Figure out how to fix compilation_counter for TP > 1
     """
     # Disable multiprocessing so that the counter is in the same process
     monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -427,8 +427,8 @@ class CompilationConfig:
     If empty list [], no ops are excluded (suitable for full cudagraphs)."""
     compile_mm_encoder: bool = False
     """Whether or not to compile the multimodal encoder.
-    Currently, this only works for `Qwen2_5_vl` and mllama4 models
-    on selected platforms. Disabled by default until more models 
+    Currently, this only works for `Qwen2_5_vl` and `mLLaMa4` models
+    on selected platforms. Disabled by default until more models
     are supported/tested to work."""
 
     # Inductor capture

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -427,8 +427,9 @@ class CompilationConfig:
     If empty list [], no ops are excluded (suitable for full cudagraphs)."""
     compile_mm_encoder: bool = False
     """Whether or not to compile the multimodal encoder.
-    Currently, this only works for `Qwen2_5_vl` on selected platforms.
-    Disabled by default until more models are supported/tested to work."""
+    Currently, this only works for `Qwen2_5_vl` and mllama4 models
+    on selected platforms. Disabled by default until more models 
+    are supported/tested to work."""
 
     # Inductor capture
     compile_sizes: list[int | str] | None = None

--- a/vllm/model_executor/layers/attention/mm_encoder_attention.py
+++ b/vllm/model_executor/layers/attention/mm_encoder_attention.py
@@ -173,8 +173,8 @@ class MMEncoderAttention(CustomOp):
             v=value,
             batch_size=bsz,
             is_rocm_aiter=(self.attn_backend == AttentionBackendEnum.ROCM_AITER_FA),
-            scale=self.scale,
             fa_version=self._fa_version,
+            scale=self.scale,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
         )

--- a/vllm/model_executor/layers/attention/mm_encoder_attention.py
+++ b/vllm/model_executor/layers/attention/mm_encoder_attention.py
@@ -171,12 +171,12 @@ class MMEncoderAttention(CustomOp):
             q=query,
             k=key,
             v=value,
-            scale=self.scale,
-            cu_seqlens=cu_seqlens,
-            max_seqlen=max_seqlen,
             batch_size=bsz,
             is_rocm_aiter=(self.attn_backend == AttentionBackendEnum.ROCM_AITER_FA),
+            scale=self.scale,
             fa_version=self._fa_version,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
         )
         if is_reshaped:
             output = output.reshape(bsz, q_len, -1)

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -370,7 +370,9 @@ def llama_model_invariants(
 
 
 @support_torch_compile(
-    mark_unbacked_dims={"input_ids": 0}, shape_invariants=llama_model_invariants
+    # TODO[#32068]: Investigate recompilation
+    # mark_unbacked_dims={"input_ids": 0},
+    shape_invariants=llama_model_invariants
 )
 class LlamaModel(nn.Module):
     def __init__(

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -369,7 +369,9 @@ def llama_model_invariants(
         torch._check(positions.size()[0] == input_ids.size()[0])
 
 
-@support_torch_compile(shape_invariants=llama_model_invariants)
+@support_torch_compile(
+    mark_unbacked_dims={"input_ids": 0}, shape_invariants=llama_model_invariants
+)
 class LlamaModel(nn.Module):
     def __init__(
         self,
@@ -415,9 +417,6 @@ class LlamaModel(nn.Module):
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        # Need explicit mark here to avoid recompile from 0/1 spec
-        # since VocabEmbedding uses a different torch.compile decorator
-        torch._dynamo.decorators.mark_unbacked(input_ids, 0)
         return self.embed_tokens(input_ids)
 
     def forward(

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -415,6 +415,9 @@ class LlamaModel(nn.Module):
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        # Need explicit mark here to avoid recompile from 0/1 spec
+        # since VocabEmbedding uses a different torch.compile decorator
+        torch._dynamo.decorators.mark_unbacked(input_ids, 0)
         return self.embed_tokens(input_ids)
 
     def forward(

--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -31,12 +31,12 @@ from transformers.models.llama4.image_processing_llama4_fast import (
     get_best_fit,
 )
 
-from vllm.attention.layers.mm_encoder_attention import MMEncoderAttention
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.forward_context import set_forward_context
+from vllm.model_executor.layers.attention.mm_encoder_attention import MMEncoderAttention
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,

--- a/vllm/v1/attention/ops/vit_attn_wrappers.py
+++ b/vllm/v1/attention/ops/vit_attn_wrappers.py
@@ -12,99 +12,12 @@ latencies by ~7% (see qwen2_5_vl for example usage)
 To use these ops, you must have a recent version of PyTorch installed (>= 2.4.0)
 """
 
-import functools
-
 import einops
 import torch
 import torch.nn.functional as F
 
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
-
-
-# NOTE: This wrapper is needed because FA does not yet support
-# torch.compile. Once it does, we can remove this wrapper.
-def llama4_flash_attn_wrapper(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cu_seqlens_q: torch.Tensor,
-    cu_seqlens_k: torch.Tensor,
-    max_seqlen_q: int,
-    max_seqlen_k: int,
-    softmax_scale: float,
-    is_rocm_aiter: bool,
-) -> torch.Tensor:
-    if is_rocm_aiter:
-        from aiter import flash_attn_varlen_func
-    else:
-        # Is FA so we need to get version
-        from vllm.attention.utils.fa_utils import (
-            flash_attn_varlen_func,
-            get_flash_attn_version,
-        )
-
-        fa_version = get_flash_attn_version()
-        flash_attn_varlen_func = functools.partial(
-            flash_attn_varlen_func, fa_version=fa_version
-        )
-
-    return flash_attn_varlen_func(
-        q,
-        k,
-        v,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=max_seqlen_q,
-        max_seqlen_k=max_seqlen_k,
-        softmax_scale=softmax_scale,
-    )
-
-
-def llama4_flash_attn_wrapper_fake(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cu_seqlens_q: torch.Tensor,
-    cu_seqlens_k: torch.Tensor,
-    max_seqlen_q: int,
-    max_seqlen_k: int,
-    softmax_scale: float,
-    is_rocm_aiter: bool,
-) -> torch.Tensor:
-    bs, h, d = q.shape
-    return torch.empty_like(q)
-
-
-direct_register_custom_op(
-    op_name="llama4_flash_attn_wrapper",
-    op_func=llama4_flash_attn_wrapper,
-    fake_impl=llama4_flash_attn_wrapper_fake,
-)
-
-
-def llama4_flash_attn_wrapper_call(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cu_seqlens_q: torch.Tensor,
-    cu_seqlens_k: torch.Tensor,
-    max_seqlen_q: int,
-    max_seqlen_k: int,
-    softmax_scale: float,
-    is_rocm_aiter: bool = False,
-) -> torch.Tensor:
-    return torch.ops.vllm.llama4_flash_attn_wrapper(
-        q,
-        k,
-        v,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=max_seqlen_q,
-        max_seqlen_k=max_seqlen_k,
-        softmax_scale=softmax_scale,
-        is_rocm_aiter=is_rocm_aiter,
-    )
 
 
 def flash_attn_maxseqlen_wrapper(
@@ -159,9 +72,9 @@ def flash_attn_maxseqlen_wrapper_fake(
     batch_size: int,
     is_rocm_aiter: bool,
     fa_version: int | None,
-    scale: float | None,
-    cu_seqlens: torch.Tensor | None,
-    max_seqlen: torch.Tensor | None,
+    scale: float | None = None, 
+    cu_seqlens: torch.Tensor | None = None,
+    max_seqlen: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return torch.empty_like(q)
 

--- a/vllm/v1/attention/ops/vit_attn_wrappers.py
+++ b/vllm/v1/attention/ops/vit_attn_wrappers.py
@@ -72,7 +72,7 @@ def flash_attn_maxseqlen_wrapper_fake(
     batch_size: int,
     is_rocm_aiter: bool,
     fa_version: int | None,
-    scale: float | None = None, 
+    scale: float | None = None,
     cu_seqlens: torch.Tensor | None = None,
     max_seqlen: torch.Tensor | None = None,
 ) -> torch.Tensor:


### PR DESCRIPTION
## Purpose
We want to speedup up inference for mllama4 by applying `torch.compile` to the intensive workload, similar to what is done in #23207.  We start by enabling the VisionEncoder + PixelShuffle

## Test Plan
### Unit Test
```
with-proxy pytest tests/compile/fullgraph/test_multimodal_compile.py::test_mllama4_vit_compilation
```
Result:
```
 1 passed, 27 warnings in 176.88s (0:02:56) 
```

### Offline Test
```
with-proxy VLLM_USE_V1=1 python examples/offline_inference/vision_language.py -m llama4
```
With `compilation_config={"compile_mm_encoder": True}` monkey patched to EngineArgs

Results in
```
--------------------------------------------------
The image depicts a tower, likely Tokyo Tower, framed by cherry blossoms. The tower is white and has a distinctive shape, with a large sphere at the top and a long, thin spire extending from it. It appears to be made of metal and has a lattice-like structure.

In the foreground, there are
--------------------------------------------------
The image depicts a tower, likely Tokyo Tower, framed by cherry blossoms. The tower is white and has a distinctive shape, with a large sphere at the top and a series of latticework sections below it. It appears to be made of metal and has a tall, slender design.

In the foreground, there are
--------------------------------------------------
The image depicts a serene scene of Tokyo Tower, partially obscured by the vibrant pink blossoms of cherry blossom trees. The tower's white and gold structure is visible through the branches and flowers, set against a clear blue sky.

**Key Features:**

* **Tokyo Tower:** A prominent landmark in Tokyo, Japan,
--------------------------------------------------
The image depicts a serene scene of Tokyo Tower, partially obscured by blooming cherry blossoms. The tower's distinctive shape and structure are visible through the branches of the trees, which are adorned with vibrant pink flowers.

**Key Features:**

* **Tokyo Tower:** A prominent landmark in Tokyo, Japan, known for
--------------------------------------------------
```

### Server Benchmark
```
vllm serve meta-llama/Llama-4-Scout-17B-16E-Instruct --tensor-parallel-size=8 --gpu_memory_utilization=.8 --max_model_len=8192 --compilation-config='{"compile_mm_encoder":"true"}'
```

```
vllm bench serve   --backend openai-chat   --model meta-llama/Llama-4-Scout-17B-16E-Instruct    --endpoint /v1/chat/completions   --dataset-name hf   --dataset-path lmarena-ai/VisionArena-Chat   --hf-split train   --num-prompts 1000
```
## Test Result
|  | Main |  This PR  |
|----------|:--------:|---------:|
| Successful requests | 998 | 998 |
| Benchmark duration (s) | 63.54 | 61.71 |
| Total generated tokens | 117050 | 117397 |
| Request throughput (req/s) | 15.71 | 16.17 | 
| Output token throughput (tok/s) | 1842.17 | 1909.91 |
| Mean TTFT (ms) | 29224.49 | 28011.36 | 
| Mean TPOT (ms) | 240.21 | 231.26 | 
| Mean ITL (ms)| 232.45 | 223.91 |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Speeds up mLLaMA4 vision by compiling its encoder path and tightening related infra.
> 
> - Compile `Llama4VisionModel` (VisionEncoder + PixelShuffleMLP) via `support_torch_compile`, gated by `compile_mm_encoder`; tag with `set_model_tag` and run under `set_forward_context`
> - Update `CompilationConfig.compile_mm_encoder` docs to include `mLLaMa4`; add test `test_mllama4_vit_compilation` (forked/skipped in CI)
> - Fix arg order/defaults in ViT flash-attn wrapper and its fake impl; plumb args in `MMEncoderAttention`
> - Optimize `Llama4VisionRotaryEmbedding` to avoid in-place cache updates; minor embed path change in `LlamaModel` to prevent recompiles
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1e0f0a868f633557e31e9195de92bbdff35d722. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 84c926015cf934954bf3e1eaf51049d5e3003492. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Speeds up mLLaMA4 vision by compiling its encoder path and tightening related infra.
> 
> - Compile `Llama4VisionModel` (VisionEncoder + PixelShuffleMLP) via `support_torch_compile`, gated by `CompilationConfig.compile_mm_encoder`; tag with `set_model_tag` and run under `set_forward_context`
> - Update `CompilationConfig.compile_mm_encoder` docs to include `mLLaMa4`; add `test_mllama4_vit_compilation` (forked/skipped in CI)
> - Fix arg order/defaults in ViT flash-attn wrapper (`vit_attn_wrappers.py`) and plumb args in `MMEncoderAttention`
> - Optimize `Llama4VisionRotaryEmbedding` to avoid in-place cache updates; add dynamic-shape hints to `LlamaModel` to reduce recompiles
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84c926015cf934954bf3e1eaf51049d5e3003492. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 8935253245665bb7b66ed35b63846b7ec513a9b9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Speeds up mLLaMA4 vision by compiling its encoder path and aligning infra.
> 
> - Compile `Llama4VisionModel` (VisionEncoder + PixelShuffleMLP) via `support_torch_compile` gated by `CompilationConfig.compile_mm_encoder`; tag with `set_model_tag` and run under `set_forward_context`
> - Update `CompilationConfig.compile_mm_encoder` doc to include `mLLaMa4`; add `test_mllama4_vit_compilation` (forked/skipped in CI)
> - Fix ViT flash-attn wrapper arg order/defaults (`vit_attn_wrappers.py`) and plumb args in `MMEncoderAttention`
> - Optimize `Llama4VisionRotaryEmbedding` to avoid in-place cache updates; add `mark_unbacked_dims` to `LlamaModel` to reduce recompiles
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8935253245665bb7b66ed35b63846b7ec513a9b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Speeds up mLLaMA4 vision by compiling its encoder path and aligning related infra.
> 
> - Compile `Llama4VisionModel` via `support_torch_compile` (gated by `compile_mm_encoder`), tag with `set_model_tag`, and run under `set_forward_context`
> - Update `CompilationConfig.compile_mm_encoder` docs to include `mLLaMa4`; add `test_mllama4_vit_compilation` (forked/skipped in CI) and refine Qwen2.5-VL tests
> - Fix ViT flash-attn wrapper arg order/defaults in `vit_attn_wrappers.py` and plumb args in `MMEncoderAttention`
> - Optimize `Llama4VisionRotaryEmbedding` to avoid in-place cache updates
> - Add dynamic-shape hints to `LlamaModel` (`mark_unbacked_dims`) to reduce recompiles
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95c46163d6bd821501831369f971913f85883666. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 31bc1de347bd352f8b5bcbf77039724a8f2affe7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Speeds up mLLaMA4 vision by compiling its encoder path and aligning related infra.
> 
> - Wraps `Llama4VisionModel` with `support_torch_compile` (dynamic arg dims; gated by `should_torch_compile_mm_vit`), constructs under `set_current_vllm_config` and tags via `set_model_tag`; runs image embed under `set_forward_context`
> - Documents `CompilationConfig.compile_mm_encoder` to include `mLLaMa4`
> - Fixes ViT flash-attn wrapper plumbing: reorder args in `MMEncoderAttention` call; add defaults in `flash_attn_maxseqlen_wrapper_fake`
> - Optimizes `Llama4VisionRotaryEmbedding` to avoid in-place cache updates; tweaks `LlamaModel` compile decorator to reduce recompiles
> - Adds `test_mllama4_vit_compilation` (forked/skipped due to CI constraints)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31bc1de347bd352f8b5bcbf77039724a8f2affe7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
