### PR TITLE
Add Loraconfig parameter to  get_punica_wrapper function

### DIFF
--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -366,7 +366,6 @@ def test_lm_head_logits_processor(
     punica_wrapper = get_punica_wrapper(8192, 256, device, lora_config=lora_config)
     assert check_punica_wrapper(punica_wrapper)
 
-
     def _pretest():
         linear = ParallelLMHead(
             num_embeddings=vocab_size,
@@ -489,7 +488,6 @@ def test_linear_replicated(
     punica_wrapper = get_punica_wrapper(8192, 256, device, lora_config=lora_config)
     assert check_punica_wrapper(punica_wrapper)
 
-
     def create_random_linear_replicated_layer():
         linear = ReplicatedLinear(4096, 4096, bias=False, params_dtype=torch.float16)
         linear.weight.data = torch.rand_like(linear.weight.data)
@@ -597,7 +595,6 @@ def test_linear_parallel(
     )
     punica_wrapper = get_punica_wrapper(8192, 256, device, lora_config=lora_config)
     assert check_punica_wrapper(punica_wrapper)
-
 
     def create_random_linear_parallel_layer():
         if orientation == "row":
@@ -723,7 +720,6 @@ def test_column_parallel_packed(
     )
     punica_wrapper = get_punica_wrapper(8192, 256, device, lora_config=lora_config)
     assert check_punica_wrapper(punica_wrapper)
-
 
     def create_column_parallel_packed_layer():
         if repeats == 2:

--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -261,11 +261,11 @@ def test_embeddings(dist_init, num_loras, device, vocab_size, stage) -> None:
 
     torch.set_default_device(device)
     max_loras = 8
-    punica_wrapper = get_punica_wrapper(8192, 256, device, max_loras=max_loras)
-    assert check_punica_wrapper(punica_wrapper)
     lora_config = LoRAConfig(
         max_loras=max_loras, max_lora_rank=8, lora_dtype=torch.float16
     )
+    punica_wrapper = get_punica_wrapper(8192, 256, device, lora_config=lora_config)
+    assert check_punica_wrapper(punica_wrapper)
 
     def create_random_embedding_layer():
         embedding = VocabParallelEmbedding(vocab_size, 256)
@@ -360,11 +360,12 @@ def test_lm_head_logits_processor(
 
     torch.set_default_device(device)
     max_loras = 8
-    punica_wrapper = get_punica_wrapper(8192, 256, device, max_loras=max_loras)
-    assert check_punica_wrapper(punica_wrapper)
     lora_config = LoRAConfig(
         max_loras=max_loras, max_lora_rank=8, lora_dtype=torch.float16
     )
+    punica_wrapper = get_punica_wrapper(8192, 256, device, lora_config=lora_config)
+    assert check_punica_wrapper(punica_wrapper)
+
 
     def _pretest():
         linear = ParallelLMHead(
@@ -480,13 +481,14 @@ def test_linear_replicated(
 
     max_loras = 8
     torch.set_default_device(device)
-    punica_wrapper = get_punica_wrapper(8192, 256, device, max_loras=max_loras)
-    assert check_punica_wrapper(punica_wrapper)
     lora_config = LoRAConfig(
         max_loras=max_loras,
         max_lora_rank=8,
         lora_dtype=torch.float16,
     )
+    punica_wrapper = get_punica_wrapper(8192, 256, device, lora_config=lora_config)
+    assert check_punica_wrapper(punica_wrapper)
+
 
     def create_random_linear_replicated_layer():
         linear = ReplicatedLinear(4096, 4096, bias=False, params_dtype=torch.float16)
@@ -587,14 +589,15 @@ def test_linear_parallel(
 
     max_loras = 8
     torch.set_default_device(device)
-    punica_wrapper = get_punica_wrapper(8192, 256, device, max_loras=max_loras)
-    assert check_punica_wrapper(punica_wrapper)
     lora_config = LoRAConfig(
         max_loras=max_loras,
         max_lora_rank=8,
         fully_sharded_loras=fully_shard,
         lora_dtype=torch.float16,
     )
+    punica_wrapper = get_punica_wrapper(8192, 256, device, lora_config=lora_config)
+    assert check_punica_wrapper(punica_wrapper)
+
 
     def create_random_linear_parallel_layer():
         if orientation == "row":
@@ -712,14 +715,15 @@ def test_column_parallel_packed(
 
     max_loras = 8
     torch.set_default_device(device)
-    punica_wrapper = get_punica_wrapper(8192, 256, device, max_loras=max_loras)
-    assert check_punica_wrapper(punica_wrapper)
     lora_config = LoRAConfig(
         max_loras=max_loras,
         max_lora_rank=8,
         fully_sharded_loras=fully_shard,
         lora_dtype=torch.float16,
     )
+    punica_wrapper = get_punica_wrapper(8192, 256, device, lora_config=lora_config)
+    assert check_punica_wrapper(punica_wrapper)
+
 
     def create_column_parallel_packed_layer():
         if repeats == 2:

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -128,7 +128,6 @@ class LoRAModelManager:
                 max_num_batched_tokens,
                 max_batches=self.max_num_seqs,
                 device=self.device,
-                max_loras=self.lora_config.max_loras,
                 lora_config=self.lora_config,
             )
 
@@ -149,7 +148,6 @@ class LoRAModelManager:
             max_num_batched_tokens,
             max_batches=self.max_num_seqs,
             device=self.device,
-            max_loras=self.lora_config.max_loras,
             lora_config=self.lora_config,
         )
         lm_prefix = self.mm_mapping.language_model[0]
@@ -188,7 +186,6 @@ class LoRAModelManager:
             num_encoder_tokens,
             max_batches=self.max_num_seqs * limit_per_prompt,
             device=self.device,
-            max_loras=self.lora_config.max_loras,
             lora_config=self.lora_config,
         )
         for prefix in self.mm_mapping.tower_model:
@@ -204,7 +201,6 @@ class LoRAModelManager:
                     connector_tokens,
                     max_batches=self.max_num_seqs * limit_per_prompt,
                     device=self.device,
-                    max_loras=self.lora_config.max_loras,
                     lora_config=self.lora_config,
                 )
                 for prefix in self.mm_mapping.connector:

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -129,6 +129,7 @@ class LoRAModelManager:
                 max_batches=self.max_num_seqs,
                 device=self.device,
                 max_loras=self.lora_config.max_loras,
+                lora_config=self.lora_config,
             )
 
             self.punica_wrapper_mapping[DEFAULT_LANGUAGE_WRAPPER_KEY] = (
@@ -149,6 +150,7 @@ class LoRAModelManager:
             max_batches=self.max_num_seqs,
             device=self.device,
             max_loras=self.lora_config.max_loras,
+            lora_config=self.lora_config,
         )
         lm_prefix = self.mm_mapping.language_model[0]
         self.punica_wrapper_mapping[lm_prefix] = llm_punica_wrapper
@@ -187,6 +189,7 @@ class LoRAModelManager:
             max_batches=self.max_num_seqs * limit_per_prompt,
             device=self.device,
             max_loras=self.lora_config.max_loras,
+            lora_config=self.lora_config,
         )
         for prefix in self.mm_mapping.tower_model:
             self.punica_wrapper_mapping[prefix] = tower_punica_wrapper
@@ -202,6 +205,7 @@ class LoRAModelManager:
                     max_batches=self.max_num_seqs * limit_per_prompt,
                     device=self.device,
                     max_loras=self.lora_config.max_loras,
+                    lora_config=self.lora_config,
                 )
                 for prefix in self.mm_mapping.connector:
                     self.punica_wrapper_mapping[prefix] = connector_punica_wrapper

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -45,7 +45,8 @@ class PunicaWrapperGPU(PunicaWrapperBase):
     ):
         PunicaWrapperBase.__init__(self, max_num_batched_tokens, max_batches, device)
 
-        self.max_loras = kwargs["max_loras"]
+        self.lora_config = kwargs["lora_config"]
+        self.max_loras = self.lora_config.max_loras
 
         self.token_mapping_meta = LoRAKernelMeta.make(
             self.max_loras, max_num_batched_tokens, device=device


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
In some scenarios, it is necessary to call different operators based on different LoRA configurations(https://github.com/vllm-project/vllm-ascend/pull/5394). At this time, get_current_vllm_config cannot be used, so a lora_config parameter was added to the function get_punica_wrapper ; at the same time, max_loras is retained to avoid affecting the use of other models. I suggest that  it can be switched to lora_config later.
## Test Plan
Because of **kwargs, there is no impact
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

