### PR TITLE
[Core] Concurrent partial prefills for V1

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -15,8 +15,6 @@ from vllm.config import (
     SpeculativeConfig,
     VllmConfig,
 )
-from vllm.engine.arg_utils import EngineArgs
-from vllm.engine.llm_engine import LLMEngine
 from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,
     MultiModalKwargsItem,
@@ -3462,7 +3460,8 @@ def test_finishing_prefill_prioritized():
 
     assert output.num_scheduled_tokens[requests[0].request_id] == 500
     assert output.num_scheduled_tokens[requests[1].request_id] == 400
-    # Request 1 will be finished after this scheduling, so it should be first in running list
+    # Request 1 will be finished after this scheduling
+    # so it should be first in running list
     assert scheduler.running[0].request_id == requests[1].request_id
     assert scheduler.running[1].request_id == requests[0].request_id
 

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3460,11 +3460,9 @@ def test_finishing_prefill_prioritized():
 
     output = scheduler.schedule()
 
-    # Each request consumes one 512-token chunk in the first step.
     assert output.num_scheduled_tokens[requests[0].request_id] == 500
     assert output.num_scheduled_tokens[requests[1].request_id] == 400
-    # Request 1 only needs 188 more prompt tokens, so it should be moved
-    # ahead of the longer prompt for the next iteration.
+    # Request 1 will be finished after this scheduling, so it should be first in running list
     assert scheduler.running[0].request_id == requests[1].request_id
     assert scheduler.running[1].request_id == requests[0].request_id
 

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -55,6 +55,7 @@ def create_scheduler(
     async_scheduling: bool = False,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
+    max_num_partial_prefills: int | None = None,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -87,6 +88,7 @@ def create_scheduler(
         enable_chunked_prefill=enable_chunked_prefill,
         async_scheduling=async_scheduling,
         is_encoder_decoder=model_config.is_encoder_decoder,
+        max_num_partial_prefills=max_num_partial_prefills,
     )
     # Cache config, optionally force APC
     cache_config = CacheConfig(
@@ -162,7 +164,7 @@ _none_hash_initialized = False
 
 def create_requests(
     num_requests: int,
-    num_tokens: int = 10,
+    num_tokens: int | list[int] = 10,
     mm_hashes_list: list[list[str]] | None = None,
     mm_positions: list[list[PlaceholderRange]] | None = None,
     max_tokens: int = 16,
@@ -233,8 +235,12 @@ def create_requests(
                 modality="image",
             )
             mm_features.append(mm_feature)
-
-        prompt_token_ids = [0] * num_tokens if same_prompt else [i] * num_tokens
+        if isinstance(num_tokens, list):
+            prompt_token_ids = (
+                [0] * num_tokens[i] if same_prompt else [i] * num_tokens[i]
+            )
+        else:
+            prompt_token_ids = [0] * num_tokens if same_prompt else [i] * num_tokens
         request = Request(
             request_id=req_ids[i],
             prompt_token_ids=prompt_token_ids,

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -278,6 +278,18 @@ class SchedulerConfig:
             )
 
         if self.max_num_partial_prefills > 1:
+            if self.max_number_partial_prefills > self.max_num_batched_tokens:
+                # Ensure that each partial prefill can make progress.
+                raise ValueError(
+                    f"max_num_partial_prefills ({self.max_num_partial_prefills}) "
+                    "cannot be greater than max_num_batched_tokens "
+                    f"({self.max_num_batched_tokens})."
+                )
+
+            if self.long_prefill_token_threshold == 0:
+                # heuristic: 4% of max_model_len as default threshold
+                self.long_prefill_token_threshold = int(max_model_len * 0.04)
+
             if not self.enable_chunked_prefill:
                 raise ValueError(
                     "Chunked prefill must be enabled to set "

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -278,7 +278,7 @@ class SchedulerConfig:
             )
 
         if self.max_num_partial_prefills > 1:
-            if self.max_number_partial_prefills > self.max_num_batched_tokens:
+            if self.max_num_partial_prefills > self.max_num_batched_tokens:
                 # Ensure that each partial prefill can make progress.
                 raise ValueError(
                     f"max_num_partial_prefills ({self.max_num_partial_prefills}) "

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1763,14 +1763,6 @@ class EngineArgs:
         if self.logits_processor_pattern != EngineArgs.logits_processor_pattern:
             _raise_unsupported_error(feature_name="--logits-processor-pattern")
 
-        # No Concurrent Partial Prefills so far.
-        if (
-            self.max_num_partial_prefills != SchedulerConfig.max_num_partial_prefills
-            or self.max_long_partial_prefills
-            != SchedulerConfig.max_long_partial_prefills
-        ):
-            _raise_unsupported_error(feature_name="Concurrent Partial Prefill")
-
         # N-gram, Medusa, and Eagle are supported for speculative decoding.
         if self.speculative_config is not None:
             # speculative_config could still be a dict at this point

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -284,6 +284,7 @@ class KVCacheManager:
 
         Returns:
             A list of new allocated blocks.
+            None if the allocation fails.
         """
         # When loading KV data asynchronously, we may have zero new tokens to
         # compute while still allocating slots for externally computed tokens.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -340,11 +340,6 @@ class Scheduler(SchedulerInterface):
         partial_prefill_slot_budget = self._get_prefill_slot_budget(
             partial_prefill_metadata
         )
-        print(
-            f"Partial prefill metadata: {partial_prefill_metadata.active_prefills}, {partial_prefill_metadata.long_prefills}, {partial_prefill_metadata.schedulable_prefills}"
-        )
-        print(f"Partial prefill slot budget: {partial_prefill_slot_budget}")
-
         # First, schedule the RUNNING requests.
         req_index = 0
         while req_index < len(self.running) and token_budget > 0:
@@ -371,11 +366,9 @@ class Scheduler(SchedulerInterface):
                 + request.num_output_placeholders
                 - request.num_computed_tokens
             )
-            print(f"num_new_token_1 for request {request.request_id}: {num_new_tokens}")
             if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
                 num_new_tokens = self.scheduler_config.long_prefill_token_threshold
             num_new_tokens = min(num_new_tokens, token_budget)
-            print(f"num_new_token_2 for request {request.request_id}: {num_new_tokens}")
             if (
                 self.enable_concurrent_partial_prefill_scheduling
                 and partial_prefill_slot_budget is not None
@@ -385,16 +378,12 @@ class Scheduler(SchedulerInterface):
                 )
                 if prefill_state.is_prefill:
                     num_new_tokens = min(num_new_tokens, partial_prefill_slot_budget)
-                    print(
-                        f"num_new_token_3 for request {request.request_id}: {num_new_tokens}"
-                    )
 
             # Make sure the input position does not exceed the max model len.
             # This is necessary when using spec decoding.
             num_new_tokens = min(
                 num_new_tokens, self.max_model_len - 1 - request.num_computed_tokens
             )
-            print(f"num_new_token_4 for request {request.request_id}: {num_new_tokens}")
 
             # Schedule encoder inputs.
             encoder_inputs_to_schedule = None
@@ -1110,15 +1099,15 @@ class Scheduler(SchedulerInterface):
         for request in running_reqs:
             scheduled_tokens = num_scheduled_tokens.get(request.request_id, 0)
             num_tokens_after_step = request.num_computed_tokens + scheduled_tokens
-            print(
-                f"scheduled_tokens: {scheduled_tokens}, computed_token: {request.num_computed_tokens}, num_tokens_after_step: {num_tokens_after_step}, request.num_prompt_tokens: {request.num_prompt_tokens}"
-            )
-            if num_tokens_after_step >= request.num_prompt_tokens:
+            if (
+                num_tokens_after_step >= request.num_prompt_tokens
+                # note that we only care about requests that are still in prefill phase
+                # if it's in decoding phase, we don't prioritize it
+                and self._is_prefill_with_tokens(request, num_tokens_after_step)
+            ):
                 finishing_prefills.append(request)
             else:
                 non_finishing_prefills.append(request)
-        print("Finished prefills:", [r.request_id for r in finishing_prefills])
-        print("Non-finishing prefills:", [r.request_id for r in non_finishing_prefills])
         return finishing_prefills + non_finishing_prefills
 
     def _get_request_prefill_state(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1103,7 +1103,7 @@ class Scheduler(SchedulerInterface):
                 num_tokens_after_step >= request.num_prompt_tokens
                 # note that we only care about requests that are still in prefill phase
                 # if it's in decoding phase, we don't prioritize it
-                and self._is_prefill_with_tokens(request, num_tokens_after_step)
+                and self._is_prefill_with_tokens(request, request.num_computed_tokens)
             ):
                 finishing_prefills.append(request)
             else:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -776,6 +776,7 @@ class Scheduler(SchedulerInterface):
                 request.num_computed_tokens = num_computed_tokens
                 if (
                     self.enable_concurrent_partial_prefill_scheduling
+                    and partial_prefill_metadata is not None
                     and prefill_state is not None
                     and prefill_state.is_prefill
                     and prefill_state.remaining_tokens > 0

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -625,7 +625,8 @@ class Scheduler(SchedulerInterface):
                     else None
                 )
                 if (
-                    partial_prefill_metadata is not None
+                    self.enable_concurrent_partial_prefill_scheduling
+                    and partial_prefill_metadata is not None
                     and prefill_state is not None
                     and prefill_state.is_prefill
                     and (


### PR DESCRIPTION
## Purpose
Implements https://github.com/vllm-project/vllm/issues/14003, since we decide to include it in v1.
Referencing the implementation of the original PR: https://github.com/vllm-project/vllm/pull/10235

In short, concurrent partial prefill technique limits the number of large requests from starving small requests, improving throughput and TTFT overall. There are three key parameters for this strategy:
- `max_num_partial_prefills`: this controls how many requests that are **guaranteed** to progress in this run. At the start of each scheduler run, we make speculation and distribute the budget to each partial prefill slots evenly. The budget distribution makes sure that at least `max_num_partial_prefills` can get new tokens prefilled. If some request does not use all budgets distributed to it, it can happen that there are some budgets left, so more requests can be served.
- `max_long_partial_prefills`: this controls how many large requests can we put in the partial prefill slots. For example, if `max_num_partial_prefills=4 & max_long_partial_prefills=2`, we can have 2 large requests and 2 small requests each run. The default number is `1`.
- `long_prefill_token_threshold`: this controls the criteria for determination of "large request". If the number of token of the prompt exeeds the threshold, it is considered large request and will be limited by `max_long_partial_prefills`.

## Test Plan
Unit test with parity to the original PR.
I'm not sure about whether we should have parity to this unit test, because based on my testing it seems like the alignment gets abstracted away from scheduler. Would need some help here.
https://github.com/vllm-project/vllm/pull/10235/files#diff-2c6af6e25b8d1074f25ef5ad2901121b30bc1528de74d2b3625636fcb8181624R782-R831


## Test Result
### Benchmark plan
I followed the setup of the original PR with custom dataset I generated from [shareGPT creative writing](https://huggingface.co/datasets/Nitral-AI/Creative_Writing-ShareGPT/tree/main) dataset. The distribution of token count is shown below, showing a three groups of small/medium/large prompts:
<img width="792" height="488" alt="image" src="https://github.com/user-attachments/assets/6dde814d-dcde-4535-a64e-41a63411b655" />

I tested three versions on the dataset with A40, with the dataset: [benchmark-final.jsonl.zip](https://github.com/user-attachments/files/24355838/benchmark-final.jsonl.zip)
1. `main` branch
2. This branch with `max_num_partial_prefills=1`
3. this branch with `max_num_partial_prefills=4 & long_prefill_token_threshold=2048`
For each version, I also tested with `output_num=128`(which is default) and `output_num=1`.

```bash
vllm serve NousResearch/Hermes-3-Llama-3.1-8B [--max_num_partial_prefills=4 --long_prefill_token_threshold=2048]


vllm bench serve \
  --model NousResearch/Hermes-3-Llama-3.1-8B \
    --dataset-name custom \
  --dataset-path benchmark.jsonl \
  --num-prompts -1 \
  --metric-percentiles 80,85,90,95,99 \
  --request-rate 12 \
  --disable_shuffle \
  [--output_len=1]
```

Sorry that the chart is probably not organized in the clearest way. Please compare the stats in greyed column together and in white column together.
<img width="1185" height="628" alt="image" src="https://github.com/user-attachments/assets/fe764729-fc11-4d74-b66e-d0d259d57cc1" />


Some interesting observation:
1. The performance boost on TTFT for `output_len=128` experiment group is not significant (~20%). I did some investigation and I think it's because the decoding phase largely averaged out the TTFT since even after the small requests get prefilled, they still need to be in the queue for fairly large number of times, and therefore capped by `max_num_seqs` which is 128 by default. If we only consider the prefilling phase (i.e. we set `output_len` to be 1), the TTFT improvement is significant (~400%). I did an extra experiment to further confirm this issue (in the last column of the chart, where `max_num_seqs=1024`)
2. As we increase `max_num_prefills`(1->4->16), we increase the throughput pretty consistently.
3. There's a tradeoff for TTFT P99. The performance gets consistently worse as we increase the throughput.

# Considerations
Some best practice suggestion around this feature:
1. `long_prefill_token_threshold` is best used if around `max_num_batched_tokens`. If it's too high away, the single large request can still starve the queue. If it's lower, then the throughput for large requests get degraded quickly. In this case, if a large request is the only request in queue, it does not get full budget of the run.
2. `max_num_seqs` must be tuned up in accordance with the throughput improvement.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

