### PR TITLE
[BugFix] fixing stream interval > 1 will cause tool call bug

### DIFF
--- a/tests/entrypoints/openai/test_streaming_tool_calls.py
+++ b/tests/entrypoints/openai/test_streaming_tool_calls.py
@@ -39,7 +39,9 @@ def server():
         yield remote_server
 
 
-@pytest.mark.parametrize("stream_interval", [1, 8, 9, 10, 18, 19, 20])
+@pytest.mark.parametrize(
+    "stream_interval", [1, 8, 9, 10, 18, 19, 20, 100, 1000, 1_000_000]
+)
 def test_streaming_tool_calls_with_different_intervals(stream_interval: int):
     """
     Test that streaming tool calls work correctly with different stream intervals.

--- a/tests/entrypoints/openai/test_streaming_tool_calls.py
+++ b/tests/entrypoints/openai/test_streaming_tool_calls.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+from ...utils import RemoteOpenAIServer
+
+MODEL_NAME = "Qwen/Qwen2.5-1.5B-Instruct"
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "list_directory",
+            "description": "List contents of a directory.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "dir": {"type": "string", "description": "Directory path"}
+                },
+                "required": ["dir"],
+            },
+        },
+    }
+]
+
+
+@pytest.fixture(scope="module")
+def server():
+    """Start vLLM server with tool calling enabled."""
+    args = [
+        "--enable-auto-tool-choice",
+        "--tool-call-parser",
+        "hermes",
+        "--max-model-len",
+        "2048",
+    ]
+
+    with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
+        yield remote_server
+
+
+@pytest.mark.parametrize("stream_interval", [1, 8, 9, 10, 18, 19, 20])
+def test_streaming_tool_calls_with_different_intervals(stream_interval: int):
+    """
+    Test that streaming tool calls work correctly with different stream intervals.
+
+    Regression test for issue #31501 where tool calls failed when stream_interval > 1.
+    """
+    # Restart server with the specific stream_interval for this test
+    args = [
+        "--enable-auto-tool-choice",
+        "--tool-call-parser",
+        "hermes",
+        "--max-model-len",
+        "2048",
+        "--stream-interval",
+        str(stream_interval),
+    ]
+
+    with RemoteOpenAIServer(MODEL_NAME, args) as test_server:
+        client = test_server.get_client()
+
+        response = client.chat.completions.create(
+            model=MODEL_NAME,
+            messages=[
+                {
+                    "role": "system",
+                    "content": "Use the list_directory tool when asked about files.",
+                },
+                {"role": "user", "content": "List files in the src folder"},
+            ],
+            tools=TOOLS,
+            stream=True,
+        )
+
+        # Accumulate streamed tool call
+        accumulated_args = ""
+        tool_name = None
+
+        for chunk in response:
+            delta = chunk.choices[0].delta
+            if delta.tool_calls:
+                for tc in delta.tool_calls:
+                    if tc.function.name:
+                        tool_name = tc.function.name
+                    if tc.function.arguments:
+                        accumulated_args += tc.function.arguments
+
+        # Verify tool call was correctly accumulated
+        assert tool_name == "list_directory", (
+            f"Expected tool name 'list_directory', got {tool_name}"
+        )
+        assert accumulated_args, (
+            f"Expected non-empty arguments, got {accumulated_args!r}"
+        )
+
+        # Verify the arguments contain the expected directory
+        assert '{"dir": "/src"}' in accumulated_args, (
+            f'Expected {{"dir": "/src"}} in arguments, got {accumulated_args!r}'
+        )
+
+
+def test_streaming_tool_calls_basic(server):
+    """Basic test that streaming tool calls work with default settings."""
+    client = server.get_client()
+
+    response = client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=[
+            {
+                "role": "system",
+                "content": "Use the list_directory tool when asked about files.",
+            },
+            {"role": "user", "content": "List files in the src folder"},
+        ],
+        tools=TOOLS,
+        stream=True,
+    )
+
+    # Accumulate streamed tool call
+    accumulated_args = ""
+    tool_name = None
+
+    for chunk in response:
+        delta = chunk.choices[0].delta
+        if delta.tool_calls:
+            for tc in delta.tool_calls:
+                if tc.function.name:
+                    tool_name = tc.function.name
+                if tc.function.arguments:
+                    accumulated_args += tc.function.arguments
+
+    # Verify results
+    assert tool_name == "list_directory"
+    assert accumulated_args
+    assert '{"dir": "/src"}' in accumulated_args

--- a/tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py
@@ -395,6 +395,159 @@ def test_hermes_parser_streaming(
     )
 
 
+def test_hermes_parser_streaming_different_intervals_tool_1(
+    qwen_tokenizer: TokenizerLike,
+    hermes_parser: Hermes2ProToolParser,
+    any_chat_request: ChatCompletionRequest,
+) -> None:
+    text = '<tool_call>\
+{"name": "get_current_temperature","arguments\
+": {"location":\
+"San Francisco, California, United States", "unit": "celsius"}}\
+</tool_call>'
+    tokens = qwen_tokenizer.encode(text)
+    for interval in range(1, 21):
+        previous_text = ""
+        delta_messages = []
+
+        # Group tokens into chunks based on interval
+        for i in range(0, len(tokens), interval):
+            # Get chunk of tokens (up to 'interval' tokens, or whatever's left)
+            token_chunk = tokens[i : i + interval]
+
+            # Decode the chunk
+            text = qwen_tokenizer.decode(token_chunk)
+            current_text = previous_text + text
+
+            delta = hermes_parser.extract_tool_calls_streaming(
+                previous_text=previous_text,
+                current_text=current_text,
+                delta_text=text,
+                previous_token_ids=[],
+                current_token_ids=[],
+                delta_token_ids=[],
+                request=any_chat_request,
+            )
+            previous_text = current_text
+            if delta is not None:
+                delta_messages.append(delta)
+
+        print(f"Interval: {interval}")
+        for delta in delta_messages:
+            print(delta)
+        assert (
+            delta_messages[0].tool_calls[0].function.name == "get_current_temperature"
+        )
+        tool_call_args = "".join(
+            delta.tool_calls[0].function.arguments or "" for delta in delta_messages
+        )
+        assert tool_call_args == (
+            '{"location":"San Francisco, California, United States", "unit": "celsius"}'
+        )
+
+
+# This test replicates the exact streaming behavior of running the vLLM server below
+# with different --stream-interval values. It correctly handles:
+# - First token processed separately (matching server behavior)
+# - Special tokens like <tool_call> and <|im_end|>
+#
+# Command simulated:
+# vllm serve Qwen/Qwen2.5-1.5B-Instruct
+#   --stream-interval 10
+#   --enable-auto-tool-choice
+#   --tool-call-parser hermes
+#   --max-model-len 2048
+def test_hermes_parser_streaming_different_intervals_tool_2(
+    qwen_tokenizer: TokenizerLike,
+    hermes_parser: Hermes2ProToolParser,
+    any_chat_request: ChatCompletionRequest,
+) -> None:
+    text = """<tool_call>
+{"name": "list_directory", "arguments": {"dir": "/src"}}
+</tool_call><|im_end|>"""
+    tokens = qwen_tokenizer.encode(text)
+    expected_tokens = [
+        151657,
+        198,
+        4913,
+        606,
+        788,
+        330,
+        1607,
+        14846,
+        497,
+        330,
+        16370,
+        788,
+        5212,
+        3741,
+        788,
+        3521,
+        3548,
+        95642,
+        151658,
+        151645,
+    ]
+    assert tokens == expected_tokens
+
+    for interval in range(1, 21):
+        # The first token is processed separately to simulate server behavior
+        previous_text = ""
+        delta_messages = []
+
+        # Process first token separately
+        first_token = tokens[0:1]
+        text = qwen_tokenizer.decode(first_token)
+        current_text = text
+
+        delta = hermes_parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=text,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=any_chat_request,
+        )
+        previous_text = current_text
+        if delta is not None:
+            delta_messages.append(delta)
+
+        # Process remaining tokens in chunks based on interval
+        remaining_tokens = tokens[1:]
+        for i in range(0, len(remaining_tokens), interval):
+            # Get chunk of tokens (up to 'interval' tokens, or whatever's left)
+            token_chunk = remaining_tokens[i : i + interval]
+
+            # Decode the chunk
+            text = qwen_tokenizer.decode(token_chunk)
+            current_text = previous_text + text
+
+            delta = hermes_parser.extract_tool_calls_streaming(
+                previous_text=previous_text,
+                current_text=current_text,
+                delta_text=text,
+                previous_token_ids=[],
+                current_token_ids=[],
+                delta_token_ids=[],
+                request=any_chat_request,
+            )
+            previous_text = current_text
+            if delta is not None:
+                delta_messages.append(delta)
+
+        print(f"Interval: {interval}")
+        for delta in delta_messages:
+            print(delta)
+        assert delta_messages[0].tool_calls[0].function.name == "list_directory"
+        tool_call_args = "".join(
+            delta.tool_calls[0].function.arguments or ""
+            for delta in delta_messages
+            if delta.tool_calls  # Skips if None or empty list
+        )
+        assert tool_call_args == '{"dir": "/src"}'
+
+
 def test_hermes_parser_non_streaming_no_tool_call(
     hermes_parser: Hermes2ProToolParser,
     any_chat_request: ChatCompletionRequest,

--- a/tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py
@@ -406,7 +406,9 @@ def test_hermes_parser_streaming_different_intervals_tool_1(
 "San Francisco, California, United States", "unit": "celsius"}}\
 </tool_call>'
     tokens = qwen_tokenizer.encode(text)
-    for interval in range(1, 21):
+    interval_sizes = list(range(1, 21))
+    interval_sizes.extend([100, 1000, 10_000, 100_000, 1_000_000, 10_000_000])
+    for interval in interval_sizes:
         previous_text = ""
         delta_messages = []
 
@@ -490,7 +492,9 @@ def test_hermes_parser_streaming_different_intervals_tool_2(
     ]
     assert tokens == expected_tokens
 
-    for interval in range(1, 21):
+    interval_sizes = list(range(1, 21))
+    interval_sizes.extend([100, 1000, 10_000, 100_000, 1_000_000, 10_000_000])
+    for interval in interval_sizes:
         # The first token is processed separately to simulate server behavior
         previous_text = ""
         delta_messages = []
@@ -558,7 +562,9 @@ def test_hermes_parser_streaming_different_intervals_bug_30229(
 </tool_call>"""
     tokens = qwen_tokenizer.encode(text)
 
-    for interval in range(1, 21):
+    interval_sizes = list(range(1, 21))
+    interval_sizes.extend([100, 1000, 10_000, 100_000, 1_000_000, 10_000_000])
+    for interval in interval_sizes:
         # The first token is processed separately to simulate server behavior
         previous_text = ""
         delta_messages = []

--- a/vllm/tool_parsers/hermes_tool_parser.py
+++ b/vllm/tool_parsers/hermes_tool_parser.py
@@ -321,8 +321,6 @@ class Hermes2ProToolParser(ToolParser):
                 if isinstance(function_arguments, dict):
                     function_arguments = json.dumps(function_arguments)
                 if function_name:
-                    logger.debug("Function name: %s", function_name)
-                    logger.debug("Function arguments: %s", function_arguments)
                     self.current_tool_name_sent = True
                     self.streamed_args_for_tool[self.current_tool_id] += (
                         function_arguments


### PR DESCRIPTION
## Purpose
This PR fixes #31501. Testing indicates it also resolves #32152, #31871 and #30229.

## Limitations
This parser currently supports at most one tool call per `delta_text` chunk. Multiple tool calls across different `delta_text` chunks are supported, but multiple tool calls within a single `delta_text` chunk are not.

In practice, this is not an issue because `OpenAIServingChat` currently emits the `<tool_call_start>` token in its own separate `delta_text` chunk.

## What is wrong
### Summary
When delta_text contains more than one token, the parser is very likely to fail.
If a single `delta_text` includes `{full_tool_call}<tool_end_token>` within a stream-interval, the parser fails and returns `Tool: None, Args: ''`.
If a single `delta_text` includes `{part_of_tool_call}<tool_end_token>` within a stream-interval, the parser fails and returns `Tool: list_directory, Args: '{}'`.

### Detailed tracing
In the test python script, the tool call had a total of 20 tokens (including start and end token). 
Let's see what happens when interval is set to 20, `counters` in the log stands for these four
```
prev_tool_start_count = previous_text.count(self.tool_call_start_token)
prev_tool_end_count = previous_text.count(self.tool_call_end_token)
cur_tool_start_count = current_text.count(self.tool_call_start_token)
cur_tool_end_count = current_text.count(self.tool_call_end_token)
```
and here is the log
```
This parser is called
INFO 01-04 21:42:33 [hermes_tool_parser.py:200] delta_text: <tool_call>
INFO 01-04 21:42:33 [hermes_tool_parser.py:201] delta_token_ids: [151657]
INFO 01-04 21:42:33 [hermes_tool_parser.py:216] counters: 0, 0, 1, 0
INFO 01-04 21:42:33 [hermes_tool_parser.py:264] Starting on a new tool 0
INFO 01-04 21:42:33 [hermes_tool_parser.py:327] Parsed tool call None

This parser is called
INFO 01-04 21:42:34 [hermes_tool_parser.py:200] delta_text: 
INFO 01-04 21:42:34 [hermes_tool_parser.py:200] {"name": "list_directory", "arguments": {"dir": "/src"}}
INFO 01-04 21:42:34 [hermes_tool_parser.py:200] </tool_call>
INFO 01-04 21:42:34 [hermes_tool_parser.py:201] delta_token_ids: [198, 4913, 606, 788, 330, 1607, 14846, 497, 330, 16370, 788, 5212, 3741, 788, 3521, 3548, 95642, 151658, 151645]
INFO 01-04 21:42:34 [hermes_tool_parser.py:216] counters: 1, 0, 1, 1
INFO 01-04 21:42:34 [hermes_tool_parser.py:228] tool_call_end_token in delta_text
INFO 01-04 21:42:34 [hermes_tool_parser.py:282] attempting to close tool call, but no tool call
```
There is a total of 2 iterations, in the 1st one, the `delta_text` is just a `<tool_call>`. In the 2nd one, it is actually `\n{"name": "list_directory", "arguments": {"dir": "/src"}}\n</tool_call>` The `\n` character makes the content of `delta_text` appear on 3 lines but actually they are in the same `delta_text`

Because in the 1st iteration, we never updated `self.prev_tool_call_arr`, so on the 2nd iteration, we saw the message "attempting to close tool call, but no tool call" This is an easy fix, that we just need to append an empty `{}` to it whenever we create a new tool call. This will help us pass the first null check in `# case -- the current tool call is being closed.` But remember our interval value (20) can contain all 19 tokens, which means we are getting the tool call content at the same time as the `</tool_call>` token. Therefore, `self.prev_tool_call_arr` was not yet updated, and `diff` would be empty. Then we fall through to 
```
current_tool_call = (
    partial_json_parser.loads(tool_call_portion or "{}", flags)
    if tool_call_portion
    else None
)
```
Luckily, when there is `</tool_call>` in the `delta_text`, `tool_call_portion` will always give good results (this can be verified by checking how it is created in the code above). Because we are on only the 2nd iteration where the 1st one only starts the call, we have not set the function name yet. So we enter `if not self.current_tool_name_sent:` Here is another oversight: we didn't expect function name and `</tool_call>` can be inside one `delta_text`, so we never actually handle the tool call arguments in this section. Easy fix right? Just add them and update the states properly! But what about partial arguments? Luckily `DeltaFunctionCall` handles partial arguments using `+=`. As long as we don't add extra auto-complete JSON control characters, we will be fine.

So far, we have talked about the case for `delta_text` contains `{full_tool_call}<tool_end_token>`. Now we need to consider the case for `{partial_tool_call}<tool_end_token>`. Let's set the `stream-interval` to 10. 

Here is the new log
```
This parser is called
INFO 01-06 00:34:21 [hermes_tool_parser.py:200] delta_text: <tool_call>
INFO 01-06 00:34:21 [hermes_tool_parser.py:201] delta_token_ids: [151657]
INFO 01-06 00:34:21 [hermes_tool_parser.py:214] counters: 0 0 1 0
INFO 01-06 00:34:21 [hermes_tool_parser.py:265] Starting on a new tool 0
INFO 01-06 00:34:21 [hermes_tool_parser.py:325] Parsed tool call None
This parser is called
INFO 01-06 00:34:21 [hermes_tool_parser.py:200] delta_text: 
INFO 01-06 00:34:21 [hermes_tool_parser.py:200] {"name": "list_directory", "arguments
INFO 01-06 00:34:21 [hermes_tool_parser.py:201] delta_token_ids: [198, 4913, 606, 788, 330, 1607, 14846, 497, 330, 16370]
INFO 01-06 00:34:21 [hermes_tool_parser.py:214] counters: 1 0 1 0
INFO 01-06 00:34:21 [hermes_tool_parser.py:325] Parsed tool call {'name': 'list_directory'}
This parser is called
INFO 01-06 00:34:21 [hermes_tool_parser.py:200] delta_text: ": {"dir": "/src"}}
INFO 01-06 00:34:21 [hermes_tool_parser.py:200] </tool_call>
INFO 01-06 00:34:21 [hermes_tool_parser.py:201] delta_token_ids: [788, 5212, 3741, 788, 3521, 3548, 95642, 151658, 151645]
INFO 01-06 00:34:21 [hermes_tool_parser.py:214] counters: 1 0 1 1
INFO 01-06 00:34:21 [hermes_tool_parser.py:229] tool_call_end_token in delta_text
INFO 01-06 00:34:21 [hermes_tool_parser.py:282] attempting to close tool call, but no tool call
```
At this point, you should be familiar with this message "attempting to close tool call, but no tool call". Briefly: 1st iteration returns None, 2nd iteration returns function name without specifying arguments in `if not self.current_tool_name_sent:`, and 3rd iteration finds `prev_tool_call_arr` was never properly initialized. These are all old info we already know. The part I want to point out is suppose we properly initialized `prev_tool_call_arr` with an empty `{}`. What happens next?

The 3rd iteration becomes this
```
INFO 01-06 00:46:31 [hermes_tool_parser.py:200] delta_text: ": {"dir": "/src"}}
INFO 01-06 00:46:31 [hermes_tool_parser.py:200] </tool_call>
INFO 01-06 00:46:31 [hermes_tool_parser.py:201] delta_token_ids: [788, 5212, 3741, 788, 3521, 3548, 95642, 151658, 151645]
INFO 01-06 00:46:31 [hermes_tool_parser.py:214] counters: 1 0 1 1
INFO 01-06 00:46:31 [hermes_tool_parser.py:229] tool_call_end_token in delta_text
INFO 01-06 00:46:31 [hermes_tool_parser.py:326] Parsed tool call {'name': 'list_directory', 'arguments': {'dir': '/src'}}
INFO 01-06 00:46:31 [hermes_tool_parser.py:372] Trying to parse current tool call with ID 0
INFO 01-06 00:46:31 [hermes_tool_parser.py:388] diffing old arguments: None
INFO 01-06 00:46:31 [hermes_tool_parser.py:389] against new ones: {'dir': '/src'}
INFO 01-06 00:46:31 [hermes_tool_parser.py:429] finding ": {"dir": "/src"}} in {"dir": "/src"}}
```
Notice the part `finding ": {"dir": "/src"}} in {"dir": "/src"}}`. Because the 2 `delta_text` are `{"name": "list_directory", "arguments` and ` ": {"dir": "/src"}}`. The 3rd iteration `delta_text` actually has structural JSON characters `": ` which made the check fail and returns None. After some analysis, my solution was to first locate `delta_text` within `tool_call_portion`, then compare its position with `cur_arguments_json`'s position to extract only the arguments portion of `delta_text`. This gives us the correct substring to work with.

## Test Plan
Unit Tests:
Exhaustive unit tests with 2 different tool calls, each tested with stream-interval values from 1 to 20:
- Strict simulation: Mimics my local server behavior where the opening `<tool_call>` token is always sent alone, followed by token groups based on stream-interval values
- General simulation: Models typical behavior where `<tool_call>`, `</tool_call>`, and other text tokens can be grouped together in any combination

Location: `tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py`


E2E Test:
`./tests/v1/e2e/test_streaming_tool_calls.py`


Manual Testing:
Ran the following command with various stream-interval values [1, 8, 9, 10, 18, 19, 20] on my local machine:
```
vllm serve Qwen/Qwen2.5-1.5B-Instruct   
--stream-interval 18   
--enable-auto-tool-choice   
--tool-call-parser hermes   
--max-model-len 2048
```
and then run this python script from [ktsaou](https://github.com/ktsaou)  (special thanks)
```
#!/usr/bin/env python3
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
"""Reproduction script for vLLM issue #31501"""

from openai import OpenAI

client = OpenAI(base_url="http://localhost:8000/v1", api_key="dummy")

tools = [
    {
        "type": "function",
        "function": {
            "name": "list_directory",
            "description": "List contents of a directory.",
            "parameters": {
                "type": "object",
                "properties": {
                    "dir": {"type": "string", "description": "Directory path"}
                },
                "required": ["dir"],
            },
        },
    }
]

response = client.chat.completions.create(
    model="Qwen/Qwen2.5-1.5B-Instruct",
    messages=[
        {
            "role": "system",
            "content": "Use the list_directory tool when asked about files.",
        },
        {"role": "user", "content": "List files in the src folder"},
    ],
    tools=tools,
    stream=True,
)

# Accumulate streamed tool call
accumulated_args = ""
tool_name = None

for chunk in response:
    delta = chunk.choices[0].delta
    if delta.tool_calls:
        for tc in delta.tool_calls:
            if tc.function.name:
                tool_name = tc.function.name
            if tc.function.arguments:
                accumulated_args += tc.function.arguments

print(f"Tool: {tool_name}, Args: {accumulated_args!r}")

```


## Test Result
### Before the fix:

| Setting | Output | Status |
|---------|--------|--------|
| `--stream-interval 20` | Tool: None, Args: `''` | **BUG** |
| `--stream-interval 1` (default) | Tool: list_directory, Args: `'{"dir": "/src"}'` | **OK** |

### After the fix:
| Setting | Output | Status |
|---------|--------|--------|
| `--stream-interval 1`  | Tool: list_directory, Args: `'{"dir": "/src"}'` | **OK** |
| `--stream-interval 8`  | Tool: list_directory, Args: `'{"dir": "/src"}'` | **OK** |
| `--stream-interval 9`  | Tool: list_directory, Args: `'{"dir": "/src"}'` | **OK** |
| `--stream-interval 10`  | Tool: list_directory, Args: `'{"dir": "/src"}'` | **OK** |
| `--stream-interval 18`  | Tool: list_directory, Args: `'{"dir": "/src"}'` | **OK** |
| `--stream-interval 19`  | Tool: list_directory, Args: `'{"dir": "/src"}'` | **OK** |
| `--stream-interval 20`  | Tool: list_directory, Args: `'{"dir": "/src"}'` | **OK** |


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Fixes Hermes streaming tool-call parsing to work with larger `stream_interval` values and adds e2e coverage.
> 
> - Initialize `prev_tool_call_arr` on new tool and avoid premature return when encountering `</tool_call>`
> - When first emitting a tool call, include both `name` and `arguments`, persist them to state, and accumulate streamed args
> - For first-arguments emission, stream the full arguments JSON extracted from the current chunk instead of a computed substring diff
> - Maintain `streamed_args_for_tool` and `prev_tool_call_arr` consistently across updates
> - Add `tests/v1/e2e/test_streaming_tool_calls.py` covering multiple `stream_interval` values (1, 8, 9, 10, 18, 19, 20)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6dd3654c931a56b35568c0b4af266d911f8559e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Strengthens Hermes streaming tool-call parsing so tool calls stream correctly when `stream_interval > 1` and adds tests.
> 
> - Initialize `prev_tool_call_arr` on new tool and avoid premature return when encountering `</tool_call>`
> - On first emission, include both `name` and `arguments`, persist state, and accumulate `arguments`
> - For initial arguments, stream the full arguments JSON from the current chunk (not a substring diff); consistently update `streamed_args_for_tool`
> - Minor robustness tweaks for partial JSON handling and text/tool-call segmentation
> - Adds `tests/v1/e2e/test_streaming_tool_calls.py` covering multiple `stream_interval` values (1, 8, 9, 10, 18, 19, 20)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94fe92aa4191ebd3d691ef8b838253bdc0e56b95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit b280e04a3bd6b01f40485c4acf70e7f745c15942. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Improves robustness of Hermes streaming tool-call parsing, resolving failures when `stream_interval > 1`.
> 
> - Initialize `prev_tool_call_arr` on new tool, avoid premature return on `</tool_call>`, and on first emission include both `name` and `arguments`, persisting them to state and accumulating `arguments`
> - For initial arguments, stream the full arguments JSON from the current chunk instead of a substring diff; maintain `streamed_args_for_tool` and `prev_tool_call_arr` consistently; minor tweaks to partial JSON handling and text/tool-call segmentation
> - Add `tests/entrypoints/openai/test_streaming_tool_calls.py` validating streaming tool calls across `stream_interval` values `[1, 8, 9, 10, 18, 19, 20]`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad6010085c4812ab8ab521f73f43553f2627c2f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
