### PR TITLE
[Bug] Fix `Number of dimensions of tensors must match.` for Deepseek V3.2

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -878,11 +878,14 @@ class Indexer(nn.Module):
         )
 
         q_pe, k_pe = rotary_emb(positions, q_pe, k_pe.unsqueeze(1))
-        # `rotary_emb` is shape-preserving; `q_pe` is already
-        # [num_tokens, n_head, rope_dim].
+        # Note: RoPE (NeoX) can introduce extra leading dimensions during compilation
+        # so we need to reshape back to token-flattened shapes
+        q_pe = q_pe.reshape(-1, q_pe.shape[-2], q_pe.shape[-1])
+        k_pe = k_pe.reshape(-1, k_pe.shape[-2], k_pe.shape[-1])
+
         q = torch.cat([q_pe, q_nope], dim=-1)
         # `k_pe` is [num_tokens, 1, rope_dim] (MQA).
-        k = torch.cat([k_pe.squeeze(1), k_nope], dim=-1)
+        k = torch.cat([k_pe.squeeze(-2), k_nope], dim=-1)
 
         # we only quant q here since k quant is fused with cache insertion
         q = q.view(-1, self.head_dim)
@@ -1043,7 +1046,7 @@ class DeepseekV2MLAAttention(nn.Module):
                 qk_rope_head_dim,
                 max_position=max_position_embeddings,
                 rope_parameters=config.rope_parameters,
-                is_neox_style=False,
+                is_neox_style=True,
             )
             self.indexer = Indexer(
                 vllm_config,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1043,7 +1043,9 @@ class DeepseekV2MLAAttention(nn.Module):
                 qk_rope_head_dim,
                 max_position=max_position_embeddings,
                 rope_parameters=config.rope_parameters,
-                is_neox_style=True,
+                # Indexer tensors are token-flattened ([num_tokens, ...]) so we
+                # must use non-NeoX RoPE layout to preserve ranks.
+                is_neox_style=False,
             )
             self.indexer = Indexer(
                 vllm_config,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1043,8 +1043,6 @@ class DeepseekV2MLAAttention(nn.Module):
                 qk_rope_head_dim,
                 max_position=max_position_embeddings,
                 rope_parameters=config.rope_parameters,
-                # Indexer tensors are token-flattened ([num_tokens, ...]) so we
-                # must use non-NeoX RoPE layout to preserve ranks.
                 is_neox_style=False,
             )
             self.indexer = Indexer(

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -880,8 +880,8 @@ class Indexer(nn.Module):
         q_pe, k_pe = rotary_emb(positions, q_pe, k_pe.unsqueeze(1))
         # Note: RoPE (NeoX) can introduce extra leading dimensions during compilation
         # so we need to reshape back to token-flattened shapes
-        q_pe = q_pe.reshape(-1, q_pe.shape[-2], q_pe.shape[-1])
-        k_pe = k_pe.reshape(-1, k_pe.shape[-2], k_pe.shape[-1])
+        q_pe = q_pe.reshape(-1, self.n_head, self.rope_dim)
+        k_pe = k_pe.reshape(-1, 1, self.rope_dim)
 
         q = torch.cat([q_pe, q_nope], dim=-1)
         # `k_pe` is [num_tokens, 1, rope_dim] (MQA).


### PR DESCRIPTION
## Purpose

`export MODEL="deepseek-ai/DeepSeek-V3.2"`
`vllm serve "$MODEL" -tp 8 --port 9256 --enable-expert-parallel`

Will trigger error

```bash
(EngineCore_DP0 pid=1198832)   File "/home/wentao/vllm-source/vllm/v1/engine/core.py", line 859, in run_engine_core
(EngineCore_DP0 pid=1198832)     engine_core = EngineCoreProc(*args, **kwargs)
(EngineCore_DP0 pid=1198832)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1198832)   File "/home/wentao/vllm-source/vllm/v1/engine/core.py", line 639, in __init__
(EngineCore_DP0 pid=1198832)     super().__init__(
(EngineCore_DP0 pid=1198832)   File "/home/wentao/vllm-source/vllm/v1/engine/core.py", line 111, in __init__
(EngineCore_DP0 pid=1198832)     num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
(EngineCore_DP0 pid=1198832)                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1198832)   File "/home/wentao/vllm-source/vllm/v1/engine/core.py", line 242, in _initialize_kv_caches
(EngineCore_DP0 pid=1198832)     available_gpu_memory = self.model_executor.determine_available_memory()
(EngineCore_DP0 pid=1198832)                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1198832)   File "/home/wentao/vllm-source/vllm/v1/executor/abstract.py", line 126, in determine_available_memory
(EngineCore_DP0 pid=1198832)     return self.collective_rpc("determine_available_memory")
(EngineCore_DP0 pid=1198832)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1198832)   File "/home/wentao/vllm-source/vllm/v1/executor/multiproc_executor.py", line 359, in collective_rpc
(EngineCore_DP0 pid=1198832)     return aggregate(get_response())
(EngineCore_DP0 pid=1198832)                      ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1198832)   File "/home/wentao/vllm-source/vllm/v1/executor/multiproc_executor.py", line 342, in get_response
(EngineCore_DP0 pid=1198832)     raise RuntimeError(
(EngineCore_DP0 pid=1198832) RuntimeError: Worker failed with error 'Dynamo failed to run FX node with fake tensors: call_function <built-in method cat of type object at 0x72b9f25d6c20>(*([FakeTensor(..., device='cuda:0', size=(1, s72, 64, 64), dtype=torch.bfloat16), FakeTensor(..., device='cuda:0', size=(s72, 64, 64), dtype=torch.bfloat16)],), **{'dim': -1}): got RuntimeError('Number of dimensions of tensors must match.  Expected 4-D tensors, but got 3-D for tensor number 1 in the list')
(EngineCore_DP0 pid=1198832) 
(EngineCore_DP0 pid=1198832) from user code:
(EngineCore_DP0 pid=1198832)    File "/home/wentao/vllm-source/vllm/model_executor/models/deepseek_v2.py", line 1328, in forward
(EngineCore_DP0 pid=1198832)     hidden_states, residual = layer(
(EngineCore_DP0 pid=1198832)   File "/home/wentao/vllm-source/vllm/model_executor/models/deepseek_v2.py", line 1212, in forward
(EngineCore_DP0 pid=1198832)     hidden_states = self.self_attn(**attn_kwargs)
(EngineCore_DP0 pid=1198832)   File "/home/wentao/vllm-source/vllm/model_executor/models/deepseek_v2.py", line 1105, in forward
(EngineCore_DP0 pid=1198832)     return self.mla_attn(positions, hidden_states, llama_4_scaling)
(EngineCore_DP0 pid=1198832)   File "/home/wentao/vllm-source/vllm/model_executor/custom_op.py", line 47, in forward
(EngineCore_DP0 pid=1198832)     return self._forward_method(*args, **kwargs)
(EngineCore_DP0 pid=1198832)   File "/home/wentao/vllm-source/vllm/model_executor/layers/mla.py", line 159, in forward_native
(EngineCore_DP0 pid=1198832)     _topk_indices = self.indexer(
(EngineCore_DP0 pid=1198832)   File "/home/wentao/vllm-source/vllm/model_executor/models/deepseek_v2.py", line 883, in forward
(EngineCore_DP0 pid=1198832)     q = torch.cat([q_pe, q_nope], dim=-1)
```

The root cause: Number of dimensions of tensors must match.  Expected 4-D tensors, but got 3-D for tensor number 1 in the list

## Test

Now fixed

```bash
direct, Methods: HEAD, GET
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /redoc, Methods: HEAD, GET
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /start_profile, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /stop_profile, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /pause, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /resume, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /is_paused, Methods: GET
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /v1/audio/transcriptions, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /v1/audio/translations, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /classify, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /v1/embeddings, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /score, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /v1/score, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /rerank, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /v1/rerank, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /v2/rerank, Methods: POST
(APIServer pid=1204133) INFO 12-22 08:03:24 [launcher.py:46] Route: /pooling, Methods: POST
(APIServer pid=1204133) INFO:     Started server process [1204133]
(APIServer pid=1204133) INFO:     Waiting for application startup.
(APIServer pid=1204133) INFO:     Application startup complete.
```

`lm_eval --model local-completions --model_args "base_url=http://127.0.0.1:9256/v1/completions,model=$MODEL,num_concurrent=1024" --tasks gsm8k`

```bash
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9538|±  |0.0058|
|     |       |strict-match    |     5|exact_match|↑  |0.9530|±  |0.0058|
```

Is there any reason we specifically set `is_neox_style` to True for indexer? `self.rotary_emb` uses `is_neox_style=False` for main attention, CC @zyongye 