### PR TITLE
[ROCm] Migrate xgrammar to upstream release

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -24,7 +24,7 @@ outlines_core == 0.2.11
 # required for outlines backend disk cache
 diskcache == 5.6.3
 lark == 1.2.2
-xgrammar == 0.1.27; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
+xgrammar == 0.1.29; platform_machine == "x86_64" or platform_machine == "aarch64" or platform_machine == "arm64" or platform_machine == "s390x" or platform_machine == "ppc64le"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs

--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -74,10 +74,6 @@ torchgeo==0.7.0
 # MTEB Benchmark Test
 mteb==2.1.2
 
-# Data processing
-xgrammar==0.1.29
-# Test async scheduling
-
 # Utilities
 num2words==0.5.14
     # via lm-eval

--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -75,7 +75,7 @@ torchgeo==0.7.0
 mteb==2.1.2
 
 # Data processing
-xgrammar @ git+https://github.com/divakar-amd/xgrammar@3272f7c520564858056a60480d5afdf69ae79c84
+xgrammar==0.1.29
 # Test async scheduling
 
 # Utilities


### PR DESCRIPTION
This PR updates the xgrammar dependency in `requirements/rocm-test.txt` from a custom fork to the upstream PyPI release.

### Changes
- Replaced `xgrammar @ git+https://github.com/divakar-amd/xgrammar@3272f7c...` with `xgrammar==0.1.29`

### Motivation
It's better practice to use upstream repositories instead of maintaining custom forks when possible. This is a follow-up to a comment from #29702 to eventually migrate to the upstream xgrammar repo.

### Testing
Verified on ROCm with the following tests passing:
```bash
pytest -v -s tests/v1/e2e/test_async_scheduling.py
pytest -v -s tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output_auto_mode[Qwen/Qwen2.5-1.5B-Instruct-auto]
pytest -v -s tests/v1/e2e/test_spec_decode.py
```