### PR TITLE
[Feature] Add /v1/kv_cache/status API endpoint

### DIFF
--- a/tests/entrypoints/openai/test_kv_cache_status.py
+++ b/tests/entrypoints/openai/test_kv_cache_status.py
@@ -6,15 +6,13 @@ import asyncio
 import json
 from unittest.mock import patch
 
-import pytest
-
 from vllm.v1.metrics.reader import Counter, Gauge
 
 
 class TestKVCacheStatusEndpoint:
     """Tests for the /v1/kv_cache/status endpoint logic."""
 
-    @patch('vllm.entrypoints.openai.api_server.get_metrics_snapshot')
+    @patch("vllm.entrypoints.openai.api_server.get_metrics_snapshot")
     def test_response_structure_with_metrics(self, mock_get_metrics_snapshot):
         """Test that the response has all required fields with valid metrics."""
         from vllm.entrypoints.openai.api_server import get_kv_cache_status
@@ -50,7 +48,7 @@ class TestKVCacheStatusEndpoint:
         assert response["prefix_cache_hits_total"] == 750
         assert response["prefix_cache_hit_rate"] == 0.75
 
-    @patch('vllm.entrypoints.openai.api_server.get_metrics_snapshot')
+    @patch("vllm.entrypoints.openai.api_server.get_metrics_snapshot")
     def test_prefix_cache_hit_rate_calculation(self, mock_get_metrics_snapshot):
         """Test that hit rate is calculated correctly."""
         from vllm.entrypoints.openai.api_server import get_kv_cache_status
@@ -69,9 +67,9 @@ class TestKVCacheStatusEndpoint:
 
         assert response["prefix_cache_hit_rate"] == 0.75
 
-    @patch('vllm.entrypoints.openai.api_server.get_metrics_snapshot')
+    @patch("vllm.entrypoints.openai.api_server.get_metrics_snapshot")
     def test_prefix_cache_hit_rate_zero_queries(self, mock_get_metrics_snapshot):
-        """Test hit rate when no queries have been made (avoid division by zero)."""
+        """Test hit rate when no queries have been made."""
         from vllm.entrypoints.openai.api_server import get_kv_cache_status
 
         mock_metrics = [
@@ -88,9 +86,9 @@ class TestKVCacheStatusEndpoint:
 
         assert response["prefix_cache_hit_rate"] == 0.0
 
-    @patch('vllm.entrypoints.openai.api_server.get_metrics_snapshot')
+    @patch("vllm.entrypoints.openai.api_server.get_metrics_snapshot")
     def test_response_with_empty_metrics(self, mock_get_metrics_snapshot):
-        """Test that response returns default values when no metrics available."""
+        """Test that response returns default values when no metrics."""
         from vllm.entrypoints.openai.api_server import get_kv_cache_status
 
         mock_get_metrics_snapshot.return_value = []
@@ -112,7 +110,7 @@ class TestKVCacheStatusEndpoint:
         assert response["prefix_cache_queries_total"] == 0
         assert response["prefix_cache_hits_total"] == 0
 
-    @patch('vllm.entrypoints.openai.api_server.get_metrics_snapshot')
+    @patch("vllm.entrypoints.openai.api_server.get_metrics_snapshot")
     def test_num_used_blocks_calculation(self, mock_get_metrics_snapshot):
         """Test that num_used_blocks is correctly calculated."""
         from vllm.entrypoints.openai.api_server import get_kv_cache_status

--- a/tests/entrypoints/openai/test_kv_cache_status.py
+++ b/tests/entrypoints/openai/test_kv_cache_status.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the /v1/kv_cache/status endpoint."""
+
+import pytest
+from unittest.mock import patch
+
+from vllm.v1.metrics.reader import Counter, Gauge
+
+
+class TestKVCacheStatusEndpoint:
+    """Tests for the /v1/kv_cache/status endpoint logic."""
+
+    def test_response_structure_with_metrics(self):
+        """Test that the response has all required fields with valid metrics."""
+        # Mock metrics data
+        mock_metrics = [
+            Gauge(name="vllm:kv_cache_usage_perc", labels={}, value=0.65),
+            Gauge(name="vllm:num_kv_cache_blocks_total", labels={}, value=4096),
+            Gauge(name="vllm:num_kv_cache_blocks_free", labels={}, value=1433),
+            Gauge(name="vllm:num_requests_running", labels={}, value=10),
+            Gauge(name="vllm:num_requests_waiting", labels={}, value=5),
+            Counter(name="vllm:prefix_cache_queries", labels={}, value=1000),
+            Counter(name="vllm:prefix_cache_hits", labels={}, value=750),
+        ]
+
+        # Simulate the endpoint logic
+        response = {
+            "kv_cache_usage": 0.0,
+            "num_total_blocks": 0,
+            "num_free_blocks": 0,
+            "num_used_blocks": 0,
+            "num_running_requests": 0,
+            "num_waiting_requests": 0,
+            "prefix_cache_hit_rate": 0.0,
+            "prefix_cache_queries_total": 0,
+            "prefix_cache_hits_total": 0,
+        }
+
+        metric_mapping = {
+            "vllm:kv_cache_usage_perc": "kv_cache_usage",
+            "vllm:num_kv_cache_blocks_total": "num_total_blocks",
+            "vllm:num_kv_cache_blocks_free": "num_free_blocks",
+            "vllm:num_requests_running": "num_running_requests",
+            "vllm:num_requests_waiting": "num_waiting_requests",
+            "vllm:prefix_cache_queries": "prefix_cache_queries_total",
+            "vllm:prefix_cache_hits": "prefix_cache_hits_total",
+        }
+
+        for metric in mock_metrics:
+            if metric.name in metric_mapping:
+                field_name = metric_mapping[metric.name]
+                if isinstance(metric, Gauge):
+                    response[field_name] = float(metric.value)
+                elif isinstance(metric, Counter):
+                    response[field_name] = int(metric.value)
+
+        # Calculate derived metrics
+        response["num_used_blocks"] = int(
+            response["num_total_blocks"] - response["num_free_blocks"]
+        )
+
+        # Calculate hit rate
+        if response["prefix_cache_queries_total"] > 0:
+            response["prefix_cache_hit_rate"] = (
+                response["prefix_cache_hits_total"]
+                / response["prefix_cache_queries_total"]
+            )
+
+        # Assertions
+        assert response["kv_cache_usage"] == 0.65
+        assert response["num_total_blocks"] == 4096
+        assert response["num_free_blocks"] == 1433
+        assert response["num_used_blocks"] == 2663
+        assert response["num_running_requests"] == 10
+        assert response["num_waiting_requests"] == 5
+        assert response["prefix_cache_queries_total"] == 1000
+        assert response["prefix_cache_hits_total"] == 750
+        assert response["prefix_cache_hit_rate"] == 0.75
+
+    def test_prefix_cache_hit_rate_calculation(self):
+        """Test that hit rate is calculated correctly."""
+        queries = 1000
+        hits = 750
+        expected_rate = 0.75
+
+        actual_rate = hits / queries if queries > 0 else 0.0
+        assert actual_rate == expected_rate
+
+    def test_prefix_cache_hit_rate_zero_queries(self):
+        """Test hit rate when no queries have been made (avoid division by zero)."""
+        queries = 0
+        hits = 0
+
+        rate = hits / queries if queries > 0 else 0.0
+        assert rate == 0.0
+
+    def test_response_with_empty_metrics(self):
+        """Test that response returns default values when no metrics available."""
+        mock_metrics = []
+
+        response = {
+            "kv_cache_usage": 0.0,
+            "num_running_requests": 0,
+            "num_waiting_requests": 0,
+            "prefix_cache_hit_rate": 0.0,
+            "prefix_cache_queries_total": 0,
+            "prefix_cache_hits_total": 0,
+        }
+
+        # Simulate the endpoint logic with empty metrics
+        metric_mapping = {
+            "vllm:kv_cache_usage_perc": "kv_cache_usage",
+            "vllm:num_requests_running": "num_running_requests",
+            "vllm:num_requests_waiting": "num_waiting_requests",
+            "vllm:prefix_cache_queries": "prefix_cache_queries_total",
+            "vllm:prefix_cache_hits": "prefix_cache_hits_total",
+        }
+
+        for metric in mock_metrics:
+            if metric.name in metric_mapping:
+                field_name = metric_mapping[metric.name]
+                if isinstance(metric, Gauge):
+                    response[field_name] = float(metric.value)
+                elif isinstance(metric, Counter):
+                    response[field_name] = int(metric.value)
+
+        # All values should remain at defaults
+        assert response["kv_cache_usage"] == 0.0
+        assert response["num_running_requests"] == 0
+        assert response["num_waiting_requests"] == 0
+        assert response["prefix_cache_hit_rate"] == 0.0
+        assert response["prefix_cache_queries_total"] == 0
+        assert response["prefix_cache_hits_total"] == 0
+
+    def test_response_fields_are_correct_types(self):
+        """Test that response fields have correct data types."""
+        mock_metrics = [
+            Gauge(name="vllm:kv_cache_usage_perc", labels={}, value=0.5),
+            Gauge(name="vllm:num_requests_running", labels={}, value=5),
+            Counter(name="vllm:prefix_cache_queries", labels={}, value=100),
+        ]
+
+        response = {
+            "kv_cache_usage": 0.0,
+            "num_running_requests": 0,
+            "num_waiting_requests": 0,
+            "prefix_cache_hit_rate": 0.0,
+            "prefix_cache_queries_total": 0,
+            "prefix_cache_hits_total": 0,
+        }
+
+        metric_mapping = {
+            "vllm:kv_cache_usage_perc": "kv_cache_usage",
+            "vllm:num_requests_running": "num_running_requests",
+            "vllm:num_requests_waiting": "num_waiting_requests",
+            "vllm:prefix_cache_queries": "prefix_cache_queries_total",
+            "vllm:prefix_cache_hits": "prefix_cache_hits_total",
+        }
+
+        for metric in mock_metrics:
+            if metric.name in metric_mapping:
+                field_name = metric_mapping[metric.name]
+                if isinstance(metric, Gauge):
+                    response[field_name] = float(metric.value)
+                elif isinstance(metric, Counter):
+                    response[field_name] = int(metric.value)
+
+        # Check types
+        assert isinstance(response["kv_cache_usage"], float)
+        assert isinstance(response["num_running_requests"], float)  # Gauge returns float
+        assert isinstance(response["prefix_cache_queries_total"], int)
+        assert isinstance(response["prefix_cache_hit_rate"], float)

--- a/tests/entrypoints/openai/test_kv_cache_status.py
+++ b/tests/entrypoints/openai/test_kv_cache_status.py
@@ -2,8 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for the /v1/kv_cache/status endpoint."""
 
-import pytest
+import asyncio
+import json
 from unittest.mock import patch
+
+import pytest
 
 from vllm.v1.metrics.reader import Counter, Gauge
 
@@ -11,8 +14,11 @@ from vllm.v1.metrics.reader import Counter, Gauge
 class TestKVCacheStatusEndpoint:
     """Tests for the /v1/kv_cache/status endpoint logic."""
 
-    def test_response_structure_with_metrics(self):
+    @patch('vllm.entrypoints.openai.api_server.get_metrics_snapshot')
+    def test_response_structure_with_metrics(self, mock_get_metrics_snapshot):
         """Test that the response has all required fields with valid metrics."""
+        from vllm.entrypoints.openai.api_server import get_kv_cache_status
+
         # Mock metrics data
         mock_metrics = [
             Gauge(name="vllm:kv_cache_usage_perc", labels={}, value=0.65),
@@ -23,49 +29,15 @@ class TestKVCacheStatusEndpoint:
             Counter(name="vllm:prefix_cache_queries", labels={}, value=1000),
             Counter(name="vllm:prefix_cache_hits", labels={}, value=750),
         ]
+        mock_get_metrics_snapshot.return_value = mock_metrics
 
-        # Simulate the endpoint logic
-        response = {
-            "kv_cache_usage": 0.0,
-            "num_total_blocks": 0,
-            "num_free_blocks": 0,
-            "num_used_blocks": 0,
-            "num_running_requests": 0,
-            "num_waiting_requests": 0,
-            "prefix_cache_hit_rate": 0.0,
-            "prefix_cache_queries_total": 0,
-            "prefix_cache_hits_total": 0,
-        }
+        # Mock request object (not used in current implementation)
+        class MockRequest:
+            pass
 
-        metric_mapping = {
-            "vllm:kv_cache_usage_perc": "kv_cache_usage",
-            "vllm:num_kv_cache_blocks_total": "num_total_blocks",
-            "vllm:num_kv_cache_blocks_free": "num_free_blocks",
-            "vllm:num_requests_running": "num_running_requests",
-            "vllm:num_requests_waiting": "num_waiting_requests",
-            "vllm:prefix_cache_queries": "prefix_cache_queries_total",
-            "vllm:prefix_cache_hits": "prefix_cache_hits_total",
-        }
-
-        for metric in mock_metrics:
-            if metric.name in metric_mapping:
-                field_name = metric_mapping[metric.name]
-                if isinstance(metric, Gauge):
-                    response[field_name] = float(metric.value)
-                elif isinstance(metric, Counter):
-                    response[field_name] = int(metric.value)
-
-        # Calculate derived metrics
-        response["num_used_blocks"] = int(
-            response["num_total_blocks"] - response["num_free_blocks"]
-        )
-
-        # Calculate hit rate
-        if response["prefix_cache_queries_total"] > 0:
-            response["prefix_cache_hit_rate"] = (
-                response["prefix_cache_hits_total"]
-                / response["prefix_cache_queries_total"]
-            )
+        # Run the async endpoint function
+        response_obj = asyncio.run(get_kv_cache_status(MockRequest()))
+        response = json.loads(response_obj.body)
 
         # Assertions
         assert response["kv_cache_usage"] == 0.65
@@ -78,96 +50,85 @@ class TestKVCacheStatusEndpoint:
         assert response["prefix_cache_hits_total"] == 750
         assert response["prefix_cache_hit_rate"] == 0.75
 
-    def test_prefix_cache_hit_rate_calculation(self):
+    @patch('vllm.entrypoints.openai.api_server.get_metrics_snapshot')
+    def test_prefix_cache_hit_rate_calculation(self, mock_get_metrics_snapshot):
         """Test that hit rate is calculated correctly."""
-        queries = 1000
-        hits = 750
-        expected_rate = 0.75
+        from vllm.entrypoints.openai.api_server import get_kv_cache_status
 
-        actual_rate = hits / queries if queries > 0 else 0.0
-        assert actual_rate == expected_rate
+        mock_metrics = [
+            Counter(name="vllm:prefix_cache_queries", labels={}, value=1000),
+            Counter(name="vllm:prefix_cache_hits", labels={}, value=750),
+        ]
+        mock_get_metrics_snapshot.return_value = mock_metrics
 
-    def test_prefix_cache_hit_rate_zero_queries(self):
+        class MockRequest:
+            pass
+
+        response_obj = asyncio.run(get_kv_cache_status(MockRequest()))
+        response = json.loads(response_obj.body)
+
+        assert response["prefix_cache_hit_rate"] == 0.75
+
+    @patch('vllm.entrypoints.openai.api_server.get_metrics_snapshot')
+    def test_prefix_cache_hit_rate_zero_queries(self, mock_get_metrics_snapshot):
         """Test hit rate when no queries have been made (avoid division by zero)."""
-        queries = 0
-        hits = 0
+        from vllm.entrypoints.openai.api_server import get_kv_cache_status
 
-        rate = hits / queries if queries > 0 else 0.0
-        assert rate == 0.0
+        mock_metrics = [
+            Counter(name="vllm:prefix_cache_queries", labels={}, value=0),
+            Counter(name="vllm:prefix_cache_hits", labels={}, value=0),
+        ]
+        mock_get_metrics_snapshot.return_value = mock_metrics
 
-    def test_response_with_empty_metrics(self):
+        class MockRequest:
+            pass
+
+        response_obj = asyncio.run(get_kv_cache_status(MockRequest()))
+        response = json.loads(response_obj.body)
+
+        assert response["prefix_cache_hit_rate"] == 0.0
+
+    @patch('vllm.entrypoints.openai.api_server.get_metrics_snapshot')
+    def test_response_with_empty_metrics(self, mock_get_metrics_snapshot):
         """Test that response returns default values when no metrics available."""
-        mock_metrics = []
+        from vllm.entrypoints.openai.api_server import get_kv_cache_status
 
-        response = {
-            "kv_cache_usage": 0.0,
-            "num_running_requests": 0,
-            "num_waiting_requests": 0,
-            "prefix_cache_hit_rate": 0.0,
-            "prefix_cache_queries_total": 0,
-            "prefix_cache_hits_total": 0,
-        }
+        mock_get_metrics_snapshot.return_value = []
 
-        # Simulate the endpoint logic with empty metrics
-        metric_mapping = {
-            "vllm:kv_cache_usage_perc": "kv_cache_usage",
-            "vllm:num_requests_running": "num_running_requests",
-            "vllm:num_requests_waiting": "num_waiting_requests",
-            "vllm:prefix_cache_queries": "prefix_cache_queries_total",
-            "vllm:prefix_cache_hits": "prefix_cache_hits_total",
-        }
+        class MockRequest:
+            pass
 
-        for metric in mock_metrics:
-            if metric.name in metric_mapping:
-                field_name = metric_mapping[metric.name]
-                if isinstance(metric, Gauge):
-                    response[field_name] = float(metric.value)
-                elif isinstance(metric, Counter):
-                    response[field_name] = int(metric.value)
+        response_obj = asyncio.run(get_kv_cache_status(MockRequest()))
+        response = json.loads(response_obj.body)
 
-        # All values should remain at defaults
+        # All values should be at defaults
         assert response["kv_cache_usage"] == 0.0
+        assert response["num_total_blocks"] == 0
+        assert response["num_free_blocks"] == 0
+        assert response["num_used_blocks"] == 0
         assert response["num_running_requests"] == 0
         assert response["num_waiting_requests"] == 0
         assert response["prefix_cache_hit_rate"] == 0.0
         assert response["prefix_cache_queries_total"] == 0
         assert response["prefix_cache_hits_total"] == 0
 
-    def test_response_fields_are_correct_types(self):
-        """Test that response fields have correct data types."""
+    @patch('vllm.entrypoints.openai.api_server.get_metrics_snapshot')
+    def test_num_used_blocks_calculation(self, mock_get_metrics_snapshot):
+        """Test that num_used_blocks is correctly calculated."""
+        from vllm.entrypoints.openai.api_server import get_kv_cache_status
+
         mock_metrics = [
-            Gauge(name="vllm:kv_cache_usage_perc", labels={}, value=0.5),
-            Gauge(name="vllm:num_requests_running", labels={}, value=5),
-            Counter(name="vllm:prefix_cache_queries", labels={}, value=100),
+            Gauge(name="vllm:num_kv_cache_blocks_total", labels={}, value=4096),
+            Gauge(name="vllm:num_kv_cache_blocks_free", labels={}, value=1000),
         ]
+        mock_get_metrics_snapshot.return_value = mock_metrics
 
-        response = {
-            "kv_cache_usage": 0.0,
-            "num_running_requests": 0,
-            "num_waiting_requests": 0,
-            "prefix_cache_hit_rate": 0.0,
-            "prefix_cache_queries_total": 0,
-            "prefix_cache_hits_total": 0,
-        }
+        class MockRequest:
+            pass
 
-        metric_mapping = {
-            "vllm:kv_cache_usage_perc": "kv_cache_usage",
-            "vllm:num_requests_running": "num_running_requests",
-            "vllm:num_requests_waiting": "num_waiting_requests",
-            "vllm:prefix_cache_queries": "prefix_cache_queries_total",
-            "vllm:prefix_cache_hits": "prefix_cache_hits_total",
-        }
+        response_obj = asyncio.run(get_kv_cache_status(MockRequest()))
+        response = json.loads(response_obj.body)
 
-        for metric in mock_metrics:
-            if metric.name in metric_mapping:
-                field_name = metric_mapping[metric.name]
-                if isinstance(metric, Gauge):
-                    response[field_name] = float(metric.value)
-                elif isinstance(metric, Counter):
-                    response[field_name] = int(metric.value)
-
-        # Check types
-        assert isinstance(response["kv_cache_usage"], float)
-        assert isinstance(response["num_running_requests"], float)  # Gauge returns float
-        assert isinstance(response["prefix_cache_queries_total"], int)
-        assert isinstance(response["prefix_cache_hit_rate"], float)
+        assert response["num_total_blocks"] == 4096
+        assert response["num_free_blocks"] == 1000
+        assert response["num_used_blocks"] == 3096  # 4096 - 1000

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -354,8 +354,7 @@ async def get_kv_cache_status(request: Request):
     # Calculate hit rate
     if response["prefix_cache_queries_total"] > 0:
         response["prefix_cache_hit_rate"] = (
-            response["prefix_cache_hits_total"]
-            / response["prefix_cache_queries_total"]
+            response["prefix_cache_hits_total"] / response["prefix_cache_queries_total"]
         )
 
     return JSONResponse(content=response)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1500,10 +1500,18 @@ class Scheduler(SchedulerInterface):
         connector_stats_payload = (
             kv_connector_stats.data if kv_connector_stats else None
         )
+
+        # Get block information from block_pool
+        block_pool = self.kv_cache_manager.block_pool
+        num_total_blocks = block_pool.num_gpu_blocks - 1  # Exclude null block
+        num_free_blocks = block_pool.get_num_free_blocks()
+
         return SchedulerStats(
             num_running_reqs=len(self.running),
             num_waiting_reqs=len(self.waiting),
             kv_cache_usage=self.kv_cache_manager.usage,
+            num_total_blocks=num_total_blocks,
+            num_free_blocks=num_free_blocks,
             prefix_cache_stats=prefix_cache_stats,
             connector_prefix_cache_stats=connector_prefix_cache_stats,
             kv_cache_eviction_events=eviction_events,

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -467,6 +467,26 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             gauge_kv_cache_usage, engine_indexes, model_name
         )
 
+        gauge_num_kv_cache_blocks_total = self._gauge_cls(
+            name="vllm:num_kv_cache_blocks_total",
+            documentation="Total number of KV cache blocks available.",
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_num_kv_cache_blocks_total = make_per_engine(
+            gauge_num_kv_cache_blocks_total, engine_indexes, model_name
+        )
+
+        gauge_num_kv_cache_blocks_free = self._gauge_cls(
+            name="vllm:num_kv_cache_blocks_free",
+            documentation="Number of free KV cache blocks.",
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_num_kv_cache_blocks_free = make_per_engine(
+            gauge_num_kv_cache_blocks_free, engine_indexes, model_name
+        )
+
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
             counter_corrupted_requests = self._counter_cls(
                 name="vllm:corrupted_requests",
@@ -1024,6 +1044,12 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 scheduler_stats.num_waiting_reqs
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
+            self.gauge_num_kv_cache_blocks_total[engine_idx].set(
+                scheduler_stats.num_total_blocks
+            )
+            self.gauge_num_kv_cache_blocks_free[engine_idx].set(
+                scheduler_stats.num_free_blocks
+            )
 
             self.counter_prefix_cache_queries[engine_idx].inc(
                 scheduler_stats.prefix_cache_stats.queries

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -173,6 +173,10 @@ class SchedulerStats:
 
     kv_cache_usage: float = 0.0
 
+    # KV cache block information
+    num_total_blocks: int = 0
+    num_free_blocks: int = 0
+
     prefix_cache_stats: PrefixCacheStats = field(default_factory=PrefixCacheStats)
     connector_prefix_cache_stats: PrefixCacheStats | None = None
 


### PR DESCRIPTION
This PR adds a new REST API endpoint `/v1/kv_cache/status` that returns detailed KV cache status information in JSON format.

## Changes

- Add `/v1/kv_cache/status` endpoint to api_server.py
- Add `num_total_blocks` and `num_free_blocks` fields to SchedulerStats
- Add new Prometheus gauges for block metrics
- Update Scheduler.make_stats() to collect block information
- Add unit tests for the new endpoint

## Response Format

```json
{
  "kv_cache_usage": 0.65,
  "num_total_blocks": 4096,
  "num_free_blocks": 1433,
  "num_used_blocks": 2663,
  "num_running_requests": 10,
  "num_waiting_requests": 5,
  "prefix_cache_hit_rate": 0.75,
  "prefix_cache_queries_total": 1000,
  "prefix_cache_hits_total": 750
}
```

## Motivation

This endpoint helps users monitor and debug KV cache utilization in production environments without relying solely on Prometheus metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

