### PR TITLE
Fix skip_tokenizer_init=True crash for multimodal models

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1050,3 +1050,13 @@ def test_scheduler_config_init():
     with pytest.raises(AttributeError):
         # InitVar does not become an attribute
         print(SchedulerConfig.default_factory().max_model_len)
+
+
+def test_skip_tokenizer_init_multimodal_not_allowed():
+    """Test that skip_tokenizer_init=True is not allowed for multimodal models."""
+    with pytest.raises(ValueError, match="skip_tokenizer_init=True is not supported"):
+        ModelConfig(
+            "Qwen/Qwen2-VL-2B-Instruct",
+            skip_tokenizer_init=True,
+        )
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1059,4 +1059,3 @@ def test_skip_tokenizer_init_multimodal_not_allowed():
             "Qwen/Qwen2-VL-2B-Instruct",
             skip_tokenizer_init=True,
         )
-

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -588,6 +588,14 @@ class ModelConfig:
                 "repo name or path using the --tokenizer argument."
             )
 
+        # Multimodal models require tokenizer for processor initialization
+        if self.skip_tokenizer_init and self.is_multimodal_model:
+            raise ValueError(
+                "skip_tokenizer_init=True is not supported for multimodal "
+                "models. Multimodal models require a tokenizer to initialize "
+                "their processor. Please set skip_tokenizer_init=False."
+            )
+
         if self.disable_sliding_window:
             # Set after get_and_verify_max_len to ensure that max_model_len
             # can be correctly capped to sliding window size


### PR DESCRIPTION
## Summary
- Add validation to prevent `skip_tokenizer_init=True` with multimodal models
- Multimodal models require tokenizer for processor initialization
- Provides clear error message guiding users to set `skip_tokenizer_init=False`

Fixes #31123

## Test plan
- Added test case `test_skip_tokenizer_init_multimodal_not_allowed`
- Verified validation raises `ValueError` with descriptive message

Signed-off-by: majiayu000 <1835304752@qq.com>