### PR TITLE
[Cleanup] Add descriptive messages to empty exceptions

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/transform/module.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/transform/module.py
@@ -160,7 +160,10 @@ class HadamardTransform(torch.nn.Module):
             elif args.location == TransformLocation.OUTPUT:
                 return input_size
 
-        raise ValueError()
+        raise ValueError(
+            f"Unsupported layer type {type(layer).__name__} for transform. "
+            f"Expected LinearBase or VocabParallelEmbedding."
+        )
 
     def _validate_input_transforms(self):
         assert len(self.transforms) > 0
@@ -170,4 +173,8 @@ class HadamardTransform(torch.nn.Module):
             first_data = self.weight.partitions[0].data
             for partition in self.weight.partitions.values():
                 if partition.data.data_ptr() != first_data.data_ptr():
-                    raise ValueError("")
+                    raise ValueError(
+                        "Input transforms require all weight partitions to "
+                        "share the same underlying data pointer, but found "
+                        "partitions with different data pointers."
+                    )

--- a/vllm/model_executor/models/phi4mm_audio.py
+++ b/vllm/model_executor/models/phi4mm_audio.py
@@ -1135,7 +1135,15 @@ class AudioEmbedding(nn.Module):
             audio_dim_out = encoder_config["attention_dim"]
             n_mels = encoder_config["input_size"]
         else:
-            raise NotImplementedError("")
+            processor_name = (
+                config.audio_processor.get("name", None)
+                if isinstance(config.audio_processor, dict)
+                else config.audio_processor
+            )
+            raise NotImplementedError(
+                f"Audio processor '{processor_name}' is not supported. "
+                f"Only 'cascades' audio processor is currently implemented."
+            )
 
         assert audio_dim_out is not None, "Remember to set values for audio_dim_out"
         self.audio_dim_out = audio_dim_out


### PR DESCRIPTION
## Summary
Add meaningful error messages to previously empty or missing exception messages.

## Changes
| File | Line | Before | After |
|------|------|--------|-------|
| `compressed_tensors/transform/module.py` | 163 | `raise ValueError()` | Explains unsupported layer type |
| `compressed_tensors/transform/module.py` | 176 | `raise ValueError("")` | Explains partition data pointer requirement |
| `phi4mm_audio.py` | 1138 | `raise NotImplementedError("")` | Explains unsupported audio processor |

## Motivation
Empty exception messages make debugging significantly harder:
- Users have no context about what went wrong
- Stack traces only show the exception type, not the cause
- Developers need to read source code to understand the error

After this change, each exception provides:
- What was expected
- What was received (where applicable)
- Actionable context for fixing the issue

## Test plan
- [x] `ruff check` passes
- [x] No functional changes - only improved error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)