### PR TITLE
[Bugfix] Correct misleading warning message in Ray executor

### DIFF
--- a/vllm/v1/executor/ray_utils.py
+++ b/vllm/v1/executor/ray_utils.py
@@ -329,14 +329,15 @@ def initialize_ray_cluster(
         available_gpus = cuda_device_count_stateless()
         if parallel_config.world_size > available_gpus:
             logger.warning(
-                "Tensor parallel size (%d) exceeds available GPUs (%d). "
-                "This may result in Ray placement group allocation failures. "
-                "Consider reducing tensor_parallel_size to %d or less, "
-                "or ensure your Ray cluster has %d GPUs available.",
+                "Total GPU requirement (world_size=%d) exceeds locally "
+                "visible GPUs (%d). For multi-node Ray clusters, this may be "
+                "expected if the total cluster has enough GPUs. "
+                "If running single-node, consider reducing "
+                "tensor_parallel_size (%d) or pipeline_parallel_size (%d).",
                 parallel_config.world_size,
                 available_gpus,
-                available_gpus,
-                parallel_config.world_size,
+                parallel_config.tensor_parallel_size,
+                parallel_config.pipeline_parallel_size,
             )
 
     if ray.is_initialized():


### PR DESCRIPTION
## Summary

Fixes the incorrect and misleading warning message in `ray_utils.py` when using Ray with multi-node/pipeline parallel configurations.

Fixes #31005

## Problem

The original warning message:
```
Tensor parallel size (16) exceeds available GPUs (8).
This may result in Ray placement group allocation failures.
Consider reducing tensor_parallel_size to 8 or less,
or ensure your Ray cluster has 16 GPUs available.
```

Issues:
1. Says "Tensor parallel size" but shows `world_size` (TP × PP × PCP)
2. "available GPUs" is local GPU count, not Ray cluster total
3. Misleading for valid multi-node configurations

## Solution

Updated warning message:
```
Total GPU requirement (world_size=16) exceeds locally visible GPUs (8).
For multi-node Ray clusters, this may be expected if the total cluster
has enough GPUs. If running single-node, consider reducing
tensor_parallel_size (8) or pipeline_parallel_size (2).
```

Changes:
- Correctly identifies `world_size` as total GPU requirement
- Clarifies GPU count is local, not cluster-wide
- Notes multi-node clusters may legitimately exceed local count
- Shows actual TP and PP values for actionable advice

## Test plan

- [x] Linting passes
- [ ] Message correctly displays with multi-node Ray configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)