### PR TITLE
[KVconnector][LMCache] remove the import of legacy LMCache code

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/utils.py
@@ -6,7 +6,6 @@ import threading
 from typing import TYPE_CHECKING, Union
 
 import torch
-from lmcache.config import LMCacheEngineConfig as Config
 from lmcache.logging import init_logger
 from lmcache.v1.config import LMCacheEngineConfig as V1Config
 
@@ -20,7 +19,7 @@ logger = init_logger(__name__)
 ENGINE_NAME = "vllm-instance"
 
 # Thread-safe singleton storage
-_config_instance: Config | V1Config | None = None
+_config_instance: V1Config | None = None
 _config_lock = threading.Lock()
 
 
@@ -29,7 +28,7 @@ def is_false(value: str) -> bool:
     return value.lower() in ("false", "0", "no", "n", "off")
 
 
-def lmcache_get_or_create_config() -> Config | V1Config:
+def lmcache_get_or_create_config() -> V1Config:
     """Get the LMCache configuration from the environment variable
     `LMCACHE_CONFIG_FILE`. If the environment variable is not set, this
     function will return the default configuration.
@@ -43,16 +42,7 @@ def lmcache_get_or_create_config() -> Config | V1Config:
     if _config_instance is None:
         with _config_lock:
             if _config_instance is None:  # Check again within lock
-                if is_false(os.getenv("LMCACHE_USE_EXPERIMENTAL", "True")):
-                    logger.warning(
-                        "Detected LMCACHE_USE_EXPERIMENTAL is set to False. "
-                        "Using legacy configuration is deprecated and will "
-                        "be remove soon! Please set LMCACHE_USE_EXPERIMENTAL "
-                        "to True."
-                    )
-                    LMCacheEngineConfig = Config  # type: ignore[assignment]
-                else:
-                    LMCacheEngineConfig = V1Config  # type: ignore[assignment]
+                LMCacheEngineConfig = V1Config  # type: ignore[assignment]
 
                 if "LMCACHE_CONFIG_FILE" not in os.environ:
                     logger.warning(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This removes the import of the old LMCache code before 0.3.11

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

