### PR TITLE
[ROCm][AITER] bugfix accuracy regression in ROCM_AITER_TRITON_MLA backend

### DIFF
--- a/vllm/v1/attention/backends/mla/aiter_triton_mla.py
+++ b/vllm/v1/attention/backends/mla/aiter_triton_mla.py
@@ -1,13 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from vllm.v1.attention.backends.mla.common import MLACommonBackend
-from vllm.v1.attention.backends.mla.rocm_aiter_mla import (
-    AiterMLAImpl,
-    AiterMLAMetadataBuilder,
-)
+from vllm.v1.attention.backends.mla.rocm_aiter_mla import AiterMLABackend, AiterMLAImpl
 
 
-class AiterTritonMLABackend(MLACommonBackend):
+class AiterTritonMLABackend(AiterMLABackend):
     @staticmethod
     def get_name() -> str:
         return "AITER_TRITON_MLA"
@@ -15,10 +11,6 @@ class AiterTritonMLABackend(MLACommonBackend):
     @staticmethod
     def get_impl_cls() -> type["AiterTritonMLAImpl"]:
         return AiterTritonMLAImpl
-
-    @staticmethod
-    def get_builder_cls() -> type["AiterMLAMetadataBuilder"]:
-        return AiterMLAMetadataBuilder
 
 
 class AiterTritonMLAImpl(AiterMLAImpl):


### PR DESCRIPTION

## Purpose
Running deepseek using the AITER_TRITON_MLA backend results in low accuracy as follow:
command:
`
export VLLM_USE_V1=1
export SAFETENSORS_FAST_GPU=1
export VLLM_ROCM_USE_AITER=1
export VLLM_ATTENTION_BACKEND=ROCM_AITER_TRITON_MLA
vllm serve deepseek-ai/DeepSeek-V3 -tp 8 
`
lm_eval score:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.0067|±  |0.0047|
|     |       |strict-match    |     5|exact_match|↑  |0.0000|±  |0.0000|

This PR fixes the issue by inheriting from `AiterMLABackend` instead of `MLACommonBackend` since AiterMLABackend in shared for aiter triton backend as well.

## Test Plan
verify lm_eval score

`
export VLLM_USE_V1=1
export SAFETENSORS_FAST_GPU=1
export VLLM_ROCM_USE_AITER=1
export VLLM_ATTENTION_BACKEND=ROCM_AITER_TRITON_MLA
vllm serve deepseek-ai/DeepSeek-V3 -tp 8 
`

`lm_eval --model local-completions \
--tasks gsm8k \
--model_args model=deepseek-ai/DeepSeek-V3,base_url=http://localhost:8000/v1/completions \
--trust_remote_code \
--num_fewshot 5 \
--limit 300 \
--batch_size 128 
`
## Test Result

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.96|±  |0.0113|
|     |       |strict-match    |     5|exact_match|↑  | 0.96|±  |0.0113|

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

