### PR TITLE
[Bugfix][Hardware][AMD] Fix uninitialized Qlocal registers in ROCm attention kernel

### DIFF
--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -1839,6 +1839,13 @@ __launch_bounds__(NUM_THREADS, 3) void paged_attention_ll4mi_QKV_mfma16_kernel(
             reinterpret_cast<const _B16x16*>(q_fetch_ptr);
         Qlocal[qkhe_depth] = *q_fetch_ptr_32B;
       }
+    } else {
+      // Zero out Qlocal for lanes that don't load Q data to prevent
+      // uninitialized register values from contaminating wmma results
+  #pragma unroll
+      for (int qkhe_depth = 0; qkhe_depth < QKHELOOP / 2; qkhe_depth++) {
+        Qlocal[qkhe_depth] = {};
+      }
     }
   } else {
     // fetch Q in shared across warps and then write to registers
@@ -2607,6 +2614,13 @@ __launch_bounds__(NUM_THREADS, 3) void paged_attention_ll4mi_QKV_mfma16_kernel(
         const _B16x8* q_fetch_ptr_16B =
             reinterpret_cast<const _B16x8*>(q_fetch_ptr);
         Qlocal[qkhe_depth] = *q_fetch_ptr_16B;
+      }
+    } else {
+      // Zero out Qlocal for lanes that don't load Q data to prevent
+      // uninitialized register values from contaminating wmma results
+  #pragma unroll
+      for (int qkhe_depth = 0; qkhe_depth < QKHELOOP; qkhe_depth++) {
+        Qlocal[qkhe_depth] = {};
       }
     }
   } else {


### PR DESCRIPTION
## Summary

Fixes uninitialized `Qlocal` register values in the ROCm PagedAttention wmma kernel that can cause numerical accuracy issues on AMD GPUs.

## The Bug

In `paged_attention_ll4_kv_kernel`, when `GQA_RATIO == 1` (non-GQA models like Llama-2), only lane 0 loads valid Q data into `Qlocal` registers. **Lanes 1-15 retain garbage values from previous GPU cycles.**

These uninitialized values then propagate into the `gcn_wmma16x16x16_instr` (Wave Matrix Multiply-Accumulate) instruction, contaminating the attention score computation.

### Affected Locations

| Location | Type | Condition | Missing |
|----------|------|-----------|---------|
| Lines 1834-1842 | `_B16x16 Qlocal` | `if (lane16id < GQA_RATIO)` | No `else` to zero |
| Lines 2610-2617 | `_B16x8 Qlocal` | `if (lane16id < GQA_RATIO)` | No `else` to zero |

### Proof: Correct Pattern Exists

The proper zero-initialization pattern already exists at lines 1067-1070:

```cpp
if (final_qhead_idx < GQA_RATIO) {
  Qlocal[QHLOOP - 1] = q_ptrh8[...];
} else {
  Qlocal[QHLOOP - 1].xy[0] = {0};  // ✅ Properly zeroed
  Qlocal[QHLOOP - 1].xy[1] = {0};  // ✅ Properly zeroed
}
```

## The Fix

Add `else` clauses to zero out `Qlocal` for lanes that don't load Q data:

```cpp
} else {
  // Zero out Qlocal for lanes that don't load Q data to prevent
  // uninitialized register values from contaminating wmma results
  #pragma unroll
  for (int qkhe_depth = 0; qkhe_depth < QKHELOOP; qkhe_depth++) {
    Qlocal[qkhe_depth] = {};
  }
}
```

## Impact

- **Affected configs:** `GQA_RATIO == 1` (non-GQA models like Llama-2)
- **Symptom:** Random numerical drift, potential NaNs in softmax
- **Root cause:** Uninitialized GPU registers containing garbage from previous kernel invocations
- **Fix ensures:** Deterministic behavior across all wave lanes in wmma operations

## Hardware Validation

Tested on AMD Instinct MI300X (gfx942) with ROCm 6.2. See related PRs for lm_eval benchmark results demonstrating functional correctness of ROCm attention paths.