### PR TITLE
[ROCm][CI/Build] Fix triton version to one that has triton_kernels required for gpt-oss to run

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=rocm/dev-ubuntu-22.04:7.0-complete
-ARG TRITON_BRANCH="a272dfa8"
+ARG TRITON_BRANCH="57c693b6"
 ARG TRITON_REPO="https://github.com/ROCm/triton.git"
 ARG PYTORCH_BRANCH="89075173"
 ARG PYTORCH_REPO="https://github.com/ROCm/pytorch.git"


### PR DESCRIPTION
Updating to match the new rocm/vllm-dev:base
A fix for `ImportError: cannot import name 'GFX950MXScaleLayout' from 'triton_kernels.tensor_details.layout'` on gfx950 with GPT-OSS due to a missing feature in triton_kernels from 3.5.x on ROCm