### PR TITLE
[Bugfix][ROCm] Fix AITER method typos and invalid staticmethod

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1152,7 +1152,7 @@ class rocm_aiter_ops:
         return torch.ops.vllm.rocm_aiter_per_token_quant(x, quant_dtype, scale)
 
     @staticmethod
-    def triton_fp4_gemm_dynamic_qaunt(
+    def triton_fp4_gemm_dynamic_quant(
         x: torch.Tensor,
         weight: torch.Tensor,
         weight_scale: torch.Tensor,
@@ -1306,7 +1306,7 @@ class rocm_aiter_ops:
 
     @staticmethod
     def shuffle_weight(
-        self, tensor: torch.Tensor, layout: tuple[int, int] = (16, 16)
+        tensor: torch.Tensor, layout: tuple[int, int] = (16, 16)
     ) -> torch.Tensor:
         from aiter.ops.shuffle import shuffle_weight
 

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
@@ -38,7 +38,7 @@ logger = init_logger(__name__)
 # for envs checks which does not require @cache anymore.
 # triton kernel is torch compile compatible.
 # does not require direct registration.
-# use `rocm_aiter_ops.triton_fp4_gemm_dynamic_qaunt`.
+# use `rocm_aiter_ops.triton_fp4_gemm_dynamic_quant`.
 @cache
 def is_rocm_aiter_fp4_asm_gemm_enabled() -> bool:
     return (


### PR DESCRIPTION
## Summary

Fix two issues in AITER operations:

1. **Typo fix:** `triton_fp4_gemm_dynamic_qaunt` → `triton_fp4_gemm_dynamic_quant`
2. **Invalid decorator:** `@staticmethod` with `self` parameter - removed unused `self`

## Changes

- `vllm/_aiter_ops.py`:
  - Fixed method name typo (line 1155)
  - Removed invalid `self` parameter from `shuffle_weight()` (line 1308)
- `vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py`:
  - Fixed comment reference (line 41)

## Test Plan

- [x] Syntax verification passes
- [x] No other references to typos found

🤖 Generated with [Claude Code](https://claude.com/claude-code)