### PR TITLE
[Multimodal] Add FIPS 140-3 compliant hashing support

### DIFF
--- a/vllm/config/multimodal.py
+++ b/vllm/config/multimodal.py
@@ -140,6 +140,14 @@ class MultiModalConfig:
     Value sits in range [0;1) and determines fraction of media tokens
     from each video to be pruned.
     """
+    use_fips_hashing: bool | None = None
+    """Enable FIPS 140-3 compliant hashing for multimodal content cache keys.
+
+    - `None` (default): Use the `VLLM_USE_FIPS_HASHING` environment variable,
+        or auto-detect based on blake3 availability.
+    - `True`: Force FIPS-compliant SHA-256 hashing (required for government,
+        healthcare, and financial environments).
+    - `False`: Use blake3 for faster hashing (if available)."""
 
     @field_validator("limit_per_prompt", mode="before")
     @classmethod

--- a/vllm/multimodal/__init__.py
+++ b/vllm/multimodal/__init__.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from .hasher import MultiModalHasher
+from .hasher import MultiModalHasher, configure_fips_hashing
 from .inputs import (
     BatchedTensorInputs,
     ModalityData,
@@ -26,6 +26,7 @@ Info:
 
 __all__ = [
     "BatchedTensorInputs",
+    "configure_fips_hashing",
     "ModalityData",
     "MultiModalDataBuiltins",
     "MultiModalDataDict",

--- a/vllm/multimodal/cache.py
+++ b/vllm/multimodal/cache.py
@@ -21,6 +21,7 @@ from vllm.utils.cache import CacheInfo, LRUCache
 from vllm.utils.jsontree import json_count_leaves, json_map_leaves, json_reduce_leaves
 from vllm.utils.mem_constants import GiB_bytes, MiB_bytes
 
+from .hasher import configure_fips_hashing
 from .inputs import (
     MultiModalBatchedField,
     MultiModalFeatureSpec,
@@ -598,6 +599,11 @@ def processor_cache_from_config(
 ) -> BaseMultiModalProcessorCache | None:
     """Return a `BaseMultiModalProcessorCache`, if enabled."""
     model_config = vllm_config.model_config
+
+    # Configure FIPS-compliant hashing based on MultiModalConfig
+    mm_config = model_config.multimodal_config
+    if mm_config is not None:
+        configure_fips_hashing(mm_config.use_fips_hashing)
 
     if not _enable_processor_cache(model_config, mm_registry):
         return None


### PR DESCRIPTION
## Summary

This PR adds FIPS 140-3 compliant SHA-256 hashing as an alternative to blake3 for multimodal content hashing in vLLM. This enables vLLM deployment in regulated environments (government, healthcare, finance) that require FIPS-approved cryptographic algorithms.

### Changes
- Add `_Sha256Hasher` wrapper class providing FIPS-compliant SHA-256 hashing
- Add `_Blake3Hasher` wrapper class maintaining consistent interface
- Add `_create_hasher()` factory function for automatic hasher selection
- Add `VLLM_USE_FIPS_HASHING` environment variable for explicit FIPS mode
- Automatic fallback to SHA-256 when blake3 is unavailable
- Comprehensive test suite for FIPS hashing functionality

### Usage
```bash
# Enable FIPS-compliant hashing
export VLLM_USE_FIPS_HASHING=1
```

The system automatically uses SHA-256 when:
1. `VLLM_USE_FIPS_HASHING` is set to "1", "true", or "yes"
2. blake3 is not available (automatic fallback)

## Test Plan
- [x] Added `TestFIPSHashing` test class with comprehensive coverage
- [x] Tests for `_Sha256Hasher` basic functionality
- [x] Tests for memoryview handling
- [x] Tests for `_Blake3Hasher` when available
- [x] Tests verifying blake3 and SHA-256 produce different hashes
- [x] Tests for `_create_hasher()` returning correct type
- [x] Tests for hash consistency with kwargs
- [x] Tests for image, tensor, and numpy array hashing in FIPS mode

## Related Issue
Fixes #18334