### PR TITLE
[Bugfix] Narrow broad exceptions in FLA shared memory detection

### DIFF
--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -166,7 +166,7 @@ def get_all_max_shared_mem():
             ]
             for i in range(device_torch_lib.device_count())
         ]
-    except BaseException:
+    except (RuntimeError, AttributeError, TypeError, KeyError):
         return [-1]
 
 
@@ -190,5 +190,5 @@ def check_shared_mem(arch: str = "none", tensor_idx: int = 0) -> bool:
         device_shared_mem_list = get_all_max_shared_mem()
         max_shared_memory = device_shared_mem_list[tensor_idx]
         return max_shared_memory >= Backend.get_shared_memory(arch)
-    except Exception:
+    except (IndexError, TypeError):
         return False


### PR DESCRIPTION
## Summary

This PR narrows overly broad exception handling in the FLA (Flash Linear Attention) shared memory detection utilities.

### Changes

**`vllm/model_executor/layers/fla/ops/utils.py`:**

1. **`get_all_max_shared_mem()` (line 169):** Changed `except BaseException:` to `except (RuntimeError, AttributeError, TypeError, KeyError):` - These are the specific exceptions that can occur when accessing Triton driver properties.

2. **`check_shared_mem()` (line 193):** Changed `except Exception:` to `except (IndexError, TypeError):` - These are the specific exceptions from array indexing operations.

### Why This Matters

Broad exception handlers like `except BaseException:` and `except Exception:` can:
- Mask programming errors and unexpected conditions
- Catch system-exiting exceptions (`KeyboardInterrupt`, `SystemExit`) unintentionally
- Make debugging harder by silently swallowing unrelated errors

### Testing

- These are defensive error handlers for hardware capability detection
- The narrowed exceptions cover all expected failure modes
- No functional change to normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)