### PR TITLE
[BugFix] scheduler: Fix resuming of preempted requests after async load

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1261,10 +1261,11 @@ def test_kv_connector_unable_to_allocate(use_ec_connector, ec_role):
     assert len(scheduler.waiting) == 0
 
 
+@pytest.mark.parametrize("is_async", [False, True])
 @pytest.mark.parametrize(
     "use_ec_connector, ec_role", [(False, None), (True, "ec_consumer")]
 )
-def test_kv_connector_handles_preemption(use_ec_connector, ec_role):
+def test_kv_connector_handles_preemption(is_async, use_ec_connector, ec_role):
     """
     Test whether scheduler with KVConnector is able to handle
     unable to allocate (run out of blocks in allocate_slots().
@@ -1277,7 +1278,9 @@ def test_kv_connector_handles_preemption(use_ec_connector, ec_role):
     NUM_MATCHED_NEW_TOKENS = BLOCK_SIZE
     scheduler = create_scheduler(
         enable_prefix_caching=True,
-        use_kv_connector=mock_kv(matched_tokens=NUM_MATCHED_NEW_TOKENS, is_async=False),
+        use_kv_connector=mock_kv(
+            matched_tokens=NUM_MATCHED_NEW_TOKENS, is_async=is_async
+        ),
         block_size=BLOCK_SIZE,
         num_blocks=NUM_BLOCKS,
         # encoder connector should not affect test results
@@ -1315,6 +1318,12 @@ def test_kv_connector_handles_preemption(use_ec_connector, ec_role):
 
     # All can be scheduled - 1st token.
     output = scheduler.schedule()
+    if is_async:
+        assert len(scheduler.waiting) == 2
+        assert scheduler.running == []
+        _step_until_kv_transfer_finished(scheduler, req_ids)
+        output = scheduler.schedule()
+
     _assert_right_scheduler_output(
         output,
         # 2 remote kv cache hits.
@@ -1367,6 +1376,12 @@ def test_kv_connector_handles_preemption(use_ec_connector, ec_role):
     # Restarts the preempted request - generate 3rd token.
     # This will have a local and remote cache hit.
     output = scheduler.schedule()
+    if is_async:
+        waiting_req_ids = [req.request_id for req in scheduler.waiting]
+        assert len(waiting_req_ids) == 1
+        _step_until_kv_transfer_finished(scheduler, waiting_req_ids)
+        output = scheduler.schedule()
+
     _assert_right_scheduler_output(
         output,
         # 1 remote kv_cache hit!
@@ -1377,6 +1392,8 @@ def test_kv_connector_handles_preemption(use_ec_connector, ec_role):
     )
     assert len(scheduler.running) == 1
     assert len(scheduler.waiting) == 0
+    assert output.scheduled_cached_reqs.num_reqs == 1
+    assert output.scheduled_new_reqs == []
     _ = scheduler.update_from_output(output, MODEL_RUNNER_OUTPUT)
     assert len(scheduler.running) == 1
     assert len(scheduler.waiting) == 0
@@ -1389,6 +1406,8 @@ def test_kv_connector_handles_preemption(use_ec_connector, ec_role):
         num_requests=0,
         expected_num_scheduled_tokens=1,
     )
+    assert output.scheduled_cached_reqs.num_reqs == 1
+    assert output.scheduled_new_reqs == []
     assert len(scheduler.running) == 1
     _ = scheduler.update_from_output(output, MODEL_RUNNER_OUTPUT)
     assert len(scheduler.running) == 0

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -445,7 +445,12 @@ class Scheduler(SchedulerInterface):
                 if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
                     is_ready = self._update_waiting_for_remote_kv(request)
                     if is_ready:
-                        request.status = RequestStatus.WAITING
+                        if request.num_preemptions:
+                            # We must be loading for a resumed preemption
+                            # rather than a new request.
+                            request.status = RequestStatus.PREEMPTED
+                        else:
+                            request.status = RequestStatus.WAITING
                     else:
                         logger.debug(
                             "%s is still in WAITING_FOR_REMOTE_KVS state.",

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -123,7 +123,7 @@ class Request:
         # indicates that the output is corrupted
         self.num_nans_in_logits = 0
 
-        # The number of requests being preempted by the scheduler
+        # The number of times this request has been preempted by the scheduler.
         self.num_preemptions = 0
 
         # The number of tokens that have been computed remotely.


### PR DESCRIPTION
The correct flow is for resuming preempted requests is:
RequestStatus.PREEMTPED -> resumed req in SchedulerOutput

However, for requests going through async loading after preemption this becomes:
RequestStatus.PREEMTPED -> RequestStatus.WAITING_FOR_REMOTE_KVS -> RequestStatus.WAITING
then, the scheduler incorrectly flags it as a new request in SchedulerOutput, instead of a resumed request.

This PR fixes the scheduler to correctly resume preempted requests after being async loaded.
RequestStatus.PREEMTPED ->  RequestStatus.WAITING_FOR_REMOTE_KVS -> RequestStatus.PREEMTPED -> resumed

---

> [!NOTE]
> Fixes incorrect classification of resumed requests after async KV loading.
> 
> - In `scheduler.schedule()`, when a request exits `WAITING_FOR_REMOTE_KVS`, set status to `PREEMPTED` if `num_preemptions > 0` (otherwise `WAITING`), so resumed requests are emitted as resumed (not new) in `SchedulerOutput`.
> - Test updates: parameterize KV preemption tests with `is_async`, add `_step_until_kv_transfer_finished(...)`, and assert correct scheduling/output behavior for async KV transfers (including cached vs new reqs counts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25476ad33e86c13746f894393ae7a2c9d129ec83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures preempted requests that underwent async KV loading are resumed correctly instead of being reclassified as new.
> 
> - In `scheduler.schedule()`, when leaving `WAITING_FOR_REMOTE_KVS`, set `status=PREEMPTED` if `num_preemptions>0` (else `WAITING`), so resumed requests appear in `scheduled_cached_reqs` as resumed.
> - Extend tests: parameterize KV preemption scenarios with `is_async`, add `_step_until_kv_transfer_finished(...)`, and assert correct waiting/running transitions and cached vs new request counts.
> - Minor doc tweak: clarify `Request.num_preemptions` meaning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 399053a497be3ccfc1bb17179a156c1bbb1bb8ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit cb37857d209dbdca4f080484dcbd7a78aedd7dfc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Fixes misclassification of resumed requests after async KV loading.
> 
> - In `scheduler.schedule()`, when leaving `WAITING_FOR_REMOTE_KVS`, set `status=PREEMPTED` if `num_preemptions>0` (else `WAITING`) so resumed requests appear in `scheduled_cached_reqs`.
> - Tests: parameterize KV preemption with `is_async`, add `_step_until_kv_transfer_finished(...)`, and assert correct waiting/running transitions and cached vs new request counts.
> - Minor doc tweak: clarify meaning of `Request.num_preemptions`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb37857d209dbdca4f080484dcbd7a78aedd7dfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Fixes misclassification of resumed requests following async KV transfers.
> 
> - In `scheduler.schedule()`, when leaving `WAITING_FOR_REMOTE_KVS`, set `status=PREEMPTED` if `num_preemptions>0` (else `WAITING`), so resumed requests are emitted as resumed in `scheduled_cached_reqs`.
> - Tests: parameterize KV preemption path with `is_async`, add `_step_until_kv_transfer_finished(...)`, and assert correct waiting/running transitions and cached vs new request counts.
> - Minor doc tweak: clarify `Request.num_preemptions` meaning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3162ea59039b916a9628a22d6c45f4a4bd0106d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Fixes misclassification of resumed requests after async KV loading.
> 
> - In `scheduler.schedule()`, when leaving `WAITING_FOR_REMOTE_KVS`, set status to `PREEMPTED` if `num_preemptions>0` (else `WAITING`), so resumed requests appear in `scheduled_cached_reqs` rather than `scheduled_new_reqs`.
> - Extend tests: parameterize KV preemption path with `is_async`, add `_step_until_kv_transfer_finished(...)`, and assert correct waiting/running transitions and cached vs new request counts.
> - Clarify `Request.num_preemptions` comment to reflect "times preempted".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2e70f04ea11027bd8657c87db8984c629638c16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
