### PR TITLE
[Bug] Fix `error 'Dynamo failed to run FX node with fake tensors` for Deepseek V3.2

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -878,8 +878,11 @@ class Indexer(nn.Module):
         )
 
         q_pe, k_pe = rotary_emb(positions, q_pe, k_pe.unsqueeze(1))
-        q = torch.cat([q_pe.squeeze(0), q_nope], dim=-1)
-        k = torch.cat([k_pe.squeeze((0, 2)), k_nope], dim=-1)
+        # `rotary_emb` is shape-preserving; `q_pe` is already
+        # [num_tokens, n_head, rope_dim].
+        q = torch.cat([q_pe, q_nope], dim=-1)
+        # `k_pe` is [num_tokens, 1, rope_dim] (MQA).
+        k = torch.cat([k_pe.squeeze(1), k_nope], dim=-1)
 
         # we only quant q here since k quant is fused with cache insertion
         q = q.view(-1, self.head_dim)


### PR DESCRIPTION
## Purpose

`export MODEL="deepseek-ai/DeepSeek-V3.2"`
`vllm serve "$MODEL" -tp 8 --port 9256 --enable-expert-parallel -cc '{"mode":3,"pass_config":{"fuse_norm_quant":true,"eliminate_noops":true},"custom_ops":["all"]}'`

When using fused rms + quant, we will meet an error

```bash
llmWorker-0 died unexpectedly, shutting down executor.
(EngineCore_DP0 pid=3144299) Process EngineCore_DP0:
(EngineCore_DP0 pid=3144299) Traceback (most recent call last):
(EngineCore_DP0 pid=3144299)   File "/usr/lib64/python3.12/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore_DP0 pid=3144299)     self.run()
(EngineCore_DP0 pid=3144299)   File "/usr/lib64/python3.12/multiprocessing/process.py", line 108, in run
(EngineCore_DP0 pid=3144299)     self._target(*self._args, **self._kwargs)
(EngineCore_DP0 pid=3144299)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 872, in run_engine_core
(EngineCore_DP0 pid=3144299)     raise e
(EngineCore_DP0 pid=3144299)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 859, in run_engine_core
(EngineCore_DP0 pid=3144299)     engine_core = EngineCoreProc(*args, **kwargs)
(EngineCore_DP0 pid=3144299)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3144299)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 639, in __init__
(EngineCore_DP0 pid=3144299)     super().__init__(
(EngineCore_DP0 pid=3144299)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 111, in __init__
(EngineCore_DP0 pid=3144299)     num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
(EngineCore_DP0 pid=3144299)                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3144299)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 242, in _initialize_kv_caches
(EngineCore_DP0 pid=3144299)     available_gpu_memory = self.model_executor.determine_available_memory()
(EngineCore_DP0 pid=3144299)                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3144299)   File "/home/yewentao256/vllm-source/vllm/v1/executor/abstract.py", line 126, in determine_available_memory
(EngineCore_DP0 pid=3144299)     return self.collective_rpc("determine_available_memory")
(EngineCore_DP0 pid=3144299)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3144299)   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 359, in collective_rpc
(EngineCore_DP0 pid=3144299)     return aggregate(get_response())
(EngineCore_DP0 pid=3144299)                      ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3144299)   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 342, in get_response
(EngineCore_DP0 pid=3144299)     raise RuntimeError(
(EngineCore_DP0 pid=3144299) RuntimeError: Worker failed with error 'Dynamo failed to run FX node with fake tensors: call_function <built-in method cat of type object at 0x7fce989d6c20>(*([FakeTensor(..., device='cuda:0', size=(s72, 1, 64), dtype=torch.bfloat16), FakeTensor(..., device='cuda:0', size=(s72, 64), dtype=torch.bfloat16)],), **{'dim': -1}): got RuntimeError('Number of dimensions of tensors must match.  Expected 3-D tensors, but got 2-D for tensor number 1 in the list')
```

This PR fixes the issue

## Test

```bash
ethods: POST
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /v1/audio/transcriptions, Methods: POST
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /v1/audio/translations, Methods: POST
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /classify, Methods: POST
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /v1/embeddings, Methods: POST
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /score, Methods: POST
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /v1/score, Methods: POST
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /rerank, Methods: POST
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /v1/rerank, Methods: POST
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /v2/rerank, Methods: POST
(APIServer pid=3233616) INFO 12-19 21:10:51 [launcher.py:46] Route: /pooling, Methods: POST
(APIServer pid=3233616) INFO:     Started server process [3233616]
(APIServer pid=3233616) INFO:     Waiting for application startup.
(APIServer pid=3233616) INFO:     Application startup complete.
```