### PR TITLE
[Bug]: Fix port race condition in distributed initialization

### DIFF
--- a/vllm/utils/__init__.py
+++ b/vllm/utils/__init__.py
@@ -12,6 +12,11 @@ _DEPRECATED_MAPPINGS = {
     "cprofile_context": "profiling",
     # Used by lm-eval
     "get_open_port": "network_utils",
+    "get_reserved_port": "network_utils",
+    "get_reserved_ports_list": "network_utils",
+    "get_reserved_ports_as_int_list": "network_utils",
+    "release_reserved_port": "network_utils",
+    "ReservedPort": "network_utils",
 }
 
 


### PR DESCRIPTION
## Summary

Fixes #28498 - Port conflict race condition during distributed initialization.

**Problem**: When vLLM discovers free ports using `_get_open_port()`, it binds to port 0, gets the assigned port, then closes the socket - releasing the port. During the ~5 minute engine startup window, other services (like Ray) can claim those ports, causing "Address already in use" errors.

**Solution**: Implement port reservation that holds sockets open until ports are actually needed:

- Add `ReservedPort` class that keeps socket bound until `release()` is called
- Add `get_reserved_port()` and `get_reserved_ports_list()` functions
- Update `ParallelConfig` to use reserved ports for data parallel messaging
- Ports are held until `get_next_dp_init_port()` is called, minimizing the race window

## Changes

- `vllm/utils/network_utils.py`: Add `ReservedPort` class and reservation functions
- `vllm/config/parallel.py`: Use `ReservedPort` for `_data_parallel_master_port_list`
- `vllm/utils/__init__.py`: Export new functions
- `tests/utils_/test_network_utils.py`: Add 5 new tests for port reservation

## Test plan

- [x] Added unit tests for `ReservedPort` class
- [x] Added test verifying port cannot be claimed while reserved
- [x] Added test for context manager usage
- [x] Added test for `get_reserved_ports_list()`
- [ ] Manual testing with distributed configuration (2P 4D setup as in issue)