### PR TITLE
fix(v1): Break circular reference in Request class to prevent memory leak

### DIFF
--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -3,6 +3,7 @@
 
 import enum
 import time
+import weakref
 from collections.abc import Callable, Mapping
 from functools import partial
 from typing import TYPE_CHECKING, Any, Optional
@@ -132,7 +133,9 @@ class Request:
         self.block_hashes: list[BlockHash] = []
         self.get_hash_new_full_blocks: Callable[[], list[BlockHash]] | None = None
         if block_hasher is not None:
-            self.get_hash_new_full_blocks = partial(block_hasher, self)
+            # Use weakref.proxy to avoid circular reference between Request
+            # and block_hasher, which could cause memory leaks.
+            self.get_hash_new_full_blocks = partial(block_hasher, weakref.proxy(self))
             self.block_hashes = self.get_hash_new_full_blocks()
 
         self.skip_reading_prefix_cache = self.get_skip_reading_prefix_cache()


### PR DESCRIPTION
## Summary
- Use `weakref.proxy(self)` instead of `self` when creating the partial function for `block_hasher`
- This breaks a circular reference that prevented proper garbage collection of `Request` objects

## Root Cause
The `Request` class creates a circular reference at initialization:

```python
# Before (circular reference)
self.get_hash_new_full_blocks = partial(block_hasher, self)
```

This creates a cycle:
- `Request` → `get_hash_new_full_blocks` (partial function)
- `partial function` → `Request` (via the bound `self` argument)

Python's garbage collector can handle cycles, but the leak becomes significant with multimodal models where `Request.mm_features` holds `MultiModalFeatureSpec` objects containing large tensors (image_pixels).

**Leak chain:** `block_hasher` → `MultiModalFeatureSpec` → `MultiModalKwargsItem` → `MultiModalFieldElem` → `image_pixels (Tensor)`

## Solution
```python
# After (no circular reference)
self.get_hash_new_full_blocks = partial(block_hasher, weakref.proxy(self))
```

Using `weakref.proxy(self)` allows the `Request` to be garbage collected when there are no other strong references, breaking the cycle.

## Test plan
- [x] Code review for correctness
- [ ] Run with multimodal model and monitor memory usage
- [ ] Verify prefix caching still works correctly

Fixes #31200

🤖 Generated with [Claude Code](https://claude.com/claude-code)