### PR TITLE
[Bugfix][Hardware][AMD] Use cub_helpers.h in sampler.cu for ROCm namespace alias

### DIFF
--- a/csrc/moe/moe_align_sum_kernels.cu
+++ b/csrc/moe/moe_align_sum_kernels.cu
@@ -1,7 +1,8 @@
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
-#include <cub/cub.cuh>
+
+#include "../cub_helpers.h"
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/Atomic.cuh>

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
@@ -5,9 +5,14 @@
 #include <c10/core/ScalarType.h>
 #include <torch/all.h>
 #include "dispatch.h"
-#include <cub/cub.cuh>
-#include <cub/device/device_radix_sort.cuh>
-#include <cub/util_type.cuh>
+
+#include "../cub_helpers.h"
+#ifndef USE_ROCM
+  #include <cub/device/device_radix_sort.cuh>
+  #include <cub/util_type.cuh>
+#else
+// hipcub includes these via hipcub.hpp
+#endif
 #include "cutlass/numeric_size.h"
 #include "cutlass/array.h"
 

--- a/csrc/sampler.cu
+++ b/csrc/sampler.cu
@@ -3,11 +3,7 @@
 #include <torch/cuda.h>
 #include <c10/cuda/CUDAGuard.h>
 
-#ifndef USE_ROCM
-  #include <cub/cub.cuh>
-#else
-  #include <hipcub/hipcub.hpp>
-#endif
+#include "cub_helpers.h"
 
 namespace vllm {
 


### PR DESCRIPTION
## Summary

Replace direct `cub/cub.cuh` includes with `cub_helpers.h` in multiple CUDA kernel files. This provides the `namespace cub = hipcub;` alias needed for ROCm builds.

## Files Fixed

| File | CUB Usage |
|------|-----------|
| `csrc/sampler.cu` | `cub::BlockScan`, `cub::BlockRadixSort` |
| `csrc/moe/moe_align_sum_kernels.cu` | `cub::BlockScan` |
| `csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h` | `cub::DeviceRadixSort` |

## Problem

When building vLLM from source on ROCm 7.0, these files fail to compile:
```
error: use of undeclared identifier 'cub'
  using FinalSort = cub::BlockRadixSort<float, kNumThreadsPerBlock, ...>
```

The current code includes `<cub/cub.cuh>` directly but uses `cub::` namespace which doesn't exist on ROCm - only `hipcub::` is defined.

## Solution

Use `cub_helpers.h` which already provides:
```cpp
#include <hipcub/hipcub.hpp>
namespace cub = hipcub;
```

This aligns these files with other vLLM source files (e.g., `layernorm_kernels.cu`, `topk_softmax_kernels.cu`) that correctly use `cub_helpers.h` for cross-platform CUDA/ROCm compatibility.

## Test Plan

- Built vLLM from source on ROCm 7.0 (MI300X) with this fix - compilation succeeds
- No functional change on CUDA builds - `cub_helpers.h` includes `<cub/cub.cuh>` on non-ROCm platforms