### PR TITLE
[UX] Display model name in Swagger documentation title

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -866,12 +866,26 @@ def _log_non_streaming_response(response_body: list) -> None:
 
 
 def build_app(args: Namespace) -> FastAPI:
+    # Use served model name for Swagger docs title, falling back to model path
+    if args.served_model_name is not None:
+        if isinstance(args.served_model_name, list):
+            model_name = args.served_model_name[0]
+        else:
+            model_name = args.served_model_name
+    else:
+        model_name = args.model
+    docs_title = f"vLLM - {model_name}"
+
     if args.disable_fastapi_docs:
         app = FastAPI(
-            openapi_url=None, docs_url=None, redoc_url=None, lifespan=lifespan
+            title=docs_title,
+            openapi_url=None,
+            docs_url=None,
+            redoc_url=None,
+            lifespan=lifespan,
         )
     else:
-        app = FastAPI(lifespan=lifespan)
+        app = FastAPI(title=docs_title, lifespan=lifespan)
     app.state.args = args
     from vllm.entrypoints.serve import register_vllm_serve_api_routers
 


### PR DESCRIPTION
## Summary

Update FastAPI app to use the served model name in the Swagger documentation title instead of the default "FastAPI" title.

This helps users easily identify which model is being served when managing multiple vLLM instances on different ports.

**Before:**
- Swagger UI shows "FastAPI" as the title

**After:**
- Swagger UI shows "vLLM - meta-llama/Llama-3.1-8B-Instruct" (or whatever model is being served)

## Changes

The title format is `vLLM - <model_name>` where model_name is determined by:
1. The first entry in `--served-model-name` if specified
2. Otherwise, the `--model` path

## Test plan

1. Start vLLM server with a model
2. Navigate to `/docs` endpoint
3. Verify the browser tab and Swagger UI header shows the model name

Closes #24182

🤖 Generated with [Claude Code](https://claude.com/claude-code)