### PR TITLE
[Bugfix][Hardware][ROCm] Narrow broad exception in PyNCCL library loading

### DIFF
--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -94,9 +94,9 @@ class PyNcclCommunicator:
             return
         try:
             self.nccl = NCCLLibrary(library_path)
-        except Exception:
-            # disable because of missing NCCL library
-            # e.g. in a non-GPU environment
+        except (OSError, ValueError, RuntimeError):
+            # disable because of missing NCCL/RCCL library
+            # e.g. in a non-GPU environment or ROCm without RCCL
             self.available = False
             self.disabled = True
             return


### PR DESCRIPTION
## Summary
- Replace `except Exception:` with `except (OSError, ValueError, RuntimeError):` when loading the NCCL/RCCL library
- This prevents masking unexpected errors during library loading, especially important for ROCm/RCCL debugging

## Details
The current broad exception handler can hide the actual cause of NCCL/RCCL loading failures. Narrowing to specific exceptions helps debug issues on both CUDA and ROCm platforms.

- `OSError`: Library file not found or can't be loaded (from `ctypes.CDLL`)
- `ValueError`: Non-CUDA/ROCm backend (from `find_nccl_library()`)
- `RuntimeError`: Library initialization errors

## Test plan
- [x] Code review confirms change is safe
- [x] Existing tests pass
- [ ] Hardware verification on ROCm (will post results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)