### PR TITLE
[Reasoning] Add GLM-4.7 reasoning parser for template-injected <think> tag

### DIFF
--- a/vllm/reasoning/__init__.py
+++ b/vllm/reasoning/__init__.py
@@ -36,6 +36,10 @@ _REASONING_PARSERS_TO_REGISTER = {
         "glm4_moe_reasoning_parser",
         "Glm4MoeModelReasoningParser",
     ),
+    "glm47": (
+        "glm4_moe_reasoning_parser",
+        "Glm47ReasoningParser",
+    ),
     "openai_gptoss": (
         "gptoss_reasoning_parser",
         "GptOssReasoningParser",


### PR DESCRIPTION
## Summary
- Adds a new `Glm47ReasoningParser` for GLM-4.7 models that inject `<think>` in the chat template
- Fixes #31319

### Problem
GLM-4.7 chat templates include `<think>` at the end of the prompt (after `<|assistant|>`), so the model output:
- Starts directly with thinking content (no `<think>` tag)
- Ends with `</think>` when thinking is complete

This causes the existing parser to fail to detect reasoning content.

### Solution
The new `Glm47ReasoningParser` class:
1. **Streaming**: Treats initial output as reasoning when no `<think>` token is present
2. **Non-streaming**: Prepends `<think>` to model output when `</think>` exists without `<think>`
3. Falls back to parent `Glm4MoeModelReasoningParser` for standard cases

### Usage
```bash
vllm serve <model> --reasoning-parser glm47
```

## Test plan
- [x] Ruff checks pass
- [ ] Manual testing with GLM-4.7 model

Fixes #31319

🤖 Generated with [Claude Code](https://claude.com/claude-code)