### PR TITLE
[ROCm][CI] Skip DeepGemm-dependent test on ROCm platform

### DIFF
--- a/tests/kernels/moe/test_silu_mul_per_token_group_quant_fp8_colmajor.py
+++ b/tests/kernels/moe/test_silu_mul_per_token_group_quant_fp8_colmajor.py
@@ -67,6 +67,10 @@ def reference(x: torch.Tensor, use_ue8m0: bool) -> tuple[torch.Tensor, torch.Ten
 
 @pytest.mark.parametrize("T", [128, 256, 512])
 @pytest.mark.parametrize("N", [128 * 2, 256 * 2, 768 * 2, 2048 * 2, 7168 * 2])
+@pytest.mark.skipif(
+    current_platform.is_rocm(),
+    reason="ROCm does not support DeepGemm.",
+)
 def test_silu_mul_fp8_quant_deep_gemm(T: int, N: int):
     current_platform.seed_everything(42)
 


### PR DESCRIPTION
Skip `test_silu_mul_fp8_quant_deep_gemm` on ROCm platforms since DeepGemm is not supported.

### Problem

The test `test_silu_mul_fp8_quant_deep_gemm` fails on ROCm:

```
FAILED kernels/moe/test_silu_mul_per_token_group_quant_fp8_colmajor.py::test_silu_mul_fp8_quant_deep_gemm[256-512]
FAILED kernels/moe/test_silu_mul_per_token_group_quant_fp8_colmajor.py::test_silu_mul_fp8_quant_deep_gemm[4096-256]
FAILED kernels/moe/test_silu_mul_per_token_group_quant_fp8_colmajor.py::test_silu_mul_fp8_quant_deep_gemm[14336-128]
```

### Solution

Added `pytest.mark.skipif` decorator to skip the test on ROCm platforms, as DeepGemm is a CUDA-specific feature that is not available on ROCm.