### PR TITLE
Fix instantiation of `HfHubHTTPError` in LoRA test

### DIFF
--- a/tests/lora/test_utils.py
+++ b/tests/lora/test_utils.py
@@ -3,7 +3,7 @@
 
 from collections import OrderedDict
 from typing import NamedTuple
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from huggingface_hub.utils import HfHubHTTPError
@@ -194,5 +194,8 @@ def test_get_adapter_absolute_path_huggingface_error(
     # Hugging Face model identifier with download error
     path = "org/repo"
     mock_exist.return_value = False
-    mock_snapshot_download.side_effect = HfHubHTTPError("failed to query model info")
+    mock_snapshot_download.side_effect = HfHubHTTPError(
+        "failed to query model info",
+        response=MagicMock(),
+    )
     assert get_adapter_absolute_path(path) == path


### PR DESCRIPTION
`response` became required in the latest version of `huggingface_hub`. Since we only use it for testing we can just give it a mock. This is what's done in `huggingface_hub` testing too.