### PR TITLE
[AMD][CI] fix v1/engine test_preprocess_error_handling

### DIFF
--- a/tests/v1/engine/test_preprocess_error_handling.py
+++ b/tests/v1/engine/test_preprocess_error_handling.py
@@ -5,6 +5,7 @@ import pytest
 import torch.cuda
 
 from vllm import LLM, SamplingParams
+from vllm.platforms import current_platform
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.core import EngineCore
 
@@ -13,6 +14,11 @@ MODEL_NAME = "hmellor/tiny-random-LlamaForCausalLM"
 
 def test_preprocess_error_handling(monkeypatch: pytest.MonkeyPatch):
     """Test that preprocessing errors are handled gracefully."""
+
+    if current_platform.is_rocm():
+        pytest.skip(
+            "Skipped on ROCm: this test only works with 'fork', but ROCm uses 'spawn'."
+        )
 
     assert not torch.cuda.is_initialized(), (
         "fork needs to be used for the engine "


### PR DESCRIPTION
This PR skips `v1/engine/test_preprocess_error_handling.py` on ROCm. The test relies on `fork` multiprocessing whereas ROCm uses `spawn`