### PR TITLE
[ROCm][CI] Fix ModernBERT token classification test numerical accuracy on ROCm

### DIFF
--- a/tests/models/language/pooling/conftest.py
+++ b/tests/models/language/pooling/conftest.py
@@ -20,7 +20,7 @@ def pytest_sessionstart(session):
     torch.backends.cuda.enable_flash_sdp(False)
     torch.backends.cuda.enable_mem_efficient_sdp(False)
     torch.backends.cuda.enable_math_sdp(True)
-    torch.set_float32_matmul_precision("highest")
+    torch.set_float32_matmul_precision("high")
     warnings.warn(
         "ROCm: Disabled flash_sdp and mem_efficient_sdp, enabled math_sdp "
         "to avoid HuggingFace Transformers accuracy issues",

--- a/tests/models/language/pooling/conftest.py
+++ b/tests/models/language/pooling/conftest.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pytest configuration for vLLM language generation tests."""
+
+import warnings
+
+import torch
+
+from vllm.platforms import current_platform
+
+
+def pytest_sessionstart(session):
+    """Configure ROCm-specific settings before test session starts."""
+    if not current_platform.is_rocm():
+        return
+
+    # Disable Flash/MemEfficient SDP on ROCm to avoid HF Transformers
+    # accuracy issues: https://github.com/vllm-project/vllm/issues/30167
+    # TODO: Remove once ROCm SDP accuracy issues are resolved on HuggingFace
+    torch.backends.cuda.enable_flash_sdp(False)
+    torch.backends.cuda.enable_mem_efficient_sdp(False)
+    torch.backends.cuda.enable_math_sdp(True)
+    torch.set_float32_matmul_precision("highest")
+    warnings.warn(
+        "ROCm: Disabled flash_sdp and mem_efficient_sdp, enabled math_sdp "
+        "to avoid HuggingFace Transformers accuracy issues",
+        UserWarning,
+        stacklevel=1,
+    )


### PR DESCRIPTION
`test_modernbert_models` fails sometimes on ROCm due to numerical precision differences between vLLM's custom kernels and HuggingFace eager attention, with max diff ~0.03 exceeding the 0.01 threshold in only 2 floats.

## Root Cause
ROCm's default matmul precision settings produce slightly different numerical results. 

## Testing
Ran test 100+ times in loop with cache clearing to recompile model from scratch.