### PR TITLE
FP8 KV cache append optimized with precomputed inverse scale

### DIFF
--- a/csrc/quantization/w8a8/fp8/nvidia/quant_utils.cuh
+++ b/csrc/quantization/w8a8/fp8/nvidia/quant_utils.cuh
@@ -292,68 +292,72 @@ __inline__ __device__ bf16_8_t vec_conversion<bf16_8_t, Float8_>(
     #endif
 
 /* Scaled and vectorized conversions, for data exchange between high and low
-   precision domains Convention of the scale in API, e.g: FP8_data =
-   Quantization( High_Precision_data / scale ) s.t. Quantize(HP / scale) => FP8
-     Dequant(FP8) * scale =>  HP
+   precision domains. All functions MULTIPLY by scale_factor:
+     - Dequantization (FP8 -> HP): pass scale, result = FP8 * scale
+     - Quantization (HP -> FP8): pass 1/scale, result = HP * (1/scale)
+   This avoids per-element division for better performance.
  */
 
 template <typename Tout, typename Tin>
-__inline__ __device__ Tout scaled_vec_conversion(
-    const Tin& x, const float scale, const __nv_fp8_interpretation_t fp8_type) {
+__inline__ __device__ Tout
+scaled_vec_conversion(const Tin& x, const float scale_factor,
+                      const __nv_fp8_interpretation_t fp8_type) {
   return x;
 }
 
 // fp8 -> half
 template <>
 __inline__ __device__ uint16_t scaled_vec_conversion<uint16_t, uint8_t>(
-    const uint8_t& a, const float scale,
+    const uint8_t& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
   __half_raw tmp = __nv_cvt_fp8_to_halfraw(a, fp8_type);
-  return float_to_half(half_to_float(tmp.x) * scale);
+  return float_to_half(half_to_float(tmp.x) * scale_factor);
 }
 
 // fp8x2 -> half2
 template <>
 __inline__ __device__ uint32_t scaled_vec_conversion<uint32_t, uint16_t>(
-    const uint16_t& a, const float scale,
+    const uint16_t& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
   union {
     uint16_t u16[2];
     uint32_t u32;
   } tmp;
   __half2_raw res = __nv_cvt_fp8x2_to_halfraw2(a, fp8_type);
-  tmp.u16[0] = float_to_half(half_to_float(res.x) * scale);
-  tmp.u16[1] = float_to_half(half_to_float(res.y) * scale);
+  tmp.u16[0] = float_to_half(half_to_float(res.x) * scale_factor);
+  tmp.u16[1] = float_to_half(half_to_float(res.y) * scale_factor);
   return tmp.u32;
 }
 
 // fp8x4 -> half2x2
 template <>
 __inline__ __device__ uint2 scaled_vec_conversion<uint2, uint32_t>(
-    const uint32_t& a, const float scale,
+    const uint32_t& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
   union {
     uint2 u32x2;
     uint32_t u32[2];
   } tmp;
-  tmp.u32[0] =
-      scaled_vec_conversion<uint32_t, uint16_t>((uint16_t)a, scale, fp8_type);
-  tmp.u32[1] = scaled_vec_conversion<uint32_t, uint16_t>((uint16_t)(a >> 16U),
-                                                         scale, fp8_type);
+  tmp.u32[0] = scaled_vec_conversion<uint32_t, uint16_t>(
+      (uint16_t)a, scale_factor, fp8_type);
+  tmp.u32[1] = scaled_vec_conversion<uint32_t, uint16_t>(
+      (uint16_t)(a >> 16U), scale_factor, fp8_type);
   return tmp.u32x2;
 }
 
 // fp8x8 -> half2x4
 template <>
 __inline__ __device__ uint4
-scaled_vec_conversion<uint4, uint2>(const uint2& a, const float scale,
+scaled_vec_conversion<uint4, uint2>(const uint2& a, const float scale_factor,
                                     const __nv_fp8_interpretation_t fp8_type) {
   union {
     uint4 u64x2;
     uint2 u64[2];
   } tmp;
-  tmp.u64[0] = scaled_vec_conversion<uint2, uint32_t>(a.x, scale, fp8_type);
-  tmp.u64[1] = scaled_vec_conversion<uint2, uint32_t>(a.y, scale, fp8_type);
+  tmp.u64[0] =
+      scaled_vec_conversion<uint2, uint32_t>(a.x, scale_factor, fp8_type);
+  tmp.u64[1] =
+      scaled_vec_conversion<uint2, uint32_t>(a.y, scale_factor, fp8_type);
   return tmp.u64x2;
 }
 
@@ -361,51 +365,51 @@ scaled_vec_conversion<uint4, uint2>(const uint2& a, const float scale,
 template <>
 __inline__ __device__ __nv_bfloat16
 scaled_vec_conversion<__nv_bfloat16, uint8_t>(
-    const uint8_t& a, const float scale,
+    const uint8_t& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
   // Note there is no direct convert function from fp8 to bf16.
   // fp8 -> half
   __half_raw res = __nv_cvt_fp8_to_halfraw(a, fp8_type);
   // half -> float -> bf16
   float tmp = half_to_float(res.x);
-  return __float2bfloat16(tmp * scale);
+  return __float2bfloat16(tmp * scale_factor);
 }
 
 // fp8x2 -> __nv_bfloat162
 template <>
 __inline__ __device__ __nv_bfloat162
 scaled_vec_conversion<__nv_bfloat162, uint16_t>(
-    const uint16_t& a, const float scale,
+    const uint16_t& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
   __nv_bfloat162 res;
-  res.x = scaled_vec_conversion<__nv_bfloat16, uint8_t>((uint8_t)a, scale,
-                                                        fp8_type);
+  res.x = scaled_vec_conversion<__nv_bfloat16, uint8_t>((uint8_t)a,
+                                                        scale_factor, fp8_type);
   res.y = scaled_vec_conversion<__nv_bfloat16, uint8_t>((uint8_t)(a >> 8U),
-                                                        scale, fp8_type);
+                                                        scale_factor, fp8_type);
   return res;
 }
 
 // fp8x4 -> bf16_4_t
 template <>
 __inline__ __device__ bf16_4_t scaled_vec_conversion<bf16_4_t, uint32_t>(
-    const uint32_t& a, const float scale,
+    const uint32_t& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
   bf16_4_t res;
-  res.x = scaled_vec_conversion<__nv_bfloat162, uint16_t>((uint16_t)a, scale,
-                                                          fp8_type);
-  res.y = scaled_vec_conversion<__nv_bfloat162, uint16_t>((uint16_t)(a >> 16U),
-                                                          scale, fp8_type);
+  res.x = scaled_vec_conversion<__nv_bfloat162, uint16_t>(
+      (uint16_t)a, scale_factor, fp8_type);
+  res.y = scaled_vec_conversion<__nv_bfloat162, uint16_t>(
+      (uint16_t)(a >> 16U), scale_factor, fp8_type);
   return res;
 }
 
 // fp8x8 -> bf16_8_t
 template <>
 __inline__ __device__ bf16_8_t scaled_vec_conversion<bf16_8_t, uint2>(
-    const uint2& a, const float scale,
+    const uint2& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
   bf16_4_t tmp1, tmp2;
-  tmp1 = scaled_vec_conversion<bf16_4_t, uint32_t>(a.x, scale, fp8_type);
-  tmp2 = scaled_vec_conversion<bf16_4_t, uint32_t>(a.y, scale, fp8_type);
+  tmp1 = scaled_vec_conversion<bf16_4_t, uint32_t>(a.x, scale_factor, fp8_type);
+  tmp2 = scaled_vec_conversion<bf16_4_t, uint32_t>(a.y, scale_factor, fp8_type);
   bf16_8_t res;
   res.x = tmp1.x;
   res.y = tmp1.y;
@@ -417,23 +421,24 @@ __inline__ __device__ bf16_8_t scaled_vec_conversion<bf16_8_t, uint2>(
 // fp8 -> float
 template <>
 __inline__ __device__ float scaled_vec_conversion<float, uint8_t>(
-    const uint8_t& a, const float scale,
+    const uint8_t& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
   // fp8 -> half
   __half_raw res = __nv_cvt_fp8_to_halfraw(a, fp8_type);
   uint16_t tmp = res.x;
 
   // half -> float
-  return half_to_float(tmp) * scale;
+  return half_to_float(tmp) * scale_factor;
 }
 
 // fp8x2 -> float2
 template <>
 __inline__ __device__ float2 scaled_vec_conversion<float2, uint16_t>(
-    const uint16_t& a, const float scale,
+    const uint16_t& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
   // fp8x2 -> half2
-  uint32_t tmp = scaled_vec_conversion<uint32_t, uint16_t>(a, scale, fp8_type);
+  uint32_t tmp =
+      scaled_vec_conversion<uint32_t, uint16_t>(a, scale_factor, fp8_type);
   // half2 -> float2
   return half2_to_float2(tmp);
 }
@@ -441,23 +446,24 @@ __inline__ __device__ float2 scaled_vec_conversion<float2, uint16_t>(
 // fp8x4 -> float4
 template <>
 __inline__ __device__ Float4_ scaled_vec_conversion<Float4_, uint32_t>(
-    const uint32_t& a, const float scale,
+    const uint32_t& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
   Float4_ res;
-  res.x = scaled_vec_conversion<float2, uint16_t>((uint16_t)a, scale, fp8_type);
-  res.y = scaled_vec_conversion<float2, uint16_t>((uint16_t)(a >> 16U), scale,
+  res.x = scaled_vec_conversion<float2, uint16_t>((uint16_t)a, scale_factor,
                                                   fp8_type);
+  res.y = scaled_vec_conversion<float2, uint16_t>((uint16_t)(a >> 16U),
+                                                  scale_factor, fp8_type);
   return res;
 }
 
 // fp8x8 -> float8
 template <>
 __inline__ __device__ Float8_ scaled_vec_conversion<Float8_, uint2>(
-    const uint2& a, const float scale,
+    const uint2& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
   Float4_ tmp1, tmp2;
-  tmp1 = scaled_vec_conversion<Float4_, uint32_t>(a.x, scale, fp8_type);
-  tmp2 = scaled_vec_conversion<Float4_, uint32_t>(a.y, scale, fp8_type);
+  tmp1 = scaled_vec_conversion<Float4_, uint32_t>(a.x, scale_factor, fp8_type);
+  tmp2 = scaled_vec_conversion<Float4_, uint32_t>(a.y, scale_factor, fp8_type);
   Float8_ res;
   res.x = tmp1.x;
   res.y = tmp1.y;
@@ -469,23 +475,23 @@ __inline__ __device__ Float8_ scaled_vec_conversion<Float8_, uint2>(
 // half -> fp8
 template <>
 __inline__ __device__ uint8_t scaled_vec_conversion<uint8_t, uint16_t>(
-    const uint16_t& a, const float scale,
+    const uint16_t& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
-  __nv_fp8_storage_t res =
-      __nv_cvt_float_to_fp8(half_to_float(a) / scale, __NV_SATFINITE, fp8_type);
+  __nv_fp8_storage_t res = __nv_cvt_float_to_fp8(
+      half_to_float(a) * scale_factor, __NV_SATFINITE, fp8_type);
   return (uint8_t)res;
 }
 
 // bf16 -> fp8
 template <>
 __inline__ __device__ uint8_t scaled_vec_conversion<uint8_t, __nv_bfloat16>(
-    const __nv_bfloat16& a, const float scale,
+    const __nv_bfloat16& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
     #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
   assert(false);
     #else
-  __nv_fp8_storage_t res = __nv_cvt_float_to_fp8(__bfloat162float(a) / scale,
-                                                 __NV_SATFINITE, fp8_type);
+  __nv_fp8_storage_t res = __nv_cvt_float_to_fp8(
+      __bfloat162float(a) * scale_factor, __NV_SATFINITE, fp8_type);
   return (uint8_t)res;
     #endif
   __builtin_unreachable();  // Suppress missing return statement warning
@@ -494,22 +500,24 @@ __inline__ __device__ uint8_t scaled_vec_conversion<uint8_t, __nv_bfloat16>(
 // float -> fp8
 template <>
 __inline__ __device__ uint8_t scaled_vec_conversion<uint8_t, float>(
-    const float& a, const float scale,
+    const float& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
   __nv_fp8_storage_t res =
-      __nv_cvt_float_to_fp8(a / scale, __NV_SATFINITE, fp8_type);
+      __nv_cvt_float_to_fp8(a * scale_factor, __NV_SATFINITE, fp8_type);
   return (uint8_t)res;
 }
 
 // fp8x4 -> float4
 template <>
 __inline__ __device__ float4 scaled_vec_conversion<float4, uint32_t>(
-    const uint32_t& a, const float scale,
+    const uint32_t& a, const float scale_factor,
     const __nv_fp8_interpretation_t fp8_type) {
-  Float4_ tmp = scaled_vec_conversion<Float4_, uint32_t>(a, scale, fp8_type);
+  Float4_ tmp =
+      scaled_vec_conversion<Float4_, uint32_t>(a, scale_factor, fp8_type);
   float4 res = make_float4(tmp.x.x, tmp.x.y, tmp.y.x, tmp.y.y);
   return res;
 }
+
   #endif  // ENABLE_FP8
 
 template <typename Tout, typename Tin, Fp8KVCacheDataType kv_dt>
@@ -526,12 +534,13 @@ __inline__ __device__ Tout convert(const Tin& x) {
 }
 
 template <typename Tout, typename Tin, Fp8KVCacheDataType kv_dt>
-__inline__ __device__ Tout scaled_convert(const Tin& x, const float scale) {
+__inline__ __device__ Tout scaled_convert(const Tin& x,
+                                          const float scale_factor) {
   #ifdef ENABLE_FP8
   if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E4M3) {
-    return scaled_vec_conversion<Tout, Tin>(x, scale, __NV_E4M3);
+    return scaled_vec_conversion<Tout, Tin>(x, scale_factor, __NV_E4M3);
   } else if constexpr (kv_dt == Fp8KVCacheDataType::kFp8E5M2) {
-    return scaled_vec_conversion<Tout, Tin>(x, scale, __NV_E5M2);
+    return scaled_vec_conversion<Tout, Tin>(x, scale_factor, __NV_E5M2);
   }
   #endif
   assert(false);


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
FP8 KV cache append (`reshape_and_cache_flash`) runs every layer, every decode step. The FP8 quantization path was doing per-element division to convert FP16→FP8:

```cpp
// Before: division per element (expensive)
__nv_cvt_float_to_fp8(half_to_float(a) / scale, ...)
```

Division is slower than multiplication on NVIDIA GPUs. This fixed per-token tax dominated short-context decode latency, causing FP8 to regress vs FP16 even though FP8 attention (read path) is faster at long context.
Replaced per-element division (`x / scale`) with multiplication by precomputed reciprocal (`x * inv_scale`) in FP8 KV cache append kernels. The reciprocal is computed once per kernel launch instead of per element.
## Test Plan
```bash
# Setup
uv venv --python 3.12 --seed
source .venv/bin/activate
uv pip install -e .

# 1-token kernel benchmark (FP16 vs FP8)
python -c "
import torch
import vllm._custom_ops as ops

device = torch.device('cuda')
key = torch.randn(1, 32, 128, dtype=torch.float16, device=device)
value = torch.randn(1, 32, 128, dtype=torch.float16, device=device)
slot_mapping = torch.tensor([0], dtype=torch.int64, device=device)
k_scale = torch.tensor(1.0, dtype=torch.float32, device=device)
v_scale = torch.tensor(1.0, dtype=torch.float32, device=device)

for label, kv_str, kv_dtype in [('FP16', 'auto', torch.float16), ('FP8', 'fp8_e4m3', torch.float8_e4m3fn)]:
    kv_cache = torch.zeros(2048, 2, 16, 32, 128, dtype=kv_dtype, device=device)
    for _ in range(100):  # warmup
        ops.reshape_and_cache_flash(key, value, kv_cache[:, 0], kv_cache[:, 1],
                                     slot_mapping, kv_str, k_scale, v_scale)
    torch.cuda.synchronize()
    start = torch.cuda.Event(enable_timing=True)
    end = torch.cuda.Event(enable_timing=True)
    start.record()
    for _ in range(1000):
        ops.reshape_and_cache_flash(key, value, kv_cache[:, 0], kv_cache[:, 1],
                                     slot_mapping, kv_str, k_scale, v_scale)
    end.record()
    torch.cuda.synchronize()
    t = start.elapsed_time(end) / 1000 * 1000
    print(f'{label}: {t:.3f} us')
"

# Unit tests
pytest tests/kernels/attention/test_cache.py -v
```
## Test Result
**Hardware:** RTX 4090 (SM89), CUDA 12.8, PyTorch 2.9.1

### 1-Token Append Kernel (True Decode Regime)

Config: `tokens=1, heads=32, head_dim=128, blocks=2048, block_size=16`

| Version | FP16 | FP8 | FP8 Overhead |
|---------|------|-----|--------------|
| Baseline (upstream/main @ b9793e6) | 2.416 µs | 2.785 µs | **+15.3%** |
| This PR | 2.408 µs | 2.492 µs | **+3.5%** |

### Decode-Dominant End-to-End

Config: `opt-1.3b, FlashInfer backend, prompt=32 tokens, output=256 tokens`

| KV Cache | TPOT (ms) | vs BF16 |
|----------|-----------|---------|
| BF16 | 4.310 | baseline |
| FP8 | 4.363 | **+1.2%** |

- `pytest tests/kernels/attention/test_cache.py` passed (480)
- FP8 correctness test (MSE vs FP16 reference) passed
- Scale edge cases (0.5, 1.0, 2.0) passed
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
