### PR TITLE
Fix missing tool call fields in streaming responses

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1207,12 +1207,21 @@ class OpenAIServingChat(OpenAIServing):
 
                             # check to see if there's anything left to stream
                             remaining_call = expected_call.replace(actual_call, "", 1)
-                            # set that as a delta message
+                            # set that as a delta message, preserving id, type,
+                            # and name from the original tool call
+                            original_tool_call = next(
+                                tc for tc in reversed(delta_message.tool_calls)
+                                if tc.index == index)
                             delta_message = DeltaMessage(
                                 tool_calls=[
                                     DeltaToolCall(
                                         index=index,
+                                        id=original_tool_call.id,
+                                        type=original_tool_call.type,
                                         function=DeltaFunctionCall(
+                                            name=(original_tool_call.function.name
+                                                  if original_tool_call.function
+                                                  else None),
                                             arguments=remaining_call
                                         ).model_dump(exclude_none=True),
                                     )

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1210,8 +1210,10 @@ class OpenAIServingChat(OpenAIServing):
                             # set that as a delta message, preserving id, type,
                             # and name from the original tool call
                             original_tool_call = next(
-                                tc for tc in reversed(delta_message.tool_calls)
-                                if tc.index == index)
+                                tc
+                                for tc in reversed(delta_message.tool_calls)
+                                if tc.index == index
+                            )
                             delta_message = DeltaMessage(
                                 tool_calls=[
                                     DeltaToolCall(
@@ -1219,10 +1221,12 @@ class OpenAIServingChat(OpenAIServing):
                                         id=original_tool_call.id,
                                         type=original_tool_call.type,
                                         function=DeltaFunctionCall(
-                                            name=(original_tool_call.function.name
-                                                  if original_tool_call.function
-                                                  else None),
-                                            arguments=remaining_call
+                                            name=(
+                                                original_tool_call.function.name
+                                                if original_tool_call.function
+                                                else None
+                                            ),
+                                            arguments=remaining_call,
                                         ).model_dump(exclude_none=True),
                                     )
                                 ]


### PR DESCRIPTION
Hey folks,

I ran into an issue where streaming tool calls were coming back with missing `id`, `type`, and `function.name` fields. After some debugging, I traced it to the code that handles unstreamed argument tokens in `serving_chat.py`.

The problem is around line 1211 - when we create a new DeltaMessage for the remaining arguments, we were only setting `index` and `arguments`, but not preserving the other fields from the original tool call.

The fix is pretty simple: just grab the original tool call's `id`, `type`, and `function.name` before creating the new DeltaMessage.

Tested locally and the fields are now properly preserved.

Fixes #31443