### PR TITLE
[ROCm][CI] Pinning timm lib version to fix ImportError in Multi-Modal Tests (Nemotron)

### DIFF
--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -86,3 +86,5 @@ arctic-inference == 0.1.1
 open-clip-torch==2.32.0
 # Required for isaac Multi-Modal generation test
 perceptron==0.1.4
+# Required for the multi-modal models test
+timm==1.0.17


### PR DESCRIPTION
There was an ImportError:

```log
    # NOTE timm.models.layers is DEPRECATED, please use timm.layers, this is here to reduce breakages in transition
    from timm.layers.activations import *
    from timm.layers.adaptive_avgmax_pool import \
        adaptive_avgmax_pool2d, select_adaptive_pool2d, AdaptiveAvgMaxPool2d, SelectAdaptivePool2d
>   from timm.layers.attention_pool2d import AttentionPool2d, RotAttentionPool2d, RotaryEmbedding
E   ImportError: cannot import name 'RotaryEmbedding' from 'timm.layers.attention_pool2d' (/usr/local/lib/python3.12/dist-packages/timm/layers/attention_pool2d.py)
```

This is because the auto-installed (through third package) version of timm was `timm-1.0.23` which apparently created this error during Multi-Modal models tests. Example:

```bash
pytest -s -v tests/models/multimodal/processing/test_nemotron_vl.py::test_processor_override[False-False-1-8-size_factors3-nvidia/Llama-3.1-Nemotron-Nano-VL-8B-V1]
```

After pinning the version of this package, which is the same one found in `test.txt`, the test passes.