### PR TITLE
[Bugfix] Fix torch.compile error for DP + MoE on CPU Backend

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1899,11 +1899,11 @@ class FusedMoE(CustomOp):
                 )
 
                 post_quant_allgather = (
-                    has_flashinfer_trtllm_fused_moe()
-                    and self.quant_method is not None
+                    self.quant_method is not None
                     and self.dp_size > 1
                     and self.use_ep
                     and isinstance(self.quant_method, ModelOptNvFp4FusedMoE)
+                    and has_flashinfer_trtllm_fused_moe()
                 )
                 if post_quant_allgather:
                     hidden_states_to_dispatch, extra_tensors = (


### PR DESCRIPTION
## Purpose

Fix https://github.com/vllm-project/vllm/issues/31648 (torch.compile fails for MoE models on CPU backend with `-dp 2`).

Fix the error by reordering `has_flashinfer_trtllm_fused_moe()` in post_quant_allgather.



## Test Plan

`vllm serve "Qwen/Qwen1.5-MoE-A2.7B-Chat" -dp 2`

## Test Result

The service can start successfully.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
