### PR TITLE
[Bugfix] Narrow broad exception in custom all-reduce detection

### DIFF
--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -22,8 +22,8 @@ from vllm.utils.torch_utils import cuda_device_count_stateless
 try:
     ops.meta_size()
     custom_ar = True
-except Exception:
-    # For CPUs
+except (RuntimeError, AttributeError):
+    # For CPUs or when custom AR ops not available
     custom_ar = False
 
 logger = init_logger(__name__)


### PR DESCRIPTION
## Summary
- Replace `except Exception:` with `except (RuntimeError, AttributeError):` when detecting custom all-reduce availability via `ops.meta_size()`
- This prevents masking unexpected errors during custom AR detection

## Details
The current broad exception handler can hide programming errors or unexpected conditions. Narrowing to specific exceptions improves debuggability.

- `RuntimeError`: Operation not supported on current platform  
- `AttributeError`: Function not available in ops module

## Test plan
- [x] Code review confirms change is safe
- [x] Existing tests pass
- [ ] Hardware verification (will post results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)