### PR TITLE
fix: handle None tokenizer in multimodal processor initialization

### DIFF
--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -1046,10 +1046,19 @@ class InputProcessingContext:
 
             typ = ProcessorMixin
 
+        # Only pass tokenizer if not None to allow the processor to
+        # load its own tokenizer from the model path when skip_tokenizer_init
+        # is True. Passing tokenizer=None would override the processor's
+        # tokenizer loading and cause crashes in multimodal models that
+        # require a tokenizer during processor initialization.
+        tokenizer_kwargs = {}
+        if self.tokenizer is not None:
+            tokenizer_kwargs["tokenizer"] = self.tokenizer
+
         return cached_processor_from_config(
             self.model_config,
             processor_cls=typ,
-            tokenizer=self.tokenizer,
+            **tokenizer_kwargs,
             **kwargs,
         )
 


### PR DESCRIPTION
## Summary

When `skip_tokenizer_init=True` is set, the tokenizer is `None`. Previously, this `None` value was unconditionally passed to the processor, which overrode the processor's ability to load its own tokenizer from the model path. This caused crashes in multimodal models like `gemma-3` that require a tokenizer during processor initialization.

**Root cause**: In `get_hf_processor()`, the tokenizer was always passed via `tokenizer=self.tokenizer`, even when `self.tokenizer` is `None`. This `None` value then gets propagated to `AutoProcessor.from_pretrained()`, which passes it to the processor constructor (e.g., `Gemma3Processor.__init__`), overriding the tokenizer that would normally be loaded from the model path.

**Fix**: Only pass the `tokenizer` kwarg when it's not `None`, allowing the processor to load its own tokenizer from the model path when `skip_tokenizer_init=True`.

## Error before fix

```python
vllm.LLM("google/gemma-3-27b-it", skip_tokenizer_init=True)
```

```
AttributeError: 'NoneType' object has no attribute 'image_token_id'
```

The error occurred because `Gemma3Processor.__init__` tried to access `tokenizer.image_token_id` on a `None` tokenizer.

## Test plan

- [ ] Verify `vllm.LLM("google/gemma-3-27b-it", skip_tokenizer_init=True)` no longer crashes
- [ ] Verify normal multimodal model loading still works (tokenizer passed correctly when not None)

Fixes #31123