### PR TITLE
[Core] Add optional flags to check for repetitive token patterns in engine output

### DIFF
--- a/tests/v1/core/test_repetition_detection.py
+++ b/tests/v1/core/test_repetition_detection.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.utils import check_sequence_repetition, check_stop
+from vllm.v1.request import Request, RequestStatus
+
+pytestmark = pytest.mark.cpu_test
+
+# ============================================================================
+# UNIT TESTS - check_sequence_repetition function
+# ============================================================================
+
+
+class TestCheckSequenceRepetition:
+    """Unit tests for the check_sequence_repetition function"""
+
+    def test_simple_repetition_detected(self):
+        """Test detection of simple repetitive patterns"""
+        token_ids = [1, 2, 3, 1, 2, 3, 1, 2, 3]
+        assert check_sequence_repetition(
+            token_ids,
+            max_repetition_pattern_size=3,
+            min_repetition_pattern_size=2,
+            repetition_min_count=3,
+        )
+
+    def test_repetition_below_min_count(self):
+        """Test that pattern below min_count is not detected"""
+        token_ids = [1, 2, 3, 1, 2, 3]
+        assert not check_sequence_repetition(
+            token_ids,
+            max_repetition_pattern_size=3,
+            min_repetition_pattern_size=2,
+            repetition_min_count=3,
+        )
+
+    def test_two_token_pattern(self):
+        """Test detection of 2-token patterns"""
+        token_ids = [1, 2, 1, 2, 1, 2, 1, 2]
+        assert check_sequence_repetition(
+            token_ids,
+            max_repetition_pattern_size=5,
+            min_repetition_pattern_size=2,
+            repetition_min_count=4,
+        )
+
+    def test_no_repetition_varied_sequence(self):
+        """Test that non-repetitive sequences are not flagged"""
+        token_ids = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        assert not check_sequence_repetition(
+            token_ids,
+            max_repetition_pattern_size=5,
+            min_repetition_pattern_size=2,
+            repetition_min_count=2,
+        )
+
+    def test_partial_repetition_not_detected(self):
+        """Test that incomplete repetitions are not detected"""
+        token_ids = [1, 2, 3, 1, 2, 3, 1, 2, 4]
+        assert not check_sequence_repetition(
+            token_ids,
+            max_repetition_pattern_size=3,
+            min_repetition_pattern_size=2,
+            repetition_min_count=3,
+        )
+
+    def test_empty_token_list(self):
+        """Test with empty token list"""
+        assert not check_sequence_repetition(
+            [],
+            max_repetition_pattern_size=3,
+            min_repetition_pattern_size=2,
+            repetition_min_count=2,
+        )
+
+    def test_detection_disabled_max_size_zero(self):
+        """Test that zero max_pattern_size disables detection"""
+        token_ids = [1, 2, 1, 2, 1, 2]
+        assert not check_sequence_repetition(
+            token_ids,
+            max_repetition_pattern_size=0,
+            min_repetition_pattern_size=2,
+            repetition_min_count=2,
+        )
+
+    def test_invalid_min_count(self):
+        """Test that min_count < 2 returns False"""
+        token_ids = [1, 2, 1, 2]
+        assert not check_sequence_repetition(
+            token_ids,
+            max_repetition_pattern_size=3,
+            min_repetition_pattern_size=2,
+            repetition_min_count=1,
+        )
+
+    def test_repetition_at_end_of_sequence(self):
+        """Test detection when repetition occurs at the end"""
+        token_ids = [1, 2, 3, 4, 5, 6, 5, 6, 5, 6]
+        assert check_sequence_repetition(
+            token_ids,
+            max_repetition_pattern_size=3,
+            min_repetition_pattern_size=2,
+            repetition_min_count=3,
+        )
+
+    def test_large_pattern_many_repetitions(self):
+        """Test large pattern repeated many times"""
+        token_ids = [1, 2, 3, 4, 5, 6, 7, 8] * 5
+        assert check_sequence_repetition(
+            token_ids,
+            max_repetition_pattern_size=10,
+            min_repetition_pattern_size=2,
+            repetition_min_count=3,
+        )
+
+
+# ============================================================================
+# INTEGRATION TESTS - check_stop with repetition detection
+# ============================================================================
+
+
+class TestRepetitionDetectionIntegration:
+    """Integration tests for repetition detection in check_stop"""
+
+    def test_basic_repetition_stops_generation(self):
+        """Test that repetition is detected and stops generation"""
+        params = SamplingParams(
+            max_tokens=100,
+            max_repetition_pattern_size=5,
+            min_repetition_pattern_size=2,
+            repetition_min_count=3,
+        )
+        request = Request(
+            request_id="test",
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=params,
+            pooling_params=None,
+            eos_token_id=0,
+        )
+        request.append_output_token_ids([10, 20, 10, 20, 10, 20])
+        assert check_stop(request, max_model_len=1024)
+        assert request.status == RequestStatus.FINISHED_REPETITION
+        assert request.stop_reason == "repetition_detected"
+
+    def test_detection_disabled_no_stop(self):
+        """Test that disabled detection doesn't stop generation"""
+        params = SamplingParams(
+            max_tokens=100,
+            max_repetition_pattern_size=0,
+            min_repetition_pattern_size=0,
+            repetition_min_count=0,
+        )
+        request = Request(
+            request_id="test",
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=params,
+            pooling_params=None,
+            eos_token_id=0,
+        )
+        request.append_output_token_ids([10, 20, 10, 20, 10, 20])
+        assert not check_stop(request, max_model_len=1024)
+
+    def test_repetition_respects_min_tokens(self):
+        """Test that repetition detection respects min_tokens"""
+        params = SamplingParams(
+            min_tokens=10,
+            max_tokens=100,
+            max_repetition_pattern_size=5,
+            min_repetition_pattern_size=2,
+            repetition_min_count=3,
+        )
+        request = Request(
+            request_id="test",
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=params,
+            pooling_params=None,
+            eos_token_id=0,
+        )
+        request.append_output_token_ids([10, 20, 10, 20, 10, 20])
+        assert not check_stop(request, max_model_len=1024)
+
+    def test_no_repetition_continues_generation(self):
+        """Test that non-repetitive tokens don't stop generation"""
+        params = SamplingParams(
+            max_tokens=100,
+            max_repetition_pattern_size=5,
+            min_repetition_pattern_size=2,
+            repetition_min_count=3,
+        )
+        request = Request(
+            request_id="test",
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=params,
+            pooling_params=None,
+            eos_token_id=0,
+        )
+        request.append_output_token_ids([10, 20, 30, 40, 50, 60])
+        assert not check_stop(request, max_model_len=1024)
+
+    def test_pattern_at_size_boundary(self):
+        """Test detection at exact pattern size boundary"""
+        params = SamplingParams(
+            max_tokens=100,
+            max_repetition_pattern_size=3,
+            min_repetition_pattern_size=3,
+            repetition_min_count=2,
+        )
+        request = Request(
+            request_id="test",
+            prompt_token_ids=[1, 2],
+            sampling_params=params,
+            pooling_params=None,
+            eos_token_id=0,
+        )
+        request.append_output_token_ids([10, 20, 30, 10, 20, 30])
+        assert check_stop(request, max_model_len=1024)
+        assert request.status == RequestStatus.FINISHED_REPETITION
+
+    def test_multiple_pattern_sizes_checked(self):
+        """Test that function checks pattern sizes in range"""
+        params = SamplingParams(
+            max_tokens=100,
+            max_repetition_pattern_size=5,
+            min_repetition_pattern_size=2,
+            repetition_min_count=3,
+        )
+        request = Request(
+            request_id="test",
+            prompt_token_ids=[1],
+            sampling_params=params,
+            pooling_params=None,
+            eos_token_id=0,
+        )
+        request.append_output_token_ids([7, 8, 9, 10, 7, 8, 9, 10, 7, 8, 9, 10])
+        assert check_stop(request, max_model_len=1024)
+        assert request.status == RequestStatus.FINISHED_REPETITION
+
+    def test_eos_takes_precedence_over_repetition(self):
+        """Test that EOS token stops before repetition check"""
+        params = SamplingParams(
+            max_tokens=100,
+            max_repetition_pattern_size=5,
+            min_repetition_pattern_size=2,
+            repetition_min_count=3,
+        )
+        request = Request(
+            request_id="test",
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=params,
+            pooling_params=None,
+            eos_token_id=999,
+        )
+        request.append_output_token_ids([10, 20, 10, 20, 999])
+        assert check_stop(request, max_model_len=1024)
+        assert request.status == RequestStatus.FINISHED_STOPPED
+
+    def test_min_pattern_size_filters_small_patterns(self):
+        """Test that min_pattern_size filters out smaller patterns"""
+        params = SamplingParams(
+            max_tokens=100,
+            max_repetition_pattern_size=5,
+            min_repetition_pattern_size=3,
+            repetition_min_count=3,
+        )
+        request = Request(
+            request_id="test",
+            prompt_token_ids=[1],
+            sampling_params=params,
+            pooling_params=None,
+            eos_token_id=0,
+        )
+        request.append_output_token_ids([10, 20, 10, 20, 10, 20])
+        assert not check_stop(request, max_model_len=1024)
+
+    def test_high_repetition_threshold(self):
+        """Test that high min_count requires many repetitions"""
+        params = SamplingParams(
+            max_tokens=100,
+            max_repetition_pattern_size=5,
+            min_repetition_pattern_size=2,
+            repetition_min_count=5,
+        )
+        request = Request(
+            request_id="test",
+            prompt_token_ids=[1],
+            sampling_params=params,
+            pooling_params=None,
+            eos_token_id=0,
+        )
+        request.append_output_token_ids([10, 20, 10, 20, 10, 20])
+        assert not check_stop(request, max_model_len=1024)

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -348,6 +348,30 @@ class ChatCompletionRequest(OpenAIBaseModel):
         ),
     )
 
+    max_repetition_pattern_size: int = Field(
+        default=0,
+        description=(
+            "Max repetition pattern size to check for "
+            "stopping generation on repetitive token patterns."
+        ),
+    )
+
+    min_repetition_pattern_size: int = Field(
+        default=0,
+        description=(
+            "Min repetition pattern size to check for "
+            "stopping generation on repetitive token patterns."
+        ),
+    )
+
+    repetition_min_count: int = Field(
+        default=0,
+        description=(
+            "Minimum number of repetitions to detect for "
+            "stopping generation on repetitive token patterns"
+        ),
+    )
+
     # --8<-- [end:chat-completion-extra-params]
 
     def build_chat_params(
@@ -516,6 +540,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone
+            max_repetition_pattern_size=self.max_repetition_pattern_size,
+            min_repetition_pattern_size=self.min_repetition_pattern_size,
+            repetition_min_count=self.repetition_min_count,
         )
 
     @model_validator(mode="before")

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -175,6 +175,30 @@ class CompletionRequest(OpenAIBaseModel):
         ),
     )
 
+    max_repetition_pattern_size: int = Field(
+        default=0,
+        description=(
+            "Max repetition pattern size to check for "
+            "stopping generation on repetitive token patterns."
+        ),
+    )
+
+    min_repetition_pattern_size: int = Field(
+        default=0,
+        description=(
+            "Min repetition pattern size to check for "
+            "stopping generation on repetitive token patterns."
+        ),
+    )
+
+    repetition_min_count: int = Field(
+        default=0,
+        description=(
+            "Minimum number of repetitions to detect for "
+            "stopping generation on repetitive token patterns."
+        ),
+    )
+
     # --8<-- [end:completion-extra-params]
 
     def build_tok_params(self, model_config: ModelConfig) -> TokenizeParams:
@@ -324,6 +348,9 @@ class CompletionRequest(OpenAIBaseModel):
             allowed_token_ids=self.allowed_token_ids,
             extra_args=extra_args or None,
             skip_clone=True,  # Created fresh per request, safe to skip clone
+            max_repetition_pattern_size=self.max_repetition_pattern_size,
+            min_repetition_pattern_size=self.min_repetition_pattern_size,
+            repetition_min_count=self.repetition_min_count,
         )
 
     @model_validator(mode="before")

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -20,12 +20,12 @@ from vllm.v1.serial_utils import UtilityResult
 
 # These are possible values of RequestOutput.finish_reason,
 # so form part of the external API.
-FINISH_REASON_STRINGS = ("stop", "length", "abort", "error")
+FINISH_REASON_STRINGS = ("stop", "length", "abort", "error", "repetition")
 
 
 class FinishReason(enum.IntEnum):
     """
-    Reason a request finished - stop, length, abort, or error.
+    Reason a request finished - stop, length, abort, error, or repetition.
 
     Int rather than Str for more compact serialization.
 
@@ -34,6 +34,7 @@ class FinishReason(enum.IntEnum):
     abort - aborted by client
     error - retryable request-level internal error (e.g., KV load failure).
             Invariant: always converted to 500 Internal Server Error.
+    repetition - repetitive token pattern detected (hallucination)
 
     """
 
@@ -41,6 +42,7 @@ class FinishReason(enum.IntEnum):
     LENGTH = 1
     ABORT = 2
     ERROR = 3
+    REPETITION = 4
 
     def __str__(self):
         return FINISH_REASON_STRINGS[self.value]

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -298,6 +298,7 @@ class RequestStatus(enum.IntEnum):
     FINISHED_ABORTED = enum.auto()
     FINISHED_IGNORED = enum.auto()
     FINISHED_ERROR = enum.auto()
+    FINISHED_REPETITION = enum.auto()
 
     def __str__(self) -> str:
         return self.name
@@ -322,4 +323,5 @@ _FINISHED_REASON_MAP = {
     RequestStatus.FINISHED_IGNORED: FinishReason.LENGTH,
     RequestStatus.FINISHED_ERROR: FinishReason.ERROR,
     RequestStatus.WAITING_FOR_STREAMING_REQ: FinishReason.STOP,
+    RequestStatus.FINISHED_REPETITION: FinishReason.REPETITION,
 }


### PR DESCRIPTION
## Purpose
This PR allows users to end generation early if they see repetitive token patterns (for example, nonsensically repeated sentences) in their output. This is a real failure case for models prone to hallucination. Testing with Qwen3 VL on multimodal input shows a ~33% increase in throughput and near-total reduction in models hitting the configured max_output_len.

This feature is off by default. We include it in the core so that this can be leveraged for non-streaming generation too.

## Test Plan
New test file, online tests

## Test Result
Huge increase in throughput for error-prone multimodal input without sacrificing quality/latency.
