### PR TITLE
feat(frontend): add --default-chat-template-kwargs CLI argument

### DIFF
--- a/docs/features/reasoning_outputs.md
+++ b/docs/features/reasoning_outputs.md
@@ -204,6 +204,42 @@ The reasoning content is also available when both tool calling and the reasoning
 
 For more examples, please refer to [examples/online_serving/openai_chat_completion_tool_calls_with_reasoning.py](../../examples/online_serving/openai_chat_completion_tool_calls_with_reasoning.py).
 
+## Server-Level Default Chat Template Kwargs
+
+You can set default `chat_template_kwargs` at the server level using the `--default-chat-template-kwargs` CLI argument. This is useful for configuring reasoning behavior across all requests without requiring clients to specify it in each request.
+
+### Disabling Thinking Mode by Default
+
+For models like Qwen3 where thinking is enabled by default, you can disable it server-wide:
+
+```bash
+vllm serve Qwen/Qwen3-8B \
+    --reasoning-parser qwen3 \
+    --default-chat-template-kwargs '{"enable_thinking": false}'
+```
+
+### Enabling Thinking Mode by Default
+
+For models like IBM Granite 3.2 or DeepSeek-V3.1 where thinking is disabled by default, you can enable it server-wide:
+
+```bash
+vllm serve ibm-granite/granite-3.2-2b-instruct \
+    --reasoning-parser granite \
+    --default-chat-template-kwargs '{"thinking": true}'
+```
+
+### Request-Level Override
+
+Request-level `chat_template_kwargs` always take priority over server defaults. For example, if the server is started with `enable_thinking=false`, a client can still enable it for a specific request:
+
+```python
+response = client.chat.completions.create(
+    model=model,
+    messages=messages,
+    extra_body={"chat_template_kwargs": {"enable_thinking": True}}  # Overrides server default
+)
+```
+
 ## Limitations
 
 - The reasoning content is only available for online serving's chat completion endpoint (`/v1/chat/completions`).

--- a/tests/entrypoints/openai/test_cli_args.py
+++ b/tests/entrypoints/openai/test_cli_args.py
@@ -208,3 +208,38 @@ def test_middleware(serve_parser, cli_args, expected_middleware):
     """Ensure multiple middleware args are parsed properly"""
     args = serve_parser.parse_args(args=cli_args)
     assert args.middleware == expected_middleware
+
+
+def test_default_chat_template_kwargs_parsing(serve_parser):
+    """Ensure default_chat_template_kwargs JSON is parsed correctly"""
+    args = serve_parser.parse_args(
+        args=["--default-chat-template-kwargs", '{"enable_thinking": false}']
+    )
+    assert args.default_chat_template_kwargs == {"enable_thinking": False}
+
+
+def test_default_chat_template_kwargs_complex(serve_parser):
+    """Ensure complex default_chat_template_kwargs JSON is parsed correctly"""
+    kwargs_json = '{"enable_thinking": false, "custom_param": "value", "num": 42}'
+    args = serve_parser.parse_args(
+        args=["--default-chat-template-kwargs", kwargs_json]
+    )
+    assert args.default_chat_template_kwargs == {
+        "enable_thinking": False,
+        "custom_param": "value",
+        "num": 42,
+    }
+
+
+def test_default_chat_template_kwargs_default_none(serve_parser):
+    """Ensure default_chat_template_kwargs defaults to None"""
+    args = serve_parser.parse_args(args=[])
+    assert args.default_chat_template_kwargs is None
+
+
+def test_default_chat_template_kwargs_invalid_json(serve_parser):
+    """Ensure invalid JSON raises an error"""
+    with pytest.raises(SystemExit):
+        serve_parser.parse_args(
+            args=["--default-chat-template-kwargs", "not valid json"]
+        )

--- a/tests/entrypoints/openai/test_cli_args.py
+++ b/tests/entrypoints/openai/test_cli_args.py
@@ -221,9 +221,7 @@ def test_default_chat_template_kwargs_parsing(serve_parser):
 def test_default_chat_template_kwargs_complex(serve_parser):
     """Ensure complex default_chat_template_kwargs JSON is parsed correctly"""
     kwargs_json = '{"enable_thinking": false, "custom_param": "value", "num": 42}'
-    args = serve_parser.parse_args(
-        args=["--default-chat-template-kwargs", kwargs_json]
-    )
+    args = serve_parser.parse_args(args=["--default-chat-template-kwargs", kwargs_json])
     assert args.default_chat_template_kwargs == {
         "enable_thinking": False,
         "custom_param": "value",

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1079,6 +1079,7 @@ async def init_app_state(
             request_logger=request_logger,
             chat_template=resolved_chat_template,
             chat_template_content_format=args.chat_template_content_format,
+            default_chat_template_kwargs=args.default_chat_template_kwargs,
             trust_request_chat_template=args.trust_request_chat_template,
             return_tokens_as_token_ids=args.return_tokens_as_token_ids,
             enable_auto_tools=args.enable_auto_tool_choice,
@@ -1089,7 +1090,6 @@ async def init_app_state(
             enable_force_include_usage=args.enable_force_include_usage,
             enable_log_outputs=args.enable_log_outputs,
             log_error_stack=args.log_error_stack,
-            default_chat_template_kwargs=args.default_chat_template_kwargs,
         )
         if "generate" in supported_tasks
         else None

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1089,6 +1089,7 @@ async def init_app_state(
             enable_force_include_usage=args.enable_force_include_usage,
             enable_log_outputs=args.enable_log_outputs,
             log_error_stack=args.log_error_stack,
+            default_chat_template_kwargs=args.default_chat_template_kwargs,
         )
         if "generate" in supported_tasks
         else None

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -11,7 +11,7 @@ import json
 import ssl
 from collections.abc import Sequence
 from dataclasses import field
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic.dataclasses import dataclass
 
@@ -114,6 +114,12 @@ class FrontendArgs:
     """Whether to trust the chat template provided in the request. If False,
     the server will always use the chat template specified by `--chat-template`
     or the ones from tokenizer."""
+    default_chat_template_kwargs: dict[str, Any] | None = None
+    """Default keyword arguments to pass to the chat template renderer.
+    These will be merged with request-level chat_template_kwargs,
+    with request values taking precedence. Useful for setting default
+    behavior for reasoning models. Example: '{"enable_thinking": false}'
+    to disable thinking mode by default for Qwen3/DeepSeek models."""
     response_role: str = "assistant"
     """The role name to return if `request.add_generation_prompt=true`."""
     ssl_keyfile: str | None = None
@@ -210,6 +216,9 @@ class FrontendArgs:
         del frontend_kwargs["allowed_origins"]["nargs"]
         del frontend_kwargs["allowed_methods"]["nargs"]
         del frontend_kwargs["allowed_headers"]["nargs"]
+
+        # Special case: default_chat_template_kwargs needs json.loads type
+        frontend_kwargs["default_chat_template_kwargs"]["type"] = json.loads
 
         # Special case: LoRA modules need custom parser action and
         # optional_type(str)

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -468,6 +468,9 @@ async def run_batch(
             reasoning_parser=args.structured_outputs_config.reasoning_parser,
             enable_prompt_tokens_details=args.enable_prompt_tokens_details,
             enable_force_include_usage=args.enable_force_include_usage,
+            default_chat_template_kwargs=getattr(
+                args, "default_chat_template_kwargs", None
+            ),
         )
         if "generate" in supported_tasks
         else None

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -6,7 +6,7 @@ import json
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
-from typing import Final
+from typing import Any, Final
 
 import jinja2
 import partial_json_parser
@@ -102,6 +102,7 @@ class OpenAIServingChat(OpenAIServing):
         enable_force_include_usage: bool = False,
         enable_log_outputs: bool = False,
         log_error_stack: bool = False,
+        default_chat_template_kwargs: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(
             engine_client=engine_client,
@@ -115,6 +116,7 @@ class OpenAIServingChat(OpenAIServing):
         self.chat_template = chat_template
         self.chat_template_content_format: Final = chat_template_content_format
         self.trust_request_chat_template = trust_request_chat_template
+        self.default_chat_template_kwargs = default_chat_template_kwargs or {}
         self.enable_log_outputs = enable_log_outputs
 
         # set up logits processors
@@ -203,6 +205,7 @@ class OpenAIServingChat(OpenAIServing):
                 tool_dicts=None,
                 documents=None,
                 chat_template_kwargs=None,
+                default_chat_template_kwargs=self.default_chat_template_kwargs,
                 tool_parser=None,
                 add_special_tokens=False,
             )
@@ -310,6 +313,7 @@ class OpenAIServingChat(OpenAIServing):
                     tool_dicts=tool_dicts,
                     documents=request.documents,
                     chat_template_kwargs=request.chat_template_kwargs,
+                    default_chat_template_kwargs=self.default_chat_template_kwargs,
                     tool_parser=tool_parser,
                     add_special_tokens=request.add_special_tokens,
                 )

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -1158,6 +1158,7 @@ class OpenAIServing:
         tool_dicts: list[dict[str, Any]] | None = None,
         documents: list[dict[str, str]] | None = None,
         chat_template_kwargs: dict[str, Any] | None = None,
+        default_chat_template_kwargs: dict[str, Any] | None = None,
         tool_parser: Callable[[TokenizerLike], ToolParser] | None = None,
         add_special_tokens: bool = False,
     ) -> tuple[list[ConversationMessage], list[TokensPrompt]]:
@@ -1183,6 +1184,8 @@ class OpenAIServing:
             tools=tool_dicts,
             documents=documents,
         )
+        if default_chat_template_kwargs:
+            _chat_template_kwargs.update(default_chat_template_kwargs)
         _chat_template_kwargs.update(chat_template_kwargs or {})
 
         request_prompt: str | list[int]


### PR DESCRIPTION
Fixes #28070

<!-- markdownlint-disable -->

## Purpose
Add server-level default chat_template_kwargs to control reasoning model behavior at deployment time. Request-level kwargs override these defaults. 

## Test Plan

This PR allows explicit control of reasoning/non-reasoning mode at the vllm serve command level using `--default-chat-template-kwargs`.

For reasoning models like Qwen3, you can now disable thinking mode server-wide by setting {"enable_thinking": false} as a default, eliminating the need to specify it in every request. Request-level chat_template_kwargs will override these server defaults when provided.

Manual test command:

```
vllm serve Qwen/Qwen3-8B --tensor-parallel-size 2 --served-model-name xionic-test --host 0.0.0.0 --port 8000
```

Minimal python code for test: 
```python
from openai import OpenAI
BASE_URL = "http://localhost:8000/v1"  # Change to your server
MODEL = "xionic-test"
client = OpenAI(api_key="EMPTY", base_url=BASE_URL)
# Same request to both servers
messages = [{"role": "user", "content": "What is 2+2?"}]
print("=" * 60)
print("WITHOUT --default-chat-template-kwargs (thinking enabled)")
print("=" * 60)
resp1 = client.chat.completions.create(model=MODEL, messages=messages, max_tokens=200)
print(resp1.choices[0].message.content)
print("\n" + "=" * 60)
print("WITH --default-chat-template-kwargs (thinking disabled)")
print("Or using client-side override (current workaround):")
print("=" * 60)
resp2 = client.chat.completions.create(
    model=MODEL,
    messages=messages,
    max_tokens=200,
    extra_body={"chat_template_kwargs": {"enable_thinking": False}},
)
print(resp2.choices[0].message.content)
print("\n" + "=" * 60)
print("SUMMARY")
print("=" * 60)
print(f"Response 1 length: {len(resp1.choices[0].message.content)} chars")
print(f"Response 2 length: {len(resp2.choices[0].message.content)} chars")
print(f"Has <think> tag in resp1: {'<think>' in resp1.choices[0].message.content}")
print(f"Has <think> tag in resp2: {'<think>' in resp2.choices[0].message.content}")
```


## Test Result


### WITHOUT --default-chat-template-kwargs (thinking enabled):

Result: <think>
Okay, the user is asking "What is 2+2?" That seems straightforward, but maybe they want a detailed explanation. Let me think. First, I should confirm the basic arithmetic. 2 plus 2 is 4. But maybe they're testing if I know the answer or if there's a trick. Sometimes people ask simple questions to see if the AI is reliable.

Wait, could there be a different interpretation? Like in some contexts, 2+2 might not be 4? For example, in modular arithmetic, if we're working modulo 3, 2+2 would be 1. But the question doesn't specify any context, so the default is standard arithmetic. 

Also, maybe they want to know the steps involved. Let me break it down. Starting with two units and adding another two units. So 2 + 2 equals 4. But perhaps they want a more detailed explanation, like using number lines or visual aids.



### WITH --default-chat-template-kwargs (thinking disabled):


Result: 2 + 2 equals 4.




<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

