### PR TITLE
[LoRA]Disable linear LoRA  kernel PDL

### DIFF
--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -277,7 +277,7 @@ The new format of `--lora-modules` is mainly to support the display of parent mo
 
 ## LoRA Support for Tower and Connector of Multi-Modal Model
 
-Currently, vLLM experimentally supports LoRA for the Tower and Connector components of multi-modal models. To enable this feature, you need to implement the corresponding token helper functions for the tower and connector. For more details on the rationale behind this approach, please refer to [PR 26674](https://github.com/vllm-project/vllm/pull/26674). We welcome contributions to extend LoRA support to additional models' tower and connector.
+Currently, vLLM experimentally supports LoRA for the Tower and Connector components of multi-modal models. To enable this feature, you need to implement the corresponding token helper functions for the tower and connector. For more details on the rationale behind this approach, please refer to [PR 26674](https://github.com/vllm-project/vllm/pull/26674). We welcome contributions to extend LoRA support to additional models' tower and connector. Please refer to [Issue ](https://github.com/vllm-project/vllm/issues/31479) to check the current model support status.
 
 ## Default LoRA Models For Multimodal Models
 

--- a/docs/features/lora.md
+++ b/docs/features/lora.md
@@ -277,7 +277,7 @@ The new format of `--lora-modules` is mainly to support the display of parent mo
 
 ## LoRA Support for Tower and Connector of Multi-Modal Model
 
-Currently, vLLM experimentally supports LoRA for the Tower and Connector components of multi-modal models. To enable this feature, you need to implement the corresponding token helper functions for the tower and connector. For more details on the rationale behind this approach, please refer to [PR 26674](https://github.com/vllm-project/vllm/pull/26674). We welcome contributions to extend LoRA support to additional models' tower and connector. Please refer to [Issue ](https://github.com/vllm-project/vllm/issues/31479) to check the current model support status.
+Currently, vLLM experimentally supports LoRA for the Tower and Connector components of multi-modal models. To enable this feature, you need to implement the corresponding token helper functions for the tower and connector. For more details on the rationale behind this approach, please refer to [PR 26674](https://github.com/vllm-project/vllm/pull/26674). We welcome contributions to extend LoRA support to additional models' tower and connector. Please refer to [Issue 31479](https://github.com/vllm-project/vllm/issues/31479) to check the current model support status.
 
 ## Default LoRA Models For Multimodal Models
 

--- a/vllm/lora/ops/triton_ops/fused_moe_lora_op.py
+++ b/vllm/lora/ops/triton_ops/fused_moe_lora_op.py
@@ -231,9 +231,9 @@ def _fused_moe_lora_shrink(
     num_stages: int,
     split_k: int,
     mul_routed_weight: bool = False,
+    use_gdc: bool = False,
 ) -> None:
     w1_lora_a_stacked = lora_a_stacked[0]
-    use_gdc = supports_pdl(qcurr_hidden_states.device)
     shrink_config = {
         "BLOCK_SIZE_M": block_size_m,
         "BLOCK_SIZE_N": block_size_n,
@@ -326,6 +326,7 @@ def _fused_moe_lora_expand(
     split_k: int,
     mul_routed_weight: bool = False,
     offset: int = 0,
+    use_gdc: bool = False,
 ) -> None:
     b_ptr = _get_ptr(lora_b_stacked, device)
     K = max_lora_rank
@@ -337,7 +338,6 @@ def _fused_moe_lora_expand(
         -1, a_intermediate_cache1.shape[3]
     )
 
-    use_gdc = supports_pdl(a_intermediate_cache1.device)
     expand_config = {
         "BLOCK_SIZE_M": block_size_m,
         "BLOCK_SIZE_N": block_size_n,
@@ -466,7 +466,7 @@ def _fused_moe_lora(
         dtype=output.dtype,
         device=device,
     )
-
+    use_gdc = supports_pdl(device) and not fully_sharded
     _fused_moe_lora_shrink(
         a_intermediate_cache1,
         qcurr_hidden_states,
@@ -495,6 +495,7 @@ def _fused_moe_lora(
         shrink_num_stages,
         shrink_split_k,
         mul_routed_weight,
+        use_gdc=use_gdc,
     )
 
     if fully_sharded:
@@ -542,6 +543,7 @@ def _fused_moe_lora(
         expand_split_k,
         mul_routed_weight,
         offset,
+        use_gdc=use_gdc,
     )
 
 
@@ -604,6 +606,7 @@ def _fused_moe_lora_shrink_fake(
     num_stages: int,
     split_k: int,
     mul_routed_weight: bool = False,
+    use_gdc: bool = False,
 ) -> None:
     return
 
@@ -637,6 +640,7 @@ def _fused_moe_lora_expand_fake(
     num_stages: int,
     split_k: int,
     mul_routed_weight: bool = False,
+    use_gdc: bool = False,
 ) -> None:
     return
 

--- a/vllm/lora/ops/triton_ops/lora_expand_op.py
+++ b/vllm/lora/ops/triton_ops/lora_expand_op.py
@@ -14,8 +14,6 @@ from vllm.lora.ops.triton_ops.utils import _get_lora_b_ptr, get_lora_op_configs
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op
 
-from .utils import supports_pdl
-
 
 @triton.jit
 def _lora_expand_kernel(
@@ -241,7 +239,9 @@ def _lora_expand(
         # thread blocks simply exit.
         MAX_LORAS,
     )
-    use_gdc = supports_pdl(inputs.device)
+    # We disable PDL temporarily because LoRA kernels are not launching back-to-back,
+    # making PDL invalid and affecting the kernel performance.
+    use_gdc = False  # supports_pdl(inputs.device)
     _lora_expand_kernel[grid](
         inputs,
         lora_ptr_tensor,

--- a/vllm/lora/ops/triton_ops/lora_shrink_op.py
+++ b/vllm/lora/ops/triton_ops/lora_shrink_op.py
@@ -14,8 +14,6 @@ from vllm.lora.ops.triton_ops.utils import _get_lora_a_ptr, get_lora_op_configs
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op
 
-from .utils import supports_pdl
-
 
 @triton.jit
 def _lora_shrink_kernel(
@@ -221,7 +219,9 @@ def _lora_shrink(
         # thread blocks exit early.
         MAX_LORAS,
     )
-    use_gdc = supports_pdl(inputs.device)
+    # We disable PDL temporarily because LoRA kernels are not launching back-to-back,
+    # making PDL invalid and affecting the kernel performance.
+    use_gdc = False  # supports_pdl(inputs.device)
     _lora_shrink_kernel[grid](
         inputs,
         lora_ptr_tensor,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Currently, we found that there is a base model GEMM operator between the two LoRA operators in linear LoRA. This causes PDL to be ineffective and actually negatively impacts LoRA performance. Therefore, this PR temporarily disables PDL.
<img width="1396" height="602" alt="image" src="https://github.com/user-attachments/assets/7d2fcab3-b514-464d-bb75-8c0243e03d4c" />
<img width="1026" height="436" alt="image" src="https://github.com/user-attachments/assets/b2f11972-cbc6-4b69-91ed-4f2f604de8b7" />

- main branch
```bash
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Benchmark duration (s):                  40.08     
Total input tokens:                      204700    
Total generated tokens:                  102400    
Request throughput (req/s):              2.49      
Output token throughput (tok/s):         2554.87   
Peak output token throughput (tok/s):    3900.00   
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          7662.13   
---------------Time to First Token----------------
Mean TTFT (ms):                          5831.36   
Median TTFT (ms):                        5925.33   
P90 TTFT (ms):                           10330.85  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          33.29     
Median TPOT (ms):                        33.23     
P90 TPOT (ms):                           37.24     
---------------Inter-token Latency----------------
Mean ITL (ms):                           33.29     
Median ITL (ms):                         28.30     
P90 ITL (ms):                            31.06     
==================================================
```

- This PR
```bash
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Benchmark duration (s):                  39.72     
Total input tokens:                      204700    
Total generated tokens:                  102400    
Request throughput (req/s):              2.52      
Output token throughput (tok/s):         2577.76   
Peak output token throughput (tok/s):    3905.00   
Peak concurrent requests:                100.00    
Total token throughput (tok/s):          7730.75   
---------------Time to First Token----------------
Mean TTFT (ms):                          5826.86   
Median TTFT (ms):                        5710.47   
P90 TTFT (ms):                           10110.86  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          32.95     
Median TPOT (ms):                        33.09     
P90 TPOT (ms):                           37.10     
---------------Inter-token Latency----------------
Mean ITL (ms):                           32.95     
Median ITL (ms):                         27.81     
P90 ITL (ms):                            30.99     
==================================================
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

