### PR TITLE
[Docs][API] Remove warning about LoRARequest being internal-only

### DIFF
--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -14,11 +14,6 @@ class LoRARequest(
     """
     Request for a LoRA adapter.
 
-    Note that this class should be used internally. For online
-    serving, it is recommended to not allow users to use this class but
-    instead provide another layer of abstraction to prevent users from
-    accessing unauthorized LoRA adapters.
-
     lora_int_id must be globally unique for a given adapter.
     This is currently not enforced in vLLM.
     """


### PR DESCRIPTION
Since `LoRARequest` is part of the public API - e.g. as a parameter to `LLM.generate()` or since #30636 a member of `RequestOutput` - this warning looks outdated:

```python
class LoRARequest(...):
    """
    Request for a LoRA adapter.

    Note that this class should be used internally. For online
    serving, it is recommended to not allow users to use this class but
    instead provide another layer of abstraction to prevent users from
    accessing unauthorized LoRA adapters.
    ...
    """
```

Indeed, `LoRAReqest` seems to have been part of the public API since it was added in #1804
