### PR TITLE
[Misc] Disable default `--ready-check-timeout-sec` extra call in vllm bench

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1333,10 +1333,9 @@ def add_cli_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--ready-check-timeout-sec",
         type=int,
-        default=600,
+        default=0,
         help="Maximum time to wait for the endpoint to become ready "
-        "in seconds (default: 600 seconds / 10 minutes). If set to 0, "
-        "the ready check will be skipped.",
+        "in seconds. Ready check will be skipped by default.",
     )
 
     parser.add_argument(


### PR DESCRIPTION
As per brief offline discussion with @mgoin, current `vllm bench serve` implementation will default to sending (at least) one extra request to probe for server up status.
I suppose this is due to a non-uniform backend `/health` check API, so we've been defaulting to sending the same test request https://github.com/vllm-project/vllm/blob/686cbaac643c3412036728dd5e6bc29d6cce1a9f/vllm/benchmarks/serve.py#L596

I believe this is largely misleading for most use-cases as it results in an ambiguous "warm-up", where afaik, for dev purposes we can just wait for the server to come up, or we can easily wrap the bench command in a `while not curl /health..` backend-specific check for automated use.

This PR just sets the default to skip the probe request above.


