### PR TITLE
[perf]skip embedding check if have computed

### DIFF
--- a/vllm/distributed/ec_transfer/ec_connector/base.py
+++ b/vllm/distributed/ec_transfer/ec_connector/base.py
@@ -185,12 +185,14 @@ class ECConnectorBase(ABC):
     def has_caches(
         self,
         request: "Request",
-    ) -> list[bool]:
+        index: int | None = None,
+    ) -> bool | list[bool]:
         """
         Check if encoder cache exists for each mm data of requests
 
         Args:
             request (Request): the request object.
+            index(int | None): The index of mm data to check.
 
         Returns:
             A list bool where ith value is True if cache exist for

--- a/vllm/distributed/ec_transfer/ec_connector/example_connector.py
+++ b/vllm/distributed/ec_transfer/ec_connector/example_connector.py
@@ -123,16 +123,21 @@ class ECExampleConnector(ECConnectorBase):
     def has_caches(
         self,
         request: "Request",
-    ) -> list[bool]:
+        index: int | None = None,
+    ) -> bool | list[bool]:
         """
         Check if cache exist externally for each mm_data of request
 
         Args:
             request (Request): the request object.
+            index(int | None): The index of mm data to check.
 
         Returns:
             List of bool indicate that ith mm_data exist in cache or not
         """
+        if index is not None:
+            return self._found_match_for_mm_data(request.mm_features[index].identifier)
+
         result = []
         for feature in request.mm_features:
             result.append(self._found_match_for_mm_data(feature.identifier))

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -909,9 +909,6 @@ class Scheduler(SchedulerInterface):
         assert len(mm_features) > 0
         external_load_encoder_input = []
 
-        # Check remote cache first
-        if self.ec_connector is not None:
-            remote_cache_has_item = self.ec_connector.has_caches(request)
         # NOTE: since scheduler operates on the request level (possibly with
         # multiple encoder inputs per request), we need to create temporary
         # trackers for accounting at the encoder input level.
@@ -1014,7 +1011,9 @@ class Scheduler(SchedulerInterface):
             if curr_embeds_end - curr_embeds_start == 0:
                 continue
 
-            if self.ec_connector is not None and remote_cache_has_item[i]:
+            if self.ec_connector is not None and self.ec_connector.has_caches(
+                request, i
+            ):
                 mm_hashes_to_schedule.add(request.mm_features[i].identifier)
                 external_load_encoder_input.append(i)
                 num_embeds_to_schedule += num_encoder_embeds


### PR DESCRIPTION
## Purpose
skip the embedding check if it have computed in HBM

## Test Plan
compare TPOT before and after the optimization
## Test Result
before optimization:
```
╒══════════════════════════╤═════════╤════════════════╤═══════════════╤═════════════════╤═══════════════╤═══════════════╤════════════════╤═════════════════╤═════╕
│ Performance Parameters   │ Stage   │ Average        │ Min           │ Max             │ Median        │ P75           │ P90            │ P99             │  N  │ 
╞══════════════════════════╪═════════╪════════════════╪═══════════════╪═════════════════╪═══════════════╪═══════════════╪════════════════╪═════════════════╪═════╡
│ E2EL                     │ total   │ 100711.789 ms  │ 14172.9246 ms │ 228017.5781 ms  │ 99316.7265 ms │ 124687.098 ms │ 161772.0773 ms │ 211895.186 ms   │ 200 │ 
├──────────────────────────┼─────────┼────────────────┼───────────────┼─────────────────┼───────────────┼───────────────┼────────────────┼─────────────────┼─────┤
│ TTFT                     │ total   │ 751.4103 ms    │ 270.1385 ms   │ 2113.4006 ms    │ 660.5894 ms   │ 857.885 ms    │ 1284.7753 ms   │ 1862.229 ms     │ 200 │ 
├──────────────────────────┼─────────┼────────────────┼───────────────┼─────────────────┼───────────────┼───────────────┼────────────────┼─────────────────┼─────┤
│ TPOT                     │ total   │ 176.7507 ms    │ 52.4575 ms    │ 252.5558 ms     │ 184.0085 ms   │ 204.4603 ms   │ 235.4305 ms    │ 250.5656 ms     │ 200 │
├──────────────────────────┼─────────┼────────────────┼───────────────┼─────────────────┼───────────────┼───────────────┼────────────────┼─────────────────┼─────┤
│ ITL                      │ total   │ 175.0263 ms    │ 0.057 ms      │ 1018.0525 ms    │ 185.0799 ms   │ 223.5024 ms   │ 247.7204 ms    │ 357.2093 ms     │ 200 │
├──────────────────────────┼─────────┼────────────────┼───────────────┼─────────────────┼───────────────┼───────────────┼────────────────┼─────────────────┼─────┤
│ InputTokens              │ total   │ 76.0           │ 76.0          │ 76.0            │ 76.0          │ 76.0          │ 76.0           │ 76.0            │ 200 │
├──────────────────────────┼─────────┼────────────────┼───────────────┼─────────────────┼───────────────┼───────────────┼────────────────┼─────────────────┼─────┤
│ OutputTokens             │ total   │ 577.4          │ 254.0         │ 1307.0          │ 523.0         │ 674.25        │ 932.0          │ 1307.0          │ 200 │
├──────────────────────────┼─────────┼────────────────┼───────────────┼─────────────────┼───────────────┼───────────────┼────────────────┼─────────────────┼─────┤
│ OutputTokenThroughput    │ total   │ 6.1729 token/s │ 3.921 token/s │ 17.9215 token/s │ 5.409 token/s │ 6.818 token/s │ 8.8494 token/s │ 15.7632 token/s │ 200 │
╘══════════════════════════╧═════════╧════════════════╧═══════════════╧═════════════════╧═══════════════╧═══════════════╧════════════════╧═════════════════╧═════╛
╒══════════════════════════╤═════════╤══════════════════╕
│ Common Metric            │ Stage   │ Value            │
╞══════════════════════════╪═════════╪══════════════════╡
│ Benchmark Duration       │ total   │ 283470.4482 ms   │
├──────────────────────────┼─────────┼──────────────────┤
│ Total Requests           │ total   │ 200              │
├──────────────────────────┼─────────┼──────────────────┤
│ Failed Requests          │ total   │ 0                │
├──────────────────────────┼─────────┼──────────────────┤
│ Success Requests         │ total   │ 200              │
├──────────────────────────┼─────────┼──────────────────┤
│ Concurrency              │ total   │ 71.0563          │
├──────────────────────────┼─────────┼──────────────────┤
│ Max Concurrency          │ total   │ 128              │
├──────────────────────────┼─────────┼──────────────────┤
│ Request Throughput       │ total   │ 0.7055 req/s     │
├──────────────────────────┼─────────┼──────────────────┤
│ Total Input Tokens       │ total   │ 15200            │
├──────────────────────────┼─────────┼──────────────────┤
│ Prefill Token Throughput │ total   │ 101.1431 token/s │
├──────────────────────────┼─────────┼──────────────────┤
│ Total generated tokens   │ total   │ 115480           │
├──────────────────────────┼─────────┼──────────────────┤
│ Input Token Throughput   │ total   │ 53.6211 token/s  │
├──────────────────────────┼─────────┼──────────────────┤
│ Output Token Throughput  │ total   │ 407.3793 token/s │
├──────────────────────────┼─────────┼──────────────────┤
│ Total Token Throughput   │ total   │ 461.0004 token/s │
╘══════════════════════════╧═════════╧══════════════════╛
```
after optimization：
```
╒══════════════════════════╤═════════╤═════════════════╤════════════════╤═════════════════╤════════════════╤═════════════════╤═════════════════╤═════════════════╤═════╕
│ Performance Parameters   │ Stage   │ Average         │ Min            │ Max             │ Median         │ P75             │ P90             │ P99             │  N  │
╞══════════════════════════╪═════════╪═════════════════╪════════════════╪═════════════════╪════════════════╪═════════════════╪═════════════════╪═════════════════╪═════╡
│ E2EL                     │ total   │ 56957.2038 ms   │ 12018.6378 ms  │ 147351.8039 ms  │ 54159.122 ms   │ 68348.4692 ms   │ 95725.9316 ms   │ 138444.7409 ms  │ 200 │
├──────────────────────────┼─────────┼─────────────────┼────────────────┼─────────────────┼────────────────┼─────────────────┼─────────────────┼─────────────────┼─────┤
│ TTFT                     │ total   │ 737.6238 ms     │ 332.8636 ms    │ 2571.7694 ms    │ 623.2919 ms    │ 838.2107 ms     │ 1269.7055 ms    │ 2018.9223 ms    │ 200 │
├──────────────────────────┼─────────┼─────────────────┼────────────────┼─────────────────┼────────────────┼─────────────────┼─────────────────┼─────────────────┼─────┤
│ TPOT                     │ total   │ 98.4476 ms      │ 44.9611 ms     │ 124.1914 ms     │ 105.8954 ms    │ 116.6295 ms     │ 121.1654 ms     │ 123.2059 ms     │ 200 │
├──────────────────────────┼─────────┼─────────────────┼────────────────┼─────────────────┼────────────────┼─────────────────┼─────────────────┼─────────────────┼─────┤
│ ITL                      │ total   │ 99.0582 ms      │ 0.0097 ms      │ 921.732 ms      │ 100.7418 ms    │ 110.3601 ms     │ 142.651 ms      │ 336.1363 ms     │ 200 │
├──────────────────────────┼─────────┼─────────────────┼────────────────┼─────────────────┼────────────────┼─────────────────┼─────────────────┼─────────────────┼─────┤
│ InputTokens              │ total   │ 76.0            │ 76.0           │ 76.0            │ 76.0           │ 76.0            │ 76.0            │ 76.0            │ 200 │
├──────────────────────────┼─────────┼─────────────────┼────────────────┼─────────────────┼────────────────┼─────────────────┼─────────────────┼─────────────────┼─────┤
│ OutputTokens             │ total   │ 577.4           │ 254.0          │ 1307.0          │ 523.0          │ 674.25          │ 932.0           │ 1307.0          │ 200 │
├──────────────────────────┼─────────┼─────────────────┼────────────────┼─────────────────┼────────────────┼─────────────────┼─────────────────┼─────────────────┼─────┤
│ OutputTokenThroughput    │ total   │ 10.6926 token/s │ 7.7227 token/s │ 21.2576 token/s │ 9.3178 token/s │ 11.8457 token/s │ 15.9361 token/s │ 20.3961 token/s │ 200 │
╘══════════════════════════╧═════════╧═════════════════╧════════════════╧═════════════════╧════════════════╧═════════════════╧═════════════════╧═════════════════╧═════╛
╒══════════════════════════╤═════════╤══════════════════╕
│ Common Metric            │ Stage   │ Value            │
╞══════════════════════════╪═════════╪══════════════════╡
│ Benchmark Duration       │ total   │ 249480.8694 ms   │
├──────────────────────────┼─────────┼──────────────────┤
│ Total Requests           │ total   │ 200              │
├──────────────────────────┼─────────┼──────────────────┤
│ Failed Requests          │ total   │ 0                │
├──────────────────────────┼─────────┼──────────────────┤
│ Success Requests         │ total   │ 200              │
├──────────────────────────┼─────────┼──────────────────┤
│ Concurrency              │ total   │ 45.6606          │
├──────────────────────────┼─────────┼──────────────────┤
│ Max Concurrency          │ total   │ 128              │
├──────────────────────────┼─────────┼──────────────────┤
│ Request Throughput       │ total   │ 0.8017 req/s     │
├──────────────────────────┼─────────┼──────────────────┤
│ Total Input Tokens       │ total   │ 15200            │
├──────────────────────────┼─────────┼──────────────────┤
│ Prefill Token Throughput │ total   │ 103.0336 token/s │
├──────────────────────────┼─────────┼──────────────────┤
│ Total generated tokens   │ total   │ 115480           │
├──────────────────────────┼─────────┼──────────────────┤
│ Input Token Throughput   │ total   │ 60.9265 token/s  │
├──────────────────────────┼─────────┼──────────────────┤
│ Output Token Throughput  │ total   │ 462.8812 token/s │
├──────────────────────────┼─────────┼──────────────────┤
│ Total Token Throughput   │ total   │ 523.8077 token/s │
╘══════════════════════════╧═════════╧══════════════════╛
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

