### PR TITLE
[Bugfix] Adjust default parameters in test_completion

### DIFF
--- a/tests/v1/entrypoints/openai/test_completion.py
+++ b/tests/v1/entrypoints/openai/test_completion.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import random
+
 import openai  # use the official client for correctness check
 import pytest
 import pytest_asyncio
@@ -19,7 +21,7 @@ MODEL_NAME = "facebook/opt-125m"
 def default_server_args():
     return [
         "--dtype",
-        "float32",
+        "bfloat16",
         "--max-model-len",
         "2048",
         "--max-num-seqs",
@@ -274,7 +276,7 @@ async def test_parallel_no_streaming(client: openai.AsyncOpenAI, model_name: str
         temperature=1.0,
         stream=False,
         logprobs=0,
-        seed=42,
+        seed=random.randint(0, 10000),
     )
 
     # Assert `n` completions
@@ -322,7 +324,7 @@ async def test_parallel_streaming(client: openai.AsyncOpenAI, model_name: str):
         n=n,
         temperature=1.0,
         stream=True,
-        seed=42,
+        seed=random.randint(0, 10000),
     )
     chunks: list[list[str]] = [[] for _ in range(n)]
     finish_reason_count = 0


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
In test_completion, we found that default_derve_args does not conform to the data types supported by Intel XPU's Flash Attention, and in some tests, sub requests cannot be completed at different times, resulting in two Asset Error. Therefore, some parameters need to be adjusted
## Test Plan
cd /workspace/vllm/tests
pytest -sv v1/entrypoints/openai/test_completion.py -k "server0"
pytest -sv v1/entrypoints/openai/test_completion.py -k "server1"
## Test Result
19 passed, 19 deselected, 2 warnings in 45.40s
19 passed, 19 deselected, 2 warnings in 46.90s
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

