### PR TITLE
fix benchmark moe int8_w8a16

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -140,10 +140,13 @@ def benchmark_config(
 
         if use_fp8_w8a8:
             quant_dtype = torch.float8_e4m3fn
+            weight_dtype = None
         elif use_int8_w8a16:
-            quant_dtype = torch.int8
+            quant_dtype = None
+            weight_dtype = torch.int8
         else:
             quant_dtype = None
+            weight_dtype = None
 
         quant_config = FusedMoEQuantConfig.make(
             quant_dtype=quant_dtype,
@@ -152,6 +155,7 @@ def benchmark_config(
             a1_scale=a1_scale,
             a2_scale=a2_scale,
             block_shape=block_quant_shape,
+            weight_dtype=weight_dtype,
         )
 
         with override_config(config):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
In benchmark suite ,the moe kernel benchmark create wrong FusedMoEQuantConfig for int8_w8a16, fix the wrong config for w8a16

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

