### PR TITLE
[Quant] Make static quant support all group shapes

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -336,7 +336,9 @@ torch::Tensor gptq_gemm(torch::Tensor a, torch::Tensor b_q_weight,
 void gptq_shuffle(torch::Tensor q_weight, torch::Tensor q_perm, int64_t bit);
 
 void static_scaled_fp8_quant(torch::Tensor& out, torch::Tensor const& input,
-                             torch::Tensor const& scale);
+                             torch::Tensor const& scale,
+                             std::optional<int64_t> group_m = std::nullopt,
+                             std::optional<int64_t> group_n = std::nullopt);
 
 void dynamic_scaled_fp8_quant(torch::Tensor& out, torch::Tensor const& input,
                               torch::Tensor& scale);

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <torch/library.h>
+#include <tuple>
 
 #include "core/scalar_type.hpp"
 
@@ -335,10 +336,9 @@ torch::Tensor gptq_gemm(torch::Tensor a, torch::Tensor b_q_weight,
 
 void gptq_shuffle(torch::Tensor q_weight, torch::Tensor q_perm, int64_t bit);
 
-void static_scaled_fp8_quant(torch::Tensor& out, torch::Tensor const& input,
-                             torch::Tensor const& scale,
-                             std::optional<int64_t> group_m = std::nullopt,
-                             std::optional<int64_t> group_n = std::nullopt);
+void static_scaled_fp8_quant(
+    torch::Tensor& out, torch::Tensor const& input, torch::Tensor const& scale,
+    std::optional<std::tuple<int64_t, int64_t>> group_shape = std::nullopt);
 
 void dynamic_scaled_fp8_quant(torch::Tensor& out, torch::Tensor const& input,
                               torch::Tensor& scale);

--- a/csrc/quantization/w8a8/fp8/common.cu
+++ b/csrc/quantization/w8a8/fp8/common.cu
@@ -7,25 +7,66 @@
 
 namespace vllm {
 
-template <typename scalar_t, typename fp8_type>
-__global__ void scaled_fp8_quant_kernel_strided(
+// STRIDE_0_ZERO: true if scale_stride_0 == 0 (per-tensor or per-channel)
+// STRIDE_1_ZERO: true if scale_stride_1 == 0 (per-tensor or per-token)
+template <typename scalar_t, typename fp8_type, bool STRIDE_0_ZERO,
+          bool STRIDE_1_ZERO>
+__global__ void scaled_fp8_quant_kernel_strided_group_shape(
     fp8_type* __restrict__ out, const scalar_t* __restrict__ input,
     const float* __restrict__ scale, int hidden_size, int64_t in_row_stride,
-    int64_t out_row_stride) {
-  const int64_t token_idx = blockIdx.x;  // one token per block
+    int64_t out_row_stride, int group_m, int group_n, int64_t scale_stride_0,
+    int64_t scale_stride_1) {
+  const int64_t token_idx = blockIdx.x;
   const int tid = threadIdx.x;
 
   const scalar_t* token_in = input + token_idx * in_row_stride;
   fp8_type* token_out = out + token_idx * out_row_stride;
 
-  const float inv_scale = 1.0f / (*scale);
+  // Row group index - compile-time eliminated when STRIDE_0_ZERO
+  const int gi = STRIDE_0_ZERO ? 0 : static_cast<int>(token_idx) / group_m;
 
-  vectorize_with_alignment<16>(
-      token_in, token_out, hidden_size, tid, blockDim.x,
-      [=] __device__(fp8_type & dst, const scalar_t& src) {
-        dst = scaled_fp8_conversion<true, fp8_type>(static_cast<float>(src),
-                                                    inv_scale);
-      });
+  constexpr int VEC_SIZE = 16;
+
+  if constexpr (STRIDE_1_ZERO) {
+    // Per-tensor or per-token: single scale per row, vectorize full row
+    const float inv_scale =
+        STRIDE_0_ZERO ? 1.0f / (*scale) : 1.0f / scale[gi * scale_stride_0];
+
+    vectorize_with_alignment<VEC_SIZE>(
+        token_in, token_out, hidden_size, tid, blockDim.x,
+        [=] __device__(fp8_type & dst, const scalar_t& src) {
+          dst = scaled_fp8_conversion<true, fp8_type>(static_cast<float>(src),
+                                                      inv_scale);
+        });
+  } else if (group_n >= VEC_SIZE) {
+    // Multiple column groups with vectorization
+    const int num_groups_n = hidden_size / group_n;
+
+    for (int gj = 0; gj < num_groups_n; gj++) {
+      const float inv_scale =
+          STRIDE_0_ZERO
+              ? 1.0f / scale[gj * scale_stride_1]
+              : 1.0f / scale[gi * scale_stride_0 + gj * scale_stride_1];
+
+      vectorize_with_alignment<VEC_SIZE>(
+          token_in + gj * group_n, token_out + gj * group_n, group_n, tid,
+          blockDim.x, [=] __device__(fp8_type & dst, const scalar_t& src) {
+            dst = scaled_fp8_conversion<true, fp8_type>(static_cast<float>(src),
+                                                        inv_scale);
+          });
+    }
+  } else {
+    // Scalar path for small column groups (group_n < VEC_SIZE)
+    for (int n = tid; n < hidden_size; n += blockDim.x) {
+      const int gj = n / group_n;
+      const float inv_scale =
+          STRIDE_0_ZERO
+              ? 1.0f / scale[gj * scale_stride_1]
+              : 1.0f / scale[gi * scale_stride_0 + gj * scale_stride_1];
+      token_out[n] = scaled_fp8_conversion<true, fp8_type>(
+          static_cast<float>(token_in[n]), inv_scale);
+    }
+  }
 }
 
 template <typename scalar_t, typename fp8_type>
@@ -133,17 +174,125 @@ __global__ void dynamic_per_token_scaled_fp8_quant_kernel_strided(
 
 }  // namespace vllm
 
-void static_scaled_fp8_quant(torch::Tensor& out,          // [..., d]
-                             torch::Tensor const& input,  // [..., d]
-                             torch::Tensor const& scale)  // [1]
+void static_scaled_fp8_quant(
+    torch::Tensor& out,                  // [..., d]
+    torch::Tensor const& input,          // [..., d]
+    torch::Tensor const& scale,          // various shapes
+    std::optional<int64_t> opt_group_m,  // optional explicit group_m
+    std::optional<int64_t> opt_group_n)  // optional explicit group_n
 {
   TORCH_CHECK(input.stride(-1) == 1,
               "last dimension of input must be contiguous");
   TORCH_CHECK(out.stride(-1) == 1,
               "last dimension of output must be contiguous");
 
-  const int hidden_size = input.size(-1);
-  const int num_tokens = input.numel() / hidden_size;
+  const int hidden_size = input.size(-1);              // N (columns)
+  const int num_tokens = input.numel() / hidden_size;  // M (rows)
+
+  // Determine group_m, group_n, and scale strides from scale shape
+  // Scale indexing: scale[gi * scale_stride_1 + gj * scale_stride_0]
+  // where gi = m / group_m, gj = n / group_n
+  int group_m, group_n;
+  int64_t scale_stride_0, scale_stride_1;
+
+  // If explicit group shape is provided, use it
+  const bool has_explicit_group =
+      opt_group_m.has_value() && opt_group_n.has_value();
+
+  if (scale.dim() == 0 || scale.numel() == 1) {
+    // Per-tensor: one scale for the entire tensor
+    group_m = num_tokens;
+    group_n = hidden_size;
+    scale_stride_0 = 0;
+    scale_stride_1 = 0;
+  } else if (scale.dim() == 1) {
+    // 1D scale: require explicit group_shape to disambiguate per-channel vs
+    // per-token (avoids edge case where num_tokens == hidden_size)
+    TORCH_CHECK(has_explicit_group,
+                "1D scale requires explicit group_shape to disambiguate "
+                "per-channel vs per-token quantization. "
+                "Use group_shape=(-1, 1) for per-channel or group_shape=(1, "
+                "-1) for per-token.");
+
+    group_m = opt_group_m.value() == -1 ? num_tokens
+                                        : static_cast<int>(opt_group_m.value());
+    group_n = opt_group_n.value() == -1 ? hidden_size
+                                        : static_cast<int>(opt_group_n.value());
+
+    // Validate the explicit group shape matches the 1D scale
+    const int64_t scale_len = scale.numel();
+    const int64_t expected_scale_m = num_tokens / group_m;
+    const int64_t expected_scale_n = hidden_size / group_n;
+    const int64_t expected_scale_numel = expected_scale_m * expected_scale_n;
+
+    TORCH_CHECK(scale_len == expected_scale_numel, "1D scale length (",
+                scale_len, ") does not match expected size (",
+                expected_scale_numel, ") for group_shape (",
+                opt_group_m.value(), ", ", opt_group_n.value(),
+                ") with input shape (", num_tokens, ", ", hidden_size, ")");
+
+    // For 1D scale, determine strides based on which dim is trivial
+    // Scale indexing: scale[gi * scale_stride_0 + gj * scale_stride_1]
+    // where gi = m / group_m (row group), gj = n / group_n (col group)
+    if (expected_scale_m == 1) {
+      // Per-channel style: one scale in M dim, scale varies along N
+      // gi = 0 always, gj varies, so stride_1 traverses the scale
+      scale_stride_0 = 0;
+      scale_stride_1 = scale.stride(0);
+    } else if (expected_scale_n == 1) {
+      // Per-token style: one scale in N dim, scale varies along M
+      // gj = 0 always, gi varies, so stride_0 traverses the scale
+      scale_stride_0 = scale.stride(0);
+      scale_stride_1 = 0;
+    } else {
+      TORCH_CHECK(
+          false,
+          "1D scale can only be used when one of the scale dimensions is 1. "
+          "For 2D group scaling, use a 2D scale tensor.");
+    }
+  } else if (scale.dim() == 2) {
+    // 2D scale: infer group sizes from scale dimensions (or use explicit if
+    // provided)
+    const int64_t scale_size_0 = scale.size(0);
+    const int64_t scale_size_1 = scale.size(1);
+
+    TORCH_CHECK(num_tokens % scale_size_0 == 0, "num_tokens (", num_tokens,
+                ") must be divisible by scale.size(0) (", scale_size_0, ")");
+    TORCH_CHECK(hidden_size % scale_size_1 == 0, "hidden_size (", hidden_size,
+                ") must be divisible by scale.size(1) (", scale_size_1, ")");
+
+    // Infer from 2D scale shape
+    int inferred_group_m = num_tokens / scale_size_0;
+    int inferred_group_n = hidden_size / scale_size_1;
+
+    // Use explicit if provided, otherwise use inferred
+    if (has_explicit_group) {
+      group_m = opt_group_m.value() == -1
+                    ? num_tokens
+                    : static_cast<int>(opt_group_m.value());
+      group_n = opt_group_n.value() == -1
+                    ? hidden_size
+                    : static_cast<int>(opt_group_n.value());
+
+      // Validate explicit matches inferred
+      TORCH_CHECK(group_m == inferred_group_m && group_n == inferred_group_n,
+                  "Explicit group_shape (", opt_group_m.value(), ", ",
+                  opt_group_n.value(),
+                  ") does not match inferred group shape (", inferred_group_m,
+                  ", ", inferred_group_n, ") from 2D scale tensor shape (",
+                  scale_size_0, ", ", scale_size_1, ")");
+    } else {
+      group_m = inferred_group_m;
+      group_n = inferred_group_n;
+    }
+
+    scale_stride_0 = scale.stride(0);
+    scale_stride_1 = scale.stride(1);
+  } else {
+    TORCH_CHECK(false, "scale must be 0D, 1D, or 2D tensor, but got ",
+                scale.dim(), "D");
+  }
+
   const int block_size = 256;
   dim3 grid(num_tokens);
   dim3 block(block_size);
@@ -153,17 +302,32 @@ void static_scaled_fp8_quant(torch::Tensor& out,          // [..., d]
 
   const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+// Dispatch to template-specialized kernel based on stride pattern
+#define LAUNCH_KERNEL(S0_ZERO, S1_ZERO)                                        \
+  vllm::scaled_fp8_quant_kernel_strided_group_shape<scalar_t, fp8_t, S0_ZERO,  \
+                                                    S1_ZERO>                   \
+      <<<grid, block, 0, stream>>>(                                            \
+          out.data_ptr<fp8_t>(), input.data_ptr<scalar_t>(),                   \
+          scale.data_ptr<float>(), hidden_size, in_row_stride, out_row_stride, \
+          group_m, group_n, scale_stride_0, scale_stride_1)
+
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "scaled_fp8_quant_kernel_scalar_type", [&] {
         VLLM_DISPATCH_FP8_TYPES(
             out.scalar_type(), "scaled_fp8_quant_kernel_fp8_type", [&] {
-              vllm::scaled_fp8_quant_kernel_strided<scalar_t, fp8_t>
-                  <<<grid, block, 0, stream>>>(
-                      out.data_ptr<fp8_t>(), input.data_ptr<scalar_t>(),
-                      scale.data_ptr<float>(), hidden_size, in_row_stride,
-                      out_row_stride);
+              if (scale_stride_0 == 0 && scale_stride_1 == 0)
+                LAUNCH_KERNEL(true, true);
+              else if (scale_stride_0 == 0)
+                LAUNCH_KERNEL(true, false);
+              else if (scale_stride_1 == 0)
+                LAUNCH_KERNEL(false, true);
+              else
+                LAUNCH_KERNEL(false, false);
             });
       });
+
+#undef LAUNCH_KERNEL
 }
 
 void dynamic_scaled_fp8_quant(torch::Tensor& out,          // [..., d]

--- a/csrc/quantization/w8a8/fp8/common.cu
+++ b/csrc/quantization/w8a8/fp8/common.cu
@@ -302,7 +302,7 @@ void static_scaled_fp8_quant(
   const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-// Dispatch to template-specialized kernel based on stride pattern
+  // Dispatch to template-specialized kernel based on stride pattern
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "scaled_fp8_quant_kernel_scalar_type", [&] {
         VLLM_DISPATCH_FP8_TYPES(

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -579,9 +579,12 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("gptq_shuffle", torch::kCUDA, &gptq_shuffle);
 
   // Compute FP8 quantized tensor for given scaling factor.
+  // Supports per-tensor, per-channel, per-token, and arbitrary 2D group
+  // scaling. Optional group_m/group_n specify the group shape explicitly;
+  // required for 1D scales to disambiguate per-channel vs per-token.
   ops.def(
-      "static_scaled_fp8_quant(Tensor! result, Tensor input, Tensor scale) -> "
-      "()");
+      "static_scaled_fp8_quant(Tensor! result, Tensor input, Tensor scale, "
+      "int? group_m=None, int? group_n=None) -> ()");
   ops.impl("static_scaled_fp8_quant", torch::kCUDA, &static_scaled_fp8_quant);
 
   // Compute dynamic-per-tensor FP8 quantized tensor and scaling factor.

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -584,7 +584,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   // required for 1D scales to disambiguate per-channel vs per-token.
   ops.def(
       "static_scaled_fp8_quant(Tensor! result, Tensor input, Tensor scale, "
-      "int? group_m=None, int? group_n=None) -> ()");
+      "(int, int)? group_shape=None) -> ()");
   ops.impl("static_scaled_fp8_quant", torch::kCUDA, &static_scaled_fp8_quant);
 
   // Compute dynamic-per-tensor FP8 quantized tensor and scaling factor.

--- a/tests/kernels/quantization/test_fp8_quant.py
+++ b/tests/kernels/quantization/test_fp8_quant.py
@@ -7,11 +7,16 @@ import torch
 import vllm._custom_ops as ops
 from tests.kernels.quant_utils import (
     FP8_DTYPE,
+    ROCM_FP8FNUZ_MAX,
     ref_dynamic_per_tensor_fp8_quant,
     ref_dynamic_per_token_quant,
 )
 from tests.kernels.utils import opcheck
 from vllm.utils.torch_utils import set_random_seed
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    scaled_quantize,
+)
+from vllm.platforms import current_platform
 
 DTYPES = [torch.bfloat16, torch.float]
 HIDDEN_SIZES = [17, 1024, 1025, 1026, 5137, 8193]
@@ -21,10 +26,20 @@ SEEDS = [0]
 
 
 def opcheck_fp8_quant(
-    output, input, scale=None, scale_ub=None, use_per_token_if_dynamic=False
+    output,
+    input,
+    scale=None,
+    scale_ub=None,
+    use_per_token_if_dynamic=False,
+    group_shape=None,
 ):
     if scale is not None:
-        opcheck(torch.ops._C.static_scaled_fp8_quant, (output, input, scale))
+        group_m = group_shape[0] if group_shape else None
+        group_n = group_shape[1] if group_shape else None
+        opcheck(
+            torch.ops._C.static_scaled_fp8_quant,
+            (output, input, scale, group_m, group_n),
+        )
     elif use_per_token_if_dynamic:
         scale = torch.empty(
             (input.shape[0], 1), device=input.device, dtype=torch.float32
@@ -96,6 +111,64 @@ def test_dynamic_per_tensor_fp8_quant(
     opcheck_fp8_quant(ops_out, x)
 
 
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("per_channel", [True, False])
+@torch.inference_mode()
+def test_static_fp8_quant(
+    num_tokens: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    per_channel: bool,
+) -> None:
+    current_platform.seed_everything(seed)
+
+    x = torch.rand(num_tokens, hidden_size, dtype=dtype, device="cuda")
+
+    if per_channel:
+        scale = torch.rand(hidden_size, dtype=torch.float32, device="cuda")
+        # Per-channel requires explicit group_shape for 1D scale
+        group_shape = (-1, 1)
+    else:
+        scale = torch.rand(1, dtype=torch.float32, device="cuda")
+        group_shape = None  # Per-tensor doesn't need group_shape
+
+    # Ensure scale is not zero
+    scale = scale + 0.01
+
+    # Reference implementation
+    fp8_traits = torch.finfo(FP8_DTYPE)
+    fp8_traits_max = (
+        ROCM_FP8FNUZ_MAX
+        if current_platform.is_rocm() and current_platform.is_fp8_fnuz()
+        else fp8_traits.max
+    )
+    fp8_traits_min = (
+        -ROCM_FP8FNUZ_MAX
+        if current_platform.is_rocm() and current_platform.is_fp8_fnuz()
+        else fp8_traits.min
+    )
+
+    inv_scale = (1.0 / scale).view(1, scale.numel())
+    ref_out = (
+        (x.to(torch.float32) * inv_scale)
+        .clamp(fp8_traits_min, fp8_traits_max)
+        .to(FP8_DTYPE)
+    )
+
+    ops_out, ops_scale = ops.scaled_fp8_quant(x, scale=scale, group_shape=group_shape)
+
+    torch.testing.assert_close(scale, ops_scale)
+    torch.testing.assert_close(
+        ref_out.to(dtype=torch.float32), ops_out.to(dtype=torch.float32)
+    )
+
+    opcheck_fp8_quant(ops_out, x, scale=scale, group_shape=group_shape)
+
+
 # Regression test for a case with large activations where an int32 index cannot
 # represent the number of elements.
 @torch.inference_mode()
@@ -118,3 +191,105 @@ def test_fp8_quant_large(seed: int) -> None:
     ops_out = ops_out.to(dtype=dtype)
 
     torch.testing.assert_close(ref_out, ops_out)
+
+
+# Test static FP8 quantization with 2D group scales
+# This tests the new scaled_fp8_quant_kernel_strided_group_shape kernel
+GROUP_SHAPES_2D = [
+    (-1, -1),  # Per-tensor
+    (-1, 1),  # Per-channel
+    (1, -1),  # Per-token
+    (-1, 128),  # Per-head quantization
+    (1, 128),  # DeepSeek-style per-token-per-group (group_m=1, group_n=128)
+    (128, 128),  # DeepSeek-style block quantization
+    (1, 64),  # Smaller group size
+    (1, 16),  # Small group (scalar path in kernel)
+    (4, 256),  # Non-trivial both dimensions
+]
+# Use sizes divisible by all group shapes
+NUM_TOKENS_GROUP = [128, 512]
+HIDDEN_SIZES_GROUP = [256, 1024, 2048]
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS_GROUP)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES_GROUP)
+@pytest.mark.parametrize("group_shape", GROUP_SHAPES_2D)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@torch.inference_mode()
+def test_static_fp8_quant_group_2d(
+    num_tokens: int,
+    hidden_size: int,
+    group_shape: tuple[int, int],
+    dtype: torch.dtype,
+    seed: int,
+) -> None:
+    """Test static FP8 quantization with 2D group scales using scaled_quantize."""
+    # Normalize group_shape (-1 means full extent)
+    norm_group_m = num_tokens if group_shape[0] == -1 else group_shape[0]
+    norm_group_n = hidden_size if group_shape[1] == -1 else group_shape[1]
+
+    # Skip if sizes are not divisible by group shape
+    if num_tokens % norm_group_m != 0 or hidden_size % norm_group_n != 0:
+        pytest.skip(
+            f"Skipping: ({num_tokens}, {hidden_size}) not divisible by "
+            f"group_shape ({group_shape[0]}, {group_shape[1]})"
+        )
+
+    current_platform.seed_everything(seed)
+
+    x = torch.rand(num_tokens, hidden_size, dtype=dtype, device="cuda")
+    ref_out, scale = scaled_quantize(
+        x, group_shape, FP8_DTYPE, compute_dtype=torch.float32
+    )
+    ops_out, ops_scale = ops.scaled_fp8_quant(x, scale=scale, group_shape=group_shape)
+
+    torch.testing.assert_close(scale, ops_scale)
+
+    # Compare FP8 outputs directly.
+    # ~0.001% of values may differ by 1 FP8 ULP (~10% relative) due to:
+    # - scaled_quantize uses: x * (finfo.max / amax)
+    # - kernel uses: x * (1 / scale) where scale = amax / finfo.max
+    # These are NOT equal in float32 at exact FP8 boundaries.
+    torch.testing.assert_close(ref_out.float(), ops_out.float(), rtol=0.12, atol=0.0)
+
+    opcheck_fp8_quant(ops_out, x, scale=scale)
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS_GROUP)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES_GROUP)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("group_shape", [(1, -1), (-1, 1)])  # per-token, per-channel
+@torch.inference_mode()
+def test_static_fp8_quant_1d_scale(
+    num_tokens: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    group_shape: tuple[int, int],
+) -> None:
+    """Test static FP8 quantization with 1D scale (per-token or per-channel)."""
+    current_platform.seed_everything(seed)
+
+    x = torch.rand(num_tokens, hidden_size, dtype=dtype, device="cuda")
+    ref_out, scale_2d = scaled_quantize(
+        x, group_shape, FP8_DTYPE, compute_dtype=torch.float32
+    )
+
+    # Flatten scale to 1D for testing 1D scale path
+    scale_1d = scale_2d.flatten()
+    ops_out, ops_scale = ops.scaled_fp8_quant(
+        x, scale=scale_1d, group_shape=group_shape
+    )
+
+    torch.testing.assert_close(scale_1d, ops_scale)
+
+    # Compare FP8 outputs directly.
+    # ~0.001% of values may differ by 1 FP8 ULP (~10% relative) due to:
+    # - scaled_quantize uses: x * (finfo.max / amax)
+    # - kernel uses: x * (1 / scale) where scale = amax / finfo.max
+    # These are NOT equal in float32 at exact FP8 boundaries.
+    torch.testing.assert_close(ref_out.float(), ops_out.float(), rtol=0.12, atol=0.0)
+
+    opcheck_fp8_quant(ops_out, x, scale=scale_1d, group_shape=group_shape)

--- a/tests/kernels/quantization/test_fp8_quant.py
+++ b/tests/kernels/quantization/test_fp8_quant.py
@@ -34,11 +34,9 @@ def opcheck_fp8_quant(
     group_shape=None,
 ):
     if scale is not None:
-        group_m = group_shape[0] if group_shape else None
-        group_n = group_shape[1] if group_shape else None
         opcheck(
             torch.ops._C.static_scaled_fp8_quant,
-            (output, input, scale, group_m, group_n),
+            (output, input, scale, group_shape),
         )
     elif use_per_token_if_dynamic:
         scale = torch.empty(

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1695,10 +1695,8 @@ def scaled_fp8_quant(
             in the dynamic quantization case.
         group_shape: Optional tuple (group_m, group_n) specifying the group
             shape for static quantization. Use -1 for "full extent" (e.g.,
-            (-1, -1) for per-tensor, (-1, 1) for per-channel, (1, -1) for
-            per-token, (1, 128) for DeepSeek-style activation quant).
-            Required for 1D scales; optional for 2D scales (will validate
-            against inferred shape if provided).
+            (-1, -1) for per-tensor, (-1, 1) for per-channel, etc.)
+            Required for 1D scales; optional for 2D scales.
 
     Returns:
         tuple[torch.Tensor, torch.Tensor]: The output tensor in FP8 and

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1668,6 +1668,7 @@ def scaled_fp8_quant(
     scale_ub: torch.Tensor | None = None,
     use_per_token_if_dynamic: bool = False,
     output: torch.Tensor | None = None,
+    group_shape: tuple[int, int] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Quantize input tensor to FP8 and return quantized tensor and scale.
@@ -1679,14 +1680,25 @@ def scaled_fp8_quant(
     will benefit from padding.
 
     Args:
-        input: The input tensor to be quantized to FP8
-        scale: Optional scaling factor for the FP8 quantization
+        input: The input tensor to be quantized to FP8 (must be 2D: [M, N])
+        scale: Optional scaling factor for the FP8 quantization. Supports:
+            - 0D or [1]: per-tensor scaling
+            - 1D: requires explicit group_shape to disambiguate per-channel
+              vs per-token (use (-1, 1) for per-channel, (1, -1) for per-token)
+            - 2D [M/group_m, N/group_n]: group scaling (e.g. [M, N/128] for
+              DeepSeek-style (1,128) groups, or [M/128, N/128] for (128,128))
         scale_ub: Optional upper bound for scaling factor in dynamic
             per token case
         num_token_padding: If specified, pad the first dimension
             of the output to at least this value.
         use_per_token_if_dynamic: Whether to do per_tensor or per_token
             in the dynamic quantization case.
+        group_shape: Optional tuple (group_m, group_n) specifying the group
+            shape for static quantization. Use -1 for "full extent" (e.g.,
+            (-1, -1) for per-tensor, (-1, 1) for per-channel, (1, -1) for
+            per-token, (1, 128) for DeepSeek-style activation quant).
+            Required for 1D scales; optional for 2D scales (will validate
+            against inferred shape if provided).
 
     Returns:
         tuple[torch.Tensor, torch.Tensor]: The output tensor in FP8 and
@@ -1715,8 +1727,9 @@ def scaled_fp8_quant(
             scale = torch.empty(1, device=input.device, dtype=torch.float32)
             torch.ops._C.dynamic_scaled_fp8_quant(output, input, scale)
     else:
-        assert scale.numel() == 1, f"{scale.shape}"
-        torch.ops._C.static_scaled_fp8_quant(output, input, scale)
+        group_m = group_shape[0] if group_shape is not None else None
+        group_n = group_shape[1] if group_shape is not None else None
+        torch.ops._C.static_scaled_fp8_quant(output, input, scale, group_m, group_n)
 
     return output, scale
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1727,9 +1727,7 @@ def scaled_fp8_quant(
             scale = torch.empty(1, device=input.device, dtype=torch.float32)
             torch.ops._C.dynamic_scaled_fp8_quant(output, input, scale)
     else:
-        group_m = group_shape[0] if group_shape is not None else None
-        group_n = group_shape[1] if group_shape is not None else None
-        torch.ops._C.static_scaled_fp8_quant(output, input, scale, group_m, group_n)
+        torch.ops._C.static_scaled_fp8_quant(output, input, scale, group_shape)
 
     return output, scale
 

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -10,6 +10,7 @@ from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
     get_fp8_min_max,
+    group_broadcast,
 )
 from vllm.platforms import current_platform
 
@@ -21,7 +22,7 @@ _FP8_MIN_SCALING_FACTOR = 1.0 / (_FP8_MAX * 512.0)
 @CustomOp.register("quant_fp8")
 class QuantFP8(CustomOp):
     """
-    Quantize input tensor to FP8 (per-tensor, per-token, or per-group).
+    Quantize input tensor to FP8 (per-tensor, per-token, per-channel, or per-group).
     This CustomOp supports both static and dynamic quantization.
     """
 
@@ -54,14 +55,14 @@ class QuantFP8(CustomOp):
 
         self.is_group_quant = group_shape.is_per_group()
         if self.is_group_quant:
-            assert not static, "Group quantization only supports dynamic mode"
             self.group_size = group_shape.col
         else:
-            assert group_shape in {GroupShape.PER_TOKEN, GroupShape.PER_TENSOR}
-            assert not static or group_shape == GroupShape.PER_TENSOR, (
-                "Only per-tensor scales supported for static quantization."
-            )
             self.use_per_token_if_dynamic = group_shape == GroupShape.PER_TOKEN
+            if not static:
+                assert group_shape in (GroupShape.PER_TOKEN, GroupShape.PER_TENSOR), (
+                    "Only per-token or per-tensor scales are supported for dynamic "
+                    "non-group quantization."
+                )
 
     def forward_cuda(
         self,
@@ -69,8 +70,8 @@ class QuantFP8(CustomOp):
         scale: torch.Tensor | None = None,
         scale_ub: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if self.is_group_quant:
-            assert scale is None, "Group quantization is always dynamic"
+        if self.is_group_quant and not self.static:
+            assert scale is None, "Dynamic group quantization does not use scale"
             from vllm.model_executor.layers.quantization.utils import fp8_utils
 
             return fp8_utils.per_token_group_quant_fp8(
@@ -87,12 +88,14 @@ class QuantFP8(CustomOp):
             and self.group_shape == GroupShape.PER_TOKEN
             and scale_ub.numel() == 1
         )
+
         return ops.scaled_fp8_quant(
             x,
             scale,
             num_token_padding=self.num_token_padding,
             scale_ub=scale_ub,
             use_per_token_if_dynamic=self.use_per_token_if_dynamic,
+            group_shape=self.group_shape if self.static else None,
         )
 
     def forward_hip(
@@ -128,8 +131,8 @@ class QuantFP8(CustomOp):
         scale: torch.Tensor | None = None,
         scale_ub: torch.Tensor | None = None,
     ):
-        if self.is_group_quant:
-            assert scale is None, "Group quantization is always dynamic"
+        if self.is_group_quant and not self.static:
+            assert scale is None, "Dynamic group quantization does not use scale"
             return self._quantize_group_native(x)
 
         assert (scale is not None) == self.static
@@ -152,7 +155,10 @@ class QuantFP8(CustomOp):
 
         # Even for dynamic per-token scales,
         # reciprocal performs slightly better than division
-        out = x.to(torch.float32) * scale.reciprocal()
+        out = (
+            x.to(torch.float32)
+            * group_broadcast(scale.to(torch.float32), x.shape[-2:]).reciprocal()
+        )
         out = out.clamp(_FP8_MIN, _FP8_MAX).to(_FP8_DTYPE)
 
         # This currently generates an extra Triton kernel in compilation.

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -180,7 +180,16 @@ def scaled_quantize(
     x: torch.Tensor,
     group_shape: GroupShape,
     quant_dtype: torch.dtype,
+    compute_dtype: torch.dtype | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Args:
+        x: Input tensor to quantize
+        group_shape: Shape of quantization groups
+        quant_dtype: Target quantized dtype (e.g., torch.float8_e4m3fn)
+        compute_dtype: Optional dtype for intermediate computations.
+            If None, uses input dtype. Use torch.float32 for higher precision.
+    """
     group_shape = _normalize_quant_group_shape(x, group_shape)
     assert quant_dtype.is_floating_point, (
         "currently `scaled_quantize` only supports floating point dtypes "
@@ -189,11 +198,14 @@ def scaled_quantize(
 
     finfo = torch.finfo(quant_dtype)
 
+    # Convert to compute dtype if specified
+    x_compute = x if compute_dtype is None else x.to(compute_dtype)
+
     # Reshape (M, N) into (BLK_M, BLOCK_SIZE_M, BLK_N, BLOCK_SIZE_N)
     assert x.ndim == 2
     assert x.shape[0] % group_shape[0] == 0 and x.shape[1] % group_shape[1] == 0
     blk_m, blk_n = x.shape[0] // group_shape[0], x.shape[1] // group_shape[1]
-    x_blkd = x.reshape(blk_m, group_shape[0], blk_n, group_shape[1])
+    x_blkd = x_compute.reshape(blk_m, group_shape[0], blk_n, group_shape[1])
 
     # Permute to (BLK_M, BLK_N, BLOCK_SIZE_M, BLOCK_SIZE_N)
     x_blkd_permd = x_blkd.permute(0, 2, 1, 3)


### PR DESCRIPTION
Preparatory pr for https://github.com/vllm-project/vllm/pull/30141 (per-head quant)

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c82c073a6134ce25dbd7234699e8e6e66021dc4f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Adds flexible static FP8 quantization with explicit group shapes and multi-shape scale support.
> 
> - New CUDA kernel `scaled_fp8_quant_kernel_strided_group_shape` with stride-based dispatch, vectorized paths, and group-aware indexing (per-tensor/channel/token and arbitrary 2D groups)
> - Updates C++ op: `static_scaled_fp8_quant(result, input, scale, group_shape?)` to infer/validate group sizes from 0D/1D/2D scales; binding schema adjusted in `torch_bindings.cpp`
> - Python API: `_custom_ops.scaled_fp8_quant` accepts `group_shape`; `QuantFP8` passes `group_shape` for static mode and refines dynamic/group logic
> - Tests: add coverage for 2D group scales and 1D scales (per-token/channel) using `scaled_quantize`; opcheck updated to include `group_shape`
> - Utils: `group_broadcast` supports tensors with fewer dims; `scaled_quantize` gets `compute_dtype` for higher precision
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c82c073a6134ce25dbd7234699e8e6e66021dc4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
