### PR TITLE
[Feat][Core] Support multiple KV cache groups in Hybrid KV Coordinator

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -506,9 +506,7 @@ _HYBRID_MODEL_TEST_CASES = [
     pytest.param(["full", "mamba"], id="2g-full+mamba"),
     # 2 groups: 0 full (all other types)
     pytest.param(["sliding_window", "mamba"], id="2g-sw+mamba"),
-    pytest.param(
-        ["sliding_window", "sliding_window_large"], id="2g-sw+sw_large"
-    ),
+    pytest.param(["sliding_window", "sliding_window_large"], id="2g-sw+sw_large"),
     # 3 groups: 1 full + 2 others (same type)
     pytest.param(["full", "sliding_window", "sliding_window"], id="3g-full+2sw"),
     pytest.param(["full", "mamba", "mamba"], id="3g-full+2mamba"),
@@ -567,9 +565,7 @@ def test_prefill_hybrid_model_combinations(spec_types: list[str]):
     # Allocate enough blocks for all groups
     num_blocks = 10 * num_groups
 
-    kv_cache_config = _make_hybrid_kv_cache_config(
-        block_size, num_blocks, spec_types
-    )
+    kv_cache_config = _make_hybrid_kv_cache_config(block_size, num_blocks, spec_types)
     manager = KVCacheManager(
         kv_cache_config,
         max_model_len=8192,

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -111,10 +111,18 @@ def make_kv_cache_config_hybrid_model(
 ) -> KVCacheConfig:
     if second_spec_type == "sliding_window":
         second_spec = SlidingWindowSpec(
-            block_size, 1, 1, torch.float32, sliding_window=2 * block_size
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=2 * block_size,
         )
     elif second_spec_type == "mamba":
-        second_spec = MambaSpec(block_size, 1, 1, torch.float32)
+        second_spec = MambaSpec(
+            block_size=block_size,
+            shapes=(1, 1),
+            dtypes=(torch.float32,),
+        )
 
     return KVCacheConfig(
         num_blocks=num_blocks,
@@ -122,7 +130,12 @@ def make_kv_cache_config_hybrid_model(
         kv_cache_groups=[
             KVCacheGroupSpec(
                 ["layer1"],
-                FullAttentionSpec(block_size, 1, 1, torch.float32),
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
             ),
             KVCacheGroupSpec(
                 ["layer2"],
@@ -140,10 +153,18 @@ def make_kv_cache_config_three_types(
     block_size: int, num_blocks: int, third_spec_type: str = "mamba"
 ) -> KVCacheConfig:
     if third_spec_type == "mamba":
-        third_spec = MambaSpec(block_size, 1, 1, torch.float32)
+        third_spec = MambaSpec(
+            block_size=block_size,
+            shapes=(1, 1),
+            dtypes=(torch.float32,),
+        )
     elif third_spec_type == "sliding_window":
         third_spec = SlidingWindowSpec(
-            block_size, 1, 1, torch.float32, sliding_window=4 * block_size
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=4 * block_size,
         )
 
     return KVCacheConfig(
@@ -472,14 +493,31 @@ def _make_hybrid_kv_cache_config(
             - "mamba": MambaSpec
     """
     spec_map = {
-        "full": lambda: FullAttentionSpec(block_size, 1, 1, torch.float32),
+        "full": lambda: FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+        ),
         "sliding_window": lambda: SlidingWindowSpec(
-            block_size, 1, 1, torch.float32, sliding_window=2 * block_size
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=2 * block_size,
         ),
         "sliding_window_large": lambda: SlidingWindowSpec(
-            block_size, 1, 1, torch.float32, sliding_window=4 * block_size
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=4 * block_size,
         ),
-        "mamba": lambda: MambaSpec(block_size, 1, 1, torch.float32),
+        "mamba": lambda: MambaSpec(
+            block_size=block_size,
+            shapes=(1, 1),
+            dtypes=(torch.float32,),
+        ),
     }
 
     kv_cache_groups = [

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -478,9 +478,10 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 # Full attention: reuse cached blocks (downward-closed property)
                 cached_blocks = hit_blocks_by_group[group_ids[0]]
                 if is_full_attn and cached_blocks is not None:
-                    # Full attention is downward-closed; if the candidate
-                    # `hit_length` was reduced by other groups, trim cached blocks
-                    # so subsequent reuse reflects the current candidate length.
+                    # For full attention, we only need to compute the cache hit
+                    # length once. Starting from the second iteration, if the
+                    # hit_length is reduced by other groups, we can simply keep
+                    # the first hit_length // block_size blocks from the last iteration.
                     num_blocks = hit_length // spec.block_size
                     for group_id in group_ids:
                         blocks = hit_blocks_by_group[group_id]
@@ -504,7 +505,6 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                 if curr_hit_length < hit_length:
                     hit_length = curr_hit_length
                     reduced = True
-                    break
 
             if not reduced:
                 break

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -420,7 +420,12 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             "HybridKVCacheCoordinator requires at least two attention groups."
         )
 
-        self.attention_groups = attention_groups
+        # Put full attention first: its efficient left-to-right scan provides
+        # a tighter initial bound, reducing work for subsequent groups.
+        self.attention_groups = sorted(
+            attention_groups,
+            key=lambda x: not isinstance(x[0], FullAttentionSpec),
+        )
 
         # The LCM of the block sizes of all attention types.
         # The cache hit length must be a multiple of the LCM of the block sizes


### PR DESCRIPTION


## Purpose

The current hybrid KV cache coordinator supports at most two attention types (full attention + another sliding-window/mamba attention). However, emerging models may need more flexible support. For example, full attention + sliding window attn with various window sizes, etc., as required in #31592 and #30263.

Since prefix caching for sliding window and mamba does not have the monotonic prefix cache hit property, viz., a cache hit at position i does not imply a cache hit at position j where j < i, `find_longest_cache_hit` needs to check all attention groups until a prefix gets cache hits from all of them. This is what implemented by this PR.

## Test Plan

`pytest tests/v1/core/test_prefix_caching.py -q`

## Test Result

Passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Expands hybrid KV caching beyond the prior 2-type (full+other) limit and introduces a unified cache-hit algorithm across arbitrary attention groups.
> 
> - Refactors `HybridKVCacheCoordinator` to group KV cache groups by identical `KVCacheSpec`, prioritize `FullAttentionSpec`, and compute LCM across all block sizes for alignment
> - Implements an iterative fixed-point `find_longest_cache_hit` that iteratively constrains hit length across attention types and reuses cached full-attention hits when possible
> - Updates imports to use `SingleTypeKVCacheManager` and removes the hardcoded 2-group/full-attn assumptions
> - Keeps divisibility validation and DCP/PCP constraints; returns per-group hit blocks as a tuple aligned to group indices
> 
> - Tests: adds helpers to build mixed-spec configs and a parameterized `test_prefill_hybrid_model_combinations` covering 2–4 groups, interleaving, sliding-window variants, and Mamba; updates existing hybrid tests and fixtures accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35de55507998323ec4bf15eac3f9cca8f5ff504a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Expands hybrid KV caching beyond the prior 2-type limit and introduces a unified cache-hit algorithm across arbitrary attention groups.
> 
> - Refactors `HybridKVCacheCoordinator` to group KV cache groups by identical `KVCacheSpec`, prioritize `FullAttentionSpec`, and compute LCM across all group block sizes for alignment
> - Replaces the 2-group/full-attn assumption with a generic iterative fixed-point `find_longest_cache_hit` that reconciles hits across all groups and reuses full-attn hits when shrinking
> - Updates imports to use `SingleTypeKVCacheManager`; keeps divisibility validation and DCP/PCP constraints; returns per-group hit blocks aligned to original group indices
> - Tests: adds hybrid helpers and a parameterized `test_prefill_hybrid_model_combinations` covering 2–4 groups, interleaving, sliding-window variants, and Mamba; updates existing hybrid tests accordingly (`tests/v1/core/test_prefix_caching.py`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34ca45408e8653fca70754896a46dc7996785354. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
