### PR TITLE
Fix versions for vulnerable packages

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -45,7 +45,7 @@ python-json-logger # Used by logging as per examples/others/logging_configuratio
 scipy # Required for phi-4-multimodal-instruct
 ninja # Required for xgrammar, rocm, tpu, xpu
 pybase64 # fast base64 implementation
-cbor2 # Required for cross-language serialization of hashable objects
+cbor2>=5.8.0 # Required for cross-language serialization of hashable objects
 ijson # Required for mistral streaming tool parser
 setproctitle # Used to set process names for better debugging and monitoring
 openai-harmony >= 0.0.3  # Required for gpt-oss

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1275,7 +1275,7 @@ tzdata==2024.2
     # via pandas
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.2.3
+urllib3==2.6.0
     # via
     #   blobfile
     #   botocore


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix packages versions to resolve vulnerabilities found.

1. cbor2:
    - [CVE-2025-68131](https://access.redhat.com/security/cve/cve-2025-68131)
    - [CBORDecoder reuse can leak shareable values across decode calls](https://github.com/agronholm/cbor2/security/advisories/GHSA-wcj4-jw5j-44wh)
    - "
Patched versions 5.8.0
"
3. urllib3:
    - [CVE-2025-66418](https://access.redhat.com/security/cve/cve-2025-66418)
    - [Unbounded number of links in the decompression chain](https://github.com/urllib3/urllib3/security/advisories/GHSA-gm62-xv2j-4w53)
    - [Streaming API improperly handles highly compressed data](https://github.com/urllib3/urllib3/security/advisories/GHSA-2xpw-w6gg-jr37)
    - "
Affected versions
 \>=1.0,<2.6.0
Patched versions
 2.6.0
"

