### PR TITLE
fix: correct misleading warning message for Ray TP/PP parallelism

### DIFF
--- a/vllm/v1/executor/ray_utils.py
+++ b/vllm/v1/executor/ray_utils.py
@@ -329,12 +329,14 @@ def initialize_ray_cluster(
         available_gpus = cuda_device_count_stateless()
         if parallel_config.world_size > available_gpus:
             logger.warning(
-                "Tensor parallel size (%d) exceeds available GPUs (%d). "
-                "This may result in Ray placement group allocation failures. "
-                "Consider reducing tensor_parallel_size to %d or less, "
-                "or ensure your Ray cluster has %d GPUs available.",
+                "Parallelism world size (TP=%d x PP=%d = %d) exceeds "
+                "locally available GPUs (%d). For multi-node Ray clusters, "
+                "this is expected. For single-node setups, this may result "
+                "in Ray placement group allocation failures. "
+                "Ensure your Ray cluster has at least %d GPUs available.",
+                parallel_config.tensor_parallel_size,
+                parallel_config.pipeline_parallel_size,
                 parallel_config.world_size,
-                available_gpus,
                 available_gpus,
                 parallel_config.world_size,
             )


### PR DESCRIPTION
## Summary

Fixes #31005

The warning message in `ray_utils.py` was misleading for multi-node Ray cluster configurations:

**Before:**
```
Tensor parallel size (16) exceeds available GPUs (8).
This may result in Ray placement group allocation failures.
Consider reducing tensor_parallel_size to 8 or less,
or ensure your Ray cluster has 16 GPUs available.
```

**After:**
```
Parallelism world size (TP=8 x PP=2 = 16) exceeds locally available GPUs (8).
For multi-node Ray clusters, this is expected. For single-node setups,
this may result in Ray placement group allocation failures.
Ensure your Ray cluster has at least 16 GPUs available.
```

### Changes
- Fix warning to accurately show TP, PP, and world_size separately (instead of mislabeling world_size as "tensor parallel size")
- Clarify that this warning is expected for multi-node Ray clusters
- Update guidance to focus on total cluster GPUs rather than suggesting reducing TP size

## Test plan

This is a warning message fix only - no behavioral changes. The fix can be verified by:
1. Running vLLM with Ray backend on a multi-node setup with TP=8, PP=2
2. Observing that the warning message now correctly describes the configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)