### PR TITLE
[Bugfix] Narrow broad exceptions in quick allreduce availability check

### DIFF
--- a/vllm/distributed/device_communicators/quick_all_reduce.py
+++ b/vllm/distributed/device_communicators/quick_all_reduce.py
@@ -20,7 +20,7 @@ logger = init_logger(__name__)
 try:
     ops.qr_max_size()
     quick_ar = True
-except Exception:
+except (RuntimeError, AttributeError):
     # For CPUs and CUDA
     quick_ar = False
 
@@ -229,7 +229,7 @@ class QuickAllReduce:
             gcn_arch = getattr(props, "gcnArchName", "")
             supported_archs = ["gfx94", "gfx95"]
             return any(gfx in gcn_arch for gfx in supported_archs)
-        except Exception as e:
+        except (RuntimeError, AttributeError) as e:
             logger.warning("Failed to determine ROCm for quick allreduce: %s", e)
             return False
 


### PR DESCRIPTION
## Summary

This PR narrows overly broad exception handling in the Quick AllReduce device communicator.

### Changes

**`vllm/distributed/device_communicators/quick_all_reduce.py`:**

1. **Module-level check (line 23):** Changed `except Exception:` to `except (RuntimeError, AttributeError):` for checking `ops.qr_max_size()` availability.

2. **`_rocm_arch_available()` (line 232):** Changed `except Exception as e:` to `except (RuntimeError, AttributeError) as e:` for device properties access.

### Why This Matters

These are the specific exceptions that can occur when:
- Custom ops are not available (`AttributeError`)
- Device/driver access fails (`RuntimeError`)

Broad exception handlers like `except Exception:` can:
- Mask programming errors and unexpected conditions
- Catch system-exiting exceptions unintentionally
- Make debugging harder by silently swallowing unrelated errors

### Testing

- These are defensive error handlers for hardware capability detection
- The narrowed exceptions cover all expected failure modes
- No functional change to normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)