### PR TITLE
[Core] Sort blocks by block_id in FreeKVCacheBlockQueue.append_n

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -327,6 +327,11 @@ class FreeKVCacheBlockQueue:
         if len(blocks) == 0:
             return
 
+        # Sort blocks by block_id to enable contiguous allocation.
+        # This improves I/O efficiency for layer-wise KV cache transfers
+        # by allowing multiple blocks to be merged into single operations.
+        blocks.sort(key=lambda x: x.block_id)
+
         last_block = self.fake_free_list_tail.prev_free_block
         assert last_block is not None, (
             "prev_free_block of fake_free_list_tail should always exist"


### PR DESCRIPTION
## Summary

Sort blocks by `block_id` when returning them to the free list in `FreeKVCacheBlockQueue.append_n` to enable contiguous allocation.

This improves I/O efficiency for layer-wise KV cache transfers by allowing multiple blocks to be merged into single operations. When blocks are allocated in ascending order (e.g., `[1, 2, 3, 4, 5]`), we can merge multiple I/O submissions into a single contiguous transfer, rather than requiring separate I/O submissions for each block.

## Changes

- Added `blocks.sort(key=lambda x: x.block_id)` before inserting blocks back into the free list
- Added test `test_free_kv_cache_block_queue_append_n_sorts_by_block_id` to verify the sorting behavior

## Impact

- Minimal overhead (sorting a small list of freed blocks)
- Significant potential benefit for systems performing batched or layer-wise KV cache transfers

Fixes #31371