### PR TITLE
Docs: add OpenAI SDK example for Qwen2.5-VL classification

### DIFF
--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -7,3 +7,42 @@ Then, vLLM supports the following usage patterns:
 - [Inference and Serving](../serving/offline_inference.md): Run a single instance of a model.
 - [Deployment](../deployment/docker.md): Scale up model instances for production.
 - [Training](../training/rlhf.md): Train or fine-tune a model.
+
+## OpenAI-Compatible API Usage
+
+vLLM provides an OpenAI-compatible API for serving models. When using
+multimodal **classification** models such as Qwen2.5-VL, requests must use
+structured multimodal input.
+
+### Qwen2.5-VL Classification Example
+
+When serving a Qwen2.5-VL classification model, passing raw text or media URLs
+directly may result in a `400 Bad Request` error. Instead, use structured input
+with the OpenAI SDK.
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="EMPTY",
+)
+
+response = client.responses.create(
+    model="Qwen2.5-VL-7B",
+    input=[
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Classify this video"},
+                {
+                    "type": "input_video",
+                    "video_url": "https://example.com/video.mp4",
+                },
+            ],
+        }
+    ],
+)
+
+print(response)
+```

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -34,10 +34,10 @@ response = client.responses.create(
         {
             "role": "user",
             "content": [
-                {"type": "input_text", "text": "Classify this video"},
+                {"type": "text", "text": "Classify this video"},
                 {
-                    "type": "input_video",
-                    "video_url": "https://example.com/video.mp4",
+                    "type": "video_url",
+                    "video_url": {"url": "https://example.com/video.mp4"},
                 },
             ],
         }


### PR DESCRIPTION
## Purpose

Add a usage example demonstrating how to call Qwen2.5-VL classification models
served by vLLM using the OpenAI-compatible SDK.

This clarifies the required structured multimodal input format and helps users
avoid `400 Bad Request` errors caused by passing raw text or media URLs directly
in requests.

Fixes #27413

## Test Plan

Documentation-only change.

- Verified that the example matches the OpenAI-compatible API schema used by
  vLLM for multimodal classification models.
- Manually reviewed markdown rendering to ensure code blocks and formatting
  render correctly.

## Test Result

N/A (documentation change only).