### PR TITLE
Check for truthy `rope_parameters` not the existence of it

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -318,13 +318,13 @@ def patch_rope_parameters(config: PretrainedConfig) -> None:
         # Transformers v4 installed, legacy config fields may be present
         if (rope_scaling := getattr(config, "rope_scaling", None)) is not None:
             config.rope_parameters = rope_scaling
+        if (
+            rope_theta is not None or partial_rotary_factor is not None
+        ) and not getattr(config, "rope_parameters", None):
+            config.rope_parameters = {"rope_type": "default"}
         if rope_theta is not None:
-            if not getattr(config, "rope_parameters", None):
-                config.rope_parameters = {"rope_type": "default"}
             config.rope_parameters["rope_theta"] = rope_theta
         if partial_rotary_factor is not None:
-            if not getattr(config, "rope_parameters", None):
-                config.rope_parameters = {"rope_type": "default"}
             config.rope_parameters["partial_rotary_factor"] = partial_rotary_factor
     elif rope_theta is not None or getattr(config, "rope_parameters", None):
         # Transformers v5 installed

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -319,14 +319,14 @@ def patch_rope_parameters(config: PretrainedConfig) -> None:
         if (rope_scaling := getattr(config, "rope_scaling", None)) is not None:
             config.rope_parameters = rope_scaling
         if rope_theta is not None:
-            if not hasattr(config, "rope_parameters"):
+            if not getattr(config, "rope_parameters", None):
                 config.rope_parameters = {"rope_type": "default"}
             config.rope_parameters["rope_theta"] = rope_theta
         if partial_rotary_factor is not None:
-            if not hasattr(config, "rope_parameters"):
+            if not getattr(config, "rope_parameters", None):
                 config.rope_parameters = {"rope_type": "default"}
             config.rope_parameters["partial_rotary_factor"] = partial_rotary_factor
-    elif rope_theta is not None or hasattr(config, "rope_parameters"):
+    elif rope_theta is not None or getattr(config, "rope_parameters", None):
         # Transformers v5 installed
         # Patch these fields in case they used non-standard names
         if rope_theta is not None:


### PR DESCRIPTION
Fixes the following situation:

- Model explicitly sets `rope_parameters=None` (new name, Transfomers v5) or `rope_scaling=None` (old name, Transformers v4)
- User is using Transformers v4 with vLLM