### PR TITLE
[CI] FIx `fixture 'siglip_attention_config' not found`

### DIFF
--- a/tests/models/multimodal/pooling/conftest.py
+++ b/tests/models/multimodal/pooling/conftest.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pytest configuration for vLLM pooling tests."""
+
+import pytest
+
+from vllm.platforms import current_platform
+
+
+@pytest.fixture
+def siglip_attention_config():
+    """Return attention config for SigLIP tests on ROCm.
+
+    On ROCm, SigLIP tests require FLEX_ATTENTION backend.
+    """
+    if current_platform.is_rocm():
+        return {"backend": "FLEX_ATTENTION"}
+    return None


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/30270 broke "Multi-Modal Models Test (Extended) 1" see: https://buildkite.com/vllm/ci/builds/44399/steps/canvas?sid=019b38a1-7696-47cf-b0fc-7151b865df52 with
```
[2025-12-19T23:01:06Z] E       fixture 'siglip_attention_config' not found
```

add it back