### PR TITLE
[Bugfix] Fix truncate_prompt_tokens ignored in PoolingParams.encode()

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -654,10 +654,13 @@ class AsyncLLM(EngineClient):
                     DeprecationWarning,
                     stacklevel=2,
                 )
+            else:
+                # Fall back to pooling_params if parameter not provided
+                truncate_prompt_tokens = pooling_params.truncate_prompt_tokens
 
             _validate_truncation_size(
                 self.model_config.max_model_len,
-                pooling_params.truncate_prompt_tokens,
+                truncate_prompt_tokens,
                 tokenization_kwargs,
             )
 


### PR DESCRIPTION
## Description

Fixes #31012

This PR fixes an API inconsistency where `truncate_prompt_tokens` in `PoolingParams` was ignored by `AsyncLLM.encode()`.

### Problem
- `generate()` reads `truncate_prompt_tokens` from `sampling_params.truncate_prompt_tokens`
- `encode()` only used the function parameter, ignoring `pooling_params.truncate_prompt_tokens`

This caused users setting `truncate_prompt_tokens` in `PoolingParams` to get `ValueError: prompt is longer than max_model_len` instead of having their prompts truncated.

### Solution
Now `encode()` follows the same pattern as `generate()`:
- If `truncate_prompt_tokens` is explicitly provided as a function parameter, use it
- Otherwise, fall back to reading from `pooling_params.truncate_prompt_tokens`

### Changes
- Modified `vllm/v1/engine/async_llm.py` lines 642-648
- Added fallback to read from `pooling_params` when function parameter is `None`

### Testing
- [ ] Behavior matches `generate()` method
- [ ] Explicit parameter takes precedence
- [ ] Falls back to pooling_params when parameter is None

cc: @vllm-project/maintainers