### PR TITLE
[Bugfix] Make executor wake_up idempotent and robust to invalid tags

### DIFF
--- a/tests/basic_correctness/test_cumem.py
+++ b/tests/basic_correctness/test_cumem.py
@@ -283,34 +283,44 @@ def test_deep_sleep_fp8_kvcache():
 
 @create_new_process_for_each_test("fork" if not current_platform.is_rocm() else "spawn")
 def test_wake_up_invalid_tags():
-    """Test wake_up method's handling of invalid tags"""
+    """Test that invalid tags don't affect memory management"""
     model = "hmellor/tiny-random-LlamaForCausalLM"
+    free, total = torch.cuda.mem_get_info()
+    used_bytes_baseline = total - free
+    
     llm = LLM(model, enable_sleep_mode=True)
     prompt = "How are you?"
     sampling_params = SamplingParams(temperature=0, max_tokens=10)
-    
-    # Generate baseline output
     output = llm.generate(prompt, sampling_params)
     
     # Enter sleep mode
     llm.sleep(level=1)
-    assert llm.llm_engine.model_executor.is_sleeping
+    free_after_sleep, _ = torch.cuda.mem_get_info()
+    used_after_sleep = total - free_after_sleep - used_bytes_baseline
     
-    # Try to wake up with completely invalid tag
+    # Memory should be mostly freed (less than 7 GiB as in test_end_to_end)
+    assert used_after_sleep < 7 * GiB_bytes
+    
+    # Try to wake up with completely invalid tag - memory should stay the same
     llm.wake_up(tags=["invalid_tag"])
-    # Should still be sleeping
-    assert llm.llm_engine.model_executor.is_sleeping
+    free_after_invalid, _ = torch.cuda.mem_get_info()
+    used_after_invalid = total - free_after_invalid - used_bytes_baseline
     
-    # Wake up with mixed valid and invalid tags
+    # Memory should not change significantly (within 100MB tolerance)
+    assert abs(used_after_sleep - used_after_invalid) < 100 * 1024 * 1024
+    
+    # Wake up with mixed valid and invalid tags (only weights should wake up)
     llm.wake_up(tags=["weights", "invalid_tag", "another_invalid"])
-    # weights should be awake
-    assert "weights" not in llm.llm_engine.model_executor.sleeping_tags
-    assert "kv_cache" in llm.llm_engine.model_executor.sleeping_tags
+    free_after_weights, _ = torch.cuda.mem_get_info()
+    used_after_weights = total - free_after_weights - used_bytes_baseline
     
-    # Fully wake up
+    # Memory should increase for weights (should be less than 10 GiB as in test_end_to_end)
+    assert used_after_weights > used_after_sleep
+    assert used_after_weights < 10 * GiB_bytes
+    
+    # Fully wake up by awakening kv_cache
     llm.wake_up(tags=["kv_cache"])
-    assert not llm.llm_engine.model_executor.is_sleeping
     
-    # Verify functionality
+    # Verify functionality after full wake up
     output2 = llm.generate(prompt, sampling_params)
     assert output[0].outputs[0].text == output2[0].outputs[0].text

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -311,23 +311,38 @@ class Executor(ABC):
         if not self.is_sleeping:
             logger.warning("Executor is not sleeping.")
             return
+        
+        valid_tags = None
         if tags:
+            valid_tags = []
+            invalid_tags = []
             for tag in tags:
-                if tag not in self.sleeping_tags:
-                    logger.warning(
-                        "Tag %s is not in sleeping tags %s", tag, self.sleeping_tags
-                    )
-                    return
+                if tag in self.sleeping_tags:
+                    valid_tags.append(tag)
+                else:
+                    invalid_tags.append(tag)
+            
+            if invalid_tags:
+                logger.warning(
+                    "Tags %s are not in sleeping tags %s. They will be ignored.",
+                    invalid_tags,
+                    self.sleeping_tags,
+                )
+            
+            if not valid_tags:
+                logger.warning("No valid tags to wake up. Skipping wake up operation.")
+                return
+        
         time_before_wakeup = time.perf_counter()
-        self.collective_rpc("wake_up", kwargs=dict(tags=tags))
+        self.collective_rpc("wake_up", kwargs=dict(tags=valid_tags))
         time_after_wakeup = time.perf_counter()
         logger.info(
             "It took %.6f seconds to wake up tags %s.",
             time_after_wakeup - time_before_wakeup,
-            tags if tags is not None else self.sleeping_tags,
+            valid_tags if valid_tags is not None else self.sleeping_tags,
         )
-        if tags:
-            for tag in tags:
+        if valid_tags:
+            for tag in valid_tags:
                 self.sleeping_tags.remove(tag)
         else:
             self.sleeping_tags.clear()


### PR DESCRIPTION

## Purpose

Fix #31618

This PR improves the robustness and idempotency of the wake_up method.

The Problem: Previously, `wake_up` would abort the entire operation if any requested tag was not found in sleeping_tags. This caused failures in partial sleep states. 

For example, if kv_cache is already awake but weights are sleeping:
- Calling wake_up(["weights", "kv_cache"]) would fail completely because kv_cache is not in sleeping_tags.
- Result: weights remain asleep unexpectedly.

The Fix: The method now filters tags using a "best effort" strategy:
- Filter: Identifies which of the requested tags are actually sleeping.
- Execute: Wakes up those valid tags.
- Ignore: Skips already-awake or invalid tags (with a warning) instead of aborting.

## Test Plan

```
pytest tests/basic_correctness/test_cumem.py::test_wake_up_invalid_tags
pytest tests/entrypoints/sleep/test_sleep.py::test_wake_up_with_invalid_tags
```

## Test Result

Passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

