### PR TITLE
[Misc] Add missing return type annotations to collection_utils and deep_gemm

### DIFF
--- a/vllm/utils/collection_utils.py
+++ b/vllm/utils/collection_utils.py
@@ -7,7 +7,14 @@ This is similar in concept to the `collections` module.
 """
 
 from collections import defaultdict
-from collections.abc import Callable, Generator, Hashable, Iterable, Mapping
+from collections.abc import (
+    Callable,
+    Generator,
+    Hashable,
+    ItemsView,
+    Iterable,
+    Mapping,
+)
 from typing import Generic, Literal, TypeVar
 
 from typing_extensions import TypeIs, assert_never
@@ -85,7 +92,9 @@ def flatten_2d_lists(lists: Iterable[Iterable[T]]) -> list[T]:
     return [item for sublist in lists for item in sublist]
 
 
-def full_groupby(values: Iterable[_V], *, key: Callable[[_V], _K]):
+def full_groupby(
+    values: Iterable[_V], *, key: Callable[[_V], _K]
+) -> ItemsView[_K, list[_V]]:
     """
     Unlike [`itertools.groupby`][], groups are not broken by
     non-contiguous data.

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -363,7 +363,7 @@ def per_block_cast_to_fp8(
     )
 
 
-def calc_diff(x: torch.Tensor, y: torch.Tensor):
+def calc_diff(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     """Return a global difference metric for unit tests.
 
     DeepGEMM kernels on Blackwell/B200 currently exhibit noticeable per-element


### PR DESCRIPTION
## Purpose

This PR adds missing return type annotations to functions in `vllm/utils/collection_utils.py` and `vllm/utils/deep_gemm.py` to improve code quality and IDE support.

## Changes

### collection_utils.py

| Function | Return Type Added |
|----------|------------------|
| `full_groupby()` | `ItemsView[_K, list[_V]]` |

### deep_gemm.py

| Function | Return Type Added |
|----------|------------------|
| `calc_diff()` | `torch.Tensor` |

## Test Plan

This is a typing-only change with no runtime impact. All existing tests should pass.