### PR TITLE
Add explicit warning categories to warnings.warn() calls

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -452,6 +452,7 @@ class ModelConfig:
         if self.override_attention_dtype is not None and not current_platform.is_rocm():
             warnings.warn(
                 "override-attention-dtype is set but not using ROCm platform",
+                UserWarning,
                 stacklevel=2,
             )
 

--- a/vllm/model_executor/layers/fla/ops/chunk.py
+++ b/vllm/model_executor/layers/fla/ops/chunk.py
@@ -208,6 +208,7 @@ def chunk_gated_delta_rule(
             "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
             "when head_first=False was specified. "
             "Please verify your input tensor format matches the expected shape [B, T, H, ...].",
+            UserWarning,
             stacklevel=2,
         )
     if cu_seqlens is not None:

--- a/vllm/model_executor/layers/fla/ops/cumsum.py
+++ b/vllm/model_executor/layers/fla/ops/cumsum.py
@@ -258,6 +258,7 @@ def chunk_local_cumsum(
             "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
             "when head_first=False was specified. "
             "Please verify your input tensor format matches the expected shape [B, T, H, ...].",
+            UserWarning,
             stacklevel=2,
         )
     if cu_seqlens is not None:

--- a/vllm/model_executor/models/nano_nemotron_vl.py
+++ b/vllm/model_executor/models/nano_nemotron_vl.py
@@ -1205,6 +1205,7 @@ class NemotronH_Nano_VL_V2(
             warnings.warn(
                 "In ps_version 'v1', the height and width have not "
                 "been swapped back, which results in a transposed image.",
+                UserWarning,
                 stacklevel=2,
             )
         else:

--- a/vllm/utils/func_utils.py
+++ b/vllm/utils/func_utils.py
@@ -74,7 +74,8 @@ def deprecate_args(
                         msg += f" {additional_message}"
 
                     warnings.warn(
-                        DeprecationWarning(msg),
+                        msg,
+                        DeprecationWarning,
                         stacklevel=3,  # The inner function takes up one level
                     )
 
@@ -109,7 +110,8 @@ def deprecate_kwargs(
                         msg += f" {additional_message}"
 
                     warnings.warn(
-                        DeprecationWarning(msg),
+                        msg,
+                        DeprecationWarning,
                         stacklevel=3,  # The inner function takes up one level
                     )
 

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -67,6 +67,7 @@ def get_ip() -> str:
         "Failed to get the IP address, using 0.0.0.0 by default."
         "The value can be set by the environment variable"
         " VLLM_HOST_IP or HOST_IP.",
+        UserWarning,
         stacklevel=2,
     )
     return "0.0.0.0"


### PR DESCRIPTION
## Summary
Add explicit warning categories to `warnings.warn()` calls that were missing the category argument. Also fix an incorrect pattern in `func_utils.py`.

## Changes

### Files Modified

1. **config/model.py**: Add `UserWarning` to override-attention-dtype warning
2. **utils/network_utils.py**: Add `UserWarning` to IP fallback warning
3. **utils/func_utils.py**: Fix `deprecate_args` and `deprecate_kwargs` to use proper `warnings.warn(msg, DeprecationWarning, ...)` pattern instead of `warnings.warn(DeprecationWarning(msg), ...)`
4. **model_executor/models/nano_nemotron_vl.py**: Add `UserWarning` to ps_version v1 warning
5. **model_executor/layers/fla/ops/cumsum.py**: Add `UserWarning` to tensor format mismatch warning
6. **model_executor/layers/fla/ops/chunk.py**: Add `UserWarning` to tensor format mismatch warning

## Rationale
Python's `warnings.warn()` defaults to `UserWarning` when no category is specified, but being explicit:
- Makes code intent clearer
- Follows Python best practices
- Enables proper warning filtering by category

The fix in `func_utils.py` is particularly important as the previous pattern `warnings.warn(DeprecationWarning(msg), ...)` creates an exception instance as the message, which is not the correct pattern.

## Test Plan
- No behavioral changes (warnings still work the same way)
- Existing tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)