### PR TITLE
[Bugfix] Fix incorrect tiles creation for mm prefix triton attention

### DIFF
--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -189,9 +189,14 @@ def kernel_unified_attention_2d(
         + 1
     )
 
-    # adjust for potential padding in the last q_block by considering the
-    # actual sequence length
-    max_seq_prefix_len = tl.minimum(max_seq_prefix_len, seq_len)
+    if USE_MM_PREFIX:
+        # image bidirectional attention ranges require a full range
+        # including q_block padding to make sure doc mask is correct
+        max_seq_prefix_len = tl.maximum(max_seq_prefix_len, seq_len)
+    else:
+        # adjust for potential padding in the last q_block by considering the
+        # actual sequence length
+        max_seq_prefix_len = tl.minimum(max_seq_prefix_len, seq_len)
 
     # calculate the number of tiles that need to be processed to
     # cover the longest sequence prefix (due to causal masking, tiles beyond
@@ -202,7 +207,8 @@ def kernel_unified_attention_2d(
     # Default: keep previous global behavior
     tile_start = 0
     tile_end = num_tiles
-    if SLIDING_WINDOW > 0:
+    # TODO(Isotr0py): sliding window pruning with image bidirectional mask
+    if SLIDING_WINDOW > 0 and not USE_MM_PREFIX:
         # Query rows covered by this Q-block
         qpos_lo = q_block_local_idx * BLOCK_Q
         qpos_hi = tl.minimum(

--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -809,10 +809,6 @@ def _get_tile_size(
     the larger head dimension (128/256). For other models, use
     the default vLLM behavior.
     """
-    if is_mm_prefix:
-        # Multimodal bidirectional attention needs a larger tile size
-        return 64
-
     if _is_gemma3_attention(head_size, sliding_window):
         # Gemma3: use 32 for decode (default is 16)
         return 32

--- a/vllm/attention/ops/triton_unified_attention.py
+++ b/vllm/attention/ops/triton_unified_attention.py
@@ -800,7 +800,6 @@ def _get_tile_size(
     head_size: int,
     sliding_window: int,
     element_size: int,
-    is_mm_prefix: bool,
     is_prefill: bool,
 ) -> int:
     """Select tile size with Gemma3-specific optimization.
@@ -899,14 +898,12 @@ def unified_attention(
         head_size,
         sliding_window_val,
         q.element_size(),
-        is_mm_prefix=use_mm_prefix,
         is_prefill=True,
     )
     TILE_SIZE_DECODE = _get_tile_size(
         head_size,
         sliding_window_val,
         q.element_size(),
-        is_mm_prefix=use_mm_prefix,
         is_prefill=False,
     )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Actually, #30386's implementation is still incorrect, because the tiles are still selected casually, so the hidden_states is not fully converged.
- This PR fixes this issue to make sure correct all valid tiles are selected for computaion

## Test Plan
```
python examples/offline_inference/vision_language.py -m gemma3 --num-prompts 1
```

## Test Result
**Main**
```
(EngineCore_DP0 pid=350376) qkv in 0.0172119140625 -0.044921875 0.0927734375
(EngineCore_DP0 pid=350376) /home/mozf/develop-projects/vllm/.venv/lib/python3.12/site-packages/torch/nested/__init__.py:250: UserWarning: The PyTorch API of nested tensors is in prototype stage and will change in the near future. We recommend specifying layout=torch.jagged when constructing a nested tensor, as this layout receives active development, has better operator coverage, and works with torch.compile. (Triggered internally at /pytorch/aten/src/ATen/NestedTensorImpl.cpp:178.)
(EngineCore_DP0 pid=350376)   return _nested.nested_tensor(
(EngineCore_DP0 pid=350376) attn out 0.146484375
(EngineCore_DP0 pid=350376) qkv in -0.0203857421875 0.01385498046875 0.00927734375
(EngineCore_DP0 pid=350376) attn out 0.0169677734375
(EngineCore_DP0 pid=350376) qkv in -0.008544921875 0.056396484375 0.004791259765625
(EngineCore_DP0 pid=350376) attn out 0.021240234375
...
--------------------------------------------------
Here's a description of the image content:

The image captures a beautiful scene of cherry blossoms in full bloom against a bright blue sky. A tall, modern skyscraper (likely the Tokyo Tower) is partially framed by the branches and blossoms, creating a visually striking composition. The blossoms are a delicate shade of pink and
--------------------------------------------------
```

**This PR**
```
(EngineCore_DP0 pid=338593) qkv in 0.0172119140625 -0.044921875 0.0927734375
(EngineCore_DP0 pid=338593) attn out 0.14453125
(EngineCore_DP0 pid=338593) qkv in -0.019775390625 0.016357421875 0.006805419921875
(EngineCore_DP0 pid=338593) attn out 0.0169677734375
(EngineCore_DP0 pid=338593) qkv in -0.008544921875 0.052734375 0.0152587890625
(EngineCore_DP0 pid=338593) attn out 0.0269775390625
...
--------------------------------------------------
Here's a breakdown of the image content:

*   **Cherry Blossoms:** The dominant feature is a profusion of pink cherry blossoms filling the foreground, creating a beautiful, layered effect.
*   **Tokyo Tower:** Behind the blossoms is the iconic Tokyo Tower, a prominent landmark of Tokyo, Japan.
--------------------------------------------------
```

**FlexAttention**
```
(EngineCore_DP0 pid=359238) qkv in 0.0172119140625 -0.044921875 0.0927734375
(EngineCore_DP0 pid=359238) attn out 0.14453125
(EngineCore_DP0 pid=359238) qkv in -0.019775390625 0.016357421875 0.006805419921875
(EngineCore_DP0 pid=359238) attn out 0.0169677734375
(EngineCore_DP0 pid=359238) qkv in -0.008544921875 0.052734375 0.0152587890625
(EngineCore_DP0 pid=359238) attn out 0.0269775390625
(EngineCore_DP0 pid=359238) qkv in 0.0074462890625 0.01318359375 -0.0286865234375
(EngineCore_DP0 pid=359238) attn out -0.0272216796875
...
--------------------------------------------------
Here's a breakdown of the image content:

*   **Cherry Blossoms:** The dominant feature is a profusion of pink cherry blossoms filling the foreground, creating a beautiful, layered effect.
*   **Tokyo Tower:** Behind the blossoms, partially obscured, is the iconic Tokyo Tower.
*   **
--------------------------------------------------
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

