### PR TITLE
[Docker][ROCm] Update base image to ROCm 7.1 for GFX1150/1151 support

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=rocm/dev-ubuntu-22.04:7.0-complete
+ARG BASE_IMAGE=rocm/dev-ubuntu-22.04:7.1-complete
 ARG TRITON_BRANCH="57c693b6"
 ARG TRITON_REPO="https://github.com/ROCm/triton.git"
 ARG PYTORCH_BRANCH="89075173"


### PR DESCRIPTION
## Summary

Updates the ROCm Docker base image from 7.0 to 7.1 to enable support for Strix Point (gfx1150) and Strix Halo (gfx1151) APUs.

## Problem

The `Dockerfile.rocm_base` already includes `gfx1150` and `gfx1151` in the `PYTORCH_ROCM_ARCH` build targets, but the base image (`rocm/dev-ubuntu-22.04:7.0-complete`) doesn't have the toolchain support for these RDNA 3.5 architectures.

As reported in #31333, this prevents users from building vLLM Docker images that can run on AMD Strix Point/Halo hardware.

## Solution

Update the base image to `rocm/dev-ubuntu-22.04:7.1-complete` which includes official support for:
- **gfx1150** (Strix Point - Ryzen AI 300 series)
- **gfx1151** (Strix Halo - Ryzen AI Max+ series)

## Testing

- [x] Verified `rocm/dev-ubuntu-22.04:7.1-complete` exists on Docker Hub
- [x] ROCm 7.1 is the current stable release (7.1.1 available)
- [x] ROCm 7.1 release notes confirm Strix Point/Halo support

## References

- Issue: #31333
- [ROCm 7.1 Release Notes](https://rocm.docs.amd.com/en/latest/about/release-notes.html)
- [Phoronix: AMD ROCm 7.10 Released - Strix Point APUs Now Officially Supported](https://www.phoronix.com/news/AMD-ROCm-7.10-Released)

Fixes #31333

🤖 Generated with [Claude Code](https://claude.com/claude-code)