### PR TITLE
[v1] Improve GPU blocks error messages with actionable suggestions

### DIFF
--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -152,7 +152,12 @@ class BlockPool:
         enable_kv_cache_events: bool = False,
         metrics_collector: KVCacheMetricsCollector | None = None,
     ):
-        assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
+        if not isinstance(num_gpu_blocks, int) or num_gpu_blocks <= 0:
+            raise ValueError(
+                f"num_gpu_blocks must be a positive integer, got "
+                f"{num_gpu_blocks!r}. This indicates insufficient GPU memory "
+                "for KV cache allocation."
+            )
         self.num_gpu_blocks = num_gpu_blocks
         self.enable_caching = enable_caching
         self.hash_block_size = hash_block_size

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -136,7 +136,18 @@ class Scheduler(SchedulerInterface):
             )
 
         num_gpu_blocks = self.cache_config.num_gpu_blocks
-        assert num_gpu_blocks is not None and num_gpu_blocks > 0
+        if num_gpu_blocks is None or num_gpu_blocks <= 0:
+            raise ValueError(
+                f"Insufficient GPU memory for KV cache: num_gpu_blocks="
+                f"{num_gpu_blocks}. This usually means the model is too large "
+                "for the available GPU memory. Try one of the following:\n"
+                "  1. Reduce max_model_len (e.g., --max-model-len 2048)\n"
+                "  2. Increase gpu_memory_utilization "
+                "(e.g., --gpu-memory-utilization 0.95)\n"
+                "  3. Use tensor parallelism to distribute across GPUs "
+                "(e.g., --tensor-parallel-size 2)\n"
+                "  4. Enable KV cache offloading if supported"
+            )
 
         self.block_size = block_size
         self.dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size


### PR DESCRIPTION
## Summary
- Replace bare assertions for `num_gpu_blocks` with descriptive `ValueError` exceptions
- Provide actionable guidance when GPU memory is insufficient for KV cache

### Problem
When users run out of GPU memory for KV cache, they see an unhelpful:
```
AssertionError
```

### Solution
Now users see a clear error with suggestions:
```
ValueError: Insufficient GPU memory for KV cache: num_gpu_blocks=0. 
This usually means the model is too large for the available GPU memory. 
Try one of the following:
  1. Reduce max_model_len (e.g., --max-model-len 2048)
  2. Increase gpu_memory_utilization (e.g., --gpu-memory-utilization 0.95)
  3. Use tensor parallelism to distribute across GPUs (e.g., --tensor-parallel-size 2)
  4. Enable KV cache offloading if supported
```

### Files Changed
- `vllm/v1/core/sched/scheduler.py` - Main scheduler GPU blocks check
- `vllm/v1/core/block_pool.py` - Block pool initialization check

## Test plan
- [x] Ruff checks pass
- [ ] Error message displays correctly when GPU memory is insufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)