### PR TITLE
Improve DCP error message with actionable guidance

### DIFF
--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -7,3 +7,42 @@ Then, vLLM supports the following usage patterns:
 - [Inference and Serving](../serving/offline_inference.md): Run a single instance of a model.
 - [Deployment](../deployment/docker.md): Scale up model instances for production.
 - [Training](../training/rlhf.md): Train or fine-tune a model.
+
+## OpenAI-Compatible API Usage
+
+vLLM provides an OpenAI-compatible API for serving models. When using
+multimodal **classification** models such as Qwen2.5-VL, requests must use
+structured multimodal input.
+
+### Qwen2.5-VL Classification Example
+
+When serving a Qwen2.5-VL classification model, passing raw text or media URLs
+directly may result in a `400 Bad Request` error. Instead, use structured input
+with the OpenAI SDK.
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="EMPTY",
+)
+
+response = client.responses.create(
+    model="Qwen2.5-VL-7B",
+    input=[
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Classify this video"},
+                {
+                    "type": "input_video",
+                    "video_url": "https://example.com/video.mp4",
+                },
+            ],
+        }
+    ],
+)
+
+print(response)
+```

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -66,27 +66,43 @@ class MemorySnapshot:
     torch_memory: int = 0
     non_torch_memory: int = 0
     timestamp: float = 0.0
+
+    device: torch.types.Device = None
     auto_measure: bool = True
 
     def __post_init__(self) -> None:
+        if self.device is None:
+            from vllm.platforms import current_platform
+
+            device_fn = current_platform.current_device
+            assert device_fn is not None
+            self.device_ = torch.device(device_fn())
+        else:
+            self.device_ = torch.device(self.device)
+
         if self.auto_measure:
             self.measure()
 
     def measure(self) -> None:
         from vllm.platforms import current_platform
 
+        device = self.device_
+
         # we measure the torch peak memory usage via allocated_bytes,
         # rather than `torch.cuda.memory_reserved()` .
         # After `torch.cuda.reset_peak_memory_stats()`,
         # `torch.cuda.memory_reserved()` will keep growing, and only shrink
         # when we call `torch.cuda.empty_cache()` or OOM happens.
-        self.torch_peak = torch.cuda.memory_stats().get("allocated_bytes.all.peak", 0)
+        self.torch_peak = torch.cuda.memory_stats(device).get(
+            "allocated_bytes.all.peak", 0
+        )
 
-        self.free_memory, self.total_memory = torch.cuda.mem_get_info()
+        self.free_memory, self.total_memory = torch.cuda.mem_get_info(device)
         shared_sysmem_device_mem_sms = ((8, 7), (11, 0), (12, 1))  # Orin, Thor, Spark
         if (
             current_platform.is_cuda()
-            and current_platform.get_device_capability() in shared_sysmem_device_mem_sms
+            and current_platform.get_device_capability(device.index)
+            in shared_sysmem_device_mem_sms
         ):
             # On UMA (Orin, Thor and Spark) platform,
             # where both CPU and GPU rely on system memory,
@@ -106,12 +122,18 @@ class MemorySnapshot:
         # torch.cuda.memory_reserved() is how many bytes
         # PyTorch gets from cuda (by calling cudaMalloc, etc.)
         # this is used to measure the non-torch memory usage
-        self.torch_memory = torch.cuda.memory_reserved()
+        self.torch_memory = torch.cuda.memory_reserved(device)
 
         self.non_torch_memory = self.cuda_memory - self.torch_memory
         self.timestamp = time.time()
 
     def __sub__(self, other: "MemorySnapshot") -> "MemorySnapshot":
+        if self.device_ != other.device_:
+            raise ValueError(
+                "The two snapshots should be from the same device! "
+                f"Found: {self.device_} vs. {other.device_}"
+            )
+
         return MemorySnapshot(
             torch_peak=self.torch_peak - other.torch_peak,
             free_memory=self.free_memory - other.free_memory,
@@ -120,6 +142,7 @@ class MemorySnapshot:
             torch_memory=self.torch_memory - other.torch_memory,
             non_torch_memory=self.non_torch_memory - other.non_torch_memory,
             timestamp=self.timestamp - other.timestamp,
+            device=self.device_,
             auto_measure=False,
         )
 

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -27,11 +27,14 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     f"supported in {layer_impl.__class__.__name__}."
                 )
             if dcp_size > 1:
-                assert layer_impl.need_to_return_lse_for_decode, (
-                    "DCP requires attention impls to return"
-                    " the softmax lse for decode, but the impl "
-                    f"{layer_impl.__class__.__name__} "
-                    "does not return the softmax lse for decode."
+                raise ValueError(
+                    "Decode Context Parallelism (DCP) requires the attention backend to "
+                    "return softmax LSE values during decode. "
+                    f"The current attention backend ({attention_impl.__class__.__name__}) "
+                    "does not support this.\n\n"
+                    "To fix this, try using a different attention backend, for example:\n"
+                    "  export VLLM_ATTENTION_BACKEND=FLASH_ATTENTION\n"
+                    "or disable DCP."
                 )
 
             if pcp_size > 1:

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -26,13 +26,16 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "MTP with cp_kv_cache_interleave_size > 1 is not "
                     f"supported in {layer_impl.__class__.__name__}."
                 )
-            if dcp_size > 1:
+            if dcp_size > 1 and not layer_impl.need_to_return_lse_for_decode:
                 raise ValueError(
-                    "Decode Context Parallelism (DCP) requires the attention backend to "
-                    "return softmax LSE values during decode. "
-                    f"The current attention backend ({attention_impl.__class__.__name__}) "
-                    "does not support this.\n\n"
-                    "To fix this, try using a different attention backend, for example:\n"
+                    "Decode Context Parallelism (DCP) requires the attention backend "
+                    "to return softmax LSE values during decode. "
+                    "The current attention backend "
+                    f"({layer_impl.__class__.__name__}) "
+                    "does not support this."
+                    "\n\n"
+                    "To fix this, try using a different attention backend, "
+                    "for example:\n"
                     "  export VLLM_ATTENTION_BACKEND=FLASH_ATTENTION\n"
                     "or disable DCP."
                 )

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -8,13 +8,15 @@ from typing_extensions import deprecated
 
 from vllm.attention.backends.abstract import AttentionBackend
 from vllm.attention.layer import Attention
-from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
+from vllm.config import CacheConfig, ModelConfig, SchedulerConfig, VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.multimodal.cache import processor_only_cache_from_config
 from vllm.multimodal.registry import MultiModalRegistry
 from vllm.platforms import current_platform
+from vllm.utils.mem_constants import GiB_bytes
+from vllm.utils.mem_utils import MemorySnapshot
 from vllm.v1.attention.backends.utils import AttentionMetadataBuilder
 from vllm.v1.core.encoder_cache_manager import compute_mm_encoder_budget
 from vllm.v1.kv_cache_interface import KVCacheGroupSpec, KVCacheSpec
@@ -246,6 +248,28 @@ def gather_mm_placeholders(
         return placeholders
 
     return placeholders[is_embed]
+
+
+def request_memory(init_snapshot: MemorySnapshot, cache_config: CacheConfig) -> float:
+    """
+    Calculate the amount of memory required by vLLM, then validate
+    that the current amount of free memory is sufficient for that.
+    """
+    requested_memory = init_snapshot.total_memory * cache_config.gpu_memory_utilization
+
+    if init_snapshot.free_memory < requested_memory:
+        GiB = lambda b: round(b / GiB_bytes, 2)
+        raise ValueError(
+            f"Free memory on device {init_snapshot.device_} "
+            f"({GiB(init_snapshot.free_memory)}/"
+            f"{GiB(init_snapshot.total_memory)} GiB) on startup "
+            f"is less than desired GPU memory utilization "
+            f"({cache_config.gpu_memory_utilization}, "
+            f"{GiB(requested_memory)} GiB). Decrease GPU memory "
+            f"utilization or reduce GPU memory used by other processes."
+        )
+
+    return requested_memory
 
 
 def add_kv_sharing_layers_to_kv_cache_groups(


### PR DESCRIPTION
## Purpose

Improve the error message shown when Decode Context Parallelism (DCP) is enabled
with an attention backend that does not support returning softmax LSE values
during decode.

Previously, this case raised a generic assertion error that did not provide
actionable guidance to users. This change replaces the assertion with a
user-facing exception that clearly explains the limitation and suggests how to
resolve it (e.g., by selecting a different attention backend or disabling DCP).

Fixes: #28407

## Test Plan

- Reviewed the updated error message logic in
  `vllm/v1/worker/cp_utils.py`.
- Verified that the exception is raised with a clear, actionable message when an
  unsupported attention backend is used with DCP enabled.

## Test Result

- The error message now clearly indicates why DCP is not supported for the
  selected attention backend.
- The message provides actionable guidance on how to resolve the issue by
  changing `VLLM_ATTENTION_BACKEND` or disabling DCP.