### PR TITLE
[BugFix] Preserve tool function name in delta messages when remaining arguments are empty

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1822,8 +1822,8 @@ class OpenAIServingChat(OpenAIServing):
         if not remaining_call:
             return delta_message
 
-        current_args = delta_message.tool_calls[0].function.arguments
-        if remaining_call == current_args:
+        func = delta_message.tool_calls[0].function
+        if func and remaining_call == func.arguments:
             return delta_message
 
         return DeltaMessage(


### PR DESCRIPTION
## Purpose
 
Fixes #31443

When using tool calling in vLLM's streaming chat completion, the tool function name is lost in delta messages. This affects models like GLM-4.7 that only emit tool calls when detecting `</tool_call>`, at which point the full tool call information is already available.

**Root Cause:** In `serving_chat.py`, the code that checks for unstreamed tool argument tokens unconditionally overwrites the original `delta_message`, even when `remaining_call` is empty. This causes `name`, `id`, and `type` fields to be lost.

**Fix:** Only create a new delta when there are actually remaining arguments to send. When `remaining_call` is empty, preserve the original delta from the tool parser.
## Test Plan

Added unit tests in `TestMaybeCreateRemainingArgsDelta` class:
- `test_preserves_delta_when_remaining_call_empty`: Verifies original delta is preserved when no remaining args
- `test_overwrites_delta_when_remaining_call_not_empty`: Verifies new delta is created when there are remaining args
- `test_glm_parser_scenario`: Simulates the GLM parser scenario from issue #31443

## Test Result

`tests/entrypoints/openai/test_serving_chat.py::TestMaybeCreateRemainingArgsDelta::test_preserves_delta_when_remaining_call_empty` PASSED

`tests/entrypoints/openai/test_serving_chat.py::TestMaybeCreateRemainingArgsDelta::test_overwrites_delta_when_remaining_call_not_empty` PASSED

`tests/entrypoints/openai/test_serving_chat.py::TestMaybeCreateRemainingArgsDelta::test_glm_parser_scenario` PASSED

Existing tool parser tests also pass:
- `tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py` - 7 passed
- `tests/entrypoints/openai/tool_parsers/test_llama3_json_tool_parser.py` - 15 passed
- `tests/entrypoints/openai/tool_parsers/test_pythonic_tool_parser.py` - 18 passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

