### PR TITLE
style: add return type annotations to config and tokenizer utils

### DIFF
--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -205,7 +205,7 @@ def update_config(config: ConfigT, overrides: dict[str, Any]) -> ConfigT:
     return replace(config, **processed_overrides)
 
 
-def normalize_value(x):
+def normalize_value(x: Any) -> Any:
     """Return a stable, JSON-serializable canonical form for hashing.
     Order: primitives, special types (Enum, callable, torch.dtype, Path), then
     generic containers (Mapping/Set/Sequence) with recursion.

--- a/vllm/tokenizers/detokenizer_utils.py
+++ b/vllm/tokenizers/detokenizer_utils.py
@@ -5,7 +5,7 @@
 from vllm.tokenizers import TokenizerLike
 
 
-def _replace_none_with_empty(tokens: list[str | None]):
+def _replace_none_with_empty(tokens: list[str | None]) -> None:
     for i, token in enumerate(tokens):
         if token is None:
             tokens[i] = ""


### PR DESCRIPTION
## Purpose

This PR adds missing return type annotations to utility functions in config and tokenizer modules to improve code quality and IDE support.

## Changes

| File | Function | Return Type Added |
|------|----------|------------------|
| `tokenizers/detokenizer_utils.py` | `_replace_none_with_empty()` | `None` |
| `config/utils.py` | `normalize_value()` | `Any` |

## Test Plan

This is a typing-only change with no runtime impact. All existing tests should pass.