### PR TITLE
Add return type annotations to __post_init__ methods

### DIFF
--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -166,7 +166,7 @@ class StatelessProcessGroup:
     # A deque to store the data entries, with key and timestamp.
     entries: deque[tuple[str, float]] = dataclasses.field(default_factory=deque)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         assert self.rank < self.world_size
         self.send_dst_counter = {i: 0 for i in range(self.world_size)}
         self.recv_src_counter = {i: 0 for i in range(self.world_size)}

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -205,7 +205,7 @@ class ForwardContext:
 
     ubatch_slices: UBatchSlices | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         assert self.cudagraph_runtime_mode.valid_runtime_modes(), (
             f"Invalid cudagraph runtime mode: {self.cudagraph_runtime_mode}"
         )

--- a/vllm/lora/layers/utils.py
+++ b/vllm/lora/layers/utils.py
@@ -21,7 +21,7 @@ class LoRAMapping:
     is_prefill: bool = False
     type: LoRAMappingType = LoRAMappingType.LANGUAGE
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self.index_mapping = tuple(self.index_mapping)
         self.prompt_mapping = tuple(self.prompt_mapping)
 

--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -50,7 +50,7 @@ class PEFTHelper:
             error_msg.append("vLLM does not yet support DoRA.")
         return error_msg
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.use_rslora:
             logger.info_once("Loading LoRA weights trained with rsLoRA.")
             self.vllm_lora_scaling_factor = self.lora_alpha / math.sqrt(self.r)

--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -23,7 +23,7 @@ class LoRARequest(
     base_model_name: str | None = msgspec.field(default=None)
     tensorizer_config_dict: dict | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.lora_int_id < 1:
             raise ValueError(f"id must be > 0, got {self.lora_int_id}")
 

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -49,7 +49,7 @@ class StructuredOutputsParams:
     _backend_was_auto: bool = field(default=False, init=False)
     """CAUTION: Should only be set by Processor._validate_structured_output"""
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate that some fields are mutually exclusive."""
         count = sum(
             [


### PR DESCRIPTION
## Summary
Add `-> None` return type annotations to `__post_init__` methods in dataclasses for consistency with Python typing conventions.

## Changes
Files updated:
- `vllm/forward_context.py`: `ForwardContext.__post_init__`
- `vllm/distributed/utils.py`: `StatelessProcessGroup.__post_init__`
- `vllm/sampling_params.py`: `GuidedDecodingParams.__post_init__`
- `vllm/lora/request.py`: `LoRARequest.__post_init__`
- `vllm/lora/peft_helper.py`: `PEFTHelper.__post_init__`
- `vllm/lora/layers/utils.py`: `LoRAMapping.__post_init__`

## Rationale
Adding explicit `-> None` return type annotations to `__post_init__` methods:
- Follows Python typing best practices
- Makes the code consistent (some `__post_init__` methods already have this annotation)
- Improves IDE support and type checking

## Test Plan
- No behavioral changes
- Existing tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)