### PR TITLE
Add embedding input functionality for disabled modalities 

### DIFF
--- a/example_embedding_only_curl.py
+++ b/example_embedding_only_curl.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Helper script to generate a curl command for testing embedding-only mode.
+
+This script creates an example embedding and outputs a curl command that you can run.
+"""
+
+import json
+import torch
+from vllm.utils.serial_utils import tensor2base64
+
+def create_example_image_embedding(
+    num_images: int = 1,
+    feature_size: int = 256,
+    hidden_size: int = 4096,
+    dtype: torch.dtype = torch.float16
+) -> torch.Tensor:
+    """Create a dummy image embedding tensor."""
+    embedding = torch.randn(
+        num_images, 
+        feature_size, 
+        hidden_size,
+        dtype=dtype
+    )
+    return embedding
+
+def main():
+    # Create example embedding
+    image_embeds = create_example_image_embedding(
+        num_images=1,
+        feature_size=256,
+        hidden_size=4096,
+        dtype=torch.float16
+    )
+    
+    # Convert to base64
+    base64_image_embedding = tensor2base64(image_embeds)
+    
+    # Create the request payload
+    payload = {
+        "model": "Qwen/Qwen2.5-VL-3B-Instruct",
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant."
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "What do you see in this image? Describe it briefly."
+                    },
+                    {
+                        "type": "image_embeds",
+                        "image_embeds": base64_image_embedding,
+                    },
+                ],
+            },
+        ],
+        "max_tokens": 100,
+        "temperature": 0.7,
+    }
+    
+    # Print curl command
+    print("="*70)
+    print("CURL COMMAND:")
+    print("="*70)
+    print("\ncurl -X POST http://localhost:8000/v1/chat/completions \\")
+    print("  -H 'Content-Type: application/json' \\")
+    print("  -d '{}'".format(json.dumps(payload, indent=2)))
+    print("\n" + "="*70)
+    print("\nNote: The embedding is included in the JSON payload above.")
+    print("Embedding shape:", image_embeds.shape)
+    print("="*70)
+
+if __name__ == "__main__":
+    main()
+

--- a/example_embedding_only_serve.py
+++ b/example_embedding_only_serve.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Example: Running vLLM in embedding-only mode (text mode) with embedding inputs
+
+This example demonstrates:
+1. How to start the server with embedding-only mode for memory savings
+2. How to create and send embedding inputs via the OpenAI API
+"""
+
+import json
+import torch
+from openai import OpenAI
+from vllm.utils.serial_utils import tensor2base64
+
+# ============================================================================
+# STEP 1: Start the server with this command:
+# ============================================================================
+"""
+vllm serve Qwen/Qwen2.5-VL-7B-Instruct \
+    --enable-mm-embeds \
+    --limit-mm-per-prompt '{"image": 0, "video": 0}' \
+    --port 8000
+"""
+
+# ============================================================================
+# STEP 2: Create a client and example embedding
+# ============================================================================
+
+def create_example_image_embedding(
+    num_images: int = 1,
+    feature_size: int = 256,  # Typical image feature size
+    hidden_size: int = 4096,   # Hidden size for Qwen2.5-VL models
+    dtype: torch.dtype = torch.float16
+) -> torch.Tensor:
+    """
+    Create a dummy image embedding tensor.
+    
+    Shape: (num_images, feature_size, hidden_size)
+    For Qwen2.5-VL models: (1, 256, 4096)
+    """
+    # Create random embeddings (in practice, these would come from your encoder)
+    embedding = torch.randn(
+        num_images, 
+        feature_size, 
+        hidden_size,
+        dtype=dtype
+    )
+    return embedding
+
+
+def main():
+    # Initialize OpenAI client
+    client = OpenAI(
+        api_key="EMPTY",  # Not needed for local server
+        base_url="http://localhost:8000/v1",
+    )
+    
+    # Get the model name from the server (must match the model the server was started with)
+    try:
+        models = client.models.list()
+        if models.data:
+            model_name = models.data[0].id
+            print(f"Using model from server: {model_name}")
+        else:
+            raise ValueError("No models found on server")
+    except Exception as e:
+        print(f"Warning: Could not get model from server: {e}")
+        print("Using default model name. Make sure it matches your server.")
+        model_name = "Qwen/Qwen2.5-VL-7B-Instruct"  # Fallback: must match server
+    
+    # Create example image embedding
+    # Shape: (num_images, feature_size, hidden_size)
+    # For Qwen2.5-VL models, typical shape is (1, 256, 4096)
+    print("Creating example image embedding...")
+    image_embeds = create_example_image_embedding(
+        num_images=1,
+        feature_size=256,
+        hidden_size=4096,
+        dtype=torch.float16
+    )
+    print(f"Embedding shape: {image_embeds.shape}")
+    
+    # Convert to base64 for API transmission
+    base64_image_embedding = tensor2base64(image_embeds)
+    print("Embedding serialized to base64")
+    
+    # Send request with embedding input
+    print("\nSending chat completion request...")
+    chat_completion = client.chat.completions.create(
+        model=model_name,
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a helpful assistant."
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "What do you see in this image? Describe it briefly."
+                    },
+                    {
+                        "type": "image_embeds",
+                        "image_embeds": base64_image_embedding,
+                    },
+                ],
+            },
+        ],
+        max_tokens=100,
+        temperature=0.7,
+    )
+    
+    print("\n" + "="*60)
+    print("Response:")
+    print("="*60)
+    print(chat_completion.choices[0].message.content)
+    print("="*60)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/test_embedding_only_fix.py
+++ b/test_embedding_only_fix.py
@@ -76,16 +76,12 @@ def start_server():
     print(f"Model: {MODEL}")
     print(f"Port: {PORT}")
     
-    # Use a clean HuggingFace cache to avoid corrupted cache issues
+    # Use existing environment (including default HuggingFace cache)
     import os
     env = os.environ.copy()
-    clean_cache_dir = "/tmp/hf_cache_clean"
-    os.makedirs(clean_cache_dir, exist_ok=True)
-    env["HF_HOME"] = clean_cache_dir
-    print(f"Using HuggingFace cache: {clean_cache_dir}")
     
     cmd = [
-        "python", "-m", "vllm.entrypoints.openai.api_server",
+        sys.executable, "-m", "vllm.entrypoints.openai.api_server",
         "--model", MODEL,
         "--enable-mm-embeds",
         "--limit-mm-per-prompt", '{"image": 0, "video": 0}',

--- a/test_embedding_only_fix.py
+++ b/test_embedding_only_fix.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Combined test script: Starts server and runs embedding-only test
+This allows agentic access to test the fix in one command
+"""
+
+import subprocess
+import time
+import sys
+import signal
+import os
+import threading
+from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    print("Installing requests...")
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "requests", "-q"])
+    import requests
+
+# Import the test client
+from example_embedding_only_serve import main as run_client_test
+from openai import OpenAI
+
+MODEL = "Qwen/Qwen2.5-VL-7B-Instruct"
+PORT = 8000
+SERVER_URL = f"http://localhost:{PORT}"
+
+def check_server_ready(max_wait=300, process=None):
+    """Check if server is ready by polling /health endpoint"""
+    print(f"Waiting up to {max_wait} seconds for server to be ready...")
+    for i in range(max_wait):
+        # Check if process is still alive
+        if process and process.poll() is not None:
+            print(f"\n✗ Server process died unexpectedly (exit code: {process.returncode})")
+            # Try to read any output
+            try:
+                output = process.stdout.read()
+                if output:
+                    print("Server output:")
+                    print(output[-2000:])  # Last 2000 chars
+            except:
+                pass
+            return False
+        
+        try:
+            response = requests.get(f"{SERVER_URL}/health", timeout=2)
+            if response.status_code == 200:
+                print(f"✓ Server is ready (took {i+1}s)")
+                return True
+        except:
+            pass
+        
+        # Show progress every 10 seconds
+        if (i + 1) % 10 == 0:
+            print(f"  Still waiting... ({i+1}s/{max_wait}s)")
+        
+        time.sleep(1)
+    
+    print(f"\n✗ Server failed to start within {max_wait} seconds")
+    if process:
+        # Try to read any output
+        try:
+            output = process.stdout.read()
+            if output:
+                print("\nLast server output:")
+                print(output[-2000:])  # Last 2000 chars
+        except:
+            pass
+    return False
+
+def start_server():
+    """Start vLLM server in background"""
+    print("Starting vLLM server...")
+    print(f"Model: {MODEL}")
+    print(f"Port: {PORT}")
+    
+    # Use a clean HuggingFace cache to avoid corrupted cache issues
+    import os
+    env = os.environ.copy()
+    clean_cache_dir = "/tmp/hf_cache_clean"
+    os.makedirs(clean_cache_dir, exist_ok=True)
+    env["HF_HOME"] = clean_cache_dir
+    print(f"Using HuggingFace cache: {clean_cache_dir}")
+    
+    cmd = [
+        "python", "-m", "vllm.entrypoints.openai.api_server",
+        "--model", MODEL,
+        "--enable-mm-embeds",
+        "--limit-mm-per-prompt", '{"image": 0, "video": 0}',
+        "--port", str(PORT),
+        "--max-model-len", "2048",  # Smaller for faster startup
+    ]
+    
+    # Start server process - write to both file and capture
+    log_file = open("/tmp/vllm_server.log", "w")
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        env=env
+    )
+    
+    print(f"Server process started (PID: {process.pid})")
+    print("Server logs are being written to /tmp/vllm_server.log")
+    print("You can monitor progress with: tail -f /tmp/vllm_server.log")
+    
+    # Start a thread to copy output to log file
+    def log_output():
+        try:
+            for line in process.stdout:
+                log_file.write(line)
+                log_file.flush()
+                # Also print important lines
+                if any(keyword in line.lower() for keyword in ["error", "exception", "ready", "uvicorn", "started"]):
+                    print(f"  [SERVER] {line.rstrip()}")
+        except:
+            pass
+    
+    log_thread = threading.Thread(target=log_output, daemon=True)
+    log_thread.start()
+    
+    if not check_server_ready(max_wait=300, process=process):
+        print("✗ Server failed to start within timeout")
+        log_file.close()
+        process.terminate()
+        return None
+    
+    log_file.close()
+    return process
+
+def run_test():
+    """Run the client test"""
+    print("\n" + "="*60)
+    print("Running client test...")
+    print("="*60 + "\n")
+    
+    try:
+        run_client_test()
+        print("\n✓ Test completed successfully!")
+        return True
+    except Exception as e:
+        print(f"\n✗ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def main():
+    """Main test runner"""
+    server_process = None
+    
+    try:
+        # Start server
+        server_process = start_server()
+        if not server_process:
+            print("Failed to start server")
+            return 1
+        
+        # Run test
+        success = run_test()
+        
+        return 0 if success else 1
+        
+    except KeyboardInterrupt:
+        print("\n\nInterrupted by user")
+        return 130
+    finally:
+        # Cleanup: kill server
+        if server_process:
+            print("\nShutting down server...")
+            try:
+                server_process.terminate()
+                server_process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                print("Force killing server...")
+                server_process.kill()
+                server_process.wait()
+            print("Server stopped")
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/tests/models/utils.py
+++ b/tests/models/utils.py
@@ -278,6 +278,7 @@ def build_model_context(
     mm_processor_kwargs: dict[str, Any] | None = None,
     limit_mm_per_prompt: dict[str, int] | None = None,
     mm_processor_cache_gb: int = 0,
+    enable_mm_embeds: bool | None = None,
 ):
     """Creates an InputProcessingContext for a given model.
 
@@ -286,6 +287,8 @@ def build_model_context(
         mm_processor_kwargs: optional processor kwargs for to be leveraged
             in the input processor, mapper, dummy data creation, etc.
         limit_mm_per_prompt: Multimodal limits.
+        enable_mm_embeds: Whether to enable multimodal embedding processing.
+            If None, defaults to model_info.require_embed_inputs.
 
     Returns:
         InputProcessingContext for the model being considered.
@@ -296,6 +299,11 @@ def build_model_context(
 
     model_config_kwargs = model_config_kwargs or {}
     limit_mm_per_prompt = limit_mm_per_prompt or {}
+    enable_mm_embeds = (
+        model_info.require_embed_inputs
+        if enable_mm_embeds is None
+        else enable_mm_embeds
+    )
     model_config = ModelConfig(
         model_id,
         runner=runner,
@@ -311,7 +319,7 @@ def build_model_context(
         hf_overrides=model_info.hf_overrides,
         skip_tokenizer_init=model_info.require_embed_inputs,
         enable_prompt_embeds=model_info.require_embed_inputs,
-        enable_mm_embeds=model_info.require_embed_inputs,
+        enable_mm_embeds=enable_mm_embeds,
         enforce_eager=model_info.enforce_eager,
         **model_config_kwargs,
     )

--- a/tests/multimodal/test_registry.py
+++ b/tests/multimodal/test_registry.py
@@ -15,20 +15,58 @@ pytestmark = pytest.mark.cpu_test
 
 
 @pytest.mark.parametrize(
-    "model_id,limit_mm_per_prompt,expected",
+    "model_id,limit_mm_per_prompt,enable_mm_embeds,expected",
     [
-        ("Qwen/Qwen2-0.5B-Instruct", {}, False),
-        ("Qwen/Qwen2.5-VL-3B-Instruct", {}, True),
-        ("Qwen/Qwen2.5-VL-3B-Instruct", {"image": 0, "video": 0}, False),
-        ("Qwen/Qwen2.5-VL-3B-Instruct", {"image": 0}, True),
+        ("Qwen/Qwen2-0.5B-Instruct", {}, False, False),
+        ("Qwen/Qwen2-0.5B-Instruct", {}, True, False),
+        ("Qwen/Qwen2.5-VL-3B-Instruct", {}, False, True),
+        ("Qwen/Qwen2.5-VL-3B-Instruct", {}, True, True),
+        ("Qwen/Qwen2.5-VL-3B-Instruct", {"image": 0, "video": 0}, False, False),
+        ("Qwen/Qwen2.5-VL-3B-Instruct", {"image": 0, "video": 0}, True, True),
+        ("Qwen/Qwen2.5-VL-3B-Instruct", {"image": 0}, True, True),
+        ("Qwen/Qwen2.5-VL-3B-Instruct", {"image": 0}, False, True),
+        ("Qwen/Qwen2.5-VL-3B-Instruct", {"image": 1, "video": 1}, True, True),
+        ("Qwen/Qwen2.5-VL-3B-Instruct", {"image": 1, "video": 1}, False, True),
     ],
 )
 @pytest.mark.core_model
-def test_supports_multimodal_inputs(model_id, limit_mm_per_prompt, expected):
+def test_supports_multimodal_inputs(
+    model_id, limit_mm_per_prompt, enable_mm_embeds, expected
+):
     """Test supports_multimodal_inputs returns correct boolean for various
-    configs."""
+    configs.
+
+    This test verifies that when enable_mm_embeds=True, the multimodal
+    processing pipeline is enabled even when all modality limits are 0,
+    allowing pre-computed embeddings to be processed while skipping
+    encoder weight loading for memory optimization.
+    """
     ctx = build_model_context(
         model_id,
         limit_mm_per_prompt=limit_mm_per_prompt,
+        enable_mm_embeds=enable_mm_embeds,
     )
     assert MULTIMODAL_REGISTRY.supports_multimodal_inputs(ctx.model_config) is expected
+
+
+@pytest.mark.core_model
+def test_encoder_weight_skipping_with_enable_mm_embeds():
+    """Integration test verifying encoder weights are not loaded when all
+    modality limits are 0, even with enable_mm_embeds=True."""
+    from vllm.v1.core.encoder_cache_manager import compute_encoder_cache_budget
+
+    ctx = build_model_context(
+        "Qwen/Qwen2.5-VL-3B-Instruct",
+        limit_mm_per_prompt={"image": 0, "video": 0},
+        enable_mm_embeds=True,
+    )
+
+    assert MULTIMODAL_REGISTRY.supports_multimodal_inputs(ctx.model_config) is True
+
+    compute_budget, cache_size = compute_encoder_cache_budget(
+        ctx.model_config, ctx.scheduler_config, MULTIMODAL_REGISTRY
+    )
+    assert compute_budget == 1, (
+        "Compute budget should be minimal (1) for embeddings-only mode"
+    )
+    assert cache_size == 1, "Cache size should be minimal (1) for embeddings-only mode"

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -729,10 +729,16 @@ class BaseMultiModalItemTracker(ABC, Generic[_T]):
         An optional uuid can be added which serves as a unique identifier of the
         media.
         """
+        is_embedding = modality.endswith("_embeds")
         input_modality = modality.replace("_embeds", "")
         num_items = len(self._items_by_modality[modality]) + 1
 
-        self.mm_processor.validate_num_items(input_modality, num_items)
+        # validate_num_items now handles embedding detection internally
+        self.mm_processor.validate_num_items(
+            input_modality, 
+            num_items, 
+            is_embedding=is_embedding
+        )
 
         self._items_by_modality[modality].append(item)
         self._uuids_by_modality[modality].append(uuid)

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -1095,13 +1095,20 @@ class Qwen2VLMultiModalProcessor(BaseMultiModalProcessor[Qwen2VLProcessingInfo])
             num_tokens = int(grid_thw.prod()) // merge_length
             return [placeholder[modality]] * num_tokens
 
+        # Only create prompt updates for modalities that are present in BOTH mm_items AND out_mm_kwargs
+        # out_mm_kwargs may be empty for embeddings (passthrough data), so we need to check both
+        available_modalities = [
+            modality for modality in ("image", "video")
+            if modality in mm_items and modality in out_mm_kwargs
+        ]
+
         return [
             PromptReplacement(
                 modality=modality,
                 target=[placeholder[modality]],
                 replacement=partial(get_replacement_qwen2vl, modality=modality),
             )
-            for modality in ("image", "video")
+            for modality in available_modalities
         ]
 
     def _get_mm_fields_config(

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -1384,6 +1384,12 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
                     )
 
         for modality, items in mm_items.items():
+            # When enable_mm_embeds=True, allow embedding inputs even if
+            # modality limits are zero (for memory optimization)
+            if mm_config.enable_mm_embeds and isinstance(
+                items, (EmbeddingItems, DictEmbeddingItems)
+            ):
+                continue
             self.validate_num_items(modality, len(items))
 
         return mm_items

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -118,16 +118,19 @@ class MultiModalRegistry:
         """
         Checks if the model supports multimodal inputs.
         Returns True if the model is multimodal with any non-zero supported
-        modalities, otherwise returns False, effectively running in
-        text-only mode.
+        modalities OR if enable_mm_embeds is True (for pre-computed embeddings),
+        otherwise returns False, effectively running in text-only mode.
         """
         if not model_config.is_multimodal_model:
             return False
 
+        mm_config = model_config.get_multimodal_config()
+
+        if mm_config.enable_mm_embeds:
+            return True
+
         info = self._create_processing_info(model_config, tokenizer=None)
         supported_modalities = info.get_supported_mm_limits()
-
-        mm_config = model_config.get_multimodal_config()
 
         # Check if all supported modalities have limit == 0
         if all(

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -1052,7 +1052,24 @@ class TPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
                 mm_hash = mm_feature.identifier
                 encoder_output = self.encoder_cache.get(mm_hash, None)
-                assert encoder_output is not None, f"Encoder cache miss for {mm_hash}."
+                if encoder_output is None:
+                    mm_config = self.model_config.multimodal_config
+                    if (
+                        mm_config is not None
+                        and mm_config.enable_mm_embeds
+                        and "dummy_none" in self.encoder_cache
+                        and mm_hash not in self.encoder_cache
+                    ):
+                        # enable_mm_embeds is True and we have the dummy cache entry.
+                        # This edge case can occur when embeddings are provided
+                        # directly without going through the normal encoder caching
+                        # path. Skip this entry as the embeddings may have been
+                        # provided directly.
+                        continue
+                    else:
+                        assert encoder_output is not None, (
+                            f"Encoder cache miss for {mm_hash}."
+                        )
 
                 assert pos_info.is_embed is None, (
                     "Expected all positions to be contiguous and embeddings."
@@ -1726,7 +1743,22 @@ class TPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 assert mm_budget is not None
 
                 # TODO: handle encoder-decoder models once we support them.
-                if (encoder_budget := mm_budget.get_encoder_budget()) > 0:
+                encoder_budget = mm_budget.get_encoder_budget()
+                # Check if this is a minimal budget case (encoder_budget == 1)
+                # which occurs when all modalities are zero but enable_mm_embeds=True
+                if (
+                    encoder_budget == 1
+                    and mm_config is not None
+                    and mm_config.enable_mm_embeds
+                    and not mm_budget.max_tokens_by_modality
+                ):
+                    logger.info(
+                        "All modalities are disabled but enable_mm_embeds=True. "
+                        "Initializing encoder cache with None values for memory "
+                        "optimization."
+                    )
+                    self.encoder_cache["dummy_none"] = None
+                elif encoder_budget > 0:
                     # NOTE: Currently model is profiled with a single non-text
                     # modality with the max possible input tokens even when
                     # it supports multiple.

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -54,6 +54,7 @@ class MultiModalBudget:
         encoder_compute_budget, encoder_cache_size = compute_mm_encoder_budget(
             scheduler_config,
             max_tokens_by_modality,
+            model_config,
         )
 
         self.encoder_compute_budget = encoder_compute_budget


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

status: found bug in implementation

Resolves part of #21943. Previously, a change was made to implicitly make a model language-model only (#22299) when all modalities had limits set to 0. However, some users may want to input embeddings as an input while still saving on memory from the unused encoder. This changes behavior to allow this.

## Test Plan
Running Qwen2.5VL-7B on L40S

Command: `vllm serve Qwen/Qwen2.5-VL-7B-Instruct`
```
(EngineCore_DP0 pid=4731) INFO 12-29 21:28:42 [default_loader.py:308] Loading weights took 2.66 seconds                                                                                        
(EngineCore_DP0 pid=4731) INFO 12-29 21:28:43 [gpu_model_runner.py:3734] Model loading took 15.6270 GiB memory and 142.865302 seconds                                                          
(EngineCore_DP0 pid=4731) INFO 12-29 21:28:43 [gpu_model_runner.py:4547] Encoder cache will be initialized with a budget of 114688 tokens, and profiled with 1 video items of the maximum featu
re size.                                                                                                                                                                                       
(EngineCore_DP0 pid=4731) INFO 12-29 21:29:02 [backends.py:644] Using cache directory: /root/.cache/vllm/torch_compile_cache/9515dd7e93/rank_0_0/backbone for vLLM's torch.compile             
(EngineCore_DP0 pid=4731) INFO 12-29 21:29:02 [backends.py:704] Dynamo bytecode transform time: 3.55 s                                                                                         
(EngineCore_DP0 pid=4731) INFO 12-29 21:29:10 [backends.py:261] Cache the graph of compile range (1, 2048) for later use                                                                       
(EngineCore_DP0 pid=4731) INFO 12-29 21:29:14 [backends.py:278] Compiling a graph for compile range (1, 2048) takes 7.76 s                                                                     
(EngineCore_DP0 pid=4731) INFO 12-29 21:29:14 [monitor.py:34] torch.compile takes 11.31 s in total                                                                                             
(EngineCore_DP0 pid=4731) INFO 12-29 21:29:15 [gpu_worker.py:363] Available KV cache memory: 9.76 GiB                                                                                          
(EngineCore_DP0 pid=4731) INFO 12-29 21:29:16 [kv_cache_utils.py:1291] GPU KV cache size: 182,720 tokens                                                                                       
(EngineCore_DP0 pid=4731) INFO 12-29 21:29:16 [kv_cache_utils.py:1296] Maximum concurrency for 128,000 tokens per request: 1.43x
```

Command: `vllm serve Qwen/Qwen2.5-VL-7B-Instruct --limit-mm-per-prompt '{"image": 0, "video": 0}'`
```
(EngineCore_DP0 pid=7327) INFO 12-29 21:31:37 [default_loader.py:308] Loading weights took 2.98 seconds                                                                                        
(EngineCore_DP0 pid=7327) INFO 12-29 21:31:38 [gpu_model_runner.py:3734] Model loading took 14.3606 GiB memory and 3.536902 seconds                                                            
(EngineCore_DP0 pid=7327) INFO 12-29 21:31:42 [backends.py:644] Using cache directory: /root/.cache/vllm/torch_compile_cache/06830b85c1/rank_0_0/backbone for vLLM's torch.compile             
(EngineCore_DP0 pid=7327) INFO 12-29 21:31:42 [backends.py:704] Dynamo bytecode transform time: 3.65 s                                                                                         
(EngineCore_DP0 pid=7327) INFO 12-29 21:31:47 [backends.py:261] Cache the graph of compile range (1, 2048) for later use                                                                       
(EngineCore_DP0 pid=7327) INFO 12-29 21:31:49 [backends.py:278] Compiling a graph for compile range (1, 2048) takes 3.66 s                                                                     
(EngineCore_DP0 pid=7327) INFO 12-29 21:31:49 [monitor.py:34] torch.compile takes 7.30 s in total                                                                                              
(EngineCore_DP0 pid=7327) INFO 12-29 21:31:50 [gpu_worker.py:363] Available KV cache memory: 26.85 GiB                                                                                         
(EngineCore_DP0 pid=7327) INFO 12-29 21:31:51 [kv_cache_utils.py:1291] GPU KV cache size: 502,656 tokens                                                                                       
(EngineCore_DP0 pid=7327) INFO 12-29 21:31:51 [kv_cache_utils.py:1296] Maximum concurrency for 128,000 tokens per request: 3.93x
```

Command: `vllm serve Qwen/Qwen2.5-VL-7B-Instruct --limit-mm-per-prompt '{"image": 0, "video": 0}' --enable-mm-embeds`
```
(EngineCore_DP0 pid=9025) INFO 12-29 21:34:30 [default_loader.py:308] Loading weights took 2.38 seconds                                                                                        
(EngineCore_DP0 pid=9025) INFO 12-29 21:34:31 [gpu_model_runner.py:3734] Model loading took 14.3606 GiB memory and 2.870875 seconds                                                            
(EngineCore_DP0 pid=9025) INFO 12-29 21:34:31 [gpu_model_runner.py:4533] All modalities are disabled but enable_mm_embeds=True. Initializing encoder cache with None values for memory optimiza
tion.                                                                                                                                                                                          
(EngineCore_DP0 pid=9025) INFO 12-29 21:34:35 [backends.py:644] Using cache directory: /root/.cache/vllm/torch_compile_cache/8536fc9e9c/rank_0_0/backbone for vLLM's torch.compile             
(EngineCore_DP0 pid=9025) INFO 12-29 21:34:35 [backends.py:704] Dynamo bytecode transform time: 3.66 s                                                                                         
(EngineCore_DP0 pid=9025) INFO 12-29 21:34:39 [backends.py:261] Cache the graph of compile range (1, 2048) for later use                                                                       
(EngineCore_DP0 pid=9025) INFO 12-29 21:34:41 [backends.py:278] Compiling a graph for compile range (1, 2048) takes 2.01 s                                                                     
(EngineCore_DP0 pid=9025) INFO 12-29 21:34:41 [monitor.py:34] torch.compile takes 5.67 s in total                                                                                              
(EngineCore_DP0 pid=9025) INFO 12-29 21:34:42 [gpu_worker.py:363] Available KV cache memory: 26.84 GiB                                                                                         
(EngineCore_DP0 pid=9025) INFO 12-29 21:34:43 [kv_cache_utils.py:1291] GPU KV cache size: 502,624 tokens                                                                                       
(EngineCore_DP0 pid=9025) INFO 12-29 21:34:43 [kv_cache_utils.py:1296] Maximum concurrency for 128,000 tokens per request: 3.93x
```




## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

