### PR TITLE
[Model] Add template for qwen3-reranker

### DIFF
--- a/vllm/entrypoints/pooling/score/protocol.py
+++ b/vllm/entrypoints/pooling/score/protocol.py
@@ -99,6 +99,15 @@ class RerankRequest(OpenAIBaseModel):
         description="Whether to use activation for classification outputs. "
         "Default is True.",
     )
+
+    instruct: str | None = Field(
+        default=None,
+        description=(
+            "Optional instruction string to include in the query template. "
+            "For Qwen3-Reranker models, this provides context about the reranking task. "
+            "If not provided, the model's default template will be used."
+        ),
+    )
     # --8<-- [end:rerank-extra-params]
 
     def to_pooling_params(self):

--- a/vllm/entrypoints/pooling/score/serving.py
+++ b/vllm/entrypoints/pooling/score/serving.py
@@ -63,7 +63,7 @@ def _maybe_format_reranker_inputs(
     # Default values for Qwen3-Reranker (from
     # examples/pooling/score/offline_reranker.py).
     default_prefix = (
-        '<|im_start|>system\nJudge whether the Document meets the requirements '
+        "<|im_start|>system\nJudge whether the Document meets the requirements "
         "based on the Query and the Instruct provided. Note that the answer can "
         'only be "yes" or "no".<|im_end|>\n<|im_start|>user\n'
     )


### PR DESCRIPTION
## Purpose
Without a template, the results of qwen3-reranker are almost random, So we need to explicitly add the prefix, instruction, and suffix to the query, like this:
```
prefix = '<|im_start|>system\nJudge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be "yes" or "no".<|im_end|>\n<|im_start|>user\n'
suffix = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"

query_template = "{prefix}<Instruct>: {instruction}\n<Query>: {query}\n"
document_template = "<Document>: {doc}{suffix}"
```
This is cumbersome, whereas on the Bailian platform the client no longer needs to add these templates.

This patch adds support for a default template for the qwen3 reranker, and achieves the same invocation behavior as on the Bailian platform.

## Test Plan
```
curl -X POST http://127.0.0.1:7000/v1/rerank \
  -H "Content-Type: application/json" \
  -d '{
    "query": "法国首都是哪里？",
    "documents": [
      "法国的首都是巴黎。",
      "德国的首都是柏林。",
      "香蕉是黄色的水果。"
    ]
  }'
```
## Test Result
* Before this, results of qwen3-reranker are almost random
```
{
  "id": "rerank-8320364c10b075ce",
  "model": "Qwen3-Reranker-8B",
  "usage": {
    "prompt_tokens": 33,
    "total_tokens": 33
  },
  "results": [
    {
      "index": 1,
      "document": {
        "text": "德国的首都是柏林。",
        "multi_modal": null
      },
      "relevance_score": 0.7221383452415466
    },
    {
      "index": 2,
      "document": {
        "text": "香蕉是黄色的水果。",
        "multi_modal": null
      },
      "relevance_score": 0.5804123282432556
    },
    {
      "index": 0,
      "document": {
        "text": "法国的首都是巴黎。",
        "multi_modal": null
      },
      "relevance_score": 0.22539633512496948
    }
  ]
}

```
* After this patch
```
{
  "id": "rerank-99ebbaa9a9a899bb",
  "model": "Qwen3-Reranker-8B",
  "usage": {
    "prompt_tokens": 220,
    "total_tokens": 220
  },
  "results": [
    {
      "index": 0,
      "document": {
        "text": "法国的首都是巴黎。",
        "multi_modal": null
      },
      "relevance_score": 0.9991987347602844
    },
    {
      "index": 1,
      "document": {
        "text": "德国的首都是柏林。",
        "multi_modal": null
      },
      "relevance_score": 0.0016827614745125175
    },
    {
      "index": 2,
      "document": {
        "text": "香蕉是黄色的水果。",
        "multi_modal": null
      },
      "relevance_score": 0.000012338774467934854
    }
  ]
}

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

