### PR TITLE
[Cleanup] Replace generic Exception with ValueError in quant utils

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -350,7 +350,7 @@ def marlin_zero_points(
     elif num_bits == 8:
         interleave = numpy.array([0, 2, 1, 3])
     else:
-        raise Exception("num_bits must be 4 or 8, got {}".format(num_bits))
+        raise ValueError(f"num_bits must be 4 or 8, got {num_bits}")
 
     if not is_a_8bit:
         zp = zp.reshape((-1, len(interleave)))[:, interleave].ravel()
@@ -379,7 +379,7 @@ def awq_to_marlin_zero_points(
     elif num_bits == 8:
         undo_interleave = numpy.argsort(numpy.array([0, 2, 1, 3]))
     else:
-        raise Exception("num_bits must be 4 or 8, got {}".format(num_bits))
+        raise ValueError(f"num_bits must be 4 or 8, got {num_bits}")
 
     q_zp = q_zp.reshape((-1, len(undo_interleave)))[:, undo_interleave].ravel()
     q_zp = q_zp.reshape((-1, size_n)).contiguous()

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_test.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_test.py
@@ -118,7 +118,7 @@ def get_weight_perm(num_bits: int, is_a_8bit: bool = False):
         else:
             interleave = np.array([0, 2, 1, 3])
     else:
-        raise Exception("num_bits must be 4 or 8, got {}".format(num_bits))
+        raise ValueError(f"num_bits must be 4 or 8, got {num_bits}")
 
     perm = perm.reshape((-1, len(interleave)))[:, interleave].ravel()
     perm = torch.from_numpy(perm)

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -631,7 +631,7 @@ def awq_pack(
     elif num_bits == 8:
         interleave = numpy.array([0, 2, 1, 3])
     else:
-        raise Exception("num_bits must be 4 or 8, got {}".format(num_bits))
+        raise ValueError(f"num_bits must be 4 or 8, got {num_bits}")
 
     q_w = q_w.reshape((-1, len(interleave)))[:, interleave].ravel()
     q_w = q_w.reshape((-1, size_n)).contiguous()


### PR DESCRIPTION
## Summary
- Replace `raise Exception(...)` with `raise ValueError(...)` in quantization utility files
- Convert `.format()` strings to f-strings for consistency

## Changes
| File | Changes |
|------|---------|
| `marlin_utils.py` | 2 occurrences fixed (lines 353, 382) |
| `quant_utils.py` | 1 occurrence fixed (line 634) |
| `marlin_utils_test.py` | 1 occurrence fixed (line 121) |

## Motivation
Using generic `Exception` is discouraged in Python because:
1. It makes catching specific exceptions impossible without also catching unrelated errors
2. It provides less information about what went wrong
3. It hinders proper exception handling in calling code

`ValueError` is the appropriate exception type here since these errors occur when an argument (`num_bits`) has an invalid value.

Additionally, f-strings are preferred over `.format()` for better readability and performance.

## Test plan
- [x] `ruff check` passes
- [x] `ruff format` reports no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)