### PR TITLE
fix(core): break circular reference in Request using weakref

### DIFF
--- a/tools/pre_commit/validate_config.py
+++ b/tools/pre_commit/validate_config.py
@@ -149,11 +149,11 @@ def validate_file(file_path: str):
         print(e)
         raise SystemExit(1) from e
     else:
-        print("✅")
+        print("OK")
 
 
 def fail(message: str, node: ast.stmt):
-    raise ValueError(f"❌ line({node.lineno}): {message}")
+    raise ValueError(f"Error line({node.lineno}): {message}")
 
 
 def main():

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -3,6 +3,7 @@
 
 import enum
 import time
+import weakref
 from collections.abc import Callable, Mapping
 from functools import partial
 from typing import TYPE_CHECKING, Any, Optional
@@ -132,7 +133,9 @@ class Request:
         self.block_hashes: list[BlockHash] = []
         self.get_hash_new_full_blocks: Callable[[], list[BlockHash]] | None = None
         if block_hasher is not None:
-            self.get_hash_new_full_blocks = partial(block_hasher, self)
+            # Use weakref to avoid circular reference: Request -> partial -> Request
+            # This allows immediate reclamation by refcounting without waiting for GC.
+            self.get_hash_new_full_blocks = partial(block_hasher, weakref.proxy(self))
             self.block_hashes = self.get_hash_new_full_blocks()
 
         self.skip_reading_prefix_cache = self.get_skip_reading_prefix_cache()

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import enum
+import time
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, Optional
 


### PR DESCRIPTION
Fixes #31200.

This PR addresses a memory leak caused by a circular reference in the `Request` class initialization.
The `Request` object held a reference to `block_hasher` via `functools.partial`, which in turn held a reference back to `self`.
This cycle prevented immediate object reclamation via reference counting, relying instead on the garbage collector which may be delayed under load.

**Changes:**
- Used `weakref.proxy(self)` when binding `self` to `block_hasher` in `partial`.

**Verification:**
- Confirmed that `Request` objects are now reclaimed immediately upon deletion (refcount drops to 0) without requiring a GC collection cycle.