### PR TITLE
[Code Quality] Add missing return type annotations to compilation and metrics modules

### DIFF
--- a/vllm/compilation/monitor.py
+++ b/vllm/compilation/monitor.py
@@ -12,7 +12,7 @@ context_manager = None
 torch_compile_start_time: float = 0.0
 
 
-def start_monitoring_torch_compile(vllm_config: VllmConfig):
+def start_monitoring_torch_compile(vllm_config: VllmConfig) -> None:
     global torch_compile_start_time
     torch_compile_start_time = time.time()
 
@@ -28,7 +28,7 @@ def start_monitoring_torch_compile(vllm_config: VllmConfig):
         context_manager.__enter__()
 
 
-def end_monitoring_torch_compile(vllm_config: VllmConfig):
+def end_monitoring_torch_compile(vllm_config: VllmConfig) -> None:
     compilation_config: CompilationConfig = vllm_config.compilation_config
     if compilation_config.mode == CompilationMode.VLLM_COMPILE:
         logger.info_once(
@@ -45,7 +45,7 @@ def end_monitoring_torch_compile(vllm_config: VllmConfig):
 cudagraph_capturing_enabled: bool = True
 
 
-def validate_cudagraph_capturing_enabled():
+def validate_cudagraph_capturing_enabled() -> None:
     # used to monitor whether a cudagraph capturing is legal at runtime.
     # should be called before any cudagraph capturing.
     # if an illegal cudagraph capturing happens, raise an error.
@@ -57,6 +57,6 @@ def validate_cudagraph_capturing_enabled():
         )
 
 
-def set_cudagraph_capturing_enabled(enabled: bool):
+def set_cudagraph_capturing_enabled(enabled: bool) -> None:
     global cudagraph_capturing_enabled
     cudagraph_capturing_enabled = enabled

--- a/vllm/scripts.py
+++ b/vllm/scripts.py
@@ -9,7 +9,7 @@ logger = init_logger(__name__)
 
 # Backwards compatibility for the move from vllm.scripts to
 # vllm.entrypoints.cli.main
-def main():
+def main() -> None:
     logger.warning(
         "vllm.scripts.main() is deprecated. Please re-install "
         "vllm or use vllm.entrypoints.cli.main.main() instead."

--- a/vllm/v1/metrics/prometheus.py
+++ b/vllm/v1/metrics/prometheus.py
@@ -14,7 +14,7 @@ logger = init_logger(__name__)
 _prometheus_multiproc_dir: tempfile.TemporaryDirectory | None = None
 
 
-def setup_multiprocess_prometheus():
+def setup_multiprocess_prometheus() -> None:
     """Set up prometheus multiprocessing directory if not already configured."""
     global _prometheus_multiproc_dir
 
@@ -52,7 +52,7 @@ def get_prometheus_registry() -> CollectorRegistry:
     return REGISTRY
 
 
-def unregister_vllm_metrics():
+def unregister_vllm_metrics() -> None:
     """Unregister any existing vLLM collectors from the prometheus registry.
 
     This is useful for testing and CI/CD where metrics may be registered
@@ -68,7 +68,7 @@ def unregister_vllm_metrics():
             registry.unregister(collector)
 
 
-def shutdown_prometheus():
+def shutdown_prometheus() -> None:
     """Shutdown prometheus metrics."""
 
     path = _prometheus_multiproc_dir


### PR DESCRIPTION
## Purpose

This PR adds missing return type annotations to functions in compilation and metrics modules to improve code quality and IDE support.

## Changes

### vllm/compilation/monitor.py

| Function | Return Type Added |
|----------|------------------|
| `start_monitoring_torch_compile()` | `None` |
| `end_monitoring_torch_compile()` | `None` |
| `validate_cudagraph_capturing_enabled()` | `None` |
| `set_cudagraph_capturing_enabled()` | `None` |

### vllm/v1/metrics/prometheus.py

| Function | Return Type Added |
|----------|------------------|
| `setup_multiprocess_prometheus()` | `None` |
| `unregister_vllm_metrics()` | `None` |
| `shutdown_prometheus()` | `None` |

### vllm/scripts.py

| Function | Return Type Added |
|----------|------------------|
| `main()` | `None` |

## Test Plan

This is a typing-only change with no runtime impact. All existing tests should pass.