### PR TITLE
[UX] Improve DBO/microbatching error message for unsupported backends

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -876,11 +876,15 @@ class VllmConfig:
                 "deepep_low_latency",
                 "deepep_high_throughput",
             ], (
-                "Microbatching currently only supports the deepep_low_latency and "
-                f"deepep_high_throughput all2all backend. {a2a_backend} is not "
-                "supported. To fix use --all2all-backend=deepep_low_latency or "
-                "--all2all-backend=deepep_high_throughput and install the DeepEP"
-                " kernels."
+                f"Dual Batch Overlap (DBO) / microbatching requires DeepEP kernels "
+                f"but '{a2a_backend}' all2all backend was specified. "
+                f"DBO overlaps computation and communication for MoE models, "
+                f"but currently only works with DeepEP backends. "
+                f"To fix, either:\n"
+                f"  1. Use --all2all-backend=deepep_low_latency or "
+                f"--all2all-backend=deepep_high_throughput (requires DeepEP), or\n"
+                f"  2. Disable DBO by not using --enable-dbo if you want "
+                f"to use the '{a2a_backend}' backend"
             )
 
             if not self.model_config.disable_cascade_attn:


### PR DESCRIPTION
## Summary

Improves the error message when users try to use Dual Batch Overlap (DBO) / microbatching with unsupported all2all backends like PPLX.

Fixes #27513

## Changes

The previous error message was unclear about:
1. What DBO/microbatching actually is
2. Why certain backends don't support it
3. How to resolve the issue

The new error message:
- Explains that DBO overlaps computation and communication for MoE models
- Clearly states which backend was specified that doesn't support DBO
- Provides two clear remediation options:
  1. Switch to a DeepEP backend (`deepep_low_latency` or `deepep_high_throughput`)
  2. Disable DBO by not using `--enable-dbo` if they want to keep their current backend

## Before
```
Microbatching currently only supports the deepep_low_latency and deepep_high_throughput all2all backend. pplx is not supported. To fix use --all2all-backend=deepep_low_latency or --all2all-backend=deepep_high_throughput and install the DeepEP kernels.
```

## After
```
Dual Batch Overlap (DBO) / microbatching requires DeepEP kernels but 'pplx' all2all backend was specified. DBO overlaps computation and communication for MoE models, but currently only works with DeepEP backends. To fix, either:
  1. Use --all2all-backend=deepep_low_latency or --all2all-backend=deepep_high_throughput (requires DeepEP), or
  2. Disable DBO by not using --enable-dbo if you want to use the 'pplx' backend
```

## Test Plan
- [ ] Verified error message is grammatically correct and clear
- [ ] Verified the flag names are correct (`--enable-dbo`, `--all2all-backend`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)