### PR TITLE
fix(compile): apply partition wrapper when loading AOT cached functions

### DIFF
--- a/tests/compile/test_aot_compile.py
+++ b/tests/compile/test_aot_compile.py
@@ -28,7 +28,7 @@ from ..utils import create_new_process_for_each_test
 @pytest.fixture
 def vllm_tmp_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Fixture that sets VLLM_CACHE_ROOT to a temporary directory."""
-    monkeypatch.setenv("VLLM_CACHE_ROOT", str(tmp_path))
+    monkeypatch.setenv("VLLM_CACHE_ROOT", str(tmp_path / "vllm_cache"))
     return tmp_path
 
 

--- a/tests/compile/test_aot_compile.py
+++ b/tests/compile/test_aot_compile.py
@@ -160,7 +160,7 @@ def test_partition_wrapper_applied_on_aot_load(monkeypatch: pytest.MonkeyPatch):
     The root cause was that partition wrapper context was bypassed when
     loading from AOT cache.
     """
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
 
     from vllm.config import CUDAGraphMode
 
@@ -187,7 +187,9 @@ def test_partition_wrapper_applied_on_aot_load(monkeypatch: pytest.MonkeyPatch):
             disable_envs_cache()
 
             # Mock set_customized_partition_wrappers to track calls
-            original_set_wrappers = torch._inductor.utils.set_customized_partition_wrappers
+            original_set_wrappers = (
+                torch._inductor.utils.set_customized_partition_wrappers
+            )
             wrapper_calls = []
 
             def tracking_set_wrappers(wrapper):
@@ -239,8 +241,8 @@ def test_partition_wrapper_applied_on_aot_load(monkeypatch: pytest.MonkeyPatch):
 
                 # Verify partition wrapper was called on the subsequent call.
                 assert len(wrapper_calls) >= 2, (
-                    "Expected partition wrapper to be set and cleared on subsequent call, "
-                    f"got {len(wrapper_calls)} calls"
+                    "Expected partition wrapper set and cleared on subsequent "
+                    f"call, got {len(wrapper_calls)} calls"
                 )
                 assert wrapper_calls[0] is not None, (
                     "First call on subsequent call should set a wrapper function"

--- a/tests/compile/test_aot_compile.py
+++ b/tests/compile/test_aot_compile.py
@@ -5,6 +5,7 @@ import functools
 import multiprocessing
 import tempfile
 from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
 import torch
@@ -22,6 +23,13 @@ from vllm.forward_context import set_forward_context
 from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 from ..utils import create_new_process_for_each_test
+
+
+@pytest.fixture
+def vllm_tmp_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Fixture that sets VLLM_CACHE_ROOT to a temporary directory."""
+    monkeypatch.setenv("VLLM_CACHE_ROOT", str(tmp_path))
+    return tmp_path
 
 
 def reference_fn(x: torch.Tensor):
@@ -151,7 +159,9 @@ def test_shape_env(monkeypatch: pytest.MonkeyPatch):
 @pytest.mark.skipif(
     not is_torch_equal_or_newer("2.10.0.dev"), reason="requires torch 2.10"
 )
-def test_partition_wrapper_applied_on_aot_load(monkeypatch: pytest.MonkeyPatch):
+def test_partition_wrapper_applied_on_aot_load(
+    monkeypatch: pytest.MonkeyPatch, vllm_tmp_cache: Path, mocker
+):
     """
     Test that partition wrappers are applied when loading AOT cached functions.
 
@@ -160,96 +170,77 @@ def test_partition_wrapper_applied_on_aot_load(monkeypatch: pytest.MonkeyPatch):
     The root cause was that partition wrapper context was bypassed when
     loading from AOT cache.
     """
-    from unittest.mock import patch
-
     from vllm.config import CUDAGraphMode
 
-    with monkeypatch.context() as m:
-        args = (torch.randn(10, 10),)
+    args = (torch.randn(10, 10),)
+    monkeypatch.setenv("VLLM_USE_AOT_COMPILE", "1")
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            m.setenv("VLLM_CACHE_ROOT", tmpdirname)
-            m.setenv("VLLM_USE_AOT_COMPILE", "1")
+    # Create config with partition enabled
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            use_inductor_graph_partition=True,
+            cudagraph_mode=CUDAGraphMode.PIECEWISE,
+        )
+    )
 
-            # Create config with partition enabled
-            vllm_config = VllmConfig(
-                compilation_config=CompilationConfig(
-                    mode=CompilationMode.VLLM_COMPILE,
-                    use_inductor_graph_partition=True,
-                    cudagraph_mode=CUDAGraphMode.PIECEWISE,
-                )
-            )
+    # First compilation - save to cache
+    with use_vllm_config(vllm_config):
+        compiled_mod = CompiledMod(vllm_config=vllm_config)
+        compiled_mod(*args)
+    disable_envs_cache()
 
-            # First compilation - save to cache
-            with use_vllm_config(vllm_config):
-                compiled_mod = CompiledMod(vllm_config=vllm_config)
-                compiled_mod(*args)
-            disable_envs_cache()
+    # Second run - load from cache, verify partition wrapper applied
+    monkeypatch.setenv("VLLM_FORCE_AOT_LOAD", "1")
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            use_inductor_graph_partition=True,
+            cudagraph_mode=CUDAGraphMode.PIECEWISE,
+        )
+    )
 
-            # Mock set_customized_partition_wrappers to track calls
-            original_set_wrappers = (
-                torch._inductor.utils.set_customized_partition_wrappers
-            )
-            wrapper_calls = []
+    # Use mocker to spy on set_customized_partition_wrappers
+    spy = mocker.spy(torch._inductor.utils, "set_customized_partition_wrappers")
 
-            def tracking_set_wrappers(wrapper):
-                wrapper_calls.append(wrapper)
-                return original_set_wrappers(wrapper)
+    with use_vllm_config(vllm_config):
+        compiled_mod = CompiledMod(vllm_config=vllm_config)
 
-            # Second run - load from cache, verify partition wrapper applied
-            m.setenv("VLLM_FORCE_AOT_LOAD", "1")
-            vllm_config = VllmConfig(
-                compilation_config=CompilationConfig(
-                    mode=CompilationMode.VLLM_COMPILE,
-                    use_inductor_graph_partition=True,
-                    cudagraph_mode=CUDAGraphMode.PIECEWISE,
-                )
-            )
+        # First call after restart: loads from AOT cache.
+        # This tests the fix for the first call after a restart.
+        compiled_mod(*args)
 
-            with (
-                use_vllm_config(vllm_config),
-                patch.object(
-                    torch._inductor.utils,
-                    "set_customized_partition_wrappers",
-                    tracking_set_wrappers,
-                ),
-            ):
-                compiled_mod = CompiledMod(vllm_config=vllm_config)
+        # Verify partition wrapper was called on AOT load.
+        assert spy.call_count >= 2, (
+            "Expected partition wrapper to be set and cleared on AOT load, "
+            f"got {spy.call_count} calls"
+        )
+        # First call should set a wrapper, last call should clear it
+        assert spy.call_args_list[0][0][0] is not None, (
+            "First call on AOT load should set a wrapper function"
+        )
+        assert spy.call_args_list[-1][0][0] is None, (
+            "Last call on AOT load should clear the wrapper"
+        )
 
-                # First call after restart: loads from AOT cache.
-                # This tests the fix for the first call after a restart.
-                compiled_mod(*args)
+        # Reset for the next check.
+        spy.reset_mock()
 
-                # Verify partition wrapper was called on AOT load.
-                assert len(wrapper_calls) >= 2, (
-                    "Expected partition wrapper to be set and cleared on AOT load, "
-                    f"got {len(wrapper_calls)} calls"
-                )
-                assert wrapper_calls[0] is not None, (
-                    "First call on AOT load should set a wrapper function"
-                )
-                assert wrapper_calls[-1] is None, (
-                    "Last call on AOT load should clear the wrapper"
-                )
+        # Subsequent call: uses the cached `aot_compiled_fn`.
+        # This tests the fix for subsequent calls.
+        compiled_mod(*args)
 
-                # Reset for the next check.
-                wrapper_calls.clear()
-
-                # Subsequent call: uses the cached `aot_compiled_fn`.
-                # This tests the fix for subsequent calls.
-                compiled_mod(*args)
-
-                # Verify partition wrapper was called on the subsequent call.
-                assert len(wrapper_calls) >= 2, (
-                    "Expected partition wrapper set and cleared on subsequent "
-                    f"call, got {len(wrapper_calls)} calls"
-                )
-                assert wrapper_calls[0] is not None, (
-                    "First call on subsequent call should set a wrapper function"
-                )
-                assert wrapper_calls[-1] is None, (
-                    "Last call on subsequent call should clear the wrapper"
-                )
+        # Verify partition wrapper was called on the subsequent call.
+        assert spy.call_count >= 2, (
+            "Expected partition wrapper set and cleared on subsequent "
+            f"call, got {spy.call_count} calls"
+        )
+        assert spy.call_args_list[0][0][0] is not None, (
+            "First call on subsequent call should set a wrapper function"
+        )
+        assert spy.call_args_list[-1][0][0] is None, (
+            "Last call on subsequent call should clear the wrapper"
+        )
 
 
 @pytest.mark.skipif(

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -371,9 +371,12 @@ def _support_torch_compile(
         if self.do_not_compile or torch.compiler.is_compiling():
             return self.forward(*args, **kwargs)
 
-        # if aot_compiled_fn is set, just call it.
+        # if aot_compiled_fn is set, call it with partition wrapper context.
+        # The partition wrapper must be active at runtime for CUDA graph
+        # capture to work correctly with inductor graph partitioning.
         if getattr(self, "aot_compiled_fn", None) is not None:
-            return self.aot_compiled_fn(self, *args, **kwargs)
+            with maybe_use_cudagraph_partition_wrapper(self.vllm_config):
+                return self.aot_compiled_fn(self, *args, **kwargs)
 
         ds_type = self.compilation_config.dynamic_shapes_config.type
         cache_dir = None
@@ -432,7 +435,9 @@ def _support_torch_compile(
                 logger.info(
                     "Directly load AOT compilation from path %s", aot_compilation_path
                 )
-                return self.aot_compiled_fn(self, *args, **kwargs)
+                # Apply partition wrapper context for proper CUDA graph capture
+                with maybe_use_cudagraph_partition_wrapper(self.vllm_config):
+                    return self.aot_compiled_fn(self, *args, **kwargs)
 
         if self.compiled:
             assert (


### PR DESCRIPTION
 ## Summary
  Fixes #31439 where VLLM_USE_AOT_COMPILE=1 causes 2x latency regression when use_inductor_graph_partition=True and cudagraph_mode=PIECEWISE.

  ## Root Cause

  The bug is in vllm/compilation/decorators.py. When loading AOT-compiled functions from cache, the code bypasses maybe_use_cudagraph_partition_wrapper at two locations:

  1. Line 374-376: Early return when aot_compiled_fn already set (subsequent calls)
  2. Line 431-438: Early return after loading from AOT cache (first call after restart)

  The maybe_use_cudagraph_partition_wrapper context manager calls torch._inductor.utils.set_customized_partition_wrappers() which is required at runtime for proper CUDA graph capture with inductor partitioning.

  ## Solution

  Wrap both AOT function call paths with the partition wrapper context to ensure partition wrappers are active at runtime.

  ## Impact

  1. AOT + partition + PIECEWISE: ~5s → ~2s (fixed)
  2. AOT without partition: ~2s → ~2s (no change)
  3. Non-AOT + partition: ~2s → ~2s (no change)

  No breaking changes. The fix only adds the missing context manager.

  ## Testing

  1. Added test_partition_wrapper_applied_on_aot_load in tests/compile/test_aot_compile.py
  2. Test verifies set_customized_partition_wrappers is called when loading from AOT cache
  3. Test requires PyTorch >= 2.10.0.dev
  4. Tested on 4x RTX 3090 setup

  ## Reproduction

  1. Run without AOT (fast ~2s):
     VLLM_USE_AOT_COMPILE=0 vllm bench latency --model meta-llama/Llama-3.2-1B -cc.use_inductor_graph_partition=True -cc.cudagraph_mode=PIECEWISE

  2. Run with AOT before fix (slow ~5s):
     VLLM_USE_AOT_COMPILE=1 vllm bench latency --model meta-llama/Llama-3.2-1B -cc.use_inductor_graph_partition=True -cc.cudagraph_mode=PIECEWISE

  3. Run with AOT after fix (fast ~2s):
     Same as #2, should now match non-AOT performance