### PR TITLE
[ci] Fix Pytorch compilation test oom in 2.10

### DIFF
--- a/tests/compile/test_dynamic_shapes_compilation.py
+++ b/tests/compile/test_dynamic_shapes_compilation.py
@@ -77,6 +77,7 @@ def test_dynamic_shapes_compilation(
                 "evaluate_guards": evaluate_guards,
             },
         },
+        max_model_len=1024,
     )
 
     output = model.generate(prompt)


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/171096

With meta-llama/Llama-3.1-8B, max_model_len=131072 results in KV cache needing 16.00 GiB, but the CI runners only have ~20 GiB of memory, and loading the model takes up 15 GiB, resulting in an OOM. By specifying max_model_len=1024, this reduces the needed memory for KV cache to be 0.44 GB, which should hopefully fix the OOM? 

Currently the tests are not being run on CI as they are [gated by torch v2.10](https://github.com/vllm-project/vllm/blob/6d518ffbaa04d3e930b320830542b6baf49aa61c/tests/compile/test_dynamic_shapes_compilation.py#L42-L44) so this doesn't seem to be a regression in torch.