### PR TITLE
update piecewise cudagraph warning when splitting_ops=[]

### DIFF
--- a/tests/compile/fullgraph/test_full_graph.py
+++ b/tests/compile/fullgraph/test_full_graph.py
@@ -179,9 +179,10 @@ def test_custom_compile_config(
     ):
         pytest.skip("inductor graph partition is only available in PyTorch 2.9+")
 
-    # (fixme: @zhxchen17) aot compile breaks depyf assumption on graph module.
-    # Temporarily disable aot_compile to unblock pytorch 2.10.
-    monkeypatch.setenv("VLLM_USE_AOT_COMPILE", "0")
+    if compilation_config.debug_dump_path is not None:
+        # (fixme: @zhxchen17) aot compile breaks depyf assumption on graph module.
+        # Temporarily disable aot_compile to unblock pytorch 2.10.
+        monkeypatch.setenv("VLLM_USE_AOT_COMPILE", "0")
 
     print(f"MODEL={model}")
     run_model(compilation_config, model, **model_kwargs)

--- a/tests/compile/fullgraph/test_full_graph.py
+++ b/tests/compile/fullgraph/test_full_graph.py
@@ -161,7 +161,6 @@ def test_full_graph(
 # only test some of the models
 @create_new_process_for_each_test()
 def test_custom_compile_config(
-    monkeypatch: pytest.MonkeyPatch,
     compilation_config: CompilationConfig,
     model: str,
     model_kwargs: dict[str, Any],
@@ -178,11 +177,6 @@ def test_custom_compile_config(
         "2.9.0.dev"
     ):
         pytest.skip("inductor graph partition is only available in PyTorch 2.9+")
-
-    if compilation_config.debug_dump_path is not None:
-        # (fixme: @zhxchen17) aot compile breaks depyf assumption on graph module.
-        # Temporarily disable aot_compile to unblock pytorch 2.10.
-        monkeypatch.setenv("VLLM_USE_AOT_COMPILE", "0")
 
     print(f"MODEL={model}")
     run_model(compilation_config, model, **model_kwargs)

--- a/tests/compile/fullgraph/test_full_graph.py
+++ b/tests/compile/fullgraph/test_full_graph.py
@@ -161,6 +161,7 @@ def test_full_graph(
 # only test some of the models
 @create_new_process_for_each_test()
 def test_custom_compile_config(
+    monkeypatch: pytest.MonkeyPatch,
     compilation_config: CompilationConfig,
     model: str,
     model_kwargs: dict[str, Any],
@@ -177,6 +178,10 @@ def test_custom_compile_config(
         "2.9.0.dev"
     ):
         pytest.skip("inductor graph partition is only available in PyTorch 2.9+")
+
+    # (fixme: @zhxchen17) aot compile breaks depyf assumption on graph module.
+    # Temporarily disable aot_compile to unblock pytorch 2.10.
+    monkeypatch.setenv("VLLM_USE_AOT_COMPILE", "0")
 
     print(f"MODEL={model}")
     run_model(compilation_config, model, **model_kwargs)

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -937,7 +937,7 @@ class CompilationConfig:
                     or self.cudagraph_mode == CUDAGraphMode.FULL_AND_PIECEWISE
                 ):
                     logger.warning_once(
-                        "Using piecewise compilation with empty splitting_ops"
+                        "Using piecewise cudagraph with empty splitting_ops"
                     )
                 if self.cudagraph_mode == CUDAGraphMode.PIECEWISE:
                     logger.warning_once(


### PR DESCRIPTION
~~`aot_compile` is a new feature in pytorch 2.10. It changes `GraphModule` in a way that breaks assumptions in depyf. This leads to [ci failure](https://buildkite.com/vllm/ci/builds/43419/steps/canvas?sid=019b1833-5ff1-42a0-8b3b-2aa5886343f0) when turning on pytorch==2.10 in vllm.~~


~~This PR temporarily disables `aot_compile` for the test to unblock pytorch 2.10. @zhxchen17 will followup to fix aot compile.~~

This PR updates piecewise cudagraph log message as a followup of #30657.

