### PR TITLE
[CI/Build] Enable test_kv_cache_events_dp for AMD

### DIFF
--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -37,7 +37,7 @@ from vllm.v1.executor.abstract import Executor
 from ...distributed.conftest import MockSubscriber
 from ...utils import create_new_process_for_each_test
 
-if not current_platform.is_cuda():
+if not current_platform.is_cuda_alike():
     pytest.skip(reason="V1 currently only supported on CUDA.", allow_module_level=True)
 
 MODEL_NAME = "meta-llama/Llama-3.2-1B-Instruct"

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -38,7 +38,7 @@ from ...distributed.conftest import MockSubscriber
 from ...utils import create_new_process_for_each_test
 
 if not current_platform.is_cuda_alike():
-    pytest.skip(reason="V1 currently only supported on CUDA.", allow_module_level=True)
+    pytest.skip(reason="V1 currently only supported on CUDA-alike platforms.", allow_module_level=True)
 
 MODEL_NAME = "meta-llama/Llama-3.2-1B-Instruct"
 TOKENIZER = AutoTokenizer.from_pretrained(MODEL_NAME)

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -38,7 +38,10 @@ from ...distributed.conftest import MockSubscriber
 from ...utils import create_new_process_for_each_test
 
 if not current_platform.is_cuda_alike():
-    pytest.skip(reason="V1 currently only supported on CUDA-alike platforms.", allow_module_level=True)
+    pytest.skip(
+        reason="V1 currently only supported on CUDA-alike platforms.",
+        allow_module_level=True,
+    )
 
 MODEL_NAME = "meta-llama/Llama-3.2-1B-Instruct"
 TOKENIZER = AutoTokenizer.from_pretrained(MODEL_NAME)


### PR DESCRIPTION
## Purpose
To have the command `pytest -v -s v1/engine/test_engine_core_client.py::test_kv_cache_events_dp` pass on [AMD CI](https://github.com/vllm-project/vllm/blob/dba95378a66884c889b5dc9428ea68285a908658/.buildkite/test-amd.yaml#L247C5-L247C79).

## Test Plan
`pytest -v -s v1/engine/test_engine_core_client.py::test_kv_cache_events_dp`

## Test Result
Before:
```text
ERROR: found no collectors for vllm/tests/v1/engine/test_engine_core_client.py::test_kv_cache_events_dp
```

After
```text
1 passed
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
