### PR TITLE
[Docs] Improve malformed exception caused by backslash line continuations

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -839,9 +839,9 @@ class CompilationConfig:
         """
         if self.mode is None:
             raise ValueError(
-                "No compilation mode is set. This method should only be \
-                called via vllm config where the level is set if none is \
-                provided."
+                "No compilation mode is set. This method should only be "
+                "called via vllm config where the level is set if none is "
+                "provided."
             )
         if self.mode == CompilationMode.NONE:
             raise ValueError("No compilation mode is set.")

--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -231,8 +231,8 @@ def rocm_aiter_fused_experts(
         # w8a8 block-scaled
         if quant_config.block_shape is not None and quant_config.use_fp8_w8a8:
             assert not apply_router_weight_on_input, (
-                "apply_router_weight_on_input is\
-                not supported for block scaled moe"
+                "apply_router_weight_on_input is"
+                "not supported for block scaled moe"
             )
             assert quant_config.w1_scale is not None
             assert quant_config.w2_scale is not None

--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -231,8 +231,7 @@ def rocm_aiter_fused_experts(
         # w8a8 block-scaled
         if quant_config.block_shape is not None and quant_config.use_fp8_w8a8:
             assert not apply_router_weight_on_input, (
-                "apply_router_weight_on_input is"
-                "not supported for block scaled moe"
+                "apply_router_weight_on_input is not supported for block scaled moe"
             )
             assert quant_config.w1_scale is not None
             assert quant_config.w2_scale is not None

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -681,7 +681,7 @@ def safetensors_weights_iterator(
             # instead we reconstruct the subclasses here before returning
             if not torchao_version_at_least("0.15.0"):
                 raise ValueError(
-                    "Please use torchao version >= 0.15.0"
+                    "Please use torchao version >= 0.15.0 "
                     "to load torchao safetensors checkpoint"
                 )
             from torchao.prototype.safetensors.safetensors_support import (

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -681,8 +681,8 @@ def safetensors_weights_iterator(
             # instead we reconstruct the subclasses here before returning
             if not torchao_version_at_least("0.15.0"):
                 raise ValueError(
-                    "Please use torchao version >= 0.15.0 \
-                        to load torchao safetensors checkpoint"
+                    "Please use torchao version >= 0.15.0"
+                    "to load torchao safetensors checkpoint"
                 )
             from torchao.prototype.safetensors.safetensors_support import (
                 unflatten_tensor_state_dict,

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -201,8 +201,8 @@ class LlamaAttention(nn.Module):
                 # This is a target model, use layer_idx directly
                 effective_layer_idx = layer_idx
             assert effective_layer_idx < len(layer_types), (
-                f"effective_layer_idx: {effective_layer_idx} \
-                is out of bounds for layer_types: {layer_types}"
+                f"effective_layer_idx: {effective_layer_idx}"
+                f" is out of bounds for layer_types: {layer_types}"
             )
 
             is_sliding = layer_types[effective_layer_idx] == "sliding_attention"

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -201,8 +201,8 @@ class LlamaAttention(nn.Module):
                 # This is a target model, use layer_idx directly
                 effective_layer_idx = layer_idx
             assert effective_layer_idx < len(layer_types), (
-                f"effective_layer_idx: {effective_layer_idx}"
-                f" is out of bounds for layer_types: {layer_types}"
+                f"effective_layer_idx: {effective_layer_idx} "
+                f"is out of bounds for layer_types: {layer_types}"
             )
 
             is_sliding = layer_types[effective_layer_idx] == "sliding_attention"

--- a/vllm/model_executor/models/phi4mm.py
+++ b/vllm/model_executor/models/phi4mm.py
@@ -428,14 +428,14 @@ class Phi4MMImageEncoder(nn.Module):
                 output_imgs.append(torch.cat([sub_img, self.glb_GN, glb_img], dim=1))
             else:
                 raise NotImplementedError(
-                    f'hd_transform_order = {self.hd_transform_order}, "\
-                        "not implemented'
+                    f"hd_transform_order = {self.hd_transform_order}, "
+                    "not implemented"
                 )
 
             # temp_len = int((h*w+1)*144 + 1 + (h+1)*12)
             assert temp_len == output_imgs[-1].shape[1], (
-                f'temp_len: {temp_len}, output_imgs[-1].shape[1]: "\
-                    "{output_imgs[-1].shape[1]}'
+                f"temp_len: {temp_len}, output_imgs[-1].shape[1]: "
+                f"{output_imgs[-1].shape[1]}"
             )
 
             output_len.append(temp_len)

--- a/vllm/model_executor/models/phi4mm.py
+++ b/vllm/model_executor/models/phi4mm.py
@@ -428,8 +428,7 @@ class Phi4MMImageEncoder(nn.Module):
                 output_imgs.append(torch.cat([sub_img, self.glb_GN, glb_img], dim=1))
             else:
                 raise NotImplementedError(
-                    f"hd_transform_order = {self.hd_transform_order}, "
-                    "not implemented"
+                    f"hd_transform_order = {self.hd_transform_order}, not implemented"
                 )
 
             # temp_len = int((h*w+1)*144 + 1 + (h+1)*12)

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -367,8 +367,8 @@ class MultiModalRegistry:
             # than whisper.
             return 0
         assert len(max_tokens) == 1, (
-            "Encoder-decoder models are expected \
-            to implement the multimodal interface with at most one modality."
+            "Encoder-decoder models are expected "
+            "to implement the multimodal interface with at most one modality."
         )
 
         first_modality = next(iter(max_tokens))

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -399,8 +399,7 @@ class FlexibleArgumentParser(ArgumentParser):
         index = args.index("--config")
         if index == len(args) - 1:
             raise ValueError(
-                "No config file specified! "
-                "Please check your command-line arguments."
+                "No config file specified! Please check your command-line arguments."
             )
 
         file_path = args[index + 1]

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -399,8 +399,8 @@ class FlexibleArgumentParser(ArgumentParser):
         index = args.index("--config")
         if index == len(args) - 1:
             raise ValueError(
-                "No config file specified! \
-                             Please check your command-line arguments."
+                "No config file specified! "
+                "Please check your command-line arguments."
             )
 
         file_path = args[index + 1]


### PR DESCRIPTION

## Purpose
This PR is to clean up error messages that were being malformed due to the use of backslash (\) for line continuation within strings.

e.g.
Before:
<img width="593" height="78" alt="image" src="https://github.com/user-attachments/assets/29e5179d-fd3b-4f8b-933e-a621d0a57e8d" />

After:
<img width="543" height="57" alt="image" src="https://github.com/user-attachments/assets/0de7f9a9-bb94-43a3-a069-0cee4e22289c" />

## Test Plan

## Test Result

