### PR TITLE
[ROCm][CI] Added perceptron lib in requirements for isaac multi-modal test

### DIFF
--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -88,3 +88,5 @@ pqdm==0.2.0
 arctic-inference == 0.1.1
 # Required for Nemotron test
 open-clip-torch==2.32.0
+# Required for isaac Multi-Modal generation test
+perceptron==0.1.4


### PR DESCRIPTION
Adding perceptron package for the "Multi-Modal Models Test (Extended) 2" to resolve dependency related to isaac model: 
````
2025-12-27 21:47:37 UTC
FAILED models/multimodal/generation/test_common.py::test_single_image_models[isaac-test_case35]
2025-12-27 21:47:37 UTC
FAILED models/multimodal/generation/test_common.py::test_single_image_models[isaac-test_case36]
2025-12-27 21:47:37 UTC
FAILED models/multimodal/generation/test_common.py::test_single_image_models[isaac-test_case37]
2025-12-27 21:47:37 UTC
FAILED models/multimodal/generation/test_common.py::test_multi_image_models[isaac-test_case35]
2025-12-27 21:47:37 UTC
FAILED models/multimodal/generation/test_common.py::test_multi_image_models[isaac-test_case36]
2025-12-27 21:47:37 UTC
FAILED models/multimodal/generation/test_common.py::test_multi_image_models[isaac-test_case37]
2025-12-27 21:47:37 UTC
= 6 failed, 66 passed, 49 skipped, 151 deselected, 223 warnings in 3918.43s (1:05:18) =
```