### PR TITLE
fix: add weight mapper for Mamba2 model prefix compatibility

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import InitVar, field
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal, cast, get_args
@@ -1806,7 +1806,7 @@ class ModelConfig:
         return getattr(self.hf_config, "quantization_config", None) is not None
 
 
-def get_served_model_name(model: str, served_model_name: str | list[str] | None):
+def get_served_model_name(model: str, served_model_name: str | list[str] | None) -> str:
     """
     If the input is a non-empty list, the first model_name in
     `served_model_name` is taken.
@@ -1844,7 +1844,9 @@ _SUFFIX_TO_DEFAULTS: list[tuple[str, tuple[RunnerType, ConvertType]]] = [
 ]
 
 
-def iter_architecture_defaults():
+def iter_architecture_defaults() -> Iterator[
+    tuple[str, tuple[RunnerType, ConvertType]]
+]:
     yield from _SUFFIX_TO_DEFAULTS
 
 
@@ -1877,7 +1879,7 @@ _STR_DTYPE_TO_TORCH_DTYPE = {
 }
 
 
-def str_dtype_to_torch_dtype(type: str):
+def str_dtype_to_torch_dtype(type: str) -> torch.dtype | None:
     return _STR_DTYPE_TO_TORCH_DTYPE.get(type)
 
 
@@ -1891,14 +1893,14 @@ _FLOAT16_NOT_SUPPORTED_MODELS = {
 }
 
 
-def _is_valid_dtype(model_type: str, dtype: torch.dtype):
+def _is_valid_dtype(model_type: str, dtype: torch.dtype) -> bool:
     if model_type in _FLOAT16_NOT_SUPPORTED_MODELS and dtype == torch.float16:  # noqa: E501, SIM103
         return False
 
     return True
 
 
-def _check_valid_dtype(model_type: str, dtype: torch.dtype):
+def _check_valid_dtype(model_type: str, dtype: torch.dtype) -> bool:
     if model_type in _FLOAT16_NOT_SUPPORTED_MODELS and dtype == torch.float16:
         reason = _FLOAT16_NOT_SUPPORTED_MODELS[model_type]
         raise ValueError(
@@ -1913,7 +1915,7 @@ def _find_dtype(
     config: PretrainedConfig,
     *,
     revision: str | None,
-):
+) -> torch.dtype:
     # NOTE: getattr(config, "dtype", torch.float32) is not correct
     # because config.dtype can be None.
     config_dtype = getattr(config, "dtype", None)
@@ -1953,7 +1955,7 @@ def _resolve_auto_dtype(
     config_dtype: torch.dtype,
     *,
     is_pooling_model: bool,
-):
+) -> torch.dtype:
     from vllm.platforms import current_platform
 
     supported_dtypes = [

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1393,7 +1393,7 @@ def set_current_vllm_config(
 
 
 @lru_cache(maxsize=1)
-def get_cached_compilation_config():
+def get_cached_compilation_config() -> CompilationConfig:
     """Cache config to avoid repeated calls to get_current_vllm_config()"""
     return get_current_vllm_config().compilation_config
 

--- a/vllm/model_executor/models/mamba2.py
+++ b/vllm/model_executor/models/mamba2.py
@@ -33,6 +33,7 @@ from vllm.sequence import IntermediateTensors
 
 from .utils import (
     AutoWeightsLoader,
+    WeightsMapper,
     is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
     make_layers,
@@ -284,5 +285,8 @@ class Mamba2ForCausalLM(
         return logits
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # Some Mamba2 checkpoints (e.g., mistralai/Mamba-Codestral-7B-v0.1)
+        # use "model." prefix in weight names, but vLLM uses "backbone.".
+        mapper = WeightsMapper(orig_to_new_prefix={"model.": "backbone."})
         loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights)
+        return loader.load_weights(weights, mapper=mapper)


### PR DESCRIPTION
## Summary

Fixes #31108

Some Mamba2 checkpoints (e.g., `mistralai/Mamba-Codestral-7B-v0.1`) use `"model."` prefix in their weight names, while vLLM's `Mamba2ForCausalLM` uses `"backbone."` as the module name. This caused weight loading to fail with:

```
ValueError: There is no module or parameter named 'model' in Mamba2ForCausalLM
```

### Root Cause

The HuggingFace Mamba-Codestral model weights have names like:
- `model.layers.0.mixer.in_proj.weight`
- `model.embeddings.weight`

But vLLM's Mamba2 model structure uses:
- `backbone.layers.0.mixer.in_proj.weight`
- `backbone.embeddings.weight`

### Fix

Added a `WeightsMapper` to translate `"model."` → `"backbone."` in weight names during loading. This enables compatibility with both naming schemes without breaking existing checkpoints that may already use the `backbone.` prefix.

### Changes

- Import `WeightsMapper` from `.utils`
- Add mapper in `load_weights()` method with prefix translation

## Test plan

1. Test with `mistralai/Mamba-Codestral-7B-v0.1`:
   ```python
   from vllm import LLM
   llm = LLM(model="mistralai/Mamba-Codestral-7B-v0.1", enforce_eager=True)
   ```

2. Verify model loads without errors
3. Run simple inference to confirm model works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)