### PR TITLE
[benchmark] use model card root instead of id

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -61,7 +61,7 @@ TERM_PLOTLIB_AVAILABLE = (importlib.util.find_spec("termplotlib") is not None) a
 
 async def get_first_model_from_server(
     base_url: str, headers: dict | None = None
-) -> str:
+) -> tuple[str, str]:
     """Fetch the first model from the server's /v1/models endpoint."""
     models_url = f"{base_url}/v1/models"
     async with aiohttp.ClientSession() as session:
@@ -70,7 +70,7 @@ async def get_first_model_from_server(
                 response.raise_for_status()
                 data = await response.json()
                 if "data" in data and len(data["data"]) > 0:
-                    return data["data"][0]["id"]
+                    return data["data"][0]["id"], data["data"][0]["root"]
                 else:
                     raise ValueError(
                         f"No models found on the server at {base_url}. "
@@ -1157,7 +1157,7 @@ def add_cli_args(parser: argparse.ArgumentParser):
         "--save-detailed",
         action="store_true",
         help="When saving the results, whether to include per request "
-        "information such as response, error, ttfs, tpots, etc.",
+        "information such as response, error, ttfts, tpots, etc.",
     )
     parser.add_argument(
         "--append-result",
@@ -1396,12 +1396,12 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
     # Fetch model from server if not specified
     if args.model is None:
         print("Model not specified, fetching first model from server...")
-        model_id = await get_first_model_from_server(base_url, headers)
-        print(f"Using model: {model_id}")
+        model_name, model_id = await get_first_model_from_server(base_url, headers)
+        print(f"First model name: {model_name}, first model id: {model_id}")
     else:
+        model_name = args.served_model_name
         model_id = args.model
 
-    model_name = args.served_model_name
     tokenizer_id = args.tokenizer if args.tokenizer is not None else model_id
     tokenizer_mode = args.tokenizer_mode
 


### PR DESCRIPTION

## Purpose
When vllm serve a model with `served_model_name`, then in the `/v1/models`  endpoint response item, `id` is a renamed custom model id.
When running vllm benchmark with `vllm benchmark serve --backend openai`, i.e., without `model` arguments set. vllm benchmark will infer model name from backend by accessing `/v1/models`.
Then, vllm will try to get tokenizer with the inferred model name and access HF to fetch tokenizer. With customized model id,  the access to HF will raise not found error. 

Thus, we should use `root` filed which is the canonical model id in HF.

## Test Plan
NA
## Test Result
NA
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

