### PR TITLE
[Bug Fix]: Require explicit --dataset-name to avoid migration confusion

### DIFF
--- a/tests/benchmarks/test_serve_cli.py
+++ b/tests/benchmarks/test_serve_cli.py
@@ -28,6 +28,8 @@ def test_bench_serve(server):
         server.host,
         "--port",
         str(server.port),
+        "--dataset-name",
+        "random",
         "--input-len",
         "32",
         "--output-len",

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -11,7 +11,7 @@ On the client side, run:
         --backend <backend or endpoint type. Default 'openai'> \
         --label <benchmark result label. Default using backend> \
         --model <your_model. Optional, defaults to first model from server> \
-        --dataset-name <dataset_name. Default 'random'> \
+        --dataset-name <dataset_name. Required> \
         --input-len <general input length. Optional, maps to dataset-specific args> \
         --output-len <general output length. Optional, maps to dataset-specific args> \
         --request-rate <request_rate. Default inf> \
@@ -999,6 +999,10 @@ def save_to_pytorch_benchmark_format(
 
 def add_cli_args(parser: argparse.ArgumentParser):
     add_dataset_parser(parser)
+    # Override the default dataset-name to None (required) for vllm bench serve
+    # to avoid silent behavior differences from the deprecated benchmark_serving.py
+    # which defaulted to 'sharegpt'. See issue #24684.
+    parser.set_defaults(dataset_name=None)
     parser.add_argument(
         "--label",
         type=str,


### PR DESCRIPTION
## Summary
- Fixes #24684
- Requires explicit `--dataset-name` for `vllm bench serve` only
- Does NOT break other scripts that use `add_dataset_parser` (like `spec_decode.py`)

## Changes
1. **vllm/benchmarks/serve.py**: Use `parser.set_defaults(dataset_name=None)` to override default
2. **tests/benchmarks/test_serve_cli.py**: Explicitly specify `--dataset-name random`

## Root Cause
The old `benchmark_serving.py` defaulted to `sharegpt`, but `vllm bench serve` inherited the shared default of `random` from `add_dataset_parser`. This caused ~5x difference in input tokens when users migrated.

## Solution
Instead of modifying the shared `add_dataset_parser` function (which would break `examples/offline_inference/spec_decode.py`), we override the default specifically for `vllm bench serve`:

```python
def add_cli_args(parser):
    add_dataset_parser(parser)
    parser.set_defaults(dataset_name=None)  # Require explicit choice
```

This approach:
1. Only affects `vllm bench serve` command
2. Other scripts using `add_dataset_parser` continue to work with default `random`
3. Leverages existing validation at `serve.py:1414`

## Test Plan
- [x] Existing tests updated to explicitly specify dataset-name
- [x] Pre-commit checks pass (ruff, typos, formatting)
- [x] Codex review confirmed solution doesn't break spec_decode.py