### PR TITLE
[Bugfix] Fix byte fallback handling when using outlines 

### DIFF
--- a/vllm/v1/structured_output/backend_outlines.py
+++ b/vllm/v1/structured_output/backend_outlines.py
@@ -122,7 +122,12 @@ class OutlinesGrammar(StructuredOutputGrammar):
         Returns False if the FSM failed to advance.
         """
         if self.guide.accepts_tokens(tokens):
-            # Advance cannot fail because we checked Guide.accepts_tokens()
+            # Advance can fail when the next state reached after advancing with
+            # the current tokens is a dead state. This is because Guide.accepts_tokens()
+            # only checks whether the current tokens can be accepted,
+            # whereas guide.advance() additionally checks the next state
+            # after all tokens are accepted.
+            # We need to be aware that the FSM must be prepared without dead states.
             for t in tokens:
                 self.guide.advance(t)
                 self.num_processed_tokens += 1

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -226,7 +226,9 @@ def _reduced_vocabulary(
                 # by this point.
                 token_bytes = bytes(token_str)  # type: ignore[arg-type]
 
-            elif "\ufffd" in token_str and not re_replacement_seq.match(token_str):
+            elif (token_str == "\ufffd" and token != "\ufffd") or (
+                "\ufffd" in token_str and not re_replacement_seq.match(token_str)
+            ):
                 # Handle tokens with invalid UTF-8 sequences.
                 if re_llama_byte_token.match(token):
                     # Llama-like tokenizers use <0xXX> for incomplete sequences.


### PR DESCRIPTION
## Purpose
resolves: https://github.com/vllm-project/vllm/issues/31389

This PR Modifies byte fallback case when constructing reduced vocabulary for outlines. Most tokenizers have byte fallback functionality. 

Most tokenizers include a byte fallback mechanism that splits unknown tokens into byte tokens during tokenization. However in the V1 engine implementation, during the process of constructing a reduced vocabulary, these byte tokens were not being handled correctly. This caused issues during guided decoding when processing strings containing non-vocabulary characters, resulting in outline state transitions failing and the server crashing.
This PR modifies the conditional logic to properly handle legitimate byte tokens that were being incorrectly classified as merely invalid UTF-8 characters in this context.

## Test Plan
Run the reproducible script in https://github.com/vllm-project/vllm/issues/31389

## Test Result 
Successfully get response without crashing the server.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Fixes incorrect byte-fallback token handling when constructing the Outlines reduced vocabulary, preventing guided decoding failures on non-vocabulary characters.
> 
> - Adjusts `_reduced_vocabulary` condition to correctly detect legitimate byte tokens (e.g., Llama `<0xXX>` and GPT-2 byte mappings) vs. UTF-8 replacement chars, ensuring proper byte-to-id mapping
> - Adds clarifying comments in `OutlinesGrammar.accept_tokens` about potential dead states after advancing; behavior unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6f748c62350405dc39c45c16a9474d90d0954e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
