### PR TITLE
[ROCm] [Critical]: Remove unused variable

### DIFF
--- a/csrc/fused_qknorm_rope_kernel.cu
+++ b/csrc/fused_qknorm_rope_kernel.cu
@@ -405,7 +405,6 @@ void fused_qk_norm_rope(
                   qkv.scalar_type() == k_weight.scalar_type(),
               "qkv, q_weight and k_weight must have the same dtype");
 
-  int64_t rotary_dim = cos_sin_cache.size(1);
   int64_t num_tokens = qkv.size(0);
   TORCH_CHECK(position_ids.size(0) == num_tokens,
               "Number of tokens in position_ids must match QKV");


### PR DESCRIPTION

## Purpose

This fixes this issue. https://github.com/vllm-project/vllm/issues/31155 . On ROCm, the build command includes ` -Werror=unused-variable` . So any unused variables will make the build fails.

Error trace:

```
isystem /opt/rocm-7.0.0/include/rocrand -Wno-unused-result -O2 -g -DNDEBUG -std=gnu++17 --offload-arch=gfx90a --offload-arch=gfx942 -fPIC -D__HIP_PLATFORM_AMD__=1 -DUSE_ROCM=1 -DHIPBLAS_V2 -fPIC -DCUDA_HAS_FP16=1 -D__HIP_NO_HALF_OPERATORS__=1 -D__HIP_NO_HALF_CONVERSIONS__=1 -DHIP_ENABLE_WARP_SYNC_BUILTINS=1 -DUSE_ROCM -DENABLE_FP8 -U__HIP_NO_HALF_CONVERSIONS__ -U__HIP_NO_HALF_OPERATORS__ -Werror=unused-variable -fno-gpu-rdc -DTORCH_HIP_VERSION=700 -Wno-shift-count-negative -Wno-shift-count-overflow -Wno-duplicate-decl-specifier -DCAFFE2_USE_MIOPEN -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_HIP -std=c++17 -DHIP_ENABLE_WARP_SYNC_BUILTINS -DHIPBLASLT_OUTER_VEC -DUSE_ROCM_CK_GEMM -MD -MT CMakeFiles/_C.dir/csrc/fused_qknorm_rope_kernel.hip.o -MF CMakeFiles/_C.dir/csrc/fused_qknorm_rope_kernel.hip.o.d -o CMakeFiles/_C.dir/csrc/fused_qknorm_rope_kernel.hip.o -x hip -c /app/vllm/build/temp.linux-x86_64-cpython-312/csrc/fused_qknorm_rope_kernel.hip
#13 132.3 /app/vllm/build/temp.linux-x86_64-cpython-312/csrc/fused_qknorm_rope_kernel.hip:409:11: error: unused variable 'rotary_dim' [-Werror,-Wunused-variable]
#13 132.3   409 |   int64_t rotary_dim = cos_sin_cache.size(1);
#13 132.3       |           ^~~~~~~~~~
#13 132.3 1 error generated when compiling for gfx90a.
```

This is critical as it makes compiling on ROCm to fail.

## Test Plan

Build pass.

Pass `pytest -svvv tests/kernels/core/test_fused_qk_norm_rope.py`

## Test Result

Passed `pytest -svvv tests/kernels/core/test_fused_qk_norm_rope.py`
==========24 passed, 2 warnings in 18.55s ==============
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

