### PR TITLE
style: add return type annotations to import_utils and profiling

### DIFF
--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -34,7 +34,7 @@ def init_cached_hf_modules() -> None:
     init_hf_modules()
 
 
-def import_pynvml():
+def import_pynvml() -> ModuleType:
     """
     Historical comments:
 
@@ -67,7 +67,7 @@ def import_pynvml():
 
 
 @cache
-def import_triton_kernels():
+def import_triton_kernels() -> None:
     """
     For convenience, prioritize triton_kernels that is available in
     `site-packages`. Use `vllm.third_party.triton_kernels` as a fall-back.
@@ -95,7 +95,7 @@ def import_triton_kernels():
         )
 
 
-def import_from_path(module_name: str, file_path: str | os.PathLike):
+def import_from_path(module_name: str, file_path: str | os.PathLike) -> ModuleType:
     """
     Import a Python file according to its file path.
 
@@ -124,7 +124,7 @@ def resolve_obj_by_qualname(qualname: str) -> Any:
 
 
 @cache
-def get_vllm_optional_dependencies():
+def get_vllm_optional_dependencies() -> dict[str, list[str]]:
     metadata = importlib.metadata.metadata("vllm")
     requirements = metadata.get_all("Requires-Dist", [])
     extras = metadata.get_all("Provides-Extra", [])

--- a/vllm/utils/profiling.py
+++ b/vllm/utils/profiling.py
@@ -4,13 +4,13 @@
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from functools import wraps
 from typing import Any
 
 
 @contextlib.contextmanager
-def cprofile_context(save_file: str | None = None):
+def cprofile_context(save_file: str | None = None) -> Iterator[None]:
     """Run a cprofile
 
     Args:
@@ -32,7 +32,9 @@ def cprofile_context(save_file: str | None = None):
             prof.print_stats(sort="cumtime")
 
 
-def cprofile(save_file: str | None = None, enabled: bool = True):
+def cprofile(
+    save_file: str | None = None, enabled: bool = True
+) -> Callable[[Callable], Callable]:
     """Decorator to profile a Python method using cProfile.
 
     Args:


### PR DESCRIPTION
## Purpose

This PR adds missing return type annotations to functions in `vllm/utils/import_utils.py` and `vllm/utils/profiling.py` to improve code quality and IDE support.

## Changes

### utils/import_utils.py

| Function | Return Type Added |
|----------|------------------|
| `import_pynvml()` | `ModuleType` |
| `import_triton_kernels()` | `None` |
| `import_from_path()` | `ModuleType` |
| `get_vllm_optional_dependencies()` | `dict[str, list[str]]` |

### utils/profiling.py

| Function | Return Type Added |
|----------|------------------|
| `cprofile_context()` | `Iterator[None]` |
| `cprofile()` | `Callable[[Callable], Callable]` |

## Test Plan

This is a typing-only change with no runtime impact. All existing tests should pass.