### PR TITLE
[Bug] Fix hash issue `RuntimeError: Worker failed with error 'unhashable type: 'dict''`

### DIFF
--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -295,6 +295,10 @@ class UniformTypeKVCacheSpecs(KVCacheSpec):
 
     kv_cache_specs: dict[str, KVCacheSpec]
 
+    def __hash__(self) -> int:
+        items = tuple(sorted(self.kv_cache_specs.items()))
+        return hash((type(self), self.block_size, items))
+
     @property
     def page_size_bytes(self) -> int:
         return sum(spec.page_size_bytes for spec in self.kv_cache_specs.values())


### PR DESCRIPTION
## Purpose

`export MODEL="deepseek-ai/DeepSeek-V3.2"`
`vllm serve "$MODEL" -tp 8 --port 9256 --enable-expert-parallel`

will trigger

```bash
(Worker_TP0_EP0 pid=3577726) ERROR 12-19 09:06:16 [multiproc_executor.py:824]   File "/home/wentao/vllm-source/vllm/v1/worker/gpu_model_runner.py", line 4191, in _dummy_run
(Worker_TP0_EP0 pid=3577726) ERROR 12-19 09:06:16 [multiproc_executor.py:824]     attn_metadata, _ = self._build_attention_metadata(
(Worker_TP0_EP0 pid=3577726) ERROR 12-19 09:06:16 [multiproc_executor.py:824]                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=3577726) ERROR 12-19 09:06:16 [multiproc_executor.py:824]   File "/home/wentao/vllm-source/vllm/v1/worker/gpu_model_runner.py", line 1725, in _build_attention_metadata
(Worker_TP0_EP0 pid=3577726) ERROR 12-19 09:06:16 [multiproc_executor.py:824]     _build_attn_group_metadata(kv_cache_gid, attn_gid, cm)
(Worker_TP0_EP0 pid=3577726) ERROR 12-19 09:06:16 [multiproc_executor.py:824]   File "/home/wentao/vllm-source/vllm/v1/worker/gpu_model_runner.py", line 1667, in _build_attn_group_metadata
(Worker_TP0_EP0 pid=3577726) ERROR 12-19 09:06:16 [multiproc_executor.py:824]     cache_key in cached_attn_metadata
(Worker_TP0_EP0 pid=3577726) ERROR 12-19 09:06:16 [multiproc_executor.py:824]   File "<string>", line 3, in __hash__
(Worker_TP0_EP0 pid=3577726) ERROR 12-19 09:06:16 [multiproc_executor.py:824] TypeError: unhashable type: 'dict'
(Worker_TP0_EP0 pid=3577726) ERROR 12-19 09:06:16 [multiproc_executor.py:824] 
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868] EngineCore failed to start.
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868] Traceback (most recent call last):
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]   File "/home/wentao/vllm-source/vllm/v1/engine/core.py", line 859, in run_engine_core
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]     engine_core = EngineCoreProc(*args, **kwargs)
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]   File "/home/wentao/vllm-source/vllm/v1/engine/core.py", line 639, in __init__
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]     super().__init__(
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]   File "/home/wentao/vllm-source/vllm/v1/engine/core.py", line 111, in __init__
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]     num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]   File "/home/wentao/vllm-source/vllm/v1/engine/core.py", line 258, in _initialize_kv_caches
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]     self.model_executor.initialize_from_config(kv_cache_configs)
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]   File "/home/wentao/vllm-source/vllm/v1/executor/abstract.py", line 116, in initialize_from_config
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]     self.collective_rpc("compile_or_warm_up_model")
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]   File "/home/wentao/vllm-source/vllm/v1/executor/multiproc_executor.py", line 359, in collective_rpc
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]     return aggregate(get_response())
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]                      ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]   File "/home/wentao/vllm-source/vllm/v1/executor/multiproc_executor.py", line 342, in get_response
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868]     raise RuntimeError(
(EngineCore_DP0 pid=3577280) ERROR 12-19 09:06:16 [core.py:868] RuntimeError: Worker failed with error 'unhashable type: 'dict'', please check the stack trace above for the root cause
```

This PR fixes the issue