### PR TITLE
[FixBug] Improve exception string in `tensorizer.py`

### DIFF
--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -764,7 +764,7 @@ def tensorize_lora_adapter(lora_path: str, tensorizer_config: TensorizerConfig):
     elif tensor_path.endswith(".bin"):
         tensors = torch.load(tensor_path)
     else:
-        raise ValueError("Unsupported file: %s", tensor_path)
+        raise ValueError(f"Unsupported file: {tensor_path}")
 
     with open(config_path) as f:
         config = json.load(f)

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -764,7 +764,10 @@ def tensorize_lora_adapter(lora_path: str, tensorizer_config: TensorizerConfig):
     elif tensor_path.endswith(".bin"):
         tensors = torch.load(tensor_path)
     else:
-        raise ValueError(f"Unsupported adapter model file: {tensor_path}. Must be a .safetensors or .bin file.")
+        raise ValueError(
+            f"Unsupported adapter model file: {tensor_path}. "
+            f"Must be a .safetensors or .bin file."
+        )
 
     with open(config_path) as f:
         config = json.load(f)

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -764,7 +764,7 @@ def tensorize_lora_adapter(lora_path: str, tensorizer_config: TensorizerConfig):
     elif tensor_path.endswith(".bin"):
         tensors = torch.load(tensor_path)
     else:
-        raise ValueError(f"Unsupported file: {tensor_path}")
+        raise ValueError(f"Unsupported adapter model file: {tensor_path}. Must be a .safetensors or .bin file.")
 
     with open(config_path) as f:
         config = json.load(f)


### PR DESCRIPTION

## Purpose

Fix a bug where ValueError was called with argument, which causes the error message to be displayed as a raw tuple instead of a formatted string.
### Changes
Convert ValueError("msg %s", arg) to ValueError(f"msg {arg}") in `tensorizer.py.`

## Test Plan
None
## Test Result
None

