### PR TITLE
[Bugfix] Fix activation quantization for compressed-tensors W4A16

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -114,7 +114,7 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
             logger.info("Using %s for CompressedTensorsWNA16", kernel_type.__name__)
             self._kernel_backends_being_used.add(kernel_type.__name__)
 
-        if isinstance(kernel_type, MarlinLinearKernel):
+        if kernel_type is MarlinLinearKernel:
             input_dtype = get_marlin_input_dtype(self.layer_name)
             if input_dtype is not None:
                 mp_linear_kernel_config.act_type = input_dtype


### PR DESCRIPTION
## Purpose
This PR fixes an incorrect conditional logic that prevented the activation quantization from being correctly enabled for compressed-tensors W4A16 models (e.g., [RedHatAI/Qwen3-8B-quantized.w4a16](https://huggingface.co/RedHatAI/Qwen3-8B-quantized.w4a16)).

## Test Plan
ref to #24722
```
# for int8 activation
export VLLM_MARLIN_INPUT_DTYPE=int8
# or for fp8 activation
export VLLM_MARLIN_INPUT_DTYPE=fp8
# then run a model that using marlin kernel
vllm serve RedHatAI/Qwen3-8B-quantized.w4a16
```