### PR TITLE
[Bugfix] Fix ZMQ port bind race condition in shm_broadcast

### DIFF
--- a/tests/distributed/test_shm_broadcast_zmq_port_range.py
+++ b/tests/distributed/test_shm_broadcast_zmq_port_range.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import contextlib
+import random
+import socket
+
+import pytest
+
+from vllm import envs
+from vllm.distributed.device_communicators.shm_broadcast import (
+    MessageQueue,
+    _parse_port_range,
+)
+
+
+def _port_is_free(port: int) -> bool:
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        try:
+            s.bind(("127.0.0.1", port))
+        except OSError:
+            return False
+        return True
+
+
+def _find_free_port_range(size: int = 20) -> tuple[int, int]:
+    # Use an unprivileged range and keep the range small so that
+    # `bind_to_random_port(..., max_tries=range_size)` stays fast.
+    lo = 20_000
+    hi = 65_535 - size
+    for _ in range(200):
+        start = random.randint(lo, hi)
+        end = start + size - 1
+        if all(_port_is_free(p) for p in range(start, end + 1)):
+            return start, end
+    pytest.skip("Could not find a free contiguous TCP port range on localhost.")
+
+
+@pytest.mark.parametrize(
+    "port_range,expected",
+    [
+        ("1-1", (1, 1)),
+        ("  2-3  ", (2, 3)),
+        ("4:5", (4, 5)),
+    ],
+)
+def test_parse_port_range_valid(port_range: str, expected: tuple[int, int]) -> None:
+    assert _parse_port_range(port_range) == expected
+
+
+@pytest.mark.parametrize(
+    "port_range",
+    [
+        "",
+        "abc",
+        "1",
+        "2-1",
+        "0-1",
+        "1-65536",
+        "1-2-3",
+    ],
+)
+def test_parse_port_range_invalid(port_range: str) -> None:
+    with pytest.raises(ValueError):
+        _parse_port_range(port_range)
+
+
+def test_message_queue_binds_within_zmq_port_range(monkeypatch: pytest.MonkeyPatch):
+    start_port, end_port = _find_free_port_range(size=30)
+    monkeypatch.setenv("VLLM_ZMQ_PORT_RANGE", f"{start_port}-{end_port}")
+    if hasattr(envs.__getattr__, "cache_clear"):
+        envs.__getattr__.cache_clear()
+
+    mq = MessageQueue(
+        n_reader=1,
+        n_local_reader=0,
+        connect_ip="127.0.0.1",
+    )
+    try:
+        addr = mq.export_handle().remote_subscribe_addr
+        assert addr is not None
+        port = int(addr.rsplit(":", 1)[1])
+        assert start_port <= port <= end_port
+    finally:
+        if mq.remote_socket is not None:
+            mq.remote_socket.close(0)
+        if hasattr(envs.__getattr__, "cache_clear"):
+            envs.__getattr__.cache_clear()

--- a/tests/distributed/test_shm_broadcast_zmq_port_range.py
+++ b/tests/distributed/test_shm_broadcast_zmq_port_range.py
@@ -34,6 +34,7 @@ def _find_free_port_range(size: int = 20) -> tuple[int, int]:
         if all(_port_is_free(p) for p in range(start, end + 1)):
             return start, end
     pytest.skip("Could not find a free contiguous TCP port range on localhost.")
+    raise RuntimeError("unreachable")
 
 
 @pytest.mark.parametrize(
@@ -65,7 +66,9 @@ def test_parse_port_range_invalid(port_range: str) -> None:
         _parse_port_range(port_range)
 
 
-def test_message_queue_binds_within_zmq_port_range(monkeypatch: pytest.MonkeyPatch):
+def test_message_queue_binds_within_zmq_port_range(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     start_port, end_port = _find_free_port_range(size=30)
     monkeypatch.setenv("VLLM_ZMQ_PORT_RANGE", f"{start_port}-{end_port}")
     if hasattr(envs.__getattr__, "cache_clear"):

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -43,6 +43,7 @@ VLLM_RINGBUFFER_WARNING_INTERVAL = envs.VLLM_RINGBUFFER_WARNING_INTERVAL
 
 from_bytes_big = functools.partial(int.from_bytes, byteorder="big")
 
+
 def _parse_port_range(port_range: str) -> tuple[int, int]:
     s = port_range.strip()
     sep = "-" if "-" in s else (":" if ":" in s else None)

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import functools
-import os
 import pickle
 import threading
 import time
@@ -352,7 +351,7 @@ class MessageQueue:
             # same port and crash with "Address already in use". Bind atomically
             # and optionally constrain the port range via `VLLM_ZMQ_PORT_RANGE`.
             remote_base_addr = f"tcp://{connect_ip}"
-            port_range = os.environ.get("VLLM_ZMQ_PORT_RANGE")
+            port_range = envs.VLLM_ZMQ_PORT_RANGE
             if port_range:
                 start_port, end_port = _parse_port_range(port_range)
                 max_tries = max(1, end_port - start_port + 1)

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -49,14 +49,16 @@ def _parse_port_range(port_range: str) -> tuple[int, int]:
     sep = "-" if "-" in s else (":" if ":" in s else None)
     if sep is None:
         raise ValueError(
-            f"Invalid VLLM_ZMQ_PORT_RANGE={port_range!r}; expected 'start-end' or 'start:end'"
+            f"Invalid VLLM_ZMQ_PORT_RANGE={port_range!r}; expected 'start-end' or "
+            "'start:end'"
         )
     start_s, end_s = s.split(sep, 1)
     start_port = int(start_s)
     end_port = int(end_s)
     if not (1 <= start_port <= end_port <= 65535):
         raise ValueError(
-            f"Invalid VLLM_ZMQ_PORT_RANGE={port_range!r}; expected 1 <= start <= end <= 65535"
+            f"Invalid VLLM_ZMQ_PORT_RANGE={port_range!r}; expected "
+            "1 <= start <= end <= 65535"
         )
     return start_port, end_port
 

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import functools
+import os
 import pickle
 import threading
 import time
@@ -31,7 +32,6 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.network_utils import (
     get_ip,
-    get_open_port,
     get_open_zmq_ipc_path,
     is_valid_ipv6_address,
 )
@@ -42,6 +42,22 @@ if TYPE_CHECKING:
 VLLM_RINGBUFFER_WARNING_INTERVAL = envs.VLLM_RINGBUFFER_WARNING_INTERVAL
 
 from_bytes_big = functools.partial(int.from_bytes, byteorder="big")
+
+def _parse_port_range(port_range: str) -> tuple[int, int]:
+    s = port_range.strip()
+    sep = "-" if "-" in s else (":" if ":" in s else None)
+    if sep is None:
+        raise ValueError(
+            f"Invalid VLLM_ZMQ_PORT_RANGE={port_range!r}; expected 'start-end' or 'start:end'"
+        )
+    start_s, end_s = s.split(sep, 1)
+    start_port = int(start_s)
+    end_port = int(end_s)
+    if not (1 <= start_port <= end_port <= 65535):
+        raise ValueError(
+            f"Invalid VLLM_ZMQ_PORT_RANGE={port_range!r}; expected 1 <= start <= end <= 65535"
+        )
+    return start_port, end_port
 
 
 # Memory fence for cross-process shared memory visibility.
@@ -324,14 +340,30 @@ class MessageQueue:
                 connect_ip = get_ip()
             self.remote_socket = context.socket(XPUB)
             self.remote_socket.setsockopt(XPUB_VERBOSE, True)
-            remote_subscribe_port = get_open_port()
             if is_valid_ipv6_address(connect_ip):
                 self.remote_socket.setsockopt(IPV6, 1)
                 remote_addr_ipv6 = True
                 connect_ip = f"[{connect_ip}]"
-            socket_addr = f"tcp://{connect_ip}:{remote_subscribe_port}"
-            self.remote_socket.bind(socket_addr)
-            remote_subscribe_addr = f"tcp://{connect_ip}:{remote_subscribe_port}"
+            # NOTE: Using `get_open_port()` (check) followed by `bind()` (act) is
+            # race-prone under multiprocess start: multiple writers can pick the
+            # same port and crash with "Address already in use". Bind atomically
+            # and optionally constrain the port range via `VLLM_ZMQ_PORT_RANGE`.
+            remote_base_addr = f"tcp://{connect_ip}"
+            port_range = os.environ.get("VLLM_ZMQ_PORT_RANGE")
+            if port_range:
+                start_port, end_port = _parse_port_range(port_range)
+                max_tries = max(1, end_port - start_port + 1)
+                remote_subscribe_port = self.remote_socket.bind_to_random_port(
+                    remote_base_addr,
+                    min_port=start_port,
+                    max_port=end_port,
+                    max_tries=max_tries,
+                )
+            else:
+                remote_subscribe_port = self.remote_socket.bind_to_random_port(
+                    remote_base_addr
+                )
+            remote_subscribe_addr = f"{remote_base_addr}:{remote_subscribe_port}"
         else:
             remote_subscribe_addr = None
             self.remote_socket = None

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -537,6 +537,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # VLLM_PORT will be used as the first port, and the rest will be generated
     # by incrementing the VLLM_PORT value.
     "VLLM_PORT": get_vllm_port,
+    # Optional port range for vLLM internal ZMQ sockets (e.g. shm_broadcast).
+    # Useful in clusters where only a subset of TCP ports are reachable between
+    # nodes. Format: "start-end" or "start:end" (e.g. "18000-18799").
+    "VLLM_ZMQ_PORT_RANGE": lambda: os.getenv("VLLM_ZMQ_PORT_RANGE", ""),
     # path used for ipc when the frontend api server is running in
     # multi-processing mode to communicate with the backend engine process.
     "VLLM_RPC_BASE_PATH": lambda: os.getenv(


### PR DESCRIPTION
## Purpose
Fix a TOCTOU race in `shm_broadcast.MessageQueue` where we pick a TCP port via `get_open_port()` and later bind a ZMQ XPUB socket. Under multiprocessing this can select the same port in multiple processes and crash with `zmq.error.ZMQError: Address already in use`.

Additionally, allow constraining the port range via `VLLM_ZMQ_PORT_RANGE` (format `start-end` or `start:end`) to support clusters with restricted inter-node port reachability.

## Test Plan
- Run pre-commit hooks on `vllm/distributed/device_communicators/shm_broadcast.py`.
- Manually reproduced the original failure on a Slurm multi-node (GH200) deployment; verified the fix avoids port collisions.

## Test Result
- Pre-commit: pass.
- Manual reproduction: no `Address already in use` crashes; ports are bound atomically.
