### PR TITLE
[Doc] Add warning regarding GPU profiling limitations on WSL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,6 @@ If you use vLLM for your research, please cite our [paper](https://arxiv.org/abs
 ## Media Kit
 
 - If you wish to use vLLM's logo, please refer to [our media kit repo](https://github.com/vllm-project/media-kit)
+## Profiling Note
+
+If you are profiling vLLM on **WSL2 (Windows Subsystem for Linux)**, you might not see GPU/CUDA traces in the profiler output due to virtualization limitations. For accurate GPU profiling (e.g., viewing kernels in `torch.profiler`), it is recommended to use a native Linux environment.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ If you use vLLM for your research, please cite our [paper](https://arxiv.org/abs
 ## Media Kit
 
 - If you wish to use vLLM's logo, please refer to [our media kit repo](https://github.com/vllm-project/media-kit)
+
 ## Profiling Note
 
 If you are profiling vLLM on **WSL2 (Windows Subsystem for Linux)**, you might not see GPU/CUDA traces in the profiler output due to virtualization limitations. For accurate GPU profiling (e.g., viewing kernels in `torch.profiler`), it is recommended to use a native Linux environment.


### PR DESCRIPTION
## Purpose
This PR adds a note to `README.md` to warn users that GPU traces might not be captured correctly when profiling on WSL2 due to virtualization limitations. 

This addresses a common confusion for new contributors where `cudaDeviceSynchronize` dominates the trace but GPU kernels are missing.

## Test Plan
- Verified that the new note in `README.md` renders correctly.
- No code changes involved.

## Test Result
- Documentation update only.