### PR TITLE
[CI][Bugfix] Fix token counting in chunked prefill streaming test

### DIFF
--- a/tests/entrypoints/openai/test_chunked_prompt.py
+++ b/tests/entrypoints/openai/test_chunked_prompt.py
@@ -118,10 +118,8 @@ async def test_chat_completion_stream_options_and_logprobs_with_long_prompts(
             else:
                 # Count actual tokens from logprobs since multiple tokens
                 # can be batched into a single chunk
-                if chunk.choices[0].logprobs and chunk.choices[0].logprobs.content:
-                    tokens_received += len(chunk.choices[0].logprobs.content)
-                else:
-                    tokens_received += 1
+                assert chunk.choices[0].logprobs and chunk.choices[0].logprobs.content
+                tokens_received += len(chunk.choices[0].logprobs.content)
 
             if chunk.choices[0].finish_reason is not None:
                 finished = True

--- a/tests/entrypoints/openai/test_chunked_prompt.py
+++ b/tests/entrypoints/openai/test_chunked_prompt.py
@@ -116,7 +116,12 @@ async def test_chat_completion_stream_options_and_logprobs_with_long_prompts(
                 assert chunk.choices[0].logprobs is None
                 empty_chunks_received += 1
             else:
-                tokens_received += 1
+                # Count actual tokens from logprobs since multiple tokens
+                # can be batched into a single chunk
+                if chunk.choices[0].logprobs and chunk.choices[0].logprobs.content:
+                    tokens_received += len(chunk.choices[0].logprobs.content)
+                else:
+                    tokens_received += 1
 
             if chunk.choices[0].finish_reason is not None:
                 finished = True


### PR DESCRIPTION
Fixes flaky assertion failure in `test_chat_completion_stream_options_and_logprobs_with_long_prompts`.

## Problem

The test assumed a 1:1 correspondence between streaming chunks and tokens. However, vLLM can batch multiple tokens into a single SSE chunk, causing the assertion `chunk.usage.completion_tokens == tokens_received` to fail.

Example failure:
```
AssertionError: assert 5 == 4
```

The final chunk contained 2 tokens (`, the`) but `tokens_received` was only incremented by 1.

## Solution

Count actual tokens using `len(chunk.choices[0].logprobs.content)` instead of incrementing by 1 per chunk.

## Note

This issue manifests on ROCm due to timing differences but the underlying assumption (1 chunk = 1 token) is incorrect on all platforms.