### PR TITLE
[Bugfix] Preserve tool call id/type/name in streaming finish chunk

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1208,13 +1208,19 @@ class OpenAIServingChat(OpenAIServing):
                             # check to see if there's anything left to stream
                             remaining_call = expected_call.replace(actual_call, "", 1)
                             # set that as a delta message
+                            # preserve id/type/name from original delta_message
+                            original_tc = delta_message.tool_calls[0]
+                            original_fn = original_tc.function if original_tc else None
                             delta_message = DeltaMessage(
                                 tool_calls=[
                                     DeltaToolCall(
                                         index=index,
+                                        id=original_tc.id if original_tc else None,
+                                        type=original_tc.type if original_tc else None,
                                         function=DeltaFunctionCall(
-                                            arguments=remaining_call
-                                        ).model_dump(exclude_none=True),
+                                            name=original_fn.name if original_fn else None,
+                                            arguments=remaining_call,
+                                        ),
                                     )
                                 ]
                             )

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1209,7 +1209,9 @@ class OpenAIServingChat(OpenAIServing):
                             remaining_call = expected_call.replace(actual_call, "", 1)
                             # set that as a delta message
                             # preserve id/type/name from original delta_message
-                            original_tc = delta_message.tool_calls[0]
+                            original_tc = next(
+                                (tc for tc in delta_message.tool_calls
+                                 if tc.index == index), None)
                             original_fn = original_tc.function if original_tc else None
                             delta_message = DeltaMessage(
                                 tool_calls=[

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1208,30 +1208,8 @@ class OpenAIServingChat(OpenAIServing):
                             # check to see if there's anything left to stream
                             remaining_call = expected_call.replace(actual_call, "", 1)
                             # set that as a delta message
-                            # preserve id/type/name from original delta_message
-                            original_tc = next(
-                                (
-                                    tc
-                                    for tc in delta_message.tool_calls
-                                    if tc.index == index
-                                ),
-                                None,
-                            )
-                            original_fn = original_tc.function if original_tc else None
-                            delta_message = DeltaMessage(
-                                tool_calls=[
-                                    DeltaToolCall(
-                                        index=index,
-                                        id=original_tc.id if original_tc else None,
-                                        type=original_tc.type if original_tc else None,
-                                        function=DeltaFunctionCall(
-                                            name=original_fn.name
-                                            if original_fn
-                                            else None,
-                                            arguments=remaining_call,
-                                        ),
-                                    )
-                                ]
+                            delta_message = self._create_remaining_args_delta(
+                                delta_message, remaining_call, index
                             )
 
                         # Send the finish response for each request.n only once
@@ -1816,6 +1794,35 @@ class OpenAIServingChat(OpenAIServing):
             and delta_message.tool_calls[0]
             and delta_message.tool_calls[0].function
             and delta_message.tool_calls[0].function.arguments is not None
+        )
+
+    @staticmethod
+    def _create_remaining_args_delta(
+        delta_message: DeltaMessage,
+        remaining_call: str,
+        index: int,
+    ) -> DeltaMessage:
+        """
+        Create a delta message for remaining tool arguments, preserving
+        id/type/name from the original delta.
+        """
+        original_tc = next(
+            (tc for tc in delta_message.tool_calls if tc.index == index),
+            None,
+        )
+        original_fn = original_tc.function if original_tc else None
+        return DeltaMessage(
+            tool_calls=[
+                DeltaToolCall(
+                    index=index,
+                    id=original_tc.id if original_tc else None,
+                    type=original_tc.type if original_tc else None,
+                    function=DeltaFunctionCall(
+                        name=original_fn.name if original_fn else None,
+                        arguments=remaining_call,
+                    ),
+                )
+            ]
         )
 
     def _make_request_with_harmony(

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1210,8 +1210,13 @@ class OpenAIServingChat(OpenAIServing):
                             # set that as a delta message
                             # preserve id/type/name from original delta_message
                             original_tc = next(
-                                (tc for tc in delta_message.tool_calls
-                                 if tc.index == index), None)
+                                (
+                                    tc
+                                    for tc in delta_message.tool_calls
+                                    if tc.index == index
+                                ),
+                                None,
+                            )
                             original_fn = original_tc.function if original_tc else None
                             delta_message = DeltaMessage(
                                 tool_calls=[
@@ -1220,7 +1225,9 @@ class OpenAIServingChat(OpenAIServing):
                                         id=original_tc.id if original_tc else None,
                                         type=original_tc.type if original_tc else None,
                                         function=DeltaFunctionCall(
-                                            name=original_fn.name if original_fn else None,
+                                            name=original_fn.name
+                                            if original_fn
+                                            else None,
                                             arguments=remaining_call,
                                         ),
                                     )


### PR DESCRIPTION
## Summary

When streaming tool calls, the finish chunk code in `serving_chat.py` overwrites the tool parser's `DeltaMessage` with a stripped-down version containing only `index` and `function.arguments`. This loses the `id`, `type`, and `function.name` fields.

This fix preserves those fields from the original `delta_message` when building the finish chunk.

## Issue

Fixes #31437

## What was wrong

```python
delta_message = DeltaMessage(
    tool_calls=[
        DeltaToolCall(
            index=index,
            function=DeltaFunctionCall(
                arguments=remaining_call
            ).model_dump(exclude_none=True),
        )
    ]
)
```

The `id`, `type`, and `function.name` fields were lost.

## The fix

```python
original_tc = delta_message.tool_calls[0]
original_fn = original_tc.function if original_tc else None
delta_message = DeltaMessage(
    tool_calls=[
        DeltaToolCall(
            index=index,
            id=original_tc.id if original_tc else None,
            type=original_tc.type if original_tc else None,
            function=DeltaFunctionCall(
                name=original_fn.name if original_fn else None,
                arguments=remaining_call,
            ),
        )
    ]
)
```

## Testing

Tested with GLM-4.7-AWQ using `--tool-call-parser glm47`. Before fix: ~20% of streaming tool call responses had `id=None`. After fix: 100% success rate.

## Related

- #16340 - Similar symptoms, different root cause
- #10781 - Mentions delta not being submitted correctly