### PR TITLE
[Kernel] Add Sonic MoE integration for SM90+

### DIFF
--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -95,7 +95,7 @@ steps:
   - vllm/model_executor/layers/fused_moe/sonic_moe.py
   - tests/kernels/moe/test_sonic_moe.py
   commands:
-    - pip install --no-deps sonic-moe && pip install nvidia-cutlass-dsl==4.4.0 nvidia-cutlass-dsl-libs-base==4.4.0
+    - pip install --no-deps sonic-moe quack-kernels==0.2.5 && pip install nvidia-cutlass-dsl==4.4.0 nvidia-cutlass-dsl-libs-base==4.4.0
     - pytest -v -s kernels/moe/test_sonic_moe.py
 
 - label: Kernels Sonic MoE Benchmark (H100)
@@ -107,7 +107,7 @@ steps:
   - vllm/model_executor/layers/fused_moe/sonic_moe.py
   - benchmarks/kernels/benchmark_sonic_moe.py
   commands:
-    - pip install --no-deps sonic-moe && pip install nvidia-cutlass-dsl==4.4.0 nvidia-cutlass-dsl-libs-base==4.4.0
+    - pip install --no-deps sonic-moe quack-kernels==0.2.5 && pip install nvidia-cutlass-dsl==4.4.0 nvidia-cutlass-dsl-libs-base==4.4.0
     - python3 benchmarks/kernels/benchmark_sonic_moe.py --output-json benchmark_sonic_moe.json
 
 - label: Kernels (B200)

--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -87,6 +87,29 @@ steps:
     - pytest -v -s kernels/moe/test_batched_deepgemm.py
     - pytest -v -s kernels/attention/test_deepgemm_attention.py
 
+- label: Kernels Sonic MoE Test (H100)
+  timeout_in_minutes: 10
+  device: h100
+  num_devices: 1
+  source_file_dependencies:
+  - vllm/model_executor/layers/fused_moe/sonic_moe.py
+  - tests/kernels/moe/test_sonic_moe.py
+  commands:
+    - pip install --no-deps sonic-moe && pip install nvidia-cutlass-dsl==4.4.0 nvidia-cutlass-dsl-libs-base==4.4.0
+    - pytest -v -s kernels/moe/test_sonic_moe.py
+
+- label: Kernels Sonic MoE Benchmark (H100)
+  timeout_in_minutes: 15
+  working_dir: "/vllm-workspace/"
+  device: h100
+  num_devices: 1
+  source_file_dependencies:
+  - vllm/model_executor/layers/fused_moe/sonic_moe.py
+  - benchmarks/kernels/benchmark_sonic_moe.py
+  commands:
+    - pip install --no-deps sonic-moe && pip install nvidia-cutlass-dsl==4.4.0 nvidia-cutlass-dsl-libs-base==4.4.0
+    - python3 benchmarks/kernels/benchmark_sonic_moe.py --output-json benchmark_sonic_moe.json
+
 - label: Kernels (B200)
   timeout_in_minutes: 30
   working_dir: "/vllm-workspace/"

--- a/benchmarks/kernels/benchmark_sonic_moe.py
+++ b/benchmarks/kernels/benchmark_sonic_moe.py
@@ -14,11 +14,23 @@ from vllm.model_executor.layers.fused_moe.sonic_moe import (
 )
 
 SHAPES = [
-    # SonicMoE cutedsl kernels require hidden_dim (k) >= 512 and divisible by 64.
-    # Choose shapes that also have tuned Triton configs on H100:
-    # (e=8, n=4096)->N=2048 and (e=8, n=8192)->N=4096.
+    # (m, k, n, e, topk) — SonicMoE requires k >= 512, k % 64 == 0, (n/2) % 64 == 0.
+    # Shapes without a tuned Triton config on this device are skipped at runtime.
+    #
+    # Prefill shapes (larger M):
+    (256, 512, 2048, 8, 2),
     (256, 512, 4096, 8, 2),
+    (256, 1024, 4096, 16, 4),
+    (512, 512, 4096, 8, 2),
+    (512, 1024, 4096, 8, 2),
     (512, 1024, 8192, 8, 4),
+    (1024, 1024, 4096, 8, 2),
+    # Decode shapes (smaller M):
+    (1, 512, 4096, 8, 2),
+    (1, 1024, 4096, 8, 2),
+    (8, 512, 4096, 8, 2),
+    (8, 1024, 4096, 16, 4),
+    (64, 1024, 4096, 8, 2),
 ]
 
 

--- a/benchmarks/kernels/benchmark_sonic_moe.py
+++ b/benchmarks/kernels/benchmark_sonic_moe.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import argparse
+import json
+import os
+from functools import partial
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.sonic_moe import (
+    is_sonic_moe_supported,
+    prepare_weights_for_sonic,
+)
+
+SHAPES = [
+    # SonicMoE cutedsl kernels require hidden_dim (k) >= 512 and divisible by 64.
+    # Choose shapes that also have tuned Triton configs on H100:
+    # (e=8, n=4096)->N=2048 and (e=8, n=8192)->N=4096.
+    (256, 512, 4096, 8, 2),
+    (512, 1024, 8192, 8, 4),
+]
+
+
+def _has_tuned_triton_config(num_experts: int, n_half: int) -> bool:
+    # Triton MoE tuning files are keyed by (E, N, device_name), where
+    # N is the post-activation width (i.e., n // 2 in this benchmark).
+    from vllm.model_executor.layers.fused_moe import fused_moe as fm
+    from vllm.model_executor.layers.fused_moe.fused_moe import get_config_file_name
+
+    cfg_file = get_config_file_name(num_experts, n_half, dtype=None)
+    cfg_path = os.path.join(
+        os.path.dirname(os.path.realpath(fm.__file__)),
+        "configs",
+        cfg_file,
+    )
+    return os.path.exists(cfg_path)
+
+
+def _bench_us(fn, warmup: int, iters: int, graph_calls: int) -> tuple[float, str]:
+    # Keep benchmarking in eager mode for stability. In this SonicMoE setup,
+    # repeated graph capture can leave CUDA in a bad state ("Offset increment
+    # outside graph capture"), which skews/aborts perf runs.
+    divisor = 1
+    mode = "eager"
+    if graph_calls > 1:
+        mode = "eager(graph-disabled)"
+
+    for _ in range(warmup):
+        fn()
+    torch.accelerator.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    end.synchronize()
+
+    us = start.elapsed_time(end) * 1000.0 / iters / divisor
+    return us, mode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Benchmark SonicMoeExperts vs TritonExperts on Hopper (H100/H200)."
+    )
+    parser.add_argument("--iters", type=int, default=50)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--graph-calls", type=int, default=1)
+    parser.add_argument("--dtype", choices=["bf16", "fp16", "both"], default="both")
+    parser.add_argument("--output-json", type=str, default="")
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        print("CUDA not available; skipping.")
+        return 0
+    if not is_sonic_moe_supported():
+        print("Sonic MoE not supported (needs SonicMoE + Hopper). Skipping.")
+        return 0
+
+    # FusedMoEKernel allocates from v1 WorkspaceManager.
+    # When running as a standalone script (outside pytest), we must init it.
+    from vllm.v1.worker.workspace import (
+        init_workspace_manager,
+        is_workspace_manager_initialized,
+    )
+
+    if not is_workspace_manager_initialized():
+        init_workspace_manager(torch.device("cuda"))
+
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    from vllm.model_executor.layers.fused_moe.config import (
+        FUSED_MOE_UNQUANTIZED_CONFIG,
+        FusedMoEConfig,
+        FusedMoEParallelConfig,
+        RoutingMethodType,
+    )
+    from vllm.model_executor.layers.fused_moe.fused_moe import TritonExperts
+    from vllm.model_executor.layers.fused_moe.modular_kernel import FusedMoEKernel
+    from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
+        MoEPrepareAndFinalizeNoDPEPModular,
+    )
+    from vllm.model_executor.layers.fused_moe.sonic_moe import SonicMoeExperts
+
+    torch.manual_seed(0)
+    torch.cuda.manual_seed_all(0)
+
+    dtypes = (
+        [torch.bfloat16, torch.float16]
+        if args.dtype == "both"
+        else [torch.bfloat16 if args.dtype == "bf16" else torch.float16]
+    )
+
+    rows: list[dict] = []
+    tuned_shapes: list[tuple[int, int, int, int, int]] = []
+    for m, k, n, e, topk in SHAPES:
+        if _has_tuned_triton_config(e, n // 2):
+            tuned_shapes.append((m, k, n, e, topk))
+        else:
+            print(
+                f"Skipping untuned Triton shape: e={e}, n={n} "
+                f"(expects config for N={n // 2})"
+            )
+
+    if not tuned_shapes:
+        print("No tuned Triton shapes found for this device; skipping benchmark.")
+        return 0
+
+    for m, k, n, e, topk in tuned_shapes:
+        for dtype in dtypes:
+            hidden_states = torch.randn((m, k), device="cuda", dtype=dtype) / 10
+            w1 = torch.randn((e, n, k), device="cuda", dtype=dtype) / 10
+            w2 = torch.randn((e, k, n // 2), device="cuda", dtype=dtype) / 10
+
+            router_logits = torch.randn((m, e), device="cuda", dtype=torch.float32)
+            topk_weights, topk_ids = torch.topk(router_logits, k=topk, dim=-1)
+            topk_ids = topk_ids.to(torch.int32)
+            topk_weights = torch.nn.functional.softmax(topk_weights, dim=-1).to(dtype)
+
+            moe_config = FusedMoEConfig(
+                num_experts=e,
+                experts_per_token=topk,
+                hidden_dim=k,
+                intermediate_size_per_partition=n // 2,
+                num_local_experts=e,
+                num_logical_experts=e,
+                moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+                activation=MoEActivation.SILU,
+                in_dtype=dtype,
+                device="cuda",
+                routing_method=RoutingMethodType.TopK,
+            )
+
+            triton_kernel = FusedMoEKernel(
+                MoEPrepareAndFinalizeNoDPEPModular(),
+                TritonExperts(moe_config, FUSED_MOE_UNQUANTIZED_CONFIG),
+                inplace=False,
+            )
+
+            w1_sonic, w2_sonic = prepare_weights_for_sonic(w1, w2)
+            sonic_kernel = FusedMoEKernel(
+                MoEPrepareAndFinalizeNoDPEPModular(),
+                SonicMoeExperts(
+                    moe_config,
+                    FUSED_MOE_UNQUANTIZED_CONFIG,
+                ),
+                inplace=False,
+            )
+
+            run_triton = partial(
+                triton_kernel.apply,
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                activation=MoEActivation.SILU,
+                global_num_experts=e,
+                expert_map=None,
+                apply_router_weight_on_input=False,
+            )
+            run_sonic = partial(
+                sonic_kernel.apply,
+                hidden_states=hidden_states,
+                w1=w1_sonic,
+                w2=w2_sonic,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                activation=MoEActivation.SILU,
+                global_num_experts=e,
+                expert_map=None,
+                apply_router_weight_on_input=False,
+            )
+
+            with torch.inference_mode():
+                out_triton = run_triton()
+                out_sonic = run_sonic()
+                torch.accelerator.synchronize()
+
+                denom = out_triton.abs().max().clamp_min(1e-6)
+                rel_err = ((out_sonic - out_triton).abs().max() / denom).item()
+                if rel_err > 2e-2:
+                    raise RuntimeError(f"rel_err={rel_err:.4f} > 2e-2")
+
+                triton_us, triton_mode = _bench_us(
+                    run_triton, args.warmup, args.iters, args.graph_calls
+                )
+                sonic_us, sonic_mode = _bench_us(
+                    run_sonic, args.warmup, args.iters, args.graph_calls
+                )
+
+            rows.append(
+                {
+                    "dtype": "bf16" if dtype == torch.bfloat16 else "fp16",
+                    "m": m,
+                    "k": k,
+                    "n": n,
+                    "e": e,
+                    "topk": topk,
+                    "triton_us": triton_us,
+                    "sonic_us": sonic_us,
+                    "speedup": triton_us / sonic_us if sonic_us > 0 else float("nan"),
+                    "mode": f"{triton_mode}/{sonic_mode}",
+                    "rel_err": rel_err,
+                }
+            )
+
+    print("dtype,e,topk,m,k,n,triton_us,sonic_us,speedup,mode,rel_err")
+    for r in rows:
+        print(
+            f"{r['dtype']},{r['e']},{r['topk']},{r['m']},{r['k']},{r['n']},"
+            f"{format(r['triton_us'], '.2f')},{format(r['sonic_us'], '.2f')},"
+            f"{r['speedup']:.3f},{r['mode']},{r['rel_err']:.4f}"
+        )
+
+    payload = {"device": torch.cuda.get_device_name(0), "results": rows}
+    print(json.dumps(payload, indent=2))
+
+    if args.output_json:
+        with open(args.output_json, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+            f.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/kernels/moe/test_sonic_moe.py
+++ b/tests/kernels/moe/test_sonic_moe.py
@@ -1,0 +1,366 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for Sonic MoE integration."""
+
+import pytest
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FUSED_MOE_UNQUANTIZED_CONFIG,
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    RoutingMethodType,
+)
+from vllm.model_executor.layers.fused_moe.fused_moe import TritonExperts
+from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
+    MoEPrepareAndFinalizeNoDPEPModular,
+)
+from vllm.model_executor.layers.fused_moe.sonic_moe import (
+    SonicMoeExperts,
+    _check_sonicmoe_available,
+    _is_hopper_gpu,
+    is_sonic_moe_supported,
+    is_valid_sonic_moe,
+    permute_weights_for_sonic,
+    prepare_weights_for_sonic,
+)
+from vllm.platforms import current_platform
+from vllm.v1.worker.workspace import (
+    init_workspace_manager,
+    is_workspace_manager_initialized,
+)
+
+requires_cuda = pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="CUDA required",
+)
+
+
+def _ensure_workspace_initialized() -> None:
+    # Many tests rely on tests/conftest.py to init WorkspaceManager.
+    # Keep this file self-contained so it can be run under --confcutdir.
+    if current_platform.is_cuda() and not is_workspace_manager_initialized():
+        init_workspace_manager(torch.device("cuda"))
+
+
+def make_dummy_moe_config(
+    num_experts: int = 1,
+    experts_per_token: int = 1,
+    hidden_dim: int = 1,
+    intermediate_size_per_partition: int = 1,
+    in_dtype: torch.dtype = torch.bfloat16,
+    device: torch.device | str = "cuda",
+    activation: MoEActivation = MoEActivation.SILU,
+) -> FusedMoEConfig:
+    return FusedMoEConfig(
+        num_experts=num_experts,
+        experts_per_token=experts_per_token,
+        hidden_dim=hidden_dim,
+        intermediate_size_per_partition=intermediate_size_per_partition,
+        num_local_experts=num_experts,
+        num_logical_experts=num_experts,
+        moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+        activation=activation,
+        in_dtype=in_dtype,
+        device=device,
+        routing_method=RoutingMethodType.TopK,
+    )
+
+
+def test_check_sonicmoe_available():
+    result = _check_sonicmoe_available()
+    assert isinstance(result, bool)
+
+
+def test_is_hopper_gpu():
+    result = _is_hopper_gpu()
+    assert isinstance(result, bool)
+
+    if current_platform.is_cuda():
+        expected = current_platform.is_device_capability(90)
+        assert result == expected
+
+
+def test_is_sonic_moe_supported():
+    result = is_sonic_moe_supported()
+    assert isinstance(result, bool)
+
+    if not _check_sonicmoe_available():
+        assert result is False
+    if not _is_hopper_gpu():
+        assert result is False
+
+
+def test_permute_weights_for_sonic():
+    """Test weight permutation from vLLM to Sonic format."""
+    E, N, K = 8, 512, 256  # 8 experts, 512 intermediate (2*256), 256 hidden
+    w = torch.randn(E, N, K)
+
+    w_permuted = permute_weights_for_sonic(w)
+
+    # Shape should be preserved
+    assert w_permuted.shape == w.shape
+    # Should be contiguous
+    assert w_permuted.is_contiguous()
+
+    # Verify the permutation is correct:
+    # Original: [gate, up] = [w[:, :N//2, :], w[:, N//2:, :]]
+    # Permuted: [interleaved] where even indices = gate, odd = up
+    gate = w[:, : N // 2, :]
+    up = w[:, N // 2 :, :]
+
+    # After permutation, even columns should be from gate
+    # odd columns should be from up
+    for i in range(N // 2):
+        assert torch.allclose(w_permuted[:, 2 * i, :], gate[:, i, :])
+        assert torch.allclose(w_permuted[:, 2 * i + 1, :], up[:, i, :])
+
+
+def test_sonic_moe_experts_init():
+    """Test SonicMoeExperts initialization."""
+    moe_config = make_dummy_moe_config(
+        num_experts=1,
+        experts_per_token=1,
+        hidden_dim=1,
+        intermediate_size_per_partition=1,
+        in_dtype=torch.bfloat16,
+    )
+    experts = SonicMoeExperts(moe_config=moe_config)
+    assert experts.out_dtype == torch.bfloat16
+    assert experts.supports_chunking() is True
+    assert experts.supports_expert_map() is False
+
+
+@requires_cuda
+def test_is_valid_sonic_moe_basic():
+    M, K, two_n = 128, 512, 1024
+    num_experts, top_k = 8, 2
+
+    hidden_states = torch.randn(M, K, dtype=torch.float16, device="cuda")
+    w1 = torch.randn(num_experts, two_n, K, dtype=torch.float16, device="cuda")
+    w2 = torch.randn(num_experts, K, two_n // 2, dtype=torch.float16, device="cuda")
+
+    result = is_valid_sonic_moe(hidden_states, w1, w2, num_experts, top_k)
+    assert isinstance(result, bool)
+
+
+@requires_cuda
+def test_is_valid_sonic_moe_large_topk():
+    M, K, two_n = 128, 512, 1024
+    num_experts, top_k = 8, 32
+
+    hidden_states = torch.randn(M, K, dtype=torch.float16, device="cuda")
+    w1 = torch.randn(num_experts, two_n, K, dtype=torch.float16, device="cuda")
+    w2 = torch.randn(num_experts, K, two_n // 2, dtype=torch.float16, device="cuda")
+
+    result = is_valid_sonic_moe(hidden_states, w1, w2, num_experts, top_k)
+    # Should be False because top_k > 16, or False because not supported
+    assert result is False or not is_sonic_moe_supported()
+
+
+@requires_cuda
+def test_sonic_moe_kernel_unsupported():
+    """Test that the Sonic kernel path raises on unsupported systems."""
+    if is_sonic_moe_supported():
+        pytest.skip("Sonic MoE is supported on this system")
+
+    _ensure_workspace_initialized()
+
+    M, K, two_n = 128, 512, 1024
+    num_experts, top_k = 8, 2
+
+    hidden_states = torch.randn(M, K, dtype=torch.float16, device="cuda")
+    w1 = torch.randn(num_experts, two_n, K, dtype=torch.float16, device="cuda")
+    w2 = torch.randn(num_experts, K, two_n // 2, dtype=torch.float16, device="cuda")
+    topk_weights = torch.randn(M, top_k, dtype=torch.float16, device="cuda")
+    topk_ids = torch.randint(0, num_experts, (M, top_k), device="cuda")
+
+    moe_config = make_dummy_moe_config(
+        num_experts=num_experts,
+        experts_per_token=top_k,
+        hidden_dim=K,
+        intermediate_size_per_partition=two_n // 2,
+        in_dtype=torch.float16,
+    )
+    sonic_kernel = mk.FusedMoEKernel(
+        MoEPrepareAndFinalizeNoDPEPModular(),
+        SonicMoeExperts(moe_config=moe_config),
+    )
+
+    with pytest.raises(RuntimeError):
+        sonic_kernel.apply(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=MoEActivation.SILU,
+            global_num_experts=num_experts,
+            expert_map=None,
+            apply_router_weight_on_input=False,
+        )
+
+
+SONIC_MNKS = [
+    (256, 2048, 512),
+    (512, 4096, 1024),
+]
+SONIC_TOPKS = [2, 4]
+SONIC_NUM_EXPERTS = [8, 16]
+SONIC_DTYPES = [torch.float16, torch.bfloat16]
+
+
+@pytest.mark.parametrize(("m", "n", "k"), SONIC_MNKS)
+@pytest.mark.parametrize("topk", SONIC_TOPKS)
+@pytest.mark.parametrize("num_experts", SONIC_NUM_EXPERTS)
+@pytest.mark.parametrize("dtype", SONIC_DTYPES)
+@pytest.mark.skipif(
+    not is_sonic_moe_supported(),
+    reason="Requires SonicMoE + Hopper GPU",
+)
+def test_sonic_moe_vs_triton(
+    m: int,
+    n: int,
+    k: int,
+    topk: int,
+    num_experts: int,
+    dtype: torch.dtype,
+):
+    """Compare Sonic MoE against Triton reference."""
+    from vllm.utils.deep_gemm import calc_diff
+
+    if topk > num_experts:
+        pytest.skip(f"topk={topk} > num_experts={num_experts}")
+
+    _ensure_workspace_initialized()
+
+    hidden_states = torch.randn(m, k, device="cuda", dtype=dtype) / 10
+    w1 = torch.randn(num_experts, n, k, device="cuda", dtype=dtype) / 10
+    w2 = torch.randn(num_experts, k, n // 2, device="cuda", dtype=dtype) / 10
+    if not is_valid_sonic_moe(hidden_states, w1, w2, num_experts, topk):
+        pytest.skip("SonicMoE kernels do not support this shape/config.")
+
+    router_logits = torch.randn(m, num_experts, device="cuda", dtype=torch.float32)
+    topk_weights, topk_ids = torch.topk(router_logits, k=topk, dim=-1)
+    topk_weights = torch.nn.functional.softmax(topk_weights, dim=-1).to(dtype)
+
+    moe_config = make_dummy_moe_config(
+        num_experts=num_experts,
+        experts_per_token=topk,
+        hidden_dim=k,
+        intermediate_size_per_partition=n // 2,
+        in_dtype=dtype,
+    )
+
+    triton_kernel = mk.FusedMoEKernel(
+        MoEPrepareAndFinalizeNoDPEPModular(),
+        TritonExperts(
+            moe_config=moe_config,
+            quant_config=FUSED_MOE_UNQUANTIZED_CONFIG,
+        ),
+    )
+    out_triton = triton_kernel.apply(
+        hidden_states=hidden_states,
+        w1=w1,
+        w2=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        global_num_experts=num_experts,
+        expert_map=None,
+        apply_router_weight_on_input=False,
+    )
+
+    w1_sonic, w2_sonic = prepare_weights_for_sonic(w1, w2)
+    sonic_kernel = mk.FusedMoEKernel(
+        MoEPrepareAndFinalizeNoDPEPModular(),
+        SonicMoeExperts(moe_config=moe_config),
+    )
+    out_sonic = sonic_kernel.apply(
+        hidden_states=hidden_states,
+        w1=w1_sonic,
+        w2=w2_sonic,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        global_num_experts=num_experts,
+        expert_map=None,
+        apply_router_weight_on_input=False,
+    )
+
+    diff = calc_diff(out_sonic, out_triton)
+    assert diff < 0.01, f"Diff exceeded 1%: {diff}"
+
+
+@pytest.mark.skipif(
+    not is_sonic_moe_supported(),
+    reason="Requires sonicmoe + Hopper GPU",
+)
+def test_sonic_moe_apply_router_weight_on_input():
+    """Compare Sonic MoE against Triton with apply_router_weight_on_input."""
+    from vllm.utils.deep_gemm import calc_diff
+
+    m, n, k = 128, 2048, 512
+    topk = 1
+    num_experts = 8
+    dtype = torch.float16
+
+    _ensure_workspace_initialized()
+
+    moe_config = make_dummy_moe_config(
+        num_experts=num_experts,
+        experts_per_token=topk,
+        hidden_dim=k,
+        intermediate_size_per_partition=n // 2,
+        in_dtype=dtype,
+    )
+
+    hidden_states = torch.randn(m, k, device="cuda", dtype=dtype) / 10
+    w1 = torch.randn(num_experts, n, k, device="cuda", dtype=dtype) / 10
+    w2 = torch.randn(num_experts, k, n // 2, device="cuda", dtype=dtype) / 10
+    if not is_valid_sonic_moe(hidden_states, w1, w2, num_experts, topk):
+        pytest.skip("SonicMoE kernels do not support this shape/config.")
+
+    topk_ids = torch.randint(0, num_experts, (m, topk), device="cuda")
+    topk_weights = torch.rand(m, topk, device="cuda", dtype=dtype) + 0.1
+
+    triton_kernel = mk.FusedMoEKernel(
+        MoEPrepareAndFinalizeNoDPEPModular(),
+        TritonExperts(
+            moe_config=moe_config,
+            quant_config=FUSED_MOE_UNQUANTIZED_CONFIG,
+        ),
+    )
+    out_triton = triton_kernel.apply(
+        hidden_states=hidden_states,
+        w1=w1,
+        w2=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        apply_router_weight_on_input=True,
+        global_num_experts=num_experts,
+        expert_map=None,
+    )
+
+    w1_sonic, w2_sonic = prepare_weights_for_sonic(w1, w2)
+    sonic_kernel = mk.FusedMoEKernel(
+        MoEPrepareAndFinalizeNoDPEPModular(),
+        SonicMoeExperts(moe_config=moe_config),
+    )
+    out_sonic = sonic_kernel.apply(
+        hidden_states=hidden_states,
+        w1=w1_sonic,
+        w2=w2_sonic,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        apply_router_weight_on_input=True,
+        global_num_experts=num_experts,
+        expert_map=None,
+    )
+
+    diff = calc_diff(out_sonic, out_triton)
+    assert diff < 0.01, f"Diff exceeded 1%: {diff}"

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -35,6 +35,7 @@ logger = init_logger(__name__)
 class UnquantizedMoeBackend(Enum):
     FLASHINFER_TRTLLM = "FlashInfer TRTLLM"
     FLASHINFER_CUTLASS = "FlashInfer CUTLASS"
+    SONIC = "Sonic MoE"
     AITER = "ROCm AITER"
     TRITON = "TRITON"
     BATCHED_TRITON = "BATCHED_TRITON"
@@ -67,6 +68,7 @@ def _get_priority_backends(moe_config: FusedMoEConfig) -> list[UnquantizedMoeBac
         _AVAILABLE_BACKENDS = [
             UnquantizedMoeBackend.FLASHINFER_TRTLLM,
             UnquantizedMoeBackend.FLASHINFER_CUTLASS,
+            UnquantizedMoeBackend.SONIC,
             UnquantizedMoeBackend.TRITON,
             UnquantizedMoeBackend.BATCHED_TRITON,
         ]
@@ -119,6 +121,11 @@ def backend_to_kernel_cls(
         )
 
         return BatchedTritonExperts
+
+    elif backend == UnquantizedMoeBackend.SONIC:
+        from vllm.model_executor.layers.fused_moe.sonic_moe import SonicMoeExperts
+
+        return SonicMoeExperts
 
     elif backend == UnquantizedMoeBackend.XPU:
         from vllm.model_executor.layers.fused_moe.xpu_fused_moe import XPUExperts
@@ -304,6 +311,13 @@ def convert_to_unquantized_kernel_format(
             # Swap halves to arrange as [w3; w1] (kernel expectation)
             # Non-gated MoE: w13 is a single projection, no need to swap.
             w13_weight = swap_w13_to_w31(w13_weight)
+
+    elif unquantized_backend == UnquantizedMoeBackend.SONIC:
+        from vllm.model_executor.layers.fused_moe.sonic_moe import (
+            prepare_weights_for_sonic,
+        )
+
+        w13_weight, w2_weight = prepare_weights_for_sonic(w13_weight, w2_weight)
 
     elif unquantized_backend == UnquantizedMoeBackend.FLASHINFER_TRTLLM:
         # Swap halves to arrange as [w3; w1] (kernel expectation)

--- a/vllm/model_executor/layers/fused_moe/sonic_moe.py
+++ b/vllm/model_executor/layers/fused_moe/sonic_moe.py
@@ -202,6 +202,11 @@ class SonicMoeExperts(mk.FusedMoEExpertsModular):
     ):
         super().__init__(moe_config, quant_config)
         self.out_dtype = moe_config.in_dtype
+        # Cache for pre-allocated routing buffers keyed by
+        # (M, topk, num_experts, device) to avoid per-call GPU allocations.
+        self._routing_cache: dict[
+            tuple[int, int, int, str], dict[str, torch.Tensor]
+        ] = {}
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
@@ -378,31 +383,46 @@ class SonicMoeExperts(mk.FusedMoEExpertsModular):
                 f"K={K}, N={n}, E={num_experts}, got {tuple(w2.shape)}"
             )
 
+        # Compute routing metadata for SonicMoE.
+        # Optimized: use sort + searchsorted (2 GPU ops) instead of
+        # argsort + bincount + cumsum + scatter + arange (6+ GPU ops).
+        # Pre-allocated buffers eliminate per-call torch.empty/arange overhead.
         # TODO(https://github.com/vllm-project/vllm/issues/31578): use router logits
-        selected_experts = topk_ids.flatten()
-        # SonicMoE expects `x_gather_idx` in the order produced by sorting the
-        # flattened expert ids (equivalent to `torch.argsort(topk_ids.view(-1))`).
-        s_scatter_idx = torch.argsort(selected_experts).to(torch.int32)
+        device = hidden_states.device
+        mt = M * topk
+        cache_key = (M, topk, num_experts, str(device))
+        if cache_key not in self._routing_cache:
+            self._routing_cache[cache_key] = {
+                "expert_boundaries": torch.arange(
+                    num_experts + 1, device=device, dtype=torch.int64
+                ),
+                "arange_mt": torch.arange(mt, device=device, dtype=torch.int32),
+                "arange_router": torch.arange(
+                    0, mt + 1, topk, device=device, dtype=torch.int32
+                ),
+                "s_reverse_scatter_idx": torch.empty(
+                    mt, device=device, dtype=torch.int32
+                ),
+            }
+        buffers = self._routing_cache[cache_key]
 
-        expert_frequency = selected_experts.bincount(minlength=num_experts).to(
-            torch.int32
-        )
-        # SonicMoE expects an exclusive prefix sum with a leading 0. The i'th
-        # expert reads from [offset[i], offset[i + 1]).
-        expert_offsets = torch.empty(
-            (num_experts + 1,), device=expert_frequency.device, dtype=torch.int32
-        )
-        expert_offsets[0] = 0
-        expert_offsets[1:] = expert_frequency.cumsum(-1)
+        selected_experts = topk_ids.flatten()
+        # Sort by expert ID — returns sorted values (for searchsorted) and
+        # original indices (s_scatter_idx) in a single GPU kernel.
+        sorted_experts, s_scatter_idx = selected_experts.sort(stable=True)
+        s_scatter_idx = s_scatter_idx.to(torch.int32)
+
+        # Expert offsets via searchsorted: replaces bincount + cumsum + empty.
+        # searchsorted(sorted, i) == number of elements < i == exclusive prefix sum.
+        expert_offsets = torch.searchsorted(
+            sorted_experts, buffers["expert_boundaries"]
+        ).to(torch.int32)
         expert_schedule_order = None
 
         x_gather_idx = s_scatter_idx // topk
-        s_reverse_scatter_idx = torch.empty_like(s_scatter_idx)
-        s_reverse_scatter_idx[s_scatter_idx] = torch.arange(
-            s_scatter_idx.numel(),
-            device=s_scatter_idx.device,
-            dtype=s_scatter_idx.dtype,
-        )
+        # Inverse permutation using pre-allocated buffer.
+        s_reverse_scatter_idx = buffers["s_reverse_scatter_idx"]
+        s_reverse_scatter_idx[s_scatter_idx.long()] = buffers["arange_mt"]
 
         z = workspace13[: M * topk, :two_n].view(M * topk, two_n)
         # workspace2 is a flat buffer. Carve compact matrices for y1/y2.
@@ -428,7 +448,7 @@ class SonicMoeExperts(mk.FusedMoEExpertsModular):
                 stream_id=stream_id,
                 activation_type=act_type,
                 is_glu_activation=True,
-                is_inference_mode_enabled=False,
+                is_inference_mode_enabled=True,
             )
         except Exception as e:
             # nvidia-cutlass-dsl has known failure modes where a raised exception
@@ -486,9 +506,7 @@ class SonicMoeExperts(mk.FusedMoEExpertsModular):
                 o=output,
                 topk_scores=topk_scores,
                 s_reverse_scatter_idx=s_reverse_scatter_idx,
-                num_activated_expert_per_token_offset=torch.arange(
-                    0, M * topk + 1, topk, device=output.device, dtype=torch.int32
-                ),
+                num_activated_expert_per_token_offset=buffers["arange_router"],
                 varlen_K_max=topk,
                 H=K,
                 is_varlen_K=False,

--- a/vllm/model_executor/layers/fused_moe/sonic_moe.py
+++ b/vllm/model_executor/layers/fused_moe/sonic_moe.py
@@ -1,0 +1,503 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Sonic MoE integration for Hopper GPUs.
+
+Sonic MoE uses swiglu format with rows interleaved as:
+  [gate_row0, up_row0, gate_row1, up_row1, ...]
+and computes: silu(gate) * up.
+
+vLLM's `silu_and_mul` computes:
+  silu(gate) * up
+with the convention [gate, up] along the last dimension.
+
+Weight permutation is required during loading to convert between formats.
+See: https://github.com/Dao-AILab/sonic-moe/issues/12
+"""
+
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FUSED_MOE_UNQUANTIZED_CONFIG,
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    FusedMoEQuantConfig,
+)
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceNoOP,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
+from vllm.platforms import current_platform
+
+logger = init_logger(__name__)
+
+_sonicmoe_available: bool | None = None
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
+
+
+def _check_sonicmoe_available() -> bool:
+    global _sonicmoe_available
+    if _sonicmoe_available is not None:
+        return _sonicmoe_available
+
+    try:
+        # NOTE: Importing the functional API will import the SonicMoE package and
+        # its runtime deps (e.g. quack, nvidia-cutlass-dsl).
+        from sonicmoe.functional.forward import (  # noqa: F401
+            _down_projection_forward,
+            _router_forward,
+            _up_projection_forward,
+        )
+
+        _sonicmoe_available = True
+        logger.info("Sonic MoE is available")
+    except Exception:
+        _sonicmoe_available = False
+        # The import may fail with ImportError/ModuleNotFoundError (missing deps)
+        # or SyntaxError (unsupported Python version).
+        logger.debug(
+            "Sonic MoE not available: failed to import sonicmoe functional API",
+            exc_info=True,
+        )
+
+    return _sonicmoe_available
+
+
+def _is_hopper_gpu() -> bool:
+    if not current_platform.is_cuda():
+        return False
+    # Hopper is SM90 (compute capability 9.0)
+    return current_platform.is_device_capability(90)
+
+
+def is_sonic_moe_supported() -> bool:
+    if not _is_hopper_gpu():
+        logger.debug("Sonic MoE requires Hopper GPU (H100/H200)")
+        return False
+    # Avoid importing SonicMoE (and its heavy deps like quack/cutlass) on
+    # non-Hopper systems.
+    return _check_sonicmoe_available()
+
+
+def is_valid_sonic_moe(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    num_experts: int,
+    top_k: int,
+) -> bool:
+    if not is_sonic_moe_supported():
+        return False
+
+    # SonicMoE's cutedsl kernels have additional shape constraints (asserted
+    # inside the upstream implementation). Validate them here so callers can
+    # reliably fall back without hard failures.
+    #
+    # In SonicMoE's pinned commit, `H` is the hidden dim (x.shape[1]) and must
+    # be >= 512 and divisible by 64. The intermediate dim after GLU (`I`) must
+    # also be divisible by 64.
+    H = hidden_states.size(1)
+    if H < 512 or H % 64 != 0:
+        logger.debug("Sonic MoE: hidden_dim H=%d must be >=512 and divisible by 64", H)
+        return False
+
+    if not hidden_states.is_contiguous():
+        logger.debug("Sonic MoE: hidden_states not contiguous")
+        return False
+
+    if not w1.is_contiguous() or not w2.is_contiguous():
+        logger.debug("Sonic MoE: weights not contiguous")
+        return False
+
+    if w1.dim() != 3 or w2.dim() != 3:
+        logger.debug("Sonic MoE: expected 3D weights")
+        return False
+
+    if w1.size(0) != num_experts or w2.size(0) != num_experts:
+        logger.debug("Sonic MoE: num_experts mismatch")
+        return False
+
+    if w1.size(2) != hidden_states.size(1):
+        logger.debug("Sonic MoE: w1 K dimension mismatch")
+        return False
+
+    two_n = w1.size(1)
+    if two_n % 2 != 0:
+        logger.debug("Sonic MoE: w1 second dim must be even (2N)")
+        return False
+    intermediate_dim = two_n // 2
+    if intermediate_dim % 64 != 0:
+        logger.debug(
+            "Sonic MoE: intermediate dim I=%d must be divisible by 64",
+            intermediate_dim,
+        )
+        return False
+
+    if w2.size(1) != hidden_states.size(1) or w2.size(2) != two_n // 2:
+        logger.debug("Sonic MoE: w2 shape mismatch")
+        return False
+
+    if top_k > 16:
+        logger.debug("Sonic MoE: top_k > 16 not optimized")
+        return False
+
+    supported_dtypes = {torch.float16, torch.bfloat16}
+    if hidden_states.dtype not in supported_dtypes:
+        logger.debug("Sonic MoE: unsupported dtype %s", hidden_states.dtype)
+        return False
+
+    return True
+
+
+def permute_weights_for_sonic(w: torch.Tensor) -> torch.Tensor:
+    """
+    Permute weights from vLLM's silu_and_mul format to Sonic's swiglu format.
+
+    vLLM format: [gate, up] -> silu(gate) * up
+    Sonic format: [interleaved] -> silu(gate) * up (even=gate, odd=up)
+
+    Conversion: interleave [gate, up] so that even indices are Sonic `gate` and
+    odd indices are Sonic `up`.
+
+    Reference: https://github.com/Dao-AILab/sonic-moe/issues/12
+    """
+    if not w.is_contiguous():
+        w = w.contiguous()
+    E, two_N, K = w.shape
+    N = two_N // 2
+    # vLLM provides [gate, up]; Sonic expects [gate0, up0, gate1, up1, ...].
+    w_reshaped = w.view(E, 2, N, K)
+    w_interleaved = w_reshaped.permute(0, 2, 1, 3)
+    return w_interleaved.reshape(E, two_N, K).contiguous()
+
+
+def prepare_weights_for_sonic(
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    *,
+    weights_prepermuted: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    w1_interleaved = w1 if weights_prepermuted else permute_weights_for_sonic(w1)
+    return (
+        w1_interleaved.permute(1, 2, 0),
+        w2.contiguous().permute(1, 2, 0),
+    )
+
+
+class SonicMoeExperts(mk.FusedMoEExpertsModular):
+    """
+    Sonic MoE experts implementation for Hopper GPUs.
+
+    Uses Sonic MoE's optimized kernels for up/down projections.
+    Requires weight permutation for swiglu compatibility.
+    """
+
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig = FUSED_MOE_UNQUANTIZED_CONFIG,
+    ):
+        super().__init__(moe_config, quant_config)
+        self.out_dtype = moe_config.in_dtype
+
+    @staticmethod
+    def activation_format() -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.Standard
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        return is_sonic_moe_supported()
+
+    @staticmethod
+    def _supports_no_act_and_mul() -> bool:
+        return False
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        return (weight_key, activation_key) == (None, None)
+
+    @staticmethod
+    def is_supported_config(
+        cls: type[mk.FusedMoEExperts],
+        moe_config: FusedMoEConfig,
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+        activation_format: mk.FusedMoEActivationFormat,
+    ) -> tuple[bool, str | None]:
+        supported, reason = mk.FusedMoEExperts.is_supported_config(
+            cls,
+            moe_config,
+            weight_key,
+            activation_key,
+            activation_format,
+        )
+        if not supported:
+            return supported, reason
+        if moe_config.has_bias:
+            return False, "MoE biases are enabled"
+        if moe_config.experts_per_token > 16:
+            return False, "topk > 16"
+        if moe_config.in_dtype not in _SUPPORTED_DTYPES:
+            return False, f"input dtype is unsupported: {moe_config.in_dtype}"
+        return True, None
+
+    @staticmethod
+    def _supports_activation(activation: MoEActivation) -> bool:
+        return activation == MoEActivation.SILU
+
+    @staticmethod
+    def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
+        return (
+            not moe_parallel_config.use_ep
+            and not moe_parallel_config.is_sequence_parallel
+        )
+
+    def supports_expert_map(self) -> bool:
+        return False  # TODO: Verify Sonic MoE expert mapping support
+
+    def supports_chunking(self) -> bool:
+        return True
+
+    def moe_problem_size(
+        self,
+        a1: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> tuple[int, int, int, int, int]:
+        assert w1.dim() == 3 and w2.dim() == 3
+        two_n, _, num_experts = w1.size()
+        k = a1.size(-1)
+
+        if a1.dim() == 2:
+            assert topk_ids.size(0) == a1.size(0), f"{topk_ids.size(0)} != {a1.size(0)}"
+            m = a1.size(0)
+        else:
+            raise AssertionError(f"Unexpected activation rank {a1.dim()}")
+
+        assert topk_ids.dim() == 2
+        topk = topk_ids.size(1)
+        return num_experts, m, two_n, k, topk
+
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
+        return TopKWeightAndReduceNoOP()
+
+    def workspace_shapes(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        topk: int,
+        global_num_experts: int,
+        local_num_experts: int,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        activation: MoEActivation,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        activation_out_dim = self.adjust_N_for_activation(N, activation)
+        workspace1 = (M * topk, max(N, K))
+        # NOTE: In the non-chunked case, the modular-kernel runtime may reuse the
+        # same underlying storage for `workspace13` and the final `output`.
+        # Keep `y2` (down-projection output) out of `workspace13` to avoid any
+        # read/write aliasing with `output` during router reduction.
+        #
+        # Also keep `y1` and `y2` backed by compact contiguous storage. Slicing a
+        # wider 2D workspace (pitched layout) yields stride(0) != num_cols, and
+        # SonicMoE's CuTe wrappers reject that layout.
+        workspace2 = (M * topk * (activation_out_dim + K),)
+        output = (M, K)
+        return (workspace1, workspace2, output)
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool,
+    ):
+        """
+        Apply Sonic MoE computation.
+
+        Orchestrates:
+        1. Weight conversion (cached)
+        2. Up projection with GLU activation
+        3. Down projection
+        4. Router-weighted combination
+        """
+        if expert_map is not None:
+            raise ValueError("Sonic MoE does not support expert_map/EP.")
+        if activation != MoEActivation.SILU:
+            raise ValueError(
+                f"Sonic MoE only supports SILU activation, got {activation}"
+            )
+
+        try:
+            from sonicmoe.functional.forward import (
+                _down_projection_forward,
+                _router_forward,
+                _up_projection_forward,
+            )
+        except Exception as e:
+            raise RuntimeError(
+                "Sonic MoE functional API not available.\n"
+                "This requires installing SonicMoE from source (GitHub) plus its "
+                "dependencies (quack/cutlass), and running on a Hopper GPU "
+                "(H100/H200) with a compatible CUDA toolchain.\n"
+                "Install (example): clone SonicMoE, pip install -r requirements.txt, "
+                "then pip install -e .\n"
+                f"Original import error: {type(e).__name__}: {e}"
+            ) from e
+
+        M, K = hidden_states.shape
+        two_n, k_from_w1, num_experts = w1.shape
+        topk = topk_ids.shape[1]
+        if k_from_w1 != K:
+            raise ValueError(f"Sonic MoE expects w1 last dim {K}, got {k_from_w1}")
+        if two_n % 2 != 0:
+            raise ValueError(f"Sonic MoE expects w1 second dim to be even, got {two_n}")
+        n = two_n // 2
+        if w2.size(0) != K or w2.size(1) != n or w2.size(2) != num_experts:
+            raise ValueError(
+                "Sonic MoE expects w2 shape (K, N, E) with "
+                f"K={K}, N={n}, E={num_experts}, got {tuple(w2.shape)}"
+            )
+
+        # TODO(https://github.com/vllm-project/vllm/issues/31578): use router logits
+        selected_experts = topk_ids.flatten()
+        # SonicMoE expects `x_gather_idx` in the order produced by sorting the
+        # flattened expert ids (equivalent to `torch.argsort(topk_ids.view(-1))`).
+        s_scatter_idx = torch.argsort(selected_experts).to(torch.int32)
+
+        expert_frequency = selected_experts.bincount(minlength=num_experts).to(
+            torch.int32
+        )
+        # SonicMoE expects an exclusive prefix sum with a leading 0. The i'th
+        # expert reads from [offset[i], offset[i + 1]).
+        expert_offsets = torch.empty(
+            (num_experts + 1,), device=expert_frequency.device, dtype=torch.int32
+        )
+        expert_offsets[0] = 0
+        expert_offsets[1:] = expert_frequency.cumsum(-1)
+        expert_schedule_order = None
+
+        x_gather_idx = s_scatter_idx // topk
+        s_reverse_scatter_idx = torch.empty_like(s_scatter_idx)
+        s_reverse_scatter_idx[s_scatter_idx] = torch.arange(
+            s_scatter_idx.numel(),
+            device=s_scatter_idx.device,
+            dtype=s_scatter_idx.dtype,
+        )
+
+        z = workspace13[: M * topk, :two_n].view(M * topk, two_n)
+        # workspace2 is a flat buffer. Carve compact matrices for y1/y2.
+        y1_numel = M * topk * n
+        y2_numel = M * topk * K
+        y1 = workspace2[:y1_numel].view(M * topk, n)
+        y2 = workspace2[y1_numel : y1_numel + y2_numel].view(M * topk, K)
+
+        # SonicMoE custom op expects a string for activation_type.
+        act_type = "swiglu"
+        stream_id = int(torch.cuda.current_stream().cuda_stream)
+
+        try:
+            _up_projection_forward(
+                x=hidden_states,
+                w1=w1,
+                z=z,
+                y1=y1,
+                b1=None,
+                expert_frequency_offset=expert_offsets,
+                expert_schedule_order=expert_schedule_order,
+                x_gather_idx=x_gather_idx,
+                stream_id=stream_id,
+                activation_type=act_type,
+                is_glu_activation=True,
+                is_inference_mode_enabled=False,
+            )
+        except Exception as e:
+            # nvidia-cutlass-dsl has known failure modes where a raised exception
+            # causes pytest's traceback formatting to segfault while repr()-ing
+            # internal CuTe objects. Re-raise a plain RuntimeError to keep CI
+            # failures actionable.
+            raise RuntimeError(
+                "SonicMoE up-projection failed.\n"
+                f"Original error: {type(e).__name__}: {e}\n"
+                f"x: shape={tuple(hidden_states.shape)} "
+                f"stride={hidden_states.stride()} dtype={hidden_states.dtype}\n"
+                f"w1: shape={tuple(w1.shape)} "
+                f"stride={w1.stride()} dtype={w1.dtype}\n"
+                f"z: shape={tuple(z.shape)} stride={z.stride()} dtype={z.dtype}\n"
+                f"y1: shape={tuple(y1.shape)} stride={y1.stride()} dtype={y1.dtype}\n"
+            ) from None
+
+        try:
+            _down_projection_forward(
+                w2=w2,
+                y1=y1,
+                y2=y2,
+                b2=None,
+                expert_frequency_offset=expert_offsets,
+                expert_schedule_order=expert_schedule_order,
+                x_gather_idx=x_gather_idx,
+                stream_id=stream_id,
+            )
+        except Exception as e:
+            raise RuntimeError(
+                "SonicMoE down-projection failed.\n"
+                f"Original error: {type(e).__name__}: {e}\n"
+                f"w2: shape={tuple(w2.shape)} "
+                f"stride={w2.stride()} dtype={w2.dtype}\n"
+                f"y1: shape={tuple(y1.shape)} stride={y1.stride()} dtype={y1.dtype}\n"
+                f"y2: shape={tuple(y2.shape)} stride={y2.stride()} dtype={y2.dtype}\n"
+            ) from None
+
+        # apply_router_weight_on_input only supported for topk=1
+        # (consistent with MoEPrepareAndFinalizeNoDPEPModular)
+        if apply_router_weight_on_input:
+            if topk != 1:
+                raise ValueError(
+                    "apply_router_weight_on_input is only supported for topk=1"
+                )
+            topk_scores = torch.ones_like(topk_weights).flatten()
+        else:
+            # SonicMoE expects router scores in the original (token-major)
+            # flattened order; `s_reverse_scatter_idx` maps that order to the
+            # expert-grouped order of y2.
+            topk_scores = topk_weights.flatten()
+        try:
+            _router_forward(
+                y2=y2,
+                o=output,
+                topk_scores=topk_scores,
+                s_reverse_scatter_idx=s_reverse_scatter_idx,
+                num_activated_expert_per_token_offset=torch.arange(
+                    0, M * topk + 1, topk, device=output.device, dtype=torch.int32
+                ),
+                varlen_K_max=topk,
+                H=K,
+                is_varlen_K=False,
+            )
+        except Exception as e:
+            raise RuntimeError(
+                "SonicMoE router reduction failed.\n"
+                f"Original error: {type(e).__name__}: {e}\n"
+                f"y2: shape={tuple(y2.shape)} stride={y2.stride()} dtype={y2.dtype}\n"
+                f"o: shape={tuple(output.shape)} "
+                f"stride={output.stride()} dtype={output.dtype}\n"
+            ) from None


### PR DESCRIPTION
## Purpose

Integrate [Sonic MoE](https://github.com/Dao-AILab/sonic-moe) for Hopper GPUs. ([paper](https://arxiv.org/abs/2512.14080)) 🎸 🚀

<img width="3600" height="2160" alt="sonic_moe_h100" src="https://github.com/user-attachments/assets/3429a08f-45ec-4371-999c-d977de84c2c5" />

Weights are permuted from vLLM's concatenated format to Sonic's interleaved format during model loading (no inference runtime cost).

Addresses #31039

## Key Changes

- SonicMoeExperts class in vllm/model_executor/layers/fused_moe/sonic_moe.py
- Integrated into oracle pattern via oracle/unquantized.py (following #31827)
- Weight permutation for SwiGLU format (https://github.com/Dao-AILab/sonic-moe/issues/12)
- VLLM_USE_SONIC_MOE env flag registered in vllm/envs.py
- CI: H100 test with https://github.com/Dao-AILab/sonic-moe/issues/17 (not on PyPI)

## Usage

```bash
VLLM_USE_SONIC_MOE=1 vllm serve <model>

Requirements (per Dao AI Labs): Hopper GPU (H100/H200), CUDA 12.9+, Python 3.12+

### Compatible Models

Most MoE models using SwiGLU activation should work out of the box:

- Mixtral: mistralai/Mixtral-8x7B-v0.1
- DeepSeek: deepseek-ai/DeepSeek-V2
- Qwen-MoE: Qwen/Qwen2-57B-A14B, Qwen/Qwen3-MoE
- Others: DBRX, Jamba, OLMoE, PhiMoE, Grok1, GLM4-MoE, GraniteMoE, EXAONE-MoE, Llama4-MoE, and https://github.com/vllm-project/vllm/tree/main/vllm/model_executor/models

Not compatible:
- GPT-OSS: biased MoE layers (has_bias=True)
- Nemotron-H: non-gated MoE (is_act_and_mul=False)

### Gating Logic

Sonic MoE auto-disables when:
- Expert parallelism (EP) enabled
- MoE biases present
- FlashInfer CUTLASS MoE active
- Non-Hopper GPU

## Test Plan

pytest tests/kernels/moe/test_sonic_moe.py -v

- Platform detection, weight permutation, shape validation
- E2E comparison vs TritonExperts (48 cases, <1% diff)
- apply_router_weight_on_input parity test
- Skips gracefully on non-Hopper hardware

### Test results

#### Correctness

(venv312) ubuntu@192-222-54-80:~/vllm$ pytest -v -s tests/kernels/moe/test_sonic_moe.py
================================================================================================================================= test session starts ==================================================================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /home/ubuntu/venv312/bin/python3
cachedir: .pytest_cache
rootdir: /home/ubuntu/vllm
configfile: pyproject.toml
plugins: anyio-4.12.1
collecting ... INFO 02-11 19:41:33 [sonic_moe.py:58] Sonic MoE is available
WARNING 02-11 19:41:33 [interface.py:586] Current platform cuda does not have '__test__' attribute.
WARNING 02-11 19:41:33 [interface.py:586] Current platform cuda does not have '__bases__' attribute.
WARNING 02-11 19:41:33 [interface.py:586] Current platform cuda does not have '__test__' attribute.
collected 26 items                                                                                                                                                                                                                                                                     

tests/kernels/moe/test_sonic_moe.py::test_check_sonicmoe_available PASSED
tests/kernels/moe/test_sonic_moe.py::test_is_hopper_gpu PASSED
tests/kernels/moe/test_sonic_moe.py::test_is_sonic_moe_supported PASSED
tests/kernels/moe/test_sonic_moe.py::test_permute_weights_for_sonic PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_experts_init PASSED
tests/kernels/moe/test_sonic_moe.py::test_is_valid_sonic_moe_basic PASSED
tests/kernels/moe/test_sonic_moe.py::test_is_valid_sonic_moe_large_topk PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_forward_unsupported SKIPPED (Sonic MoE is supported on this system)
tests/kernels/moe/test_sonic_moe.py::test_import_from_fused_moe PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype0-8-2-256-2048-512] WARNING 02-11 19:41:34 [fused_moe.py:1086] Using default MoE config. Performance might be sub-optimal! Config file not found at /home/ubuntu/vllm/vllm/model_executor/layers/fused_moe/configs/E=8,N=1024,device_name=NVIDIA_H100_80GB_HBM3.json
PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype0-8-2-512-4096-1024] INFO 02-11 19:41:40 [fused_moe.py:1073] Using configuration from /home/ubuntu/vllm/vllm/model_executor/layers/fused_moe/configs/E=8,N=2048,device_name=NVIDIA_H100_80GB_HBM3.json for MoE layer.
PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype0-8-4-256-2048-512] PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype0-8-4-512-4096-1024] PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype0-16-2-256-2048-512] WARNING 02-11 19:41:47 [fused_moe.py:1086] Using default MoE config. Performance might be sub-optimal! Config file not found at /home/ubuntu/vllm/vllm/model_executor/layers/fused_moe/configs/E=16,N=1024,device_name=NVIDIA_H100_80GB_HBM3.json
PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype0-16-2-512-4096-1024] WARNING 02-11 19:41:52 [fused_moe.py:1086] Using default MoE config. Performance might be sub-optimal! Config file not found at /home/ubuntu/vllm/vllm/model_executor/layers/fused_moe/configs/E=16,N=2048,device_name=NVIDIA_H100_80GB_HBM3.json
PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype0-16-4-256-2048-512] PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype0-16-4-512-4096-1024] PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype1-8-2-256-2048-512] PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype1-8-2-512-4096-1024] PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype1-8-4-256-2048-512] PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype1-8-4-512-4096-1024] PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype1-16-2-256-2048-512] PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype1-16-2-512-4096-1024] PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype1-16-4-256-2048-512] PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_vs_triton[dtype1-16-4-512-4096-1024] PASSED
tests/kernels/moe/test_sonic_moe.py::test_sonic_moe_apply_router_weight_on_input PASSED

=================================================================================================================================== warnings summary ===================================================================================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../venv312/lib/python3.12/site-packages/torch/jit/_script.py:362: 14 warnings
  /home/ubuntu/venv312/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/kernels/moe/test_sonic_moe.py: 48 warnings
  /home/ubuntu/venv312/lib/python3.12/site-packages/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/_mlir_helpers/op.py:60: DeprecationWarning: `make_fragment` is deprecated, use `make_rmem_tensor` instead
    res_or_list = opFunc(*args, **kwargs, loc=loc)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================================================== 25 passed, 1 skipped, 64 warnings in 46.44s ======================================================================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

#### Benchmarks

(venv312) ubuntu@192-222-54-80:~/vllm$ python benchmarks/kernels/benchmark_sonic_moe.py --warmup 20 --iters 100 --output-json bench_stable.json
INFO 02-11 19:37:31 [sonic_moe.py:58] Sonic MoE is available
INFO 02-11 19:37:31 [fused_moe.py:1073] Using configuration from /home/ubuntu/vllm/vllm/model_executor/layers/fused_moe/configs/E=8,N=2048,device_name=NVIDIA_H100_80GB_HBM3.json for MoE layer.
INFO 02-11 19:37:41 [fused_moe.py:1073] Using configuration from /home/ubuntu/vllm/vllm/model_executor/layers/fused_moe/configs/E=8,N=4096,device_name=NVIDIA_H100_80GB_HBM3.json for MoE layer.
^[[Cdtype,e,topk,m,k,n,triton_us,sonic_us,speedup,mode,rel_err
bf16,8,2,256,512,4096,310.45,709.39,0.438,eager/eager,0.0045
fp16,8,2,256,512,4096,312.93,714.18,0.438,eager/eager,0.0005
bf16,8,4,512,1024,8192,4496.62,713.64,6.301,eager/eager,0.0121
fp16,8,4,512,1024,8192,4433.30,714.53,6.204,eager/eager,0.0014
{
  "device": "NVIDIA H100 80GB HBM3",
  "results": [
    {
      "dtype": "bf16",
      "m": 256,
      "k": 512,
      "n": 4096,
      "e": 8,
      "topk": 2,
      "triton_us": 310.45312881469727,
      "sonic_us": 709.3862152099609,
      "speedup": 0.43763625815989493,
      "mode": "eager/eager",
      "rel_err": 0.00445556640625
    },
    {
      "dtype": "fp16",
      "m": 256,
      "k": 512,
      "n": 4096,
      "e": 8,
      "topk": 2,
      "triton_us": 312.92640686035156,
      "sonic_us": 714.1766357421875,
      "speedup": 0.4381638815937346,
      "mode": "eager/eager",
      "rel_err": 0.0005464553833007812
    },
    {
      "dtype": "bf16",
      "m": 512,
      "k": 1024,
      "n": 8192,
      "e": 8,
      "topk": 4,
      "triton_us": 4496.620178222656,
      "sonic_us": 713.6374664306641,
      "speedup": 6.300986691061772,
      "mode": "eager/eager",
      "rel_err": 0.01214599609375
    },
    {
      "dtype": "fp16",
      "m": 512,
      "k": 1024,
      "n": 8192,
      "e": 8,
      "topk": 4,
      "triton_us": 4433.2989501953125,
      "sonic_us": 714.5299530029297,
      "speedup": 6.20449700052971,
      "mode": "eager/eager",
      "rel_err": 0.0013608932495117188
    }
  ]
}
