### PR TITLE
[XPU][CI]skip test_preprocess_error_handling due to fork/spawn issue

### DIFF
--- a/tests/v1/engine/test_preprocess_error_handling.py
+++ b/tests/v1/engine/test_preprocess_error_handling.py
@@ -15,9 +15,10 @@ MODEL_NAME = "hmellor/tiny-random-LlamaForCausalLM"
 def test_preprocess_error_handling(monkeypatch: pytest.MonkeyPatch):
     """Test that preprocessing errors are handled gracefully."""
 
-    if current_platform.is_rocm():
+    if current_platform.is_rocm() or current_platform.is_xpu():
         pytest.skip(
-            "Skipped on ROCm: this test only works with 'fork', but ROCm uses 'spawn'."
+            "Skipped on ROCm/XPU: this test only works with 'fork', "
+            "but ROCm/XPU uses 'spawn'."
         )
 
     assert not torch.cuda.is_initialized(), (


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
similar to https://github.com/vllm-project/vllm/pull/31192, xpu also doesn't support fork. skip this test on xpu.

## Test Plan
CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

