### PR TITLE
[Bugfix][Hardware][AMD] Narrow broad exception in AITER scaled MM import

### DIFF
--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/aiter.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/aiter.py
@@ -32,7 +32,7 @@ class AiterScaledMMLinearKernel(CutlassScaledMMLinearKernel):
 
         try:
             import aiter  # noqa: F401 # deliberately attempt to import aiter
-        except Exception:
+        except ImportError:
             return (
                 False,
                 "AiterScaledMMLinearKernel requires `aiter` which is not "


### PR DESCRIPTION
## Summary

Narrows the exception handling in the AITER scaled MM kernel's `is_supported()` method from catching all `Exception` types to only catching `ImportError`.

## Problem

The current code uses `except Exception:` which is too broad and can mask programming errors like `AttributeError`, `TypeError`, or other unexpected exceptions that should propagate for debugging.

## Solution

Replace `except Exception:` with `except ImportError:` since the try block is specifically checking if the `aiter` module can be imported. An `ImportError` is the only expected exception when the module is not installed.

## Changes

- `vllm/model_executor/layers/quantization/kernels/scaled_mm/aiter.py`: Line 35, narrowed exception type

## Test Plan

- [x] Syntax validation passes
- [ ] Existing AITER tests should pass (requires ROCm hardware)

## ROCm Impact

This is an AITER-specific fix that improves error handling for ROCm's scaled MM quantization kernels.