### PR TITLE
[Doc] Add tool call parser documentation for GPT-OSS models

### DIFF
--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -324,7 +324,7 @@ Supported models:
 * `openai/gpt-oss-20b`
 * `openai/gpt-oss-120b`
 
-Flags: `--tool-call-parser openai --enable-auto-tool-choice`
+Flags: `--tool-call-parser openai`
 
 ### Kimi-K2 Models (`kimi_k2`)
 

--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -317,6 +317,15 @@ Supported models:
 
 Flags: `--tool-call-parser deepseek_v31 --chat-template {see_above}`
 
+### OpenAI OSS Models ('openai`)
+
+Supported models:
+
+* `openai/gpt-oss-20b`
+* `openai/gpt-oss-120b`
+
+Flags: `--tool-call-parser openai --enable-auto-tool-choice`
+
 ### Kimi-K2 Models (`kimi_k2`)
 
 Supported models:


### PR DESCRIPTION
Adds the `openai` tool calling format docs to [the tool calling documentation](https://docs.vllm.ai/en/stable/features/tool_calling/) based on the tested instructions in the [cookbook](https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html#tool-use)

Closes #31211 