### PR TITLE
Move skipping of unused GPTQ bias to `AutoWeightsLoader`

### DIFF
--- a/vllm/model_executor/models/afmoe.py
+++ b/vllm/model_executor/models/afmoe.py
@@ -510,9 +510,6 @@ class AfmoeModel(nn.Module):
                     continue
 
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
 
@@ -561,10 +558,6 @@ class AfmoeModel(nn.Module):
                         # We've checked that this is an expert weight
                         # However it's not mapped locally to this rank
                         # So we simply skip it
-                        continue
-
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
                         continue
 
                     # Remapping the name of FP8 kv-scale.

--- a/vllm/model_executor/models/apertus.py
+++ b/vllm/model_executor/models/apertus.py
@@ -444,9 +444,6 @@ class ApertusModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -456,10 +453,6 @@ class ApertusModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-
                 if is_pp_missing_parameter(name, self):
                     continue
 

--- a/vllm/model_executor/models/arcee.py
+++ b/vllm/model_executor/models/arcee.py
@@ -316,10 +316,6 @@ class ArceeModel(nn.Module):
 
                 name = name.replace(weight_name, param_name)
 
-                if name.endswith(".bias") and name not in params_dict:
-                    mapped = True
-                    break
-
                 if is_pp_missing_parameter(name, self):
                     mapped = True
                     break
@@ -332,9 +328,6 @@ class ArceeModel(nn.Module):
                 break
 
             if mapped:
-                continue
-
-            if name.endswith(".bias") and name not in params_dict:
                 continue
 
             if is_pp_missing_parameter(name, self):

--- a/vllm/model_executor/models/arctic.py
+++ b/vllm/model_executor/models/arctic.py
@@ -585,9 +585,6 @@ class ArcticForCausalLM(nn.Module, SupportsPP, SupportsQuant):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -619,8 +616,6 @@ class ArcticForCausalLM(nn.Module, SupportsPP, SupportsQuant):
                         )
                         break
                     else:
-                        if name.endswith(".bias") and name not in params_dict:
-                            continue
                         if is_pp_missing_parameter(name, self):
                             continue
                         param = params_dict[name]

--- a/vllm/model_executor/models/aria.py
+++ b/vllm/model_executor/models/aria.py
@@ -375,9 +375,6 @@ class AriaTextModel(LlamaModel, SupportsQuant):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -387,9 +384,6 @@ class AriaTextModel(LlamaModel, SupportsQuant):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/baichuan.py
+++ b/vllm/model_executor/models/baichuan.py
@@ -358,9 +358,6 @@ class BaiChuanModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -368,9 +365,6 @@ class BaiChuanModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]

--- a/vllm/model_executor/models/bailing_moe.py
+++ b/vllm/model_executor/models/bailing_moe.py
@@ -506,9 +506,6 @@ class BailingMoeModel(nn.Module):
                 if "mlp.experts" in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if name not in params_dict:
                     continue
 
@@ -541,8 +538,6 @@ class BailingMoeModel(nn.Module):
                     )
                     break
                 else:
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
                     if name not in params_dict:
                         continue
 

--- a/vllm/model_executor/models/bamba.py
+++ b/vllm/model_executor/models/bamba.py
@@ -367,9 +367,6 @@ class BambaModel(nn.Module):
                     continue
 
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -378,9 +375,6 @@ class BambaModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
 

--- a/vllm/model_executor/models/bert_with_rope.py
+++ b/vllm/model_executor/models/bert_with_rope.py
@@ -503,17 +503,11 @@ class BertWithRope(nn.Module, SupportsQuant):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 if name.endswith((".w1", ".w2")):

--- a/vllm/model_executor/models/chameleon.py
+++ b/vllm/model_executor/models/chameleon.py
@@ -1051,9 +1051,6 @@ class ChameleonForConditionalGeneration(
                     if weight_name not in name:
                         continue
                     name = name.replace(weight_name, param_name)
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
                     if is_pp_missing_parameter(name, self):
                         continue
                     param = params_dict[name]
@@ -1061,9 +1058,6 @@ class ChameleonForConditionalGeneration(
                     weight_loader(param, loaded_weight, shard_id)
                     break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
                     # Remapping the name of FP8 kv-scale.
                     if name.endswith("kv_scale"):
                         remapped_kv_scale_name = name.replace(

--- a/vllm/model_executor/models/chatglm.py
+++ b/vllm/model_executor/models/chatglm.py
@@ -399,9 +399,6 @@ class ChatGLMModel(nn.Module, SupportsQuant):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -410,8 +407,6 @@ class ChatGLMModel(nn.Module, SupportsQuant):
                 break
             else:
                 if "rotary_pos_emb.inv_freq" in name:
-                    continue
-                if name.endswith(".bias") and name not in params_dict:
                     continue
                 if is_pp_missing_parameter(name, self):
                     continue

--- a/vllm/model_executor/models/commandr.py
+++ b/vllm/model_executor/models/commandr.py
@@ -369,9 +369,6 @@ class CohereModel(nn.Module):
                 if shard_name not in name:
                     continue
                 name = name.replace(shard_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -379,9 +376,6 @@ class CohereModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/deepseek_eagle.py
+++ b/vllm/model_executor/models/deepseek_eagle.py
@@ -142,10 +142,6 @@ class DeepseekV2Model(nn.Module):
                 else:
                     name = name_mapped
 
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
@@ -168,10 +164,6 @@ class DeepseekV2Model(nn.Module):
                     )
                     break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
-
                     # Remapping the name of FP8 kv-scale.
                     name = maybe_remap_kv_scale_name(name, params_dict)
                     if name is None:

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -293,10 +293,6 @@ class DeepSeekMTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
                 else:
                     name = name_mapped
 
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
@@ -387,10 +383,6 @@ class DeepSeekMTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
                             # We've checked that this is an expert weight
                             # However it's not mapped locally to this rank
                             # So we simply skip it
-                            continue
-
-                        # Skip loading extra bias for GPTQ models.
-                        if name.endswith(".bias") and name not in params_dict:
                             continue
 
                         name = maybe_remap_kv_scale_name(name, params_dict)

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1570,9 +1570,6 @@ class DeepseekV2ForCausalLM(
                     continue
                 else:
                     name = name_mapped
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -1674,10 +1671,6 @@ class DeepseekV2ForCausalLM(
                             # We've checked that this is an expert weight
                             # However it's not mapped locally to this rank
                             # So we simply skip it
-                            continue
-
-                        # Skip loading extra bias for GPTQ models.
-                        if name.endswith(".bias") and name not in params_dict:
                             continue
 
                         # Remapping the name of FP8 kv-scale.

--- a/vllm/model_executor/models/dots1.py
+++ b/vllm/model_executor/models/dots1.py
@@ -451,8 +451,6 @@ class Dots1Model(nn.Module):
                 if ("mlp.experts." in name) and name not in params_dict:
                     continue
                 name = name.replace(weight_name, param_name)
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -480,8 +478,6 @@ class Dots1Model(nn.Module):
                     )
                     break
                 else:
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
                     name = maybe_remap_kv_scale_name(name, params_dict)
                     if name is None:
                         continue

--- a/vllm/model_executor/models/dots_ocr.py
+++ b/vllm/model_executor/models/dots_ocr.py
@@ -378,18 +378,11 @@ class DotsSwiGLUFFN(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)

--- a/vllm/model_executor/models/exaone.py
+++ b/vllm/model_executor/models/exaone.py
@@ -407,9 +407,6 @@ class ExaoneModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -420,9 +417,6 @@ class ExaoneModel(nn.Module):
 
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/exaone4.py
+++ b/vllm/model_executor/models/exaone4.py
@@ -400,9 +400,6 @@ class Exaone4Model(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -413,9 +410,6 @@ class Exaone4Model(nn.Module):
 
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/falcon.py
+++ b/vllm/model_executor/models/falcon.py
@@ -433,9 +433,6 @@ class FalconModel(nn.Module):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
-            # Skip loading extra bias for GPTQ models.
-            if name.endswith(".bias") and name not in params_dict:
-                continue
             if is_pp_missing_parameter(name, self):
                 continue
             param = params_dict[name]

--- a/vllm/model_executor/models/falcon_h1.py
+++ b/vllm/model_executor/models/falcon_h1.py
@@ -646,9 +646,6 @@ class FalconH1ForCausalLM(
                     continue
 
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -657,9 +654,6 @@ class FalconH1ForCausalLM(
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 if self.tie_word_embeddings and "lm_head" in name:

--- a/vllm/model_executor/models/gemma.py
+++ b/vllm/model_executor/models/gemma.py
@@ -341,9 +341,6 @@ class GemmaModel(nn.Module):
                 if shard_name not in name:
                     continue
                 name = name.replace(shard_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -351,9 +348,6 @@ class GemmaModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -346,9 +346,6 @@ class Gemma2Model(nn.Module):
                 if shard_name not in name:
                     continue
                 name = name.replace(shard_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -356,9 +353,6 @@ class Gemma2Model(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -420,9 +420,6 @@ class Gemma3Model(nn.Module):
                 if shard_name not in name:
                     continue
                 name = name.replace(shard_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -430,9 +427,6 @@ class Gemma3Model(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/gemma3n.py
+++ b/vllm/model_executor/models/gemma3n.py
@@ -1073,9 +1073,6 @@ class Gemma3nTextModel(nn.Module, SupportsQuant):
                 if "altup_projections" in name:
                     continue
                 name = name.replace(shard_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -1083,9 +1080,6 @@ class Gemma3nTextModel(nn.Module, SupportsQuant):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -531,9 +531,6 @@ class Glm4MoeModel(nn.Module):
                 if ("mlp.experts." in name) and name not in params_dict:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
 
@@ -582,10 +579,6 @@ class Glm4MoeModel(nn.Module):
                         # We've checked that this is an expert weight
                         # However it's not mapped locally to this rank
                         # So we simply skip it
-                        continue
-
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
                         continue
 
                     # Remapping the name of FP8 kv-scale.

--- a/vllm/model_executor/models/glm4_moe_mtp.py
+++ b/vllm/model_executor/models/glm4_moe_mtp.py
@@ -280,9 +280,6 @@ class Glm4MoeMTP(nn.Module, SupportsPP, Glm4MixtureOfExperts):
                 if ("mlp.experts." in name) and name not in params_dict:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 param = params_dict[name]
                 weight_loader = param.weight_loader
@@ -306,10 +303,6 @@ class Glm4MoeMTP(nn.Module, SupportsPP, Glm4MixtureOfExperts):
                     )
                     break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
-
                     # According to DeepSeek-V3 Technical Report, MTP modules
                     # shares embedding layer. We only load the first weights.
                     if (

--- a/vllm/model_executor/models/gpt_j.py
+++ b/vllm/model_executor/models/gpt_j.py
@@ -271,9 +271,6 @@ class GPTJModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -283,9 +280,6 @@ class GPTJModel(nn.Module):
             else:
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:
-                    continue
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
                     continue
                 if is_pp_missing_parameter(name, self):
                     continue

--- a/vllm/model_executor/models/granite.py
+++ b/vllm/model_executor/models/granite.py
@@ -350,9 +350,6 @@ class GraniteModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -363,9 +360,6 @@ class GraniteModel(nn.Module):
 
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/hunyuan_v1.py
+++ b/vllm/model_executor/models/hunyuan_v1.py
@@ -783,9 +783,6 @@ class HunYuanModel(nn.Module):
                         if cla_factor > 1 and layer_id % cla_factor != 0:
                             continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -809,9 +806,6 @@ class HunYuanModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -834,9 +828,6 @@ class HunYuanModel(nn.Module):
 
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 is_expert_weight = False
                 for mapping in expert_params_mapping:
                     param_name, weight_name, expert_id, shard_id = mapping

--- a/vllm/model_executor/models/internlm2.py
+++ b/vllm/model_executor/models/internlm2.py
@@ -380,9 +380,6 @@ class InternLM2ForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -390,9 +387,6 @@ class InternLM2ForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]

--- a/vllm/model_executor/models/jais2.py
+++ b/vllm/model_executor/models/jais2.py
@@ -405,9 +405,6 @@ class Jais2Model(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -417,9 +414,6 @@ class Jais2Model(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/jamba.py
+++ b/vllm/model_executor/models/jamba.py
@@ -405,9 +405,6 @@ class JambaModel(nn.Module):
                 if "experts" in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -439,9 +436,6 @@ class JambaModel(nn.Module):
                     )
                     break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
                     if is_pp_missing_parameter(name, self):
                         continue
 

--- a/vllm/model_executor/models/keye.py
+++ b/vllm/model_executor/models/keye.py
@@ -820,8 +820,6 @@ class KeyeSiglipVisionModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -829,8 +827,6 @@ class KeyeSiglipVisionModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:
                     continue

--- a/vllm/model_executor/models/kimi_linear.py
+++ b/vllm/model_executor/models/kimi_linear.py
@@ -594,9 +594,6 @@ class KimiLinearForCausalLM(
                 if ("mlp.experts." in name) and name not in params_dict:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]

--- a/vllm/model_executor/models/kimi_vl.py
+++ b/vllm/model_executor/models/kimi_vl.py
@@ -508,9 +508,6 @@ class KimiVLForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
                     if ("mlp.experts." in name) and name not in params_dict:
                         continue
                     name = name.replace(weight_name, param_name)
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
 
                     if is_pp_missing_parameter(name, self):
                         continue
@@ -547,9 +544,6 @@ class KimiVLForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
                     else:
                         use_default_weight_loading = True
             if use_default_weight_loading:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -491,9 +491,6 @@ class LlamaModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -503,10 +500,6 @@ class LlamaModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-
                 if is_pp_missing_parameter(name, self):
                     continue
 

--- a/vllm/model_executor/models/longcat_flash.py
+++ b/vllm/model_executor/models/longcat_flash.py
@@ -708,9 +708,6 @@ class LongcatFlashForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
                         # However it's not mapped locally to this rank
                         # So we simply skip it
                         continue
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
                     # Skip loading kv_scale from ckpts towards new design.
                     if name.endswith(".kv_scale") and name not in params_dict:
                         continue

--- a/vllm/model_executor/models/longcat_flash_mtp.py
+++ b/vllm/model_executor/models/longcat_flash_mtp.py
@@ -238,19 +238,11 @@ class LongCatFlashMTP(nn.Module, SupportsPP):
                 if (param_name == "fused_qkv_a_proj") and name not in params_dict:
                     continue
 
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-
                 # According to DeepSeek-V3 Technical Report, MTP modules
                 # shares embedding layer. We only load the first weights.
                 if (

--- a/vllm/model_executor/models/mamba.py
+++ b/vllm/model_executor/models/mamba.py
@@ -174,9 +174,6 @@ class MambaModel(nn.Module):
         for name, loaded_weight in weights:
             if "A_log" in name:
                 name = name.replace("A_log", "A")
-            # Skip loading extra bias for GPTQ models.
-            if name.endswith(".bias") and name not in params_dict:
-                continue
             if is_pp_missing_parameter(name, self):
                 continue
 

--- a/vllm/model_executor/models/mamba2.py
+++ b/vllm/model_executor/models/mamba2.py
@@ -172,9 +172,6 @@ class Mamba2Model(nn.Module):
             if "A_log" in name:
                 name = name.replace("A_log", "A")
 
-            # Skip loading extra bias for GPTQ models.
-            if name.endswith(".bias") and name not in params_dict:
-                continue
             if is_pp_missing_parameter(name, self):
                 continue
 

--- a/vllm/model_executor/models/mimo.py
+++ b/vllm/model_executor/models/mimo.py
@@ -120,9 +120,6 @@ class MiMoModel(Qwen2Model):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -130,9 +127,6 @@ class MiMoModel(Qwen2Model):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/mimo_mtp.py
+++ b/vllm/model_executor/models/mimo_mtp.py
@@ -220,18 +220,12 @@ class MiMoMTP(nn.Module):
                 if ("mlp.experts." in name) and name not in params_dict:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if "mtp_layers" not in name and (
                     "embed_tokens" not in name and "lm_head" not in name
                 ):

--- a/vllm/model_executor/models/mimo_v2_flash.py
+++ b/vllm/model_executor/models/mimo_v2_flash.py
@@ -626,9 +626,6 @@ class MiMoV2Model(nn.Module):
             if stacked_matched:
                 continue
 
-            if name.endswith(".bias") and name not in params_dict:
-                continue
-
             orig_name = name
             mapped_name = maybe_remap_kv_scale_name(name, params_dict)
             name = mapped_name if mapped_name is not None else orig_name

--- a/vllm/model_executor/models/minicpm.py
+++ b/vllm/model_executor/models/minicpm.py
@@ -512,9 +512,6 @@ class MiniCPMModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -535,9 +532,6 @@ class MiniCPMModel(nn.Module):
                     )
                     break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
                     if is_pp_missing_parameter(name, self):
                         continue
                     param = params_dict[name]

--- a/vllm/model_executor/models/minicpm_eagle.py
+++ b/vllm/model_executor/models/minicpm_eagle.py
@@ -249,9 +249,6 @@ class EagleMiniCPMModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -272,9 +269,6 @@ class EagleMiniCPMModel(nn.Module):
                     )
                     break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
                     if is_pp_missing_parameter(name, self):
                         continue
                     param = params_dict[name]

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -433,9 +433,6 @@ class MiniMaxM2Model(nn.Module):
                 if ("mlp.experts." in name) and name not in params_dict:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -465,10 +462,6 @@ class MiniMaxM2Model(nn.Module):
                     )
                     break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
-
                     # Remapping the name of FP8 kv-scale.
                     name = maybe_remap_kv_scale_name(name, params_dict)
                     if name is None:

--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -233,8 +233,6 @@ class ModernBertModel(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
-            if name.endswith(".bias") and name not in params_dict:
-                continue
             param = params_dict[name]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)

--- a/vllm/model_executor/models/molmo.py
+++ b/vllm/model_executor/models/molmo.py
@@ -772,9 +772,6 @@ class MolmoVisionBackbone(nn.Module, SupportsQuant):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -782,8 +779,6 @@ class MolmoVisionBackbone(nn.Module, SupportsQuant):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -873,8 +868,6 @@ class MolmoModel(nn.Module, SupportsQuant):
         loaded_params: set[str] = set()
 
         for name, loaded_weight in weights:
-            if name.endswith(".bias") and name not in params_dict:
-                continue
             if is_pp_missing_parameter(name, self):
                 continue
 

--- a/vllm/model_executor/models/mpt.py
+++ b/vllm/model_executor/models/mpt.py
@@ -278,9 +278,6 @@ class MPTModel(nn.Module):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
-            # Skip loading extra bias for GPTQ models.
-            if name.endswith(".bias") and name not in params_dict:
-                continue
             if is_pp_missing_parameter(name, self):
                 continue
             param = params_dict[name]

--- a/vllm/model_executor/models/nemotron.py
+++ b/vllm/model_executor/models/nemotron.py
@@ -391,9 +391,6 @@ class NemotronModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -404,9 +401,6 @@ class NemotronModel(nn.Module):
 
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -674,9 +674,6 @@ class NemotronHModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue

--- a/vllm/model_executor/models/nemotron_nas.py
+++ b/vllm/model_executor/models/nemotron_nas.py
@@ -351,9 +351,6 @@ class DeciModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -363,10 +360,6 @@ class DeciModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-
                 if is_pp_missing_parameter(name, self):
                     continue
 

--- a/vllm/model_executor/models/olmo.py
+++ b/vllm/model_executor/models/olmo.py
@@ -316,9 +316,6 @@ class OlmoModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -326,9 +323,6 @@ class OlmoModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]

--- a/vllm/model_executor/models/olmo2.py
+++ b/vllm/model_executor/models/olmo2.py
@@ -362,17 +362,11 @@ class Olmo2Model(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 param = params_dict[name]
                 weight_loader = param.weight_loader  # type: ignore
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)

--- a/vllm/model_executor/models/olmoe.py
+++ b/vllm/model_executor/models/olmoe.py
@@ -365,9 +365,6 @@ class OlmoeModel(nn.Module):
                 if "mlp.experts" in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -398,9 +395,6 @@ class OlmoeModel(nn.Module):
                     )
                     break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
                     # Skip layers on other devices.
                     if is_pp_missing_parameter(name, self):
                         continue

--- a/vllm/model_executor/models/openpangu.py
+++ b/vllm/model_executor/models/openpangu.py
@@ -1209,8 +1209,6 @@ class OpenPanguModel(nn.Module):
             else:
                 if flag_dict["is_expert_weight"]:
                     continue
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name.endswith("e_score_correction_bias"):
                     name = name.replace(

--- a/vllm/model_executor/models/openpangu_mtp.py
+++ b/vllm/model_executor/models/openpangu_mtp.py
@@ -188,10 +188,6 @@ class OpenPanguMTP(nn.Module, SupportsPP):
                 else:
                     name = name_mapped
 
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
@@ -214,10 +210,6 @@ class OpenPanguMTP(nn.Module, SupportsPP):
                     )
                     break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
-
                     if (
                         spec_layer != self.model.mtp_start_layer_idx
                         and ".layers" not in name

--- a/vllm/model_executor/models/opt.py
+++ b/vllm/model_executor/models/opt.py
@@ -339,9 +339,6 @@ class OPTModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -349,9 +346,6 @@ class OPTModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]

--- a/vllm/model_executor/models/orion.py
+++ b/vllm/model_executor/models/orion.py
@@ -293,9 +293,6 @@ class OrionModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -303,9 +300,6 @@ class OrionModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]

--- a/vllm/model_executor/models/ouro.py
+++ b/vllm/model_executor/models/ouro.py
@@ -406,9 +406,6 @@ class OuroModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if name.endswith("scale"):
                     # Remapping the name of FP8 kv-scale.
                     name = maybe_remap_kv_scale_name(name, params_dict)
@@ -422,9 +419,6 @@ class OuroModel(nn.Module):
                     weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/paddleocr_vl.py
+++ b/vllm/model_executor/models/paddleocr_vl.py
@@ -998,8 +998,6 @@ class SiglipVisionModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -1007,8 +1005,6 @@ class SiglipVisionModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:
                     continue

--- a/vllm/model_executor/models/phi.py
+++ b/vllm/model_executor/models/phi.py
@@ -275,9 +275,6 @@ class PhiModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -285,9 +282,6 @@ class PhiModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # pylint: disable=E1136
 
                 if is_pp_missing_parameter(name, self):

--- a/vllm/model_executor/models/phimoe.py
+++ b/vllm/model_executor/models/phimoe.py
@@ -550,9 +550,6 @@ class PhiMoEModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -580,9 +577,6 @@ class PhiMoEModel(nn.Module):
                     )
                     break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
                     # Skip layers on other devices.
                     if is_pp_missing_parameter(name, self):
                         continue

--- a/vllm/model_executor/models/qwen.py
+++ b/vllm/model_executor/models/qwen.py
@@ -306,9 +306,6 @@ class QWenBaseModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -317,9 +314,6 @@ class QWenBaseModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -483,9 +483,6 @@ class Qwen2Model(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 if name.endswith("scale"):
@@ -501,9 +498,6 @@ class Qwen2Model(nn.Module):
                     weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -1065,9 +1065,6 @@ class Qwen3NextModel(nn.Module):
                     continue
 
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -1105,9 +1102,6 @@ class Qwen3NextModel(nn.Module):
                     )
                     break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
                     if is_pp_missing_parameter(name, self):
                         continue
                     if name not in params_dict:

--- a/vllm/model_executor/models/qwen3_next_mtp.py
+++ b/vllm/model_executor/models/qwen3_next_mtp.py
@@ -167,9 +167,6 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
                     continue
 
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -204,9 +201,6 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
                     )
                     break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
-                        continue
                     if is_pp_missing_parameter(name, self):
                         continue
 

--- a/vllm/model_executor/models/seed_oss.py
+++ b/vllm/model_executor/models/seed_oss.py
@@ -392,9 +392,6 @@ class SeedOssModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -402,9 +399,6 @@ class SeedOssModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/solar.py
+++ b/vllm/model_executor/models/solar.py
@@ -376,9 +376,6 @@ class SolarModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 if is_pp_missing_parameter(name, self):
                     continue
@@ -389,9 +386,6 @@ class SolarModel(nn.Module):
 
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:

--- a/vllm/model_executor/models/stablelm.py
+++ b/vllm/model_executor/models/stablelm.py
@@ -282,9 +282,6 @@ class StableLMEpochModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]
@@ -292,9 +289,6 @@ class StableLMEpochModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
                 if is_pp_missing_parameter(name, self):
                     continue
                 param = params_dict[name]

--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -160,17 +160,11 @@ class Base(
         self._output_aux_hidden_states_kwargs: dict[str, bool] = {}
         """Kwargs to pass to model forward for Eagle3 aux hidden states."""
 
-        if self.quant_config:
-            quant_method_name = self.quant_config.get_name()
-            # Check for unsupported quantization methods.
-            if quant_method_name == "mxfp4":
-                raise NotImplementedError(
-                    "Transformers modeling backend does "
-                    "not support MXFP4 quantization yet."
-                )
-            # Skip loading extra bias for GPTQ models.
-            if "gptq" in quant_method_name:
-                self.ignore_unexpected_suffixes.append(".bias")
+        # Check for unsupported quantization methods.
+        if self.quant_config and self.quant_config.get_name() == "mxfp4":
+            raise NotImplementedError(
+                "Transformers modeling backend does not support MXFP4 quantization yet."
+            )
 
         # Set correct attn and init on "meta" to delay allocating GPU tensors
         self.text_config._attn_implementation = "vllm"
@@ -485,7 +479,6 @@ class Base(
             skip_prefixes=self.skip_prefixes,
             skip_substrs=self.skip_substrs,
             ignore_unexpected_prefixes=self.ignore_unexpected_prefixes,
-            ignore_unexpected_suffixes=self.ignore_unexpected_suffixes,
         )
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -151,6 +151,13 @@ class AutoWeightsLoader:
         # update default skip_substrs
         self.skip_substrs += self.ROTARY_EMBEDS_UNUSED_WEIGHTS
 
+        # Skip loading extra bias for GPTQ models.
+        quant_config = getattr(module, "quant_config", None)
+        if quant_config and "gptq" in quant_config.get_name():
+            for suffix in [".bias", "_bias"]:
+                if suffix not in self.ignore_unexpected_suffixes:
+                    self.ignore_unexpected_suffixes.append(suffix)
+
     def _groupby_prefix(
         self,
         weights: Iterable[tuple[str, torch.Tensor]],

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -652,19 +652,12 @@ class WhisperModel(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
 
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)


### PR DESCRIPTION
Some variation of

```py
# Skip loading extra bias for GPTQ models.
if name.endswith(".bias") and name not in params_dict:
    continue
```

Is repeated in pretty much every model that tries to support GPTQ.

This PR allows us to remove all of them in place of:


```py
class AutoWeightsLoader:
    ...
    def __init__(...):
        ...
        # Skip loading extra bias for GPTQ models.
        quant_config = getattr(module, "quant_config", None)
        if quant_config and "gptq" in quant_config.get_name():
            for suffix in [".bias", "_bias"]:
                if suffix not in self.ignore_unexpected_suffixes:
                    self.ignore_unexpected_suffixes.append(suffix)
```

[Quantized Models Test](https://buildkite.com/vllm/ci/builds/45338/steps/canvas?sid=019b8099-78f5-43c4-bfeb-732acff639fb&open=false) has been triggered to verify that this works.