### PR TITLE
[Bugfix] Fix circular reference memory leak in Request class

### DIFF
--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -3,6 +3,7 @@
 
 import enum
 import time
+import weakref
 from collections.abc import Callable, Mapping
 from functools import partial
 from typing import TYPE_CHECKING, Any, Optional
@@ -132,7 +133,10 @@ class Request:
         self.block_hashes: list[BlockHash] = []
         self.get_hash_new_full_blocks: Callable[[], list[BlockHash]] | None = None
         if block_hasher is not None:
-            self.get_hash_new_full_blocks = partial(block_hasher, self)
+            # Use weakref.proxy to avoid circular reference between Request
+            # and block_hasher. Without this, the Request would not be garbage
+            # collected promptly, causing memory leaks with large mm_features.
+            self.get_hash_new_full_blocks = partial(block_hasher, weakref.proxy(self))
             self.block_hashes = self.get_hash_new_full_blocks()
 
         self.skip_reading_prefix_cache = self.get_skip_reading_prefix_cache()


### PR DESCRIPTION
## Summary

Use `weakref.proxy()` to break the circular reference between `Request` and `block_hasher`. The previous implementation created a circular reference via `partial(block_hasher, self)`, which prevented `Request` objects from being garbage collected promptly.

**Root Cause**: The code at `vllm/v1/request.py:135`:
```python
self.get_hash_new_full_blocks = partial(block_hasher, self)
```
creates a circular reference because:
- `Request` holds `get_hash_new_full_blocks` (a partial)
- The partial holds a strong reference back to `self` (the Request)

This is particularly problematic for multimodal requests where `mm_features` contains large tensor data. The leak trace:
```
block_hasher -> Request -> mm_features -> MultiModalKwargsItem -> image_pixels(Tensor)
```

**Fix**: Replace `self` with `weakref.proxy(self)`:
```python
self.get_hash_new_full_blocks = partial(block_hasher, weakref.proxy(self))
```

This allows the `Request` to be garbage collected when there are no other strong references, freeing the large multimodal tensors promptly.

## Safety Analysis

Using `weakref.proxy()` is safe here because:
1. `get_hash_new_full_blocks()` is only called from within the `Request` itself:
   - During `__init__` (line 142)
   - In `append_output_token_ids()` (line 175)
2. These are instance methods, so `self` is always alive when they're called
3. If the `Request` is garbage collected, the partial callback would never be invoked anyway

## Test plan

- [x] Code review confirms the fix addresses the circular reference
- [ ] Run existing unit tests to verify no regressions
- [ ] Manual testing with multimodal models to verify memory usage improvement

Fixes #31200

🤖 Generated with [Claude Code](https://claude.com/claude-code)