### PR TITLE
[ROCm][CI/Build] Fix Dockerfile.rocm to set VLLM_TARGET_DEVICE=rocm

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -51,6 +51,8 @@ FROM fetch_vllm_${REMOTE_VLLM} AS fetch_vllm
 # -----------------------
 # vLLM build stages
 FROM fetch_vllm AS build_vllm
+# Set target device to ROCm for build
+ENV VLLM_TARGET_DEVICE=rocm
 # Build vLLM
 RUN cd vllm \
     && python3 -m pip install -r requirements/rocm.txt \


### PR DESCRIPTION
## Summary

Fixes a bug in `docker/Dockerfile.rocm` where the `VLLM_TARGET_DEVICE` environment variable was not set, causing the build to default to CUDA instead of ROCm.

## Changes

- Added `ENV VLLM_TARGET_DEVICE=rocm` before the vLLM build step in `docker/Dockerfile.rocm`

## Root Cause

Without this environment variable, the build defaults to `VLLM_TARGET_DEVICE=cuda` as defined in `vllm/envs.py:457`:
```python
"VLLM_TARGET_DEVICE": lambda: os.getenv("VLLM_TARGET_DEVICE", "cuda").lower(),
```

This causes cmake to configure with `-DVLLM_TARGET_DEVICE=cuda` instead of `-DVLLM_TARGET_DEVICE=rocm`, resulting in build failures or incorrect CUDA-specific code paths being used.

## Testing

Verified that with this fix, cmake now correctly uses `-DVLLM_TARGET_DEVICE=rocm` in the build command.

## Related Issues

This fix is related to AMD CI builds and ensures proper ROCm target device configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>