### PR TITLE
[LoRA] Add `--lora-target-modules` to selectively apply LoRA layers

### DIFF
--- a/docs/configuration/conserving_memory.md
+++ b/docs/configuration/conserving_memory.md
@@ -201,13 +201,13 @@ By using `--lora-target-modules` to target only the self-attention layers, you c
 
 You can specify the target modules as a list of strings (matched as suffix or exact) or a regex string (matched anywhere).
 
-**Example: List of modules (suffix matching)**
+##### Example: List of modules (suffix matching)
 
 ```bash
 --lora-target-modules q_proj v_proj k_proj o_proj
 ```
 
-**Example: Regex**
+##### Example: Regex
 
 ```bash
 --lora-target-modules '.*\.self_attn\..*'

--- a/docs/configuration/conserving_memory.md
+++ b/docs/configuration/conserving_memory.md
@@ -201,13 +201,13 @@ By using `--lora-target-modules` to target only the self-attention layers, you c
 
 You can specify the target modules as a list of strings (matched as suffix or exact) or a regex string (matched anywhere).
 
-##### Example: List of modules (suffix matching)
+Example: List of modules (suffix matching)
 
 ```bash
 --lora-target-modules q_proj v_proj k_proj o_proj
 ```
 
-##### Example: Regex
+Example: Regex
 
 ```bash
 --lora-target-modules '.*\.self_attn\..*'
@@ -219,4 +219,3 @@ For example, to exclude the large FFN/MoE layers (which might be named `mlp`, `g
 ```bash
 --lora-exclude-modules '.*\.mlp\.*' gate_up_proj down_proj gate
 ```
-

--- a/docs/configuration/conserving_memory.md
+++ b/docs/configuration/conserving_memory.md
@@ -210,12 +210,5 @@ Example: List of modules (suffix matching)
 Example: Regex
 
 ```bash
---lora-target-modules '.*\.self_attn\..*'
-```
-
-You can also use `--lora-exclude-modules` to exclude specific modules.
-For example, to exclude the large FFN/MoE layers (which might be named `mlp`, `gate_up_proj`, `down_proj`, or `gate`):
-
-```bash
---lora-exclude-modules '.*\.mlp\.*' gate_up_proj down_proj gate
-```
++--lora-target-modules '.*\.self_attn\..*'
++```

--- a/docs/configuration/conserving_memory.md
+++ b/docs/configuration/conserving_memory.md
@@ -183,32 +183,3 @@ llm = LLM(
     mm_processor_kwargs={"max_dynamic_patch": 4},  # Default is 12
 )
 ```
-
-## Selective LoRA with `lora_target_modules`
-
-When `--enable-lora` is configured, vLLM allocates GPU memory for all potential LoRA adapter layers at initialization time, based on the `--max-lora-rank`. This includes layers for self-attention, Feed-Forward Networks (FFN), Mixture-of-Experts (MoE), etc. This allocation happens even if the adapters you subsequently load do not modify all these components (e.g., they lack an FFN part).
-
-This default behavior can lead to a large memory consumption, especially since typical PEFT fine-tuning often only requires adjusting the self-attention layers, leaving the large FFN/MoE parts untouched.
-
-To optimize memory usage, you can use the `--lora-target-modules` command-line parameter to selectively initialize only the required LoRA layers.
-
-For example, with a model like `Qwen3-VL-32B-Instruct` and a `lora_rank=64`, the memory footprint for the initialized LoRA adapter (calculated with bf16) could be:
-
-- Self-attention: 51MiB
-- FFN (router + experts): 2406MiB
-
-By using `--lora-target-modules` to target only the self-attention layers, you can avoid allocating memory for the FFN/MoE LoRA layers, saving over 2.4 GiB of VRAM in this specific example.
-
-You can specify the target modules as a list of strings (matched as suffix or exact) or a regex string (matched anywhere).
-
-Example: List of modules (suffix matching)
-
-```bash
---lora-target-modules q_proj v_proj k_proj o_proj
-```
-
-Example: Regex
-
-```bash
-+--lora-target-modules '.*\.self_attn\..*'
-+```

--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -371,3 +371,32 @@ vllm serve model --enable-lora --max-lora-rank 64
 # Bad: unnecessarily high, wastes memory
 vllm serve model --enable-lora --max-lora-rank 256
 ```
+
+### Selective LoRA with `lora_target_modules` to Reduce Memory Usage
+
+When `--enable-lora` is configured, vLLM allocates GPU memory for all potential LoRA adapter layers at initialization time, based on the `--max-lora-rank`. This includes layers for self-attention, Feed-Forward Networks (FFN), Mixture-of-Experts (MoE), etc. This allocation happens even if the adapters you subsequently load do not modify all these components (e.g., they lack an FFN part).
+
+This default behavior can lead to a large memory consumption, especially since typical PEFT fine-tuning often only requires adjusting the self-attention layers, leaving the large FFN/MoE parts untouched.
+
+To optimize memory usage, you can use the `--lora-target-modules` command-line parameter to selectively initialize only the required LoRA layers.
+
+For example, with a model like `Qwen3-VL-32B-Instruct` and a `lora_rank=64`, the memory footprint for the initialized LoRA adapter (calculated with bf16) could be:
+
+- Self-attention: 51MiB
+- FFN (router + experts): 2406MiB
+
+By using `--lora-target-modules` to target only the self-attention layers, you can avoid allocating memory for the FFN/MoE LoRA layers, saving over 2.4 GiB of VRAM in this specific example.
+
+You can specify the target modules as a list of strings (matched as suffix or exact) or a regex string (matched anywhere).
+
+Example: List of modules (suffix matching)
+
+```bash
+--lora-target-modules q_proj v_proj k_proj o_proj
+```
+
+Example: Regex
+
+```bash
++--lora-target-modules '.*\.self_attn\..*'
++```

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -207,7 +207,7 @@ def test_replace_submodules_with_target_modules(
         torch.device(DEVICES[0]),
     )
     model = manager.model
-    
+
     # Check that expected modules are replaced with LoRA wrappers
     for module_name in expected_lora_modules:
         module = model.get_submodule(module_name)

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -133,55 +133,34 @@ def test_replace_submodules(default_vllm_config, dist_init, dummy_model):
 
 
 @pytest.mark.parametrize(
-    "target_modules,exclude_modules,expected_lora_modules",
+    "target_modules,expected_lora_modules",
     [
         (
-            None,
             None,
             ["dense1", "layer1.dense1", "dense2", "layer1.dense2", "output"],
         ),  # All modules
         (
             "dense1",
-            None,
             ["dense1", "layer1.dense1"],
         ),  # Suffix match
         (
             ["dense1", "dense2"],
-            None,
             ["dense1", "layer1.dense1", "dense2", "layer1.dense2"],
         ),
         (
             [".*dense1"],
-            None,
             ["dense1", "layer1.dense1"],
         ),  # Regex match in list
         (
             ["dense1", ".*dense2"],
-            None,
             ["dense1", "layer1.dense1", "dense2", "layer1.dense2"],
         ),  # Mixed suffix and regex in list
-        (
-            None,
-            ["dense1"],
-            ["dense2", "layer1.dense2", "output"],
-        ),  # Exclude suffix match
-        (
-            None,
-            [".*dense1"],
-            ["dense2", "layer1.dense2", "output"],
-        ),  # Exclude regex match in list
-        (
-            ["dense1", "dense2"],
-            ["layer1.dense1"],
-            ["dense1", "dense2", "layer1.dense2"],
-        ),  # Target with exclude
     ],
 )
 def test_replace_submodules_with_target_modules(
     dist_init,
     dummy_model,
     target_modules,
-    exclude_modules,
     expected_lora_modules,
 ):
     model = dummy_model
@@ -202,7 +181,6 @@ def test_replace_submodules_with_target_modules(
             max_loras=8,
             lora_dtype=DEFAULT_DTYPE,
             lora_target_modules=target_modules,
-            lora_exclude_modules=exclude_modules,
         ),
         torch.device(DEVICES[0]),
     )

--- a/tests/lora/test_lora_manager.py
+++ b/tests/lora/test_lora_manager.py
@@ -132,6 +132,115 @@ def test_replace_submodules(default_vllm_config, dist_init, dummy_model):
     assert isinstance(model.get_submodule("layer1.dense2"), RowParallelLinearWithLoRA)
 
 
+@pytest.mark.parametrize(
+    "target_modules,exclude_modules,expected_lora_modules",
+    [
+        (
+            None,
+            None,
+            ["dense1", "layer1.dense1", "dense2", "layer1.dense2", "output"],
+        ),  # All modules
+        (
+            "dense1",
+            None,
+            ["dense1", "layer1.dense1"],
+        ),  # Suffix match
+        (
+            ["dense1", "dense2"],
+            None,
+            ["dense1", "layer1.dense1", "dense2", "layer1.dense2"],
+        ),
+        (
+            [".*dense1"],
+            None,
+            ["dense1", "layer1.dense1"],
+        ),  # Regex match in list
+        (
+            ["dense1", ".*dense2"],
+            None,
+            ["dense1", "layer1.dense1", "dense2", "layer1.dense2"],
+        ),  # Mixed suffix and regex in list
+        (
+            None,
+            ["dense1"],
+            ["dense2", "layer1.dense2", "output"],
+        ),  # Exclude suffix match
+        (
+            None,
+            [".*dense1"],
+            ["dense2", "layer1.dense2", "output"],
+        ),  # Exclude regex match in list
+        (
+            ["dense1", "dense2"],
+            ["layer1.dense1"],
+            ["dense1", "dense2", "layer1.dense2"],
+        ),  # Target with exclude
+    ],
+)
+def test_replace_submodules_with_target_modules(
+    dist_init,
+    dummy_model,
+    target_modules,
+    exclude_modules,
+    expected_lora_modules,
+):
+    model = dummy_model
+    # The dummy model has these modules that support LoRA:
+    # dense1, layer1.dense1, dense2, layer1.dense2, output, lm_head
+    # Note: lm_head is excluded from expected_lora_modules check in this test
+    # because it's handled differently in some contexts, but let's stick to
+    # the linear layers for simplicity unless specified.
+
+    manager = LoRAModelManager(
+        model,
+        1,
+        1,
+        1,
+        LoRAConfig(
+            max_lora_rank=8,
+            max_cpu_loras=8,
+            max_loras=8,
+            lora_dtype=DEFAULT_DTYPE,
+            lora_target_modules=target_modules,
+            lora_exclude_modules=exclude_modules,
+        ),
+        torch.device(DEVICES[0]),
+    )
+    model = manager.model
+    
+    # Check that expected modules are replaced with LoRA wrappers
+    for module_name in expected_lora_modules:
+        module = model.get_submodule(module_name)
+        assert isinstance(
+            module,
+            (
+                ColumnParallelLinearWithLoRA,
+                RowParallelLinearWithLoRA,
+                MergedColumnParallelLinearWithLoRA,
+            ),
+        ), f"Module {module_name} should be a LoRA layer"
+
+    # Check that other modules are NOT replaced
+    all_lora_candidates = [
+        "dense1",
+        "layer1.dense1",
+        "dense2",
+        "layer1.dense2",
+        "output",
+    ]
+    for module_name in all_lora_candidates:
+        if module_name not in expected_lora_modules:
+            module = model.get_submodule(module_name)
+            assert not isinstance(
+                module,
+                (
+                    ColumnParallelLinearWithLoRA,
+                    RowParallelLinearWithLoRA,
+                    MergedColumnParallelLinearWithLoRA,
+                ),
+            ), f"Module {module_name} should NOT be a LoRA layer"
+
+
 @pytest.mark.parametrize("device", DEVICES)
 def test_lora_model_manager(default_vllm_config, dist_init, dummy_model, device):
     model = dummy_model

--- a/vllm/config/lora.py
+++ b/vllm/config/lora.py
@@ -3,6 +3,7 @@
 
 from typing import TYPE_CHECKING, Any, Literal
 
+import regex as re
 import torch
 from pydantic import ConfigDict, Field, model_validator
 from pydantic.dataclasses import dataclass
@@ -60,6 +61,19 @@ class LoRAConfig:
     of multimodal models will be enabled. This is an experimental feature and 
     currently only supports some MM models such as the Qwen VL series. The default 
     is False."""
+    lora_target_modules: str | list[str] | None = None
+    """List of module names or regex expressions of the module names to replace
+    with LoRA. If not specified, all supported modules will be enabled for 
+    possible future LoRA adapters. If you only want to enable self-attention's 
+    q_proj and v_proj layers for LoRA adapters, you can set this to a list of module
+    names like ['q_proj', 'v_proj'], or a regex expression like
+    ['*.self_attn.*(q_proj|v_proj)$']. This helps reduce memory consumption,
+    because FFN/MoE layers is disabled, which often have a large number of parameters. 
+    """
+    lora_exclude_modules: str | list[str] | None = None
+    """List of module names or regex expression of the module names to exclude
+    from LoRA.
+    """
 
     def compute_hash(self) -> str:
         """
@@ -79,6 +93,8 @@ class LoRAConfig:
         factors.append(self.fully_sharded_loras)
         factors.append(self.lora_dtype)
         factors.append(self.enable_tower_connector_lora)
+        factors.append(self.lora_target_modules)
+        factors.append(self.lora_exclude_modules)
 
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str

--- a/vllm/config/lora.py
+++ b/vllm/config/lora.py
@@ -3,7 +3,6 @@
 
 from typing import TYPE_CHECKING, Any, Literal
 
-import regex as re
 import torch
 from pydantic import ConfigDict, Field, model_validator
 from pydantic.dataclasses import dataclass

--- a/vllm/config/lora.py
+++ b/vllm/config/lora.py
@@ -69,10 +69,6 @@ class LoRAConfig:
     ['*.self_attn.*(q_proj|v_proj)$']. This helps reduce memory consumption,
     because FFN/MoE layers is disabled, which often have a large number of parameters. 
     """
-    lora_exclude_modules: str | list[str] | None = None
-    """List of module names or regex expression of the module names to exclude
-    from LoRA.
-    """
 
     def compute_hash(self) -> str:
         """
@@ -93,7 +89,6 @@ class LoRAConfig:
         factors.append(self.lora_dtype)
         factors.append(self.enable_tower_connector_lora)
         factors.append(self.lora_target_modules)
-        factors.append(self.lora_exclude_modules)
 
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -487,7 +487,6 @@ class EngineArgs:
     lora_dtype: str | torch.dtype | None = LoRAConfig.lora_dtype
     enable_tower_connector_lora: bool = LoRAConfig.enable_tower_connector_lora
     lora_target_modules: str | list[str] | None = LoRAConfig.lora_target_modules
-    lora_exclude_modules: str | list[str] | None = LoRAConfig.lora_exclude_modules
 
     ray_workers_use_nsight: bool = ParallelConfig.ray_workers_use_nsight
     num_gpu_blocks_override: int | None = CacheConfig.num_gpu_blocks_override
@@ -1022,9 +1021,6 @@ class EngineArgs:
         lora_group.add_argument("--default-mm-loras", **lora_kwargs["default_mm_loras"])
         lora_group.add_argument(
             "--lora-target-modules", **lora_kwargs["lora_target_modules"]
-        )
-        lora_group.add_argument(
-            "--lora-exclude-modules", **lora_kwargs["lora_exclude_modules"]
         )
 
         # Observability arguments
@@ -1666,7 +1662,6 @@ class EngineArgs:
                 lora_dtype=self.lora_dtype,
                 enable_tower_connector_lora=self.enable_tower_connector_lora,
                 lora_target_modules=self.lora_target_modules,
-                lora_exclude_modules=self.lora_exclude_modules,
                 max_cpu_loras=self.max_cpu_loras
                 if self.max_cpu_loras and self.max_cpu_loras > 0
                 else None,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -486,6 +486,8 @@ class EngineArgs:
     max_cpu_loras: int | None = LoRAConfig.max_cpu_loras
     lora_dtype: str | torch.dtype | None = LoRAConfig.lora_dtype
     enable_tower_connector_lora: bool = LoRAConfig.enable_tower_connector_lora
+    lora_target_modules: str | list[str] | None = LoRAConfig.lora_target_modules
+    lora_exclude_modules: str | list[str] | None = LoRAConfig.lora_exclude_modules
 
     ray_workers_use_nsight: bool = ParallelConfig.ray_workers_use_nsight
     num_gpu_blocks_override: int | None = CacheConfig.num_gpu_blocks_override
@@ -1018,6 +1020,12 @@ class EngineArgs:
             "--fully-sharded-loras", **lora_kwargs["fully_sharded_loras"]
         )
         lora_group.add_argument("--default-mm-loras", **lora_kwargs["default_mm_loras"])
+        lora_group.add_argument(
+            "--lora-target-modules", **lora_kwargs["lora_target_modules"]
+        )
+        lora_group.add_argument(
+            "--lora-exclude-modules", **lora_kwargs["lora_exclude_modules"]
+        )
 
         # Observability arguments
         observability_kwargs = get_kwargs(ObservabilityConfig)
@@ -1657,6 +1665,8 @@ class EngineArgs:
                 fully_sharded_loras=self.fully_sharded_loras,
                 lora_dtype=self.lora_dtype,
                 enable_tower_connector_lora=self.enable_tower_connector_lora,
+                lora_target_modules=self.lora_target_modules,
+                lora_exclude_modules=self.lora_exclude_modules,
                 max_cpu_loras=self.max_cpu_loras
                 if self.max_cpu_loras and self.max_cpu_loras > 0
                 else None,

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -495,16 +495,63 @@ class LoRAModelManager:
                 else:
                     lora = PackedLoRALayerWeights.pack(subloras)
                 model.loras[module_name] = lora
+
+        if not model.loras:
+            raise ValueError(
+                "No layers in the model have LoRA applied. "
+                "It may be caused by incorrect target modules (--lora-target-modules), "
+                "or all modules are excluded (--lora-exclude-modules). "
+                "Please check your settings."
+            )
+
         return model
 
     def _match_target_modules(self, module_name: str):
-        return any(
+        is_supported = any(
             re.match(
                 r".*\.{target_module}$".format(target_module=target_module), module_name
             )
             or target_module == module_name
             for target_module in self.supported_lora_modules
         )
+        if not is_supported:
+            return False
+        return self._check_target_module_exists(self.lora_config, module_name)
+
+    def _check_target_module_exists(self, config: LoRAConfig, key: str) -> bool:
+        """Check if the module name matches target_modules and not exclude_modules."""
+
+        def match_any(patterns: list[str] | str, key: str) -> bool:
+            if isinstance(patterns, str):
+                patterns = [patterns]
+            for p in patterns:
+                # Suffix match
+                if key == p or key.endswith(f".{p}"):
+                    return True
+                # Regex match
+                try:
+                    if re.search(p, key):
+                        return True
+                except re.error:
+                    pass
+            return False
+
+        if config.lora_exclude_modules and match_any(config.lora_exclude_modules, key):
+            logger.debug(
+                "Skipping module %s because it is excluded by lora_exclude_modules.",
+                key,
+            )
+            return False
+
+        if config.lora_target_modules:
+            if not match_any(config.lora_target_modules, key):
+                logger.debug(
+                    "Skipping module %s because it is not in lora_target_modules.", key
+                )
+                return False
+            return True
+
+        return True
 
     def _get_punica_wrapper(self, module_name: str) -> PunicaWrapperBase | None:
         """

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -499,9 +499,8 @@ class LoRAModelManager:
         if not model.loras:
             raise ValueError(
                 "No layers in the model have LoRA applied. "
-                "It may be caused by incorrect target modules (--lora-target-modules), "
-                "or all modules are excluded (--lora-exclude-modules). "
-                "Please check your settings."
+                "It may be caused by incorrect target modules "
+                "(--lora-target-modules). Please check your settings."
             )
 
         return model
@@ -519,7 +518,7 @@ class LoRAModelManager:
         return self._check_target_module_exists(self.lora_config, module_name)
 
     def _check_target_module_exists(self, config: LoRAConfig, key: str) -> bool:
-        """Check if the module name matches target_modules and not exclude_modules."""
+        """Check if the module name matches target_modules."""
 
         def match_any(patterns: list[str] | str, key: str) -> bool:
             if isinstance(patterns, str):
@@ -536,21 +535,13 @@ class LoRAModelManager:
                     pass
             return False
 
-        if config.lora_exclude_modules and match_any(config.lora_exclude_modules, key):
+        if config.lora_target_modules and not match_any(
+            config.lora_target_modules, key
+        ):
             logger.debug(
-                "Skipping module %s because it is excluded by lora_exclude_modules.",
-                key,
+                "Skipping module %s because it is not in lora_target_modules.", key
             )
             return False
-
-        if config.lora_target_modules:
-            if not match_any(config.lora_target_modules, key):
-                logger.debug(
-                    "Skipping module %s because it is not in lora_target_modules.", key
-                )
-                return False
-            return True
-
         return True
 
     def _get_punica_wrapper(self, module_name: str) -> PunicaWrapperBase | None:

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -4,6 +4,7 @@
 from contextlib import contextmanager
 from typing import Any, Literal
 
+import regex as re
 import torch
 
 from vllm.config import VllmConfig
@@ -139,6 +140,23 @@ class WorkerLoRAManager:
         except Exception as e:
             # For BadRequestError
             raise e
+
+        if (
+            self.lora_config.lora_target_modules
+            or self.lora_config.lora_exclude_modules
+        ):
+            for module_name in lora.loras:
+                if not self._adapter_manager._check_target_module_exists(
+                    self.lora_config, module_name
+                ):
+                    logger.warning(
+                        "LoRA module '%s' in adapter '%s' is not targeted "
+                        "by the current configuration (lora_target_modules "
+                        "or lora_exclude_modules). These parameters will be "
+                        "ignored, which may cause abnormal model behavior.",
+                        module_name,
+                        lora_request.lora_path,
+                    )
 
         return lora
 

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -4,7 +4,6 @@
 from contextlib import contextmanager
 from typing import Any, Literal
 
-import regex as re
 import torch
 
 from vllm.config import VllmConfig

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -140,19 +140,16 @@ class WorkerLoRAManager:
             # For BadRequestError
             raise e
 
-        if (
-            self.lora_config.lora_target_modules
-            or self.lora_config.lora_exclude_modules
-        ):
+        if self.lora_config.lora_target_modules:
             for module_name in lora.loras:
                 if not self._adapter_manager._check_target_module_exists(
                     self.lora_config, module_name
                 ):
                     logger.warning(
-                        "LoRA module '%s' in adapter '%s' is not targeted "
-                        "by the current configuration (lora_target_modules "
-                        "or lora_exclude_modules). These parameters will be "
-                        "ignored, which may cause abnormal model behavior.",
+                        "LoRA module '%s' in adapter '%s' is not targeted by "
+                        "the current configuration (lora_target_modules). "
+                        "These parameters will be ignored, which may cause "
+                        "abnormal model behavior.",
                         module_name,
                         lora_request.lora_path,
                     )


### PR DESCRIPTION
## Purpose
This commit introduces a new feature, `--lora-target-modules`, and `--lora-exclude-modules`, which allows users to specify a regular expression to filter the modules where LoRA layers are applied. This is particularly useful for conserving memory by avoiding the initialization of LoRA layers for parts of the model that are not being fine-tuned, such as the FFN layers.
    
The changes include:
- Added lora_target_modules to LoRAConfig and the corresponding CLI argument.
- Implemented the filtering logic in LoRAModelManager to apply LoRA layers only to modules matching the regex.
- Added validation for the regex syntax.
- Added a check to ensure at least one LoRA layer is applied when a regex is provided.
- Added a warning when loading a LoRA adapter if it contains layers that do not match the provided regex.
- Updated documentation to explain the new feature and its memory-saving benefits.

## Test Plan
1.  Run models in both offline/serve mode, without new param `lora_target_modules` (baseline behavior), and do memory profiling.
2.  Run models in both model, with `--lora-target-modules ".*\\.self_attn\\..*"`, and do memory profiling.
3. `--lora-target-modules "NOT_EXSITING_LAYER"` to get a friendly error message.


## Test Result
1 & 2: tested on Qwen/Qwen3-VL-32B-Instruct-FP8, params:
```
--model /root/.cache/modelscope/hub/models/Qwen/Qwen3-VL-32B-Instruct-FP8 --max_model_len=1000 --enforce-eager --enable-lora
```

Both cases works, here is the difference of Pytorch memory result:

#### Test case1: Without `lora-target-modules`:
<img height="800" alt="Without `lora_target_modules`" src="https://github.com/user-attachments/assets/d8efd34f-2e9d-496d-ade5-e76f7f696263" />

#### Test case 2, add ` --lora-target-modules ".*\\.self_attn\\..*"`
<img  height="800" alt="add ` --lora-target-modules`" src="https://github.com/user-attachments/assets/53896f89-ab6b-439b-88e8-cd9df9a88e38" />

#### Test case 3
Run with `--lora-target-modules "NOT_EXSITING_LAYER"`

Got a friendly error message:
```
(EngineCore_DP0 pid=3768408)   File "/app/data/heyuxuan/vllm/vllm/v1/worker/lora_model_runner_mixin.py", line 194, in maybe_dummy_run_with_lora
(EngineCore_DP0 pid=3768408)     with (
(EngineCore_DP0 pid=3768408)   File "/app/data/heyuxuan/miniconda3/envs/vllm013/lib/python3.11/contextlib.py", line 137, in __enter__
(EngineCore_DP0 pid=3768408)     return next(self.gen)
(EngineCore_DP0 pid=3768408)            ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3768408)   File "/app/data/heyuxuan/vllm/vllm/v1/worker/lora_model_runner_mixin.py", line 121, in maybe_setup_dummy_loras
(EngineCore_DP0 pid=3768408)     self.lora_manager.add_dummy_lora(lr, rank=lora_warmup_rank)
(EngineCore_DP0 pid=3768408)   File "/app/data/heyuxuan/vllm/vllm/lora/worker_manager.py", line 169, in add_dummy_lora
(EngineCore_DP0 pid=3768408)     dummy_lora = self._adapter_manager.create_dummy_lora(
(EngineCore_DP0 pid=3768408)                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=3768408)   File "/app/data/heyuxuan/vllm/vllm/lora/model_manager.py", line 554, in create_dummy_lora
(EngineCore_DP0 pid=3768408)     raise ValueError(
(EngineCore_DP0 pid=3768408) ValueError: No layers in the model have LoRA applied. It may be caused by incorrect target modules (--lora-target-modules), or all modules are excluded (--lora-exclude-modules). Please check your settings.
```



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
        The PR itself reduces memory usage about unused LoRA modules. 
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Introduces selective LoRA initialization to reduce VRAM by limiting which modules receive LoRA layers.
> 
> - Adds `lora_target_modules` to `LoRAConfig`, included in hash and exposed via `--lora-target-modules`
> - Applies filtering in `LoRAModelManager` to only wrap modules matching list/regex; raises a clear error if no layers match
> - Logs warnings in `WorkerLoRAManager` when loaded adapters contain non-targeted modules that will be ignored
> - Updates docs (`docs/features/lora.md`) with guidance and examples (suffix list and regex) highlighting memory savings
> - Adds tests validating selective replacement behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b84348580c8ec45e03dea9174c050c0ae88989e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 59dee6e08e94b66c70c0a24b0d869991c3617a3d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
