### PR TITLE
[Bugfix] Record metrics for aborted requests

### DIFF
--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -106,6 +106,7 @@ class SchedulerInterface(ABC):
         self,
         request_ids: str | Iterable[str],
         finished_status: "RequestStatus",
+        record_metrics: bool = False,
     ) -> None:
         """Finish the requests in the scheduler's internal queue. If the request
         is not in the queue, this method will do nothing.
@@ -118,6 +119,9 @@ class SchedulerInterface(ABC):
         Args:
             request_ids: A single or a list of request IDs.
             finished_status: The finished status of the given requests.
+            record_metrics: If True and status is FINISHED_ABORTED, create
+                EngineCoreOutput so abort metrics are recorded. Should be True
+                for user-initiated aborts, False for stop-string cleanup.
         """
         raise NotImplementedError
 

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -554,7 +554,10 @@ class AsyncLLM(EngineClient):
             (request_id,) if isinstance(request_id, str) else as_list(request_id)
         )
         all_request_ids = self.output_processor.abort_requests(request_ids, internal)
-        await self.engine_core.abort_requests_async(all_request_ids)
+        # record_metrics=True for user-initiated aborts (need metrics recorded)
+        await self.engine_core.abort_requests_async(
+            all_request_ids, record_metrics=True
+        )
 
         if self.log_requests:
             logger.info("Aborted request(s) %s.", ",".join(request_ids))

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -209,7 +209,8 @@ class LLMEngine:
         """Remove request_ids from EngineCore and Detokenizer."""
 
         request_ids = self.output_processor.abort_requests(request_ids, internal)
-        self.engine_core.abort_requests(request_ids)
+        # record_metrics=True for user-initiated aborts (need metrics recorded)
+        self.engine_core.abort_requests(request_ids, record_metrics=True)
 
     def add_request(
         self,


### PR DESCRIPTION
When requests are aborted, the abort path bypasses the normal metrics recording flow. This causes vllm:request_success_total{finished_reason="abort"} to always show 0.

Fix by collecting abort statistics in OutputProcessor.abort_requests() and having LLMEngine/AsyncLLM record them via logger_manager.record().

Changes:
- Add AbortedRequestStats dataclass to capture abort stats
- Modify OutputProcessor.abort_requests() to optionally collect stats
- Add _record_abort_metrics() helper to LLMEngine and AsyncLLM
- Call logger_manager.record() with abort stats when requests are aborted

Fixes #31503

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>