### PR TITLE
[DeepSeek v3.2] Remove unnecessary syncwarps

### DIFF
--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -539,9 +539,6 @@ __global__ void indexer_k_quant_and_cache_kernel(
   for (int i = 0; i < VEC_SIZE; i++) {
     amax = fmaxf(amax, fabsf(float(k_val_ptr[i])));
   }
-#ifndef USE_ROCM
-  __syncwarp();
-#endif
 
   // Reduced amax
   for (int mask = 16; mask > 0; mask /= 2) {
@@ -551,9 +548,7 @@ __global__ void indexer_k_quant_and_cache_kernel(
     amax = fmaxf(amax, __shfl_xor_sync(unsigned(-1), amax, mask));
 #endif
   }
-#ifndef USE_ROCM
-  __syncwarp();
-#endif
+
 #if defined(__gfx942__)
   float scale = fmaxf(amax, 1e-4) / 224.0f;
 #else


### PR DESCRIPTION

## Purpose
`indexer_k_quant_and_cache_kernel` has two unnecessary `__syncwarp` calls (the synchronization is already guaranteed by `__shfl_xor_sync`). This PR removes them.

## Test Plan
```
vllm serve deepseek-ai/DeepSeek-V3.2 -tp 8 --enable-expert-parallel
```
with
```
lm_eval --model local-completions --model_args base_url=http://localhost:8000/v1/completions,model=deepseek-ai/DeepSeek-V3.2,num_concurrent=128,tokenized_requests=False --tasks gsm8k
```

## Test Result
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9515|±  |0.0059|
|     |       |strict-match    |     5|exact_match|↑  |0.9515|±  |0.0059|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

