### PR TITLE
[Cleanup] Replace generic Exception with specific types (part 2)

### DIFF
--- a/vllm/tool_parsers/granite_tool_parser.py
+++ b/vllm/tool_parsers/granite_tool_parser.py
@@ -65,7 +65,7 @@ class GraniteToolParser(ToolParser):
         try:
             raw_function_calls = json.loads(stripped)
             if not isinstance(raw_function_calls, list):
-                raise Exception(
+                raise ValueError(
                     f"Expected dict or list, got {type(raw_function_calls)}"
                 )
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1455,7 +1455,7 @@ class DPEngineCoreActor(DPEngineCoreProc):
             )
             os.environ[device_control_env_var] = value
         except IndexError as e:
-            raise Exception(
+            raise RuntimeError(
                 f"Error setting {device_control_env_var}: "
                 f"local range: [{local_dp_rank * world_size}, "
                 f"{(local_dp_rank + 1) * world_size}) "

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -215,7 +215,7 @@ def get_device_indices(
             )
         )
     except IndexError as e:
-        raise Exception(
+        raise RuntimeError(
             f"Error setting {device_control_env_var}: "
             f"local range: [{local_dp_rank * world_size}, "
             f"{(local_dp_rank + 1) * world_size}) "

--- a/vllm/v1/kv_offload/cpu.py
+++ b/vllm/v1/kv_offload/cpu.py
@@ -23,7 +23,7 @@ class CPUOffloadingSpec(OffloadingSpec):
 
         num_cpu_blocks = self.extra_config.get("num_cpu_blocks")
         if not num_cpu_blocks:
-            raise Exception(
+            raise ValueError(
                 "num_cpu_blocks must be specified in kv_connector_extra_config"
             )
         self.num_cpu_blocks: int = num_cpu_blocks
@@ -69,7 +69,7 @@ class CPUOffloadingSpec(OffloadingSpec):
     ) -> Iterator[tuple[type[LoadStoreSpec], type[LoadStoreSpec], OffloadingHandler]]:
         if not self._handlers:
             if not current_platform.is_cuda_alike():
-                raise Exception(
+                raise RuntimeError(
                     "CPU Offloading is currently only supported on CUDA-alike GPUs"
                 )
 


### PR DESCRIPTION
## Summary
Continuation of #31419 - replacing generic `raise Exception(...)` with appropriate specific exception types.

## Changes
| File | Old | New | Rationale |
|------|-----|-----|-----------|
| `v1/engine/core.py` | `Exception` | `RuntimeError` | Device configuration error during setup |
| `v1/engine/utils.py` | `Exception` | `RuntimeError` | Device configuration error during setup |
| `v1/kv_offload/cpu.py:26` | `Exception` | `ValueError` | Missing required config parameter |
| `v1/kv_offload/cpu.py:72` | `Exception` | `RuntimeError` | Platform not supported |
| `tool_parsers/granite_tool_parser.py` | `Exception` | `ValueError` | Unexpected type in parsed data |

## Motivation
Using specific exception types:
- Enables targeted exception handling in calling code
- Provides clearer semantics about the error type
- Follows Python best practices (PEP 8 recommends specific exceptions)

Note: I intentionally skipped `run_batch.py` as those exceptions are part of a retry loop that catches `Exception`, and changing them could affect retry behavior.

## Test plan
- [x] `ruff check` passes
- [x] No behavior change - just more specific exception types

🤖 Generated with [Claude Code](https://claude.com/claude-code)