### PR TITLE
[Bugfix] Add missing extra_tensors arg to DeviceCommunicatorBase.disp…

### DIFF
--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -285,6 +285,7 @@ class DeviceCommunicatorBase:
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
         is_sequence_parallel: bool = False,
+        extra_tensors: list[torch.Tensor] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Dispatch the hidden states and router logits to the appropriate device.

--- a/vllm/distributed/device_communicators/xpu_communicator.py
+++ b/vllm/distributed/device_communicators/xpu_communicator.py
@@ -23,11 +23,11 @@ class XpuCommunicator(DeviceCommunicatorBase):
     ):
         super().__init__(cpu_group, device, device_group, unique_name)
         if self.use_all2all:
-            if self.all2all_backend != "naive":
+            if self.all2all_backend != "naive":  # type: ignore[has-type]
                 logger.warning(
                     "`%s` all2all manager is not supported on XPU. "
                     "Falling back to `naive` all2all manager for XPU.",
-                    self.all2all_backend,
+                    self.all2all_backend,  # type: ignore[has-type]
                 )
                 self.all2all_backend = "naive"
             if self.all2all_backend == "naive":
@@ -78,12 +78,15 @@ class XpuCommunicator(DeviceCommunicatorBase):
         hidden_states: torch.Tensor,
         router_logits: torch.Tensor,
         is_sequence_parallel: bool = False,
+        extra_tensors: list[torch.Tensor] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         assert self.all2all_manager is not None
-        hidden_states, router_logits = self.all2all_manager.dispatch(
-            hidden_states, router_logits, is_sequence_parallel
+        return self.all2all_manager.dispatch(
+            hidden_states,
+            router_logits,
+            is_sequence_parallel,
+            extra_tensors,  # type: ignore[call-arg]
         )
-        return hidden_states, router_logits
 
     def combine(
         self, hidden_states: torch.Tensor, is_sequence_parallel: bool = False


### PR DESCRIPTION
## Purpose

Fix https://github.com/vllm-project/vllm/issues/31642.

This bug occurs with **MoE** models and **dp > 1** on the **CPU backend** or other backends that do not implement dispatch().

Reason:

The DeviceCommunicatorBase.dispatch method was missing the `extra_tensors`
argument in its signature, causing a signature mismatch (TypeError) when
called from fused_moe/layer.py. 

This fix aligns the base class signature with the caller and other
communicator implementations, resolving the crash observed when running
MoE models with data parallelism on CPU Backend or other backends which don't implemented dispatch().

## Test Plan

`vllm serve "Qwen/Qwen1.5-MoE-A2.7B-Chat" -dp 2 --enforce-eager`

## Test Result

The service can start successfully.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
