### PR TITLE
fix(config): validate skip_tokenizer_init is not used with multimodal models

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -588,6 +588,19 @@ class ModelConfig:
                 "repo name or path using the --tokenizer argument."
             )
 
+        # Multimodal models require a tokenizer for processor initialization
+        # unless embedded inputs are enabled (enable_mm_embeds=True)
+        if self.skip_tokenizer_init and self.is_multimodal_model:
+            mm_config = getattr(self, "multimodal_config", None)
+            if mm_config is None or not mm_config.enable_mm_embeds:
+                raise ValueError(
+                    "Multimodal models require a tokenizer for processing. "
+                    "Please set skip_tokenizer_init=False when using multimodal "
+                    f"models like {self.model}. Alternatively, enable embedded "
+                    "inputs with enable_mm_embeds=True if your inputs are "
+                    "pre-embedded."
+                )
+
         if self.disable_sliding_window:
             # Set after get_and_verify_max_len to ensure that max_model_len
             # can be correctly capped to sliding window size


### PR DESCRIPTION
## Summary

Fixes #31123

Add early validation to detect when `skip_tokenizer_init=True` is used with multimodal models like Gemma3. This combination is not supported because multimodal processors require a tokenizer for initialization.

### Root Cause
- Multimodal processors (e.g., `Gemma3Processor`) require a tokenizer in their constructor
- When `skip_tokenizer_init=True`, the tokenizer is `None`
- This causes `AttributeError: 'NoneType' object has no attribute 'image_token_id'` deep in transformers

### Fix
- Add validation in `ModelConfig.__init__` right after the existing GGUF multimodal check
- Provide a clear error message explaining the incompatibility

### Before
```
AttributeError: 'NoneType' object has no attribute 'image_token_id'
```

### After
```
ValueError: Multimodal models require a tokenizer for processing. 
Please set skip_tokenizer_init=False when using multimodal models like google/gemma-3-27b-it.
```

## Test plan
- [ ] Try `LLM("google/gemma-3-27b-it", skip_tokenizer_init=True)` - should get clear error
- [ ] Verify normal multimodal usage still works (without skip_tokenizer_init)
- [ ] CI checks pass