### PR TITLE
[Feature]nvfp4 universal fallback emulation

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -354,6 +354,13 @@ class FusedMoEQuantConfig:
     def use_nvfp4_w4a4(self) -> bool:
         return self.quant_dtype == "nvfp4"
 
+    @property
+    def nvfp4_scheme(self) -> str | None:
+        """Return NVFP4 scheme string if using nvfp4, else None."""
+        if self.use_nvfp4_w4a4:
+            return "w_nvfp4_a_nvfp4"
+        return None
+
     def config_name(self, dtype: torch.dtype) -> str | None:
         """
         Return a string used to construct the filename that contains the

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -49,6 +49,10 @@ from vllm.model_executor.layers.fused_moe.utils import (
 )
 from vllm.model_executor.layers.quantization.utils.mxfp4_utils import dequant_mxfp4
 from vllm.model_executor.layers.quantization.utils.mxfp6_utils import dequant_mxfp6
+from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (
+    dequant_nvfp4,
+)
+from vllm.model_executor.layers.quantization.utils.nvfp4_utils import NVFP4_Scheme
 from vllm.model_executor.layers.quantization.utils.ocp_mx_utils import OCP_MX_Scheme
 from vllm.model_executor.utils import maybe_disable_graph_partition
 from vllm.platforms import current_platform
@@ -1416,11 +1420,14 @@ def inplace_fused_experts(
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
     ocp_mx_scheme: str | None = None,
+    nvfp4_scheme: str | None = None,
     per_channel_quant: bool = False,
     global_num_experts: int = -1,
     expert_map: torch.Tensor | None = None,
     w1_scale: torch.Tensor | None = None,
     w2_scale: torch.Tensor | None = None,
+    w1_row_scalar: torch.Tensor | None = None,
+    w2_row_scalar: torch.Tensor | None = None,
     w1_zp: torch.Tensor | None = None,
     w2_zp: torch.Tensor | None = None,
     a1_scale: torch.Tensor | None = None,
@@ -1443,11 +1450,14 @@ def inplace_fused_experts(
         use_int8_w8a16,
         use_int4_w4a16,
         ocp_mx_scheme,
+        nvfp4_scheme,
         per_channel_quant,
         global_num_experts,
         expert_map,
         w1_scale,
         w2_scale,
+        w1_row_scalar,
+        w2_row_scalar,
         w1_zp,
         w2_zp,
         a1_scale,
@@ -1471,11 +1481,14 @@ def inplace_fused_experts_fake(
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
     ocp_mx_scheme: str | None = None,
+    nvfp4_scheme: str | None = None,
     per_channel_quant: bool = False,
     global_num_experts: int = -1,
     expert_map: torch.Tensor | None = None,
     w1_scale: torch.Tensor | None = None,
     w2_scale: torch.Tensor | None = None,
+    w1_row_scalar: torch.Tensor | None = None,
+    w2_row_scalar: torch.Tensor | None = None,
     w1_zp: torch.Tensor | None = None,
     w2_zp: torch.Tensor | None = None,
     a1_scale: torch.Tensor | None = None,
@@ -1513,11 +1526,14 @@ def outplace_fused_experts(
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
     ocp_mx_scheme: str | None = None,
+    nvfp4_scheme: str | None = None,
     per_channel_quant: bool = False,
     global_num_experts: int = -1,
     expert_map: torch.Tensor | None = None,
     w1_scale: torch.Tensor | None = None,
     w2_scale: torch.Tensor | None = None,
+    w1_row_scalar: torch.Tensor | None = None,
+    w2_row_scalar: torch.Tensor | None = None,
     w1_zp: torch.Tensor | None = None,
     w2_zp: torch.Tensor | None = None,
     a1_scale: torch.Tensor | None = None,
@@ -1540,11 +1556,14 @@ def outplace_fused_experts(
         use_int8_w8a16,
         use_int4_w4a16,
         ocp_mx_scheme,
+        nvfp4_scheme,
         per_channel_quant,
         global_num_experts,
         expert_map,
         w1_scale,
         w2_scale,
+        w1_row_scalar,
+        w2_row_scalar,
         w1_zp,
         w2_zp,
         a1_scale,
@@ -1562,16 +1581,20 @@ def outplace_fused_experts_fake(
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,
     activation: str = "silu",
+    apply_router_weight_on_input: bool = False,
     use_fp8_w8a8: bool = False,
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
     ocp_mx_scheme: str | None = None,
+    nvfp4_scheme: str | None = None,
     per_channel_quant: bool = False,
     global_num_experts: int = -1,
     expert_map: torch.Tensor | None = None,
     w1_scale: torch.Tensor | None = None,
     w2_scale: torch.Tensor | None = None,
+    w1_row_scalar: torch.Tensor | None = None,
+    w2_row_scalar: torch.Tensor | None = None,
     w1_zp: torch.Tensor | None = None,
     w2_zp: torch.Tensor | None = None,
     a1_scale: torch.Tensor | None = None,
@@ -1692,11 +1715,14 @@ def fused_experts(
             use_int8_w8a16=quant_config.use_int8_w8a16,
             use_int4_w4a16=quant_config.use_int4_w4a16,
             ocp_mx_scheme=quant_config.ocp_mx_scheme,
+            nvfp4_scheme=quant_config.nvfp4_scheme,
             per_channel_quant=quant_config.per_act_token_quant,
             global_num_experts=global_num_experts,
             expert_map=expert_map,
             w1_scale=quant_config.w1_scale,
             w2_scale=quant_config.w2_scale,
+            w1_row_scalar=quant_config.g1_alphas,
+            w2_row_scalar=quant_config.g2_alphas,
             w1_zp=quant_config.w1_zp,
             w2_zp=quant_config.w2_zp,
             a1_scale=quant_config.a1_scale,
@@ -1751,11 +1777,14 @@ def fused_experts_impl(
     use_int8_w8a16: bool = False,
     use_int4_w4a16: bool = False,
     ocp_mx_scheme: str | None = None,
+    nvfp4_scheme: str | None = None,
     per_channel_quant: bool = False,
     global_num_experts: int = -1,
     expert_map: torch.Tensor | None = None,
     w1_scale: torch.Tensor | None = None,
     w2_scale: torch.Tensor | None = None,
+    w1_row_scalar: torch.Tensor | None = None,
+    w2_row_scalar: torch.Tensor | None = None,
     w1_zp: torch.Tensor | None = None,
     w2_zp: torch.Tensor | None = None,
     a1_scale: torch.Tensor | None = None,
@@ -1784,6 +1813,9 @@ def fused_experts_impl(
             )
         else:
             raise NotImplementedError(f"Unsupported ocp_mx_scheme={ocp_mx_scheme}")
+    elif nvfp4_scheme is not None:
+        # 16bit activation and fp4x2 packed weight
+        assert hidden_states.size(1) == w1.size(2) * 2, "hidden size mismatch"
     else:
         assert hidden_states.size(1) == w1.size(2), (
             f"Hidden size mismatch {hidden_states.size(1)} != {w1.size(2)}"
@@ -1896,6 +1928,17 @@ def fused_experts_impl(
             w2_scale = None
         else:
             raise NotImplementedError(f"Unsupported ocp_mx_scheme={ocp_mx_scheme}")
+
+    if nvfp4_scheme is not None:
+        if nvfp4_scheme in {NVFP4_Scheme.w_nvfp4_a_nvfp4}:
+            # NVFP4 dequant: (weights, group_scale_swizzled, global_scale, dtype)
+            # Reusing row_scalar for the FP32 global scale
+            w1 = dequant_nvfp4(w1, w1_scale, w1_row_scalar, hidden_states.dtype)
+            w1_scale = None
+            w2 = dequant_nvfp4(w2, w2_scale, w2_row_scalar, hidden_states.dtype)
+            w2_scale = None
+        else:
+            raise NotImplementedError(f"Unsupported nvfp4_scheme={nvfp4_scheme}")
 
     for chunk in range((num_tokens // CHUNK_SIZE) + 1):
         begin_chunk_idx, end_chunk_idx = (

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1814,7 +1814,6 @@ def fused_experts_impl(
         else:
             raise NotImplementedError(f"Unsupported ocp_mx_scheme={ocp_mx_scheme}")
     elif nvfp4_scheme is not None:
-        # 16bit activation and fp4x2 packed weight
         assert hidden_states.size(1) == w1.size(2) * 2, "hidden size mismatch"
     else:
         assert hidden_states.size(1) == w1.size(2), (

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1184,6 +1184,7 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         self.cutlass_nvfp4_supported = _nvfp4.cutlass_supported
         self.allow_flashinfer = _nvfp4.allow_flashinfer
         self.use_marlin = _nvfp4.use_marlin
+        self.use_emulation = _nvfp4.use_emulation
         self.marlin_input_dtype = None
         self.flashinfer_moe_backend = None
         if self.allow_flashinfer:
@@ -1194,6 +1195,8 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             )
         elif self.use_marlin:
             logger.info_once("Using Marlin for ModelOptNvFp4FusedMoE.")
+        elif self.use_emulation:
+            logger.info_once("Using emulation (dequant to FP16) for ModelOptNvFp4FusedMoE.")
         else:
             logger.info_once("Using Cutlass for ModelOptNvFp4FusedMoE.")
 
@@ -1201,7 +1204,9 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         self,
         routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
     ) -> mk.FusedMoEPrepareAndFinalize | None:
-        if self.use_marlin or (
+        if self.use_emulation:
+            return super().maybe_make_prepare_finalize(routing_tables)
+        elif self.use_marlin or (
             self.allow_flashinfer
             and self.flashinfer_moe_backend == FlashinferMoeBackend.TENSORRT_LLM
         ):
@@ -1224,6 +1229,9 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         prepare_finalize: mk.FusedMoEPrepareAndFinalize,
         layer: torch.nn.Module,
     ) -> mk.FusedMoEPermuteExpertsUnpermute:
+        if self.use_emulation:
+            logger.debug_once("Using Triton emulation path for NVFP4 MoE")
+            return super().select_gemm_impl(prepare_finalize, layer)
         assert self.moe_quant_config is not None
         experts = select_nvfp4_gemm_impl(
             self.moe,
@@ -1601,6 +1609,23 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
                 topk_weights=topk_weights,
                 top_k=layer.top_k,
                 global_num_experts=layer.global_num_experts,
+            )
+
+        if self.use_emulation:
+            from vllm.model_executor.layers.fused_moe import fused_experts
+
+            return fused_experts(
+                x,
+                layer.w13_weight,
+                layer.w2_weight,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                inplace=False,
+                activation=layer.activation,
+                global_num_experts=layer.global_num_experts,
+                expert_map=layer.expert_map,
+                apply_router_weight_on_input=layer.apply_router_weight_on_input,
+                quant_config=self.moe_quant_config,
             )
 
         if self.use_marlin:

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_emulation_utils.py
@@ -154,18 +154,7 @@ def _dequant_nvfp4(
     dtype: torch.dtype,
     block_size: int = NVFP4_BLOCK_SIZE,
 ) -> torch.Tensor:
-    """Dequantize NVFP4 weights to high precision for fused MoE emulation.
 
-    Args:
-        tensor_fp4: Packed FP4 weights as uint8, shape [M, K//2]
-        tensor_sf: FP8 E4M3FN per-group scales (swizzled), shape depends on layout
-        global_scale: FP32 global scale tensor
-        dtype: Target dtype (torch.float16 or torch.bfloat16)
-        block_size: Group size for scaling (default 16 for NVFP4)
-
-    Returns:
-        Dequantized weights, shape [M, K], dtype as specified
-    """
     return dequantize_to_dtype(
         tensor_fp4,
         tensor_sf,
@@ -175,7 +164,6 @@ def _dequant_nvfp4(
         block_size,
     )
 
-
 def _dequant_nvfp4_fake(
     tensor_fp4: torch.Tensor,
     tensor_sf: torch.Tensor,
@@ -183,13 +171,11 @@ def _dequant_nvfp4_fake(
     dtype: torch.dtype,
     block_size: int = NVFP4_BLOCK_SIZE,
 ) -> torch.Tensor:
-    """Fake implementation for torch.compile symbolic tracing."""
     m, packed_k = tensor_fp4.shape
     k = packed_k * 2
     return torch.empty((m, k), dtype=dtype, device=tensor_fp4.device)
 
 
-# Register as custom op for torch.compile compatibility
 try:
     direct_register_custom_op(
         op_name="dequant_nvfp4",

--- a/vllm/model_executor/layers/quantization/utils/nvfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/nvfp4_utils.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+NVFP4 Scheme utilities and enum definitions for fused MoE emulation fallback.
+"""
+from enum import Enum
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+NVFP4_BLOCK_SIZE = 16
+
+NVFP4_DTYPES = {
+    "nvfp4",
+}
+
+SUPPORTED_NVFP4_DTYPES = {"nvfp4"}
+
+
+class NVFP4_Scheme(str, Enum):
+    w_nvfp4_a_nvfp4 = "w_nvfp4_a_nvfp4"
+
+    @classmethod
+    def from_quant_dtype(cls, input_dtype: str | None, weight_dtype: str | None):
+        if input_dtype not in NVFP4_DTYPES or weight_dtype not in NVFP4_DTYPES:
+            return None
+        elif input_dtype == "nvfp4" and weight_dtype == "nvfp4":
+            return cls.w_nvfp4_a_nvfp4
+        else:
+            logger.warning(
+                "input_dtype='%s' and"
+                " weight_dtype='%s' is not supported "
+                "in NVFP4_Scheme at the moment.",
+                input_dtype,
+                weight_dtype,
+            )
+            return None


### PR DESCRIPTION

## Purpose
Enable use of NVFP4 models on non-FP4 enabled GPUs by adding automatic emulation fallback.
Previously, loading NVFP4 quantized models on unsupported hardware (AMD GPUs, older NVIDIA GPUs) threw:

ValueError: Current platform does not support NVFP4 quantization. Please use Blackwell GPUs or enable FlashInfer.

This PR adds automatic detection and fallback to FP16 dequantization (similar to existing MXFP4 emulation), allowing NVFP4 models to run on any GPU while still benefiting from the improved quantization accuracy vs other 4-bit formats.

### Changes
- Add `use_emulation` field to `NvFp4Support` dataclass in `nvfp4_moe_support.py`
- Register `dequant_nvfp4` custom op in `nvfp4_emulation_utils.py` for torch.compile compatibility
- Add `NVFP4_Scheme` enum in new `nvfp4_utils.py`
- Add `nvfp4_scheme` property to `FusedMoEQuantConfig` in `config.py`
- Add nvfp4 dequant path in `fused_experts_impl` in `fused_moe.py`
- Add emulation path in `ModelOptNvFp4FusedMoE` in `modelopt.py`

## Test Plan
Attempt loading an NVFP4 model on a non-enabled GPU, the result will be:
ValueError: Current platform does not support NVFP4 quantization
 
With patch in place results are: 
WARNING: Current platform does not support native NVFP4 quantization. 
Falling back to emulation mode (dequantize weights to FP16).

## Test Result
Currently sampling models to ensure they work without issue but none have failed thus far.

---
