### PR TITLE
[AMD][CI] Add "V1 Test e2e + engine" to mi325_8 Agent Pool

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -349,7 +349,7 @@ steps:
 - label: V1 Test e2e + engine # 65min
   timeout_in_minutes: 90
   mirror_hardwares: [amdexperimental]
-  agent_pool: mi325_4
+  agent_pool: mi325_8
   # grade: Blocking
   source_file_dependencies:
     - vllm/

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -349,6 +349,8 @@ steps:
 - label: V1 Test e2e + engine # 65min
   timeout_in_minutes: 90
   mirror_hardwares: [amdexperimental]
+  # The test uses 4 GPUs, but we schedule it on 8-GPU machines for stability.
+  # See discussion here: https://github.com/vllm-project/vllm/pull/31040
   agent_pool: mi325_8
   # grade: Blocking
   source_file_dependencies:


### PR DESCRIPTION
<!-- markdownlint-disable -->
We have seen two failures in the past week for the`V1 Test e2e + engine` test group in AMD CI for which there is no error message, and the test group passes after a retry. The only commonality between both occurrences of this issue is that it failed during `v1/e2e/test_spec_decode.py::test_eagle_correctness` in different test cases involving `llama4_eagle_mm`. Buildkite shows the failures with an "agent lost" error.  Here is one example from yesterday :https://buildkite.com/vllm/amd-ci/builds/1823/steps/canvas?jid=019b3266-bd08-4042-ad23-9c040a1d6daa

In an effort to get this test group as solid as possible in AMD CI, we investigated the issue and have reason to believe that it is due to resource constraints on the node when the test runs at the same time as another highly resource-demanding test on the same node. Specifically, when running two instances of `v1/e2e/test_spec_decode.py::test_eagle_correctness[ROCM_AITER_FA-llama4_eagle_mm]` on the same MI325X machine (with one using GPUs 0-3 and the other using GPUs 4-7), I noticed that one instance failed with an error near the end while the other ran to completion and passed the test, which is similar to the behavior we see in the Buildkite logs. For now, our solution is to move this test group to `mi325_8` so that it does not get scheduled alongside other tests on the same node.