### PR TITLE
[Qwen3-Omni] Prefer CUDA for faster Whisper audio feature extraction

### DIFF
--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -750,15 +750,20 @@ class Qwen3OmniMoeThinkerMultiModalProcessor(
             # https://github.com/huggingface/transformers/pull/41473
             mm_kwargs = dict(mm_kwargs)
             tok_kwargs = dict(tok_kwargs)
+            mm_kwargs["text_kwargs"] = dict(mm_kwargs.get("text_kwargs") or {})
+            mm_kwargs["audio_kwargs"] = dict(mm_kwargs.get("audio_kwargs") or {})
+            mm_kwargs["audio_kwargs"].setdefault(
+                "device", "cuda" if torch.cuda.is_available() else "cpu"
+            )  # prefer CUDA for faster Whisper audio feature extraction
             if Version(TRANSFORMERS_VERSION) < Version("4.58.0"):
                 # move truncation to audio_kwargs level to avoid conflict
                 # with tok_kwargs
-                mm_kwargs["audio_kwargs"] = {
-                    "truncation": mm_kwargs.pop("truncation", False)
-                }
-                mm_kwargs["text_kwargs"] = {
-                    "truncation": tok_kwargs.pop("truncation", False)
-                }
+                mm_kwargs["audio_kwargs"]["truncation"] = mm_kwargs.pop(
+                    "truncation", False
+                )
+                mm_kwargs["text_kwargs"]["truncation"] = tok_kwargs.pop(
+                    "truncation", False
+                )
 
         hf_inputs = super()._call_hf_processor(
             prompt=prompt,


### PR DESCRIPTION
## Purpose
This PR makes a improvement to the Qwen3-Omni :
 Prefer CUDA for Whisper audio feature extraction when available:
   ```python
   mm_kwargs["audio_kwargs"].setdefault(
       "device", "cuda" if torch.cuda.is_available() else "cpu"
   )
```
This speeds up audio feature extraction on GPU-capable systems while keeping CPU as a safe fallback.