### PR TITLE
Add missing return type annotations to config, weight_utils, and deep_gemm modules

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1806,7 +1806,7 @@ class ModelConfig:
         return getattr(self.hf_config, "quantization_config", None) is not None
 
 
-def get_served_model_name(model: str, served_model_name: str | list[str] | None):
+def get_served_model_name(model: str, served_model_name: str | list[str] | None) -> str:
     """
     If the input is a non-empty list, the first model_name in
     `served_model_name` is taken.
@@ -1877,7 +1877,7 @@ _STR_DTYPE_TO_TORCH_DTYPE = {
 }
 
 
-def str_dtype_to_torch_dtype(type: str):
+def str_dtype_to_torch_dtype(type: str) -> torch.dtype | None:
     return _STR_DTYPE_TO_TORCH_DTYPE.get(type)
 
 

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -66,7 +66,7 @@ logger = init_logger(__name__)
 temp_dir = tempfile.gettempdir()
 
 
-def enable_hf_transfer():
+def enable_hf_transfer() -> None:
     """automatically activates hf_transfer"""
     if "HF_HUB_ENABLE_HF_TRANSFER" not in os.environ:
         try:

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -363,7 +363,7 @@ def per_block_cast_to_fp8(
     )
 
 
-def calc_diff(x: torch.Tensor, y: torch.Tensor):
+def calc_diff(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     """Return a global difference metric for unit tests.
 
     DeepGEMM kernels on Blackwell/B200 currently exhibit noticeable per-element


### PR DESCRIPTION
## Purpose

This PR adds missing return type annotations to functions in `vllm/config/model.py`, `vllm/model_executor/model_loader/weight_utils.py`, and `vllm/utils/deep_gemm.py` to improve code quality and IDE support.

## Changes

### vllm/config/model.py

| Function | Return Type Added |
|----------|------------------|
| `get_served_model_name()` | `str` |
| `str_dtype_to_torch_dtype()` | `torch.dtype \| None` |

### vllm/model_executor/model_loader/weight_utils.py

| Function | Return Type Added |
|----------|------------------|
| `enable_hf_transfer()` | `None` |

### vllm/utils/deep_gemm.py

| Function | Return Type Added |
|----------|------------------|
| `calc_diff()` | `torch.Tensor` |

## Test Plan

This is a typing-only change with no runtime impact. All existing tests should pass.