### PR TITLE
fix: Suppress torch.frombuffer UserWarning for non-writable buffers

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -29,6 +29,7 @@ import vllm.envs as envs
 from vllm.distributed.utils import StatelessProcessGroup, sched_yield
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.utils.torch_utils import frombuffer_with_writable_warning_suppressed
 from vllm.utils.network_utils import (
     get_ip,
     get_open_port,
@@ -198,8 +199,10 @@ class ShmRingBuffer:
                 create=True, size=self.total_bytes_of_buffer
             )
             # initialize the metadata section to 0
-            with self.shared_memory.buf[self.metadata_offset :] as metadata_buffer:
-                torch.frombuffer(metadata_buffer, dtype=torch.uint8).fill_(0)
+            with self.shared_memory.buf[self.metadata_offset:] as metadata_buffer:
+                frombuffer_with_writable_warning_suppressed(
+                    metadata_buffer, torch.uint8
+                ).fill_(0)
         else:
             # we are opening an existing buffer
             self.is_creator = False

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -29,13 +29,13 @@ import vllm.envs as envs
 from vllm.distributed.utils import StatelessProcessGroup, sched_yield
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
-from vllm.utils.torch_utils import frombuffer_with_writable_warning_suppressed
 from vllm.utils.network_utils import (
     get_ip,
     get_open_port,
     get_open_zmq_ipc_path,
     is_valid_ipv6_address,
 )
+from vllm.utils.torch_utils import frombuffer_with_writable_warning_suppressed
 
 if TYPE_CHECKING:
     from _typeshed import SizedBuffer
@@ -199,7 +199,7 @@ class ShmRingBuffer:
                 create=True, size=self.total_bytes_of_buffer
             )
             # initialize the metadata section to 0
-            with self.shared_memory.buf[self.metadata_offset:] as metadata_buffer:
+            with self.shared_memory.buf[self.metadata_offset :] as metadata_buffer:
                 frombuffer_with_writable_warning_suppressed(
                     metadata_buffer, torch.uint8
                 ).fill_(0)

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -52,8 +52,8 @@ from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.network_utils import get_distributed_init_method
 from vllm.utils.system_utils import suppress_stdout
 from vllm.utils.torch_utils import (
-    frombuffer_with_writable_warning_suppressed,
     direct_register_custom_op,
+    frombuffer_with_writable_warning_suppressed,
     supports_custom_op,
 )
 

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -52,6 +52,7 @@ from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.network_utils import get_distributed_init_method
 from vllm.utils.system_utils import suppress_stdout
 from vllm.utils.torch_utils import (
+    frombuffer_with_writable_warning_suppressed,
     direct_register_custom_op,
     supports_custom_op,
 )
@@ -649,7 +650,9 @@ class GroupCoordinator:
         )
 
         # Serialize object to tensor and get the size as well
-        object_tensor = torch.frombuffer(pickle.dumps(obj), dtype=torch.uint8)
+        object_tensor = frombuffer_with_writable_warning_suppressed(
+            pickle.dumps(obj), torch.uint8
+        )
 
         size_tensor = torch.tensor(
             [object_tensor.numel()], dtype=torch.long, device="cpu"


### PR DESCRIPTION
## Summary
Fixes #26781 - Suppress UserWarning from `torch.frombuffer()` on non-writable buffers

## Problem
`torch.frombuffer()` emits a `UserWarning` when given a non-writable buffer (e.g., from `pickle.dumps()` or shared memory):
```
UserWarning: The given buffer is not writable, and PyTorch does not support non-writable tensors.
This means you can write to the underlying (supposedly non-writable) buffer using the tensor...
```

This warning clutters logs but is harmless in our use cases since we either clone the tensor immediately, don't mutate it, or know the buffer will be properly handled.

## Solution
Add `frombuffer_with_writable_warning_suppressed()` helper function to `vllm/utils/torch_utils.py` and use it at affected call sites.

This approach was approved by @zou3519 in the issue discussion.

## Changes
- `vllm/utils/torch_utils.py`: Add helper function that wraps `torch.frombuffer()` with warning suppression
- `vllm/distributed/parallel_state.py`: Use helper for pickle serialization (line 653)
- `vllm/distributed/device_communicators/shm_broadcast.py`: Use helper for shared memory initialization (line 203)

## Testing
- The warning suppression is targeted specifically to the "buffer is not writable" message
- No functional changes to tensor creation behavior
- Existing tests should pass unchanged