### PR TITLE
Replace `nn.ConvNd` with vLLM's `ConvNdLayer` for Transformers modeling backend

### DIFF
--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -47,7 +47,7 @@ from vllm.model_executor.models.transformers.utils import (
     get_feature_request_tip,
     init_on_device_without_buffers,
     log_replacement,
-    replace_conv2d_class,
+    replace_conv_class,
     replace_linear_class,
     replace_rms_norm_class,
 )
@@ -315,8 +315,8 @@ class Base(
                     new_module = replace_linear_class(
                         child_module, style, self.quant_config, prefix=qual_name
                     )
-                elif isinstance(child_module, nn.Conv2d):
-                    new_module = replace_conv2d_class(child_module)
+                elif isinstance(child_module, (nn.Conv2d, nn.Conv3d)):
+                    new_module = replace_conv_class(child_module)
                 elif child_module.__class__.__name__.endswith("RMSNorm"):
                     new_module = replace_rms_norm_class(
                         child_module, self.text_config.hidden_size

--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -47,6 +47,7 @@ from vllm.model_executor.models.transformers.utils import (
     get_feature_request_tip,
     init_on_device_without_buffers,
     log_replacement,
+    replace_conv2d_class,
     replace_linear_class,
     replace_rms_norm_class,
 )
@@ -314,6 +315,8 @@ class Base(
                     new_module = replace_linear_class(
                         child_module, style, self.quant_config, prefix=qual_name
                     )
+                elif isinstance(child_module, nn.Conv2d):
+                    new_module = replace_conv2d_class(child_module)
                 elif child_module.__class__.__name__.endswith("RMSNorm"):
                     new_module = replace_rms_norm_class(
                         child_module, self.text_config.hidden_size

--- a/vllm/model_executor/models/transformers/utils.py
+++ b/vllm/model_executor/models/transformers/utils.py
@@ -156,6 +156,7 @@ def replace_conv2d_class(conv2d: nn.Conv2d) -> Conv2dLayer:
         groups=conv2d.groups,
         bias=conv2d.bias is not None,
         padding_mode=conv2d.padding_mode,
+        params_dtype=conv2d.weight.dtype,
     )
 
 

--- a/vllm/model_executor/models/transformers/utils.py
+++ b/vllm/model_executor/models/transformers/utils.py
@@ -25,7 +25,7 @@ from torch import nn
 
 from vllm.config.utils import getattr_iter
 from vllm.logger import init_logger
-from vllm.model_executor.layers.conv import Conv2dLayer
+from vllm.model_executor.layers.conv import Conv2dLayer, Conv3dLayer
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -137,26 +137,42 @@ def replace_linear_class(
     )
 
 
-def replace_conv2d_class(conv2d: nn.Conv2d) -> Conv2dLayer:
-    """
-    Replace nn.Conv2d with vLLM's Conv2dLayer.
+TorchConv = nn.Conv2d | nn.Conv3d
+VllmConv = Conv2dLayer | Conv3dLayer
+
+
+def replace_conv_class(conv: TorchConv) -> VllmConv | TorchConv:
+    """Replace a Transformers Conv2d/Conv3d with vLLM's Conv2d/Conv3d.
 
     Args:
-        conv2d: `nn.Conv2d` to be replaced.
+        conv: `nn.Conv2d` or `nn.Conv3d` to be replaced.
     Returns:
-        The new Conv2dLayer.
+        The new `Conv2dLayer` or `Conv3dLayer`. If the conv module is not supported,
+        returns the original conv module.
     """
-    return Conv2dLayer(
-        in_channels=conv2d.in_channels,
-        out_channels=conv2d.out_channels,
-        kernel_size=conv2d.kernel_size,
-        stride=conv2d.stride,
-        padding=conv2d.padding,
-        dilation=conv2d.dilation,
-        groups=conv2d.groups,
-        bias=conv2d.bias is not None,
-        padding_mode=conv2d.padding_mode,
-        params_dtype=conv2d.weight.dtype,
+    # vLLM does not handle non-zero padding modes
+    if conv.padding_mode != "zeros":
+        return conv
+
+    vllm_conv_cls = {
+        nn.Conv2d: Conv2dLayer,
+        nn.Conv3d: Conv3dLayer,
+    }.get(type(conv))
+
+    if vllm_conv_cls is None:
+        return conv
+
+    return vllm_conv_cls(
+        in_channels=conv.in_channels,
+        out_channels=conv.out_channels,
+        kernel_size=conv.kernel_size,
+        stride=conv.stride,
+        padding=conv.padding,
+        dilation=conv.dilation,
+        groups=conv.groups,
+        bias=conv.bias is not None,
+        padding_mode=conv.padding_mode,
+        params_dtype=conv.weight.dtype,
     )
 
 

--- a/vllm/model_executor/models/transformers/utils.py
+++ b/vllm/model_executor/models/transformers/utils.py
@@ -25,6 +25,7 @@ from torch import nn
 
 from vllm.config.utils import getattr_iter
 from vllm.logger import init_logger
+from vllm.model_executor.layers.conv import Conv2dLayer
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm, RMSNorm
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -133,6 +134,28 @@ def replace_linear_class(
         prefix=prefix,
         return_bias=False,
         **vllm_linear_kwargs,
+    )
+
+
+def replace_conv2d_class(conv2d: nn.Conv2d) -> Conv2dLayer:
+    """
+    Replace nn.Conv2d with vLLM's Conv2dLayer.
+
+    Args:
+        conv2d: `nn.Conv2d` to be replaced.
+    Returns:
+        The new Conv2dLayer.
+    """
+    return Conv2dLayer(
+        in_channels=conv2d.in_channels,
+        out_channels=conv2d.out_channels,
+        kernel_size=conv2d.kernel_size,
+        stride=conv2d.stride,
+        padding=conv2d.padding,
+        dilation=conv2d.dilation,
+        groups=conv2d.groups,
+        bias=conv2d.bias is not None,
+        padding_mode=conv2d.padding_mode,
     )
 
 


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/28455 added `Conv2dLayer` to vLLM which improves conv performance in vLLM (particularly in OOT devices where these custom ops can be specialised to that hardware).

https://github.com/vllm-project/vllm/pull/28842 replaced `nn.Conv2d` with this custom op for all explicitly defined models.

This PR adds this substitution for Conv2d and Conv3d when using models loaded with the Transformers modelling backend.