### PR TITLE
[Bugfix][MTP] Fix GLM4 MoE fp8 loading with MTP on

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -199,7 +199,6 @@ class SpeculativeConfig:
             n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
             hf_config.update(
                 {
-                    "num_hidden_layers": 0,
                     "n_predict": n_predict,
                     "architectures": ["Glm4MoeMTPModel"],
                 }

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -199,6 +199,7 @@ class SpeculativeConfig:
             n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
             hf_config.update(
                 {
+                    "num_hidden_layers": 0,
                     "n_predict": n_predict,
                     "architectures": ["Glm4MoeMTPModel"],
                 }

--- a/vllm/model_executor/models/glm4_moe_mtp.py
+++ b/vllm/model_executor/models/glm4_moe_mtp.py
@@ -106,7 +106,7 @@ class Glm4MoeMultiTokenPredictorLayer(nn.Module):
     ) -> torch.Tensor:
         assert inputs_embeds is not None
         # masking inputs at position 0, as not needed by MTP
-        inputs_embeds[positions == 0] = 0
+        inputs_embeds = torch.where(positions.unsqueeze(-1) == 0, 0, inputs_embeds)
         inputs_embeds = self.enorm(inputs_embeds)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 

--- a/vllm/model_executor/models/glm4_moe_mtp.py
+++ b/vllm/model_executor/models/glm4_moe_mtp.py
@@ -262,6 +262,9 @@ class Glm4MoeMTP(nn.Module, SupportsPP, Glm4MixtureOfExperts):
                 name = f"model.layers.{spec_layer}.shared_head.head.weight"
             elif name == "model.embed_tokens.weight":
                 spec_layer = self.model.mtp_start_layer_idx
+            elif name == "lm_head.weight_scale":
+                spec_layer = self.model.mtp_start_layer_idx
+                name = f"model.layers.{spec_layer}.shared_head.head.weight_scale"
             else:
                 spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
                 if spec_layer is None:


### PR DESCRIPTION
## Purpose

This PR enables loading of FP8 checkpoints for the GLM-4 moe w/ MTP by handling mismatched scale parameters.

The issue arises because the checkpoint contains FP8 scale parameters (e.g., `xx.weight_scale`) for layers that vLLM does not currently quantize or where the parameter naming/structure differs:
1.  **`ParallelLMHead`**: The MTP model's shared head uses `ParallelLMHead`, which vLLM's FP8 implementation treats as unquantized. The checkpoint provides a `weight_scale`, but the model has no corresponding parameter, causing a `KeyError`.
2.  **MoE Experts**: The checkpoint provides individual expert scales (e.g., `gate_proj.weight_scale`), while vLLM's `FusedMoE` expects fused scales (`w13_weight_scale`).

This PR adds logic to explicitly skip these scale parameters if they are not found in the model's `params_dict`, preventing the crash and allowing the model to load.
## Test Plan

Load GLM-4.6-FP8 with MTP on.

Command:
`vllm serve zai-org/GLM-4.6-FP8 --tensor-parallel-size 8 --enable-auto-tool-choice --tool-call-parser glm45 --reasoning-parser glm45 --kv-cache-dtype fp8 --speculative-config '{"method":"deepseek_mtp","num_speculative_tokens":1, "model":""}'`

**Before:**
The loading process crashes with `KeyError: 'model.layers.92.shared_head.head.weight_scale'` (and similar errors for expert scales).

**After:**
The model loads successfully with skipping unrecognized scale parameters.