### PR TITLE
[Feature] Support weight-shape-unaligned block-scale fp8 models

### DIFF
--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -100,6 +100,7 @@ class NemotronHMLP(nn.Module):
             quant_config=quant_config,
             disable_tp=is_sequence_parallel,
             prefix=f"{prefix}.up_proj",
+            slice_padding=False,
         )
         self.down_proj = RowParallelLinear(
             input_size=intermediate_size,
@@ -109,6 +110,7 @@ class NemotronHMLP(nn.Module):
             reduce_results=reduce_results,
             disable_tp=is_sequence_parallel,
             prefix=f"{prefix}.down_proj",
+            slice_padding=False,
         )
         self.act_fn = ReLUSquaredActivation()
 


### PR DESCRIPTION
## Purpose

- Support Nemotron-3-Nano block-scale fp8 models for now.

## Test Plan

* Step 1: Generate block-scale fp8 model for Nemotron-3-Nano
```
(using [modelopt](https://github.com/NVIDIA/Model-Optimizer) to quantize bf16 model.

# CMD:
python examples/llm_ptq/hf_ptq.py \
--pyt_ckpt_path nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 \
--qformat fp8_pb_wo \
--kv_cache_qformat none \
--export_path Nemotron-3-Nano-FP8-pb-wo \
--trust_remote_code
```

* Step 2: Test it with GPQA-diamond / LCB_v6 and compare with bf16 model ckpt.

## Test Result

* GPQA-diamond:  71.82@bf16, 70.2@fp8-blockscale.
* LCB_v6: 64.36@bf16, 66.74@fp8-blockscale.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

