### PR TITLE
[Kernels][FI] Skip trtllm attention when num_kv_heads=1

### DIFF
--- a/tests/kernels/attention/test_flashinfer_trtllm_attention.py
+++ b/tests/kernels/attention/test_flashinfer_trtllm_attention.py
@@ -455,3 +455,38 @@ def test_flashinfer_trtllm_prefill_with_baseline(
         torch.testing.assert_close(output, output_trtllm, atol=atol, rtol=rtol),
         f"{torch.max(torch.abs(output - output_trtllm))}",
     )
+
+
+def test_trtllm_attention_rejects_num_kv_heads_1() -> None:
+    """Test that TRTLLM attention correctly rejects num_kv_heads=1.
+
+    When num_kv_heads=1 (MQA), the KV cache strides become degenerate
+    (stride_heads == stride_batch), which causes CUDA's cuTensorMapEncodeTiled
+    to fail because TMA descriptors cannot handle degenerate 4D tensors with
+    singleton dimensions.
+
+    This test verifies that can_use_trtllm_attention returns False for
+    num_kv_heads=1 configurations.
+    """
+    from vllm.utils.flashinfer import can_use_trtllm_attention
+
+    # num_kv_heads=1 should be rejected
+    assert not can_use_trtllm_attention(num_qo_heads=64, num_kv_heads=1), (
+        "can_use_trtllm_attention should return False for num_kv_heads=1"
+    )
+    assert not can_use_trtllm_attention(num_qo_heads=32, num_kv_heads=1), (
+        "can_use_trtllm_attention should return False for num_kv_heads=1"
+    )
+
+    # num_kv_heads > 1 should be accepted (if platform supports it)
+    # Note: This may return False on non-Blackwell platforms, which is fine
+    result_kv8 = can_use_trtllm_attention(num_qo_heads=64, num_kv_heads=8)
+    result_kv1 = can_use_trtllm_attention(num_qo_heads=64, num_kv_heads=1)
+
+    # Even if platform doesn't support TRTLLM, num_kv_heads=1 should never
+    # return True when num_kv_heads > 1 returns True
+    if result_kv8:
+        assert not result_kv1, (
+            "If TRTLLM is supported for num_kv_heads=8, "
+            "it must be rejected for num_kv_heads=1"
+        )

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -305,7 +305,18 @@ def can_use_trtllm_attention(num_qo_heads: int, num_kv_heads: int) -> bool:
     if force_use_trtllm_attention() is False:
         return False
     has_trtllm = supports_trtllm_attention()
-    return has_trtllm and (num_qo_heads % num_kv_heads == 0)
+    # num_kv_heads=1 is not supported due to TMA descriptor building limitations.
+    # When num_kv_heads=1, the KV cache strides become degenerate (stride_heads ==
+    # stride_batch), which causes CUDA's cuTensorMapEncodeTiled to fail because
+    # TMA descriptors cannot handle degenerate 4D tensors with singleton dimensions.
+    # See: https://fburl.com/352mrydz
+    if has_trtllm and num_kv_heads == 1:
+        logger.warning_once(
+            "TRTLLM attention does not support num_kv_heads=1. "
+            "This configuration causes TMA descriptor building to fail due to "
+            "degenerate tensor strides. Falling back to FlashInfer attention."
+        )
+    return has_trtllm and (num_qo_heads % num_kv_heads == 0) and (num_kv_heads != 1)
 
 
 def use_trtllm_attention(
@@ -352,6 +363,15 @@ def use_trtllm_attention(
                 "TRTLLM attention is not supported for this combination of "
                 "query and key heads, but --attention-config.use_trtllm_attention is "
                 "set to 1"
+            )
+        return False
+
+    # num_kv_heads=1 is not supported
+    if num_kv_heads == 1:
+        if force_use_trtllm:
+            logger.warning_once(
+                "TRTLLM attention does not support num_kv_heads=1, "
+                "but --attention-config.use_trtllm_attention is set to 1"
             )
         return False
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
We got the following error when running a small model on blackwell 
```
[WORKER]:  File "/redacted/path/executor/abstract.py", line 116, in initialize_from_config
[WORKER]:    self.collective_rpc("compile_or_warm_up_model")
[WORKER]:  File "/redacted/path/executor/uniproc_executor.py", line 75, in collective_rpc
[WORKER]:    result = run_method(self.driver_worker, method, args, kwargs)
[WORKER]:  File "/redacted/path/serial_utils.py", line 460, in run_method
[WORKER]:    return func(*args, **kwargs)
[WORKER]:  File "/redacted/path/worker/gpu_worker.py", line 444, in compile_or_warm_up_model
[WORKER]:    kernel_warmup(self)
[WORKER]:  File "/redacted/path/model_executor/warmup/kernel_warmup.py", line 68, in kernel_warmup
[WORKER]:    worker.model_runner._dummy_run(
[WORKER]:  File "/redacted/env/utils/_contextlib.py", line 116, in decorate_context
[WORKER]:    return func(*args, **kwargs)
[WORKER]:  File "/redacted/path/worker/gpu_model_runner.py", line 4130, in _dummy_run
[WORKER]:    outputs = self.model(
[WORKER]:  File "/redacted/path/compilation/cuda_graph.py", line 220, in __call__
[WORKER]:    return self.runnable(*args, **kwargs)
[WORKER]:  File "/redacted/env/nn/modules/module.py", line 1767, in _wrapped_call_impl
[WORKER]:    return self._call_impl(*args, **kwargs)
[WORKER]:  File "/redacted/env/nn/modules/module.py", line 1778, in _call_impl
[WORKER]:    return forward_call(*args, **kwargs)
[WORKER]:  File "/redacted/path/model.py", line 664, in forward
[WORKER]:    transformer_output, _ = self.model_core(
[WORKER]:  File "/redacted/env/nn/modules/module.py", line 1767, in _wrapped_call_impl
[WORKER]:    return self._call_impl(*args, **kwargs)
[WORKER]:  File "/redacted/env/nn/modules/module.py", line 1778, in _call_impl
[WORKER]:    return forward_call(*args, **kwargs)
[WORKER]:  File "/redacted/path/model/transformer.py", line 1804, in forward
[WORKER]:    h, cache = self.transformer_layers_forward(
[WORKER]:  File "/redacted/path/model/transformer.py", line 1930, in transformer_layers_forward
[WORKER]:    h, new_cache = layer_fn(
[WORKER]:  File "/redacted/env/nn/modules/module.py", line 1767, in _wrapped_call_impl
[WORKER]:    return self._call_impl(*args, **kwargs)
[WORKER]:  File "/redacted/env/nn/modules/module.py", line 1778, in _call_impl
[WORKER]:    return forward_call(*args, **kwargs)
[WORKER]:  File "/redacted/path/model/transformer.py", line 1103, in forward
[WORKER]:    residual_stream, new_cache = self.pre_feed_forward_processing(
[WORKER]:  File "/redacted/path/model/transformer.py", line 1045, in pre_feed_forward_processing
[WORKER]:    attn_out, new_cache = self.attention(  # Pre-norm applied inside attention
[WORKER]:  File "/redacted/env/nn/modules/module.py", line 1767, in _wrapped_call_impl
[WORKER]:    return self._call_impl(*args, **kwargs)
[WORKER]:  File "/redacted/env/nn/modules/module.py", line 1778, in _call_impl
[WORKER]:    return forward_call(*args, **kwargs)
[WORKER]:  File "/redacted/path/model/transformer.py", line 572, in forward
[WORKER]:    return self._attention_forward(
[WORKER]:  File "/redacted/path/model/transformer.py", line 704, in _attention_forward
[WORKER]:    output = self.attention(
[WORKER]:  File "/redacted/env/nn/modules/module.py", line 1767, in _wrapped_call_impl
[WORKER]:    return self._call_impl(*args, **kwargs)
[WORKER]:  File "/redacted/env/nn/modules/module.py", line 1778, in _call_impl
[WORKER]:    return forward_call(*args, **kwargs)
[WORKER]:  File "/redacted/path/model/custom_op.py", line 493, in forward
[WORKER]:    return method(*args, **kwargs)
[WORKER]:  File "/redacted/path/model/layers/paged_attention.py", line 268, in forward_native
[WORKER]:    output_vllm = self._attention.forward(query, key, value)
[WORKER]:  File "/redacted/path/attention/layer.py", line 367, in forward
[WORKER]:    torch.ops.vllm.unified_attention_with_output(
[WORKER]:  File "/redacted/env/_ops.py", line 1208, in __call__
[WORKER]:    return self._op(*args, **(kwargs or {}))
[WORKER]:  File "/redacted/path/attention/utils/kv_transfer_utils.py", line 39, in wrapper
[WORKER]:    return func(*args, **kwargs)
[WORKER]:  File "/redacted/path/attention/layer.py", line 869, in unified_attention_with_output
[WORKER]:    self.impl.forward(
[WORKER]:  File "/redacted/path/attention/backends/flashinfer.py", line 1295, in forward
[WORKER]:    trtllm_batch_context_with_kv_cache(
[WORKER]:  File "/redacted/env/flashinfer/prefill.py", line 3513, in trtllm_batch_context_with_kv_cache
[WORKER]:    run_func(
[WORKER]:  File "python/tvm_ffi/cython/function.pxi", line 923, in tvm_ffi.core.Function.__call__
[WORKER]:RuntimeError: Error in function 'buildNdTmaDescriptor' at /workspace/include/flashinfer/trtllm/fmha/kernelParams.h:536: Check failed: false
```

Detailed errors 
```
Error: Failed to initialize the TMA descriptor due to invalid argument
tmaFormat: 9 dim: 4 gmem: 0xf64d740000
Shape: 64 16 1 7721128 7149852580857340533
Stride: 128 2 4096 337
tileShapes: 64 16 1 1 1024
tileStrides: 1 1 1 1 1969767282
swizzleType: 3
```

We confirmed that the dummy run failed when num_kv_heads=1 which causes stride of 0. in those case we can fall back to flashinfer's native attention instead of trtllm. Existing test cases ignore this any way.


## Test Plan
```
 pytest -v tests/kernels/attention/test_flashinfer_trtllm_attention.py::test_trtllm_attention_rejects_num_kv_heads_1
```

## Test Result
```
tests/kernels/attention/test_flashinfer_trtllm_attention.py::test_trtllm_attention_rejects_num_kv_heads_1 PASSED [100%]

========================================= warnings summary ==========================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================== 1 passed, 2 warnings in 18.72s ===================================
```
Our internal run succeed on this. Remaining will depend on CI.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

