### PR TITLE
[Kernel] Configure BlockReduce block size in RMSNorm kernel

### DIFF
--- a/csrc/layernorm_quant_kernels.cu
+++ b/csrc/layernorm_quant_kernels.cu
@@ -18,7 +18,7 @@
 namespace vllm {
 
 // TODO(woosuk): Further optimize this kernel.
-template <typename scalar_t, typename fp8_type, int VEC_SIZE>
+template <typename scalar_t, typename fp8_type, int BLOCK_SIZE, int VEC_SIZE>
 __global__ void rms_norm_static_fp8_quant_kernel(
     fp8_type* __restrict__ out,          // [..., hidden_size]
     const scalar_t* __restrict__ input,  // [..., hidden_size]
@@ -45,7 +45,7 @@ __global__ void rms_norm_static_fp8_quant_kernel(
   vllm::vectorize_read_with_alignment<VEC_SIZE>(
       input_row, hidden_size, threadIdx.x, blockDim.x, vec_op, scalar_op);
 
-  using BlockReduce = cub::BlockReduce<float, 1024>;
+  using BlockReduce = cub::BlockReduce<float, BLOCK_SIZE>;
   __shared__ typename BlockReduce::TempStorage reduceStore;
   variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
 
@@ -76,7 +76,7 @@ __global__ void rms_norm_static_fp8_quant_kernel(
    Additional optimizations we can make in this case are
    packed and vectorized operations, which help with the
    memory latency bottleneck. */
-template <typename scalar_t, int width, typename fp8_type>
+template <typename scalar_t, int block_size, int width, typename fp8_type>
 __global__ std::enable_if_t<(width > 0) && _typeConvert<scalar_t>::exists>
 fused_add_rms_norm_static_fp8_quant_kernel(
     fp8_type* __restrict__ out,    // [..., hidden_size]
@@ -113,7 +113,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
     residual_v[id] = temp;
   }
 
-  using BlockReduce = cub::BlockReduce<float, 1024>;
+  using BlockReduce = cub::BlockReduce<float, block_size>;
   __shared__ typename BlockReduce::TempStorage reduceStore;
   variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
 
@@ -141,7 +141,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
 /* Generic fused_add_rms_norm_kernel
    The width field is not used here but necessary for other specializations.
  */
-template <typename scalar_t, int width, typename fp8_type>
+template <typename scalar_t, int block_size, int width, typename fp8_type>
 __global__ std::enable_if_t<(width == 0) || !_typeConvert<scalar_t>::exists>
 fused_add_rms_norm_static_fp8_quant_kernel(
     fp8_type* __restrict__ out,    // [..., hidden_size]
@@ -162,7 +162,7 @@ fused_add_rms_norm_static_fp8_quant_kernel(
     residual[blockIdx.x * hidden_size + idx] = z;
   }
 
-  using BlockReduce = cub::BlockReduce<float, 1024>;
+  using BlockReduce = cub::BlockReduce<float, block_size>;
   __shared__ typename BlockReduce::TempStorage reduceStore;
   variance = BlockReduce(reduceStore).Reduce(variance, CubAddOp{}, blockDim.x);
 
@@ -209,32 +209,51 @@ void rms_norm_static_fp8_quant(torch::Tensor& out,     // [..., hidden_size]
                   std::min(hidden_size / calculated_vec_size, max_block_size);
               dim3 block(block_size);
               VLLM_DISPATCH_VEC_SIZE(calculated_vec_size, [&] {
-                vllm::rms_norm_static_fp8_quant_kernel<scalar_t, fp8_t,
-                                                       vec_size>
-                    <<<grid, block, 0, stream>>>(
-                        out.data_ptr<fp8_t>(), input.data_ptr<scalar_t>(),
-                        input_stride, weight.data_ptr<scalar_t>(),
-                        scale.data_ptr<float>(), epsilon, num_tokens,
-                        hidden_size);
+                if (max_block_size == 256) {
+                  vllm::rms_norm_static_fp8_quant_kernel<scalar_t, fp8_t, 256,
+                                                         vec_size>
+                      <<<grid, block, 0, stream>>>(
+                          out.data_ptr<fp8_t>(), input.data_ptr<scalar_t>(),
+                          input_stride, weight.data_ptr<scalar_t>(),
+                          scale.data_ptr<float>(), epsilon, num_tokens,
+                          hidden_size);
+                } else {
+                  vllm::rms_norm_static_fp8_quant_kernel<scalar_t, fp8_t, 1024,
+                                                         vec_size>
+                      <<<grid, block, 0, stream>>>(
+                          out.data_ptr<fp8_t>(), input.data_ptr<scalar_t>(),
+                          input_stride, weight.data_ptr<scalar_t>(),
+                          scale.data_ptr<float>(), epsilon, num_tokens,
+                          hidden_size);
+                }
               });
             });
       });
 }
 
-#define LAUNCH_FUSED_ADD_RMS_NORM(width)                                     \
-  VLLM_DISPATCH_FLOATING_TYPES(                                              \
-      input.scalar_type(), "fused_add_rms_norm_kernel_scalar_type", [&] {    \
-        VLLM_DISPATCH_FP8_TYPES(                                             \
-            out.scalar_type(), "fused_add_rms_norm_kernel_fp8_type", [&] {   \
-              vllm::fused_add_rms_norm_static_fp8_quant_kernel<scalar_t,     \
-                                                               width, fp8_t> \
-                  <<<grid, block, 0, stream>>>(                              \
-                      out.data_ptr<fp8_t>(), input.data_ptr<scalar_t>(),     \
-                      input_stride, residual.data_ptr<scalar_t>(),           \
-                      weight.data_ptr<scalar_t>(), scale.data_ptr<float>(),  \
-                      epsilon, num_tokens, hidden_size);                     \
-            });                                                              \
+#define LAUNCH_FUSED_ADD_RMS_NORM(width)                                       \
+  VLLM_DISPATCH_FLOATING_TYPES(                                                \
+      input.scalar_type(), "fused_add_rms_norm_kernel_scalar_type", [&] {      \
+        VLLM_DISPATCH_FP8_TYPES(                                               \
+            out.scalar_type(), "fused_add_rms_norm_kernel_fp8_type", [&] {     \
+              if (max_block_size == 256) {                                     \
+                vllm::fused_add_rms_norm_static_fp8_quant_kernel<              \
+                    scalar_t, 256, width, fp8_t><<<grid, block, 0, stream>>>(  \
+                    out.data_ptr<fp8_t>(), input.data_ptr<scalar_t>(),         \
+                    input_stride, residual.data_ptr<scalar_t>(),               \
+                    weight.data_ptr<scalar_t>(), scale.data_ptr<float>(),      \
+                    epsilon, num_tokens, hidden_size);                         \
+              } else {                                                         \
+                vllm::fused_add_rms_norm_static_fp8_quant_kernel<              \
+                    scalar_t, 1024, width, fp8_t><<<grid, block, 0, stream>>>( \
+                    out.data_ptr<fp8_t>(), input.data_ptr<scalar_t>(),         \
+                    input_stride, residual.data_ptr<scalar_t>(),               \
+                    weight.data_ptr<scalar_t>(), scale.data_ptr<float>(),      \
+                    epsilon, num_tokens, hidden_size);                         \
+              }                                                                \
+            });                                                                \
       });
+
 void fused_add_rms_norm_static_fp8_quant(
     torch::Tensor& out,       // [..., hidden_size],
     torch::Tensor& input,     // [..., hidden_size]


### PR DESCRIPTION

## Purpose

This PR is to configure `BlockReduce` block size template parameter in RMSNorm kernel.

* The max_block_size to launch kernel can be 256 or 1024, see [here](https://github.com/vllm-project/vllm/blob/v0.12.0/csrc/layernorm_kernels.cu#L256). If max_block_size=256, `BlockReduce` only need to performance reduction across up to 256 threads.
* So this PR pass BLOCK_SIZE as template parameter and use it for `BlockReduce`.

## Test Plan

```
pytest -s -v tests/kernels/core/test_layernorm.py
```

## Test Result

Tests passed.

## Benchmark

```
python3 benchmarks/kernels/benchmark_rmsnorm.py
```

Main:

```
    head_num  batch_size  seq_len  HuggingFace   FlashInfer        vLLM
0       32.0         1.0     64.0   187.999994     8.640000   10.912000
1       32.0         1.0    128.0   174.191996    10.144000   11.712000
2       32.0         1.0    256.0   170.240000    10.784000   12.608000
3       32.0         1.0    512.0   173.936002    12.352000   14.048000
4       32.0         1.0   1024.0   177.024007    17.344000   18.271999
5       32.0         4.0     64.0   173.312001    11.424000   12.704000
6       32.0         4.0    128.0   175.856002    12.384000   13.984000
7       32.0         4.0    256.0   174.687997    17.344000   18.271999
8       32.0         4.0    512.0   175.999999    27.104000   27.008001
9       32.0         4.0   1024.0   270.032004    52.000001   50.528001
10      32.0        16.0     64.0   176.159993    17.344000   18.271999
11      32.0        16.0    128.0   175.392002    27.136000   27.039999
12      32.0        16.0    256.0   269.183993    52.032001   50.239999
13      32.0        16.0    512.0   490.528002    93.695998   87.711997
14      32.0        16.0   1024.0   942.144006   176.592000  162.047997
15      32.0        64.0     64.0   269.344002    52.064002   50.336000
16      32.0        64.0    128.0   490.431994    93.471996   87.456003
17      32.0        64.0    256.0   942.943990   176.256001  161.855996
18      32.0        64.0    512.0  1835.247993   341.055989  309.215993
19      32.0        64.0   1024.0  3623.903990   672.927976  607.680023
20      48.0         1.0     64.0   174.128003     8.864000   11.232000
21      48.0         1.0    128.0   171.936005    10.528000   12.192000
22      48.0         1.0    256.0   172.895998    12.288000   13.888000
23      48.0         1.0    512.0   174.128003    15.584000   16.480001
24      48.0         1.0   1024.0   174.255997    23.232000   22.464000
25      48.0         4.0     64.0   172.767997    12.576000   13.952000
26      48.0         4.0    128.0   173.872001    15.584000   16.448000
27      48.0         4.0    256.0   172.928005    23.232000   22.464000
28      48.0         4.0    512.0   217.759997    42.943999   36.672000
29      48.0         4.0   1024.0   383.327991    80.704004   69.151998
30      48.0        16.0     64.0   174.559996    23.232000   22.464000
31      48.0        16.0    128.0   217.695996    42.911999   36.640000
32      48.0        16.0    256.0   383.935988    80.735996   69.151998
33      48.0        16.0    512.0   714.272022   150.751993  123.999998
34      48.0        16.0   1024.0  1386.976004   292.320013  233.584002
35      48.0        64.0     64.0   384.543985    80.863997   69.375999
36      48.0        64.0    128.0   714.464009   150.879994  123.967998
37      48.0        64.0    256.0  1385.375977   292.127997  233.567998
38      48.0        64.0    512.0  2721.503973   573.519975  453.887999
39      48.0        64.0   1024.0  5400.367975  1132.768035  890.879989
```

PR:

```
    head_num  batch_size  seq_len  HuggingFace   FlashInfer        vLLM
0       32.0         1.0     64.0   183.279999     8.704000   10.976000
1       32.0         1.0    128.0   175.632000    10.976000   11.320000
2       32.0         1.0    256.0   171.360001    11.584000   12.248000
3       32.0         1.0    512.0   173.792005    12.384000   13.856000
4       32.0         1.0   1024.0   172.639996    17.376000   18.239999
5       32.0         4.0     64.0   170.064002    10.784000   12.576000
6       32.0         4.0    128.0   170.399994    12.800000   14.144000
7       32.0         4.0    256.0   171.920002    17.376000   18.208001
8       32.0         4.0    512.0   174.303994    27.551999   27.039999
9       32.0         4.0   1024.0   269.439995    52.288000   50.448000
10      32.0        16.0     64.0   174.464002    17.376000   18.239999
11      32.0        16.0    128.0   175.007999    27.616000   27.039999
12      32.0        16.0    256.0   270.368010    52.320000   50.175998
13      32.0        16.0    512.0   491.456002    93.599997   87.360002
14      32.0        16.0   1024.0   943.264008   176.223993  161.408007
15      32.0        64.0     64.0   269.600004    52.384000   49.888000
16      32.0        64.0    128.0   491.903991    93.535997   87.296002
17      32.0        64.0    256.0   943.359971   176.479995  161.632001
18      32.0        64.0    512.0  1836.256027   340.703994  308.256000
19      32.0        64.0   1024.0  3623.008013   674.336016  607.360005
20      48.0         1.0     64.0   170.192003     9.728000   11.840000
21      48.0         1.0    128.0   171.120003    11.264000   12.384000
22      48.0         1.0    256.0   171.120003    12.320000   13.632000
23      48.0         1.0    512.0   172.656000    16.352000   16.448000
24      48.0         1.0   1024.0   181.648001    23.232000   22.624001
25      48.0         4.0     64.0   171.391994    12.352000   13.632000
26      48.0         4.0    128.0   172.224000    16.352000   16.480001
27      48.0         4.0    256.0   172.511995    23.264000   22.464000
28      48.0         4.0    512.0   217.904001    43.455999   36.672000
29      48.0         4.0   1024.0   383.648008    80.704004   69.119997
30      48.0        16.0     64.0   172.160000    23.328001   22.431999
31      48.0        16.0    128.0   217.104003    43.391999   36.607999
32      48.0        16.0    256.0   383.455992    80.704004   69.087997
33      48.0        16.0    512.0   715.327978   150.879994  123.903997
34      48.0        16.0   1024.0  1386.144042   292.255998  233.152002
35      48.0        64.0     64.0   383.599997    80.672003   69.055997
36      48.0        64.0    128.0   714.079976   150.751993  123.712003
37      48.0        64.0    256.0  1386.559963   292.095989  233.231999
38      48.0        64.0    512.0  2724.416018   573.888004  453.280002
39      48.0        64.0   1024.0  5397.791862  1136.064053  890.847981
```

No performance regression.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

