### PR TITLE
[Bugfix] Fix DeepSeekV32 tool parser incorrect type conversion for array/object parameters

### DIFF
--- a/vllm/tool_parsers/deepseekv32_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv32_tool_parser.py
@@ -154,6 +154,21 @@ class DeepSeekV32ToolParser(ToolParser):
                         and "type" in param_config[param_name]
                     ):
                         return param_config[param_name]["type"]
+            # Responses API: tool.name, tool.parameters (FunctionTool)
+            elif (
+                hasattr(tool, "name")
+                and tool.name == tool_name
+                and hasattr(tool, "parameters")
+            ):
+                params = tool.parameters
+                if isinstance(params, dict) and "properties" in params:
+                    param_config = params["properties"]
+                    if (
+                        param_name in param_config
+                        and isinstance(param_config[param_name], dict)
+                        and "type" in param_config[param_name]
+                    ):
+                        return param_config[param_name]["type"]
         return "unknown"
 
     def _parse_invoke_params(


### PR DESCRIPTION


The `DeepSeekV32ToolParser` was incorrectly serializing array and object type parameters as strings instead of their proper JSON types. This caused tool calls with complex parameters (e.g., `todos: [{...}]`) to be serialized as escaped strings (e.g., `"todos": "[{...}]"`) rather than actual JSON arrays/objects.

This issue breaks integration with downstream applications (such as **Claude Code**) that perform strict type validation on tool arguments.

**Root cause:**
- The parser defaulted to extracting XML content as raw strings via Regex.
- There was no mechanism to look up the expected parameter type from the tool definition.
- Parameters were double-encoded when `json.dumps` was called on the already stringified values during the final tool call construction.

**Fix:**
- Added `_get_param_type()` helper to look up parameter types from the `ChatCompletionRequest` tools schema.
- Updated `_parse_invoke_params()` to accept `tool_name` and `request` for type lookup.
- Enhanced `_convert_param_value()` and the parsing logic (both streaming and non-streaming) to attempt `json.loads` when the expected type is `array`/`object`, or as a fallback when the type is unknown.

## Test Plan

Verified the fix by integrating DeepSeek-V3.2 with **Claude Code** (Anthropic's CLI tool), which heavily relies on `TodoWrite` tool calls containing array parameters (`todos`).

**Steps:**
1. Serve DeepSeek-V3.2 using vLLM with the modified parser.
2. Connect Claude Code to the vLLM endpoint.
3. Prompt the model to perform a task that triggers the `TodoWrite` tool (requires a list of objects).
4. Verify that the tool arguments are correctly deserialized into JSON arrays and accepted by the client.

## Test Result

**Before Fix:**
The client receives the `todos` parameter as a **string**. Validation fails.

```json
{
  "type": "assistant",
  "message": {
    "id": "chatcmpl-9068c14695bca837",
    "type": "message",
    "role": "assistant",
    "content": [
      {
        "type": "tool_use",
        "id": "chatcmpl-tool-ad2bf0b87531d72b",
        "name": "TodoWrite",
        "input": {
          "todos": "[{\"content\": \"Explore Django codebase to understand i18n_patterns and locale handling\", \"status\": \"in_progress\", \"activeForm\": \"Exploring Django codebase for i18n_patterns locale handling\"}, {\"content\": \"Find the specific code that handles language prefix matching\", \"status\": \"pending\", \"activeForm\": \"Finding language prefix matching code\"}, {\"content\": \"Reproduce the issue to confirm the bug\", \"status\": \"pending\", \"activeForm\": \"Reproducing the i18n_patterns issue\"}, {\"content\": \"Analyze the root cause of the bug\", \"status\": \"pending\", \"activeForm\": \"Analyzing root cause of locale parsing\"}, {\"content\": \"Implement fix for language locales with script and region\", \"status\": \"pending\", \"activeForm\": \"Implementing fix for language locales with script and region\"}, {\"content\": \"Test the fix with the problematic locales\", \"status\": \"pending\", \"activeForm\": \"Testing fix with problematic locales\"}]"
        }
      }
    ],
    "model": "deepseek_v3.2",
    "stop_reason": "tool_use",
    "usage": {
      "input_tokens": 17052,
      "output_tokens": 254
    },
    "context_management": null
  },
  "parent_tool_use_id": null,
  "session_id": "a8f618b7-d1d1-4306-9a6a-083f837a001e",
  "uuid": "5f4e31ae-801a-44af-bcff-921caa6b94f0"
}
{
  "type": "user",
  "message": {
    "role": "user",
    "content": [
      {
        "type": "tool_result",
        "content": "<tool_use_error>InputValidationError: TodoWrite failed due to the following issue:\nThe parameter `todos` type is expected as `array` but provided as `string`</tool_use_error>",
        "is_error": true,
        "tool_use_id": "chatcmpl-tool-ad2bf0b87531d72b"
      }
    ]
  },
  "parent_tool_use_id": null,
  "session_id": "a8f618b7-d1d1-4306-9a6a-083f837a001e",
  "uuid": "d79441e5-0476-4a68-9698-c208ff98e58d",
  "tool_use_result": "InputValidationError: [\n  {\n    \"code\": \"invalid_type\",\n    \"expected\": \"array\",\n    \"received\": \"string\",\n    \"path\": [\n      \"todos\"\n    ],\n    \"message\": \"Expected array, received string\"\n  }\n]"
}
```

**After Fix:**
The client receives the `todos` parameter as a **JSON Array**. Validation succeeds.

```json
{
  "type": "assistant",
  "message": {
    "id": "chatcmpl-adb360f4bba4c60d",
    "type": "message",
    "role": "assistant",
    "content": [
      {
        "type": "text",
        "text": "I'll help you investigate and fix the internationalization issue where `i18n_patterns` doesn't support locale containing both script and region (like `en-latn-us`). Let me start by exploring the Django codebase to understand how i18n patterns handle language codes.\n\n"
      }
    ],
    "model": "deepseek_v3.2",
    "stop_reason": "tool_use",
    "usage": {
      "input_tokens": 16689,
      "output_tokens": 306
    },
    "context_management": null
  },
  "parent_tool_use_id": null,
  "session_id": "2aa341be-b82c-4098-ad5e-8f81bc9a4ef2",
  "uuid": "bf244b3a-7287-4221-bd09-b8aeab9eaf85"
}
{
  "type": "assistant",
  "message": {
    "id": "chatcmpl-adb360f4bba4c60d",
    "type": "message",
    "role": "assistant",
    "content": [
      {
        "type": "tool_use",
        "id": "chatcmpl-tool-b58ebfb23bb032e6",
        "name": "TodoWrite",
        "input": {
          "todos": [
            {
              "content": "Explore Django codebase to understand i18n patterns and language code handling",
              "status": "in_progress",
              "activeForm": "Exploring Django codebase to understand i18n patterns and language code handling"
            },
            {
              "content": "Reproduce the issue locally to confirm the problem",
              "status": "pending",
              "activeForm": "Reproducing the issue locally to confirm the problem"
            },
            {
              "content": "Identify the root cause of the bug",
              "status": "pending",
              "activeForm": "Identifying the root cause of the bug"
            },
            {
              "content": "Implement a fix for the issue",
              "status": "pending",
              "activeForm": "Implementing a fix for the issue"
            },
            {
              "content": "Test the fix with various language code formats",
              "status": "pending",
              "activeForm": "Testing the fix with various language code formats"
            },
            {
              "content": "Update tests if necessary",
              "status": "pending",
              "activeForm": "Updating tests if necessary"
            }
          ]
        }
      }
    ],
    "model": "deepseek_v3.2",
    "stop_reason": "tool_use",
    "usage": {
      "input_tokens": 16689,
      "output_tokens": 306
    },
    "context_management": null
  },
  "parent_tool_use_id": null,
  "session_id": "2aa341be-b82c-4098-ad5e-8f81bc9a4ef2",
  "uuid": "860260f5-5dfc-4b12-9c57-6592c3adcec0"
}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>