### PR TITLE
Optimize graph capture size

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1123,9 +1123,14 @@ class VllmConfig:
                         range(8, min(max_cudagraph_capture_size + 1, 256), 8)
                     )
                 if max_cudagraph_capture_size >= 256:
-                    # Step size 16 for larger batch sizes
+                    # Step size 16 for medium batch sizes, up to 1024(not included)
                     cudagraph_capture_sizes += list(
-                        range(256, max_cudagraph_capture_size + 1, 16)
+                        range(256, min(max_cudagraph_capture_size + 1, 1024), 16)
+                    )
+                if max_cudagraph_capture_size >= 1024:
+                    # Step size 64 for larger batch sizes
+                    cudagraph_capture_sizes += list(
+                        range(1024, max_cudagraph_capture_size + 1, 64)
                     )
 
             if (


### PR DESCRIPTION

## Purpose
Use larger step when graph size is larger than 1024 to save memory
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Narrows and extends `cudagraph_capture_sizes` step ranges in `vllm/config/vllm.py`.
> 
> - Use step 16 only for `256..1023`, and introduce step 64 for `>=1024` (small sizes remain step 8 up to `<256`) to reduce capture set cardinality and memory overhead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1948ea0ce516553f250b010e6a304e5650abca7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
