### PR TITLE
[KVConnector] Auto-downgrade to PIECEWISE cudagraph mode for layerwise async ops

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -543,6 +543,28 @@ class KVConnectorBase_V1(ABC):
             )
         return None
 
+    @classmethod
+    def requires_piecewise_for_cudagraph(cls, extra_config: dict[str, Any]) -> bool:
+        """
+        Check if this connector requires PIECEWISE CUDA graph mode.
+
+        Connectors that use asynchronous layer-by-layer operations
+        (wait_for_layer_load/save_kv_layer) should override this method
+        to return True when those operations are enabled. These operations
+        cannot be captured in CUDA graphs and will be skipped during replay,
+        causing data races. PIECEWISE mode allows Python code to execute
+        between graph pieces, ensuring proper synchronization.
+
+        Args:
+            extra_config: The kv_connector_extra_config dict from
+                KVTransferConfig.
+
+        Returns:
+            True if this connector requires PIECEWISE CUDA graph mode,
+            False otherwise.
+        """
+        return False
+
     def get_finished_count(self) -> int | None:
         """
         Get the count of requests expected to complete send/receive operations

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
@@ -70,6 +70,16 @@ class LMCacheKVEvents(KVConnectorKVEvents):
 
 
 class LMCacheConnectorV1(KVConnectorBase_V1):
+    @classmethod
+    def requires_piecewise_for_cudagraph(cls, extra_config: dict[str, Any]) -> bool:
+        """
+        LMCache requires PIECEWISE CUDA graph mode when layerwise
+        operations are enabled. The wait_for_layer_load and save_kv_layer
+        methods perform actual async synchronization that cannot be
+        captured in CUDA graphs.
+        """
+        return extra_config.get("use_layerwise", False)
+
     def __init__(
         self,
         vllm_config: "VllmConfig",


### PR DESCRIPTION
## Purpose

Fixes #29608

When using async KV connectors with layerwise operations (`wait_for_layer_load`, `save_kv_layer`), these calls are made inside the `@maybe_transfer_kv_layer` decorator. During CUDA graph replay, only the captured GPU ops run - the decorator's Python code is skipped entirely. This means `wait_for_layer_load()` never executes, causing data races where attention kernels read KV cache data that hasn't finished loading.

This is a follow-up to #29755 based on @NickLucche's feedback to implement approach (b): restricting layerwise ops to piecewise mode rather than trying to trace them into CUDA graphs.

### Changes

1. Added `requires_piecewise_for_cudagraph(cls, extra_config)` class method to `KVConnectorBase_V1`
   - Returns `False` by default (most connectors don't use layerwise async ops)
   - Connectors override this if they need PIECEWISE mode

2. `LMCacheConnectorV1` overrides to return `True` when `use_layerwise=True`
   - Other connectors (Nixl, P2P, etc.) have no-op layerwise implementations, so they're fine with FULL mode

3. `VllmConfig.__post_init__()` checks this method and auto-downgrades to PIECEWISE when needed
   - Follows the same pattern used for DCP, pooler models, encoder-decoder models

## Test Plan

The fix is config-level validation that runs at engine initialization. Manual testing with LMCache + `use_layerwise=True` + CUDA graphs should show the warning message and the mode being downgraded.

## Test Result

Pre-commit checks pass. The implementation follows existing patterns in the codebase for handling CUDA graph incompatibilities.