### PR TITLE
[bugfix] add hasattr check for drafter in _build_attention_metadata with PP

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1710,7 +1710,11 @@ class GPUModelRunner(
                     _get_block_table_and_slot_mapping(kv_cache_gid)
                 )
 
-            if self.speculative_config and spec_decode_common_attn_metadata is None:
+            if (
+                self.speculative_config
+                and spec_decode_common_attn_metadata is None
+                and hasattr(self, "drafter")
+            ):
                 if isinstance(self.drafter, EagleProposer):
                     if self.drafter.attn_layer_names[0] in kv_cache_group.layer_names:
                         spec_decode_common_attn_metadata = cm


### PR DESCRIPTION
# PR Description

## Summary

Fix `AttributeError: 'GPUModelRunner' object has no attribute 'drafter'` when using speculative decoding with pipeline parallelism.

## Problem

As [issue#30436](https://github.com/vllm-project/vllm/issues/30436) described,

When running vLLM with:
- Speculative decoding enabled (e.g., `--speculative-config '{"method":"ngram", ...}'`)
- Pipeline parallelism > 1 (e.g., `--pipeline-parallel-size 2`)

The server crashes with the following error on the second request:

```
AttributeError: 'GPUModelRunner' object has no attribute 'drafter'
  File "vllm/v1/worker/gpu_model_runner.py", line 1714, in _build_attention_metadata
    if isinstance(self.drafter, EagleProposer):
```

## Root Cause

The `drafter` attribute is intentionally only initialized on the **last PP rank** (as noted in the code comment):

```python
# NOTE(Jiayi): currently we put the entire draft model on
# the last PP rank. This is not ideal if there are many
# layers in the draft model.
if self.speculative_config and get_pp_group().is_last_rank:
    self.drafter = ...
```

However, in `_build_attention_metadata`, the code only checks for `self.speculative_config` before accessing `self.drafter`:

```python
if self.speculative_config and spec_decode_common_attn_metadata is None:
    if isinstance(self.drafter, EagleProposer):  # ❌ Crashes on non-last PP ranks
```

This causes workers on non-last PP ranks to crash when they have `speculative_config` but no `drafter` attribute.

## Solution

Add a `hasattr(self, "drafter")` check before accessing the `drafter` attribute, which is consistent with other places in the codebase (e.g., line 3659, 3737):

```python
if (self.speculative_config
        and spec_decode_common_attn_metadata is None
        and hasattr(self, "drafter")):
    if isinstance(self.drafter, EagleProposer):
        if (self.drafter.attn_layer_names[0]
                in kv_cache_group.layer_names):
            spec_decode_common_attn_metadata = cm
    else:
        spec_decode_common_attn_metadata = cm
```

## Test

Tested with:
```bash
vllm serve Qwen3-14B \
    --tensor-parallel-size 2 \
    --pipeline-parallel-size 2 \
    --speculative-config '{"method":"ngram", "num_speculative_tokens": 5, "prompt_lookup_max": 4}' \
    --reasoning-parser deepseek_r1
```

Verified that streaming and non-streaming requests now work correctly without crashing.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Consistent with existing code patterns (`hasattr` check for `drafter`)
- [x] No new dependencies introduced

