### PR TITLE
Fix ROCm build to respect PYTORCH_ROCM_ARCH for GPU_TARGETS (issue #22590)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,6 +204,14 @@ class cmake_build_ext(build_ext):
         elif _is_hip():
             cmake_args += [f"-DROCM_PATH={ROCM_HOME}"]
 
+            # Pass GPU_TARGETS from PYTORCH_ROCM_ARCH if set
+            # This ensures the build uses the specified architecture
+            # instead of falling back to defaults when amdgpu-arch fails
+            # See: https://github.com/vllm-project/vllm/issues/22590
+            pytorch_rocm_arch = os.environ.get("PYTORCH_ROCM_ARCH")
+            if pytorch_rocm_arch:
+                cmake_args += [f"-DGPU_TARGETS={pytorch_rocm_arch}"]
+
         other_cmake_args = os.environ.get("CMAKE_ARGS")
         if other_cmake_args:
             cmake_args += other_cmake_args.split()


### PR DESCRIPTION
## Summary
Fixes #22590 - ROCm Docker builds ignore user-specified GPU architecture and fall back to defaults (gfx906 for dynamic / gfx942 for static builds).

## Problem
When building vLLM with Docker using `--build-arg ARG_PYTORCH_ROCM_ARCH=gfx1030`, the build process ignores the specified architecture. Users see warnings like:

```
GPU_TARGETS was not set, and system GPU detection was unsuccessful...
the default architecture (gfx906 for dynamic build / gfx942 for static build) will be used
```

This prevents users from building optimized binaries for their specific GPU architecture.

## Root Cause Analysis

### The Build Chain
1. `Dockerfile.rocm` defines `ARG_PYTORCH_ROCM_ARCH` and sets `ENV PYTORCH_ROCM_ARCH`
2. `setup.py` calls CMake with various configuration flags
3. CMake tries to detect GPU architecture using `amdgpu-arch` tool
4. During Docker builds, `amdgpu-arch` fails ("Failed to get device count" - no physical GPU in container)
5. CMake falls back to default architecture

### The Missing Link
While `Dockerfile.rocm` correctly sets the `PYTORCH_ROCM_ARCH` environment variable, `setup.py` never reads it to populate CMake's `GPU_TARGETS` variable. The architecture information stops at the environment variable and never reaches CMake.

## Solution
Modified `setup.py` to read `PYTORCH_ROCM_ARCH` from the environment and pass it to CMake as `-DGPU_TARGETS` when building for ROCm/HIP:

```python
elif _is_hip():
    cmake_args += [f"-DROCM_PATH={ROCM_HOME}"]
    
    # Pass GPU_TARGETS from PYTORCH_ROCM_ARCH if set
    pytorch_rocm_arch = os.environ.get("PYTORCH_ROCM_ARCH")
    if pytorch_rocm_arch:
        cmake_args += [f"-DGPU_TARGETS={pytorch_rocm_arch}"]
```

This ensures the architecture specified via Docker build arguments propagates through the entire build chain.

## Impact

**Before:**
- `docker build --build-arg ARG_PYTORCH_ROCM_ARCH=gfx1030` → builds for gfx906 (default)
- Users can't build for Radeon GPUs (gfx1030, gfx1100, gfx1103, etc.)
- Suboptimal performance on non-default architectures

**After:**
- `docker build --build-arg ARG_PYTORCH_ROCM_ARCH=gfx1030` → builds for gfx1030 ✓
- Users can specify any ROCm architecture (gfx906, gfx942, gfx1030, gfx1103, etc.)
- Optimized binaries for target GPU

## Testing
- **Verifiable via**: Build logs will show `-DGPU_TARGETS=<specified_arch>` instead of default
- **Use cases enabled**: 
  - Radeon RX 7000 series (gfx1030, gfx1100)
  - Radeon 780M integrated (gfx1103)
  - Any custom ROCm architecture

## Checklist
- [x] Root cause identified: `PYTORCH_ROCM_ARCH` not propagated to CMake
- [x] Fix implemented in `setup.py` ROCm build path
- [x] References upstream issue #22590
- [x] Passes all pre-commit checks
- [x] No impact on CUDA builds (NVIDIA GPUs)

## Related Issues
- Fixes #22590