### PR TITLE
[CI/Build] Add CMake warning for ignored +PTX suffix in TORCH_CUDA_ARCH_LIST

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,15 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   clear_cuda_arches(CUDA_ARCH_FLAGS)
   extract_unique_cuda_archs_ascending(CUDA_ARCHS "${CUDA_ARCH_FLAGS}")
   message(STATUS "CUDA target architectures: ${CUDA_ARCHS}")
+
+  if(DEFINED ENV{TORCH_CUDA_ARCH_LIST} AND
+     "$ENV{TORCH_CUDA_ARCH_LIST}" MATCHES "\\+PTX($|[ ,;])")
+    message(WARNING
+      "'+PTX' suffix detected in TORCH_CUDA_ARCH_LIST will be ignored. "
+      "vLLM uses per-file CUDA architecture settings, so the global +PTX "
+      "suffix has no effect. Remove '+PTX' to silence this warning.")
+  endif()
+
   # Filter the target architectures by the supported supported archs
   # since for some files we will build for all CUDA_ARCHS.
   cuda_archs_loose_intersection(CUDA_ARCHS


### PR DESCRIPTION
## Purpose

Add a CMake warning when +PTX suffix is detected in `TORCH_CUDA_ARCH_LIST`.

Since PR #8845, vLLM sets CUDA architectures per-file (for faster builds and smaller wheel size), so the global +PTX suffix from TORCH_CUDA_ARCH_LIST is silently ignored.

Implements the PTX warning task from #9129.

Closes #9129 (partial)

## Test Plan

Configure cmake with `+PTX` in `TORCH_CUDA_ARCH_LIST`:
```bash
mkdir build && cd build 
TORCH_CUDA_ARCH_LIST="8.0+PTX" cmake -G Ninja -DVLLM_PYTHON_EXECUTABLE=`which python3` -DCMAKE_INSTALL_PREFIX=.. ..
```