### PR TITLE
Don't tolerate `llm_config` instead of `text_config`

### DIFF
--- a/vllm/model_executor/models/bagel.py
+++ b/vllm/model_executor/models/bagel.py
@@ -365,10 +365,10 @@ class BagelForConditionalGeneration(
         self.multimodal_config = multimodal_config
 
         # Initialize language model (Qwen2)
-        # Pass the llm_config from BagelConfig to initialize Qwen2 properly
+        # Pass the text_config from BagelConfig to initialize Qwen2 properly
         self.language_model = init_vllm_registered_model(
             vllm_config=vllm_config,
-            hf_config=config.llm_config,
+            hf_config=config.text_config,
             prefix=maybe_prefix(prefix, "language_model"),
             architectures=["Qwen2ForCausalLM"],
         )
@@ -399,12 +399,12 @@ class BagelForConditionalGeneration(
 
             # Initialize connector (MLP)
             vit_hidden_size = config.vit_config.hidden_size
-            llm_hidden_size = config.llm_config.hidden_size
+            text_hidden_size = config.text_config.hidden_size
 
             self.connector = BagelVisionMLP(
                 in_features=vit_hidden_size,
-                hidden_features=llm_hidden_size,
-                out_features=llm_hidden_size,
+                hidden_features=text_hidden_size,
+                out_features=text_hidden_size,
                 act_layer=config.connector_act,
                 quant_config=quant_config,
                 prefix=maybe_prefix(prefix, "connector"),
@@ -413,7 +413,7 @@ class BagelForConditionalGeneration(
             # Position embedding for vision tokens
             self.vit_pos_embed = PositionEmbedding(
                 max_num_patch_per_side=config.vit_max_num_patch_per_side,
-                hidden_size=llm_hidden_size,
+                hidden_size=text_hidden_size,
             )
         else:
             self.vit_model = None

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -93,10 +93,6 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
     tarsier2="Tarsier2Config",
 )
 
-_CONFIG_ATTRS_MAPPING: dict[str, str] = {
-    "llm_config": "text_config",
-}
-
 _AUTO_CONFIG_KWARGS_OVERRIDES: dict[str, dict[str, Any]] = {
     "internvl_chat": {"has_no_defaults_at_init": True},
     "Llama_Nemotron_Nano_VL": {"attn_implementation": "eager"},
@@ -168,7 +164,6 @@ class HFConfigParser(ConfigParserBase):
                     raise RuntimeError(err_msg) from e
                 else:
                     raise e
-        config = _maybe_remap_hf_config_attrs(config)
         return config_dict, config
 
 
@@ -460,16 +455,6 @@ def _maybe_update_auto_config_kwargs(kwargs: dict[str, Any], model_type: str):
     if model_type in _AUTO_CONFIG_KWARGS_OVERRIDES:
         kwargs.update(_AUTO_CONFIG_KWARGS_OVERRIDES[model_type])
     return kwargs
-
-
-def _maybe_remap_hf_config_attrs(config: PretrainedConfig) -> PretrainedConfig:
-    """Remap config attributes to match the expected names."""
-    for old_attr, new_attr in _CONFIG_ATTRS_MAPPING.items():
-        if hasattr(config, old_attr):
-            if not hasattr(config, new_attr):
-                config.update({new_attr: getattr(config, old_attr)})
-            logger.debug("Remapped config attribute '%s' to '%s'", old_attr, new_attr)
-    return config
 
 
 def maybe_override_with_speculators(

--- a/vllm/transformers_utils/configs/bagel.py
+++ b/vllm/transformers_utils/configs/bagel.py
@@ -13,7 +13,7 @@ class BagelConfig(PretrainedConfig):
         self,
         visual_gen: bool = True,
         visual_und: bool = True,
-        llm_config: dict | Qwen2Config | None = None,
+        text_config: dict | Qwen2Config | None = None,
         vit_config: dict | SiglipVisionConfig | None = None,
         vae_config: dict | None = None,
         latent_patch_size: int = 2,
@@ -28,11 +28,15 @@ class BagelConfig(PretrainedConfig):
         self.visual_gen = visual_gen
         self.visual_und = visual_und
 
+        # Checkpoint contains llm_config but that's a non-standard name
+        if "llm_config" in kwargs:
+            text_config = kwargs.pop("llm_config")
+
         # Convert dict configs to proper config objects
-        if isinstance(llm_config, dict):
-            self.llm_config = Qwen2Config(**llm_config)
+        if isinstance(text_config, dict):
+            self.text_config = Qwen2Config(**text_config)
         else:
-            self.llm_config = llm_config or Qwen2Config()
+            self.text_config = text_config or Qwen2Config()
 
         if isinstance(vit_config, dict):
             self.vit_config = SiglipVisionConfig(**vit_config)
@@ -50,4 +54,4 @@ class BagelConfig(PretrainedConfig):
     @property
     def hidden_size(self) -> int:
         """Return the hidden size of the language model."""
-        return self.llm_config.hidden_size
+        return self.text_config.hidden_size

--- a/vllm/transformers_utils/configs/ovis.py
+++ b/vllm/transformers_utils/configs/ovis.py
@@ -142,7 +142,7 @@ class OvisConfig(PretrainedConfig):
 
     def __init__(
         self,
-        llm_config: PretrainedConfig | dict | None = None,
+        text_config: PretrainedConfig | dict | None = None,
         visual_tokenizer_config: PretrainedConfig | dict | None = None,
         multimodal_max_length=8192,
         hidden_size=None,
@@ -152,17 +152,20 @@ class OvisConfig(PretrainedConfig):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        if llm_config is not None:
-            assert isinstance(llm_config, (PretrainedConfig, dict)), (
-                f"expect `llm_config` to be instance of PretrainedConfig or dict, but got {type(llm_config)} type"
+        # Checkpoint contains llm_config but that's a non-standard name
+        if "llm_config" in kwargs:
+            text_config = kwargs.pop("llm_config")
+        if text_config is not None:
+            assert isinstance(text_config, (PretrainedConfig, dict)), (
+                f"expect `text_config` to be instance of PretrainedConfig or dict, but got {type(text_config)} type"
             )
-            if not isinstance(llm_config, PretrainedConfig):
-                model_type = llm_config["model_type"]
-                llm_config.pop("model_type")
-                llm_config = AutoConfig.for_model(model_type, **llm_config)
+            if not isinstance(text_config, PretrainedConfig):
+                model_type = text_config["model_type"]
+                text_config.pop("model_type")
+                text_config = AutoConfig.for_model(model_type, **text_config)
 
-        # map llm_config to text_config
-        self.text_config = llm_config
+        # map text_config to text_config
+        self.text_config = text_config
         if visual_tokenizer_config is not None:
             assert isinstance(visual_tokenizer_config, (PretrainedConfig, dict)), (
                 f"expect `visual_tokenizer_config` to be instance of PretrainedConfig or dict, but got {type(visual_tokenizer_config)} type"


### PR DESCRIPTION
`text_config` is the standard name in all of Transformers.

vLLM shouldn't have to handle model vendors using the wrong name. 

This PR changes the `llm_config` to be an edge case for some models rather than something we want to get used to doing.