### PR TITLE
[BUGFIX] free encode inputs in _update_after_schedule to avoid dead lock in sc…

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -805,6 +805,15 @@ class Scheduler(SchedulerInterface):
             if request.has_encoder_inputs:
                 self._free_encoder_inputs(request)
 
+        # If no tokens were scheduled this step, make sure to free encoder inputs.
+        # There is a corner case when encoder cache is full and every request want a
+        # furture encoder space, but no one is scheduled so no one is going to free
+        # their encoder cache. And Finally, it will cause a deadlock in scheduling.
+        if not num_scheduled_tokens:
+            for request in self.running:
+                if request.has_encoder_inputs:
+                    self.encoder_cache_manager.free(request)
+
         # Clear the finished request IDs.
         # NOTE: We shouldn't do self.finished_req_ids.clear() here because
         # it will also affect the scheduler output.


### PR DESCRIPTION
Trying to solve the dead lock in schedule, when running the multimodal model inference.
Or ask if there are any solutions to similar problems.

## Purpose
In MultiModal case, I meet the following infinite loop in schedule

vllm/vllm/v1/core/sched/scheduler.py +310
```
            if num_new_tokens == 0:
                # The request cannot be scheduled because one of the following
                # reasons:
                # 1. No new tokens to schedule. This may happen when
                #    (1) PP>1 and we have already scheduled all prompt tokens
                #    but they are not finished yet.
                #    (2) Async scheduling and the request has reached to either
                #    its max_total_tokens or max_model_len.
                # 2. The encoder budget is exhausted.
                # 3. The encoder cache is exhausted.
                # NOTE(woosuk): Here, by doing `continue` instead of `break`,
                # we do not strictly follow the FCFS scheduling policy and
                # allow the lower-priority requests to be scheduled.
                req_index += 1
                continue    # Every request is running in this branch, and dead loop in this branch.
```

For Further debugging,  It is encoder cache not enough:
vllm/v1/core/encoder_cache_manager.py +155
```
        # Not enough reclaimable slots
        if num_embeds > self.num_freeable_slots:
            return False   # It always in this branch.     For example, num_embeds is 832,  but num_freeable_slots: 320
                             # And 'encoder_cache_manager.freeable' is Empty
```

It seems that every request want a futher encoder cache space, but no request can sucessfully free their own cache.
Maybe their images embeddings it hold by other request,  and encoder cache reference count can not be 0.
And Finally, no request can be scheduled because insufficient encode cache,  and no request can be scheduled.
And create a deadlock:  
request can not alloc encoder cache -> cannot be scheduled -> cannot free encoder cache -> request cannot alloc encoder cache

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

