### PR TITLE
Add docker buildx bake configuration

### DIFF
--- a/docker/docker-bake.hcl
+++ b/docker/docker-bake.hcl
@@ -1,0 +1,76 @@
+# docker-bake.hcl - vLLM Docker build configuration
+#
+# This file lives in vLLM repo at docker/docker-bake.hcl
+#
+# Usage:
+#   cd docker && docker buildx bake        # Build default target (openai)
+#   cd docker && docker buildx bake test   # Build test target
+#   docker buildx bake --print             # Show resolved config
+#
+# Reference: https://docs.docker.com/build/bake/reference/
+
+# Build configuration
+
+variable "MAX_JOBS" {
+  default = 16
+}
+
+variable "NVCC_THREADS" {
+  default = 8
+}
+
+variable "TORCH_CUDA_ARCH_LIST" {
+  default = "8.0 8.9 9.0 10.0"
+}
+
+variable "COMMIT" {
+  default = ""
+}
+
+# Groups
+
+group "default" {
+  targets = ["openai"]
+}
+
+# Base targets
+
+target "_common" {
+  dockerfile = "docker/Dockerfile"
+  context    = "."
+  args = {
+    max_jobs             = MAX_JOBS
+    nvcc_threads         = NVCC_THREADS
+    torch_cuda_arch_list = TORCH_CUDA_ARCH_LIST
+  }
+}
+
+target "_labels" {
+  labels = {
+    "org.opencontainers.image.source"      = "https://github.com/vllm-project/vllm"
+    "org.opencontainers.image.vendor"      = "vLLM"
+    "org.opencontainers.image.title"       = "vLLM"
+    "org.opencontainers.image.description" = "vLLM: A high-throughput and memory-efficient inference and serving engine for LLMs"
+    "org.opencontainers.image.licenses"    = "Apache-2.0"
+    "org.opencontainers.image.revision"    = COMMIT
+  }
+  annotations = [
+      "index,manifest:org.opencontainers.image.revision=${COMMIT}",
+  ]
+}
+
+# Build targets
+
+target "test" {
+  inherits = ["_common", "_labels"]
+  target   = "test"
+  tags     = ["vllm:test"]
+  output   = ["type=docker"]
+}
+
+target "openai" {
+  inherits = ["_common", "_labels"]
+  target   = "vllm-openai"
+  tags     = ["vllm:openai"]
+  output   = ["type=docker"]
+}


### PR DESCRIPTION
## Purpose
Add docker/docker-bake.hcl as the base build configuration for docker buildx bake. This is part of the effort to bake Docker build cache into CPU AMIs for faster CI builds. See https://github.com/vllm-project/ci-infra/pull/256

Context:
CI builds need intermediate stages cached, not just base images. To make this work, we need the exact same build configuration to run in both:
1. Regular CI image builds
2. AMI cache warm-up during AMI creation

Why docker buildx bake:
Docker buildx bake provides a declarative, composable build configuration using HCL. CI extends this base config with a ci.hcl overlay that adds caching, registry settings, and commit-based cache keys. Both contexts use the same build definition, ensuring consistency and cache key parity for maximum layer reuse.

This file provides:
- Build variables (CUDA arch lists, parallelism settings)
- Common build args shared across targets
- OCI labels and annotations for image metadata (most importantly the git commit SHA)
- Base targets (test, openai) that CI extends

Usage example:
docker buildx bake -f docker/docker-bake.hcl -f ci.hcl test-ci

CI will download ci.hcl from ci-infra and combine it with this file.

## Test Result

After completing the AMI cache baking in addition to the changes in the cin-infra repo, we expect image builds that only change leaf Python stages to go from ~17 minutes to ~7 minutes (~2.4× faster), more explanation the breakdown can be found in the ci-infra PR linked

