### PR TITLE
[UX] Reduce DeepGEMM warmup log output to single progress bar

### DIFF
--- a/vllm/model_executor/warmup/deep_gemm_warmup.py
+++ b/vllm/model_executor/warmup/deep_gemm_warmup.py
@@ -175,7 +175,30 @@ def _fused_moe_grouped_gemm_may_use_deep_gemm(module: torch.nn.Module) -> bool:
 FP8_GEMM_NT_WARMUP_CACHE: set[torch.Size] = set()
 
 
-def _deepgemm_fp8_gemm_nt_warmup(w: torch.Tensor, ws: torch.Tensor, max_tokens: int):
+def _get_fp8_gemm_nt_m_values(w: torch.Tensor, max_tokens: int) -> list[int]:
+    """Get the M values to warmup for a given weight tensor."""
+    n, _ = w.size()
+    device = w.device
+
+    # Use optimal M values only if VLLM_DEEP_GEMM_WARMUP is set to "relax".
+    # Otherwise warmup all token sizes to avoid JIT compilation in hotpath
+    if envs.VLLM_DEEP_GEMM_WARMUP == "relax":
+        return _generate_optimal_warmup_m_values(max_tokens, n, device)
+    else:
+        assert envs.VLLM_DEEP_GEMM_WARMUP == "full", (
+            "Expected "
+            'VLLM_DEEP_GEMM_WARMUP env to be set to "full" but got '
+            f"{envs.VLLM_DEEP_GEMM_WARMUP}"
+        )
+        return list(range(1, max_tokens + 1))
+
+
+def _deepgemm_fp8_gemm_nt_warmup(
+    w: torch.Tensor,
+    ws: torch.Tensor,
+    max_tokens: int,
+    pbar: tqdm | None = None,
+):
     if w.size() in FP8_GEMM_NT_WARMUP_CACHE:
         return
 
@@ -189,27 +212,14 @@ def _deepgemm_fp8_gemm_nt_warmup(w: torch.Tensor, ws: torch.Tensor, max_tokens: 
     )
     out = torch.empty((max_tokens, n), device=device, dtype=torch.bfloat16)
 
-    # Use optimal M values only if VLLM_DEEP_GEMM_WARMUP is set to "relax".
-    # Otherwise warmup all token sizes to avoid JIT compilation in hotpath
-    if envs.VLLM_DEEP_GEMM_WARMUP == "relax":
-        m_values = _generate_optimal_warmup_m_values(max_tokens, n, device)
-        desc = f"DeepGemm(fp8_gemm_nt) warmup (W={w.size()}) [relaxed]"
-    else:
-        assert envs.VLLM_DEEP_GEMM_WARMUP == "full", (
-            "Expected "
-            'VLLM_DEEP_GEMM_WARMUP env to be set to "full" but got '
-            f"{envs.VLLM_DEEP_GEMM_WARMUP}"
-        )
-        m_values = list(range(1, max_tokens + 1))
-        desc = f"DeepGemm(fp8_gemm_nt) warmup (W={w.size()}) [all tokens]"
-
-    pbar = tqdm(total=len(m_values), desc=desc)
+    m_values = _get_fp8_gemm_nt_m_values(w, max_tokens)
 
     for num_tokens in m_values:
         fp8_gemm_nt(
             (a1q[:num_tokens], a1q_scales[:num_tokens]), (w, ws), out[:num_tokens]
         )
-        pbar.update(1)
+        if pbar is not None:
+            pbar.update(1)
 
     FP8_GEMM_NT_WARMUP_CACHE.add(w.size())
 
@@ -217,20 +227,12 @@ def _deepgemm_fp8_gemm_nt_warmup(w: torch.Tensor, ws: torch.Tensor, max_tokens: 
 GROUPED_FP8_GEMM_NT_CONTIGUOUS_WARMUP_CACHE: set[torch.Size] = set()
 
 
-def _deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(
+def _get_grouped_gemm_params(
     w1: torch.Tensor,
     w2: torch.Tensor,
-    w1_scale: torch.Tensor,
-    w2_scale: torch.Tensor,
     num_topk: int,
     max_tokens: int,
-):
-    if (
-        w1.size() in GROUPED_FP8_GEMM_NT_CONTIGUOUS_WARMUP_CACHE
-        and w2.size() in GROUPED_FP8_GEMM_NT_CONTIGUOUS_WARMUP_CACHE
-    ):
-        return
-
+) -> tuple[int, int, torch.Tensor]:
     assert w1.size(0) == w2.size(0), "w1 and w2 must have the same number of experts"
 
     block_m = get_mk_alignment_for_contiguous_layout()[0]
@@ -253,6 +255,27 @@ def _deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(
     )
     expert_ids = torch.repeat_interleave(expert_ids_block, block_m, dim=0)
 
+    return MAX_M, block_m, expert_ids
+
+
+def _deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    num_topk: int,
+    max_tokens: int,
+    pbar: tqdm | None = None,
+):
+    if (
+        w1.size() in GROUPED_FP8_GEMM_NT_CONTIGUOUS_WARMUP_CACHE
+        and w2.size() in GROUPED_FP8_GEMM_NT_CONTIGUOUS_WARMUP_CACHE
+    ):
+        return
+
+    MAX_M, block_m, expert_ids = _get_grouped_gemm_params(w1, w2, num_topk, max_tokens)
+    device = w1.device
+
     def _warmup(w: torch.Tensor, w_scale: torch.Tensor):
         _, n, k = w.size()
         a1q = torch.empty((MAX_M, k), device=device, dtype=torch.float8_e4m3fn)
@@ -261,14 +284,7 @@ def _deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(
         )
         out = torch.empty((MAX_M, n), device=device, dtype=torch.bfloat16)
 
-        # Generate M values in block_m increments (already optimized for MoE)
         m_values = list(range(block_m, MAX_M + 1, block_m))
-
-        pbar = tqdm(
-            total=len(m_values),
-            desc=f"DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W={w.size()}) "
-            f"[{len(m_values)} values, block_m={block_m}]",
-        )
 
         for num_tokens in m_values:
             m_grouped_fp8_gemm_nt_contiguous(
@@ -277,7 +293,8 @@ def _deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(
                 out[:num_tokens],
                 expert_ids[:num_tokens],
             )
-            pbar.update(1)
+            if pbar is not None:
+                pbar.update(1)
 
     for w, ws in [(w1, w1_scale), (w2, w2_scale)]:
         if w.size() not in GROUPED_FP8_GEMM_NT_CONTIGUOUS_WARMUP_CACHE:
@@ -285,16 +302,18 @@ def _deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(
             GROUPED_FP8_GEMM_NT_CONTIGUOUS_WARMUP_CACHE.add(w.size())
 
 
-def deepgemm_fp8_gemm_nt_warmup(model: torch.nn.Module, max_tokens: int):
+def deepgemm_fp8_gemm_nt_warmup(
+    model: torch.nn.Module, max_tokens: int, pbar: tqdm | None = None
+):
     dg_modules = [m for m in model.modules() if _fp8_linear_may_use_deep_gemm(m)]
 
     for dgm in dg_modules:
         w, ws, _ = _extract_data_from_linear_base_module(dgm)
-        _deepgemm_fp8_gemm_nt_warmup(w=w, ws=ws, max_tokens=max_tokens)
+        _deepgemm_fp8_gemm_nt_warmup(w=w, ws=ws, max_tokens=max_tokens, pbar=pbar)
 
 
 def deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(
-    model: torch.nn.Module, max_tokens: int
+    model: torch.nn.Module, max_tokens: int, pbar: tqdm | None = None
 ):
     dg_modules = [
         m for m in model.modules() if _fused_moe_grouped_gemm_may_use_deep_gemm(m)
@@ -305,10 +324,50 @@ def deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(
             dgm
         )
         _deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(
-            w13, w2, w13_scale, w2_scale, num_topk, max_tokens
+            w13, w2, w13_scale, w2_scale, num_topk, max_tokens, pbar=pbar
         )
 
 
+def _count_warmup_iterations(model: torch.nn.Module, max_tokens: int) -> int:
+    """Count total warmup iterations for progress bar."""
+    total = 0
+    block_m = get_mk_alignment_for_contiguous_layout()[0]
+
+    for m in model.modules():
+        if _fp8_linear_may_use_deep_gemm(m):
+            w, _, _ = _extract_data_from_linear_base_module(m)
+            if w.size() not in FP8_GEMM_NT_WARMUP_CACHE:
+                total += len(_get_fp8_gemm_nt_m_values(w, max_tokens))
+
+    for m in model.modules():
+        if _fused_moe_grouped_gemm_may_use_deep_gemm(m):
+            w13, _, w2, _, num_topk = _extract_data_from_fused_moe_module(m)
+            if (
+                w13.size() in GROUPED_FP8_GEMM_NT_CONTIGUOUS_WARMUP_CACHE
+                and w2.size() in GROUPED_FP8_GEMM_NT_CONTIGUOUS_WARMUP_CACHE
+            ):
+                continue
+            num_experts = w13.size(0)
+            max_tokens_adj = min(
+                get_dp_group().world_size * max_tokens,
+                envs.VLLM_FUSED_MOE_CHUNK_SIZE,
+            )
+            MAX_M = compute_aligned_M(
+                max_tokens_adj, num_topk, num_experts, block_m, expert_tokens_meta=None
+            )
+            n_values = (MAX_M - block_m) // block_m + 1
+            if w13.size() not in GROUPED_FP8_GEMM_NT_CONTIGUOUS_WARMUP_CACHE:
+                total += n_values
+            if w2.size() not in GROUPED_FP8_GEMM_NT_CONTIGUOUS_WARMUP_CACHE:
+                total += n_values
+    return total
+
+
 def deep_gemm_warmup(model: torch.nn.Module, max_tokens: int):
-    deepgemm_fp8_gemm_nt_warmup(model, max_tokens)
-    deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(model, max_tokens)
+    total = _count_warmup_iterations(model, max_tokens)
+    if total == 0:
+        return
+
+    with tqdm(total=total, desc="DeepGEMM warmup") as pbar:
+        deepgemm_fp8_gemm_nt_warmup(model, max_tokens, pbar)
+        deepgemm_grouped_fp8_gemm_nt_contiguous_warmup(model, max_tokens, pbar)


### PR DESCRIPTION

## Purpose
Showing a progress bar for each shape during DeepGEMM warmup is unnecessary. In the interest of reducing log clutter, this PR reduces the output to a single progress bar, only shown on rank 0.

## Test Plan
```
vllm serve deepseek-ai/DeepSeek-R1 -dp 8 --enable-expert-parallel
```


## Test Result
Main:
```
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([24576, 1536])) [relaxed]:   0%|                                     | 0/297 [00:00<?, ?it/s]DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([24576, 1536])) [relaxed]: 100%|█████████████████████████| 297/297 [00:00<00:00, 6297.94it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([32768, 512])) [relaxed]:   0%|                                      | 0/305 [00:00<?, ?it/s]DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([24576, 1536])) [relaxed]: 100%|█████████████████████████| 297/297 [00:00<00:00, 6248.19it/s]
(EngineCore_DP0 pid=1770963) INFO 12-17 21:16:42 [kv_cache_utils.py:1291] GPU KV cache size: 238,656 tokens
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([32768, 512])) [relaxed]:   0%|                                      | 0/305 [00:00<?, ?it/s](EngineCore_DP0 pid=1770963) INFO 12-17 21:16:42 [kv_cache_utils.py:1296] Maximum concurrency for 4,096 tokens per request: 58.27x
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([24576, 1536])) [relaxed]:   0%|                                     | 0/297 [00:00<?, ?it/s]DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([32768, 512])) [relaxed]: 100%|██████████████████████████| 305/305 [00:00<00:00, 7881.12it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 16384])) [relaxed]:   0%|                                     | 0/292 [00:00<?, ?it/s]DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([24576, 1536])) [relaxed]: 100%|█████████████████████████| 297/297 [00:00<00:00, 6019.48it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([32768, 512])) [relaxed]:   0%|                                      | 0/305 [00:00<?, ?it/s]DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([32768, 512])) [relaxed]: 100%|██████████████████████████| 305/305 [00:00<00:00, 8053.07it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 16384])) [relaxed]:   0%|                                     | 0/292 [00:00<?, ?it/s]DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([24576, 1536])) [relaxed]: 100%|█████████████████████████| 297/297 [00:00<00:00, 6128.40it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([24576, 1536])) [relaxed]: 100%|█████████████████████████| 297/297 [00:00<00:00, 6099.54it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([24576, 1536])) [relaxed]: 100%|█████████████████████████| 297/297 [00:00<00:00, 5962.58it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([32768, 512])) [relaxed]: 100%|██████████████████████████| 305/305 [00:00<00:00, 7928.59it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([32768, 512])) [relaxed]:   0%|                                      | 0/305 [00:00<?, ?it/s]DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([24576, 1536])) [relaxed]: 100%|█████████████████████████| 297/297 [00:00<00:00, 6078.46it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([24576, 1536])) [relaxed]: 100%|█████████████████████████| 297/297 [00:00<00:00, 5993.59it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([32768, 512])) [relaxed]: 100%|██████████████████████████| 305/305 [00:00<00:00, 7907.28it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([32768, 512])) [relaxed]:   0%|                                      | 0/305 [00:00<?, ?it/s]DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([32768, 512])) [relaxed]: 100%|██████████████████████████| 305/305 [00:00<00:00, 7944.55it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([32768, 512])) [relaxed]: 100%|██████████████████████████| 305/305 [00:00<00:00, 7952.65it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([32768, 512])) [relaxed]: 100%|██████████████████████████| 305/305 [00:00<00:00, 7960.61it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([32768, 512])) [relaxed]: 100%|██████████████████████████| 305/305 [00:00<00:00, 8043.65it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 16384])) [relaxed]: 100%|█████████████████████████| 292/292 [00:00<00:00, 2376.46it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 16384])) [relaxed]: 100%|█████████████████████████| 292/292 [00:00<00:00, 2501.69it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 16384])) [relaxed]: 100%|█████████████████████████| 292/292 [00:00<00:00, 2442.79it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 16384])) [relaxed]: 100%|█████████████████████████| 292/292 [00:00<00:00, 2447.01it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 16384])) [relaxed]: 100%|█████████████████████████| 292/292 [00:00<00:00, 2388.55it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 16384])) [relaxed]: 100%|█████████████████████████| 292/292 [00:00<00:00, 2384.30it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 16384])) [relaxed]: 100%|█████████████████████████| 292/292 [00:00<00:00, 2497.61it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 16384])) [relaxed]: 100%|█████████████████████████| 292/292 [00:00<00:00, 2452.04it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([36864, 7168])) [relaxed]: 100%|█████████████████████████| 288/288 [00:00<00:00, 2240.16it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([36864, 7168])) [relaxed]: 100%|█████████████████████████| 288/288 [00:00<00:00, 2243.21it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([36864, 7168])) [relaxed]: 100%|█████████████████████████| 288/288 [00:00<00:00, 2261.88it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([36864, 7168])) [relaxed]: 100%|█████████████████████████| 288/288 [00:00<00:00, 2254.70it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([36864, 7168])) [relaxed]: 100%|█████████████████████████| 288/288 [00:00<00:00, 2259.26it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([36864, 7168])) [relaxed]: 100%|█████████████████████████| 288/288 [00:00<00:00, 2229.23it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([36864, 7168])) [relaxed]: 100%|█████████████████████████| 288/288 [00:00<00:00, 2171.00it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([36864, 7168])) [relaxed]: 100%|█████████████████████████| 288/288 [00:00<00:00, 2256.43it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 18432])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 937.06it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 18432])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 951.28it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 18432])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 946.29it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 18432])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 943.99it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 18432])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 936.60it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 18432])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 920.12it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 18432])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 940.47it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([4096, 7168])) [relaxed]:  18%|█████                       | 52/286 [00:00<00:00, 512.24it/s]DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 18432])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 921.56it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([4096, 7168])) [relaxed]: 100%|██████████████████████████| 286/286 [00:00<00:00, 1946.02it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([4096, 7168])) [relaxed]: 100%|██████████████████████████| 286/286 [00:00<00:00, 1971.10it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([4096, 7168])) [relaxed]: 100%|██████████████████████████| 286/286 [00:00<00:00, 1974.09it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([4096, 7168])) [relaxed]: 100%|██████████████████████████| 286/286 [00:00<00:00, 1950.71it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 2048])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 3840.32it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 2048])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 3958.14it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([4096, 7168])) [relaxed]: 100%|██████████████████████████| 286/286 [00:00<00:00, 1943.52it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 2048])) [relaxed]:   0%|                                      | 0/292 [00:00<?, ?it/s]DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 4096, 7168])) [1056 values, block_m=128]:   0%| | 0/1056 [00:00<?, DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([4096, 7168])) [relaxed]: 100%|██████████████████████████| 286/286 [00:00<00:00, 1941.27it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([4096, 7168])) [relaxed]: 100%|██████████████████████████| 286/286 [00:00<00:00, 1925.41it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([4096, 7168])) [relaxed]: 100%|██████████████████████████| 286/286 [00:00<00:00, 1955.72it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 2048])) [relaxed]:   0%|                                      | 0/292 [00:00<?, ?it/s]DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 2048])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 4085.21it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 2048])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 3968.31it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 2048])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 4004.65it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 2048])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 3904.46it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 2048])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 3907.28it/s]
DeepGemm(fp8_gemm_nt) warmup (W=torch.Size([7168, 2048])) [relaxed]: 100%|██████████████████████████| 292/292 [00:00<00:00, 3847.09it/s]
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 4096, 7168])) [1056 values, block_m=128]:  57%|▌| 607/1056 [00:00<0DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 4096, 7168])) [1056 values, block_m=128]:   0%| | 0/1056 [00:00<?, DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 4096, 7168])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:01<
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 4096, 7168])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:01<
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 4096, 7168])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:01<
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 4096, 7168])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:01<
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 4096, 7168])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:01<
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 4096, 7168])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:01<
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 4096, 7168])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:01<
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 4096, 7168])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:01<
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 7168, 2048])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:04<
(EngineCore_DP2 pid=1770965) 2025-12-17 21:16:49,452 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 7168, 2048])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:04<
(EngineCore_DP1 pid=1770964) 2025-12-17 21:16:49,499 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 7168, 2048])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:04<
(EngineCore_DP3 pid=1770966) 2025-12-17 21:16:49,511 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 7168, 2048])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:04<
(EngineCore_DP7 pid=1770970) 2025-12-17 21:16:49,543 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 7168, 2048])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:04<
(EngineCore_DP4 pid=1770967) 2025-12-17 21:16:49,550 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 7168, 2048])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:04<
(EngineCore_DP6 pid=1770969) 2025-12-17 21:16:49,562 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 7168, 2048])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:04<
(EngineCore_DP0 pid=1770963) 2025-12-17 21:16:49,639 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
DeepGemm(m_grouped_fp8_gemm_nt_contiguous) warmup (W=torch.Size([32, 7168, 2048])) [1056 values, block_m=128]: 100%|█| 1056/1056 [00:04<
```

PR:
```
DeepGEMM warmup: 100%|█████████████████████████████████████████████████████████████████████████████| 4164/4164 [00:06<00:00, 603.34it/s]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

