### PR TITLE
Fix: Add None check in step_with_batch_queue for async scheduling

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -461,6 +461,11 @@ class EngineCore:
         with self.log_error_detail(scheduler_output):
             model_output = future.result()
 
+            # Handle None return from execute_model (async scheduling)
+            if model_output is None:
+                grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
+                model_output = self.model_executor.sample_tokens(grammar_output)
+
         # Before processing the model output, process any aborts that happened
         # during the model execution.
         self._process_aborts_queue()


### PR DESCRIPTION
## Summary
Fix `AttributeError: 'NoneType' object has no attribute 'sampled_token_ids'` crash in V1 engine when async scheduling is enabled (default).

## Root Cause
In `step_with_batch_queue()` method, `execute_model()` can return `None` to signal async scheduling, but there was no `None` check before passing `model_output` to `scheduler.update_from_output()`.

The `step()` method already handles this correctly (line 364-366), but `step_with_batch_queue()` was missing the same check.

## Fix
Added `None` check in `step_with_batch_queue()` to call `sample_tokens()` when `model_output` is `None`, mirroring the existing pattern in `step()`.

## Environment
- GPU: NVIDIA GB10 (SM 12.1 / Blackwell)
- PyTorch: 2.9.1+cu130

Relates to: #31588