### PR TITLE
style: add return type annotations to async_utils and envs

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -248,14 +248,14 @@ if TYPE_CHECKING:
     VLLM_DEBUG_MFU_METRICS: bool = False
 
 
-def get_default_cache_root():
+def get_default_cache_root() -> str:
     return os.getenv(
         "XDG_CACHE_HOME",
         os.path.join(os.path.expanduser("~"), ".cache"),
     )
 
 
-def get_default_config_root():
+def get_default_config_root() -> str:
     return os.getenv(
         "XDG_CONFIG_HOME",
         os.path.join(os.path.expanduser("~"), ".config"),

--- a/vllm/utils/async_utils.py
+++ b/vllm/utils/async_utils.py
@@ -218,7 +218,7 @@ class AsyncMicrobatchTokenizer:
             loop.call_soon_threadsafe(cancel_tasks)
 
 
-def cancel_task_threadsafe(task: Task):
+def cancel_task_threadsafe(task: Task) -> None:
     if task and not task.done():
         run_in_loop(task.get_loop(), task.cancel)
 
@@ -243,7 +243,7 @@ def make_async(
     return _async_wrapper
 
 
-def run_in_loop(loop: AbstractEventLoop, function: Callable, *args):
+def run_in_loop(loop: AbstractEventLoop, function: Callable, *args) -> None:
     if in_loop(loop):
         function(*args)
     elif not loop.is_closed():


### PR DESCRIPTION
## Purpose

This PR adds missing return type annotations to functions in `vllm/utils/async_utils.py` and `vllm/envs.py` to improve code quality and IDE support.

## Changes

### utils/async_utils.py

| Function | Return Type Added |
|----------|------------------|
| `cancel_task_threadsafe()` | `None` |
| `run_in_loop()` | `None` |

### envs.py

| Function | Return Type Added |
|----------|------------------|
| `get_default_cache_root()` | `str` |
| `get_default_config_root()` | `str` |

## Test Plan

This is a typing-only change with no runtime impact. All existing tests should pass.