### PR TITLE
Replace deprecated enable_fusion with fuse_norm_quant in test_rms_group_quant

### DIFF
--- a/tests/compile/distributed/test_fusions_e2e.py
+++ b/tests/compile/distributed/test_fusions_e2e.py
@@ -562,7 +562,7 @@ def test_rms_group_quant(
         splitting_ops=splitting_ops,
         # Common
         mode=CompilationMode.VLLM_COMPILE,
-        pass_config=PassConfig(eliminate_noops=True, enable_fusion=True),
+        pass_config=PassConfig(eliminate_noops=True, fuse_norm_quant=True),
         # Inductor caches custom passes by default as well via uuid
         inductor_compile_config={"force_disable_caches": True},
     )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Landing strict config matching in https://github.com/vllm-project/vllm/pull/30708 caused this test to start to fail
https://buildkite.com/vllm/ci/builds/43658/steps/canvas?sid=019b2408-04fa-4f90-be13-3d338355f821#019b2408-0652-4d81-aa1d-60475172b711/86-5524
```
FAILED tests/compile/distributed/test_fusions_e2e.py::test_rms_group_quant[True-Qwen/Qwen3-30B-A3B-FP8-model_kwargs0-AttentionBackendEnum.TRITON_ATTN-matches0-+quant_fp8,+rms_norm] - pydantic_core._pydantic_core.ValidationError: 1 validation error for PassConfig
enable_fusion
  Unexpected keyword argument [type=unexpected_keyword_argument, input_value=True, input_type=bool]
    For further information visit https://errors.pydantic.dev/2.12/v/unexpected_keyword_argument
```

PR that removed enable_fusion: #30396 and #29646

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

