### PR TITLE
[Frontend] add continue_final_message parameter to /embeddings endpoint

### DIFF
--- a/vllm/entrypoints/pooling/embed/protocol.py
+++ b/vllm/entrypoints/pooling/embed/protocol.py
@@ -97,7 +97,16 @@ class EmbeddingChatRequest(OpenAIBaseModel):
             "model."
         ),
     )
-
+    continue_final_message: bool = Field(
+        default=False,
+        description=(
+            "If this is set, the chat will be formatted so that the final "
+            "message in the chat is open-ended, without any EOS tokens. The "
+            "model will continue this message rather than starting a new one. "
+            'This allows you to "prefill" part of the model\'s response for it. '
+            "Cannot be used at the same time as `add_generation_prompt`."
+        ),
+    )
     add_special_tokens: bool = Field(
         default=False,
         description=(

--- a/vllm/entrypoints/pooling/embed/serving.py
+++ b/vllm/entrypoints/pooling/embed/serving.py
@@ -89,7 +89,7 @@ class EmbeddingMixin(OpenAIServing):
                     chat_template=ctx.request.chat_template or ctx.chat_template,
                     chat_template_content_format=ctx.chat_template_content_format,
                     add_generation_prompt=ctx.request.add_generation_prompt,
-                    continue_final_message=False,
+                    continue_final_message=ctx.request.continue_final_message,
                     add_special_tokens=ctx.request.add_special_tokens,
                 )
             else:


### PR DESCRIPTION
## Purpose
This PR adds the `continue_final_message` parameter to the parameters accepted by the `/embeddings` endpoint. That feature was requested in https://github.com/vllm-project/vllm/issues/31440 to allow for better control over embeddings generated by chat-based models.

## Test Plan
We compared the quality of embeddings before and after implementation of the `continue_final_message` parameter by testing their performance on select retrieval tasks using two different methods of embedding generation. First, we generated embeddings by hardcoding a prefilled assistant message into a custom jinja chat template. Second, we generated embeddings by passing the `continue_final_message` parameter and a prefilled `assistant` message to the `/embeddings` endpoint.

## Test Result
We were able to confirm that 1) embeddings without a prefilled assistant message perform poorly on our retrieval task and 2) the embeddings generated with the custom jinja chat template and with the `continue_final_message` parameter both perform well and result in almost identical performance metrics. Our tests confirmed that this PR correctly implements the `continue_final_message` parameter to improve embedding quality.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

