### PR TITLE
[BugFix] Fix index misalignment bug in rejection sampler

### DIFF
--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -779,3 +779,80 @@ def test_allowed_token_ids(rejection_sampler):
         device=logits.device,
     )
     assert torch.equal(output.sampled_token_ids, expected)
+
+
+########################### Tests for _get_logprobs_tensors ###################
+def test_get_logprobs_tensors():
+    """Test that _get_logprobs_tensors correctly filters out-of-vocab tokens."""
+    from vllm.v1.outputs import LogprobsTensors
+    from vllm.v1.sample.sampler import Sampler
+
+    vocab_size = 50
+    batch_size = 2
+    max_num_logprobs = 5
+
+    sampler = Sampler(logprobs_mode="raw_logprobs")
+    rejection_sampler = RejectionSampler(sampler)
+
+    # Create spec_tokens for metadata with out-of-vocab tokens
+    spec_tokens = [[1, 2, vocab_size], [3, vocab_size + 10]]
+    metadata = SpecDecodeMetadata.make_dummy(spec_tokens, device=DEVICE)
+
+    # Update metadata indices to match our test setup
+    num_draft_tokens = sum(len(t) for t in spec_tokens)  # 5 total draft tokens
+    metadata.target_logits_indices = torch.arange(
+        num_draft_tokens, dtype=torch.int32, device=DEVICE
+    )
+    # bonus_logits_indices should be at the end of each request
+    num_sampled_tokens_per_request = [len(t) + 1 for t in spec_tokens]
+    cu_num_sampled_tokens = torch.cumsum(
+        torch.tensor(num_sampled_tokens_per_request, dtype=torch.int32, device=DEVICE),
+        dim=0,
+    )
+    metadata.bonus_logits_indices = cu_num_sampled_tokens - 1
+
+    # Create logits tensor: [num_draft_tokens + batch_size, vocab_size]
+    total_logits = num_draft_tokens + batch_size
+    logits = torch.randn(total_logits, vocab_size, dtype=torch.float32, device=DEVICE)
+
+    # target_logits for draft positions
+    target_logits = torch.randn(
+        num_draft_tokens, vocab_size, dtype=torch.float32, device=DEVICE
+    )
+    # bonus_logits for bonus positions
+    bonus_logits = torch.randn(
+        batch_size, vocab_size, dtype=torch.float32, device=DEVICE
+    )
+
+    # Create sampled_token_ids with out-of-vocab tokens matching spec_tokens
+    sampled_token_ids = torch.tensor(
+        [
+            [1, 2, vocab_size, PLACEHOLDER_TOKEN_ID],  # vocab_size is out of range
+            [3, vocab_size + 10, PLACEHOLDER_TOKEN_ID, PLACEHOLDER_TOKEN_ID],
+        ],
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+
+    # Call _get_logprobs_tensors
+    result = rejection_sampler._get_logprobs_tensors(
+        max_num_logprobs=max_num_logprobs,
+        metadata=metadata,
+        logits=logits,
+        target_logits=target_logits,
+        bonus_logits=bonus_logits,
+        sampled_token_ids=sampled_token_ids,
+    )
+
+    # Verify the result
+    assert isinstance(result, LogprobsTensors)
+
+    # Should only have 3 valid tokens: 1, 2, 3
+    num_valid_tokens = 3
+    assert result.logprobs.shape[0] == num_valid_tokens
+    assert result.logprob_token_ids.shape[0] == num_valid_tokens
+    assert result.selected_token_ranks.shape[0] == num_valid_tokens
+
+    # Verify the sampled token indices
+    expected_sampled_tokens = torch.tensor([1, 2, 3], dtype=torch.int32, device=DEVICE)
+    assert torch.equal(result.logprob_token_ids[:, 0], expected_sampled_tokens)

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -186,7 +186,10 @@ class RejectionSampler(nn.Module):
         final_logits[bonus_logits_indices] = bonus_logits.to(torch.float32)
 
         # Compute accepted token indices.
-        accepted_mask = sampled_token_ids != PLACEHOLDER_TOKEN_ID
+        vocab_size = logits.shape[-1]
+        accepted_mask = (sampled_token_ids != PLACEHOLDER_TOKEN_ID) & (
+            sampled_token_ids < vocab_size
+        )
         num_accepted_tokens = accepted_mask.sum(dim=-1)
         accepted_logit_indices = accepted_mask.nonzero(as_tuple=True)[1]
         accepted_logit_indices += cu_num_sampled_tokens.repeat_interleave(


### PR DESCRIPTION
## Purpose
There is an inconsistency between `_get_logprobs_tensors` and `parse_output` methods in how they filter valid tokens, which causes index misalignment when invalid token IDs (≥ `vocab_size`) are present.

## Test Plan
Existing tests should cover this fix because:
1. Test cases generate valid token IDs (within vocab_size range)
2. This fix ensures consistency between `_get_logprobs_tensors` and `parse_output` methods
3. The fixed logic matches the validation logic already used in `parse_output`

## Test Result
Pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

