### PR TITLE
improve lazy import test

### DIFF
--- a/tests/standalone_tests/lazy_imports.py
+++ b/tests/standalone_tests/lazy_imports.py
@@ -5,9 +5,6 @@
 # The utility function cannot be placed in `vllm.utils`
 # this needs to be a standalone script
 import sys
-from contextlib import nullcontext
-
-from vllm_test_utils import BlameResult, blame
 
 # List of modules that should not be imported too early.
 # Lazy import `torch._inductor.async_compile` to avoid creating
@@ -16,26 +13,10 @@ from vllm_test_utils import BlameResult, blame
 # `cv2` can easily mess up the environment.
 module_names = ["torch._inductor.async_compile", "cv2"]
 
+# set all modules in `module_names` to be None.
+# if we import any modules during `import vllm`, there would be a
+# hard error and nice stacktrace on the first import.
+for module_name in module_names:
+    sys.modules[module_name] = None  # type: ignore[assignment]
 
-def any_module_imported():
-    return any(module_name in sys.modules for module_name in module_names)
-
-
-# In CI, we only check finally if the module is imported.
-# If it is indeed imported, we can rerun the test with `use_blame=True`,
-# which will trace every function call to find the first import location,
-# and help find the root cause.
-# We don't run it in CI by default because it is slow.
-use_blame = False
-context = blame(any_module_imported) if use_blame else nullcontext()
-with context as result:
-    import vllm  # noqa
-
-if use_blame:
-    assert isinstance(result, BlameResult)
-    print(f"the first import location is:\n{result.trace_stack}")
-
-assert not any_module_imported(), (
-    f"Some the modules in {module_names} are imported. To see the first"
-    f" import location, run the test with `use_blame=True`."
-)
+import vllm  # noqa


### PR DESCRIPTION
`lazy_imports` checks some modules (specified in `module_names`) are not imported during `import vllm`. It currently uses `blame` to find the first imports when the test failed.

However, there are 2 issues:
- `blame` is slow so we cannot turn on by default in ci. We need to manually run it locally.
- While upgrading pytorch 2.10 pin, multiple people run `blame` but did not get much info. [[more context](https://github.com/pytorch/pytorch/issues/170345#issuecomment-3657829950)]

This PR sets all modules in `module_names` to be None before `import vllm`. If `import vllm` implicitly imports any of these modules, there would be a hard error with stacktrace to the first import. (original idea from @v0i0 https://github.com/pytorch/pytorch/issues/170345#issuecomment-3657829950)


## Tests

### Before this PR, run on PyTorch 2.9 x vllm:


> python3 standalone_tests/lazy_imports.py 

```
Traceback (most recent call last):
  File "/data/users/boyuan/vllm/tests/standalone_tests/lazy_imports.py", line 38, in <module>
    assert not any_module_imported(), (
           ^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Some the modules in ['torch._inductor.async_compile', 'cv2'] are imported. To see the first import location, run the test with `use_blame=True`.
```

### After this PR, run on PyTorch 2.9 x vllm:

> python3 standalone_tests/lazy_imports.py 

```
Traceback (most recent call last):
  File "/data/users/boyuan/vllm/tests/standalone_tests/lazy_imports.py", line 22, in <module>
    import vllm  # noqa
    ^^^^^^^^^^^
  File "/data/users/boyuan/vllm/vllm/__init__.py", line 14, in <module>
    import vllm.env_override  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/users/boyuan/vllm/vllm/env_override.py", line 367, in <module>
    from torch._inductor.codegen.wrapper import PythonWrapperCodegen
  File "/home/boyuan/.conda/envs/vllm-pt-2.9/lib/python3.12/site-packages/torch/_inductor/codegen/wrapper.py", line 41, in <module>
    from .. import async_compile, config, ir
ModuleNotFoundError: import of torch._inductor.async_compile halted; None in sys.modules
```




Close: #30726

cc @zou3519 
