### PR TITLE
style(utils): add return type annotations

### DIFF
--- a/vllm/model_executor/utils.py
+++ b/vllm/model_executor/utils.py
@@ -19,7 +19,7 @@ def set_random_seed(seed: int | None) -> None:
 def set_weight_attrs(
     weight: torch.Tensor,
     weight_attrs: dict[str, Any] | None,
-):
+) -> None:
     """Set attributes on a weight tensor.
 
     This method is used to set attributes on a weight tensor. This method
@@ -50,7 +50,9 @@ def set_weight_attrs(
         setattr(weight, key, value)
 
 
-def replace_parameter(layer: torch.nn.Module, param_name: str, new_data: torch.Tensor):
+def replace_parameter(
+    layer: torch.nn.Module, param_name: str, new_data: torch.Tensor
+) -> None:
     """
     Replace a parameter of a layer while maintaining the ability to reload the weight.
     Called within implementations of the `process_weights_after_loading` method.

--- a/vllm/profiler/utils.py
+++ b/vllm/profiler/utils.py
@@ -11,7 +11,7 @@ from torch._C._profiler import _EventType, _ProfilerEvent, _TensorMetadata
 #
 
 
-def trim_string_front(string, width):
+def trim_string_front(string: str, width: int) -> str:
     if len(string) > width:
         offset = len(string) - width + 3
         string = string[offset:]
@@ -20,7 +20,7 @@ def trim_string_front(string, width):
     return string
 
 
-def trim_string_back(string, width):
+def trim_string_back(string: str, width: int) -> str:
     if len(string) > width:
         offset = len(string) - width + 3
         string = string[:-offset]


### PR DESCRIPTION
## Purpose

This PR adds missing return type annotations to utility functions in `vllm/model_executor/utils.py` and `vllm/profiler/utils.py` to improve code quality and IDE support.

## Changes

### model_executor/utils.py

| Function | Return Type Added |
|----------|------------------|
| `set_weight_attrs()` | `None` |
| `replace_parameter()` | `None` |

### profiler/utils.py

| Function | Return Type Added |
|----------|------------------|
| `trim_string_front()` | `str` |
| `trim_string_back()` | `str` |

## Test Plan

This is a typing-only change with no runtime impact. All existing tests should pass.