### PR TITLE
[FIX] FP4 quantization kernel padding initialization bug

### DIFF
--- a/csrc/quantization/fp4/nvfp4_quant_kernels.cu
+++ b/csrc/quantization/fp4/nvfp4_quant_kernels.cu
@@ -35,7 +35,7 @@ template <typename Int>
 __host__ __device__ inline Int round_up(Int x, Int y) {
   static_assert(std::is_integral_v<Int>,
                 "round_up argument must be integral type");
-  return (x + y - 1) / y * y;
+  return ((x + y - 1) / y) * y;
 }
 
 // Compute effective rows for grid configuration with swizzled SF layouts.
@@ -61,37 +61,51 @@ __global__ void __launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))
   int sf_m = round_up<int>(numRows, 128);
   int sf_n_unpadded = numCols / CVT_FP4_SF_VEC_SIZE;
   int sf_n_int = round_up<int>(sf_n_unpadded, 4) / 4;
-  for (int row = numRows + blockIdx.x; row < sf_m; row += gridDim.x) {
-    // Each thread writes 4 uint32_t elements.
-    for (int col = sf_n_unpadded + threadIdx.x * 4; col < sf_n_int;
-         col += blockDim.x * 4) {
-      SFout[row * sf_n_int + col] = 0x00;
-    }
-  }
+  int num_padded_cols = sf_n_int * 4 * CVT_FP4_SF_VEC_SIZE;
 
   // Get the global scaling factor, which will be applied to the SF.
   // Note SFScale is the same as next GEMM's alpha, which is
   // (448.f / (Alpha_A / 6.f)).
   float const global_scale = SFScale == nullptr ? 1.0f : SFScale[0];
 
-  // Input tensor row/col loops.
-  for (int rowIdx = blockIdx.x; rowIdx < numRows; rowIdx += gridDim.x) {
-    for (int colIdx = threadIdx.x; colIdx < numCols / CVT_FP4_ELTS_PER_THREAD;
+  // Iterate over all rows and cols including padded ones -
+  //  ensures we visit every single scale factor address to initialize it.
+  for (int rowIdx = blockIdx.x; rowIdx < sf_m; rowIdx += gridDim.x) {
+    for (int colIdx = threadIdx.x;
+         colIdx < num_padded_cols / CVT_FP4_ELTS_PER_THREAD;
          colIdx += blockDim.x) {
-      int64_t inOffset = rowIdx * (numCols / CVT_FP4_ELTS_PER_THREAD) + colIdx;
-      PackedVec in_vec = reinterpret_cast<PackedVec const*>(in)[inOffset];
-      // Get the output tensor offset.
-      // Same as inOffset because 8 elements are packed into one uint32_t.
-      int64_t outOffset = inOffset;
-      auto& out_pos = out[outOffset];
+      int elem_idx = colIdx * CVT_FP4_ELTS_PER_THREAD;
+
+      PackedVec in_vec;
+
+      // If we are outside valid rows OR outside valid columns -> Use Zeros
+      if (rowIdx >= numRows || elem_idx >= numCols) {
+        memset(&in_vec, 0, sizeof(PackedVec));
+
+      } else {
+        // Valid Region: Load actual data
+        int64_t inOffset =
+            rowIdx * (numCols / CVT_FP4_ELTS_PER_THREAD) + colIdx;
+        in_vec = reinterpret_cast<PackedVec const*>(in)[inOffset];
+      }
 
       auto sf_out =
           cvt_quant_to_fp4_get_sf_out_offset<uint32_t,
                                              CVT_FP4_NUM_THREADS_PER_SF>(
               rowIdx, colIdx, numKTiles, SFout);
 
-      out_pos =
+      auto out_val =
           cvt_warp_fp16_to_fp4<Type, UE8M0_SF>(in_vec, global_scale, sf_out);
+
+      // We do NOT write output for padding because the 'out' tensor is not
+      // padded.
+      if (rowIdx < numRows && elem_idx < numCols) {
+        // Get the output tensor offset.
+        // Same as inOffset because 8 elements are packed into one uint32_t.
+        int64_t inOffset =
+            rowIdx * (numCols / CVT_FP4_ELTS_PER_THREAD) + colIdx;
+        out[inOffset] = out_val;
+      }
     }
   }
 }


### PR DESCRIPTION
### Summary
This PR fixes a bug in the FP4 quantization kernel (`nvfp4_quant_kernels.cu`) related to incorrect padding initialization for scale factors in padded tensor regions.

### Changes
#### Unified kernel logic for padding handling
The original implementation had separate loops:
1. First loop: attempted to zero padding regions for scale factors (was a bug in the inner loop) 
2. Second loop: processed actual input data

**Problem:** The padding zeroing logic had addressing issues and didn't correctly initialize all necessary scale factor memory locations.

Created Unified into a single loop that iterates over all rows/columns including padded regions (`sf_m` x `num_padded_cols`), using zero-filled vectors for out-of-bounds regions and loading actual data for valid regions. All data is processed through quantization to ensure scale factors are properly computed, but output is only written for valid (non-padded) regions to avoid buffer overruns.


### Performance Impact
Benchmarked on **Nemotron Nano v3** with 10k requests, 1K/1K input/output, max concurrency of 512:

| Metric | Before | After |
|--------|--------|-------|
| **TPOT (mean)** | 30.54ms | 30.26ms 
| **ITL (mean)** | 30.51ms | 30.23ms 
| **Output Throughput** |  15991.81 tok/s  | 16099.50 tok/s

Performance remains effectively unchanged while fixing the correctness issue.

### Testing
- All related tests pass



Regarding the latest changes in main (following this [PR](https://github.com/vllm-project/vllm/pull/30897)) 
`numKTiles` is calculated from ACTUAL `numCols`, BUT it automatically accounts for the padding needed, since it calculates using `(numCols + 63) / 64` (always rounds UP).

The padding formula `num_padded_cols` = sf_n_int * 4 * 16` always rounds to a multiple of 64
`numCols` must be a multiple of 16, both formulas will always agree on the padded size.

@mgoin Do you agree 


In addition, as @mgoin mentioned, i ran the script `benchmarks/kernels/bench_nvfp4_quant.py`
and got the following performance: 
<img width="350" height="790" alt="image" src="https://github.com/user-attachments/assets/def8cc6f-27ad-4762-a2ae-11603c70db7b" />
