### PR TITLE
fix: improve Mistral tokenizer auto-detection to check model architec…

### DIFF
--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -226,14 +226,23 @@ class MistralTokenizer(TokenizerLike):
                 MistralCommonTokenizer as MistralCommonBackend,
             )
 
-        tokenizer = MistralCommonBackend.from_pretrained(
-            path_or_repo_id,
-            *args,
-            mode=ValidationMode.test,
-            cache_dir=download_dir,
-            revision="main" if revision is None else revision,
-            **kwargs,
-        )
+        try:
+            tokenizer = MistralCommonBackend.from_pretrained(
+                path_or_repo_id,
+                *args,
+                mode=ValidationMode.test,
+                cache_dir=download_dir,
+                revision="main" if revision is None else revision,
+                **kwargs,
+            )
+        except (FileNotFoundError, OSError, ValueError) as e:
+            # Provide helpful error message for non-Mistral models that were
+            # incorrectly detected as Mistral (see issue #31444)
+            raise ValueError(
+                f"Failed to load Mistral tokenizer from '{path_or_repo_id}': {e}. "
+                f"If this model is not a Mistral-family model, try using "
+                f"'--tokenizer-mode hf' to force HuggingFace tokenizer."
+            ) from e
 
         return cls(tokenizer)
 

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -24,14 +24,16 @@ from vllm.utils.import_utils import resolve_obj_by_qualname
 from .protocol import TokenizerLike
 
 # Mistral architecture indicators - used to validate Mistral tokenizer selection
-_MISTRAL_ARCHITECTURE_INDICATORS = frozenset({
-    "mistral",
-    "mixtral",
-    "pixtral",
-    "mathstral",
-    "codestral",
-    "ministral",
-})
+_MISTRAL_ARCHITECTURE_INDICATORS = frozenset(
+    {
+        "mistral",
+        "mixtral",
+        "pixtral",
+        "mathstral",
+        "codestral",
+        "ministral",
+    }
+)
 
 if TYPE_CHECKING:
     from vllm.config.model import ModelConfig, RunnerType
@@ -121,16 +123,16 @@ def _is_mistral_architecture(
         architectures = getattr(config, "architectures", None) or []
         for arch in architectures:
             arch_lower = arch.lower()
-            if any(arch_lower.startswith(ind) for ind in _MISTRAL_ARCHITECTURE_INDICATORS):
+            is_mistral = any(
+                arch_lower.startswith(ind) for ind in _MISTRAL_ARCHITECTURE_INDICATORS
+            )
+            if is_mistral:
                 return True
 
         # Check model_type (e.g., "mistral") for an exact match
         # to avoid false positives like "not-mistral"
         model_type = getattr(config, "model_type", None) or ""
-        if model_type.lower() in _MISTRAL_ARCHITECTURE_INDICATORS:
-            return True
-
-        return False
+        return model_type.lower() in _MISTRAL_ARCHITECTURE_INDICATORS
     except Exception as e:
         # On any error (missing config, network issues, etc.),
         # don't assume Mistral - let the caller fall back to HF tokenizer

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -23,6 +23,16 @@ from vllm.utils.import_utils import resolve_obj_by_qualname
 
 from .protocol import TokenizerLike
 
+# Mistral architecture indicators - used to validate Mistral tokenizer selection
+_MISTRAL_ARCHITECTURE_INDICATORS = frozenset({
+    "mistral",
+    "mixtral",
+    "pixtral",
+    "mathstral",
+    "codestral",
+    "ministral",
+})
+
 if TYPE_CHECKING:
     from vllm.config.model import ModelConfig, RunnerType
 
@@ -75,6 +85,62 @@ TokenizerRegistry = _TokenizerRegistry(
         for mode, (mod_relname, cls_name) in _VLLM_TOKENIZERS.items()
     }
 )
+
+
+def _is_mistral_architecture(
+    model_name_or_path: str,
+    revision: str | None = None,
+    trust_remote_code: bool = False,
+) -> bool:
+    """
+    Check if the model's config.json indicates a Mistral-family architecture.
+
+    This prevents false-positive Mistral tokenizer selection for models that
+    happen to have files matching Mistral patterns (e.g., tokenizer.model.v*)
+    but are not actually Mistral models.
+
+    Args:
+        model_name_or_path: HuggingFace model ID or local path
+        revision: Model revision
+        trust_remote_code: Whether to trust remote code
+
+    Returns:
+        True if the model architecture indicates it's a Mistral-family model
+    """
+    try:
+        from vllm.transformers_utils.config import get_config
+
+        config = get_config(
+            model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+        )
+
+        # Check architectures list (e.g., ["MistralForCausalLM"])
+        # Use startswith to avoid false positives like "NotMistralForCausalLM"
+        architectures = getattr(config, "architectures", None) or []
+        for arch in architectures:
+            arch_lower = arch.lower()
+            if any(arch_lower.startswith(ind) for ind in _MISTRAL_ARCHITECTURE_INDICATORS):
+                return True
+
+        # Check model_type (e.g., "mistral") for an exact match
+        # to avoid false positives like "not-mistral"
+        model_type = getattr(config, "model_type", None) or ""
+        if model_type.lower() in _MISTRAL_ARCHITECTURE_INDICATORS:
+            return True
+
+        return False
+    except Exception as e:
+        # On any error (missing config, network issues, etc.),
+        # don't assume Mistral - let the caller fall back to HF tokenizer
+        logger.debug(
+            "Could not determine model architecture for %s: %s. "
+            "Will not auto-select Mistral tokenizer.",
+            model_name_or_path,
+            e,
+        )
+        return False
 
 
 def resolve_tokenizer_args(
@@ -141,6 +207,8 @@ def resolve_tokenizer_args(
         kwargs["use_fast"] = False
 
     # Try to use official Mistral tokenizer if possible
+    # We check BOTH file patterns AND model architecture to avoid false positives
+    # (e.g., MiniMax models have tokenizer.model.v* files but are not Mistral)
     if tokenizer_mode == "auto" and importlib.util.find_spec("mistral_common"):
         allow_patterns = ["tekken.json", "tokenizer.model.v*"]
         files_list = list_filtered_repo_files(
@@ -149,7 +217,20 @@ def resolve_tokenizer_args(
             revision=revision,
         )
         if len(files_list) > 0:
-            tokenizer_mode = "mistral"
+            # Verify this is actually a Mistral-family model before selecting
+            # the Mistral tokenizer (fixes issue #31444)
+            trust_remote_code = kwargs.get("trust_remote_code", False)
+            if _is_mistral_architecture(
+                str(tokenizer_name), revision, trust_remote_code
+            ):
+                tokenizer_mode = "mistral"
+            else:
+                logger.info(
+                    "Found Mistral tokenizer files (%s) but model architecture "
+                    "is not Mistral-family. Using HuggingFace tokenizer for '%s'.",
+                    files_list,
+                    tokenizer_name,
+                )
 
     # Fallback to HF tokenizer
     if tokenizer_mode == "auto":


### PR DESCRIPTION
…ture

This fixes issue #31444 where models with `tokenizer.model.v*` files (e.g., MiniMax-Text-01) were incorrectly detected as Mistral models, causing tokenizer loading to fail.

Changes:
- Add `_is_mistral_architecture()` helper that checks config.json to verify the model is actually a Mistral-family model before selecting the Mistral tokenizer
- Now requires BOTH: Mistral tokenizer files AND Mistral architecture
- Add better error message in MistralTokenizer.from_pretrained() to suggest `--tokenizer-mode hf` workaround

Fixes #31444

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

