### PR TITLE
[Bugfix][ROCm] Fix typo: triton_fp4_gemm_dynamic_qaunt -> quant

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1152,7 +1152,7 @@ class rocm_aiter_ops:
         return torch.ops.vllm.rocm_aiter_per_token_quant(x, quant_dtype, scale)
 
     @staticmethod
-    def triton_fp4_gemm_dynamic_qaunt(
+    def triton_fp4_gemm_dynamic_quant(
         x: torch.Tensor,
         weight: torch.Tensor,
         weight_scale: torch.Tensor,

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
@@ -38,7 +38,7 @@ logger = init_logger(__name__)
 # for envs checks which does not require @cache anymore.
 # triton kernel is torch compile compatible.
 # does not require direct registration.
-# use `rocm_aiter_ops.triton_fp4_gemm_dynamic_qaunt`.
+# use `rocm_aiter_ops.triton_fp4_gemm_dynamic_quant`.
 @cache
 def is_rocm_aiter_fp4_asm_gemm_enabled() -> bool:
     return (


### PR DESCRIPTION
## Summary
Fix spelling error in AITER FP4 GEMM function name.

## Changes
- `vllm/_aiter_ops.py`: Fix method name `triton_fp4_gemm_dynamic_qaunt` -> `triton_fp4_gemm_dynamic_quant`
- `vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py`: Fix comment reference

## Test Plan
- This is a typo fix in an AITER (AMD Inference Tuning and Execution Runtime) method name
- The method is not currently called anywhere, so this is a preventive fix before it gets used

🤖 Generated with [Claude Code](https://claude.com/claude-code)