### PR TITLE
Optimize QKNorm for MiniMax-M2/M2.1

### DIFF
--- a/vllm/model_executor/layers/mamba/linear_attn.py
+++ b/vllm/model_executor/layers/mamba/linear_attn.py
@@ -85,7 +85,7 @@ class MiniMaxText01RMSNormTP(CustomOp):
         k_norm: "MiniMaxText01RMSNormTP",
         q: torch.Tensor,
         k: torch.Tensor,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         orig_dtype = q.dtype
         q = q.to(torch.float32)
         k = k.to(torch.float32)

--- a/vllm/model_executor/layers/mamba/linear_attn.py
+++ b/vllm/model_executor/layers/mamba/linear_attn.py
@@ -79,6 +79,28 @@ class MiniMaxText01RMSNormTP(CustomOp):
         assert residual is None, "RMSNorm does not support residual connection."
         return self._forward(x)
 
+    @staticmethod
+    def forward_qk(
+        q_norm: "MiniMaxText01RMSNormTP",
+        k_norm: "MiniMaxText01RMSNormTP",
+        q: torch.Tensor,
+        k: torch.Tensor,
+    ) -> torch.Tensor:
+        orig_dtype = q.dtype
+        q = q.to(torch.float32)
+        k = k.to(torch.float32)
+        q_var = q.pow(2).mean(dim=-1, keepdim=True)
+        k_var = k.pow(2).mean(dim=-1, keepdim=True)
+        if q_norm.tp_world > 1:
+            qk_var = torch.cat([q_var, k_var], dim=-1)
+            qk_var = tensor_model_parallel_all_reduce(qk_var) / q_norm.tp_world
+            q_var, k_var = qk_var.chunk(2, dim=-1)
+        q = q * torch.rsqrt(q_var + q_norm.variance_epsilon) * q_norm.weight
+        k = k * torch.rsqrt(k_var + k_norm.variance_epsilon) * k_norm.weight
+        q = q.to(orig_dtype)
+        k = k.to(orig_dtype)
+        return q, k
+
 
 class MiniMaxText01LinearKernel:
     @staticmethod

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -234,8 +234,11 @@ class MiniMaxM2Attention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        q = self.q_norm(q)
-        k = self.k_norm(k)
+        # q = self.q_norm(q)
+        # k = self.k_norm(k)
+        q, k = MiniMaxText01RMSNormTP.forward_qk(
+            self.q_norm, self.k_norm, q.contiguous(), k.contiguous()
+        )
         q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)
         output, _ = self.o_proj(attn_output)

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -234,8 +234,6 @@ class MiniMaxM2Attention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        # q = self.q_norm(q)
-        # k = self.k_norm(k)
         q, k = MiniMaxText01RMSNormTP.forward_qk(
             self.q_norm, self.k_norm, q.contiguous(), k.contiguous()
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fuses QKNorm in tensor-parallel mode so that only a single all_reduce is launched, reducing communication overhead.

Part of #31478.

## Test Plan

Benchmarks were conducted on MiniMax-M2.1 with the following setup:

```bash
export SAFETENSORS_FAST_GPU=1
export VLLM_MOE_USE_DEEP_GEMM=0
vllm serve /model --trust-remote-code \
  --tensor-parallel-size 4 \
  --enable-auto-tool-choice --tool-call-parser minimax_m2 \
  --no-enable-prefix-caching \
  --reasoning-parser minimax_m2_append_think
```

Before:

```bash
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|    |   max_concurrency |   output_throughput |   mean_ttft_ms |   median_ttft_ms |   p99_ttft_ms |   mean_tpot_ms |   median_tpot_ms |   p99_tpot_ms |   per_user_throughput |
+====+===================+=====================+================+==================+===============+================+==================+===============+=======================+
|  0 |             1.000 |              64.450 |        126.890 |          120.460 |       177.110 |         15.410 |           15.380 |        15.580 |                64.450 |
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  1 |            16.000 |             676.060 |        530.350 |          473.270 |      1763.060 |         23.170 |           23.100 |        24.690 |                42.254 |
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  2 |            64.000 |            1575.820 |        717.350 |          647.210 |      2795.730 |         38.750 |           39.190 |        40.460 |                24.622 |
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
```

After:

```bash
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|    |   max_concurrency |   output_throughput |   mean_ttft_ms |   median_ttft_ms |   p99_ttft_ms |   mean_tpot_ms |   median_tpot_ms |   p99_tpot_ms |   per_user_throughput |
+====+===================+=====================+================+==================+===============+================+==================+===============+=======================+
|  0 |             1.000 |              80.840 |        122.760 |          120.560 |       166.250 |         12.260 |           12.260 |        12.360 |                80.840 |
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  1 |            16.000 |             683.880 |        502.970 |          432.970 |       812.660 |         22.930 |           22.940 |        24.620 |                42.742 |
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
|  2 |            64.000 |            1568.960 |        731.360 |          645.290 |      2667.660 |         38.920 |           39.280 |        40.550 |                24.515 |
+----+-------------------+---------------------+----------------+------------------+---------------+----------------+------------------+---------------+-----------------------+
```

## Test Result

Evaluations were run on MiniMax-M2.1:

```bash
|  Tasks  |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|---------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_cot|      3|flexible-extract|     5|exact_match|↑  |0.9325|±  |0.0069|
|         |       |strict-match    |     5|exact_match|↑  |0.9257|±  |0.0072|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

