### PR TITLE
[Bugfix] Add error message for skip_tokenizer_init with multimodal models

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -588,6 +588,14 @@ class ModelConfig:
                 "repo name or path using the --tokenizer argument."
             )
 
+        # Multimodal models require the tokenizer for processor initialization
+        if self.skip_tokenizer_init and self.is_multimodal_model:
+            raise ValueError(
+                "skip_tokenizer_init=True is not supported for multimodal "
+                "models. The tokenizer is required to initialize the "
+                "multimodal processor (e.g., to obtain image_token_id)."
+            )
+
         if self.disable_sliding_window:
             # Set after get_and_verify_max_len to ensure that max_model_len
             # can be correctly capped to sliding window size


### PR DESCRIPTION
## Summary

Add a clear error message when `skip_tokenizer_init=True` is used with multimodal models.

**Before**: Users got an obscure error deep in the transformers library:
```
AttributeError: 'NoneType' object has no attribute 'image_token_id'
```

**After**: Users get a clear error message at model config validation:
```
ValueError: skip_tokenizer_init=True is not supported for multimodal models.
The tokenizer is required to initialize the multimodal processor (e.g., to obtain image_token_id).
```

## Root Cause

Multimodal models require the tokenizer to initialize the multimodal processor. When `skip_tokenizer_init=True` is set, the tokenizer is None, which causes the processor initialization to fail when it tries to access `tokenizer.image_token_id`.

## Changes

Added a validation check in `ModelConfig.__post_init__` (in `vllm/config/model.py`) that:
1. Checks if `skip_tokenizer_init=True` and `is_multimodal_model=True`
2. If both are true, raises a `ValueError` with a helpful message

This follows the same pattern as the existing GGUF multimodal validation check.

## Test plan

```bash
# Before: obscure AttributeError
uv run --with vllm python -c 'import vllm; vllm.LLM("google/gemma-3-27b-it", load_format="dummy", enforce_eager=True, skip_tokenizer_init=True)'

# After: clear ValueError with helpful message
# ValueError: skip_tokenizer_init=True is not supported for multimodal models. The tokenizer is required to initialize the multimodal processor (e.g., to obtain image_token_id).
```

Fixes #31123

🤖 Generated with [Claude Code](https://claude.com/claude-code)