### PR TITLE
[Bugfix] Fix MLA attention crash when using DP with DCP

### DIFF
--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -1014,6 +1014,18 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
             dcp_tot_seq_lens_device = None
             if self.dcp_world_size > 1:
                 dcp_tot_seq_lens_device = seq_lens[:num_decodes]
+                if dcp_local_seq_lens_cpu is None:
+                    dcp_local_seq_lens_cpu = get_dcp_local_seq_lens(
+                        seq_lens_cpu,
+                        self.dcp_world_size,
+                        self.dcp_rank,
+                        self.dcp_local_block_size,
+                    )
+                if dcp_local_seq_lens is None:
+                    dcp_local_seq_lens = dcp_local_seq_lens_cpu.to(
+                        seq_lens.device, non_blocking=True
+                    )
+                seq_lens_cpu = dcp_local_seq_lens_cpu
                 seq_lens = dcp_local_seq_lens
 
                 # After DCP distribution, the maximum number of tokens for any rank is

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -799,7 +799,11 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         query_start_loc = common_attn_metadata.query_start_loc
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
         seq_lens = common_attn_metadata.seq_lens
+        seq_lens_cpu = seq_lens.cpu()
         dcp_local_seq_lens = common_attn_metadata.dcp_local_seq_lens
+        dcp_local_seq_lens_cpu = (
+            dcp_local_seq_lens.cpu() if dcp_local_seq_lens is not None else None
+        )
 
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
             split_decodes_and_prefills(
@@ -1022,6 +1026,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                         self.dcp_local_block_size,
                     )
                 if dcp_local_seq_lens is None:
+                    assert dcp_local_seq_lens_cpu is not None
                     dcp_local_seq_lens = dcp_local_seq_lens_cpu.to(
                         seq_lens.device, non_blocking=True
                     )

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -12,6 +12,7 @@ from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.attention.backends.utils import (
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
+    get_dcp_local_seq_lens,
 )
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
@@ -152,11 +153,24 @@ def build_attn_metadata(
     block_tables: Sequence[torch.Tensor],
     slot_mappings: torch.Tensor,
     kv_cache_config: KVCacheConfig,
+    dcp_world_size: int = 1,
+    cp_kv_cache_interleave_size: int = 1,
 ) -> dict[str, Any]:
     max_query_len = int(query_start_loc_cpu.max())
     seq_lens = seq_lens[:num_reqs]
     seq_lens_cpu = torch.from_numpy(seq_lens_np)
     max_seq_len = int(seq_lens_np.max())
+
+    # Compute DCP local sequence lengths if DCP is enabled
+    dcp_local_seq_lens: torch.Tensor | None = None
+    dcp_local_seq_lens_cpu: torch.Tensor | None = None
+    if dcp_world_size > 1:
+        dcp_local_seq_lens_cpu = get_dcp_local_seq_lens(
+            seq_lens_cpu,
+            dcp_size=dcp_world_size,
+            cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+        )
+        dcp_local_seq_lens = dcp_local_seq_lens_cpu.to(seq_lens.device)
 
     attn_metadata: dict[str, Any] = {}
     kv_cache_groups = kv_cache_config.kv_cache_groups
@@ -177,6 +191,8 @@ def build_attn_metadata(
             block_table_tensor=block_table,
             slot_mapping=slot_mapping,
             causal=True,
+            dcp_local_seq_lens=dcp_local_seq_lens,
+            dcp_local_seq_lens_cpu=dcp_local_seq_lens_cpu,
         )
 
         attn_metadata_builder = attn_metadata_builders[i]

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -154,6 +154,7 @@ def build_attn_metadata(
     slot_mappings: torch.Tensor,
     kv_cache_config: KVCacheConfig,
     dcp_world_size: int = 1,
+    dcp_rank: int = 0,
     cp_kv_cache_interleave_size: int = 1,
 ) -> dict[str, Any]:
     max_query_len = int(query_start_loc_cpu.max())
@@ -168,6 +169,7 @@ def build_attn_metadata(
         dcp_local_seq_lens_cpu = get_dcp_local_seq_lens(
             seq_lens_cpu,
             dcp_size=dcp_world_size,
+            dcp_rank=dcp_rank,
             cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
         )
         dcp_local_seq_lens = dcp_local_seq_lens_cpu.to(seq_lens.device)


### PR DESCRIPTION
## Purpose
The MLA builder assumes that when dcp_world_size > 1, the DCP sequence length metadata is already populated. However, some code paths such as CUDA graph capture with DP + DCP did not initialise this metadata, leading to missing values.
This PR adds this patch to the builder to compute the missing DCP sequence lengths when needed and to ensure the corresponding GPU tensor is created if absent. This guarantees the metadata is always available when DCP is enabled.

Fixes https://github.com/vllm-project/vllm/issues/30736


## Test Plan

I tried replicating this via MIGs on a single H200 but could not do it due to limited MIG support in vLLM. I'd love to know if there is any way to make it work on a single GPU. But for now I wrote unit tests for the code paths as given below in `tests/v1/attention`. It seemed a trivial fix for a unit test but let me know and I can add this in the PR too:

```python
import pytest
import torch

from vllm.v1.attention.backends.utils import (
    CommonAttentionMetadata,
    get_dcp_local_seq_lens,
)


class TestDCPLocalSeqLensComputation:

    def test_get_dcp_local_seq_lens_basic(self):
        seq_lens = torch.tensor([100, 200], dtype=torch.int32)
        dcp_size = 2
        dcp_rank = 0
        interleave_size = 1

        result = get_dcp_local_seq_lens(
            seq_lens, dcp_size, dcp_rank, interleave_size
        )

        assert result.shape == (2,)
        assert result.dtype == torch.int32

    def test_get_dcp_local_seq_lens_with_interleave(self):
        seq_lens = torch.tensor([128, 256], dtype=torch.int32)
        dcp_size = 4
        dcp_rank = 1
        interleave_size = 16

        result = get_dcp_local_seq_lens(
            seq_lens, dcp_size, dcp_rank, interleave_size
        )

        assert result.shape == (2,)
        assert torch.all(result <= seq_lens)

    def test_common_attn_metadata_with_none_dcp_fields(self):
        device = torch.device("cpu")
        batch_size = 2
        num_tokens = 10
        block_size = 16

        query_start_loc = torch.tensor([0, 5, 10], dtype=torch.int32, device=device)
        seq_lens = torch.tensor([50, 60], dtype=torch.int32, device=device)
        
        metadata = CommonAttentionMetadata(
            query_start_loc=query_start_loc,
            query_start_loc_cpu=query_start_loc.cpu(),
            seq_lens=seq_lens,
            _seq_lens_cpu=seq_lens.cpu(),
            num_reqs=batch_size,
            num_actual_tokens=num_tokens,
            max_query_len=5,
            max_seq_len=60,
            block_table_tensor=torch.zeros(
                (batch_size, 4), dtype=torch.int32, device=device
            ),
            slot_mapping=torch.zeros(num_tokens, dtype=torch.int64, device=device),
            causal=True,
   
            dcp_local_seq_lens=None,
            dcp_local_seq_lens_cpu=None,
        )

        assert metadata.dcp_local_seq_lens is None
        assert metadata.dcp_local_seq_lens_cpu is None

    def test_dcp_local_seq_lens_on_the_fly_computation(self):
        seq_lens_cpu = torch.tensor([100, 200, 150], dtype=torch.int32)
        dcp_world_size = 2
        dcp_rank = 0
        dcp_local_block_size = 1

        dcp_local_seq_lens_cpu = None
        dcp_local_seq_lens = None

        if dcp_world_size > 1:
            if dcp_local_seq_lens_cpu is None:
                dcp_local_seq_lens_cpu = get_dcp_local_seq_lens(
                    seq_lens_cpu,
                    dcp_world_size,
                    dcp_rank,
                    dcp_local_block_size,
                )
            if dcp_local_seq_lens is None:
                dcp_local_seq_lens = dcp_local_seq_lens_cpu.to(
                    seq_lens_cpu.device, non_blocking=True
                )

        assert dcp_local_seq_lens_cpu is not None
        assert dcp_local_seq_lens is not None
        assert dcp_local_seq_lens_cpu.shape == seq_lens_cpu.shape
        assert dcp_local_seq_lens.shape == seq_lens_cpu.shape

    def test_dcp_local_seq_lens_not_recomputed_if_provided(self):
        seq_lens_cpu = torch.tensor([100, 200], dtype=torch.int32)
        dcp_world_size = 2
        dcp_rank = 0
        dcp_local_block_size = 1

        precomputed = torch.tensor([50, 100], dtype=torch.int32)
        dcp_local_seq_lens_cpu = precomputed
        dcp_local_seq_lens = precomputed.clone()

        if dcp_world_size > 1:
            if dcp_local_seq_lens_cpu is None:
                dcp_local_seq_lens_cpu = get_dcp_local_seq_lens(
                    seq_lens_cpu,
                    dcp_world_size,
                    dcp_rank,
                    dcp_local_block_size,
                )
            if dcp_local_seq_lens is None:
                dcp_local_seq_lens = dcp_local_seq_lens_cpu.to(
                    seq_lens_cpu.device, non_blocking=True
                )

        assert torch.equal(dcp_local_seq_lens_cpu, precomputed)


if __name__ == "__main__":
    pytest.main([__file__, "-v"])
 ```

## Test Result

```bash
# pytest tests/v1/attention/test_mla_dcp_fix.py -v
/root/vllm/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
============================================================================================================================= test session starts ==============================================================================================================================
platform linux -- Python 3.12.12, pytest-8.3.5, pluggy-1.5.0 -- /root/vllm/.venv/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/root/vllm/.hypothesis/examples'))
rootdir: /root/vllm
configfile: pyproject.toml
plugins: schemathesis-3.39.15, timeout-2.3.1, hydra-core-1.3.2, hypothesis-6.131.0, buildkite-test-collector-0.1.9, mock-3.14.0, rerunfailures-14.0, anyio-4.6.2.post1, forked-1.6.0, shard-0.1.2, asyncio-0.24.0, cov-6.3.0, subtests-0.14.1
asyncio: mode=Mode.STRICT, default_loop_scope=None
collected 5 items
Running 5 items in this shard: tests/v1/attention/test_mla_dcp_fix.py::TestDCPLocalSeqLensComputation::test_get_dcp_local_seq_lens_basic, tests/v1/attention/test_mla_dcp_fix.py::TestDCPLocalSeqLensComputation::test_get_dcp_local_seq_lens_with_interleave, tests/v1/attention/test_mla_dcp_fix.py::TestDCPLocalSeqLensComputation::test_common_attn_metadata_with_none_dcp_fields, tests/v1/attention/test_mla_dcp_fix.py::TestDCPLocalSeqLensComputation::test_dcp_local_seq_lens_on_the_fly_computation, tests/v1/attention/test_mla_dcp_fix.py::TestDCPLocalSeqLensComputation::test_dcp_local_seq_lens_not_recomputed_if_provided

tests/v1/attention/test_mla_dcp_fix.py::TestDCPLocalSeqLensComputation::test_get_dcp_local_seq_lens_basic PASSED                                                                                                                                                         [ 20%]
tests/v1/attention/test_mla_dcp_fix.py::TestDCPLocalSeqLensComputation::test_get_dcp_local_seq_lens_with_interleave PASSED                                                                                                                                               [ 40%]
tests/v1/attention/test_mla_dcp_fix.py::TestDCPLocalSeqLensComputation::test_common_attn_metadata_with_none_dcp_fields PASSED                                                                                                                                            [ 60%]
tests/v1/attention/test_mla_dcp_fix.py::TestDCPLocalSeqLensComputation::test_dcp_local_seq_lens_on_the_fly_computation PASSED                                                                                                                                            [ 80%]
tests/v1/attention/test_mla_dcp_fix.py::TestDCPLocalSeqLensComputation::test_dcp_local_seq_lens_not_recomputed_if_provided PASSED                                                                                                                                        [100%]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Ensures DCP sequence length metadata is always available when DCP is enabled, including CUDA graph capture paths.
> 
> - Compute `dcp_local_seq_lens` and `dcp_local_seq_lens_cpu` in `build_attn_metadata` and attach to `CommonAttentionMetadata`
> - Propagate DCP settings via `capture_graph`/`prepare_inputs_to_capture` and into `build_attn_metadata`
> - In `MLACommonMetadataBuilder.build`, assert presence of CPU lens, materialize GPU `dcp_local_seq_lens` if missing, switch decode to local seq lens, and cap `max_seq_len` post-DCP distribution
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70ec67030d7d709e93e576eb8c4912e54c0c919b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures DCP seq-len metadata is always present and correctly used in MLA, including CUDA graph capture paths.
> 
> - Compute and attach `dcp_local_seq_lens` and `dcp_local_seq_lens_cpu` in `build_attn_metadata`
> - In MLA decode build: assert CPU lens when DCP enabled, materialize GPU `dcp_local_seq_lens` if missing, switch to local seq lens, and cap `max_seq_len` post DCP distribution
> - Propagate DCP params (`world_size`, `rank`, `cp_kv_cache_interleave_size`) through CUDA graph capture (`capture_graph`/`prepare_inputs_to_capture`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b6474fecd53a9f29f68c85284897569aefd6913. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
