### PR TITLE
Don't assume `position_embedding_type` will be present for BERT and RoBERTa models

### DIFF
--- a/vllm/model_executor/models/bert.py
+++ b/vllm/model_executor/models/bert.py
@@ -55,7 +55,9 @@ class BertEmbedding(nn.Module):
             "position_ids",
             torch.arange(config.max_position_embeddings).unsqueeze(0),
         )
-        self.position_embedding_type = config.position_embedding_type
+        self.position_embedding_type = getattr(
+            config, "position_embedding_type", "absolute"
+        )
         if self.position_embedding_type != "absolute":
             raise ValueError(
                 "Only 'absolute' position_embedding_type" + " is supported"


### PR DESCRIPTION
Bert/RoBERTa never had RoPE, so the option to use it was removed in Transformers v5. After release new architectures for BERT-like models with RoPE will be added to Transformers v5, allowing us to stop passing `--trust-remote-code` for these popular models like GTE and Nomic BERT.

This means that, going forward in Transformers v5, we cannot assume that `position_embedding_type` will be present in vanilla BERT and RoBERTa configs, so we get this config field more defensively in vLLM.