### PR TITLE
[LoRA] Simplify gpt-oss w13_lora_b weight loading

### DIFF
--- a/vllm/lora/layers/fused_moe.py
+++ b/vllm/lora/layers/fused_moe.py
@@ -639,14 +639,7 @@ class FusedMoE3DWithLoRA(FusedMoEWithLoRA):
         if self._base_model == "GptOssForCausalLM":
             # For models like GPT-OSS, the weights of w1 (gate_proj) and w3 (up_proj)
             # in the interleaved order, and corresponding LoRA need to be processed.
-            w1_lora_b = w13_lora_b[:, ::2, :]
-            w3_lora_b = w13_lora_b[:, 1::2, :]
-            sliced_w1_lora_b = w1_lora_b[:, start_idx:end_idx, :]
-            sliced_w3_lora_b = w3_lora_b[:, start_idx:end_idx, :]
-
-            return torch.stack([sliced_w1_lora_b, sliced_w3_lora_b], dim=2).flatten(
-                1, 2
-            )
+            return w13_lora_b[:, start_idx * 2 : end_idx * 2, :]
         else:
             slice_size = w13_lora_b.shape[1] // 2
             w1_lora_b = w13_lora_b[:, :slice_size, :]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR simplifies gpt-oss `w13_lora_b` weight loading code.

gpt-oss `lora_b` weights is in interleaved layout `[w1_0, w3_0, w1_1, w3_1, ...]`. The current `_slice_w13_b` code do de-interleaving, slicing, and re-interleaving. But the code can be simplified by directly returning a contiguous slice of the original interleaved dimension.

Below is a short example of the original code:

```
>>> start_idx = 0
>>> end_idx = 2
>>> w13_lora_b = torch.tensor([[[11], [21], [12], [22], [13], [23], [14], [24]]]) # shape [num_experts, output_size, rank]
>>> print(w13_lora_b)
tensor([[[11],
         [21],
         [12],
         [22],
         [13],
         [23],
         [14],
         [24]]])
>>> 
>>> w1_lora_b = w13_lora_b[:, ::2, :] # even positions
>>> print(w1_lora_b)
tensor([[[11],
         [12],
         [13],
         [14]]])
>>> 
>>> w3_lora_b = w13_lora_b[:, 1::2, :] # odd positions
>>> print(w3_lora_b)
tensor([[[21],
         [22],
         [23],
         [24]]])
>>> 
>>> sliced_w1_lora_b = w1_lora_b[:, start_idx:end_idx, :]
>>> print(sliced_w1_lora_b)
tensor([[[11],
         [12]]])
>>> 
>>> sliced_w3_lora_b = w3_lora_b[:, start_idx:end_idx, :]
>>> print(sliced_w3_lora_b)
tensor([[[21],
         [22]]])
>>> 
>>> out = torch.stack([sliced_w1_lora_b, sliced_w3_lora_b], dim=2) # shape [num_experts, output_size / 2, 2, rank]
>>> print(out)
tensor([[[[11],
          [21]],

         [[12],
          [22]]]])
>>> 
>>> out = out.flatten(1, 2) # shape [num_experts, output_size, rank]
>>> print(out)
tensor([[[11],
         [21],
         [12],
         [22]]])
```

From above we can see `torch.stack(dim=2)` actually re-interleaves the tensor because it inserts a new dimension at dim=2 in the following layout:

```
out[e, o, 0, r] = sliced_w1_lora_b[e, o, r]
out[e, o, 1, r] = sliced_w3_lora_b[e, o, r]
```

So this code can be simplified as directly returning a contiguous slice of the original interleaved dimension:

```
>>> out = w13_lora_b[:, start_idx * 2 : end_idx * 2, :]
>>> print(out)
tensor([[[11],
         [21],
         [12],
         [22]]])
```

## Test Plan

```
pytest -s -v tests/lora/test_gptoss_tp.py
```
## Test Result

Tests passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

