### PR TITLE
[Model] Enable LoRA support for LLaVA family

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -702,7 +702,7 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `Llama4ForConditionalGeneration` | Llama 4 | T + I<sup>+</sup> | `meta-llama/Llama-4-Scout-17B-16E-Instruct`, `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8`, `meta-llama/Llama-4-Maverick-17B-128E-Instruct`, etc. | ✅︎ | ✅︎ |
 | `Llama_Nemotron_Nano_VL` | Llama Nemotron Nano VL | T + I<sup>E+</sup> | `nvidia/Llama-3.1-Nemotron-Nano-VL-8B-V1` | ✅︎ | ✅︎ |
 | `LlavaForConditionalGeneration` | LLaVA-1.5, Pixtral (HF Transformers) | T + I<sup>E+</sup> | `llava-hf/llava-1.5-7b-hf`, `TIGER-Lab/Mantis-8B-siglip-llama3` (see note), `mistral-community/pixtral-12b`, etc. | ✅︎ | ✅︎ |
-| `LlavaNextForConditionalGeneration` | LLaVA-NeXT | T + I<sup>E+</sup> | `llava-hf/llava-v1.6-mistral-7b-hf`, `llava-hf/llava-v1.6-vicuna-7b-hf`, etc. | | ✅︎ |
+| `LlavaNextForConditionalGeneration` | LLaVA-NeXT | T + I<sup>E+</sup> | `llava-hf/llava-v1.6-mistral-7b-hf`, `llava-hf/llava-v1.6-vicuna-7b-hf`, etc. | ✅︎ | ✅︎ |
 | `LlavaNextVideoForConditionalGeneration` | LLaVA-NeXT-Video | T + V | `llava-hf/LLaVA-NeXT-Video-7B-hf`, etc. | | ✅︎ |
 | `LlavaOnevisionForConditionalGeneration` | LLaVA-Onevision | T + I<sup>+</sup> + V<sup>+</sup> | `llava-hf/llava-onevision-qwen2-7b-ov-hf`, `llava-hf/llava-onevision-qwen2-0.5b-ov-hf`, etc. | | ✅︎ |
 | `MiDashengLMModel` | MiDashengLM | T + A<sup>+</sup> | `mispeech/midashenglm-7b` | | ✅︎ |

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -703,8 +703,8 @@ These models primarily accept the [`LLM.generate`](./generative_models.md#llmgen
 | `Llama_Nemotron_Nano_VL` | Llama Nemotron Nano VL | T + I<sup>E+</sup> | `nvidia/Llama-3.1-Nemotron-Nano-VL-8B-V1` | ✅︎ | ✅︎ |
 | `LlavaForConditionalGeneration` | LLaVA-1.5, Pixtral (HF Transformers) | T + I<sup>E+</sup> | `llava-hf/llava-1.5-7b-hf`, `TIGER-Lab/Mantis-8B-siglip-llama3` (see note), `mistral-community/pixtral-12b`, etc. | ✅︎ | ✅︎ |
 | `LlavaNextForConditionalGeneration` | LLaVA-NeXT | T + I<sup>E+</sup> | `llava-hf/llava-v1.6-mistral-7b-hf`, `llava-hf/llava-v1.6-vicuna-7b-hf`, etc. | ✅︎ | ✅︎ |
-| `LlavaNextVideoForConditionalGeneration` | LLaVA-NeXT-Video | T + V | `llava-hf/LLaVA-NeXT-Video-7B-hf`, etc. | | ✅︎ |
-| `LlavaOnevisionForConditionalGeneration` | LLaVA-Onevision | T + I<sup>+</sup> + V<sup>+</sup> | `llava-hf/llava-onevision-qwen2-7b-ov-hf`, `llava-hf/llava-onevision-qwen2-0.5b-ov-hf`, etc. | | ✅︎ |
+| `LlavaNextVideoForConditionalGeneration` | LLaVA-NeXT-Video | T + V | `llava-hf/LLaVA-NeXT-Video-7B-hf`, etc. | ✅︎ | ✅︎ |
+| `LlavaOnevisionForConditionalGeneration` | LLaVA-Onevision | T + I<sup>+</sup> + V<sup>+</sup> | `llava-hf/llava-onevision-qwen2-7b-ov-hf`, `llava-hf/llava-onevision-qwen2-0.5b-ov-hf`, etc. | ✅︎ | ✅︎ |
 | `MiDashengLMModel` | MiDashengLM | T + A<sup>+</sup> | `mispeech/midashenglm-7b` | | ✅︎ |
 | `MiniCPMO` | MiniCPM-O | T + I<sup>E+</sup> + V<sup>E+</sup> + A<sup>E+</sup> | `openbmb/MiniCPM-o-2_6`, etc. | ✅︎ | ✅︎ |
 | `MiniCPMV` | MiniCPM-V | T + I<sup>E+</sup> + V<sup>E+</sup> | `openbmb/MiniCPM-V-2` (see note), `openbmb/MiniCPM-Llama3-V-2_5`, `openbmb/MiniCPM-V-2_6`, `openbmb/MiniCPM-V-4`, `openbmb/MiniCPM-V-4_5`, etc. | ✅︎ | |

--- a/vllm/model_executor/models/llava_next.py
+++ b/vllm/model_executor/models/llava_next.py
@@ -21,12 +21,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
 from .clip import CLIPVisionModel
-from .interfaces import (
-    MultiModalEmbeddings,
-    SupportsLoRA,
-    SupportsMultiModal,
-    SupportsPP,
-)
+from .interfaces import MultiModalEmbeddings, SupportsMultiModal, SupportsPP
 from .llava import (
     BaseLlavaMultiModalProcessor,
     BaseLlavaProcessingInfo,
@@ -35,7 +30,6 @@ from .llava import (
     LlavaMultiModalProjector,
     init_vision_tower_for_llava,
 )
-from .module_mapping import MultiModelKeys
 from .siglip import SiglipVisionModel
 from .utils import (
     AutoWeightsLoader,
@@ -228,9 +222,7 @@ class LlavaNextMultiModalProcessor(
     info=LlavaNextProcessingInfo,
     dummy_inputs=LlavaDummyInputsBuilder,
 )
-class LlavaNextForConditionalGeneration(
-    nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA
-):
+class LlavaNextForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
             # mapping for new names in checkpoint saved after transformers v4.52
@@ -587,28 +579,3 @@ model_executor.models.llava_next.LlavaNextProcessingInfo.get_num_image_tokens].
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
-
-    def get_mm_mapping(self) -> MultiModelKeys:
-        """
-        Get the module prefix in multimodal models.
-        """
-        return MultiModelKeys.from_string_field(
-            language_model="language_model",
-            connector="multi_modal_projector",
-            tower_model="vision_tower",
-        )
-
-    def get_num_mm_encoder_tokens(
-        self,
-        num_image_tokens: int,
-    ) -> int:
-        # Vision tower outputs one token per selected patch plus newline tokens; the
-        # count already matches the placeholder tokens inserted for the LM.
-        return num_image_tokens
-
-    def get_num_mm_connector_tokens(
-        self,
-        num_vision_tokens: int,
-    ) -> int:
-        # Projector is an MLP that preserves sequence length (1:1 mapping).
-        return num_vision_tokens

--- a/vllm/model_executor/models/llava_next.py
+++ b/vllm/model_executor/models/llava_next.py
@@ -590,7 +590,7 @@ model_executor.models.llava_next.LlavaNextProcessingInfo.get_num_image_tokens].
 
     def get_mm_mapping(self) -> MultiModelKeys:
         """
-        Get the module prefix in multimodal models.
+        Get the module prefix in multimodal models
         """
         return MultiModelKeys.from_string_field(
             language_model="language_model",
@@ -602,10 +602,14 @@ model_executor.models.llava_next.LlavaNextProcessingInfo.get_num_image_tokens].
         self,
         num_image_tokens: int,
     ) -> int:
+        # LLaVA's vision encoder outputs one token per patch without
+        # spatial merging or pixel shuffle
         return num_image_tokens
 
     def get_num_mm_connector_tokens(
         self,
         num_vision_tokens: int,
     ) -> int:
+        # LLaVA's MLP projector outputs the same number of tokens
+        # as it receives from the vision encoder (1:1 mapping)
         return num_vision_tokens

--- a/vllm/model_executor/models/llava_next.py
+++ b/vllm/model_executor/models/llava_next.py
@@ -21,7 +21,12 @@ from vllm.sequence import IntermediateTensors
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
 from .clip import CLIPVisionModel
-from .interfaces import MultiModalEmbeddings, SupportsMultiModal, SupportsPP
+from .interfaces import (
+    MultiModalEmbeddings,
+    SupportsLoRA,
+    SupportsMultiModal,
+    SupportsPP,
+)
 from .llava import (
     BaseLlavaMultiModalProcessor,
     BaseLlavaProcessingInfo,
@@ -30,6 +35,7 @@ from .llava import (
     LlavaMultiModalProjector,
     init_vision_tower_for_llava,
 )
+from .module_mapping import MultiModelKeys
 from .siglip import SiglipVisionModel
 from .utils import (
     AutoWeightsLoader,
@@ -222,7 +228,9 @@ class LlavaNextMultiModalProcessor(
     info=LlavaNextProcessingInfo,
     dummy_inputs=LlavaDummyInputsBuilder,
 )
-class LlavaNextForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
+class LlavaNextForConditionalGeneration(
+    nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA
+):
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
             # mapping for new names in checkpoint saved after transformers v4.52
@@ -579,3 +587,28 @@ model_executor.models.llava_next.LlavaNextProcessingInfo.get_num_image_tokens].
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+    def get_mm_mapping(self) -> MultiModelKeys:
+        """
+        Get the module prefix in multimodal models.
+        """
+        return MultiModelKeys.from_string_field(
+            language_model="language_model",
+            connector="multi_modal_projector",
+            tower_model="vision_tower",
+        )
+
+    def get_num_mm_encoder_tokens(
+        self,
+        num_image_tokens: int,
+    ) -> int:
+        # Vision tower outputs one token per selected patch plus newline tokens; the
+        # count already matches the placeholder tokens inserted for the LM.
+        return num_image_tokens
+
+    def get_num_mm_connector_tokens(
+        self,
+        num_vision_tokens: int,
+    ) -> int:
+        # Projector is an MLP that preserves sequence length (1:1 mapping).
+        return num_vision_tokens

--- a/vllm/model_executor/models/llava_next_video.py
+++ b/vllm/model_executor/models/llava_next_video.py
@@ -474,7 +474,7 @@ class LlavaNextVideoForConditionalGeneration(
 
     def get_mm_mapping(self) -> MultiModelKeys:
         """
-        Map multimodal submodules for LoRA targeting.
+        Get the module prefix in multimodal models
         """
         return MultiModelKeys.from_string_field(
             language_model="language_model",
@@ -486,10 +486,14 @@ class LlavaNextVideoForConditionalGeneration(
         self,
         num_image_tokens: int,
     ) -> int:
+        # LLaVA's vision encoder outputs one token per patch without
+        # spatial merging or pixel shuffle
         return num_image_tokens
 
     def get_num_mm_connector_tokens(
         self,
         num_vision_tokens: int,
     ) -> int:
+        # LLaVA's MLP projector outputs the same number of tokens
+        # as it receives from the vision encoder (1:1 mapping)
         return num_vision_tokens

--- a/vllm/model_executor/models/llava_onevision.py
+++ b/vllm/model_executor/models/llava_onevision.py
@@ -930,7 +930,7 @@ class LlavaOnevisionForConditionalGeneration(
 
     def get_mm_mapping(self) -> MultiModelKeys:
         """
-        Map multimodal submodules for LoRA targeting.
+        Get the module prefix in multimodal models
         """
         return MultiModelKeys.from_string_field(
             language_model="language_model",
@@ -942,10 +942,14 @@ class LlavaOnevisionForConditionalGeneration(
         self,
         num_image_tokens: int,
     ) -> int:
+        # LLaVA's vision encoder outputs one token per patch without
+        # spatial merging or pixel shuffle
         return num_image_tokens
 
     def get_num_mm_connector_tokens(
         self,
         num_vision_tokens: int,
     ) -> int:
+        # LLaVA's MLP projector outputs the same number of tokens
+        # as it receives from the vision encoder (1:1 mapping)
         return num_vision_tokens


### PR DESCRIPTION
## Purpose
Master issue: https://github.com/vllm-project/vllm/issues/31479
PR for LLaVA support: https://github.com/vllm-project/vllm/pull/31513
LLaVA family (LLaVA-Next, LLaVA OneVision, LLaVA-Next-Video) are pretty similar to LLaVA.

### Vision tower


> same vision tower that emits one token per selected patch
https://github.com/vllm-project/vllm/blob/cd1245a1848d866fa640cb1051c6bbb5b1c68f4a/vllm/model_executor/models/llava.py#L468-L474

> for LLaVA next video, we downsample when doing video preprocessing, but the video tokens are already computed in advance by `get_num_video_tokens` and padded in the prompt, so image-token -> encoder token should still be 1:1
https://github.com/vllm-project/vllm/blob/cd1245a1848d866fa640cb1051c6bbb5b1c68f4a/vllm/model_executor/models/llava_next_video.py#L209-L224


### Connector

> connector is length preserving
https://github.com/vllm-project/vllm/blob/cd1245a1848d866fa640cb1051c6bbb5b1c68f4a/vllm/model_executor/models/llava.py#L136-L150

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

