### PR TITLE
pin lora_b moe weights on cpu

### DIFF
--- a/vllm/lora/layers/fused_moe.py
+++ b/vllm/lora/layers/fused_moe.py
@@ -672,19 +672,8 @@ class FusedMoE3DWithLoRA(FusedMoEWithLoRA):
         self.reset_lora(index)
         self.adapter_enabled[index] = 1
 
-        num_experts = self.w13_lora_a_stacked[0].shape[1]
         w13_lora_a, w2_lora_a = lora_a
         w13_lora_b, w2_lora_b = lora_b
-
-        # (num_experts,rank,input_size)
-        w13_lora_a = w13_lora_a.reshape(num_experts, -1, w13_lora_a.shape[-1])
-        w2_lora_a = w2_lora_a.reshape(num_experts, -1, w2_lora_a.shape[-1])
-        # (output_size,rank,num_experts)
-        w13_lora_b = w13_lora_b.reshape(w13_lora_b.shape[0], -1, num_experts)
-        w2_lora_b = w2_lora_b.reshape(w2_lora_b.shape[0], -1, num_experts)
-        # (num_experts,output_size,rank)
-        w13_lora_b = w13_lora_b.permute(2, 0, 1)
-        w2_lora_b = w2_lora_b.permute(2, 0, 1)
 
         sliced_w13_lora_a = self._slice_w13_a(w13_lora_a)
         sliced_w13_lora_b = self._slice_w13_b(w13_lora_b)

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -574,91 +574,8 @@ class LoRAModelManager:
             lora.optimize()
 
         for module_name, module in self.modules.items():
-            module_lora = self._get_lora_layer_weights(lora_model, module_name)
-            if not module_lora:
-                continue
-
-            # Note (gnovack) - If MOE lora weights are not split into
-            # num_experts chunks, we split them here
-            if isinstance(module, FusedMoE3DWithLoRA) and torch.is_tensor(
-                module_lora.lora_a
-            ):
-                # Handle PEFT file format where experts.base_layer is the
-                # gate_up_proj and experts is the down_proj
-                gate_up_proj_lora = self._get_lora_layer_weights(
-                    lora_model, module_name + ".base_layer"
-                )
-                down_proj_lora = module_lora
-                # FIXME Edge case where LoRA is not added to gate_up_proj
-                # or down_proj
-                assert gate_up_proj_lora is not None
-                assert down_proj_lora is not None
-                if self._is_3d_moe_model:
-                    num_experts = module.w13_lora_a_stacked[0].shape[1]
-
-                    # (num_experts,rank,input_size)
-                    gate_up_proj_lora.lora_a = gate_up_proj_lora.lora_a.reshape(
-                        num_experts, -1, gate_up_proj_lora.lora_a.shape[-1]
-                    )
-                    down_proj_lora.lora_a = down_proj_lora.lora_a.reshape(
-                        num_experts, -1, down_proj_lora.lora_a.shape[-1]
-                    )
-
-                    # (output_size,num_experts,rank)
-                    gate_up_proj_lora.lora_b = gate_up_proj_lora.lora_b.reshape(
-                        gate_up_proj_lora.lora_b.shape[0], -1, num_experts
-                    )
-                    down_proj_lora.lora_b = down_proj_lora.lora_b.reshape(
-                        down_proj_lora.lora_b.shape[0], -1, num_experts
-                    )
-
-                    # (num_experts,output_size,rank)
-                    gate_up_proj_lora.lora_b = gate_up_proj_lora.lora_b.permute(
-                        1, 0, 2
-                    ).contiguous()
-                    down_proj_lora.lora_b = down_proj_lora.lora_b.permute(
-                        1, 0, 2
-                    ).contiguous()
-
-                    module_lora.lora_a = [
-                        gate_up_proj_lora.lora_a,
-                        down_proj_lora.lora_a,
-                    ]
-                    module_lora.lora_b = [
-                        gate_up_proj_lora.lora_b,
-                        down_proj_lora.lora_b,
-                    ]
-                else:
-                    # Some 3D MoE models haven't added the `is_3d_moe_weight`
-                    # attribute yet, so fallback here
-                    num_experts = module_lora.lora_a.shape[0] // module_lora.rank
-
-                    gate_proj_a = gate_up_proj_lora.lora_a.chunk(num_experts, dim=0)
-                    up_proj_a = gate_up_proj_lora.lora_a.chunk(num_experts, dim=0)
-
-                    gate_proj_b = gate_up_proj_lora.lora_b[::2, ...].chunk(
-                        num_experts, dim=-1
-                    )
-                    up_proj_b = gate_up_proj_lora.lora_b[1::2, ...].chunk(
-                        num_experts, dim=-1
-                    )
-
-                    down_proj_a = down_proj_lora.lora_a.chunk(num_experts, dim=0)
-                    down_proj_b = down_proj_lora.lora_b.chunk(num_experts, dim=-1)
-
-                    lora_a = []
-                    lora_b = []
-                    for i in range(num_experts):
-                        lora_a.append(gate_proj_a[i])
-                        lora_a.append(down_proj_a[i])
-                        lora_a.append(up_proj_a[i])
-
-                        lora_b.append(gate_proj_b[i])
-                        lora_b.append(down_proj_b[i])
-                        lora_b.append(up_proj_b[i])
-
-                    module_lora.lora_a = lora_a
-                    module_lora.lora_b = lora_b
+            if isinstance(module, FusedMoE3DWithLoRA):
+                self._stack_moe_lora_weights(lora_model, module, module_name)
 
         first_lora: LoRALayerWeights = next(iter(lora_model.loras.values()))
         assert first_lora.lora_a is not None
@@ -685,6 +602,91 @@ class LoRAModelManager:
                 else:
                     lora.lora_a = lora.lora_a.pin_memory()
                     lora.lora_b = lora.lora_b.pin_memory()
+
+    def _stack_moe_lora_weights(
+        self, lora_model: LoRAModel, module: FusedMoE3DWithLoRA, module_name: str
+    ):
+        module_lora = self._get_lora_layer_weights(lora_model, module_name)
+
+        # Note (gnovack) - If MOE lora weights are not split into
+        # num_experts chunks, we split them here
+        if module_lora and torch.is_tensor(module_lora.lora_a):
+            # Handle PEFT file format where experts.base_layer is the
+            # gate_up_proj and experts is the down_proj
+            gate_up_proj_lora = self._get_lora_layer_weights(
+                lora_model, module_name + ".base_layer"
+            )
+            down_proj_lora = module_lora
+            # FIXME Edge case where LoRA is not added to gate_up_proj
+            # or down_proj
+            assert gate_up_proj_lora is not None
+            assert down_proj_lora is not None
+            if self._is_3d_moe_model:
+                num_experts = module.w13_lora_a_stacked[0].shape[1]
+
+                # (num_experts,rank,input_size)
+                gate_up_proj_lora.lora_a = gate_up_proj_lora.lora_a.reshape(
+                    num_experts, -1, gate_up_proj_lora.lora_a.shape[-1]
+                )
+                down_proj_lora.lora_a = down_proj_lora.lora_a.reshape(
+                    num_experts, -1, down_proj_lora.lora_a.shape[-1]
+                )
+
+                # (output_size,num_experts,rank)
+                gate_up_proj_lora.lora_b = gate_up_proj_lora.lora_b.reshape(
+                    gate_up_proj_lora.lora_b.shape[0], -1, num_experts
+                )
+                down_proj_lora.lora_b = down_proj_lora.lora_b.reshape(
+                    down_proj_lora.lora_b.shape[0], -1, num_experts
+                )
+
+                # (num_experts,output_size,rank)
+                gate_up_proj_lora.lora_b = gate_up_proj_lora.lora_b.permute(
+                    2, 0, 1
+                ).contiguous()
+                down_proj_lora.lora_b = down_proj_lora.lora_b.permute(
+                    2, 0, 1
+                ).contiguous()
+
+                module_lora.lora_a = [
+                    gate_up_proj_lora.lora_a,
+                    down_proj_lora.lora_a,
+                ]
+                module_lora.lora_b = [
+                    gate_up_proj_lora.lora_b,
+                    down_proj_lora.lora_b,
+                ]
+            else:
+                # Some 3D MoE models haven't added the `is_3d_moe_weight`
+                # attribute yet, so fallback here
+                num_experts = module_lora.lora_a.shape[0] // module_lora.rank
+
+                gate_proj_a = gate_up_proj_lora.lora_a.chunk(num_experts, dim=0)
+                up_proj_a = gate_up_proj_lora.lora_a.chunk(num_experts, dim=0)
+
+                gate_proj_b = gate_up_proj_lora.lora_b[::2, ...].chunk(
+                    num_experts, dim=-1
+                )
+                up_proj_b = gate_up_proj_lora.lora_b[1::2, ...].chunk(
+                    num_experts, dim=-1
+                )
+
+                down_proj_a = down_proj_lora.lora_a.chunk(num_experts, dim=0)
+                down_proj_b = down_proj_lora.lora_b.chunk(num_experts, dim=-1)
+
+                lora_a = []
+                lora_b = []
+                for i in range(num_experts):
+                    lora_a.append(gate_proj_a[i])
+                    lora_a.append(down_proj_a[i])
+                    lora_a.append(up_proj_a[i])
+
+                    lora_b.append(gate_proj_b[i])
+                    lora_b.append(down_proj_b[i])
+                    lora_b.append(up_proj_b[i])
+
+                module_lora.lora_a = lora_a
+                module_lora.lora_b = lora_b
 
     def _get_lora_layer_weights(
         self, lora_model: LoRAModel, module_name: str


### PR DESCRIPTION
## Purpose
The current weight loading logic in `FusedMoE3DWithLoRA` permutes the LoRA B weights on CPU before copying to GPU, this results in a slow copy of non-contigous, pageable memory (see below):
<img width="686" height="343" alt="Screenshot 2025-12-24 at 9 32 25 AM" src="https://github.com/user-attachments/assets/2516ba7e-f09d-4d56-a79e-381a73c462af" />

This PR moves the LoRA B weight permutation logic one layer up, into the model manager's `activate_adapter` function, so that it is only run the first time that the LoRA is loaded from disk, and will not run again if/when this adapter is swapped between CPU/GPU.

This ensures that all LoRA weight copies from CPU to GPU use pinned, contiguous memory, reducing the total transfer time by ~40%:
![Image 12-24-25 at 9 38 AM](https://github.com/user-attachments/assets/3b222231-a179-46f6-98eb-fc3fc0a6ed2d)


## Test Plan

### Ran LoRA test cases for 3D MoE models:
```
pytest tests/lora/test_gptoss_tp.py tests/lora/test_qwen3moe_tp.py 
```

### Benchmarked e2e TTFT when loading LoRAs from CPU to GPU

**tl;dr** - benchmarking shows a ~40% decrease in median TTFT when frequently loading LoRA adapters from CPU to GPU.

Server command (loads 8 LoRAs, with only one on CPU, causing frequent swapping in from CPU to GPU during runtime):
```
vllm serve openai/gpt-oss-20b \
	--trust-remote-code --enable-lora --max-loras 1 --max-cpu-loras 8 \
	-tp=1 --port 8001 --lora-modules \
		lora1=/mnt/models/rank-32-adapters/gpt-oss-20b-gsm8k-rank32-lr1e-5 \
		lora2=/mnt/models/rank-32-adapters/gpt-oss-20b-gsm8k-rank32-lr1e-5 \
		lora3=/mnt/models/rank-32-adapters/gpt-oss-20b-gsm8k-rank32-lr1e-5 \
		lora4=/mnt/models/rank-32-adapters/gpt-oss-20b-gsm8k-rank32-lr1e-5 \
		lora5=/mnt/models/rank-32-adapters/gpt-oss-20b-gsm8k-rank32-lr1e-5 \
		lora6=/mnt/models/rank-32-adapters/gpt-oss-20b-gsm8k-rank32-lr1e-5 \
		lora7=/mnt/models/rank-32-adapters/gpt-oss-20b-gsm8k-rank32-lr1e-5 \
		lora8=/mnt/models/rank-32-adapters/gpt-oss-20b-gsm8k-rank32-lr1e-5 \
	--max-lora-rank 32 \
	--max-num-seqs 8 --gpu-memory-utilization 0.95 \
	--no-enable-prefix-caching
```

Benchmark command:
```
vllm bench serve --model openai/gpt-oss-20b --backend vllm --endpoint /v1/completions --ignore-eos --random-range-ratio=0.05 --random-input-len=1600  --random-output-len=200 --max-concurrency 1 --lora-modules lora1 --lora-modules lora2 --lora-modules lora3 --lora-modules lora4 --lora-modules lora5 --lora-modules lora6 --lora-modules lora7 --lora-modules lora8 --num-prompts 100 --port 8001
```

Results before PR:
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  163.72    
Total input tokens:                      160151    
Total generated tokens:                  20118     
Request throughput (req/s):              0.61      
Output token throughput (tok/s):         122.88    
Peak output token throughput (tok/s):    144.00    
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          1101.09   
---------------Time to First Token----------------
Mean TTFT (ms):                          232.66    
Median TTFT (ms):                        222.25    
P99 TTFT (ms):                           386.80    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          7.02      
Median TPOT (ms):                        7.01      
P99 TPOT (ms):                           7.15      
---------------Inter-token Latency----------------
Mean ITL (ms):                           7.02      
Median ITL (ms):                         7.00      
P99 ITL (ms):                            7.42      
==================================================
```

Results after PR:
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  152.80    
Total input tokens:                      160151    
Total generated tokens:                  20118     
Request throughput (req/s):              0.65      
Output token throughput (tok/s):         131.66    
Peak output token throughput (tok/s):    144.00    
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          1179.73   
---------------Time to First Token----------------
Mean TTFT (ms):                          127.39    
Median TTFT (ms):                        134.17    
P99 TTFT (ms):                           138.23    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          7.00      
Median TPOT (ms):                        6.99      
P99 TPOT (ms):                           7.04      
---------------Inter-token Latency----------------
Mean ITL (ms):                           7.00      
Median ITL (ms):                         6.99      
P99 ITL (ms):                            7.33      
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

