### PR TITLE
[Code Quality] Add missing return type annotations to misc modules

### DIFF
--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -205,7 +205,7 @@ def update_config(config: ConfigT, overrides: dict[str, Any]) -> ConfigT:
     return replace(config, **processed_overrides)
 
 
-def normalize_value(x):
+def normalize_value(x: Any) -> Any:
     """Return a stable, JSON-serializable canonical form for hashing.
     Order: primitives, special types (Enum, callable, torch.dtype, Path), then
     generic containers (Mapping/Set/Sequence) with recursion.

--- a/vllm/tokenizers/detokenizer_utils.py
+++ b/vllm/tokenizers/detokenizer_utils.py
@@ -5,7 +5,7 @@
 from vllm.tokenizers import TokenizerLike
 
 
-def _replace_none_with_empty(tokens: list[str | None]):
+def _replace_none_with_empty(tokens: list[str | None]) -> None:
     for i, token in enumerate(tokens):
         if token is None:
             tokens[i] = ""


### PR DESCRIPTION
## Purpose

This PR adds missing return type annotations to functions in miscellaneous vLLM modules to improve code quality and IDE support.

## Changes

### vllm/version.py

| Function | Return Type Added |
|----------|------------------|
| `_prev_minor_version_was()` | `bool` |
| `_prev_minor_version()` | `str` |

### vllm/config/pooler.py

| Function | Return Type Added |
|----------|------------------|
| `get_use_activation()` | `bool \| None` |

### vllm/multimodal/image.py

| Function | Return Type Added |
|----------|------------------|
| `convert_image_mode()` | `Image.Image` |

### vllm/profiler/utils.py

| Function | Return Type Added |
|----------|------------------|
| `trim_string_front()` | `str` |
| `trim_string_back()` | `str` |

## Test Plan

This is a typing-only change with no runtime impact. All existing tests should pass.