### PR TITLE
[Bugfix] Support LoRA and GPTQModel for PLaMo 2/3 

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -438,8 +438,8 @@ th {
 | `Phi3ForCausalLM` | Phi-4, Phi-3 | `microsoft/Phi-4-mini-instruct`, `microsoft/Phi-4`, `microsoft/Phi-3-mini-4k-instruct`, `microsoft/Phi-3-mini-128k-instruct`, `microsoft/Phi-3-medium-128k-instruct`, etc. | ✅︎ | ✅︎ |
 | `PhiMoEForCausalLM` | Phi-3.5-MoE | `microsoft/Phi-3.5-MoE-instruct`, etc. | ✅︎ | ✅︎ |
 | `PersimmonForCausalLM` | Persimmon | `adept/persimmon-8b-base`, `adept/persimmon-8b-chat`, etc. | | ✅︎ |
-| `Plamo2ForCausalLM` | PLaMo2 | `pfnet/plamo-2-1b`, `pfnet/plamo-2-8b`, etc. | | ✅︎ |
-| `Plamo3ForCausalLM` | PLaMo3 | `pfnet/plamo-3-nict-2b-base`, `pfnet/plamo-3-nict-8b-base`, etc. | | ✅︎ |
+| `Plamo2ForCausalLM` | PLaMo2 | `pfnet/plamo-2-1b`, `pfnet/plamo-2-8b`, etc. | ✅ | ✅︎ |
+| `Plamo3ForCausalLM` | PLaMo3 | `pfnet/plamo-3-nict-2b-base`, `pfnet/plamo-3-nict-8b-base`, etc. | ✅ | ✅︎ |
 | `QWenLMHeadModel` | Qwen | `Qwen/Qwen-7B`, `Qwen/Qwen-7B-Chat`, etc. | ✅︎ | ✅︎ |
 | `Qwen2ForCausalLM` | QwQ, Qwen2 | `Qwen/QwQ-32B-Preview`, `Qwen/Qwen2-7B-Instruct`, `Qwen/Qwen2-7B`, etc. | ✅︎ | ✅︎ |
 | `Qwen2MoeForCausalLM` | Qwen2MoE | `Qwen/Qwen1.5-MoE-A2.7B`, `Qwen/Qwen1.5-MoE-A2.7B-Chat`, etc. | ✅︎ | ✅︎ |

--- a/vllm/model_executor/models/plamo2.py
+++ b/vllm/model_executor/models/plamo2.py
@@ -50,7 +50,12 @@ from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
     sharded_weight_loader,
 )
-from vllm.model_executor.models.interfaces import HasInnerState, IsHybrid, SupportsPP
+from vllm.model_executor.models.interfaces import (
+    HasInnerState,
+    IsHybrid,
+    SupportsLoRA,
+    SupportsPP,
+)
 from vllm.model_executor.models.utils import (
     is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
@@ -105,6 +110,7 @@ class Plamo2MambaMixer(MambaBase, CustomOp):
         self.cache_config = vllm_config.cache_config
         self.model_config = vllm_config.model_config
         self.quant_config = vllm_config.quant_config
+        self.is_lora_enabled = bool(vllm_config.lora_config)
         self.hidden_size = self.config.hidden_size
         self.ssm_state_size = self.config.mamba_d_state
         self.conv_kernel_size = self.config.mamba_d_conv
@@ -202,7 +208,11 @@ class Plamo2MambaMixer(MambaBase, CustomOp):
         self.prefix = prefix
 
     def _project_ssm_parameters(self, hidden_states):
-        ssm_parameters = self.bcdt_proj(hidden_states)
+        if self.is_lora_enabled:
+            #  Lora kernel requires contiguous tensor.
+            ssm_parameters = self.bcdt_proj(hidden_states.contiguous())
+        else:
+            ssm_parameters = self.bcdt_proj(hidden_states)
         B, C, time_step = torch.split(
             ssm_parameters,
             [self.ssm_state_size, self.ssm_state_size, self.time_step_rank],
@@ -780,13 +790,13 @@ class Plamo2Model(torch.nn.Module):
         return hidden_states
 
 
-class Plamo2ForCausalLM(torch.nn.Module, HasInnerState, SupportsPP, IsHybrid):
+class Plamo2ForCausalLM(
+    torch.nn.Module, HasInnerState, SupportsLoRA, SupportsPP, IsHybrid
+):
     packed_modules_mapping = {
-        "qkv_proj": [
-            "q_proj",
-            "k_proj",
-            "v_proj",
-        ],
+        "qkv_proj": ["qkv_proj"],
+        "gate_up_proj": ["gate_up_proj"],
+        "in_proj": ["in_proj"],
     }
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:

--- a/vllm/model_executor/models/plamo2.py
+++ b/vllm/model_executor/models/plamo2.py
@@ -57,6 +57,7 @@ from vllm.model_executor.models.interfaces import (
     SupportsPP,
 )
 from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
     is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
     make_layers,
@@ -901,6 +902,12 @@ class Plamo2ForCausalLM(
             # at the same time causes dict key access error.
             if name == "lm_head.weight" and self.config.tie_word_embeddings:
                 assert "lm_head.weight" not in params_dict
+                continue
+            # Same workaround as AutoWeightsLoader for GPTQModel
+            if any(
+                substr in name
+                for substr in AutoWeightsLoader.ROTARY_EMBEDS_UNUSED_WEIGHTS
+            ):
                 continue
 
             # Update the weight names to be compatible with the vllm version

--- a/vllm/model_executor/models/plamo3.py
+++ b/vllm/model_executor/models/plamo3.py
@@ -35,7 +35,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     composed_weight_loader,
     default_weight_loader,
 )
-from vllm.model_executor.models.interfaces import SupportsPP
+from vllm.model_executor.models.interfaces import SupportsLoRA, SupportsPP
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
     extract_layer_index,
@@ -369,13 +369,10 @@ class Plamo3Model(nn.Module):
         return hidden_states
 
 
-class Plamo3ForCausalLM(nn.Module, SupportsPP):
+class Plamo3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
     packed_modules_mapping = {
-        "qkv_proj": [
-            "q_proj",
-            "k_proj",
-            "v_proj",
-        ],
+        "qkv_proj": ["qkv_proj"],
+        "gate_up_proj": ["gate_up_proj"],
     }
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:


### PR DESCRIPTION
## Purpose
This PR 
- corrects the `packed_modules_mapping` configuration for the PLaMo2/3 model to prevent incorrect layer splitting
- adds the same workaround as `AutoWeightsLoader` to load latest-gptqmodel-quantized model 
- supports LoRA functionality.


A recent change introduced in https://github.com/vllm-project/vllm/pull/25455 implements a renaming mechanism for fused layers in GPTQ models layers based on `packed_modules_mapping`. This change negatively impacts the PLaMo model series as `packed_modules_mapping` are not properly set. Specifically, it forces a split on the qkv_proj layers, which is natively implemented as a fused layer in PLaMo 2/3. 
This PR updates the `packed_modules_mapping` for PLaMo2/3 to ensure that standard fused layers, specifically `qkv_proj` and `gate_up_proj`, remain unsplit by `gptq_utils.py`.


https://github.com/vllm-project/vllm/blob/c881db364e2bbcc90350db857fe294ae01ff71b7/vllm/model_executor/layers/quantization/utils/gptq_utils.py#L83-L125

## Test Plan
- Run existing unit tests in `tests/distributed/test_pipeline_parallel.py`
- Run model inference with a adopter

## Test Result
### Unit test
```bash
> pytest /root/vllm/tests/distributed/test_pipeline_parallel.py
/root/vllm/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
=========================================== test session starts ===========================================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /root/vllm
configfile: pyproject.toml
plugins: anyio-4.6.2.post1, hypothesis-6.131.0, rerunfailures-14.0, schemathesis-3.39.15, asyncio-0.24.0, shard-0.1.2, timeout-2.3.1, hydra-core-1.3.2, subtests-0.14.1, buildkite-test-collector-0.1.9, cov-6.3.0, mock-3.14.0, forked-1.6.0
asyncio: mode=Mode.STRICT, default_loop_scope=None
collected 4 items                                                                                         
Running 4 items in this shard

tests/distributed/test_pipeline_parallel.py ..ss                                                    [100%]
```

### Run with a LoRA adapter
<details>

```python
import torch
import os
from peft import LoraConfig, get_peft_model
from transformers import AutoModelForCausalLM, AutoTokenizer

config = [
    (
        "pfnet/plamo-2-1b",
        [
            "in_proj",
            "bcdt_proj",
            "dt_proj",
            "out_proj",
            "qkv_proj",
            "o_proj",
            "gate_up_proj",
            "down_proj",
        ],
    ),
    (
        "pfnet/plamo-3-nict-2b-base",
        [
            "qkv_proj",
            "o_proj",
            "gate_up_proj",
            "down_proj",
        ],
    ),
]

if __name__ == "__main__":
    from vllm import LLM, SamplingParams
    from vllm.lora.request import LoRARequest

    lora_path = "./lora_adapter"
    prompt = "Hello, world"

    for model_path, target_modules in config:
        print(f"Processing model: {model_path}")
        print(f"target_modules: {target_modules}")
        model = AutoModelForCausalLM.from_pretrained(
            model_path,
            torch_dtype=torch.float16,
            device_map="auto",
            trust_remote_code=True,
        )
        tokenizer = AutoTokenizer.from_pretrained(
            model_path,
            trust_remote_code=True,
        )
        lora_config = LoraConfig(
            r=8,
            lora_alpha=16,
            target_modules=target_modules,
            lora_dropout=0.05,
            bias="none",
            init_lora_weights=False,
            task_type="CAUSAL_LM",
        )
        lora_model = get_peft_model(model, lora_config)
        os.makedirs(lora_path, exist_ok=True)
        lora_model.save_pretrained(lora_path)
        del model
        del lora_model
        torch.cuda.empty_cache()

        # Run with vLLM LoRA model
        llm = LLM(
            model=model_path,
            enable_lora=True,
            max_model_len=4096,
            trust_remote_code=True,
        )
        lora_request = LoRARequest(
            lora_name="lora-adapter", lora_int_id=1, lora_local_path=lora_path
        )
        outputs_lora = llm.generate(
            prompt,
            sampling_params=SamplingParams(
                max_tokens=50,
                temperature=0.0,
                logprobs=10,
            ),
            lora_request=lora_request,
        )
        del llm
        torch.cuda.empty_cache()
```


```bash
> python run.py
...
Adding requests: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.33it/s]
Processed prompts: 100%|████████████████████████████████████████████████████████████████████| 1/1 [00:08<00:00,  8.36s/it, est. speed input: 0.48 toks/s, output: 1.20 toks/s]
!

Hello, world!

Hello, world
...
Adding requests: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  2.33it/s]
Processed prompts: 100%|████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.50s/it, est. speed input: 2.67 toks/s, output: 6.67 toks/s]
!

The Raspberry Pi is a tiny computer that can
(EngineCore_DP0 pid=532377) [rank0]:[W1225 06:19:41.179029307 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```
</details>


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

