### PR TITLE
[Bug] Fix GLM4 tool parser TypeError with empty arguments

### DIFF
--- a/tests/tool_parsers/test_glm4_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm4_moe_tool_parser.py
@@ -447,3 +447,54 @@ def test_extract_tool_calls_incomplete_tool_call(glm4_moe_tool_parser):
     assert not extracted_tool_calls.tools_called
     assert extracted_tool_calls.tool_calls == []
     assert extracted_tool_calls.content == model_output
+
+
+def test_extract_tool_calls_empty_tool_name(glm4_moe_tool_parser):
+    """Test that tool calls with empty names are skipped."""
+    model_output = """<tool_call>
+</tool_call>"""
+
+    extracted_tool_calls = glm4_moe_tool_parser.extract_tool_calls(
+        model_output, request=None
+    )  # type: ignore[arg-type]
+
+    # Empty tool name should result in no tool calls
+    assert not extracted_tool_calls.tools_called
+    assert extracted_tool_calls.tool_calls == []
+
+
+def test_extract_tool_calls_whitespace_tool_name(glm4_moe_tool_parser):
+    """Test that whitespace in tool names is stripped."""
+    model_output = """<tool_call>  get_weather
+<arg_key>city</arg_key>
+<arg_value>Beijing</arg_value>
+</tool_call>"""
+
+    extracted_tool_calls = glm4_moe_tool_parser.extract_tool_calls(
+        model_output, request=None
+    )  # type: ignore[arg-type]
+
+    assert extracted_tool_calls.tools_called
+    assert len(extracted_tool_calls.tool_calls) == 1
+    # Tool name should be stripped of whitespace
+    assert extracted_tool_calls.tool_calls[0].function.name == "get_weather"
+
+
+def test_extract_tool_calls_back_to_back(glm4_moe_tool_parser):
+    """Test back-to-back tool calls without whitespace between them."""
+    model_output = """<tool_call>func1
+<arg_key>a</arg_key>
+<arg_value>1</arg_value>
+</tool_call><tool_call>func2
+<arg_key>b</arg_key>
+<arg_value>2</arg_value>
+</tool_call>"""
+
+    extracted_tool_calls = glm4_moe_tool_parser.extract_tool_calls(
+        model_output, request=None
+    )  # type: ignore[arg-type]
+
+    assert extracted_tool_calls.tools_called
+    assert len(extracted_tool_calls.tool_calls) == 2
+    assert extracted_tool_calls.tool_calls[0].function.name == "func1"
+    assert extracted_tool_calls.tool_calls[1].function.name == "func2"


### PR DESCRIPTION
## Summary

Fixes TypeError when GLM4 tool parser encounters tools with no parameters.

Fixes #31379

## Problem

When a tool has no parameters, the regex group for arguments (`tc_args`) is `None`. 
Calling `self.func_arg_regex.findall(None)` raises:
```
TypeError: expected string or buffer
```

## Solution

Handle the `None` case by using an empty list when there are no arguments:
```python
pairs = self.func_arg_regex.findall(tc_args) if tc_args else []
```

## Test Plan
- [x] Ruff checks pass
- [ ] Test with tool calls that have no parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)