### PR TITLE
[ROCm][CI] Add TorchCodec source build for transcription tests

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -774,8 +774,9 @@ steps:
   - csrc/
   - vllm/entrypoints/openai/
   - vllm/model_executor/models/whisper.py
+  - tools/
   commands: # LMEval+Transcription WER check
-  - bash tools/install_torchcodec_rocm.sh || exit 1
+  - bash ../tools/install_torchcodec_rocm.sh || exit 1
   - pytest -s entrypoints/openai/correctness/
 
 
@@ -1604,6 +1605,8 @@ steps:
   - .buildkite/scripts/run-prime-rl-test.sh
   commands:
     - bash .buildkite/scripts/run-prime-rl-test.sh
+
+##### EPLB Accuracy Tests #####
 - label: DeepSeek V2-Lite Accuracy
   mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_4

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -775,7 +775,7 @@ steps:
   - vllm/entrypoints/openai/
   - vllm/model_executor/models/whisper.py
   commands: # LMEval+Transcription WER check
-  # Transcription WER check is skipped because encoder-decoder models are not supported on ROCm, see https://github.com/vllm-project/vllm/issues/27442
+  - bash tools/install_torchcodec_rocm.sh || exit 1
   - pytest -s entrypoints/openai/correctness/
 
 

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -97,6 +97,14 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system hf_transfer
 ENV HF_HUB_ENABLE_HF_TRANSFER=1
 
+# install audio decode package `torchcodec` from source (required due to 
+# ROCm and torch version mismatch) for tests with datasets package
+COPY tools/install_torchcodec_rocm.sh /tmp/install_torchcodec.sh
+RUN bash /tmp/install_torchcodec.sh \
+    && rm /tmp/install_torchcodec.sh \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy in the v1 package (for python-only install test group)
 COPY --from=export_vllm /vllm_v1 /usr/local/lib/python${PYTHON_VERSION}/dist-packages/vllm/v1
 

--- a/tools/install_torchcodec_rocm.sh
+++ b/tools/install_torchcodec_rocm.sh
@@ -23,7 +23,7 @@ echo "TorchCodec not found. Installing from source..."
 install_system_deps() {
     if command -v apt-get &> /dev/null; then
         echo "Installing system dependencies..."
-        apt-get update && apt-get install -y \
+        apt-get update && apt-get install -y --no-install-recommends \
             pkg-config \
             ffmpeg libavcodec-dev libavformat-dev libavutil-dev \
             libswscale-dev libavdevice-dev libavfilter-dev libswresample-dev
@@ -68,8 +68,7 @@ trap cleanup EXIT
 # Clone and build
 cd "$BUILD_DIR"
 echo "Cloning TorchCodec from $TORCHCODEC_REPO (branch: $TORCHCODEC_BRANCH)..."
-git clone --depth 1 --branch "$TORCHCODEC_BRANCH" "$TORCHCODEC_REPO" torchcodec || \
-    git clone --depth 1 "$TORCHCODEC_REPO" torchcodec
+git clone --depth 1 --branch "$TORCHCODEC_BRANCH" "$TORCHCODEC_REPO" torchcodec
 
 cd torchcodec
 

--- a/tools/install_torchcodec_rocm.sh
+++ b/tools/install_torchcodec_rocm.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Script to install TorchCodec from source (required for ROCm compatibility)
+
+set -e
+
+TORCHCODEC_REPO="${TORCHCODEC_REPO:-https://github.com/pytorch/torchcodec.git}"
+TORCHCODEC_BRANCH="${TORCHCODEC_BRANCH:-main}"
+
+echo "=== TorchCodec Installation Script ==="
+
+# Check if torchcodec is already installed and working
+if python3 -c "from torchcodec.decoders import VideoDecoder" 2>/dev/null; then
+    echo "TorchCodec is already installed and working. Skipping."
+    exit 0
+fi
+
+echo "TorchCodec not found. Installing from source..."
+
+# Install system dependencies (FFmpeg + pkg-config)
+install_system_deps() {
+    if command -v apt-get &> /dev/null; then
+        echo "Installing system dependencies..."
+        apt-get update && apt-get install -y \
+            pkg-config \
+            ffmpeg libavcodec-dev libavformat-dev libavutil-dev \
+            libswscale-dev libavdevice-dev libavfilter-dev libswresample-dev
+    else
+        echo "Warning: apt-get did not work. Please install dependencies manually."
+        return 1
+    fi
+}
+
+# Check for pkg-config
+if ! command -v pkg-config &> /dev/null; then
+    echo "pkg-config not found. Installing system dependencies..."
+    install_system_deps
+fi
+
+# Check for required FFmpeg libraries
+echo "Checking for FFmpeg libraries..."
+if ! pkg-config --exists libavcodec libavformat libavutil libswscale libavdevice libavfilter libswresample 2>/dev/null; then
+    echo "FFmpeg development libraries not found. Installing..."
+    install_system_deps
+fi
+
+# Install Python build dependencies
+echo "Installing Python build dependencies..."
+pip install pybind11 setuptools wheel
+
+# Set pybind11 cmake path so CMake can find it
+export pybind11_DIR=$(python3 -c "import pybind11; print(pybind11.get_cmake_dir())")
+export CMAKE_PREFIX_PATH="${pybind11_DIR}:${CMAKE_PREFIX_PATH}"
+echo "pybind11_DIR set to: $pybind11_DIR"
+
+# Create temp directory for build
+BUILD_DIR=$(mktemp -d -t torchcodec-XXXXXX)
+echo "Building in temporary directory: $BUILD_DIR"
+
+cleanup() {
+    echo "Cleaning up $BUILD_DIR"
+    rm -rf "$BUILD_DIR"
+}
+trap cleanup EXIT
+
+# Clone and build
+cd "$BUILD_DIR"
+echo "Cloning TorchCodec from $TORCHCODEC_REPO (branch: $TORCHCODEC_BRANCH)..."
+git clone --depth 1 --branch "$TORCHCODEC_BRANCH" "$TORCHCODEC_REPO" torchcodec || \
+    git clone --depth 1 "$TORCHCODEC_REPO" torchcodec
+
+cd torchcodec
+
+# Set build environment for ROCm compatibility
+export TORCHCODEC_CMAKE_BUILD_DIR="${PWD}/build"
+export TORCHCODEC_DISABLE_COMPILE_WARNING_AS_ERROR=1
+export I_CONFIRM_THIS_IS_NOT_A_LICENSE_VIOLATION=1
+
+echo "Building TorchCodec..."
+pip install . --no-build-isolation
+
+# Verify installation
+echo "Verifying installation..."
+if python3 -c "from torchcodec.decoders import VideoDecoder; print('TorchCodec installed successfully!')"; then
+    echo "=== TorchCodec installation complete ==="
+else
+    echo "Error: TorchCodec installation failed verification"
+    exit 1
+fi


### PR DESCRIPTION
Adds TorchCodec support for ROCm by building from source, enabling audio/video transcription tests on AMD GPUs.

## Problem

The HuggingFace `datasets` package requires TorchCodec for audio decoding (https://github.com/huggingface/datasets/issues/7914). However:
- No pre-built TorchCodec wheels exist for ROCm
- The `datasets` package has no fallback decoding solution
- Pre-built wheels have compiler flag incompatibilities with ROCm PyTorch
- Potential version mismatches with pre-installed PyTorch

## Solution

1. **Added `tools/install_torchcodec_rocm.sh`** - Builds TorchCodec from source with ROCm-compatible flags
2. **Updated ROCm Dockerfile** - Added FFmpeg dev dependencies
3. **Updated BuildKite CI** - Added install step before transcription tests

## Testing
```bash
pytest -s -v tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
```

Test group: `OpenAI API correctness`