### PR TITLE
[Doc] Clarify tensor parallelism support for EAGLE-based draft models

### DIFF
--- a/docs/features/spec_decode.md
+++ b/docs/features/spec_decode.md
@@ -263,9 +263,7 @@ A few important things to consider when using the EAGLE based draft models:
    [script](https://gist.github.com/abhigoyal1997/1e7a4109ccb7704fbc67f625e86b2d6d) to convert the speculative model,
    and specify `"model": "path/to/modified/eagle/model"` in `speculative_config`. If weight-loading problems still occur when using the latest version of vLLM, please leave a comment or raise an issue.
 
-2. It's possible to run the EAGLE based draft models with tensor_parallel using tp_size=1
-   or target_model_tpsize (i.e. draft_tensor_parallel_size is set to either 1 or the same
-   value as the target_model in speculative_config).
+2. It's possible to run EAGLE-based draft models with tensor parallelism. The `draft_tensor_parallel_size` in `speculative_config` can be set to either 1 or the same value as the target model's tensor parallel size.
 
 3. When using EAGLE-based speculators with vLLM, the observed speedup is lower than what is
    reported in the reference implementation [here](https://github.com/SafeAILab/EAGLE). This issue is under

--- a/docs/features/spec_decode.md
+++ b/docs/features/spec_decode.md
@@ -263,9 +263,9 @@ A few important things to consider when using the EAGLE based draft models:
    [script](https://gist.github.com/abhigoyal1997/1e7a4109ccb7704fbc67f625e86b2d6d) to convert the speculative model,
    and specify `"model": "path/to/modified/eagle/model"` in `speculative_config`. If weight-loading problems still occur when using the latest version of vLLM, please leave a comment or raise an issue.
 
-2. The EAGLE based draft models need to be run without tensor parallelism
-   (i.e. draft_tensor_parallel_size is set to 1 in `speculative_config`), although
-   it is possible to run the main model using tensor parallelism (see example above).
+2. It's possible to run the EAGLE based draft models with tensor_parallel using tp_size=1
+   or target_model_tpsize (i.e. draft_tensor_parallel_size is set to either 1 or the same
+   value as the target_model in speculative_config).
 
 3. When using EAGLE-based speculators with vLLM, the observed speedup is lower than what is
    reported in the reference implementation [here](https://github.com/SafeAILab/EAGLE). This issue is under


### PR DESCRIPTION
## Purpose
This PR updates the documentation to reflect the actual behavior of EAGLE-based draft models, where `draft_tensor_parallel_size` can be set to either 1 or the same value as the target model.

Related to https://github.com/vllm-project/vllm/issues/31398
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

