### PR TITLE
[Bugfix][Hardware][AMD] Fix hardcoded device in MLA sparse attention

### DIFF
--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -43,10 +43,10 @@ def fp8_mqa_logits_torch(
     q = q.to(torch.bfloat16)
 
     mask_lo = (
-        torch.arange(0, seq_len_kv, device="cuda")[None, :] >= cu_seqlen_ks[:, None]
+        torch.arange(0, seq_len_kv, device=q.device)[None, :] >= cu_seqlen_ks[:, None]
     )
     mask_hi = (
-        torch.arange(0, seq_len_kv, device="cuda")[None, :] < cu_seqlen_ke[:, None]
+        torch.arange(0, seq_len_kv, device=q.device)[None, :] < cu_seqlen_ke[:, None]
     )
     mask = mask_lo & mask_hi
 
@@ -124,7 +124,7 @@ def fp8_paged_mqa_logits_torch(
     context_lens = context_lens.tolist()
     for i in range(batch_size):
         context_len = context_lens[i]
-        q_offsets = torch.arange(context_len - next_n, context_len, device="cuda")
+        q_offsets = torch.arange(context_len - next_n, context_len, device=q.device)
         weight_slice = (
             weights[i * next_n : (i + 1) * next_n, :].transpose(0, 1).contiguous()
         )
@@ -132,7 +132,7 @@ def fp8_paged_mqa_logits_torch(
             block_idx = block_tables[i][block_rk]
             qx, kx = q[i], kv_cache[block_idx]
             k_offsets = torch.arange(
-                block_rk * block_size, (block_rk + 1) * block_size, device="cuda"
+                block_rk * block_size, (block_rk + 1) * block_size, device=q.device
             )
             mask = (k_offsets[None, :] < context_len) & (
                 k_offsets[None, :] <= q_offsets[:, None]
@@ -191,7 +191,7 @@ def rocm_fp8_paged_mqa_logits(
         out_qk = torch.full(
             (heads, batch_size * next_n, max_model_len),
             float("-inf"),
-            device="cuda",
+            device=q_fp8.device,
             dtype=torch.float32,
         )
         deepgemm_fp8_paged_mqa_logits_stage1(


### PR DESCRIPTION
## Summary

Replace hardcoded `device="cuda"` with input tensor device (`q.device` or `q_fp8.device`) in `rocm_aiter_mla_sparse.py` for consistency and to avoid potential device mismatch errors.

## Changes

Fixed 5 instances of hardcoded `device="cuda"`:

| Location | Function | Fix |
|----------|----------|-----|
| Line 46 | `fp8_mqa_logits_torch` | `device=q.device` |
| Line 49 | `fp8_mqa_logits_torch` | `device=q.device` |
| Line 127 | `fp8_paged_mqa_logits_torch` | `device=q.device` |
| Line 135 | `fp8_paged_mqa_logits_torch` | `device=q.device` |
| Line 194 | `rocm_fp8_paged_mqa_logits` | `device=q_fp8.device` |

This aligns with the existing pattern at line 121 which correctly uses `device=q.device`.

## Test Plan

- [ ] Verify MLA sparse attention ops work correctly with the device fix
- [ ] No functional change expected, only device consistency improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

> [!NOTE]
> Ensures MLA sparse attention ops respect the input tensor device instead of assuming CUDA.
> 
> - In `fp8_mqa_logits_torch`, masks now use `torch.arange(..., device=q.device)`
> - In `fp8_paged_mqa_logits_torch`, `q_offsets` and `k_offsets` use `device=q.device`
> - In `rocm_fp8_paged_mqa_logits`, `out_qk` is allocated on `q_fp8.device`
> 
> Reduces device-mismatch risk on ROCm/AMD without functional changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3b7e26a8e0cb7cd271f31f0adaa7ebe252f8716. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
