### PR TITLE
[Misc] Add missing return type annotations to lora/utils and engine/arg_utils

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -16,6 +16,7 @@ from typing import (
     Annotated,
     Any,
     Literal,
+    NoReturn,
     TypeAlias,
     TypeVar,
     Union,
@@ -2032,7 +2033,7 @@ class AsyncEngineArgs(EngineArgs):
         return parser
 
 
-def _raise_unsupported_error(feature_name: str):
+def _raise_unsupported_error(feature_name: str) -> NoReturn:
     msg = (
         f"{feature_name} is not supported. We recommend to "
         f"remove {feature_name} from your config."

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -50,7 +50,7 @@ logger = init_logger(__name__)
 _GLOBAL_LORA_ID = 0
 
 
-def get_lora_id():
+def get_lora_id() -> int:
     global _GLOBAL_LORA_ID
     _GLOBAL_LORA_ID += 1
     return _GLOBAL_LORA_ID


### PR DESCRIPTION
## Purpose

This PR adds missing return type annotations to functions in `vllm/lora/utils.py` and `vllm/engine/arg_utils.py` to improve code quality and IDE support.

## Changes

### lora/utils.py

| Function | Return Type Added |
|----------|------------------|
| `get_lora_id()` | `int` |

### engine/arg_utils.py

| Function | Return Type Added |
|----------|------------------|
| `_raise_unsupported_error()` | `NoReturn` |

## Test Plan

This is a typing-only change with no runtime impact. All existing tests should pass.