### PR TITLE
[Bugfix] Preserve original tokenizer class name for transformers compatibility

### DIFF
--- a/vllm/tokenizers/hf.py
+++ b/vllm/tokenizers/hf.py
@@ -58,7 +58,9 @@ def get_cached_tokenizer(tokenizer: HfTokenizer) -> HfTokenizer:
         def __reduce__(self):
             return get_cached_tokenizer, (tokenizer,)
 
-    CachedTokenizer.__name__ = f"Cached{tokenizer.__class__.__name__}"
+    # Preserve original class name for HuggingFace compatibility.
+    # Some processors validate tokenizer type by checking __name__.
+    CachedTokenizer.__name__ = tokenizer.__class__.__name__
 
     cached_tokenizer.__class__ = CachedTokenizer
     return cached_tokenizer


### PR DESCRIPTION
## Summary

Fixes TypeError when using cached tokenizers with HuggingFace processors that perform class name validation.

Fixes #31080

## Problem

When vLLM wraps a tokenizer with caching (e.g., `Qwen2TokenizerFast` → `CachedQwen2TokenizerFast`), the class name is changed. This causes `transformers.ProcessorMixin.check_argument_for_proper_class` to reject the tokenizer:

```
TypeError: Received a CachedQwen2TokenizerFast for argument tokenizer, 
but a ('Qwen2Tokenizer', 'Qwen2TokenizerFast') was expected.
```

## Solution

Remove the line that renames the `CachedTokenizer` class. The cached tokenizer:
- Still inherits from the original tokenizer class (maintains `isinstance()` compatibility)
- Now keeps the original class name (passes class name checks in transformers)

## Changes

- Removed: `CachedTokenizer.__name__ = f"Cached{tokenizer.__class__.__name__}"`
- Added comment explaining why we preserve the original class name

## Test plan

- [x] Linting passes
- [ ] Multimodal models with cached tokenizers should work with HuggingFace processors

🤖 Generated with [Claude Code](https://claude.com/claude-code)