### PR TITLE
[ROCm][Refactor] Move the contiguous logic for ROCm in `torch_sdpa_wrapper` into MMEncoderAttention

### DIFF
--- a/vllm/attention/ops/vit_attn_wrappers.py
+++ b/vllm/attention/ops/vit_attn_wrappers.py
@@ -124,13 +124,6 @@ def torch_sdpa_wrapper(
     v: torch.Tensor,
     cu_seqlens: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    # Never remove the contiguous logic for ROCm
-    # Without it, hallucinations occur with the backend
-    if current_platform.is_rocm():
-        q = q.contiguous()
-        k = k.contiguous()
-        v = v.contiguous()
-
     if cu_seqlens is None:
         return apply_sdpa(q, k, v)
 


### PR DESCRIPTION
## Purpose

Minor refactor following https://github.com/vllm-project/vllm/pull/30789.

I just move the contiguous processing logic for ROCm in `torch_sdpa_wrapper` into the `forward_hip()` of `MMEncoderAttention` to unify the dispatch management for platform inside the CustomOp.

## Test Plan

Run (on NVIDIA A100):

```bash
python examples/offline_inference/vision_language.py -m qwen2_5_vl
```

## Test Result

```
--------------------------------------------------
The image depicts a scenic view of a tall tower, likely a landmark, with a clear blue sky in the background. In the foreground, there are branches of cherry blossom trees, which are in full bloom, creating a beautiful contrast with the tower. The cherry blossoms are pink and white, and the scene is likely
--------------------------------------------------
The image depicts a scenic view of the Tokyo Skytree, a prominent landmark in Tokyo, Japan. The Skytree is framed by cherry blossoms in full bloom, which are a symbol of spring in Japan. The cherry blossoms are in the foreground, creating a beautiful contrast with the modern structure of the Skytree in
--------------------------------------------------
The image depicts a scenic view of the Tokyo Skytree, a prominent landmark in Tokyo, Japan. The Skytree is framed by cherry blossoms in full bloom, creating a picturesque and vibrant scene. The cherry blossoms, known as sakura, are a symbol of spring in Japan and are celebrated during the cherry blossom
--------------------------------------------------
The image depicts a scenic view of a tall tower, likely a landmark, with cherry blossoms in full bloom in the foreground. The cherry blossoms are vibrant pink and create a beautiful contrast against the clear blue sky. The tower appears to be a modern structure, possibly a television or observation tower, given its design and
--------------------------------------------------
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

