### PR TITLE
[Bugfix][Hardware][AMD] Fix uninitialized prefix_scheduler_metadata

### DIFF
--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -121,6 +121,7 @@ class RocmAttentionMetadataBuilder(AttentionMetadataBuilder[RocmAttentionMetadat
         slot_mapping = common_attn_metadata.slot_mapping
 
         use_cascade = common_prefix_len > 0
+        prefix_scheduler_metadata = None
 
         if use_cascade:
             cu_prefix_query_lens = torch.tensor(
@@ -135,7 +136,6 @@ class RocmAttentionMetadataBuilder(AttentionMetadataBuilder[RocmAttentionMetadat
             cu_prefix_query_lens = None
             prefix_kv_lens = None
             suffix_kv_lens = None
-            prefix_scheduler_metadata = None
 
         attn_metadata = RocmAttentionMetadata(
             num_actual_tokens=num_actual_tokens,


### PR DESCRIPTION
## Summary
Fix UnboundLocalError in ROCm attention backend when `use_cascade=True`.

**Bug:** In `RocmAttentionMetadataBuilder.build()`, the `prefix_scheduler_metadata` variable was only initialized in the `else` branch (when `use_cascade=False`), but used unconditionally at line 148 when creating `RocmAttentionMetadata`.

When `use_cascade=True` (i.e., `common_prefix_len > 0`), the variable was never assigned, causing:
```
UnboundLocalError: local variable 'prefix_scheduler_metadata' referenced before assignment
```

**Fix:** Initialize `prefix_scheduler_metadata = None` before the if/else block to ensure it's always defined.

## Test plan
- Code inspection confirms the variable is now always initialized before use
- The fix aligns with the dataclass default value (`prefix_scheduler_metadata: torch.Tensor | None = None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)