### PR TITLE
[CI/Build] add new target for building CPU image with model

### DIFF
--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -201,3 +201,35 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install dist/*.whl
 
 ENTRYPOINT ["vllm", "serve"]
+
+######################### RELEASE IMAGE WITH MODEL #########################
+FROM base AS vllm-openai-model
+
+WORKDIR /workspace/
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=cache,target=/root/.cache/ccache \
+    --mount=type=bind,from=vllm-build,src=/workspace/vllm/dist,target=dist \
+    uv pip install dist/*.whl && \
+    uv pip install "huggingface-hub[cli]"
+
+ARG MODEL_NAME=""
+ENV MODEL_NAME="${MODEL_NAME}"
+ENV MODEL_PATH="/root/.cache/${MODEL_NAME}"
+
+RUN if [ -z "${MODEL_NAME}" ]; then \
+        echo "ERROR: MODEL_NAME build argument is required" >&2 && exit 1; \
+    fi && \
+    mkdir -p "${MODEL_PATH}"
+
+RUN --mount=type=secret,id=hf_token \
+    if [ -f /run/secrets/hf_token ]; then \
+        HF_TOKEN=$(cat /run/secrets/hf_token) && \
+        hf download "${MODEL_NAME}" --local-dir "${MODEL_PATH}" --token "${HF_TOKEN}"; \
+    else \
+        hf download "${MODEL_NAME}" --local-dir "${MODEL_PATH}"; \
+    fi && rm -rf /root/.cache/huggingface "${MODEL_PATH}/original"
+
+# Use shell form to enable MODEL_PATH environment variable substitution
+# Additional arguments passed to `docker run` are appended via "$@"
+ENTRYPOINT ["sh", "-c", "exec vllm serve \"$MODEL_PATH\" \"$@\"", "--"]


### PR DESCRIPTION
## Purpose
this commit adds a new build target to Dockerfile.cpu

the new	target is designed to build a CPU image with 
a HuggingFace model pre-loaded into the container at
runtime. this allows for quicker startup times for    
users willing to sacrifice buildtimes.

## Test Plan
```
DOCKER_BUILDKIT=1 docker build . \
    --target vllm-openai-model \
    --build-arg MODEL_NAME="meta-llama/Llama-3.2-1B-Instruct" \
    --secret id=hf_token,env=HF_TOKEN \
    --tag vllm/vllm-openai-model \
    --file docker/Dockerfile.cpu

docker run --name vllm --privileged=true --net=host vllm/vllm-openai-model:latest --host 0.0.0.0 --port 8000
```

## Test Result
vLLM should start up as expected

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Adds a new Docker build target to produce a CPU image with a pre-downloaded HuggingFace model and updates docs with usage examples.
> 
> - Introduces `vllm-openai-model` stage in `docker/Dockerfile.cpu` that installs `huggingface-hub[cli]`, requires `MODEL_NAME`, downloads the model at build-time (supports Docker build secret `hf_token`), and serves from `MODEL_PATH` via a shell-form `ENTRYPOINT`
> - Cleans up HF cache artifacts post-download and ensures predictable model location
> - Documents build/run instructions and secure token handling in `docs/deployment/docker.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2d870989f122cfb44702310a6c12c8d9e19754a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Adds a new CPU image build stage for predictable, fast-start inference with a pre-downloaded model.
> 
> - New `vllm-openai-model` target in `docker/Dockerfile.cpu` installs `huggingface-hub[cli]`, requires `MODEL_NAME`, downloads the model at build-time (optional Docker secret `hf_token`), stores it at `MODEL_PATH`, cleans HF cache artifacts, and uses shell-form `ENTRYPOINT` to `vllm serve` from that path
> - Documentation update in `docs/deployment/docker.md` with build/run examples and guidance on using Docker build secrets for HF tokens
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fcb1c7949842241e96f89b5c5e2d1568e24c90d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
