### PR TITLE
Revert "[Kernels][FI] Skip trtllm attention when num_kv_heads=1 (#308…

### DIFF
--- a/tests/kernels/attention/test_flashinfer_trtllm_attention.py
+++ b/tests/kernels/attention/test_flashinfer_trtllm_attention.py
@@ -456,38 +456,3 @@ def test_flashinfer_trtllm_prefill_with_baseline(
         torch.testing.assert_close(output, output_trtllm, atol=atol, rtol=rtol),
         f"{torch.max(torch.abs(output - output_trtllm))}",
     )
-
-
-def test_trtllm_attention_rejects_num_kv_heads_1(default_vllm_config) -> None:
-    """Test that TRTLLM attention correctly rejects num_kv_heads=1.
-
-    When num_kv_heads=1 (MQA), the KV cache strides become degenerate
-    (stride_heads == stride_batch), which causes CUDA's cuTensorMapEncodeTiled
-    to fail because TMA descriptors cannot handle degenerate 4D tensors with
-    singleton dimensions.
-
-    This test verifies that can_use_trtllm_attention returns False for
-    num_kv_heads=1 configurations.
-    """
-    from vllm.utils.flashinfer import can_use_trtllm_attention
-
-    # num_kv_heads=1 should be rejected
-    assert not can_use_trtllm_attention(num_qo_heads=64, num_kv_heads=1), (
-        "can_use_trtllm_attention should return False for num_kv_heads=1"
-    )
-    assert not can_use_trtllm_attention(num_qo_heads=32, num_kv_heads=1), (
-        "can_use_trtllm_attention should return False for num_kv_heads=1"
-    )
-
-    # num_kv_heads > 1 should be accepted (if platform supports it)
-    # Note: This may return False on non-Blackwell platforms, which is fine
-    result_kv8 = can_use_trtllm_attention(num_qo_heads=64, num_kv_heads=8)
-    result_kv1 = can_use_trtllm_attention(num_qo_heads=64, num_kv_heads=1)
-
-    # Even if platform doesn't support TRTLLM, num_kv_heads=1 should never
-    # return True when num_kv_heads > 1 returns True
-    if result_kv8:
-        assert not result_kv1, (
-            "If TRTLLM is supported for num_kv_heads=8, "
-            "it must be rejected for num_kv_heads=1"
-        )

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -305,18 +305,7 @@ def can_use_trtllm_attention(num_qo_heads: int, num_kv_heads: int) -> bool:
     if force_use_trtllm_attention() is False:
         return False
     has_trtllm = supports_trtllm_attention()
-    # num_kv_heads=1 is not supported due to TMA descriptor building limitations.
-    # When num_kv_heads=1, the KV cache strides become degenerate (stride_heads ==
-    # stride_batch), which causes CUDA's cuTensorMapEncodeTiled to fail because
-    # TMA descriptors cannot handle degenerate 4D tensors with singleton dimensions.
-    # See: https://fburl.com/352mrydz
-    if has_trtllm and num_kv_heads == 1:
-        logger.warning_once(
-            "TRTLLM attention does not support num_kv_heads=1. "
-            "This configuration causes TMA descriptor building to fail due to "
-            "degenerate tensor strides. Falling back to FlashInfer attention."
-        )
-    return has_trtllm and (num_qo_heads % num_kv_heads == 0) and (num_kv_heads != 1)
+    return has_trtllm and (num_qo_heads % num_kv_heads == 0)
 
 
 def use_trtllm_attention(
@@ -363,15 +352,6 @@ def use_trtllm_attention(
                 "TRTLLM attention is not supported for this combination of "
                 "query and key heads, but --attention-config.use_trtllm_attention is "
                 "set to 1"
-            )
-        return False
-
-    # num_kv_heads=1 is not supported
-    if num_kv_heads == 1:
-        if force_use_trtllm:
-            logger.warning_once(
-                "TRTLLM attention does not support num_kv_heads=1, "
-                "but --attention-config.use_trtllm_attention is set to 1"
             )
         return False
 


### PR DESCRIPTION
This reverts commit a100152288c8ec50336aea842f0b3d8e36624024.

This PR causes GPT-OSS-120B TP8 has functional issue(NotImplementedError: FlashInfer backend currently does not support attention sinks).


## Purpose
Detail please see bug https://github.com/vllm-project/vllm/issues/30919.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Re-enables TRTLLM attention for MQA configs and removes the guard/test that rejected `num_kv_heads=1`.
> 
> - Updates `can_use_trtllm_attention` and `use_trtllm_attention` to drop the `num_kv_heads != 1` restriction; now only require platform support and `num_qo_heads % num_kv_heads == 0`
> - Deletes `test_trtllm_attention_rejects_num_kv_heads_1` from `tests/kernels/attention/test_flashinfer_trtllm_attention.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b482471122f9facf067f619280a5cad94cd41a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
