### PR TITLE
[Quantization] enable compressed-tensors marlin support for turing

### DIFF
--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/marlin.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/marlin.py
@@ -30,7 +30,7 @@ from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
 class MarlinLinearKernel(MPLinearKernel):
     @classmethod
     def get_min_capability(cls) -> int:
-        return 80
+        return 75
 
     @classmethod
     def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:


### PR DESCRIPTION
The Marlin support for turing have beed added in https://github.com/vllm-project/vllm/pull/29901

This PR enable it in compressed-tensors.