### PR TITLE
[Quantization] enable MXFP4 Triton backend on SM120 (Blackwell)

### DIFF
--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -61,6 +61,25 @@ from vllm.utils.torch_utils import is_torch_equal_or_newer
 logger = init_logger(__name__)
 
 
+def _is_triton_mxfp4_supported_on_cuda() -> bool:
+    """Checks if the Triton MXFP4 kernels are supported on CUDA."""
+    capability = current_platform.get_device_capability()
+    if capability is None:
+        return False
+
+    # NOTE: triton_kernels are confirmed to work on SM90, SM100, and SM120
+    # SM110 fails with this error: https://github.com/vllm-project/vllm/issues/29317
+    # SM120 support added after Triton fix: https://github.com/triton-lang/triton/pull/8498
+    is_sm90_or_sm100 = (9, 0) <= capability < (11, 0)
+    is_sm120 = current_platform.is_device_capability_family(120)
+
+    return (
+        has_triton_kernels()
+        and is_torch_equal_or_newer("2.8.0")
+        and (is_sm90_or_sm100 or is_sm120)
+    )
+
+
 # enum for mxfp4 backend
 class Mxfp4Backend(Enum):
     NONE = 0
@@ -87,17 +106,7 @@ def get_mxfp4_backend_with_lora() -> Mxfp4Backend:
         return Mxfp4Backend.NONE
 
     # If FlashInfer is not available, try either Marlin or Triton
-    triton_kernels_supported = (
-        has_triton_kernels()
-        and is_torch_equal_or_newer("2.8.0")
-        # NOTE: triton_kernels are confirmed to work on SM90, SM100, and SM120
-        # SM110 fails with this error: https://github.com/vllm-project/vllm/issues/29317
-        # SM120 support added after Triton fix: https://github.com/triton-lang/triton/pull/8498
-        and (
-            (9, 0) <= current_platform.get_device_capability() < (11, 0)
-            or current_platform.is_device_capability_family(120)
-        )
-    )
+    triton_kernels_supported = _is_triton_mxfp4_supported_on_cuda()
     if envs.VLLM_MXFP4_USE_MARLIN is False and triton_kernels_supported:
         logger.info_once("[get_mxfp4_backend_with_lora] Using Triton backend")
         return Mxfp4Backend.TRITON
@@ -152,17 +161,7 @@ def get_mxfp4_backend(with_lora_support: bool) -> Mxfp4Backend:
             )
 
         # If FlashInfer is not available, try either Marlin or Triton
-        triton_kernels_supported = (
-            has_triton_kernels()
-            and is_torch_equal_or_newer("2.8.0")
-            # NOTE: triton_kernels are confirmed to work on SM90, SM100, and SM120
-            # SM110 fails with this error: https://github.com/vllm-project/vllm/issues/29317
-            # SM120 support added after Triton fix: https://github.com/triton-lang/triton/pull/8498
-            and (
-                (9, 0) <= current_platform.get_device_capability() < (11, 0)
-                or current_platform.is_device_capability_family(120)
-            )
-        )
+        triton_kernels_supported = _is_triton_mxfp4_supported_on_cuda()
         if envs.VLLM_MXFP4_USE_MARLIN or not triton_kernels_supported:
             logger.info_once("Using Marlin backend")
             return Mxfp4Backend.MARLIN

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -90,10 +90,13 @@ def get_mxfp4_backend_with_lora() -> Mxfp4Backend:
     triton_kernels_supported = (
         has_triton_kernels()
         and is_torch_equal_or_newer("2.8.0")
-        # NOTE: triton_kernels are only confirmed to work on SM90 and SM100
+        # NOTE: triton_kernels are confirmed to work on SM90, SM100, and SM120
         # SM110 fails with this error: https://github.com/vllm-project/vllm/issues/29317
-        # SM120 needs this fix: https://github.com/triton-lang/triton/pull/8498
-        and (9, 0) <= current_platform.get_device_capability() < (11, 0)
+        # SM120 support added after Triton fix: https://github.com/triton-lang/triton/pull/8498
+        and (
+            (9, 0) <= current_platform.get_device_capability() < (11, 0)
+            or current_platform.is_device_capability_family(120)
+        )
     )
     if envs.VLLM_MXFP4_USE_MARLIN is False and triton_kernels_supported:
         logger.info_once("[get_mxfp4_backend_with_lora] Using Triton backend")
@@ -152,10 +155,13 @@ def get_mxfp4_backend(with_lora_support: bool) -> Mxfp4Backend:
         triton_kernels_supported = (
             has_triton_kernels()
             and is_torch_equal_or_newer("2.8.0")
-            # NOTE: triton_kernels are only confirmed to work on SM90 and SM100
+            # NOTE: triton_kernels are confirmed to work on SM90, SM100, and SM120
             # SM110 fails with this error: https://github.com/vllm-project/vllm/issues/29317
-            # SM120 needs this fix: https://github.com/triton-lang/triton/pull/8498
-            and (9, 0) <= current_platform.get_device_capability() < (11, 0)
+            # SM120 support added after Triton fix: https://github.com/triton-lang/triton/pull/8498
+            and (
+                (9, 0) <= current_platform.get_device_capability() < (11, 0)
+                or current_platform.is_device_capability_family(120)
+            )
         )
         if envs.VLLM_MXFP4_USE_MARLIN or not triton_kernels_supported:
             logger.info_once("Using Marlin backend")


### PR DESCRIPTION
## Purpose

Enable MXFP4 Triton kernel backend on NVIDIA Blackwell consumer GPUs (SM120, compute capability 12.0).

## Test Plan

Tested with a version compiled from current source code on NVIDIA RTX PRO 6000 Blackwell 96GB:

```bash
vllm serve \
  "openai/gpt-oss-120b" \
  --async-scheduling \
  --trust-remote-code \
  --gpu-memory-utilization 0.91 \
  --enable-chunked-prefill \
  --enable-prefix-caching \
  --tensor-parallel-size 1 \
  --max-num-batched-tokens 32768 \
  --max-model-len 131072 \
  --max-num-seqs 512 \
  --disable-log-requests \
  --reasoning-parser openai_gptoss \
  --enable-auto-tool-choice \
  --tool-call-parser openai \
  --port 8000
```

## Test Result

Tested on NVIDIA RTX PRO 6000 Blackwell (compute capability 12.0) with AMD EPYC 9554 processor - model `openai/gpt-oss-120b` loads and runs successfully with MXFP4 Triton backend.

However, the performance is worse compared to the Marlin backend - batch 1 = 160 flow/s. Marlin with the same configuration 201 flow/s.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

