### PR TITLE
[BugFix] Fix offline inference of Qwen3 omni with use_audio_in_video=True

### DIFF
--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -814,7 +814,7 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
                     use_audio_in_video = False
 
         # normal case with `use_audio_in_video=False`
-        if is_update_applied:
+        if (not use_audio_in_video) and is_update_applied:
             mm_placeholders = self._find_mm_placeholders(
                 prompt_ids,
                 mm_prompt_updates,


### PR DESCRIPTION
## Purpose

During offline inference with Qwen3-omni using vLLM 0.12, enabling use_audio_in_video leads to nonsensical generations:
 - garbled outputs
 - repetitive tokens

Investigation suggests the cause might be related to the cache logic of processor. A temporary workaround has been proposed [here](https://github.com/vllm-project/vllm/issues/30776#issuecomment-3665853090).

For background information regarding bug reproducibility, please refer to [this related issue](https://github.com/vllm-project/vllm/issues/30776).

## Current Status
developing a new example.