### PR TITLE
[Cleanup] Unify flashinfer utility code

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -12,6 +12,7 @@ vllm.utils.flashinfer.
 import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
     FusedMoEQuantConfig,
@@ -22,9 +23,6 @@ from vllm.model_executor.layers.fused_moe.flashinfer_cutlass_moe import (
 from vllm.model_executor.layers.fused_moe.flashinfer_cutlass_prepare_finalize import (
     create_flashinfer_prepare_finalize,
 )
-from vllm.platforms import current_platform
-from vllm.utils.math_utils import round_up
-from vllm.logger import init_logger
 
 # Re-export unified utilities from vllm.utils.flashinfer for backwards
 # compatibility
@@ -37,6 +35,10 @@ from vllm.utils.flashinfer import (
     rotate_flashinfer_fp8_moe_weights,
     swap_w13_to_w31,
 )
+from vllm.utils.math_utils import round_up
+
+# Backwards compatibility alias for renamed function
+rotate_weights_for_fi_trtllm_fp8_per_tensor_moe = rotate_flashinfer_fp8_moe_weights
 
 logger = init_logger(__name__)
 
@@ -343,6 +345,7 @@ __all__ = [
     "get_moe_scaling_factors",
     "is_flashinfer_supporting_global_sf",
     "rotate_flashinfer_fp8_moe_weights",
+    "rotate_weights_for_fi_trtllm_fp8_per_tensor_moe",  # backwards compat alias
     "swap_w13_to_w31",
     # MoE-specific functions (depend on fused_moe)
     "apply_fi_trtllm_fp8_per_tensor_moe",
@@ -350,7 +353,6 @@ __all__ = [
     "flashinfer_cutlass_moe_fp8",
     "register_moe_scaling_factors",
     "select_cutlass_fp8_gemm_impl",
-    # Added/Kept from HEAD
     "register_scales_for_trtllm_fp8_per_tensor_moe",
     "prepare_fp8_moe_layer_for_fi",
     "align_fp8_moe_weights_for_fi",

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -191,7 +191,6 @@ def select_cutlass_fp8_gemm_impl(
     )
 
 
-
 def align_fp8_moe_weights_for_fi(
     w13: torch.Tensor, w2: torch.Tensor, is_act_and_mul: bool
 ) -> tuple[torch.Tensor, torch.Tensor, int]:

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -12,6 +12,7 @@ import importlib.util
 import os
 import shutil
 from collections.abc import Callable
+from enum import Enum
 from typing import Any, NoReturn
 
 import requests
@@ -597,7 +598,7 @@ def should_use_flashinfer_for_blockscale_fp8_gemm(
 # MoE utilities (unified from flashinfer_utils.py to reduce code duplication)
 # ==============================================================================
 
-from enum import Enum
+
 
 
 class FlashinferMoeBackend(Enum):
@@ -726,12 +727,13 @@ def rotate_flashinfer_fp8_moe_weights(
         )
 
     # Stack weights for all experts
-    gemm1_weights.data = torch.stack(gemm1_weights_fp8_shuffled).view(
-        torch.float8_e4m3fn
-    )
-    gemm2_weights.data = torch.stack(gemm2_weights_fp8_shuffled).view(
-        torch.float8_e4m3fn
-    )
+    with torch.no_grad():
+        gemm1_weights.copy_(torch.stack(gemm1_weights_fp8_shuffled).view(
+            torch.float8_e4m3fn
+        ))
+        gemm2_weights.copy_(torch.stack(gemm2_weights_fp8_shuffled).view(
+            torch.float8_e4m3fn
+        ))
 
 
 __all__ = [

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -599,8 +599,6 @@ def should_use_flashinfer_for_blockscale_fp8_gemm(
 # ==============================================================================
 
 
-
-
 class FlashinferMoeBackend(Enum):
     """Backend selection for FlashInfer MoE kernels."""
 
@@ -728,12 +726,12 @@ def rotate_flashinfer_fp8_moe_weights(
 
     # Stack weights for all experts
     with torch.no_grad():
-        gemm1_weights.copy_(torch.stack(gemm1_weights_fp8_shuffled).view(
-            torch.float8_e4m3fn
-        ))
-        gemm2_weights.copy_(torch.stack(gemm2_weights_fp8_shuffled).view(
-            torch.float8_e4m3fn
-        ))
+        gemm1_weights.copy_(
+            torch.stack(gemm1_weights_fp8_shuffled).view(torch.float8_e4m3fn)
+        )
+        gemm2_weights.copy_(
+            torch.stack(gemm2_weights_fp8_shuffled).view(torch.float8_e4m3fn)
+        )
 
 
 __all__ = [


### PR DESCRIPTION
## Purpose

Unify `vllm.utils.flashinfer` and `vllm.model_executor.layers.quantization.utils.flashinfer_utils` to reduce code duplication and confusion as requested in #31414.

## Test Plan

- Moved pure utility functions to `vllm/utils/flashinfer.py`
- Re-exported moved functions from `flashinfer_utils.py` for backwards compatibility
- All existing imports continue to work without modification

**Changes:**
- Move `FlashinferMoeBackend`, `swap_w13_to_w31`, `get_moe_scaling_factors`, `get_flashinfer_moe_backend`, `is_flashinfer_supporting_global_sf`, `calculate_tile_tokens_dim`, `rotate_flashinfer_fp8_moe_weights` to `vllm/utils/flashinfer.py`
- Keep fused_moe-dependent functions (`apply_flashinfer_per_tensor_scale_fp8`, `register_moe_scaling_factors`, `build_flashinfer_fp8_cutlass_moe_prepare_finalize`, `select_cutlass_fp8_gemm_impl`, `flashinfer_cutlass_moe_fp8`) in `flashinfer_utils.py`
- Re-export moved functions from `flashinfer_utils.py` for backwards compatibility

## Test Result

- Python syntax validation passed
- Backwards compatibility maintained through re-exports

Closes #31414

---

> [!NOTE]
> Centralizes MoE-related utility code to reduce duplication and clarify responsibilities.
> 
> - Moves `FlashinferMoeBackend`, backend selection, scaling helpers, tile token calculation, and FP8 weight rotation into `vllm/utils/flashinfer.py`
> - Trims `flashinfer_utils.py` to fused-MoE-dependent code; re-exports moved symbols for backwards compatibility and adds alias `rotate_weights_for_fi_trtllm_fp8_per_tensor_moe`
> - Adds `register_moe_scaling_factors` and `flashinfer_cutlass_moe_fp8`; updates call sites to `rotate_flashinfer_fp8_moe_weights`
> - Updates `__all__` in both modules to expose the unified APIs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 396db1df54b7f0a3210f5fdf8697f0f7edb0e5c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Centralizes MoE-related utilities to reduce duplication and clarify responsibilities.
> 
> - Moves `FlashinferMoeBackend`, backend selection, scaling helpers (`get_moe_scaling_factors`), tile token calc, and FP8 weight rotation to `vllm/utils/flashinfer.py`; updates `__all__`
> - `flashinfer_utils.py` now keeps fused-MoE-dependent code; re-exports moved symbols and adds alias `rotate_weights_for_fi_trtllm_fp8_per_tensor_moe`
> - Adds `register_moe_scaling_factors` and `flashinfer_cutlass_moe_fp8`; updates usage to `rotate_flashinfer_fp8_moe_weights`
> - Minor refactor: safer in-place FP8 weight `copy_` under `torch.no_grad()`; preserves backward compatibility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdf2d0865f5128a1cc527a9fe9acf3eae934c2c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Consolidates MoE utilities to reduce duplication and clarify module boundaries.
> 
> - Moves `FlashinferMoeBackend`, backend selection, scaling/tile helpers, and FP8 weight rotation into `vllm/utils/flashinfer.py`; updates `__all__`
> - `flashinfer_utils.py` now keeps fused-MoE-dependent functions; re-exports moved symbols and adds alias `rotate_weights_for_fi_trtllm_fp8_per_tensor_moe`
> - Adds `register_moe_scaling_factors` and `flashinfer_cutlass_moe_fp8`; updates usage to `rotate_flashinfer_fp8_moe_weights`
> - Minor safety tweak: FP8 weight rotation uses in-place `copy_` under `torch.no_grad()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e78399ce8df1057b0e0717d5932b502d5598ce0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
