### PR TITLE
Add missing return type annotations to usage, logging, and arg_utils modules

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -16,6 +16,7 @@ from typing import (
     Annotated,
     Any,
     Literal,
+    NoReturn,
     TypeAlias,
     TypeVar,
     Union,
@@ -2032,7 +2033,7 @@ class AsyncEngineArgs(EngineArgs):
         return parser
 
 
-def _raise_unsupported_error(feature_name: str):
+def _raise_unsupported_error(feature_name: str) -> NoReturn:
     msg = (
         f"{feature_name} is not supported. We recommend to "
         f"remove {feature_name} from your config."

--- a/vllm/logging_utils/log_time.py
+++ b/vllm/logging_utils/log_time.py
@@ -6,9 +6,13 @@ Provides a timeslice logging decorator
 
 import functools
 import time
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T", bound=Callable)
 
 
-def logtime(logger, msg=None):
+def logtime(logger, msg: str | None = None) -> Callable[[T], T]:
     """
     Logs the execution time of the decorated function.
     Always place it beneath other decorators.

--- a/vllm/usage/usage_lib.py
+++ b/vllm/usage/usage_lib.py
@@ -50,7 +50,7 @@ def set_runtime_usage_data(key: str, value: str | int | bool) -> None:
     _GLOBAL_RUNTIME_DATA[key] = value
 
 
-def is_usage_stats_enabled():
+def is_usage_stats_enabled() -> bool:
     """Determine whether or not we can send usage stats to the server.
     The logic is as follows:
     - By default, it should be enabled.
@@ -258,7 +258,7 @@ class UsageMessage:
         self._write_to_file(data)
         self._send_to_server(data)
 
-    def _report_continuous_usage(self):
+    def _report_continuous_usage(self) -> None:
         """Report usage every 10 minutes.
 
         This helps us to collect more data points for uptime of vLLM usages.


### PR DESCRIPTION
## Purpose

This PR adds missing return type annotations to functions in `vllm/usage/usage_lib.py`, `vllm/logging_utils/log_time.py`, and `vllm/engine/arg_utils.py` to improve code quality and IDE support.

## Changes

### vllm/usage/usage_lib.py

| Function | Return Type Added |
|----------|------------------|
| `is_usage_stats_enabled()` | `bool` |
| `_report_continuous_usage()` | `None` |

### vllm/logging_utils/log_time.py

| Function | Return Type Added |
|----------|------------------|
| `logtime()` | `Callable[[T], T]` (decorator factory with TypeVar for type preservation) |

### vllm/engine/arg_utils.py

| Function | Return Type Added |
|----------|------------------|
| `_raise_unsupported_error()` | `NoReturn` (function always raises) |

## Test Plan

This is a typing-only change with no runtime impact. All existing tests should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)