### PR TITLE
Add a support to disable Cutlass W8A8 kernels

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -126,6 +126,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_TRITON_GEMM: bool = True
     VLLM_ROCM_USE_SKINNY_GEMM: bool = True
     VLLM_ROCM_FP8_PADDING: bool = True
+    VLLM_DISABLE_CUTLASS_BLOCK_FP8: bool = False
     VLLM_ROCM_MOE_PADDING: bool = True
     VLLM_ROCM_CUSTOM_PAGED_ATTN: bool = True
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
@@ -1003,6 +1004,30 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Pad the fp8 weights to 256 bytes for ROCm
     "VLLM_ROCM_FP8_PADDING": lambda: bool(int(os.getenv("VLLM_ROCM_FP8_PADDING", "1"))),
+    # Disable CUTLASS block FP8 kernel and use Triton instead
+    # Default to disabled (1) on sm103 (Blackwell), enabled (0) otherwise
+    # Note: CUTLASS block FP8 on sm103 can cause accuracy issues, so we default
+    # to using Triton kernel which provides better numerical stability
+    "VLLM_DISABLE_CUTLASS_BLOCK_FP8": lambda: (
+        bool(
+            int(
+                os.getenv(
+                    "VLLM_DISABLE_CUTLASS_BLOCK_FP8",
+                    (
+                        lambda: (
+                            "1"
+                            if (
+                                __import__("torch").cuda.is_available()
+                                and __import__("torch").cuda.get_device_capability()
+                                == (10, 3)
+                            )
+                            else "0"
+                        )
+                    )(),
+                )
+            )
+        )
+    ),
     # Pad the weights for the moe kernel
     "VLLM_ROCM_MOE_PADDING": lambda: bool(int(os.getenv("VLLM_ROCM_MOE_PADDING", "1"))),
     # custom paged attention kernel for MI3* cards

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -250,6 +250,14 @@ class W8A8BlockFp8LinearOp:
         self.is_hopper = current_platform.is_device_capability(90)
         self.use_deep_gemm_e8m0 = is_deep_gemm_e8m0_used()
 
+        # Check environment variable to disable CUTLASS block FP8 and use Triton instead
+        # CUTLASS block FP8 on sm103 (Blackwell) can cause accuracy issues
+        if envs.VLLM_DISABLE_CUTLASS_BLOCK_FP8:
+            cutlass_block_fp8_supported = False
+            logger.info(
+                "VLLM_DISABLE_CUTLASS_BLOCK_FP8 is set, using Triton instead of CUTLASS"
+            )
+
         # Get the correct blockscale mul and input quant operations.
         # We can't use _dispatch_w8a8_blockscale_op to figure out if we want
         # to use deepgemm because we don't know the shape of weights (and


### PR DESCRIPTION
Summary: To work around the issue on GB300 for now.

Test Plan: Run the Qwen3 Coder and check gsm8k results.

Differential Revision: D89704391


