### PR TITLE
[CI/Build] Add CI config for Sonic MoE kernel tests on H100

### DIFF
--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -74,6 +74,17 @@ steps:
     - pytest -v -s kernels/moe/test_batched_deepgemm.py
     - pytest -v -s kernels/attention/test_deepgemm_attention.py
 
+- label: Kernels Sonic MoE Test (H100)
+  timeout_in_minutes: 45
+  gpu: h100
+  num_gpus: 1
+  source_file_dependencies:
+  - vllm/model_executor/layers/fused_moe/sonic_moe.py
+  - tests/kernels/moe/test_sonic_moe.py
+  commands:
+    - pip install sonicmoe
+    - pytest -v -s kernels/moe/test_sonic_moe.py
+
 - label: Kernels (B200)
   timeout_in_minutes: 30
   working_dir: "/vllm-workspace/"


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Adds buildkite CI configuration to run Sonic MoE kernel tests on H100 GPUs.

This config installs the [sonicmoe](https://github.com/Dao-AILab/sonic-moe) package and executes `tests/kernels/test_sonic_moe.py`, when relevant source files change.

Unblocks [#31548 (Sonic MoE integration for Hopper GPUs) ](https://github.com/vllm-project/vllm/pull/31548) by enabling CI validation.

Unblocks https://github.com/vllm-project/vllm/issues/31039.

## Test Plan

CI-only change. The test configuration will trigger when #31548 is rebased/merged after this PR merges:
- `source_file_dependencies` matches files added in #31548
- Test runs `pip install sonicmoe` then `pytest -v -s kernels/test_sonic_moe.py`

## Test Result

N/A - CI configuration change. Validation occurs when #31548 runs against updated CI.

---

Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results

