### PR TITLE
[Bugfix][Hardware][AMD] Use platform device type in compilation fusion helpers

### DIFF
--- a/vllm/compilation/fusion.py
+++ b/vllm/compilation/fusion.py
@@ -39,19 +39,27 @@ FP4_DTYPE = torch.uint8
 
 
 def empty_bf16(*args, **kwargs):
-    return torch.empty(*args, **kwargs, dtype=torch.bfloat16, device="cuda")
+    return torch.empty(
+        *args, **kwargs, dtype=torch.bfloat16, device=current_platform.device_type
+    )
 
 
 def empty_fp32(*args, **kwargs):
-    return torch.empty(*args, **kwargs, dtype=torch.float32, device="cuda")
+    return torch.empty(
+        *args, **kwargs, dtype=torch.float32, device=current_platform.device_type
+    )
 
 
 def empty_i32(*args, **kwargs):
-    return torch.empty(*args, **kwargs, dtype=torch.int32, device="cuda")
+    return torch.empty(
+        *args, **kwargs, dtype=torch.int32, device=current_platform.device_type
+    )
 
 
 def empty_i64(*args, **kwargs):
-    return torch.empty(*args, **kwargs, dtype=torch.int64, device="cuda")
+    return torch.empty(
+        *args, **kwargs, dtype=torch.int64, device=current_platform.device_type
+    )
 
 
 RMS_OP = torch.ops._C.rms_norm.default


### PR DESCRIPTION
## Summary

Replace hardcoded `device="cuda"` with `current_platform.device_type` in the compilation fusion helper functions.

## Changes

- `empty_bf16()` - Use `current_platform.device_type` instead of `"cuda"`
- `empty_fp32()` - Use `current_platform.device_type` instead of `"cuda"`
- `empty_i32()` - Use `current_platform.device_type` instead of `"cuda"`
- `empty_i64()` - Use `current_platform.device_type` instead of `"cuda"`

## Problem

The current implementation hardcodes `device="cuda"` which doesn't work correctly on ROCm where the device type is `"hip"` or `"rocm"`. This can cause the torch.compile fusion pass to fail on AMD GPUs.

## Solution

Use `current_platform.device_type` which was already imported in the file. This returns the correct device string for the current platform (CUDA, ROCm, etc.).

## Test Plan

- AMD CI will validate on MI300X
- Existing compilation tests should pass

🤖 Generated with [Claude Code](https://claude.ai/code)