### PR TITLE
fix(models): Handle weight prefix mapping for Mamba-Codestral

### DIFF
--- a/vllm/model_executor/models/mamba2.py
+++ b/vllm/model_executor/models/mamba2.py
@@ -33,6 +33,7 @@ from vllm.sequence import IntermediateTensors
 
 from .utils import (
     AutoWeightsLoader,
+    WeightsMapper,
     is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
     make_layers,
@@ -188,6 +189,13 @@ class Mamba2Model(nn.Module):
 class Mamba2ForCausalLM(
     nn.Module, HasInnerState, IsAttentionFree, SupportsMambaPrefixCaching
 ):
+    # Mapper to handle weight name differences between HuggingFace and vLLM.
+    # Some models (e.g., Mamba-Codestral) use "model." prefix in checkpoints,
+    # but vLLM uses "backbone." for the inner model.
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={"model.": "backbone."},
+    )
+
     @classmethod
     def get_mamba_state_dtype_from_config(
         cls,
@@ -285,4 +293,4 @@ class Mamba2ForCausalLM(
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights)
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)


### PR DESCRIPTION
## Summary
- Add `WeightsMapper` to `Mamba2ForCausalLM` to handle weight name differences between HuggingFace checkpoints and vLLM's model structure
- Some models like Mamba-Codestral use `"model."` prefix in their checkpoint weight names, but vLLM uses `"backbone."` for the inner model
- This caused a `"There is no module or parameter named 'model' in Mamba2ForCausalLM"` error during weight loading

## Root Cause
The `AutoWeightsLoader` groups weights by prefix and looks for child modules with matching names. When the checkpoint has `model.layers.0...` but the module uses `backbone.layers.0...`, the loader fails to find the matching module.

## Solution
Add a `hf_to_vllm_mapper` class attribute with `orig_to_new_prefix={"model.": "backbone."}` to remap weight names before `AutoWeightsLoader` processes them. This follows the same pattern used in `nemotron_h.py` for similar weight prefix mappings.

## Test plan
- [ ] Test loading Mamba-Codestral model (mistralai/Mamba-Codestral-7B-v0.1)
- [ ] Verify existing Mamba2 models still load correctly (with "backbone." prefix)

Fixes #31108

🤖 Generated with [Claude Code](https://claude.com/claude-code)