### PR TITLE
[BugFix] Workspace allocation during profile run : DeepEPHighThroughput + DeepGEMM 

### DIFF
--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -795,7 +795,10 @@ class FusedMoEModularKernel(torch.nn.Module):
                     top_k,
                     global_num_experts,
                     local_num_experts,
-                    expert_tokens_meta,
+                    # expert_tokens_meta help in allocating optimal/minimal
+                    # amount of workspace. Mark it None, so we allocate for
+                    # the worst-case scenario.
+                    expert_tokens_meta=None,
                 )
             )
 


### PR DESCRIPTION
## Purpose
Running server command, 
```
VLLM_ALL2ALL_BACKEND="deepep_high_throughput"  vllm serve Qwen/Qwen3-30B-A3B-FP8 --data-parallel-size 2 --enable-expert-parallel --no-enable-prefix-caching --port 9010
```
with the benchmark command,
```
vllm bench serve --model Qwen/Qwen3-30B-A3B-FP8 --dataset-name random --num-prompts 256 --random-input-len 4096 --random-output-len 1 --ignore-eos --port 9010 --backend vllm
```
Trips the assert [here](https://github.com/vllm-project/vllm/blob/e3a0f21e6ce78268865cafcdc3dc58c7a80dbc57/vllm/v1/worker/workspace.py#L139) 

Cause:
 DeepGEMM + DeepEPHighThroughput, uses the `expert_tokens_meta` for allocating optimal/minimal amount of workspace when `expert_tokens_meta` is available. Look [here](https://github.com/vllm-project/vllm/blob/e3a0f21e6ce78268865cafcdc3dc58c7a80dbc57/vllm/model_executor/layers/fused_moe/deep_gemm_utils.py#L26)
 This prevents profile run from estimating the maximum workspace size properly.

Fix:
 Make expert_tokens_meta None when we are attempting to compute the maximum workspace size. 

## Test Plan
Run the server command and benchmark command. 

## Test Result
With the fix, we no longer trip the assert.

