### PR TITLE
[ROCm][CI] Fix language generation test accuracy by disabling HF flash_sdp and mem_efficient_sdp

### DIFF
--- a/tests/models/language/generation/conftest.py
+++ b/tests/models/language/generation/conftest.py
@@ -9,8 +9,8 @@ import torch
 from vllm.platforms import current_platform
 
 
-def pytest_collection_modifyitems(config, items):
-    """Configure ROCm-specific settings based on collected tests."""
+def pytest_sessionstart(session):
+    """Configure ROCm-specific settings before test session starts."""
     if not current_platform.is_rocm():
         return
 

--- a/tests/models/language/generation/conftest.py
+++ b/tests/models/language/generation/conftest.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pytest configuration for vLLM language generation tests."""
+
+import warnings
+
+import torch
+
+from vllm.platforms import current_platform
+
+
+def pytest_collection_modifyitems(config, items):
+    """Configure ROCm-specific settings based on collected tests."""
+    if not current_platform.is_rocm():
+        return
+
+    # Disable Flash/MemEfficient SDP on ROCm to avoid HF Transformers
+    # accuracy issues: https://github.com/vllm-project/vllm/issues/30167
+    # TODO: Remove once ROCm SDP accuracy issues are resolved on HuggingFace
+    torch.backends.cuda.enable_flash_sdp(False)
+    torch.backends.cuda.enable_mem_efficient_sdp(False)
+    torch.backends.cuda.enable_math_sdp(True)
+    warnings.warn(
+        "ROCm: Disabled flash_sdp and mem_efficient_sdp, enabled math_sdp "
+        "to avoid HuggingFace Transformers accuracy issues",
+        UserWarning,
+        stacklevel=1,
+    )


### PR DESCRIPTION
Fixes ROCm accuracy failures in language generation tests by disabling `flash_sdp` and `mem_efficient_sdp` backends for HuggingFace Transformers inference.

## Problem

Tests comparing HuggingFace and vLLM outputs were failing on ROCm due to numerical divergence:
```
AssertionError: Test5:
hf:   'fact' (logprob=-7.794)
vllm: 'upset' (logprob=-8.045)
```

The root cause is accuracy issues in ROCm's flash attention and memory-efficient SDP implementations in HuggingFace Transformers (https://github.com/vllm-project/vllm/issues/30167).

## Solution

Add a `conftest.py` that configures PyTorch SDP backends on ROCm:
- Disable `flash_sdp`
- Disable `mem_efficient_sdp`  
- Enable `math_sdp` (more accurate reference implementation)

This ensures HuggingFace uses a numerically stable attention path for baseline comparisons.

## Related

- First applied in [#30270](https://github.com/vllm-project/vllm/pull/30270)
- Upstream issue: https://github.com/vllm-project/vllm/issues/30167

## Testing

- Verified `pytest -v -s tests/models/language/generation/test_common.py::test_models[False-True-5-32-TitanML/tiny-mixtral]` passes with this fix