### PR TITLE
Fix formatting of softmax equation in documentation

### DIFF
--- a/docs/design/paged_attention.md
+++ b/docs/design/paged_attention.md
@@ -275,8 +275,8 @@ results between the query token and all context key tokens.
 
 $$
 \begin{gather*}
-m(x):=\max _i \quad x_i \\ \quad f(x):=\left[\begin{array}{lll}e^{x_1-m(x)} & \ldots & e^{x_B-m(x)}\end{array}\right]\\ \quad \ell(x):=\sum_i f(x)_i \\
-\quad \operatorname{softmax}(x):=\frac{f(x)}{\ell(x)}
+m(x):=\max _i \quad x_i \ \quad f(x):=\left[\begin{array}{lll}e^{x_1-m(x)} & \ldots & e^{x_B-m(x)}\end{array}\right]\ \quad \ell(x):=\sum_i f(x)_i \\
+\quad \text{softmax}(x):=\frac{f(x)}{\ell(x)}
 \end{gather*}
 $$
 


### PR DESCRIPTION
Updated formatting of mathematical expressions in [paged_attention.md.](https://github.com/vllm-project/vllm/blob/ff2168bca3a195b835c64a5c9012d7b6a9f34e61/docs/design/paged_attention.md#query)

the Softmax subsection had a formatting issue with rendering because \operatorname macro is dissallowed.

**Previously** 

$$
\begin{gather*}
m(x):=\max _i \quad x_i \ \quad f(x):=\left[\begin{array}{lll}e^{x_1-m(x)} & \ldots & e^{x_B-m(x)}\end{array}\right]\ \quad \ell(x):=\sum_i f(x)_i \\ \quad \operatorname{softmax}(x):=\frac{f(x)}{\ell(x)} \end{gather*}
$$

**Fixed it now to** 

$$
\begin{gather*}
m(x):=\max _i \quad x_i \ \quad f(x):=\left[\begin{array}{lll}e^{x_1-m(x)} & \ldots & e^{x_B-m(x)}\end{array}\right]\ \quad \ell(x):=\sum_i f(x)_i \\ \quad \text{softmax}(x):=\frac{f(x)}{\ell(x)}
\end{gather*}
$$

which renders correctly

<!-- markdownlint-disable -->

## Purpose
fixed readability issues in the [readme](https://github.com/vllm-project/vllm/blob/ff2168bca3a195b835c64a5c9012d7b6a9f34e61/docs/design/paged_attention.md#query) file.
## Test Plan
fix the \operatorname macro.
## Test Result

changing \operatorname to \text fixed the issues.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

