### PR TITLE
[ROCm][CI] Fix failure in Language Models Tests (Extra Standard) by reducing agent pool size

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -859,7 +859,7 @@ steps:
 - label: Language Models Tests (Extra Standard) %N
   timeout_in_minutes: 45
   mirror_hardwares: [amdexperimental]
-  agent_pool: mi325_8
+  agent_pool: mi325_2
   # grade: Blocking
   torch_nightly: true
   source_file_dependencies:
@@ -871,6 +871,7 @@ steps:
     # Shard slow subset of standard language models tests. Only run when model
     # source is modified, or when specified test files are modified
     - pip freeze | grep -E 'torch'
+    - export TORCH_NCCL_BLOCKING_WAIT=1
     - pytest -v -s models/language -m 'core_model and slow_test' \
              --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT \
              --shard-id=$$BUILDKITE_PARALLEL_JOB


### PR DESCRIPTION
The "Language Models Tests (Extra Standard)" job on AMD CI was failing with exit code 5, even though all tests passed successfully.

**Root cause:** The `mi325_8` agent pool has 8 GPUs, and the AMD CI script shards tests across all available GPUs (8 shards). However, there are only ~19 tests matching the `'core_model and slow_test'` marker. The `pytest-shard` plugin doesn't guarantee even distribution, resulting in some shards receiving zero tests:

```
Shard 0: Running 0 items in this shard  ← EMPTY
Shard 1: Running 0 items in this shard  ← EMPTY
Shard 2: Running 3 items
Shard 3: Running 3 items
Shard 4: Running 1 items
Shard 5: Running 6 items
Shard 6: Running 3 items
Shard 7: Running 3 items
```

Empty shards exit with code 5 ("no tests collected"), causing the overall job to fail despite all actual tests passing.

## Solution

Change the agent pool from `mi325_8` to `mi325_2` to match the `parallelism: 2` setting. This ensures tests are sharded across 2 workers instead of 8, preventing empty shards.

## Changes

- `agent_pool: mi325_8` to `agent_pool: mi325_2`