### PR TITLE
[Bugfix] Replace BaseException with specific exceptions in FLA utils

### DIFF
--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -119,7 +119,7 @@ def input_guard(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
 def get_available_device() -> str:
     try:
         return triton.runtime.driver.active.get_current_target().backend
-    except BaseException:
+    except (RuntimeError, AttributeError):
         return "cpu"
 
 


### PR DESCRIPTION
## Summary
Change `except BaseException:` to `except (RuntimeError, AttributeError):` in `get_available_device()` function.

## Details
`BaseException` catches `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` which should propagate normally. The triton driver access can raise:
- `RuntimeError`: If triton backend is not available
- `AttributeError`: If driver/target attributes don't exist

This prevents masking critical system exceptions during device detection.

## Test plan
- [x] Code review confirms change is safe
- [x] Existing tests pass
- [ ] Hardware verification (will post results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)