### PR TITLE
Only patch `original_max_position_embeddings` for Transformers v4

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -336,8 +336,11 @@ def patch_rope_parameters(config: PretrainedConfig) -> None:
         # Transformers v4 installed, legacy config fields may be present
         if (rope_scaling := getattr(config, "rope_scaling", None)) is not None:
             config.rope_parameters = rope_scaling
-        needs_rope_params = (rope_theta or partial_rotary_factor or ompe) is not None
-        if needs_rope_params and not getattr(config, "rope_parameters", None):
+        if (
+            rope_theta is not None
+            or partial_rotary_factor is not None
+            or ompe is not None
+        ) and not getattr(config, "rope_parameters", None):
             config.rope_parameters = {"rope_type": "default"}
         # Patch legacy fields into rope_parameters
         if rope_theta is not None:

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -313,19 +313,22 @@ def patch_rope_parameters(config: PretrainedConfig) -> None:
     rope_theta = getattr_iter(config, names, None, warn=True)
     names = ["partial_rotary_factor", "rotary_pct", "rotary_emb_fraction"]
     partial_rotary_factor = getattr_iter(config, names, None, warn=True)
+    ompe = getattr(config, "original_max_position_embeddings", None)
 
     if Version(version("transformers")) < Version("5.0.0.dev0"):
         # Transformers v4 installed, legacy config fields may be present
         if (rope_scaling := getattr(config, "rope_scaling", None)) is not None:
             config.rope_parameters = rope_scaling
-        if (
-            rope_theta is not None or partial_rotary_factor is not None
-        ) and not getattr(config, "rope_parameters", None):
+        needs_rope_params = (rope_theta or partial_rotary_factor or ompe) is not None
+        if needs_rope_params and not getattr(config, "rope_parameters", None):
             config.rope_parameters = {"rope_type": "default"}
+        # Patch legacy fields into rope_parameters
         if rope_theta is not None:
             config.rope_parameters["rope_theta"] = rope_theta
         if partial_rotary_factor is not None:
             config.rope_parameters["partial_rotary_factor"] = partial_rotary_factor
+        if ompe is not None:
+            config.rope_parameters["original_max_position_embeddings"] = ompe
     elif rope_theta is not None or getattr(config, "rope_parameters", None):
         # Transformers v5 installed
         # Patch these fields in case they used non-standard names
@@ -340,10 +343,6 @@ def patch_rope_parameters(config: PretrainedConfig) -> None:
     # No RoPE parameters to patch
     if getattr(config, "rope_parameters", None) is None:
         return
-
-    # Add original_max_position_embeddings if present
-    if ompe := getattr(config, "original_max_position_embeddings", None):
-        config.rope_parameters["original_max_position_embeddings"] = ompe
 
     # Handle nested rope_parameters in interleaved sliding attention models
     if set(config.rope_parameters.keys()).issubset(ALLOWED_LAYER_TYPES):


### PR DESCRIPTION
As of https://github.com/huggingface/transformers/pull/42513, Transformers v5 will automatically patch `original_max_position_embeddings` into `rope_parameters`.

This means that in vLLM we only need to do this for Transformers v4.