### PR TITLE
[Triton][CustomOp] A Triton operator dispatch mechanism through modified CustomOp

### DIFF
--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -127,6 +127,7 @@ class CustomOp(nn.Module, CustomOpBase):
     Base class for torch custom ops.
     Impletments and dispatches the forward method to the appropriate backend.
     """
+
     def __init__(self, enforce_enable: bool = False):
         nn.Module.__init__(self)
         CustomOpBase.__init__(self, enforce_enable=enforce_enable)
@@ -240,6 +241,7 @@ class CustomTritonOp(CustomOpBase):
     Base class for triton custom ops.
     Impletments and dispatches the forward method to the appropriate backend.
     """
+
     def __init__(self, enforce_enable: bool = False):
         super().__init__(enforce_enable=enforce_enable)
 

--- a/vllm/model_executor/layers/fla/ops/__init__.py
+++ b/vllm/model_executor/layers/fla/ops/__init__.py
@@ -6,12 +6,12 @@
 # The original source code was licensed under the MIT license and included
 # the following copyright notice:
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
-from .chunk import chunk_gated_delta_rule
-from .fused_recurrent import fused_recurrent_gated_delta_rule
+from .chunk import ChunkGatedDeltaRule
+from .fused_recurrent import FusedRecurrentGatedDeltaRule
 from .layernorm_guard import RMSNormGated
 
 __all__ = [
     "RMSNormGated",
-    "chunk_gated_delta_rule",
-    "fused_recurrent_gated_delta_rule",
+    "ChunkGatedDeltaRule",
+    "FusedRecurrentGatedDeltaRule",
 ]

--- a/vllm/model_executor/layers/fla/ops/chunk.py
+++ b/vllm/model_executor/layers/fla/ops/chunk.py
@@ -12,6 +12,8 @@ import warnings
 import torch
 from einops import rearrange
 
+from vllm.model_executor.custom_op import CustomTritonOp
+
 from .chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from .chunk_o import chunk_fwd_o
 from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
@@ -238,3 +240,9 @@ def chunk_gated_delta_rule(
     if head_first:
         o = rearrange(o, "b t h ... -> b h t ...")
     return o, final_state
+
+
+@CustomTritonOp.register("chunk_gated_delta_rule")
+class ChunkGatedDeltaRule(CustomTritonOp):
+    def forward_cuda(self, *args, **kwargs):
+        return chunk_gated_delta_rule(*args, **kwargs)

--- a/vllm/model_executor/layers/fla/ops/fused_recurrent.py
+++ b/vllm/model_executor/layers/fla/ops/fused_recurrent.py
@@ -10,6 +10,7 @@
 
 import torch
 
+from vllm.model_executor.custom_op import CustomTritonOp
 from vllm.triton_utils import tl, triton
 
 from .op import exp
@@ -388,3 +389,9 @@ def fused_recurrent_gated_delta_rule(
         use_qk_l2norm_in_kernel,
     )
     return o, final_state
+
+
+@CustomTritonOp.register("fused_recurrent_gated_delta_rule")
+class FusedRecurrentGatedDeltaRule(CustomTritonOp):
+    def forward_cuda(self, *args, **kwargs):
+        return fused_recurrent_gated_delta_rule(*args, **kwargs)


### PR DESCRIPTION
## Purpose
plz see details in https://github.com/vllm-project/vllm/issues/31467
This is the first pr of #31467, introducing the triton dispatch machenism into vLLM and making the new triton kernel usage in Qwen3-Next as an example.

TODO:
- [ ] Add test cases for `CustomTritonOp` and `CustomOpBase`
- [ ] Refactor the exsiting triton kernels that are directly called without a python funtion warpping it, e.g., eagle_prepare_inputs_padded_kernel
- [ ] Refactor the triton python functions to be hierit from `CustomTritonOp`, and optimize the current implement of triton kernel patching.
## Test Plan
Test Qwen3-Next locally with both gpu and vllm-ascend

## Test Result
Tested qwen3-next on vllm-ascend, and it works well. Will test on gpu later

test script:
```python
import os

os.environ["VLLM_USE_MODELSCOPE"] = "True"
os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
os.environ["VLLM_VERSION"] = "0.13.0"

from vllm import LLM, SamplingParams
def main():
    prompts = [
        "窗前明月光，",
        "The president of the United States is Mr.",
        "The capital of France is",
        "The future of AI is",
        "感时花溅泪，",
    ]

    # Create a sampling params object.
    sampling_params = SamplingParams(max_tokens=50, temperature=0.0)

    # Create an LLM.
    llm = LLM(model="Qwen/Qwen3-Next-80B-A3B-Instruct",
              tensor_parallel_size=4,
              enforce_eager=True,
              max_model_len=2048,
              gpu_memory_utilization=0.8,
              )

    # Generate texts from the prompts.
    outputs = llm.generate(prompts, sampling_params)
    for output in outputs:
        prompt = output.prompt
        generated_text = output.outputs[0].text
        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

if __name__ == "__main__":
    main()
```
results:
```bash
Loading safetensors checkpoint shards:   0% Completed | 0/41 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:   2% Completed | 1/41 [00:01<00:53,  1.34s/it]
Loading safetensors checkpoint shards:   5% Completed | 2/41 [00:02<00:58,  1.50s/it]
Loading safetensors checkpoint shards:   7% Completed | 3/41 [00:04<00:57,  1.51s/it]
Loading safetensors checkpoint shards:  10% Completed | 4/41 [00:05<00:55,  1.51s/it]
Loading safetensors checkpoint shards:  12% Completed | 5/41 [00:07<00:55,  1.55s/it]
Loading safetensors checkpoint shards:  15% Completed | 6/41 [00:09<00:57,  1.63s/it]
Loading safetensors checkpoint shards:  17% Completed | 7/41 [00:10<00:53,  1.58s/it]
Loading safetensors checkpoint shards:  20% Completed | 8/41 [00:12<00:51,  1.56s/it]
Loading safetensors checkpoint shards:  22% Completed | 9/41 [00:14<00:51,  1.61s/it]
Loading safetensors checkpoint shards:  24% Completed | 10/41 [00:15<00:48,  1.57s/it]
Loading safetensors checkpoint shards:  27% Completed | 11/41 [00:17<00:48,  1.61s/it]
Loading safetensors checkpoint shards:  29% Completed | 12/41 [00:19<00:47,  1.65s/it]
Loading safetensors checkpoint shards:  32% Completed | 13/41 [00:20<00:45,  1.61s/it]
Loading safetensors checkpoint shards:  34% Completed | 14/41 [00:22<00:43,  1.60s/it]
Loading safetensors checkpoint shards:  37% Completed | 15/41 [00:23<00:42,  1.62s/it]
Loading safetensors checkpoint shards:  39% Completed | 16/41 [00:25<00:39,  1.59s/it]
Loading safetensors checkpoint shards:  41% Completed | 17/41 [00:26<00:37,  1.58s/it]
Loading safetensors checkpoint shards:  44% Completed | 18/41 [00:28<00:37,  1.64s/it]
Loading safetensors checkpoint shards:  46% Completed | 19/41 [00:30<00:36,  1.65s/it]
Loading safetensors checkpoint shards:  49% Completed | 20/41 [00:31<00:34,  1.65s/it]
Loading safetensors checkpoint shards:  51% Completed | 21/41 [00:33<00:32,  1.61s/it]
Loading safetensors checkpoint shards:  54% Completed | 22/41 [00:35<00:30,  1.59s/it]
Loading safetensors checkpoint shards:  56% Completed | 23/41 [00:36<00:28,  1.56s/it]
Loading safetensors checkpoint shards:  59% Completed | 24/41 [00:37<00:25,  1.52s/it]
Loading safetensors checkpoint shards:  61% Completed | 25/41 [00:39<00:23,  1.48s/it]
Loading safetensors checkpoint shards:  63% Completed | 26/41 [00:40<00:22,  1.49s/it]
Loading safetensors checkpoint shards:  66% Completed | 27/41 [00:42<00:20,  1.49s/it]
Loading safetensors checkpoint shards:  68% Completed | 28/41 [00:44<00:20,  1.54s/it]
Loading safetensors checkpoint shards:  71% Completed | 29/41 [00:45<00:18,  1.50s/it]
Loading safetensors checkpoint shards:  73% Completed | 30/41 [00:46<00:16,  1.53s/it]
Loading safetensors checkpoint shards:  76% Completed | 31/41 [00:48<00:15,  1.51s/it]
Loading safetensors checkpoint shards:  78% Completed | 32/41 [00:48<00:09,  1.09s/it]
Loading safetensors checkpoint shards:  80% Completed | 33/41 [00:49<00:09,  1.19s/it]
Loading safetensors checkpoint shards:  83% Completed | 34/41 [00:51<00:08,  1.27s/it]
Loading safetensors checkpoint shards:  85% Completed | 35/41 [00:53<00:08,  1.36s/it]
Loading safetensors checkpoint shards:  88% Completed | 36/41 [00:54<00:06,  1.32s/it]
Loading safetensors checkpoint shards:  90% Completed | 37/41 [00:55<00:05,  1.34s/it]
Loading safetensors checkpoint shards:  93% Completed | 38/41 [00:57<00:04,  1.39s/it]
Loading safetensors checkpoint shards:  95% Completed | 39/41 [00:58<00:02,  1.47s/it]
(Worker_TP1 pid=1905564) INFO 01-04 07:13:23 [model_runner_v1.py:2243] Loading model weights took 37.2627 GB
Loading safetensors checkpoint shards:  98% Completed | 40/41 [01:00<00:01,  1.57s/it]
(Worker_TP2 pid=1905565) INFO 01-04 07:13:24 [model_runner_v1.py:2243] Loading model weights took 37.2627 GB
Loading safetensors checkpoint shards: 100% Completed | 41/41 [01:02<00:00,  1.54s/it]
Loading safetensors checkpoint shards: 100% Completed | 41/41 [01:02<00:00,  1.51s/it]
(Worker_TP0 pid=1905563) 
(Worker_TP0 pid=1905563) INFO 01-04 07:13:25 [default_loader.py:308] Loading weights took 62.22 seconds
(Worker_TP0 pid=1905563) INFO 01-04 07:13:26 [model_runner_v1.py:2243] Loading model weights took 37.2627 GB
(Worker_TP3 pid=1905566) INFO 01-04 07:13:27 [model_runner_v1.py:2243] Loading model weights took 37.2627 GB
(Worker_TP0 pid=1905563) INFO 01-04 07:13:30 [worker.py:287] Available memory: 9392377344, total memory: 65452113920
(Worker_TP1 pid=1905564) INFO 01-04 07:13:30 [worker.py:287] Available memory: 9669205504, total memory: 65452113920
(Worker_TP3 pid=1905566) INFO 01-04 07:13:30 [worker.py:287] Available memory: 9675931136, total memory: 65452113920
(Worker_TP2 pid=1905565) INFO 01-04 07:13:31 [worker.py:287] Available memory: 9675873792, total memory: 65452113920
(EngineCore_DP0 pid=1905161) INFO 01-04 07:13:31 [kv_cache_utils.py:1291] GPU KV cache size: 190,848 tokens
(EngineCore_DP0 pid=1905161) INFO 01-04 07:13:31 [kv_cache_utils.py:1296] Maximum concurrency for 2,048 tokens per request: 221.11x
(EngineCore_DP0 pid=1905161) INFO 01-04 07:13:31 [core.py:259] init engine (profile, create kv cache, warmup model) took 4.22 seconds
(EngineCore_DP0 pid=1905161) WARNING 01-04 07:13:32 [vllm.py:629] Inductor compilation was disabled by user settings,Optimizations settings that are only active duringInductor compilation will be ignored.
(EngineCore_DP0 pid=1905161) INFO 01-04 07:13:32 [vllm.py:722] Cudagraph is disabled under eager mode
(EngineCore_DP0 pid=1905161) INFO 01-04 07:13:32 [platform.py:189] Compilation disabled, using eager mode by default
INFO 01-04 07:13:32 [llm.py:360] Supported tasks: ['generate']
Adding requests: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 329.22it/s]
Processed prompts:   0%|                                                                            | 0/5 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]INFO 01-04 07:13:43 [__init__.py:43] Available plugins for group vllm.platform_plugins:
INFO 01-04 07:13:43 [__init__.py:45] - ascend -> vllm_ascend:register
INFO 01-04 07:13:43 [__init__.py:48] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 01-04 07:13:43 [__init__.py:217] Platform plugin ascend is activated
INFO 01-04 07:13:43 [__init__.py:43] Available plugins for group vllm.platform_plugins:
INFO 01-04 07:13:43 [__init__.py:45] - ascend -> vllm_ascend:register
INFO 01-04 07:13:43 [__init__.py:48] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 01-04 07:13:44 [__init__.py:217] Platform plugin ascend is activated
INFO 01-04 07:13:44 [__init__.py:43] Available plugins for group vllm.platform_plugins:
INFO 01-04 07:13:44 [__init__.py:45] - ascend -> vllm_ascend:register
INFO 01-04 07:13:44 [__init__.py:48] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 01-04 07:13:44 [__init__.py:217] Platform plugin ascend is activated
INFO 01-04 07:13:44 [__init__.py:43] Available plugins for group vllm.platform_plugins:
INFO 01-04 07:13:44 [__init__.py:45] - ascend -> vllm_ascend:register
INFO 01-04 07:13:44 [__init__.py:48] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 01-04 07:13:44 [__init__.py:217] Platform plugin ascend is activated
Modular Diffusers is currently an experimental feature under active development. The API is subject to breaking changes in future releases.
(Worker_TP1 pid=1905564) [WARNING] Please DO NOT tune args ['num_warps', 'num_stages']!
WARNING: Grid 40 > physical limit 20, performance maybe reduced.
(Worker_TP1 pid=1905564) [WARNING] Please DO NOT tune args ['num_warps', 'num_stages']!
(Worker_TP3 pid=1905566) [WARNING] Please DO NOT tune args ['num_warps', 'num_stages']!
(Worker_TP0 pid=1905563) [WARNING] Please DO NOT tune args ['num_warps', 'num_stages']!
(Worker_TP2 pid=1905565) [WARNING] Please DO NOT tune args ['num_warps', 'num_stages']!
WARNING: Grid 80 > physical limit 40, performance maybe reduced.
WARNING: Grid 80 > physical limit 40, performance maybe reduced.
WARNING: Grid 80 > physical limit 40, performance maybe reduced.
WARNING: Grid 80 > physical limit 40, performance maybe reduced.
Processed prompts: 100%|████████████████████████████████████████████████████████████████████| 5/5 [00:47<00:00,  9.42s/it, est. speed input: 0.66 toks/s, output: 5.31 toks/s]
Prompt: '窗前明月光，', Generated text: '疑是地上霜。举头望明月，低头思故乡。这首诗的作者是谁？\n\n这首诗《静夜思》的作者是唐代著名诗人**李白**。\n\n全诗如下：\n\n> 床前明月光，'
Prompt: 'The president of the United States is Mr.', Generated text: ' Joe Biden. He is the 46th president of the United States, and he was inaugurated on January 20, 2021. He is a member of the Democratic Party. He was born on November 20'
Prompt: 'The capital of France is', Generated text: ' Paris. The capital of Germany is Berlin. The capital of Italy is Rome. The capital of Spain is Madrid. The capital of the United Kingdom is London. The capital of Russia is Moscow. The capital of Japan is Tokyo. The capital of China'
Prompt: 'The future of AI is', Generated text: ' not just about technology—it’s about people. As AI becomes more integrated into our daily lives, the need for skilled professionals who can design, manage, and ethically guide these systems grows exponentially. This is where AI education comes in. By equipping'
Prompt: '感时花溅泪，', Generated text: '恨别鸟惊心。这两句诗表达了诗人怎样的情感？ “感时花溅泪，恨别鸟惊心”这两句诗出自唐代诗人杜甫的《春望》，表达了诗人深沉的忧国伤时'
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

