### PR TITLE
[ROCm][Perf] Tune fused_moe and add int4 w4a16 config

### DIFF
--- a/vllm/model_executor/layers/fused_moe/configs/E=128,N=1536,device_name=AMD_Instinct_MI308X,dtype=int4_w4a16.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=128,N=1536,device_name=AMD_Instinct_MI308X,dtype=int4_w4a16.json
@@ -1,0 +1,18 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+	     "num_warps": 4,
+          "num_stages": 4
+    },
+    "128": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 1,
+	     "num_warps": 4,
+          "num_stages": 4
+    }
+}


### PR DESCRIPTION
## What this PR does
- Tunes fused_moe kernel behavior
- Adds an int4 w4a16 fused_moe config for MI308X

## Scope
- Only fused_moe logic and config are updated
- No changes to AWQ Triton kernels in this PR

## Platform
- ROCm