### PR TITLE
[Fix] pass chat_template_kwargs to get_system_message in gpt-oss

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -6,7 +6,7 @@ import json
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
-from typing import Any, Final
+from typing import Final
 
 import jinja2
 import partial_json_parser
@@ -1804,10 +1804,18 @@ class OpenAIServingChat(OpenAIServing):
             **(request.chat_template_kwargs or {}),
         }
         allowed_keys = {
-            "model_identity", "reasoning_effort", "start_date", "browser_description",
-            "python_description", "container_description", "instructions", "with_custom_tools"
+            "model_identity",
+            "reasoning_effort",
+            "start_date",
+            "browser_description",
+            "python_description",
+            "container_description",
+            "instructions",
+            "with_custom_tools",
         }
-        sys_msg = get_system_message(**{k: v for k, v in sys_msg_kwargs.items() if k in allowed_keys})
+        sys_msg = get_system_message(
+            **{k: v for k, v in sys_msg_kwargs.items() if k in allowed_keys}
+        )
         messages.append(sys_msg)
 
         # Add developer message.

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1796,14 +1796,18 @@ class OpenAIServingChat(OpenAIServing):
         # if the model supports it. TODO: Support browsing.
         assert not self.supports_browsing
         assert not self.supports_code_interpreter
-        _chat_template_kwargs: dict[str, Any] = request.chat_template_kwargs or {}
-        sys_msg = get_system_message(
-            reasoning_effort=request.reasoning_effort,
-            browser_description=None,
-            python_description=None,
-            with_custom_tools=request.tools is not None,
-            **_chat_template_kwargs,
-        )
+        sys_msg_kwargs = {
+            "reasoning_effort": request.reasoning_effort,
+            "browser_description": None,
+            "python_description": None,
+            "with_custom_tools": request.tools is not None,
+            **(request.chat_template_kwargs or {}),
+        }
+        allowed_keys = {
+            "model_identity", "reasoning_effort", "start_date", "browser_description",
+            "python_description", "container_description", "instructions", "with_custom_tools"
+        }
+        sys_msg = get_system_message(**{k: v for k, v in sys_msg_kwargs.items() if k in allowed_keys})
         messages.append(sys_msg)
 
         # Add developer message.

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -6,7 +6,7 @@ import json
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
-from typing import Final
+from typing import Any, Final
 
 import jinja2
 import partial_json_parser
@@ -1796,11 +1796,13 @@ class OpenAIServingChat(OpenAIServing):
         # if the model supports it. TODO: Support browsing.
         assert not self.supports_browsing
         assert not self.supports_code_interpreter
+        _chat_template_kwargs: dict[str, Any] = request.chat_template_kwargs or {}
         sys_msg = get_system_message(
             reasoning_effort=request.reasoning_effort,
             browser_description=None,
             python_description=None,
             with_custom_tools=request.tools is not None,
+            **_chat_template_kwargs,
         )
         messages.append(sys_msg)
 


### PR DESCRIPTION

## Purpose

This PR addresses the issue where `chat_template_kwargs` (specifically `model_identity`) is ignored when using `gpt-oss` models.

Currently, `gpt-oss` models use a custom request handling method `_make_request_with_harmony` instead of the standard `apply_hf_chat_template`. Inside this method, the `get_system_message` function is called without passing `chat_template_kwargs`. As a result, the `model_identity` parameter defaults to a hardcoded value ("You are ChatGPT..."), preventing users from dynamically customizing the system prompt per request.

This fix passes `chat_template_kwargs` to `get_system_message` in `vllm/entrypoints/openai/serving_chat.py`, allowing users to override the default model identity and other parameters supported by the harmony library.

This fix implements the solution discussed in https://github.com/vllm-project/vllm/issues/23975#issuecomment-3665566378

Partially Fixes #23015
Fixes #23975


## Test Plan

**Environment:**
- **GPU:** NVIDIA H100
- **vLLM Version:** v0.12.0 (Docker image `vllm/vllm-openai:v0.12.0`)

1.  **Start the vLLM server with a `gpt-oss` model (e.g., `gpt-oss-20b`):**
    ```bash
    docker run --rm --gpus all \
      -e VLLM_LOGGING_LEVEL=DEBUG \
      -v /path/to/gpt-oss-20b:/app/model \
      vllm/vllm-openai:v0.12.0 \
      --model /app/model \
      --served-model-name vllm/gpt-oss-20b \
      --enable-log-requests
    ```

2.  **Send a chat completion request with a custom `model_identity` in `chat_template_kwargs`:**
    ```bash
    curl --location 'http://localhost:8000/v1/chat/completions' \
    --header 'Content-Type: application/json' \
    --data '{
        "model": "vllm/gpt-oss-20b",
        "messages": [
            {
                "role": "user",
                "content": "Who are you?"
            }
        ],
        "chat_template_kwargs":{
            "model_identity":"I am a custom AI assistant."
        },
        "temperature": 0
    }'
    ```


## Test Result

**Before Fix:**
The model ignores the `model_identity` and responds with the default identity.

```json
{
    "object": "chat.completion",
    "created": 1765981514,
    "model": "vllm/gpt-oss-20b",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": "I’m ChatGPT, a large language model created by OpenAI. I’m designed to understand and generate natural language, so I can help answer questions, brainstorm ideas, explain concepts, draft text, and more. I don’t have personal experiences or feelings—just a lot of patterns learned from text. How can I assist you today?",
                "refusal": null,
                "annotations": null,
                "audio": null,
                "function_call": null,
                "tool_calls": [],
                "reasoning": "The user asks \"Who are you?\" We need to respond as ChatGPT. The user might want a brief introduction. We should mention that we are ChatGPT, a large language model trained by OpenAI, etc. Also mention that we can help with many tasks. We should keep it concise.",
                "reasoning_content": "The user asks \"Who are you?\" We need to respond as ChatGPT. The user might want a brief introduction. We should mention that we are ChatGPT, a large language model trained by OpenAI, etc. Also mention that we can help with many tasks. We should keep it concise."
            },
            "logprobs": null,
            "finish_reason": "stop",
            "stop_reason": null,
            "token_ids": null
        }
    ],
    "usage": {
        "prompt_tokens": 73,
        "total_tokens": 211,
        "completion_tokens": 138,
        "prompt_tokens_details": null
    },
}
```

**After Fix:**
The model correctly adopts the `model_identity` provided in `chat_template_kwargs`.

```json

{
    "id": "chatcmpl-9fb8cfe7a67f083a",
    "object": "chat.completion",
    "created": 1765981838,
    "model": "vllm/gpt-oss-20b",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": "I’m your custom AI assistant—an advanced language model built on OpenAI’s GPT‑4 architecture, fine‑tuned to help you with information, ideas, and tasks. I’m here to answer questions, offer suggestions, and chat about almost anything you’re curious about. Just let me know what you need!",
                "refusal": null,
                "annotations": null,
                "audio": null,
                "function_call": null,
                "tool_calls": [],
                "reasoning": "We need to respond as the custom AI assistant. The user asks \"Who are you?\" We should answer in a friendly manner, describing ourselves as a custom AI assistant. Probably mention that we are a language model trained by OpenAI, but customized. We should keep it concise.",
                "reasoning_content": "We need to respond as the custom AI assistant. The user asks \"Who are you?\" We should answer in a friendly manner, describing ourselves as a custom AI assistant. Probably mention that we are a language model trained by OpenAI, but customized. We should keep it concise."
            },
            "logprobs": null,
            "finish_reason": "stop",
            "stop_reason": null,
            "token_ids": null
        }
    ],
    "usage": {
        "prompt_tokens": 66,
        "total_tokens": 196,
        "completion_tokens": 130,
        "prompt_tokens_details": null
    },
}
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

