### PR TITLE
[Feature] Add --disable-metrics-access-log to filter monitoring logs

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1354,6 +1354,7 @@ async def run_server_worker(
             app,
             sock=sock,
             enable_ssl_refresh=args.enable_ssl_refresh,
+            disable_metrics_access_log=args.disable_metrics_access_log,
             host=args.host,
             port=args.port,
             log_level=args.uvicorn_log_level,

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -85,6 +85,8 @@ class FrontendArgs:
     """Log level for uvicorn."""
     disable_uvicorn_access_log: bool = False
     """Disable uvicorn access log."""
+    disable_metrics_access_log: bool = False
+    """Disable access log for /metrics and /health endpoints only."""
     allow_credentials: bool = False
     """Allow credentials."""
     allowed_origins: list[str] = field(default_factory=lambda: ["*"])


### PR DESCRIPTION
## Summary

Adds a new CLI option `--disable-metrics-access-log` that filters out access logs for `/metrics` and `/health` endpoints while keeping all other access logs.

Fixes #29023

## Motivation

When monitoring systems (like IGW) frequently poll `/metrics` and `/health` endpoints, they create excessive log noise. Previously, users had to use `--disable-uvicorn-access-log` which disables ALL access logs, losing visibility into actual API requests.

## Changes

1. **New CLI argument**: `--disable-metrics-access-log` in `FrontendArgs`
2. **Logging filter**: `MetricsEndpointFilter` class that filters uvicorn access logs by path
3. **Integration**: Filter is applied to `uvicorn.access` logger when the option is enabled

## Usage

```bash
# Only filter out /metrics and /health logs
vllm serve model --disable-metrics-access-log

# Can be combined with other options
vllm serve model --disable-metrics-access-log --uvicorn-log-level warning
```

## Implementation Details

The filter checks the path argument in uvicorn access log records and excludes entries for:
- `/metrics`
- `/health`

All other access logs (API requests, completions, etc.) continue to be logged normally.

## Test Plan
- [x] Ruff checks pass
- [ ] Manual testing with monitoring endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)