### PR TITLE
[Bugfix] Whisper fix number of allocated CrossAttn blocks per-request

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -187,6 +187,14 @@ class Scheduler(SchedulerInterface):
             if self.is_encoder_decoder
             else EncoderCacheManager(cache_size=encoder_cache_size)
         )
+        # For encoder-decoder models, allocate the maximum number of tokens for Cross
+        # Attn blocks, as for Whisper its input is always padded to the maximum length.
+        # TODO (NickLucche): Generalize to models with variable-length encoder inputs.
+        self._num_encoder_input_tokens = (
+            MULTIMODAL_REGISTRY.get_encdec_max_encoder_len(vllm_config.model_config)
+            if self.is_encoder_decoder
+            else 0
+        )
 
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
@@ -568,18 +576,6 @@ class Scheduler(SchedulerInterface):
                     0 if request.num_computed_tokens == 0 else self.num_lookahead_tokens
                 )
 
-                # Determine if we need to allocate cross-attention blocks.
-                if self.is_encoder_decoder and request.has_encoder_inputs:
-                    # TODO(russellb): For Whisper, we know that the input is
-                    # always padded to the maximum length. If we support other
-                    # encoder-decoder models, this will need to be updated if we
-                    # want to only allocate what is needed.
-                    num_encoder_tokens = (
-                        self.scheduler_config.max_num_encoder_input_tokens
-                    )
-                else:
-                    num_encoder_tokens = 0
-
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
                     num_new_tokens + num_external_computed_tokens,
@@ -587,7 +583,7 @@ class Scheduler(SchedulerInterface):
                     new_computed_blocks,
                     num_lookahead_tokens=effective_lookahead_tokens,
                     delay_cache_blocks=load_kv_async,
-                    num_encoder_tokens=num_encoder_tokens,
+                    num_encoder_tokens=self._num_encoder_input_tokens,
                 )
 
                 if new_blocks is None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -576,6 +576,12 @@ class Scheduler(SchedulerInterface):
                     0 if request.num_computed_tokens == 0 else self.num_lookahead_tokens
                 )
 
+                num_encoder_tokens = (
+                    self._num_encoder_input_tokens
+                    if self.is_encoder_decoder and request.has_encoder_inputs
+                    else 0
+                )
+
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,
                     num_new_tokens + num_external_computed_tokens,
@@ -583,7 +589,7 @@ class Scheduler(SchedulerInterface):
                     new_computed_blocks,
                     num_lookahead_tokens=effective_lookahead_tokens,
                     delay_cache_blocks=load_kv_async,
-                    num_encoder_tokens=self._num_encoder_input_tokens,
+                    num_encoder_tokens=num_encoder_tokens,
                 )
 
                 if new_blocks is None:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -190,10 +190,8 @@ class Scheduler(SchedulerInterface):
         # For encoder-decoder models, allocate the maximum number of tokens for Cross
         # Attn blocks, as for Whisper its input is always padded to the maximum length.
         # TODO (NickLucche): Generalize to models with variable-length encoder inputs.
-        self._num_encoder_input_tokens = (
+        self._num_encoder_max_input_tokens = (
             MULTIMODAL_REGISTRY.get_encdec_max_encoder_len(vllm_config.model_config)
-            if self.is_encoder_decoder
-            else 0
         )
 
         speculative_config = vllm_config.speculative_config
@@ -577,7 +575,7 @@ class Scheduler(SchedulerInterface):
                 )
 
                 num_encoder_tokens = (
-                    self._num_encoder_input_tokens
+                    self._num_encoder_max_input_tokens
                     if self.is_encoder_decoder and request.has_encoder_inputs
                     else 0
                 )


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/vllm-project/vllm/pull/29421, which in order to allow for multiple encoder requests to be processed at the same time, upped the `scheduler_config.max_num_encoder_input_tokens` which was previously capped at 1 item (1500 for whisper).
This change results in allocating `max_num_batched_tokens` blocks per-request, as the crossattn blocks are currently using the same `scheduler_config.max_num_encoder_input_tokens` value to determine allocation.

This PR makes sure we're only allocating one item-size per-request, by adding a separate independent variable to determine this value.

```
# vllm serve openai/whisper-large-v3-turbo (defaults to max-num-batched-tokens 8192)
...
(EngineCore_DP0 pid=401191) BEFORE 8192 (self.scheduler_config.max_num_encoder_input_tokens)
(EngineCore_DP0 pid=401191) AFTER 1500 (1 item, self._num_encoder_input_tokens)
```

cc @DarkLight1337
