### PR TITLE
[Chore] Factor out logic for requesting initial memory

### DIFF
--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -76,7 +76,7 @@ class MemorySnapshot:
 
             device_fn = current_platform.current_device
             assert device_fn is not None
-            self._device: torch.device = device_fn()
+            self._device = torch.device(device_fn())
         else:
             self._device = torch.device(self.device)
 

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -76,9 +76,9 @@ class MemorySnapshot:
 
             device_fn = current_platform.current_device
             assert device_fn is not None
-            self._device = torch.device(device_fn())
+            self.device_ = torch.device(device_fn())
         else:
-            self._device = torch.device(self.device)
+            self.device_ = torch.device(self.device)
 
         if self.auto_measure:
             self.measure()
@@ -86,7 +86,7 @@ class MemorySnapshot:
     def measure(self) -> None:
         from vllm.platforms import current_platform
 
-        device = self._device
+        device = self.device_
 
         # we measure the torch peak memory usage via allocated_bytes,
         # rather than `torch.cuda.memory_reserved()` .
@@ -128,10 +128,10 @@ class MemorySnapshot:
         self.timestamp = time.time()
 
     def __sub__(self, other: "MemorySnapshot") -> "MemorySnapshot":
-        if self._device != other._device:
+        if self.device_ != other.device_:
             raise ValueError(
                 "The two snapshots should be from the same device! "
-                f"Found: {self._device} vs. {other._device}"
+                f"Found: {self.device_} vs. {other.device_}"
             )
 
         return MemorySnapshot(
@@ -142,7 +142,7 @@ class MemorySnapshot:
             torch_memory=self.torch_memory - other.torch_memory,
             non_torch_memory=self.non_torch_memory - other.non_torch_memory,
             timestamp=self.timestamp - other.timestamp,
-            device=self._device,
+            device=self.device_,
             auto_measure=False,
         )
 

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -66,6 +66,8 @@ class MemorySnapshot:
     torch_memory: int = 0
     non_torch_memory: int = 0
     timestamp: float = 0.0
+
+    device: torch.types.Device = None
     auto_measure: bool = True
 
     def __post_init__(self) -> None:
@@ -75,18 +77,29 @@ class MemorySnapshot:
     def measure(self) -> None:
         from vllm.platforms import current_platform
 
+        device = self.device
+        if device is None:
+            device_fn = current_platform.current_device
+            assert device_fn is not None
+            device = device_fn()
+
+        device_id = torch.device(device).index
+
         # we measure the torch peak memory usage via allocated_bytes,
         # rather than `torch.cuda.memory_reserved()` .
         # After `torch.cuda.reset_peak_memory_stats()`,
         # `torch.cuda.memory_reserved()` will keep growing, and only shrink
         # when we call `torch.cuda.empty_cache()` or OOM happens.
-        self.torch_peak = torch.cuda.memory_stats().get("allocated_bytes.all.peak", 0)
+        self.torch_peak = torch.cuda.memory_stats(device).get(
+            "allocated_bytes.all.peak", 0
+        )
 
-        self.free_memory, self.total_memory = torch.cuda.mem_get_info()
+        self.free_memory, self.total_memory = torch.cuda.mem_get_info(device)
         shared_sysmem_device_mem_sms = ((8, 7), (11, 0), (12, 1))  # Orin, Thor, Spark
         if (
             current_platform.is_cuda()
-            and current_platform.get_device_capability() in shared_sysmem_device_mem_sms
+            and current_platform.get_device_capability(device_id)
+            in shared_sysmem_device_mem_sms
         ):
             # On UMA (Orin, Thor and Spark) platform,
             # where both CPU and GPU rely on system memory,
@@ -106,12 +119,18 @@ class MemorySnapshot:
         # torch.cuda.memory_reserved() is how many bytes
         # PyTorch gets from cuda (by calling cudaMalloc, etc.)
         # this is used to measure the non-torch memory usage
-        self.torch_memory = torch.cuda.memory_reserved()
+        self.torch_memory = torch.cuda.memory_reserved(device)
 
         self.non_torch_memory = self.cuda_memory - self.torch_memory
         self.timestamp = time.time()
 
     def __sub__(self, other: "MemorySnapshot") -> "MemorySnapshot":
+        if self.device != other.device:
+            raise ValueError(
+                "The two snapshots should be from the same device! "
+                f"Found: {self.device} vs. {other.device}"
+            )
+
         return MemorySnapshot(
             torch_peak=self.torch_peak - other.torch_peak,
             free_memory=self.free_memory - other.free_memory,
@@ -120,6 +139,7 @@ class MemorySnapshot:
             torch_memory=self.torch_memory - other.torch_memory,
             non_torch_memory=self.non_torch_memory - other.non_torch_memory,
             timestamp=self.timestamp - other.timestamp,
+            device=self.device,
             auto_measure=False,
         )
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -56,7 +56,7 @@ from vllm.v1.worker.utils import is_residual_scattered_for_sp
 from vllm.v1.worker.worker_base import WorkerBase
 from vllm.v1.worker.workspace import init_workspace_manager
 
-from .utils import check_enough_init_memory
+from .utils import request_memory
 
 logger = init_logger(__name__)
 
@@ -239,11 +239,8 @@ class Worker(WorkerBase):
             torch.cuda.empty_cache()
 
             # take current memory snapshot
-            self.init_snapshot = MemorySnapshot()
-            self.requested_memory = check_enough_init_memory(
-                self.init_snapshot,
-                self.cache_config,
-            )
+            self.init_snapshot = init_snapshot = MemorySnapshot()
+            self.requested_memory = request_memory(init_snapshot, self.cache_config)
         else:
             raise RuntimeError(f"Not support device type: {self.device_config.device}")
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -56,6 +56,8 @@ from vllm.v1.worker.utils import is_residual_scattered_for_sp
 from vllm.v1.worker.worker_base import WorkerBase
 from vllm.v1.worker.workspace import init_workspace_manager
 
+from .utils import check_enough_init_memory
+
 logger = init_logger(__name__)
 
 if TYPE_CHECKING:
@@ -238,21 +240,10 @@ class Worker(WorkerBase):
 
             # take current memory snapshot
             self.init_snapshot = MemorySnapshot()
-            self.requested_memory = (
-                self.init_snapshot.total_memory
-                * self.cache_config.gpu_memory_utilization
+            self.requested_memory = check_enough_init_memory(
+                self.init_snapshot,
+                self.cache_config,
             )
-            if self.init_snapshot.free_memory < self.requested_memory:
-                GiB = lambda b: round(b / GiB_bytes, 2)
-                raise ValueError(
-                    f"Free memory on device "
-                    f"({GiB(self.init_snapshot.free_memory)}/"
-                    f"{GiB(self.init_snapshot.total_memory)} GiB) on startup "
-                    f"is less than desired GPU memory utilization "
-                    f"({self.cache_config.gpu_memory_utilization}, "
-                    f"{GiB(self.requested_memory)} GiB). Decrease GPU memory "
-                    f"utilization or reduce GPU memory used by other processes."
-                )
         else:
             raise RuntimeError(f"Not support device type: {self.device_config.device}")
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -239,7 +239,7 @@ class Worker(WorkerBase):
             torch.cuda.empty_cache()
 
             # take current memory snapshot
-            self.init_snapshot = init_snapshot = MemorySnapshot()
+            self.init_snapshot = init_snapshot = MemorySnapshot(device=self.device)
             self.requested_memory = request_memory(init_snapshot, self.cache_config)
         else:
             raise RuntimeError(f"Not support device type: {self.device_config.device}")

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -250,10 +250,7 @@ def gather_mm_placeholders(
     return placeholders[is_embed]
 
 
-def check_enough_init_memory(
-    init_snapshot: MemorySnapshot,
-    cache_config: CacheConfig,
-) -> float:
+def request_memory(init_snapshot: MemorySnapshot, cache_config: CacheConfig) -> float:
     """
     Calculate the amount of memory required by vLLM, then validate
     that the current amount of free memory is sufficient for that.

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -260,7 +260,7 @@ def request_memory(init_snapshot: MemorySnapshot, cache_config: CacheConfig) -> 
     if init_snapshot.free_memory < requested_memory:
         GiB = lambda b: round(b / GiB_bytes, 2)
         raise ValueError(
-            f"Free memory on device {init_snapshot._device} "
+            f"Free memory on device {init_snapshot.device_} "
             f"({GiB(init_snapshot.free_memory)}/"
             f"{GiB(init_snapshot.total_memory)} GiB) on startup "
             f"is less than desired GPU memory utilization "

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -260,7 +260,7 @@ def request_memory(init_snapshot: MemorySnapshot, cache_config: CacheConfig) -> 
     if init_snapshot.free_memory < requested_memory:
         GiB = lambda b: round(b / GiB_bytes, 2)
         raise ValueError(
-            f"Free memory on device {init_snapshot.device} "
+            f"Free memory on device {init_snapshot._device} "
             f"({GiB(init_snapshot.free_memory)}/"
             f"{GiB(init_snapshot.total_memory)} GiB) on startup "
             f"is less than desired GPU memory utilization "

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -8,13 +8,15 @@ from typing_extensions import deprecated
 
 from vllm.attention.backends.abstract import AttentionBackend
 from vllm.attention.layer import Attention
-from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
+from vllm.config import CacheConfig, ModelConfig, SchedulerConfig, VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.multimodal.cache import processor_only_cache_from_config
 from vllm.multimodal.registry import MultiModalRegistry
 from vllm.platforms import current_platform
+from vllm.utils.mem_constants import GiB_bytes
+from vllm.utils.mem_utils import MemorySnapshot
 from vllm.v1.attention.backends.utils import AttentionMetadataBuilder
 from vllm.v1.core.encoder_cache_manager import compute_mm_encoder_budget
 from vllm.v1.kv_cache_interface import KVCacheGroupSpec, KVCacheSpec
@@ -246,6 +248,31 @@ def gather_mm_placeholders(
         return placeholders
 
     return placeholders[is_embed]
+
+
+def check_enough_init_memory(
+    init_snapshot: MemorySnapshot,
+    cache_config: CacheConfig,
+) -> float:
+    """
+    Calculate the amount of memory required by vLLM, then validate
+    that the current amount of free memory is sufficient for that.
+    """
+    requested_memory = init_snapshot.total_memory * cache_config.gpu_memory_utilization
+
+    if init_snapshot.free_memory < requested_memory:
+        GiB = lambda b: round(b / GiB_bytes, 2)
+        raise ValueError(
+            f"Free memory on device {init_snapshot.device} "
+            f"({GiB(init_snapshot.free_memory)}/"
+            f"{GiB(init_snapshot.total_memory)} GiB) on startup "
+            f"is less than desired GPU memory utilization "
+            f"({cache_config.gpu_memory_utilization}, "
+            f"{GiB(requested_memory)} GiB). Decrease GPU memory "
+            f"utilization or reduce GPU memory used by other processes."
+        )
+
+    return requested_memory
 
 
 def add_kv_sharing_layers_to_kv_cache_groups(


### PR DESCRIPTION
## Purpose

I saw that this logic is duplicated by vllm-omni:

- https://github.com/vllm-project/vllm-omni/blob/acf66ee2cc3799f22e01ec5eeddfe86f39a14388/vllm_omni/worker/gpu_ar_worker.py#L61
- https://github.com/vllm-project/vllm-omni/blob/acf66ee2cc3799f22e01ec5eeddfe86f39a14388/vllm_omni/worker/gpu_generation_worker.py#L7

Let's factor this out into a separate function. cc @hsliuustc0106 @tzhouam

I have also improved the error message to show exactly which device has insufficient memory (more relevant for vllm-omni which can put different loads on each GPU).

Split out from https://github.com/vllm-project/vllm/pull/22070

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

