### PR TITLE
[Cleanup] Remove redundant `decoder_layer_type` assignment in `Qwen2`

### DIFF
--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -389,8 +389,6 @@ class Qwen2Model(nn.Module):
         else:
             self.embed_tokens = PPMissingLayer()
 
-        # Use the provided decoder layer type or default to Qwen2DecoderLayer
-        decoder_layer_type = decoder_layer_type or Qwen2DecoderLayer
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,
             lambda prefix: decoder_layer_type(


### PR DESCRIPTION

## Purpose
Remove redundant code in the Qwen2 model implementation to improve code cleanliness.
### Changes
- Removed the redundant line `decoder_layer_type = decoder_layer_type or Qwen2DecoderLayer` in vllm/model_executor/models/qwen2.py.
- Removed the accompanying comment.
- The parameter already has the same default value in the __init__ signature, making this internal check unnecessary.
## Test Plan

## Test Result


