### PR TITLE
[CI] add polling for precompiled wheel in python_only_compile.sh, fix index generation for releases

### DIFF
--- a/.buildkite/scripts/generate-nightly-index.py
+++ b/.buildkite/scripts/generate-nightly-index.py
@@ -291,6 +291,7 @@ if __name__ == "__main__":
     """
     Arguments:
         --version <version> : version string for the current build (e.g., commit hash)
+        --wheel-dir <wheel_directory> : directory containing wheel files (default to be same as `version`)
         --current-objects <path_to_json> : path to JSON file containing current S3 objects listing in this version directory
         --output-dir <output_directory> : directory to store generated index files
         --alias-to-default <alias_variant_name> : (optional) alias variant name for the default variant
@@ -317,6 +318,12 @@ if __name__ == "__main__":
         type=str,
         required=True,
         help="Directory to store generated index files",
+    )
+    parser.add_argument(
+        "--wheel-dir",
+        type=str,
+        default=None,
+        help="Directory containing wheel files (default to be same as `version`)",
     )
     parser.add_argument(
         "--alias-to-default",
@@ -384,9 +391,10 @@ if __name__ == "__main__":
         print("Nightly version detected, keeping all wheel files.")
 
     # Generate index and metadata, assuming wheels and indices are stored as:
-    # s3://vllm-wheels/{version}/<wheel files>
+    # s3://vllm-wheels/{wheel_dir}/<wheel files>
     # s3://vllm-wheels/<anything>/<index files>
-    wheel_base_dir = Path(output_dir).parent / version
+    wheel_dir = args.wheel_dir or version
+    wheel_base_dir = Path(output_dir).parent / wheel_dir.strip().rstrip("/")
     index_base_dir = Path(output_dir)
 
     generate_index_and_metadata(

--- a/.buildkite/scripts/upload-wheels.sh
+++ b/.buildkite/scripts/upload-wheels.sh
@@ -102,6 +102,7 @@ if [[ "$version" != *"dev"* ]]; then
     echo "Re-generating indices for /$pure_version/"
     rm -rf "$INDICES_OUTPUT_DIR/*"
     mkdir -p "$INDICES_OUTPUT_DIR"
-    $PYTHON .buildkite/scripts/generate-nightly-index.py --version "$pure_version" --current-objects "$obj_json" --output-dir "$INDICES_OUTPUT_DIR" --comment "version $pure_version" $alias_arg
+    # wheel-dir is overridden to be the commit directory, so that the indices point to the correct wheel path
+    $PYTHON .buildkite/scripts/generate-nightly-index.py --version "$pure_version" --wheel-dir "$SUBPATH" --current-objects "$obj_json" --output-dir "$INDICES_OUTPUT_DIR" --comment "version $pure_version" $alias_arg
     aws s3 cp --recursive "$INDICES_OUTPUT_DIR/" "s3://$BUCKET/$pure_version/"
 fi


### PR DESCRIPTION
## Purpose

@hmellor mentioned there was error like:

```
[2025-12-11T15:49:07Z] 7.844 ValueError: No precompiled vllm wheel found for architecture x86_64 from repo https://wheels.vllm.ai/3a3b06ee706e6ff99b711b20a6c431b43e490dbc/cu129/vllm/. All available wheels: [{'package_name': 'vllm', 'version': '0.13.0rc2.dev47+g3a3b06ee7', 'build_tag': None, 'python_tag': 'cp38', 'abi_tag': 'abi3', 'platform_tag': 'manylinux_2_31_aarch64', 'variant': None, 'filename': 'vllm-0.13.0rc2.dev47+g3a3b06ee7-cp38-abi3-manylinux_2_31_aarch64.whl', 'path': '../../../3a3b06ee706e6ff99b711b20a6c431b43e490dbc/vllm-0.13.0rc2.dev47%2Bg3a3b06ee7-cp38-abi3-manylinux_2_31_aarch64.whl'}]
```

This is a tricky timing issue, because the release pipeline has not yet finished when this test is run in the CI pipeline.
Since we do not yet have inter-pipeline dependency in Buildkite, a simple way is to implement polling in the test script before actually running `setup.py`. Previously it only tests the existence of `metadata.json`, now more checks are added, especially the architecture.

@bigPYJ1151 reported in #31022 that indices generated for releases contain wrong paths to wheels. This PR also fixes it.

## Test Plan

Tested locally and will be tested by CI (but most probably will not hit my new code).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

