### PR TITLE
[NVIDIA] Add env var to override FlashInfer FP8 BMM

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -213,6 +213,7 @@ if TYPE_CHECKING:
     VLLM_USE_TRTLLM_ATTENTION: str | None = None
     VLLM_NVFP4_GEMM_BACKEND: str | None = None
     VLLM_FLASHINFER_DISABLE_Q_QUANTIZATION: bool = False
+    VLLM_FLASHINFER_FP8_BACKEND: str | None = None
     VLLM_HAS_FLASHINFER_CUBIN: bool = False
     VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: bool = False
     VLLM_USE_FLASHINFER_MOE_MXFP4_BF16: bool = False
@@ -1402,6 +1403,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set to 1, when we use fp8 kv, we do not quantize Q to fp8
     "VLLM_FLASHINFER_DISABLE_Q_QUANTIZATION": lambda: bool(
         int(os.getenv("VLLM_FLASHINFER_DISABLE_Q_QUANTIZATION", "0"))
+    ),
+    # Override the backend used for FlashInfer FP8 BMM operations.
+    # Supported options: "auto", "cutlass", "cudnn", "trtllm"
+    # If not set, defaults to "auto" which lets FlashInfer choose.
+    "VLLM_FLASHINFER_FP8_BACKEND": lambda: os.getenv(
+        "VLLM_FLASHINFER_FP8_BACKEND", None
     ),
     # If set, it means we pre-downloaded cubin files and flashinfer will
     # read the cubin files directly.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1407,8 +1407,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Override the backend used for FlashInfer FP8 BMM operations.
     # Supported options: "auto", "cutlass", "cudnn", "trtllm"
     # If not set, defaults to "auto" which lets FlashInfer choose.
-    "VLLM_FLASHINFER_FP8_BACKEND": lambda: os.getenv(
-        "VLLM_FLASHINFER_FP8_BACKEND", None
+    "VLLM_FLASHINFER_FP8_BACKEND": env_with_choices(
+        "VLLM_FLASHINFER_FP8_BACKEND",
+        None,
+        ["auto", "cutlass", "cudnn", "trtllm"],
     ),
     # If set, it means we pre-downloaded cubin files and flashinfer will
     # read the cubin files directly.

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -463,7 +463,9 @@ if has_flashinfer():
     ) -> torch.Tensor:
         from flashinfer import bmm_fp8 as bmm_fp8_
 
-        return bmm_fp8_(A, B, A_scale, B_scale, dtype, None, backend)
+        # Use env var override if set, otherwise use the passed backend
+        effective_backend = envs.VLLM_FLASHINFER_FP8_BACKEND or backend
+        return bmm_fp8_(A, B, A_scale, B_scale, dtype, None, effective_backend)
 
     @torch.library.register_fake(
         "vllm::bmm_fp8",
@@ -532,7 +534,7 @@ def flashinfer_scaled_fp8_mm(
         scale_a,
         scale_b,
         out_dtype,
-        "auto",
+        envs.VLLM_FLASHINFER_FP8_BACKEND or "auto",
     ).view(a.shape[0], b.shape[1])
 
     if bias is not None:


### PR DESCRIPTION
## Purpose

Add `VLLM_FLASHINFER_FP8_BACKEND` environment variable to override the backend used for FlashInfer FP8 BMM operations
Supported options: `"auto", "cutlass", "cudnn", "trtllm"`
When not set, defaults to "auto" which lets FlashInfer choose the backend automatically.


