### PR TITLE
[Doc] Add developer guide for CustomOp

### DIFF
--- a/docs/design/custom_op.md
+++ b/docs/design/custom_op.md
@@ -59,74 +59,96 @@ For example:
 
 **1. Attention:**
 
---8<-- "../../vllm/attention/layers/mm_encoder_attention.py:mm_encoder_attn"
---8<-- "../../vllm/model_executor/layers/mla.py:multi_head_latent_attention"
+```python
+--8<-- "vllm/attention/layers/mm_encoder_attention.py:mm_encoder_attn"
+--8<-- "vllm/model_executor/layers/mla.py:multi_head_latent_attention"
+```
 
 **2. Activation:**
 
---8<-- "../../vllm/model_executor/layers/activation.py:silu_and_mul"
---8<-- "../../vllm/model_executor/layers/activation.py:mul_and_silu"
---8<-- "../../vllm/model_executor/layers/activation.py:gelu_new"
---8<-- "../../vllm/model_executor/layers/activation.py:gelu_fast"
---8<-- "../../vllm/model_executor/layers/activation.py:quick_gelu"
---8<-- "../../vllm/model_executor/layers/activation.py:gelu_and_mul"
---8<-- "../../vllm/model_executor/layers/activation.py:gelu_and_mul_sparse"
---8<-- "../../vllm/model_executor/layers/activation.py:relu2"
---8<-- "../../vllm/model_executor/layers/activation.py:xielu"
---8<-- "../../vllm/model_executor/layers/activation.py:swigluoai_and_mul"
---8<-- "../../vllm/model_executor/layers/activation.py:fatrelu_and_mul"
+```python
+--8<-- "vllm/model_executor/layers/activation.py:silu_and_mul"
+--8<-- "vllm/model_executor/layers/activation.py:mul_and_silu"
+--8<-- "vllm/model_executor/layers/activation.py:gelu_new"
+--8<-- "vllm/model_executor/layers/activation.py:gelu_fast"
+--8<-- "vllm/model_executor/layers/activation.py:quick_gelu"
+--8<-- "vllm/model_executor/layers/activation.py:gelu_and_mul"
+--8<-- "vllm/model_executor/layers/activation.py:gelu_and_mul_sparse"
+--8<-- "vllm/model_executor/layers/activation.py:relu2"
+--8<-- "vllm/model_executor/layers/activation.py:xielu"
+--8<-- "vllm/model_executor/layers/activation.py:swigluoai_and_mul"
+--8<-- "vllm/model_executor/layers/activation.py:fatrelu_and_mul"
+```
 
 **3. MM-Conv:**
 
---8<-- "../../vllm/model_executor/layers/conv.py:conv2d"
---8<-- "../../vllm/model_executor/layers/conv.py:conv3d"
+```python
+--8<-- "vllm/model_executor/layers/conv.py:conv2d"
+--8<-- "vllm/model_executor/layers/conv.py:conv3d"
+```
 
 **4. Embedding:**
 
---8<-- "../../vllm/model_executor/layers/vocab_parallel_embedding.py:vocab_parallel_embedding"
---8<-- "../../vllm/model_executor/layers/vocab_parallel_embedding.py:parallel_lm_head"
+```python
+--8<-- "vllm/model_executor/layers/vocab_parallel_embedding.py:vocab_parallel_embedding"
+--8<-- "vllm/model_executor/layers/vocab_parallel_embedding.py:parallel_lm_head"
+```
 
 **5. Linear:**
 
---8<-- "../../vllm/model_executor/layers/linear.py:row_parallel_linear"
---8<-- "../../vllm/model_executor/layers/linear.py:row_parallel_linear:column_parallel_linear"
---8<-- "../../vllm/model_executor/layers/linear.py:row_parallel_linear:replicated_linear"
+```python
+--8<-- "vllm/model_executor/layers/linear.py:row_parallel_linear"
+--8<-- "vllm/model_executor/layers/linear.py:row_parallel_linear:column_parallel_linear"
+--8<-- "vllm/model_executor/layers/linear.py:row_parallel_linear:replicated_linear"
+```
 
 **6. Logits Processor:**
 
---8<-- "../../vllm/model_executor/layers/logits_processor.py:logits_processor"
+```python
+--8<-- "vllm/model_executor/layers/logits_processor.py:logits_processor"
+```
 
 **7. Mamba:**
 
---8<-- "../../vllm/model_executor/layers/mamba/mamba_mixer.py:mamba_mixer"
---8<-- "../../vllm/model_executor/layers/mamba/mamba_mixer2.py:mamba_mixer2"
---8<-- "../../vllm/model_executor/layers/mamba/mamba_mixer2.py:mixer2_gated_rms_norm"
---8<-- "../../vllm/model_executor/models/plamo2.py:plamo2_mamba_mixer"
---8<-- "../../vllm/model_executor/layers/mamba/short_conv.py:short_conv"
+```python
+--8<-- "vllm/model_executor/layers/mamba/mamba_mixer.py:mamba_mixer"
+--8<-- "vllm/model_executor/layers/mamba/mamba_mixer2.py:mamba_mixer2"
+--8<-- "vllm/model_executor/layers/mamba/mamba_mixer2.py:mixer2_gated_rms_norm"
+--8<-- "vllm/model_executor/models/plamo2.py:plamo2_mamba_mixer"
+--8<-- "vllm/model_executor/layers/mamba/short_conv.py:short_conv"
+```
 
 **8. MoE:**
 
---8<-- "../../vllm/model_executor/layers/fused_moe/layer.py:fused_moe"
---8<-- "../../vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py:modular_fused_moe"
---8<-- "../../vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py:unquantized_fused_moe"
---8<-- "../../vllm/model_executor/models/transformers/moe.py:transformers_fused_moe"
---8<-- "../../vllm/model_executor/layers/fused_moe/fused_moe.py:grouped_topk"
+```python
+--8<-- "vllm/model_executor/layers/fused_moe/layer.py:fused_moe"
+--8<-- "vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py:modular_fused_moe"
+--8<-- "vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py:unquantized_fused_moe"
+--8<-- "vllm/model_executor/models/transformers/moe.py:transformers_fused_moe"
+--8<-- "vllm/model_executor/layers/fused_moe/fused_moe.py:grouped_topk"
+```
 
 **9. Norm:**
 
---8<-- "../../vllm/model_executor/layers/layernorm.py:rms_norm"
---8<-- "../../vllm/model_executor/layers/layernorm.py:rms_norm_gated"
---8<-- "../../vllm/model_executor/layers/layernorm.py:gemma_rms_norm"
+```python
+--8<-- "vllm/model_executor/layers/layernorm.py:rms_norm"
+--8<-- "vllm/model_executor/layers/layernorm.py:rms_norm_gated"
+--8<-- "vllm/model_executor/layers/layernorm.py:gemma_rms_norm"
+```
 
 **10. Quantization:**
 
---8<-- "../../vllm/model_executor/layers/quantization/input_quant_fp8.py:quant_fp8"
+```python
+--8<-- "vllm/model_executor/layers/quantization/input_quant_fp8.py:quant_fp8"
+```
 
 **11. Rope:**
 
---8<-- "../../vllm/model_executor/layers/rotary_embedding/base.py:rotary_embedding"
---8<-- "../../vllm/model_executor/layers/rotary_embedding/dual_chunk_rope.py:dual_chunk_rotary_embedding"
---8<-- "../../vllm/model_executor/layers/rotary_embedding/common.py:apply_rotary_emb"
+```python
+--8<-- "vllm/model_executor/layers/rotary_embedding/base.py:rotary_embedding"
+--8<-- "vllm/model_executor/layers/rotary_embedding/dual_chunk_rope.py:dual_chunk_rotary_embedding"
+--8<-- "vllm/model_executor/layers/rotary_embedding/common.py:apply_rotary_emb"
+```
 
 ## Guidelines for Implementing a New CustomOp
 

--- a/docs/design/custom_op.md
+++ b/docs/design/custom_op.md
@@ -29,12 +29,15 @@ When a `CustomOp` is called (i.e., call its `forward()` method), if it is enable
 - **OOT platform:** dispatch to `forward_oot()`. This will only be called on OOT platforms.
 - **Default:** dispatch to `forward_native()` as a final fallback for all platforms.
 
+!!! note
+    Note that the dispatching logic might not be absolute because of class inheritance. Derived class might override the behavior.
+
 Furthur more, vLLM decides whether enable or disable a `CustomOp` by `compilation_config.custom_ops`. To be specific, if a `CustomOp` is not registered (i.e., use default config), it will be enabled if there is a `all` in `compilation_config.custom_ops` or will be disabled if there is a `none`.
 
 !!! note
     Note that `all` and `none` cannot coexist in `compilation_config.custom_ops`.
 
-By default, if `compilation_config.backend == "inductor"` and `compilation_config.mode != CompilationMode.NONE`, a `none` will be appended into `compilation_config.custom_ops`, otherwise a `all` will be appended. In other words, this means `CustomOp` will be disabled in some platforms (i.e., those use `inductor` as dafault backend for `torch.compile`) when running with graph mode. In this case, Inductor generates (fused) Triton kernels for those disabled custom ops.
+By default, if `compilation_config.backend == "inductor"` and `compilation_config.mode != CompilationMode.NONE`, a `none` will be appended into `compilation_config.custom_ops`, otherwise a `all` will be appended. In other words, this means `CustomOp` will be disabled in some platforms (i.e., those use `inductor` as dafault backend for `torch.compile`) when running with torch compile mode. In this case, Inductor generates (fused) Triton kernels for those disabled custom ops.
 
 !!! note
     For multi-modal models, vLLM has enforece enabled some custom ops to use device-specific deep-optimized kernels for better performance in ViT part, such as `MMEncoderAttention` and `ApplyRotaryEmb`. We can also pass a `enforce_enable=True` param to the `__init__()` method of the `CustomOp` to enforce enable itself at object-level.

--- a/docs/design/custom_op.md
+++ b/docs/design/custom_op.md
@@ -57,46 +57,76 @@ For example:
 
 ## Types of Supported CustomOp in vLLM
 
-| Category | OP Name | OP Class |
-|----------|---------|----------|
-| Attention | `mm_encoder_attn` | `MMEncoderAttention` |
-| Attention | `multi_head_latent_attention` | `MultiHeadLatentAttentionWrapper` |
-| Activation | `fatrelu_and_mul` | `FatreluAndMul` |
-| Activation | `silu_and_mul` | `SiluAndMul` |
-| Activation | `mul_and_silu` | `MulAndSilu` |
-| Activation | `gelu_and_mul_sparse` | `GeluAndMulSparse` |
-| Activation | `gelu_and_mul` | `GeluAndMul` |
-| Activation | `swigluoai_and_mul` | `SwigluOAIAndMul` |
-| Activation | `gelu_new` | `NewGELU` |
-| Activation | `gelu_fast` | `FastGELU` |
-| Activation | `quick_gelu` | `QuickGELU` |
-| Activation | `relu2` | `ReLUSquaredActivation` |
-| Activation | `xielu` | `XIELU` |
-| Conv | `conv2d` | `Conv2dLayer` |
-| Conv | `conv3d` | `Conv3dLayer` |
-| Conv | `short_conv` | `ShortConv` |
-| Embedding | `vocab_parallel_embedding` | `VocabParallelEmbedding` |
-| Embedding | `parallel_lm_head` | `ParallelLMHead` |
-| Linear | `row_parallel_linear` | `RowParallelLinear` |
-| Linear | `column_parallel_linear` | `ColumnParallelLinear` |
-| Linear | `replicated_linear` | `ReplicatedLinear` |
-| Logits Processor | `logits_processor` | `LogitsProcessor` |
-| Mamba | `mamba_mixer` | `MambaMixer` |
-| Mamba | `mamba_mixer2` | `MambaMixer2` |
-| Mamba | `plamo2_mamba_mixer` | `Plamo2MambaMixer` |
-| Mamba | `mixer2_gated_rms_norm` | `Mixer2RMSNormGated` |
-| MoE | `fused_moe` | `FusedMoE` |
-| MoE | `modular_fused_moe` | `FusedMoEModularMethod` |
-| MoE | `unquantized_fused_moe` | `UnquantizedFusedMoEMethod` |
-| MoE | `transformers_fused_moe` | `TransformersFusedMoE` |
-| MoE | `grouped_topk` | `GroupedTopk` |
-| Norm | `rms_norm` | `RMSNorm` |
-| Norm | `gemma_rms_norm` | `GemmaRMSNorm` |
-| Norm | `rms_norm_gated` | `RMSNormGated` |
-| Quantization | `quant_fp8` | `QuantFP8` |
-| Rope | `rotary_embedding` | `RotaryEmbeddingBase` |
-| Rope | `dual_chunk_rotary_embedding` | `DualChunkRotaryEmbedding` |
-| Rope | `apply_rotary_emb` | `ApplyRotaryEmb` |
+**1. Attention:**
+
+--8<-- "../../vllm/attention/layers/mm_encoder_attention.py:mm_encoder_attn"
+--8<-- "../../vllm/model_executor/layers/mla.py:multi_head_latent_attention"
+
+**2. Activation:**
+
+--8<-- "../../vllm/model_executor/layers/activation.py:silu_and_mul"
+--8<-- "../../vllm/model_executor/layers/activation.py:mul_and_silu"
+--8<-- "../../vllm/model_executor/layers/activation.py:gelu_new"
+--8<-- "../../vllm/model_executor/layers/activation.py:gelu_fast"
+--8<-- "../../vllm/model_executor/layers/activation.py:quick_gelu"
+--8<-- "../../vllm/model_executor/layers/activation.py:gelu_and_mul"
+--8<-- "../../vllm/model_executor/layers/activation.py:gelu_and_mul_sparse"
+--8<-- "../../vllm/model_executor/layers/activation.py:relu2"
+--8<-- "../../vllm/model_executor/layers/activation.py:xielu"
+--8<-- "../../vllm/model_executor/layers/activation.py:swigluoai_and_mul"
+--8<-- "../../vllm/model_executor/layers/activation.py:fatrelu_and_mul"
+
+**3. MM-Conv:**
+
+--8<-- "../../vllm/model_executor/layers/conv.py:conv2d"
+--8<-- "../../vllm/model_executor/layers/conv.py:conv3d"
+
+**4. Embedding:**
+
+--8<-- "../../vllm/model_executor/layers/vocab_parallel_embedding.py:vocab_parallel_embedding"
+--8<-- "../../vllm/model_executor/layers/vocab_parallel_embedding.py:parallel_lm_head"
+
+**5. Linear:**
+
+--8<-- "../../vllm/model_executor/layers/linear.py:row_parallel_linear"
+--8<-- "../../vllm/model_executor/layers/linear.py:row_parallel_linear:column_parallel_linear"
+--8<-- "../../vllm/model_executor/layers/linear.py:row_parallel_linear:replicated_linear"
+
+**6. Logits Processor:**
+
+--8<-- "../../vllm/model_executor/layers/logits_processor.py:logits_processor"
+
+**7. Mamba:**
+
+--8<-- "../../vllm/model_executor/layers/mamba/mamba_mixer.py:mamba_mixer"
+--8<-- "../../vllm/model_executor/layers/mamba/mamba_mixer2.py:mamba_mixer2"
+--8<-- "../../vllm/model_executor/layers/mamba/mamba_mixer2.py:mixer2_gated_rms_norm"
+--8<-- "../../vllm/model_executor/models/plamo2.py:plamo2_mamba_mixer"
+--8<-- "../../vllm/model_executor/layers/mamba/short_conv.py:short_conv"
+
+**8. MoE:**
+
+--8<-- "../../vllm/model_executor/layers/fused_moe/layer.py:fused_moe"
+--8<-- "../../vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py:modular_fused_moe"
+--8<-- "../../vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py:unquantized_fused_moe"
+--8<-- "../../vllm/model_executor/models/transformers/moe.py:transformers_fused_moe"
+--8<-- "../../vllm/model_executor/layers/fused_moe/fused_moe.py:grouped_topk"
+
+**9. Norm:**
+
+--8<-- "../../vllm/model_executor/layers/layernorm.py:rms_norm"
+--8<-- "../../vllm/model_executor/layers/layernorm.py:rms_norm_gated"
+--8<-- "../../vllm/model_executor/layers/layernorm.py:gemma_rms_norm"
+
+**10. Quantization:**
+
+--8<-- "../../vllm/model_executor/layers/quantization/input_quant_fp8.py:quant_fp8"
+
+**11. Rope:**
+
+--8<-- "../../vllm/model_executor/layers/rotary_embedding/base.py:rotary_embedding"
+--8<-- "../../vllm/model_executor/layers/rotary_embedding/dual_chunk_rope.py:dual_chunk_rotary_embedding"
+--8<-- "../../vllm/model_executor/layers/rotary_embedding/common.py:apply_rotary_emb"
 
 ## Guidelines for Implementing a New CustomOp
 

--- a/docs/design/custom_op.md
+++ b/docs/design/custom_op.md
@@ -61,6 +61,7 @@ For example:
 
 ```python
 --8<-- "vllm/attention/layers/mm_encoder_attention.py:mm_encoder_attn"
+
 --8<-- "vllm/model_executor/layers/mla.py:multi_head_latent_attention"
 ```
 
@@ -68,15 +69,25 @@ For example:
 
 ```python
 --8<-- "vllm/model_executor/layers/activation.py:silu_and_mul"
+
 --8<-- "vllm/model_executor/layers/activation.py:mul_and_silu"
+
 --8<-- "vllm/model_executor/layers/activation.py:gelu_new"
+
 --8<-- "vllm/model_executor/layers/activation.py:gelu_fast"
+
 --8<-- "vllm/model_executor/layers/activation.py:quick_gelu"
+
 --8<-- "vllm/model_executor/layers/activation.py:gelu_and_mul"
+
 --8<-- "vllm/model_executor/layers/activation.py:gelu_and_mul_sparse"
+
 --8<-- "vllm/model_executor/layers/activation.py:relu2"
+
 --8<-- "vllm/model_executor/layers/activation.py:xielu"
+
 --8<-- "vllm/model_executor/layers/activation.py:swigluoai_and_mul"
+
 --8<-- "vllm/model_executor/layers/activation.py:fatrelu_and_mul"
 ```
 
@@ -84,6 +95,7 @@ For example:
 
 ```python
 --8<-- "vllm/model_executor/layers/conv.py:conv2d"
+
 --8<-- "vllm/model_executor/layers/conv.py:conv3d"
 ```
 
@@ -91,6 +103,7 @@ For example:
 
 ```python
 --8<-- "vllm/model_executor/layers/vocab_parallel_embedding.py:vocab_parallel_embedding"
+
 --8<-- "vllm/model_executor/layers/vocab_parallel_embedding.py:parallel_lm_head"
 ```
 
@@ -98,8 +111,10 @@ For example:
 
 ```python
 --8<-- "vllm/model_executor/layers/linear.py:row_parallel_linear"
---8<-- "vllm/model_executor/layers/linear.py:row_parallel_linear:column_parallel_linear"
---8<-- "vllm/model_executor/layers/linear.py:row_parallel_linear:replicated_linear"
+
+--8<-- "vllm/model_executor/layers/linear.py:column_parallel_linear"
+
+--8<-- "vllm/model_executor/layers/linear.py:replicated_linear"
 ```
 
 **6. Logits Processor:**
@@ -112,9 +127,13 @@ For example:
 
 ```python
 --8<-- "vllm/model_executor/layers/mamba/mamba_mixer.py:mamba_mixer"
+
 --8<-- "vllm/model_executor/layers/mamba/mamba_mixer2.py:mamba_mixer2"
+
 --8<-- "vllm/model_executor/layers/mamba/mamba_mixer2.py:mixer2_gated_rms_norm"
+
 --8<-- "vllm/model_executor/models/plamo2.py:plamo2_mamba_mixer"
+
 --8<-- "vllm/model_executor/layers/mamba/short_conv.py:short_conv"
 ```
 
@@ -122,9 +141,13 @@ For example:
 
 ```python
 --8<-- "vllm/model_executor/layers/fused_moe/layer.py:fused_moe"
+
 --8<-- "vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py:modular_fused_moe"
+
 --8<-- "vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py:unquantized_fused_moe"
+
 --8<-- "vllm/model_executor/models/transformers/moe.py:transformers_fused_moe"
+
 --8<-- "vllm/model_executor/layers/fused_moe/fused_moe.py:grouped_topk"
 ```
 
@@ -132,7 +155,9 @@ For example:
 
 ```python
 --8<-- "vllm/model_executor/layers/layernorm.py:rms_norm"
+
 --8<-- "vllm/model_executor/layers/layernorm.py:rms_norm_gated"
+
 --8<-- "vllm/model_executor/layers/layernorm.py:gemma_rms_norm"
 ```
 
@@ -146,7 +171,9 @@ For example:
 
 ```python
 --8<-- "vllm/model_executor/layers/rotary_embedding/base.py:rotary_embedding"
+
 --8<-- "vllm/model_executor/layers/rotary_embedding/dual_chunk_rope.py:dual_chunk_rotary_embedding"
+
 --8<-- "vllm/model_executor/layers/rotary_embedding/common.py:apply_rotary_emb"
 ```
 

--- a/docs/design/custom_op.md
+++ b/docs/design/custom_op.md
@@ -19,7 +19,7 @@ This document will introduce how CustomOp works in vLLM and how to implement a n
 
 We can use `@CustomOp.register("op_name")` to register an op class to the `CustomOp` system. After this, the `op_name` and its class will be added into the `op_registry` dictionary. In addition, We can also register an OOT op by `@CustomOp.register_oot("op_name")`. We will introduce this mechanism in detail later.
 
-When a `CustomOp` is called (i.e., call its `forward()` method), if it is enabled, it will automatically dispatch the forward method to the appropriate backend according to `current_platform`. Otherwise (i.e., it is disabled), it will only call the `forward_native()` method to use PyTorch-native implementation of this forward method.
+When a `CustomOp` is called (i.e., call its `forward()` method), if it is enabled (i.e., with `--compilation_config.custom_ops '["+op_name"]'`), it will automatically dispatch the forward method to the appropriate backend according to `current_platform`. Otherwise (i.e., it is disabled), it will only call the `forward_native()` method to use PyTorch-native implementation of this forward method.
 
 - **CPU platform:** dispatch to `forward_cpu()`.
 - **CUDA platform:** dispatch to `forward_cuda()`.
@@ -32,7 +32,7 @@ When a `CustomOp` is called (i.e., call its `forward()` method), if it is enable
 !!! note
     Note that the dispatching logic might not be absolute because of class inheritance. Derived class might override the behavior.
 
-Furthur more, vLLM decides whether enable or disable a `CustomOp` by `compilation_config.custom_ops`. To be specific, if a `CustomOp` is not registered (i.e., use default config), it will be enabled if there is a `all` in `compilation_config.custom_ops` or will be disabled if there is a `none`.
+Furthermore, vLLM decides whether to enable or disable a `CustomOp` based on `compilation_config.custom_ops`. To be specific, if a `CustomOp` is not registered in `compilation_config.custom_ops` (i.e., uses the default config), it will be enabled if `compilation_config.custom_ops` contains `all`, or will be disabled if it contains `none`.
 
 !!! note
     Note that `all` and `none` cannot coexist in `compilation_config.custom_ops`.

--- a/docs/design/custom_op.md
+++ b/docs/design/custom_op.md
@@ -29,7 +29,7 @@ When a `CustomOp` is called (i.e., call its `forward()` method), if it is enable
 - **OOT platform:** dispatch to `forward_oot()`. This will only be called on OOT platforms.
 - **Default:** dispatch to `forward_native()` as a final fallback for all platforms.
 
-Furthur more, vLLM decides whether enable or disable a `CustomOp` by `compilation_config.custom_ops`. To be specific, if a `CustomOp` is not registered (i.e., use default config), it will be enabled if there is a `all` in `compilation_config.custom_ops` or will be disabled if there is a `none`. 
+Furthur more, vLLM decides whether enable or disable a `CustomOp` by `compilation_config.custom_ops`. To be specific, if a `CustomOp` is not registered (i.e., use default config), it will be enabled if there is a `all` in `compilation_config.custom_ops` or will be disabled if there is a `none`.
 
 !!! note
     Note that `all` and `none` cannot coexist in `compilation_config.custom_ops`.
@@ -38,7 +38,7 @@ By default, if `compilation_config.backend == "inductor"` and `compilation_confi
 
 !!! note
     For multi-modal models, vLLM has enforece enabled some custom ops to use device-specific deep-optimized kernels for better performance in ViT part, such as `MMEncoderAttention` and `ApplyRotaryEmb`. We can also pass a `enforce_enable=True` param to the `__init__()` method of the `CustomOp` to enforce enable itself at object-level.
-    
+
     Note that this `enforce_enable` mechanism will be removed after we adding a separate `compilation_config` for multi-modal part.
 
 ## How to Customise Your Configuration for CustomOp

--- a/vllm/attention/layers/mm_encoder_attention.py
+++ b/vllm/attention/layers/mm_encoder_attention.py
@@ -18,9 +18,12 @@ from vllm.model_executor.models.vision import get_vit_attn_backend
 logger = init_logger(__name__)
 
 
+# --8<-- [start:mm_encoder_attn]
 @CustomOp.register("mm_encoder_attn")
 class MMEncoderAttention(CustomOp):
     """Multi-headed attention without any cache, used for multimodal encoder."""
+
+    # --8<-- [end:mm_encoder_attn]
 
     def __init__(
         self,

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -404,7 +404,8 @@ class CompilationConfig:
     - 'none,+op1,+op2' to enable only op1 and op2
 
     By default, all custom ops are enabled when running without Inductor and
-    disabled when running with Inductor: mode>=VLLM_COMPILE and backend="inductor".
+    disabled when running with Inductor: mode>=CompilationMode.NONE and
+    backend="inductor".
     Inductor generates (fused) Triton kernels for disabled custom ops."""
     splitting_ops: list[str] | None = None
     """A list of ops to exclude from cudagraphs, used in piecewise compilation.

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -404,7 +404,7 @@ class CompilationConfig:
     - 'none,+op1,+op2' to enable only op1 and op2
 
     By default, all custom ops are enabled when running without Inductor and
-    disabled when running with Inductor: mode>=CompilationMode.NONE and
+    disabled when running with Inductor: mode>CompilationMode.NONE and
     backend="inductor".
     Inductor generates (fused) Triton kernels for disabled custom ops."""
     splitting_ops: list[str] | None = None

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -87,9 +87,12 @@ class CustomOp(nn.Module):
         # specific backend. Currently, we do not support dynamic dispatching.
         compilation_config = get_cached_compilation_config()
 
-        # CustomOp object can be enforce enabled, e.g., enable device-specific
-        # kernels in ViT models when enabling graph mode. By default, it will
-        # follow the compilation_config to determine whether enable itself.
+        # NOTE(shen-shanshan): CustomOp object can be enforce enabled, e.g.,
+        # enable device-specific kernels in ViT models when enabling graph
+        # mode. By default, it will follow the compilation_config to determine
+        # whether enable itself.
+        # This enforce_enable mechanism will be removed after we adding a
+        # separate compilation_config for multi-modal part.
         enabled = self._enforce_enable or self.enabled()
         if enabled:
             compilation_config.enabled_custom_ops.update([self.__class__.name])

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -22,6 +22,7 @@ from vllm.utils.collection_utils import LazyDict
 logger = init_logger(__name__)
 
 
+# --8<-- [start:fatrelu_and_mul]
 @CustomOp.register("fatrelu_and_mul")
 class FatreluAndMul(CustomOp):
     """An activation function for FATReLU.
@@ -34,6 +35,8 @@ class FatreluAndMul(CustomOp):
         x: (num_tokens, 2 * d) or (batch_size, seq_len, 2 * d)
         return: (num_tokens, d) or (batch_size, seq_len, d)
     """
+
+    # --8<-- [end:fatrelu_and_mul]
 
     def __init__(self, threshold: float = 0.0):
         super().__init__()
@@ -58,6 +61,7 @@ class FatreluAndMul(CustomOp):
         return out
 
 
+# --8<-- [start:silu_and_mul]
 @CustomOp.register("silu_and_mul")
 class SiluAndMul(CustomOp):
     """An activation function for SwiGLU.
@@ -68,6 +72,8 @@ class SiluAndMul(CustomOp):
         x: (num_tokens, 2 * d) or (batch_size, seq_len, 2 * d)
         return: (num_tokens, d) or (batch_size, seq_len, d)
     """
+
+    # --8<-- [end:silu_and_mul]
 
     def __init__(self):
         super().__init__()
@@ -101,6 +107,7 @@ class SiluAndMul(CustomOp):
         return out
 
 
+# --8<-- [start:mul_and_silu]
 @CustomOp.register("mul_and_silu")
 class MulAndSilu(CustomOp):
     """An activation function for SwiGLU.
@@ -111,6 +118,8 @@ class MulAndSilu(CustomOp):
         x: (num_tokens, 2 * d) or (batch_size, seq_len, 2 * d)
         return: (num_tokens, d) or (batch_size, seq_len, d)
     """
+
+    # --8<-- [end:mul_and_silu]
 
     def __init__(self):
         super().__init__()
@@ -139,6 +148,7 @@ class MulAndSilu(CustomOp):
     # def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
 
 
+# --8<-- [start:gelu_and_mul_sparse]
 @CustomOp.register("gelu_and_mul_sparse")
 class GeluAndMulSparse(CustomOp):
     """An activation function for GeluAndMulSparse.
@@ -152,6 +162,8 @@ class GeluAndMulSparse(CustomOp):
         x: (num_tokens, 2 * d) or (batch_size, seq_len, 2 * d)
         return: (num_tokens, d) or (batch_size, seq_len, d)
     """
+
+    # --8<-- [end:gelu_and_mul_sparse]
 
     def __init__(self, activation_sparsity: float, approximate: str = "none"):
         super().__init__()
@@ -195,6 +207,7 @@ class GeluAndMulSparse(CustomOp):
         return self.forward_native(x)
 
 
+# --8<-- [start:gelu_and_mul]
 @CustomOp.register("gelu_and_mul")
 class GeluAndMul(CustomOp):
     """An activation function for GeGLU.
@@ -205,6 +218,8 @@ class GeluAndMul(CustomOp):
         x: (batch_size, seq_len, 2 * d) or (num_tokens, 2 * d)
         return: (batch_size, seq_len, d) or (num_tokens, d)
     """
+
+    # --8<-- [end:gelu_and_mul]
 
     def __init__(self, approximate: str = "none"):
         super().__init__()
@@ -257,9 +272,12 @@ class GeluAndMul(CustomOp):
         return f"approximate={repr(self.approximate)}"
 
 
+# --8<-- [start:swigluoai_and_mul]
 @CustomOp.register("swigluoai_and_mul")
 class SwigluOAIAndMul(CustomOp):
     # https://github.com/huggingface/transformers/blob/v4.55.0/src/transformers/models/gpt_oss/modeling_gpt_oss.py#L106-L110
+    # --8<-- [end:swigluoai_and_mul]
+
     def __init__(self, alpha: float = 1.702, limit: float = 7.0):
         super().__init__()
         self.alpha = alpha
@@ -286,8 +304,11 @@ class SwigluOAIAndMul(CustomOp):
         return f"alpha={repr(self.alpha)}, limit={repr(self.limit)}"
 
 
+# --8<-- [start:gelu_new]
 @CustomOp.register("gelu_new")
 class NewGELU(CustomOp):
+    # --8<-- [end:gelu_new]
+
     def __init__(self):
         super().__init__()
         if current_platform.is_cuda_alike() or current_platform.is_cpu():
@@ -311,8 +332,11 @@ class NewGELU(CustomOp):
         return self.op(x)
 
 
+# --8<-- [start:gelu_fast]
 @CustomOp.register("gelu_fast")
 class FastGELU(CustomOp):
+    # --8<-- [end:gelu_fast]
+
     def __init__(self):
         super().__init__()
         if current_platform.is_cuda_alike() or current_platform.is_cpu():
@@ -335,9 +359,12 @@ class FastGELU(CustomOp):
         return self.op(x)
 
 
+# --8<-- [start:quick_gelu]
 @CustomOp.register("quick_gelu")
 class QuickGELU(CustomOp):
     # https://github.com/huggingface/transformers/blob/main/src/transformers/activations.py#L90
+    # --8<-- [end:quick_gelu]
+
     def __init__(self):
         super().__init__()
         if current_platform.is_cuda_alike() or current_platform.is_cpu():
@@ -365,11 +392,14 @@ class QuickGELU(CustomOp):
     # def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
 
 
+# --8<-- [start:relu2]
 @CustomOp.register("relu2")
 class ReLUSquaredActivation(CustomOp):
     """
     Applies the relu^2 activation introduced in https://arxiv.org/abs/2109.08668v2
     """
+
+    # --8<-- [end:relu2]
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""
@@ -380,6 +410,7 @@ class ReLUSquaredActivation(CustomOp):
         return self.forward_native(x)
 
 
+# --8<-- [start:xielu]
 @CustomOp.register("xielu")
 class XIELU(CustomOp):
     """
@@ -387,6 +418,8 @@ class XIELU(CustomOp):
     If the user has installed the nickjbrowning/XIELU, we import xIELU CUDA
     Otherwise, we emit a single warning and use xIELU Python
     """
+
+    # --8<-- [end:xielu]
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/conv.py
+++ b/vllm/model_executor/layers/conv.py
@@ -105,9 +105,12 @@ class ConvLayerBase(CustomOp):
         return s
 
 
+# --8<-- [start:conv2d]
 @CustomOp.register("conv2d")
 class Conv2dLayer(ConvLayerBase):
     """Conv layer with Conv2d."""
+
+    # --8<-- [end:conv2d]
 
     num_dim = 2
 
@@ -204,9 +207,12 @@ class CausalConv2dLayer(Conv2dLayer):
         return x
 
 
+# --8<-- [start:conv3d]
 @CustomOp.register("conv3d")
 class Conv3dLayer(ConvLayerBase):
     """Conv layer with Conv3d."""
+
+    # --8<-- [end:conv3d]
 
     num_dim = 3
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1459,9 +1459,12 @@ def grouped_topk(
     return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
 
 
+# --8<-- [start:grouped_topk]
 @CustomOp.register("grouped_topk")
 class GroupedTopk(CustomOp):
     """GroupedTopk used by the Deepseek-V2 and Deepseek-V3 model."""
+
+    # --8<-- [end:grouped_topk]
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
@@ -21,8 +21,11 @@ from vllm.model_executor.layers.fused_moe.modular_kernel import (
 logger = init_logger(__name__)
 
 
+# --8<-- [start:modular_fused_moe]
 @CustomOp.register("modular_fused_moe")
 class FusedMoEModularMethod(FusedMoEMethodBase, CustomOp):
+    # --8<-- [end:modular_fused_moe]
+
     def __init__(
         self, old_quant_method: FusedMoEMethodBase, experts: FusedMoEModularKernel
     ):

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -302,6 +302,7 @@ class FusedMoERouterImpl(FusedMoERouter):
         return self.layer._select_experts(hidden_states, router_logits)
 
 
+# --8<-- [start:fused_moe]
 @CustomOp.register("fused_moe")
 class FusedMoE(CustomOp):
     """FusedMoE layer for MoE models.
@@ -325,6 +326,8 @@ class FusedMoE(CustomOp):
         enable_eplb: Whether to enable expert parallelism load balancer.
         router_logits_dtype: Data type for router logits buffers.
     """
+
+    # --8<-- [end:fused_moe]
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -52,9 +52,12 @@ else:
 logger = init_logger(__name__)
 
 
+# --8<-- [start:unquantized_fused_moe]
 @CustomOp.register("unquantized_fused_moe")
 class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
     """MoE method without quantization."""
+
+    # --8<-- [end:unquantized_fused_moe]
 
     def __init__(self, moe: FusedMoEConfig):
         super().__init__(moe)

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -88,6 +88,7 @@ def dispatch_rocm_rmsnorm_func(
     return rms_norm
 
 
+# --8<-- [start:rms_norm]
 @CustomOp.register("rms_norm")
 class RMSNorm(CustomOp):
     """Root mean square normalization.
@@ -95,6 +96,8 @@ class RMSNorm(CustomOp):
     Computes x -> w * x / sqrt(E[x^2] + eps) where w is the learned weight.
     Refer to https://arxiv.org/abs/1910.07467
     """
+
+    # --8<-- [end:rms_norm]
 
     def __init__(
         self,
@@ -253,6 +256,7 @@ class RMSNorm(CustomOp):
         return s
 
 
+# --8<-- [start:gemma_rms_norm]
 @CustomOp.register("gemma_rms_norm")
 class GemmaRMSNorm(CustomOp):
     """RMS normalization for Gemma.
@@ -261,6 +265,8 @@ class GemmaRMSNorm(CustomOp):
         1. x * (1 + w) instead of x * w.
         2. (x * w).to(orig_dtype) instead of x.to(orig_dtype) * w.
     """
+
+    # --8<-- [end:gemma_rms_norm]
 
     def __init__(
         self,
@@ -321,6 +327,7 @@ class GemmaRMSNorm(CustomOp):
         return self.forward_native(x, residual)
 
 
+# --8<-- [start:rms_norm_gated]
 @CustomOp.register("rms_norm_gated")
 class RMSNormGated(CustomOp):
     """RMS Normalization with optional gating.
@@ -330,6 +337,8 @@ class RMSNormGated(CustomOp):
     - Group RMS normalization
     - Optional gating with SiLU activation
     """
+
+    # --8<-- [end:rms_norm_gated]
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -304,6 +304,7 @@ class LinearBase(CustomOp):
                 param.tp_size = self.tp_size
 
 
+# --8<-- [start:replicated_linear]
 @CustomOp.register("replicated_linear")
 class ReplicatedLinear(LinearBase):
     """Replicated linear layer.
@@ -320,6 +321,8 @@ class ReplicatedLinear(LinearBase):
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: Take no effect for replicated linear layers.
     """
+
+    # --8<-- [end:replicated_linear]
 
     def __init__(
         self,
@@ -421,6 +424,7 @@ class ReplicatedLinear(LinearBase):
         return s
 
 
+# --8<-- [start:column_parallel_linear]
 @CustomOp.register("column_parallel_linear")
 class ColumnParallelLinear(LinearBase):
     """Linear layer with column parallelism.
@@ -447,6 +451,8 @@ class ColumnParallelLinear(LinearBase):
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, weights matrix won't be sharded through tp rank.
     """
+
+    # --8<-- [end:column_parallel_linear]
 
     def __init__(
         self,
@@ -1289,6 +1295,7 @@ class QKVParallelLinear(ColumnParallelLinear):
         param_data.copy_(loaded_weight)
 
 
+# --8<-- [start:row_parallel_linear]
 @CustomOp.register("row_parallel_linear")
 class RowParallelLinear(LinearBase):
     """Linear layer with row parallelism.
@@ -1322,6 +1329,8 @@ class RowParallelLinear(LinearBase):
         return_bias: If true, return bias together with outputs in forward pass.
         disable_tp: If true, weights matrix won't be sharded through tp rank.
     """
+
+    # --8<-- [end:row_parallel_linear]
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmb
 from vllm.platforms import current_platform
 
 
+# --8<-- [start:logits_processor]
 @CustomOp.register("logits_processor")
 class LogitsProcessor(CustomOp):
     """Process logits and apply logits processors from sampling metadata.
@@ -22,6 +23,8 @@ class LogitsProcessor(CustomOp):
     2. Scale logits if needed.
     3. Apply logits processors (if any).
     """
+
+    # --8<-- [end:logits_processor]
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/mamba/mamba_mixer.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer.py
@@ -39,6 +39,7 @@ from vllm.v1.attention.backends.mamba1_attn import Mamba1AttentionMetadata
 
 
 # Adapted from transformers.models.mamba.modeling_mamba.MambaMixer
+# --8<-- [start:mamba_mixer]
 @CustomOp.register("mamba_mixer")
 class MambaMixer(MambaBase, CustomOp):
     """
@@ -50,6 +51,8 @@ class MambaMixer(MambaBase, CustomOp):
     invariant S4, and is why Mamba is called
     **selective** state spaces)
     """
+
+    # --8<-- [end:mamba_mixer]
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -49,8 +49,11 @@ from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadata
 
 
 # Adapted from transformers.models.mamba2.modeling_mamba2.MambaRMSNormGated
+# --8<-- [start:mixer2_gated_rms_norm]
 @CustomOp.register("mixer2_gated_rms_norm")
 class Mixer2RMSNormGated(CustomOp):
+    # --8<-- [end:mixer2_gated_rms_norm]
+
     def __init__(
         self,
         full_hidden_size: int,
@@ -214,6 +217,7 @@ def mamba_v2_sharded_weight_loader(
 
 
 # Adapted from transformers.models.mamba.modeling_mamba.MambaMixer
+# --8<-- [start:mamba_mixer2]
 @CustomOp.register("mamba_mixer2")
 class MambaMixer2(MambaBase, CustomOp):
     """
@@ -225,6 +229,8 @@ class MambaMixer2(MambaBase, CustomOp):
     invariant S4, and is why Mamba is called
     **selective** state spaces)
     """
+
+    # --8<-- [end:mamba_mixer2]
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/mamba/short_conv.py
+++ b/vllm/model_executor/layers/mamba/short_conv.py
@@ -27,8 +27,11 @@ from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backends.short_conv_attn import ShortConvAttentionMetadata
 
 
+# --8<-- [start:short_conv]
 @CustomOp.register("short_conv")
 class ShortConv(MambaBase, CustomOp):
+    # --8<-- [end:short_conv]
+
     def __init__(
         self,
         config,

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -29,6 +29,7 @@ class MLAModules:
     indexer_rotary_emb: torch.nn.Module | None = None
 
 
+# --8<-- [start:multi_head_latent_attention]
 @CustomOp.register("multi_head_latent_attention")
 class MultiHeadLatentAttentionWrapper(CustomOp):
     """MLA layer registered as CustomOp to allow OOT backends to add
@@ -46,6 +47,8 @@ class MultiHeadLatentAttentionWrapper(CustomOp):
        multi-query attention to decode tokens separately.
     3. Return the output tensor.
     """
+
+    # --8<-- [end:multi_head_latent_attention]
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -18,12 +18,15 @@ _FP8_MIN, _FP8_MAX = get_fp8_min_max()
 _FP8_MIN_SCALING_FACTOR = 1.0 / (_FP8_MAX * 512.0)
 
 
+# --8<-- [start:quant_fp8]
 @CustomOp.register("quant_fp8")
 class QuantFP8(CustomOp):
     """
     Quantize input tensor to FP8 (per-tensor, per-token, or per-group).
     This CustomOp supports both static and dynamic quantization.
     """
+
+    # --8<-- [end:quant_fp8]
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/rotary_embedding/base.py
+++ b/vllm/model_executor/layers/rotary_embedding/base.py
@@ -10,9 +10,12 @@ from vllm.model_executor.custom_op import CustomOp
 from .common import ApplyRotaryEmb
 
 
+# --8<-- [start:rotary_embedding]
 @CustomOp.register("rotary_embedding")
 class RotaryEmbeddingBase(CustomOp):
     """Original rotary positional embedding."""
+
+    # --8<-- [end:rotary_embedding]
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -118,8 +118,11 @@ direct_register_custom_op(
 )
 
 
+# --8<-- [start:apply_rotary_emb]
 @CustomOp.register("apply_rotary_emb")
 class ApplyRotaryEmb(CustomOp):
+    # --8<-- [end:apply_rotary_emb]
+
     def __init__(
         self,
         enforce_enable: bool = False,

--- a/vllm/model_executor/layers/rotary_embedding/dual_chunk_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/dual_chunk_rope.py
@@ -9,9 +9,12 @@ from vllm.model_executor.custom_op import CustomOp
 from .common import rotate_gptj, rotate_neox
 
 
+# --8<-- [start:dual_chunk_rotary_embedding]
 @CustomOp.register("dual_chunk_rotary_embedding")
 class DualChunkRotaryEmbedding(CustomOp):
     """Rotary positional embedding for Dual Chunk Attention."""
+
+    # --8<-- [end:dual_chunk_rotary_embedding]
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -181,6 +181,7 @@ def get_masked_input_and_mask(
     return input_, ~vocab_mask
 
 
+# --8<-- [start:vocab_parallel_embedding]
 @CustomOp.register("vocab_parallel_embedding")
 class VocabParallelEmbedding(CustomOp):
     """Embedding parallelized in the vocabulary dimension.
@@ -220,6 +221,8 @@ class VocabParallelEmbedding(CustomOp):
         quant_config: quant config for the layer
         prefix: full name of the layer in the state dict
     """  # noqa: E501
+
+    # --8<-- [end:vocab_parallel_embedding]
 
     def __init__(
         self,
@@ -492,6 +495,7 @@ class VocabParallelEmbedding(CustomOp):
         return s
 
 
+# --8<-- [start:parallel_lm_head]
 @CustomOp.register("parallel_lm_head")
 class ParallelLMHead(VocabParallelEmbedding):
     """Parallelized LM head.
@@ -508,6 +512,8 @@ class ParallelLMHead(VocabParallelEmbedding):
         org_num_embeddings: original vocabulary size (without LoRA).
         padding_size: padding size for the vocabulary.
     """
+
+    # --8<-- [end:parallel_lm_head]
 
     def __init__(
         self,

--- a/vllm/model_executor/models/plamo2.py
+++ b/vllm/model_executor/models/plamo2.py
@@ -103,8 +103,11 @@ def is_mamba(config: Plamo2Config, i: int) -> bool:
 # Adapted from:
 # vllm.model_executor.layers.mamba.mamba_mixer2.MambaMixer2
 # transformers.models.mamba.modeling_mamba.MambaMixer
-@CustomOp.register(name="plamo2_mamba_mixer")
+# --8<-- [start:plamo2_mamba_mixer]
+@CustomOp.register("plamo2_mamba_mixer")
 class Plamo2MambaMixer(MambaBase, CustomOp):
+    # --8<-- [end:plamo2_mamba_mixer]
+
     def __init__(self, vllm_config: VllmConfig, *, prefix: str = "", **kwargs) -> None:
         super().__init__()
         self.config = vllm_config.model_config.hf_config

--- a/vllm/model_executor/models/transformers/moe.py
+++ b/vllm/model_executor/models/transformers/moe.py
@@ -37,9 +37,12 @@ if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
 
+# --8<-- [start:transformers_fused_moe]
 @CustomOp.register("transformers_fused_moe")
 class TransformersFusedMoE(FusedMoE):
     """Custom FusedMoE for the Transformers modeling backend."""
+
+    # --8<-- [end:transformers_fused_moe]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
## Purpose

Currently, there are more and more `CustomOp` defined both in vLLM and other OOT plugin devices. Following https://github.com/vllm-project/vllm/pull/30125#issuecomment-3648916991, I have written a doc about the principle and usage of `CustomOp`.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Introduces a developer guide for `CustomOp` explaining registration, enable/disable semantics, backend dispatch, and OOT plugin integration, plus customization examples.
> 
> - Adds `docs/design/custom_op.md` with how-to, config controls, supported ops list, and OOT plugin registration examples
> - Inserts snippet anchors (`--8<-- [start:...]`/`[end:...]`) around numerous in-tree op classes (attention, activation, conv, embedding/LM head, linear, logits processor, Mamba, MoE, norms, quantization, RoPE) to enable docs inclusion
> - Minor docstring/comment clarifications (e.g., `CompilationConfig.custom_ops` default behavior wording; notes in `CustomOp.dispatch_forward`); no logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27b46eb95f2f81b3953184da148367659aa620dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 42e8aa793297f6e260711b576a294f4b4ceeb381. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces a developer guide for `CustomOp` and prepares code for docs inclusion.
> 
> - Adds `docs/design/custom_op.md` covering registration, backend dispatch, enable/disable controls, OOT plugin integration, and examples
> - Inserts snippet anchors (`--8<-- [start:...]/[end:...]`) around numerous in-tree ops (attention, activations, conv, embedding/LM head, linear, logits processor, Mamba, MoE, norms, quantization, RoPE) to enable reuse in docs
> - Minor documentation/comment tweaks: refine `CompilationConfig.custom_ops` default description and add notes in `CustomOp.dispatch_forward`; no logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42e8aa793297f6e260711b576a294f4b4ceeb381. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
