### PR TITLE
[BugFix] Fix NUMA node validation in CPU platform

### DIFF
--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -388,7 +388,7 @@ class CpuPlatform(Platform):
         if env_key in os.environ and os.environ[env_key] != "":
             visible_nodes = [int(s) for s in os.environ[env_key].split(",")]
             allowed_numa_nodes_list = [
-                x for x in visible_nodes if x in allowed_cpu_id_list
+                x for x in visible_nodes if x in allowed_numa_nodes
             ]
 
         return allowed_numa_nodes_list, logical_cpu_list

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -388,7 +388,7 @@ class CpuPlatform(Platform):
         if env_key in os.environ and os.environ[env_key] != "":
             visible_nodes = [int(s) for s in os.environ[env_key].split(",")]
             allowed_numa_nodes_list = [
-                x for x in visible_nodes if x in allowed_numa_nodes
+                x for x in sorted(list(set(visible_nodes))) if x in allowed_numa_nodes
             ]
 
         return allowed_numa_nodes_list, logical_cpu_list


### PR DESCRIPTION
## Description

Fixes #31518

Fixed a bug in `CpuPlatform.get_allowed_cpu_core_node_list()` where NUMA node IDs from the `CPU_VISIBLE_MEMORY_NODES` environment variable were incorrectly validated against CPU IDs instead of NUMA node IDs.

## Issue

When the `CPU_VISIBLE_MEMORY_NODES` environment variable was set, the validation logic at line 391 in `vllm/platforms/cpu.py` compared NUMA node IDs against the list of allowed CPU IDs. This caused invalid NUMA nodes to pass validation, leading to CPU binding failures with errors like:

```
libnuma: Warning: cpu argument 30 out of range
```

## Root Cause

The bug was introduced in PR #23903 (commit ad39106b1) which added data parallel support for CPU backend. The validation code incorrectly compared NUMA node IDs against CPU IDs:

```python
# Before (buggy):
allowed_numa_nodes_list = [x for x in visible_nodes if x in allowed_cpu_id_list]
```

This is incorrect because NUMA node IDs and CPU IDs are different concepts:
- `visible_nodes` contains NUMA node IDs (e.g., 0, 1, 2, ...)
- `allowed_cpu_id_list` contains CPU core IDs (e.g., 0, 1, 2, ..., 19)

## Fix

Changed line 391 to compare `visible_nodes` against `allowed_numa_nodes` instead of `allowed_cpu_id_list`:

```python
# After (fixed):
allowed_numa_nodes_list = [x for x in visible_nodes if x in allowed_numa_nodes]
```

## Testing

- Verified that NUMA node validation now correctly filters visible nodes against available NUMA nodes
- Confirmed CPU thread binding works properly without out-of-range errors
- Tested with vLLM running successfully on CPU with the chatbot demo

## Impact

This fix ensures that the `CPU_VISIBLE_MEMORY_NODES` feature works correctly for controlling NUMA node visibility on CPU platforms with NUMA architecture.
