### PR TITLE
[Bugfix] Remove spurious NVFP4 'GPU does not support FP4' warning

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -146,13 +146,6 @@ def apply_fp4_marlin_linear(
 def prepare_fp4_layer_for_marlin(
     layer: torch.nn.Module, input_dtype: torch.dtype | None = None
 ) -> None:
-    logger.warning_once(
-        "Your GPU does not have native support for FP4 computation but "
-        "FP4 quantization is being used. Weight-only FP4 compression will "
-        "be used leveraging the Marlin kernel. This may degrade "
-        "performance for compute-heavy workloads."
-    )
-
     is_nvfp4 = hasattr(layer, "weight_scale_2")
     if input_dtype is not None and input_dtype.itemsize == 1:
         if is_nvfp4:
@@ -229,13 +222,6 @@ def prepare_fp4_layer_for_marlin(
 def prepare_moe_fp4_layer_for_marlin(
     layer: torch.nn.Module, input_dtype: torch.dtype | None = None
 ) -> None:
-    logger.warning_once(
-        "Your GPU does not have native support for FP4 computation but "
-        "FP4 quantization is being used. Weight-only FP4 compression will "
-        "be used leveraging the Marlin kernel. This may degrade "
-        "performance for compute-heavy workloads."
-    )
-
     is_nvfp4 = hasattr(layer, "w13_weight_scale_2")
     if input_dtype is not None and input_dtype.itemsize == 1:
         if is_nvfp4:


### PR DESCRIPTION
## Summary

Removes misleading warning from `prepare_fp4_layer_for_marlin` and `prepare_moe_fp4_layer_for_marlin` that incorrectly claims the GPU does not have native FP4 support.

## Problem

When loading NVFP4 quantized models, users see this warning even on GPUs with native FP4 support (like RTX Pro 6000):

```
WARNING marlin_utils_fp4.py:137 Your GPU does not have native support for FP4 computation but FP4 quantization is being used. Weight-only FP4 compression will be used leveraging the Marlin kernel. This may degrade performance for compute-heavy workloads.
```

This warning was added when there was a slow emulation path, but that path was removed in #18000. The Marlin kernel is now the standard efficient implementation for FP4 quantization, not a fallback for unsupported GPUs.

## Changes

- Remove spurious warning from `prepare_fp4_layer_for_marlin()`
- Remove spurious warning from `prepare_moe_fp4_layer_for_marlin()`

## Test Plan

- Verified linting passes
- The removed warning was purely informational and does not affect functionality

Fixes #27471

🤖 Generated with [Claude Code](https://claude.com/claude-code)