### PR TITLE
[CI] Replace `pre-commit` with `prek` for faster pre-commit checks

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -26,14 +26,14 @@ pull_request_rules:
         Hi @{{author}}, the pre-commit checks have failed. Please run:
 
         ```bash 
-        uv pip install pre-commit
-        pre-commit install
-        pre-commit run --all-files
+        uv pip install prek
+        prek install
+        prek run --all-files
         ```
 
         Then, commit the changes and push to your branch.
 
-        For future commits, `pre-commit` will run automatically on changed files before each commit.
+        For future commits, `prek` will run automatically on changed files before each commit.
 
         > [!TIP]
         > <details>
@@ -43,9 +43,9 @@ pull_request_rules:
         >
         > ```bash
         > # For mypy (substitute "3.10" with the failing version if needed)
-        > pre-commit run --hook-stage manual mypy-3.10
+        > prek run --hook-stage manual mypy-3.10
         > # For markdownlint
-        > pre-commit run --hook-stage manual markdownlint
+        > prek run --hook-stage manual markdownlint
         > ```
         > </details>
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,6 +23,6 @@ jobs:
     - run: echo "::add-matcher::.github/workflows/matchers/actionlint.json"
     - run: echo "::add-matcher::.github/workflows/matchers/markdownlint.json"
     - run: echo "::add-matcher::.github/workflows/matchers/mypy.json"
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+    - uses: j178/prek-action@91fd7d7cf70ae1dee9f4f44e7dfa5d1073fe6623 # v1.0.11
       with:
         extra_args: --all-files --hook-stage manual

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
   hooks:
   - id: typos
     args: [--force-exclude]
+    priority: 1
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v21.1.2
   hooks:
@@ -40,6 +41,7 @@ repos:
     - id: pip-compile
       args: [requirements/test.in, -o, requirements/test.txt, --index-strategy, unsafe-best-match, --torch-backend, cu129, --python-platform, x86_64-manylinux_2_28, --python-version, "3.12"]
       files: ^requirements/test\.(in|txt)$
+      priority: 1
 - repo: local
   hooks:
   - id: format-torch-nightly-test
@@ -51,6 +53,7 @@ repos:
     name: Run mypy locally for lowest supported Python version
     entry: python tools/pre_commit/mypy.py 0 "3.10"
     stages: [pre-commit] # Don't run in CI
+    priority: 1
     <<: &mypy_common
       language: python
       types_or: [python, pyi]
@@ -59,21 +62,25 @@ repos:
   - id: mypy-3.10 # TODO: Use https://github.com/pre-commit/mirrors-mypy when mypy setup is less awkward
     name: Run mypy for Python 3.10
     entry: python tools/pre_commit/mypy.py 1 "3.10"
+    priority: 1
     <<: *mypy_common
     stages: [manual] # Only run in CI
   - id: mypy-3.11 # TODO: Use https://github.com/pre-commit/mirrors-mypy when mypy setup is less awkward
     name: Run mypy for Python 3.11
     entry: python tools/pre_commit/mypy.py 1 "3.11"
+    priority: 1
     <<: *mypy_common
     stages: [manual] # Only run in CI
   - id: mypy-3.12 # TODO: Use https://github.com/pre-commit/mirrors-mypy when mypy setup is less awkward
     name: Run mypy for Python 3.12
     entry: python tools/pre_commit/mypy.py 1 "3.12"
+    priority: 1
     <<: *mypy_common
     stages: [manual] # Only run in CI
   - id: mypy-3.13 # TODO: Use https://github.com/pre-commit/mirrors-mypy when mypy setup is less awkward
     name: Run mypy for Python 3.13
     entry: python tools/pre_commit/mypy.py 1 "3.13"
+    priority: 1
     <<: *mypy_common
     stages: [manual] # Only run in CI
   - id: shellcheck
@@ -86,6 +93,7 @@ repos:
     entry: tools/pre_commit/png-lint.sh
     language: script
     types: [png]
+    priority: 1
   - id: signoff-commit
     name: Sign-off Commit
     entry: bash
@@ -121,6 +129,7 @@ repos:
     name: Update Dockerfile dependency graph
     entry: tools/pre_commit/update-dockerfile-graph.sh
     language: script
+    priority: 1
   - id: enforce-import-regex-instead-of-re
     name: Enforce import regex as re
     entry: python tools/pre_commit/enforce_regex_import.py

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -164,7 +164,7 @@ COPY --from=vllm-test-deps /workspace/vllm/requirements/cpu-test.txt requirement
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install -r requirements/dev.txt && \
-    pre-commit install --hook-type pre-commit --hook-type commit-msg
+    prek install --hook-type pre-commit --hook-type commit-msg
 
 ENTRYPOINT ["bash"]
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -60,30 +60,30 @@ For an optimized workflow when iterating on C++/CUDA kernels, see the [Increment
 
 ### Linting
 
-vLLM uses `pre-commit` to lint and format the codebase. See <https://pre-commit.com/#usage> if `pre-commit` is new to you. Setting up `pre-commit` is as easy as:
+vLLM uses `prek` to lint and format the codebase. See <https://prek.j178.dev/quickstart/> if `prek` is new to you. Setting up `prek` is as easy as:
 
 ```bash
-uv pip install pre-commit
-pre-commit install
+uv pip install prek
+prek install
 ```
 
-vLLM's `pre-commit` hooks will now run automatically every time you commit.
+vLLM's `prek` hooks will now run automatically every time you commit.
 
 !!! tip "Tips"
-    You can manually run the `pre-commit` hooks using:
+    You can manually run the `prek` hooks using:
 
     ```bash
-    pre-commit run     # runs on staged files
-    pre-commit run -a  # runs on all files (short for --all-files)
+    prek run     # runs on staged files
+    prek run -a  # runs on all files (short for --all-files)
     ```
 
     ---
 
-    Some `pre-commit` hooks only run in CI. If you need to, you can run them locally with:
+    Some `prek` hooks only run in CI. If you need to, you can run them locally with:
 
     ```bash
-    pre-commit run --hook-stage manual markdownlint
-    pre-commit run --hook-stage manual mypy-3.10
+    prek run --hook-stage manual markdownlint
+    prek run --hook-stage manual mypy-3.10
     ```
 
 ### Documentation

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,2 +1,2 @@
 # formatting
-pre-commit==4.0.1
+prek==0.2.25


### PR DESCRIPTION
Signed-off-by: Jo <10510431+j178@users.noreply.github.com>

## Purpose

Replace [`pre-commit`](https://github.com/pre-commit/pre-commit) with [`prek`](https://github.com/j178/prek) for faster pre-commit checks.

On my Mac, this change reduced:

- **Cold run**  from **~55s** to **~17s**
- **Warm-cache** run from **~12s** to **~7s**

## Test Plan

Cold run (no cache)

```console
❯ hyperfine --warmup 2 --runs 5 \
        --prepare "prek cache clean" "prek run --all-files" \
        --prepare "pre-commit clean" "pre-commit run --all-files"
Benchmark 1: prek run --all-files
  Time (mean ± σ):     17.527 s ±  0.863 s    [User: 24.755 s, System: 18.198 s]
  Range (min … max):   16.270 s … 18.380 s    5 runs

Benchmark 2: pre-commit run --all-files
  Time (mean ± σ):     55.452 s ±  3.147 s    [User: 36.584 s, System: 21.337 s]
  Range (min … max):   51.810 s … 60.216 s    5 runs

Summary
  prek run --all-files ran
    3.16 ± 0.24 times faster than pre-commit run --all-files
```

Warm cache

```console
> hyperfine 'prek run -a' 'pre-commit run -a' --warmup 3
Benchmark 1: prek run -a
  Time (mean ± σ):      7.080 s ±  0.342 s    [User: 18.901 s, System: 14.657 s]
  Range (min … max):    6.696 s …  7.959 s    10 runs

Benchmark 2: pre-commit run -a
  Time (mean ± σ):     12.767 s ±  0.251 s    [User: 18.367 s, System: 13.410 s]
  Range (min … max):   12.310 s … 13.084 s    10 runs

Summary
  prek run -a ran
    1.80 ± 0.09 times faster than pre-commit run -a
```

## Background: What is prek?

prek is a reimagined version of pre-commit, built in Rust. It is designed to be a faster, dependency-free and drop-in alternative for it, while also providing some additional long-requested features.

prek has already been adopted by projects like [Apache Airflow](https://github.com/apache/airflow/issues/44995) and [FastAPI](https://github.com/fastapi/fastapi/pull/14572) (see more examples [here](https://github.com/j178/prek/?tab=readme-ov-file#who-is-using-prek)). CPython is also discussing adpotion: https://github.com/python/cpython/issues/143148

## Changes in this PR

- Updated the contributor documentation and development requirements to use prek.
- Updated the `pre-commit.yml` CI workflow to run prek instead of pre-commit.
- Added `priority: 1` to the slowest hooks (typos, pip-compile, mypy-local, png-lint, update-dockerfile-graph) so they can run in parallel, reducing end-to-end wall time.

Note: [priority](https://prek.j178.dev/configuration/#priority) is a prek feature (not supported by pre-commit). If you run pre-commit with this config, it will warn about “Unexpected keys”, but the hooks will still run; the warning is safe to ignore.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

