### PR TITLE
[Doc] Add GPT-OSS (openai) tool parser documentation

### DIFF
--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -396,6 +396,24 @@ Supported models:
 
 Flags: `--tool-call-parser gigachat3`
 
+### GPT-OSS Models (`openai`)
+
+OpenAI's GPT-OSS models use a special token-based format (Harmony format) for tool calling that is parsed using the `openai` tool parser.
+
+Supported models:
+
+* `openai/gpt-oss-120b`
+* `openai/gpt-oss-20b`
+
+Known limitations:
+
+* Only `tool_choice='auto'` is currently supported
+* Streaming tool calls have limited support
+
+Flags: `--tool-call-parser openai --enable-auto-tool-choice`
+
+For more detailed examples and usage patterns, see the [GPT-OSS cookbook](https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html).
+
 ### Models with Pythonic Tool Calls (`pythonic`)
 
 A growing number of models output a python list to represent tool calls instead of using JSON. This has the advantage of inherently supporting parallel tool calls and removing ambiguity around the JSON schema required for tool calls. The `pythonic` tool parser can support such models.


### PR DESCRIPTION
## Summary

Adds documentation for the `openai` tool call parser that supports GPT-OSS models. This parser was previously only documented in the cookbook but was missing from the main tool calling documentation.

Fixes #31211

## Changes

Added a new section in `docs/features/tool_calling.md` for GPT-OSS models that includes:
- Supported models (`openai/gpt-oss-120b`, `openai/gpt-oss-20b`)
- Known limitations (only `tool_choice='auto'`, limited streaming support)
- Required flags (`--tool-call-parser openai --enable-auto-tool-choice`)
- Link to the cookbook for more examples

## Test plan

- [x] Documentation builds correctly (no broken links)
- [ ] ReadTheDocs preview shows the new section correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)