### PR TITLE
[Bugfix] Narrow broad exceptions in rank detection functions

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1735,8 +1735,8 @@ def is_global_first_rank() -> bool:
         # Fallback to torch's global rank
         return torch.distributed.get_rank() == 0
 
-    except Exception:
-        # If anything goes wrong, assume this is the first rank
+    except RuntimeError:
+        # torch.distributed not initialized or other runtime errors
         return True
 
 
@@ -1757,9 +1757,10 @@ def is_local_first_rank() -> bool:
         # note: envs.LOCAL_RANK is set when using env:// launchers (e.g., torchrun)
         try:
             return int(envs.LOCAL_RANK) == 0  # type: ignore[arg-type]
-        except Exception:
+        except (ValueError, TypeError):
             return torch.distributed.get_rank() == 0
-    except Exception:
+    except RuntimeError:
+        # torch.distributed not initialized or other runtime errors
         return True
 
 


### PR DESCRIPTION
## Summary
Replace `except Exception:` with specific exceptions in `is_first_rank()` and `is_local_first_rank()` functions.

## Details
The current broad exception handlers mask underlying errors during distributed rank detection. Narrowing to specific exceptions improves debuggability, especially for ROCm/RCCL communication issues.

Changes:
- Line 1738: `Exception` -> `RuntimeError` (torch.distributed errors)
- Line 1760: `Exception` -> `(ValueError, TypeError)` (int() conversion errors)
- Line 1762: `Exception` -> `RuntimeError` (torch.distributed errors)

## Test plan
- [x] Code review confirms change is safe
- [x] Existing tests pass
- [ ] Hardware verification (will post results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)