### PR TITLE
Update how docs are rendered for cli reference

### DIFF
--- a/docs/mkdocs/hooks/generate_argparse.py
+++ b/docs/mkdocs/hooks/generate_argparse.py
@@ -152,21 +152,26 @@ class MarkdownFormatter(HelpFormatter):
             heading_md = f"{self._argument_heading_prefix} {option_strings}\n\n"
             self._markdown_output.append(heading_md)
 
-            if choices := action.choices:
-                choices = f"`{'`, `'.join(str(c) for c in choices)}`"
-                self._markdown_output.append(f"Possible choices: {choices}\n\n")
-            elif (metavar := action.metavar) and isinstance(metavar, (list, tuple)):
-                metavar = f"`{'`, `'.join(str(m) for m in metavar)}`"
-                self._markdown_output.append(f"Possible choices: {metavar}\n\n")
+            description = []
 
             if action.help:
-                self._markdown_output.append(f"{action.help}\n\n")
+                description.append(f"{action.help}\n")
+
+            if choices := action.choices:
+                choices = f"`{'`, `'.join(str(c) for c in choices)}`"
+                description.append(f"- **Possible choices**: {choices}\n")
+            elif (metavar := action.metavar) and isinstance(metavar, (list, tuple)):
+                metavar = f"`{'`, `'.join(str(m) for m in metavar)}`"
+                description.append(f"- **Possible choices**: {metavar}\n")
 
             if (default := action.default) != SUPPRESS:
                 # Make empty string defaults visible
                 if default == "":
                     default = '""'
-                self._markdown_output.append(f"Default: `{default}`\n\n")
+                description.append(f"- **Default**: `{default}`\n")
+
+            self._markdown_output.append("\n".join(description) + "\n")
+            self._markdown_output.append("---\n")
 
     def format_help(self):
         """Return the formatted help as markdown."""


### PR DESCRIPTION

## Purpose
1. the `CLI reference` among other sections are barely readable.
2. there is no start and end clearly visible between arguments
3. the older docs were visibly better for this particular section (the rest looks good on mkdocs)
## Test Plan
1. draft PR to view docs and get comments
## Test Result
This PR is an alternative way to view docs that may build.

For some reason `mkdocs serve` gets stuck at
```
INFO    -  Doc file 'features/spec_decode.md' contains an unrecognized relative link '../../tests/spec_decode/e2e', it was
           left as is.
```
for more than 20+ minutes and there is no way to serve or test this locally on Windows+VSCode/Antigravity.
which now gets stuck at

<details><summary>Error log for UTF-8 encoding on windows</summary>
<p>

INFO    -  api-autonav: Documenting 'vllm.v1.worker.gpu.spec_decode' in virtual file:
           api\vllm\v1\worker\gpu\spec_decode\index.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.gpu.spec_decode.eagle' in virtual file:
           api\vllm\v1\worker\gpu\spec_decode\eagle.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.gpu.spec_decode.eagle_cudagraph' in virtual file:        
           api\vllm\v1\worker\gpu\spec_decode\eagle_cudagraph.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.gpu.spec_decode.rejection_sample' in virtual file:       
           api\vllm\v1\worker\gpu\spec_decode\rejection_sample.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.gpu.states' in virtual file:
           api\vllm\v1\worker\gpu\states.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.gpu.structured_outputs' in virtual file:
           api\vllm\v1\worker\gpu\structured_outputs.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.gpu_input_batch' in virtual file:
           api\vllm\v1\worker\gpu_input_batch.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.gpu_model_runner' in virtual file:
           api\vllm\v1\worker\gpu_model_runner.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.gpu_ubatch_wrapper' in virtual file:
           api\vllm\v1\worker\gpu_ubatch_wrapper.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.gpu_worker' in virtual file:
           api\vllm\v1\worker\gpu_worker.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.kv_connector_model_runner_mixin' in virtual file:        
           api\vllm\v1\worker\kv_connector_model_runner_mixin.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.lora_model_runner_mixin' in virtual file:
           api\vllm\v1\worker\lora_model_runner_mixin.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.tpu_input_batch' in virtual file:
           api\vllm\v1\worker\tpu_input_batch.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.tpu_model_runner' in virtual file:
           api\vllm\v1\worker\tpu_model_runner.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.tpu_worker' in virtual file:
           api\vllm\v1\worker\tpu_worker.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.ubatch_utils' in virtual file:
           api\vllm\v1\worker\ubatch_utils.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.ubatching' in virtual file:
           api\vllm\v1\worker\ubatching.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.utils' in virtual file: api\vllm\v1\worker\utils.md      
INFO    -  api-autonav: Documenting 'vllm.v1.worker.worker_base' in virtual file:
           api\vllm\v1\worker\worker_base.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.workspace' in virtual file:
           api\vllm\v1\worker\workspace.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.xpu_model_runner' in virtual file:
           api\vllm\v1\worker\xpu_model_runner.md
INFO    -  api-autonav: Documenting 'vllm.v1.worker.xpu_worker' in virtual file:
           api\vllm\v1\worker\xpu_worker.md
INFO    -  api-autonav: Documenting 'vllm.version' in virtual file: api\vllm\version.md
INFO    -  Doc file 'features/spec_decode.md' contains an unrecognized relative link
           '../../tests/spec_decode/e2e', it was left as is.
ERROR   -  Error reading page 'api/vllm/model_executor/models/gritlm.md': 'charmap' codec can't encode
           character '\u2581' in position 36: character maps to <undefined>
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Python311\Scripts\mkdocs.exe\__main__.py", line 10, in <module>
  File "C:\Python311\Lib\site-packages\click\core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\click\core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocs\__main__.py", line 272, in serve_command
    serve.serve(**kwargs)
  File "C:\Python311\Lib\site-packages\mkdocs\commands\serve.py", line 85, in serve
    builder(config)
  File "C:\Python311\Lib\site-packages\mkdocs\commands\serve.py", line 67, in builder
    build(config, serve_url=None if is_clean else serve_url, dirty=is_dirty)
  File "C:\Python311\Lib\site-packages\mkdocs\commands\build.py", line 310, in build
    _populate_page(file.page, config, files, dirty)
  File "C:\Python311\Lib\site-packages\mkdocs\commands\build.py", line 167, in _populate_page
    page.render(config, files)
  File "C:\Python311\Lib\site-packages\mkdocs\structure\pages.py", line 285, in render
    self.content = md.convert(self.markdown)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\markdown\core.py", line 357, in convert
    root = self.parser.parseDocument(self.lines).getroot()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\markdown\blockparser.py", line 117, in parseDocument
    self.parseChunk(self.root, '\n'.join(lines))
  File "C:\Python311\Lib\site-packages\markdown\blockparser.py", line 136, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
  File "C:\Python311\Lib\site-packages\markdown\blockparser.py", line 158, in parseBlocks
    if processor.run(parent, blocks) is not False:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings\_internal\extension.py", line 128, in run
    html, handler, data = self._process_block(identifier, block, heading_level)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings\_internal\extension.py", line 207, in _process_block     
    rendered = render(data, options)
               ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\_internal\handler.py", line 295, in render
    return template.render(
           ^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\jinja2\environment.py", line 1295, in render
    self.environment.handle_exception()
  File "C:\Python311\Lib\site-packages\jinja2\environment.py", line 942, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\module.html.jinja", line 1, in top-level template code
    {% extends "_base/module.html.jinja" %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\_base\module.html.jinja", line 88, in top-level template code
    {% block contents scoped %}
^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\_base\module.html.jinja", line 119, in block 'contents'
    {% block children scoped %}
^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\_base\module.html.jinja", line 127, in block 'children'
    {% include "children"|get_template with context %}
^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\children.html.jinja", line 1, in top-level template code
    {% extends "_base/children.html.jinja" %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\_base\children.html.jinja", line 93, in top-level template code
    {% include class|get_template with context %}
^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\class.html.jinja", line 1, in top-level template code
    {% extends "_base/class.html.jinja" %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\_base\class.html.jinja", line 134, in top-level template code
    {% block contents scoped %}
^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\_base\class.html.jinja", line 234, in block 'contents'
    {% block children scoped %}
^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\_base\class.html.jinja", line 242, in block 'children'
    {% include "children"|get_template with context %}
^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\children.html.jinja", line 1, in top-level template code
    {% extends "_base/children.html.jinja" %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\_base\children.html.jinja", line 53, in top-level template code
    {% include attribute|get_template with context %}
^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\attribute.html.jinja", line 1, in top-level template code
    {% extends "_base/attribute.html.jinja" %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\_base\attribute.html.jinja", line 77, in top-level template code
    {% block signature scoped %}
^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\templates\material\_base\attribute.html.jinja", line 83, in block 'signature'
    {% filter format_attribute(attribute, config.line_length, crossrefs=config.signature_crossrefs, show_value=config.show_attribute_values) %}
^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\_internal\rendering.py", line 250, in do_format_attribute
    signature = do_format_code(signature, line_length)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\_internal\rendering.py", line 98, in do_format_code
    return formatter(code, line_length)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\site-packages\mkdocstrings_handlers\python\_internal\rendering.py", line 605, in formatter
    completed_process = subprocess.run(  # noqa: S603
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\subprocess.py", line 550, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\subprocess.py", line 1209, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\subprocess.py", line 1620, in _communicate
    self._stdin_write(input)
  File "C:\Python311\Lib\subprocess.py", line 1143, in _stdin_write
    self.stdin.write(input)
  File "C:\Python311\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\u2581' in position 36: character maps to <undefined

</p>
</details> 
---