### PR TITLE
[ROCm][Bugfix] Fix `fa_version` argument error in `flash_attn_maxseqlen_wrapper` for ROCm without aiter

### DIFF
--- a/vllm/attention/ops/vit_attn_wrappers.py
+++ b/vllm/attention/ops/vit_attn_wrappers.py
@@ -63,7 +63,7 @@ def flash_attn_maxseqlen_wrapper_fake(
     max_seqlen: torch.Tensor,
     batch_size: int,
     is_rocm_aiter: bool,
-    fa_version: int,
+    fa_version: int | None,
 ) -> torch.Tensor:
     return torch.empty_like(q)
 
@@ -83,7 +83,7 @@ def vit_flash_attn_wrapper(
     max_seqlen: torch.Tensor,
     batch_size: int,
     is_rocm_aiter: bool,
-    fa_version: int,
+    fa_version: int | None,
 ) -> torch.Tensor:
     return torch.ops.vllm.flash_attn_maxseqlen_wrapper(
         q, k, v, cu_seqlens, max_seqlen, batch_size, is_rocm_aiter, fa_version

--- a/vllm/attention/ops/vit_attn_wrappers.py
+++ b/vllm/attention/ops/vit_attn_wrappers.py
@@ -28,7 +28,7 @@ def flash_attn_maxseqlen_wrapper(
     max_seqlen: torch.Tensor,
     batch_size: int,
     is_rocm_aiter: bool,
-    fa_version: int,
+    fa_version: int | None,
 ) -> torch.Tensor:
     kwargs = {}
     if is_rocm_aiter:
@@ -36,7 +36,8 @@ def flash_attn_maxseqlen_wrapper(
     else:
         from vllm.attention.utils.fa_utils import flash_attn_varlen_func
 
-        kwargs["fa_version"] = fa_version
+        if not current_platform.is_rocm() and fa_version is not None:
+            kwargs["fa_version"] = fa_version
     q, k, v = (einops.rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
     output = flash_attn_varlen_func(
         q,


### PR DESCRIPTION
### Problem
On ROCm platforms with `AITER` either uninstalled or disabled, `flash_attn_varlen_func` fails with:
```
TypeError: flash_attn_varlen_func() got an unexpected keyword argument 'fa_version'
```

This occurs because `is_rocm_aiter` is `False` when `aiter` is disabled, causing the code to fall through to the else branch which unconditionally passes `fa_version` to `flash_attn_varlen_func`. However, the ROCm version of Flash Attention (via `vllm.attention.utils.fa_utils`) does not support the `fa_version` argument.

### Root Cause

The existing logic only checks for `is_rocm_aiter` to determine whether to pass `fa_version`, but this doesn't account for ROCm users who don't have `aiter` enabled. The `fa_version` parameter is CUDA-specific and should never be passed on ROCm platforms.

### Solution

Add an explicit `current_platform.is_rocm()` check before adding `fa_version` to kwargs. This ensures that:
- CUDA users continue to get `fa_version` passed through as expected
- ROCm users with `aiter` use the aiter path (unchanged)
- ROCm users without `aiter` now correctly skip the `fa_version` argument