### PR TITLE
[Model] Add Grok-2 

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -399,7 +399,7 @@ th {
 | `GraniteMoeSharedForCausalLM` | Granite MoE Shared | `ibm-research/moe-7b-1b-active-shared-experts` (test model) | ✅︎ | ✅︎ |
 | `GritLM` | GritLM | `parasail-ai/GritLM-7B-vllm`. | ✅︎ | ✅︎ |
 | `Grok1ModelForCausalLM` | Grok1 | `hpcai-tech/grok-1`. | ✅︎ | ✅︎ |
-| `Grok1ForCausalLM` | Grok2 | `xai-org/grok-2` (requires `tokenizer.tok.json` with `tiktoken` installed; optional `moe_router_renormalize` override). | ✅︎ | ✅︎ |
+| `Grok1ForCausalLM` | Grok2 | `xai-org/grok-2` | ✅︎ | ✅︎ |
 | `HunYuanDenseV1ForCausalLM` | Hunyuan Dense | `tencent/Hunyuan-7B-Instruct` | ✅︎ | ✅︎ |
 | `HunYuanMoEV1ForCausalLM` | Hunyuan-A13B | `tencent/Hunyuan-A13B-Instruct`, `tencent/Hunyuan-A13B-Pretrain`, `tencent/Hunyuan-A13B-Instruct-FP8`, etc. | ✅︎ | ✅︎ |
 | `HCXVisionForCausalLM` | HyperCLOVAX-SEED-Vision-Instruct-3B | `naver-hyperclovax/HyperCLOVAX-SEED-Vision-Instruct-3B` | | |
@@ -459,6 +459,9 @@ th {
 | `MiniMaxText01ForCausalLM` | MiniMax-Text | `MiniMaxAI/MiniMax-Text-01`, etc. | | |
 | `Zamba2ForCausalLM` | Zamba2 | `Zyphra/Zamba2-7B-instruct`, `Zyphra/Zamba2-2.7B-instruct`, `Zyphra/Zamba2-1.2B-instruct`, etc. | | |
 | `LongcatFlashForCausalLM` | LongCat-Flash | `meituan-longcat/LongCat-Flash-Chat`, `meituan-longcat/LongCat-Flash-Chat-FP8` | ✅︎ | ✅︎ |
+
+!!! note
+    Grok2 requires `tokenizer.tok.json` with `tiktoken` installed. You can optionally override MoE router renormalization with `moe_router_renormalize`.
 
 Some models are supported only via the [Transformers modeling backend](#transformers). The purpose of the table below is to acknowledge models which we officially support in this way. The logs will say that the Transformers modeling backend is being used, and you will see no warning that this is fallback behaviour. This means that, if you have issues with any of the models listed below, please [make an issue](https://github.com/vllm-project/vllm/issues/new/choose) and we'll do our best to fix it!
 

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -399,6 +399,7 @@ th {
 | `GraniteMoeSharedForCausalLM` | Granite MoE Shared | `ibm-research/moe-7b-1b-active-shared-experts` (test model) | ✅︎ | ✅︎ |
 | `GritLM` | GritLM | `parasail-ai/GritLM-7B-vllm`. | ✅︎ | ✅︎ |
 | `Grok1ModelForCausalLM` | Grok1 | `hpcai-tech/grok-1`. | ✅︎ | ✅︎ |
+| `Grok1ForCausalLM` | Grok2 | `xai-org/grok-2` (requires `tokenizer.tok.json` with `tiktoken` installed; optional `moe_router_renormalize` override). | ✅︎ | ✅︎ |
 | `HunYuanDenseV1ForCausalLM` | Hunyuan Dense | `tencent/Hunyuan-7B-Instruct` | ✅︎ | ✅︎ |
 | `HunYuanMoEV1ForCausalLM` | Hunyuan-A13B | `tencent/Hunyuan-A13B-Instruct`, `tencent/Hunyuan-A13B-Pretrain`, `tencent/Hunyuan-A13B-Instruct-FP8`, etc. | ✅︎ | ✅︎ |
 | `HCXVisionForCausalLM` | HyperCLOVAX-SEED-Vision-Instruct-3B | `naver-hyperclovax/HyperCLOVAX-SEED-Vision-Instruct-3B` | | |

--- a/tests/models/language/generation/test_grok.py
+++ b/tests/models/language/generation/test_grok.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+from ...utils import dummy_hf_overrides
+
+MODELS = ["xai-org/grok-2"]
+
+
+def _grok2_dummy_overrides(hf_config):
+    hf_config = dummy_hf_overrides(hf_config, model_arch="Grok1ForCausalLM")
+    text_config = hf_config.get_text_config()
+    text_config.update(
+        {
+            "hidden_size": 256,
+            "intermediate_size": 512,
+            "moe_intermediate_size": 256,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 64,
+            "vocab_size": 4096,
+        }
+    )
+    return hf_config
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_dummy_generate(vllm_runner, monkeypatch, model: str) -> None:
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+        with vllm_runner(
+            model,
+            load_format="dummy",
+            max_model_len=128,
+            hf_overrides=_grok2_dummy_overrides,
+            enforce_eager=True,
+        ) as llm:
+            prompt = "Hello from Grok-2"
+            tokenizer = llm.get_llm().get_tokenizer()
+            prompt_len = len(tokenizer.encode(prompt))
+            outputs = llm.generate_greedy([prompt], max_tokens=1)
+            output_ids, output_str = outputs[0]
+            assert len(output_ids) > prompt_len
+            assert output_str is not None

--- a/tests/models/language/generation/test_grok.py
+++ b/tests/models/language/generation/test_grok.py
@@ -18,7 +18,6 @@ def _grok2_dummy_overrides(hf_config):
             "num_attention_heads": 4,
             "num_key_value_heads": 2,
             "head_dim": 64,
-            "vocab_size": 4096,
         }
     )
     return hf_config

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -289,9 +289,7 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
     "Grok1ModelForCausalLM": _HfExamplesInfo(
         "hpcai-tech/grok-1", trust_remote_code=True
     ),
-    "Grok1ForCausalLM": _HfExamplesInfo(
-        "xai-org/grok-2", trust_remote_code=True
-    ),
+    "Grok1ForCausalLM": _HfExamplesInfo("xai-org/grok-2", trust_remote_code=True),
     "HunYuanDenseV1ForCausalLM": _HfExamplesInfo("tencent/Hunyuan-7B-Instruct"),
     "HunYuanMoEV1ForCausalLM": _HfExamplesInfo(
         "tencent/Hunyuan-A13B-Instruct", trust_remote_code=True

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -289,6 +289,9 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
     "Grok1ModelForCausalLM": _HfExamplesInfo(
         "hpcai-tech/grok-1", trust_remote_code=True
     ),
+    "Grok1ForCausalLM": _HfExamplesInfo(
+        "xai-org/grok-2", trust_remote_code=True
+    ),
     "HunYuanDenseV1ForCausalLM": _HfExamplesInfo("tencent/Hunyuan-7B-Instruct"),
     "HunYuanMoEV1ForCausalLM": _HfExamplesInfo(
         "tencent/Hunyuan-A13B-Instruct", trust_remote_code=True

--- a/tests/tokenizers_/test_basic.py
+++ b/tests/tokenizers_/test_basic.py
@@ -10,6 +10,7 @@ from transformers import (
 )
 
 from vllm.tokenizers import TokenizerLike, get_tokenizer
+from vllm.tokenizers.grok2 import Grok2Tokenizer
 from vllm.tokenizers.mistral import MistralTokenizer
 
 
@@ -35,6 +36,10 @@ def test_tokenizer_like_protocol():
         "mistralai/Mistral-7B-Instruct-v0.3", tokenizer_mode="mistral"
     )
     assert isinstance(tokenizer, MistralTokenizer)
+    _assert_tokenizer_like(tokenizer)
+
+    tokenizer = get_tokenizer("xai-org/grok-2", tokenizer_mode="grok2")
+    assert isinstance(tokenizer, Grok2Tokenizer)
     _assert_tokenizer_like(tokenizer)
 
 

--- a/tests/tokenizers_/test_registry.py
+++ b/tests/tokenizers_/test_registry.py
@@ -75,3 +75,12 @@ def test_customized_tokenizer():
     assert tokenizer.bos_token_id == 0
     assert tokenizer.eos_token_id == 1
     assert tokenizer.pad_token_id == 2
+
+
+def test_resolve_tokenizer_args_grok2(tmp_path: Path):
+    (tmp_path / "tokenizer.tok.json").write_text("{}", encoding="utf-8")
+
+    tokenizer_mode, tokenizer_name, args, kwargs = resolve_tokenizer_args(tmp_path)
+
+    assert tokenizer_mode == "grok2"
+    assert tokenizer_name == tmp_path

--- a/tests/tokenizers_/test_registry.py
+++ b/tests/tokenizers_/test_registry.py
@@ -75,12 +75,3 @@ def test_customized_tokenizer():
     assert tokenizer.bos_token_id == 0
     assert tokenizer.eos_token_id == 1
     assert tokenizer.pad_token_id == 2
-
-
-def test_resolve_tokenizer_args_grok2(tmp_path: Path):
-    (tmp_path / "tokenizer.tok.json").write_text("{}", encoding="utf-8")
-
-    tokenizer_mode, tokenizer_name, args, kwargs = resolve_tokenizer_args(tmp_path)
-
-    assert tokenizer_mode == "grok2"
-    assert tokenizer_name == tmp_path

--- a/vllm/model_executor/models/grok1.py
+++ b/vllm/model_executor/models/grok1.py
@@ -21,8 +21,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Inference-only Grok1 model."""
+"""Inference-only Grok (Grok1/Grok2) model."""
 
+import math
 from collections.abc import Iterable
 from itertools import islice
 from typing import Any
@@ -35,9 +36,11 @@ from vllm.attention.layer import Attention
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from vllm.model_executor.layers.activation import GeluAndMul
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
+    MergedColumnParallelLinear,
     QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
@@ -63,11 +66,99 @@ from .utils import (
     make_layers,
     maybe_prefix,
 )
+from vllm.logger import init_logger
 
 # Default Grok1-specific constants, overridden by config values if present
 DEFAULT_ATTN_OUTPUT_MULTIPLIER = 0.08838834764831845
 DEFAULT_OUTPUT_MULTIPLIER_SCALE = 0.5773502691896257
 DEFAULT_EMBEDDING_MULTIPLIER_SCALE = 78.38367176906169
+DEFAULT_ROUTER_LOGIT_SOFTCAP = 30.0
+
+logger = init_logger(__name__)
+
+
+def _get_num_experts(config) -> int:
+    return getattr(config, "num_experts", getattr(config, "num_local_experts", 8))
+
+
+def _get_moe_intermediate_size(config) -> int:
+    return getattr(config, "moe_intermediate_size", config.intermediate_size)
+
+
+def _is_grok1_arch(config) -> bool:
+    architectures = getattr(config, "architectures", None) or []
+    return bool(architectures) and architectures[0] == "Grok1ModelForCausalLM"
+
+
+def _get_rope_parameters(config) -> dict[str, Any] | None:
+    rope_parameters = getattr(config, "rope_parameters", None)
+    if rope_parameters is None:
+        rope_type = getattr(config, "rope_type", None)
+        if rope_type is None:
+            return None
+        rope_parameters = {"rope_type": rope_type}
+        rope_theta = getattr(config, "rope_theta", None)
+        if rope_theta is not None:
+            rope_parameters["rope_theta"] = rope_theta
+        scaling_factor = getattr(config, "scaling_factor", None)
+        if scaling_factor is not None:
+            rope_parameters["factor"] = scaling_factor
+        for name in (
+            "original_max_position_embeddings",
+            "extrapolation_factor",
+            "attn_factor",
+            "beta_fast",
+            "beta_slow",
+        ):
+            value = getattr(config, name, None)
+            if value is not None:
+                rope_parameters[name] = value
+
+    if rope_parameters.get("rope_type") == "original":
+        rope_parameters = dict(rope_parameters)
+        rope_parameters["rope_type"] = "default"
+    return rope_parameters
+
+
+def _get_moe_renormalize(config) -> bool:
+    explicit_value = getattr(
+        config, "moe_router_renormalize", getattr(config, "moe_renormalize", None)
+    )
+    if explicit_value is not None:
+        return bool(explicit_value)
+    return not getattr(config, "residual_moe", False)
+
+
+class Grok1MLP(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=hidden_size,
+            output_sizes=[intermediate_size] * 2,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+        )
+        self.down_proj = RowParallelLinear(
+            input_size=intermediate_size,
+            output_size=hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.down_proj",
+        )
+        self.act_fn = GeluAndMul()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x, _ = self.gate_up_proj(x)
+        x = self.act_fn(x)
+        x, _ = self.down_proj(x)
+        return x
 
 
 class Grok1MoE(nn.Module):
@@ -85,9 +176,11 @@ class Grok1MoE(nn.Module):
         top_k: int,
         hidden_size: int,
         intermediate_size: int,
+        router_logit_soft_cap: float | None = None,
         params_dtype: torch.dtype | None = None,
         quant_config: QuantizationConfig | None = None,
         tp_size: int | None = None,
+        renormalize: bool = False,
         prefix: str = "",
     ):
         super().__init__()
@@ -110,12 +203,13 @@ class Grok1MoE(nn.Module):
             intermediate_size=intermediate_size,
             params_dtype=params_dtype,
             reduce_results=True,
-            renormalize=True,
+            renormalize=renormalize,
             quant_config=quant_config,
             tp_size=tp_size,
             activation="gelu",
             prefix=f"{prefix}.experts",
         )
+        self.router_logit_soft_cap = router_logit_soft_cap
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         # NOTE: hidden_states can have either 1D or 2D shape.
@@ -123,7 +217,10 @@ class Grok1MoE(nn.Module):
         hidden_states = hidden_states.view(-1, self.hidden_size)
         # router_logits: (num_tokens, n_experts)
         router_logits, _ = self.gate(hidden_states)
-        router_logits = 30.0 * F.tanh(router_logits / 30.0)
+        if self.router_logit_soft_cap is not None and self.router_logit_soft_cap > 0:
+            router_logits = self.router_logit_soft_cap * F.tanh(
+                router_logits / self.router_logit_soft_cap
+            )
         final_hidden_states = self.experts(hidden_states, router_logits)
         return final_hidden_states.view(orig_shape)
 
@@ -186,7 +283,18 @@ class Grok1Attention(nn.Module):
             is_neox_style=True,
         )
 
-        attn_logits_soft_cap = max(getattr(config, "attn_logit_softcapping", 30.0), 0.0)
+        attn_logits_soft_cap = max(
+            getattr(config, "attn_logit_softcapping", 30.0), 0.0
+        )
+        attn_logit_softcapping_method = getattr(
+            config, "attn_logit_softcapping_method", None
+        )
+        if attn_logit_softcapping_method not in (None, "tanh"):
+            logger.warning_once(
+                "Grok attention logit softcapping method '%s' is not "
+                "supported; falling back to default behavior.",
+                attn_logit_softcapping_method,
+            )
 
         self.attn = Attention(
             self.num_heads,
@@ -238,30 +346,50 @@ class Grok1DecoderLayer(nn.Module):
             num_heads=config.num_attention_heads,
             max_position=config.max_position_embeddings,
             num_kv_heads=config.num_key_value_heads,
-            rope_parameters=getattr(config, "rope_parameters", None),
+            rope_parameters=_get_rope_parameters(config),
             cache_config=cache_config,
             quant_config=quant_config,
             prefix=f"{prefix}.attn",
             config=config,
         )  # Pass config to Grok1Attention
 
-        # Grok1 uses "num_experts" in its config
-        num_experts = getattr(config, "num_experts", 8)
+        num_experts = _get_num_experts(config)
         num_experts_per_tok = getattr(config, "num_experts_per_tok", 2)
+        moe_intermediate_size = _get_moe_intermediate_size(config)
+        moe_renormalize = _get_moe_renormalize(config)
 
         self.moe_block = Grok1MoE(
             num_experts=num_experts,
             top_k=num_experts_per_tok,
             hidden_size=config.hidden_size,
-            intermediate_size=config.intermediate_size,
+            intermediate_size=moe_intermediate_size,
+            router_logit_soft_cap=max(
+                getattr(
+                    config,
+                    "router_logit_softcapping",
+                    DEFAULT_ROUTER_LOGIT_SOFTCAP,
+                ),
+                0.0,
+            ),
             quant_config=quant_config,
+            renormalize=moe_renormalize,
             prefix=f"{prefix}.moe_block",
         )
+        self.residual_moe = getattr(config, "residual_moe", False)
+        self.residual_moe_scale = 1.0 / math.sqrt(2.0)
 
         self.pre_attn_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attn_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.pre_moe_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_moe_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.mlp = None
+        if self.residual_moe:
+            self.mlp = Grok1MLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+            )
 
     def forward(
         self,
@@ -286,7 +414,13 @@ class Grok1DecoderLayer(nn.Module):
 
         # MoE block with normalization
         hidden_states, residual = self.pre_moe_norm(hidden_states, residual)
-        hidden_states = self.moe_block(hidden_states)
+        if self.residual_moe:
+            assert self.mlp is not None
+            hidden_states = (
+                self.moe_block(hidden_states) + self.mlp(hidden_states)
+            ) * self.residual_moe_scale
+        else:
+            hidden_states = self.moe_block(hidden_states)
         hidden_states = self.post_moe_norm(hidden_states)
 
         return hidden_states, residual
@@ -366,13 +500,13 @@ class Grok1Model(nn.Module):
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Map Grok1's unique expert parameter names to standard names
-        # Grok1 uses "num_experts" in its config
-        num_experts = getattr(self.config, "num_experts", 8)
+        num_experts = _get_num_experts(self.config)
+        is_grok1 = _is_grok1_arch(self.config)
         return FusedMoE.make_expert_params_mapping(
             self,
-            ckpt_gate_proj_name="linear",  # Grok1 specific
-            ckpt_down_proj_name="linear_1",  # Grok1 specific
-            ckpt_up_proj_name="linear_v",  # Grok1 specific
+            ckpt_gate_proj_name="linear" if is_grok1 else "w1",
+            ckpt_down_proj_name="linear_1" if is_grok1 else "w2",
+            ckpt_up_proj_name="linear_v" if is_grok1 else "w3",
             num_experts=num_experts,
         )
 
@@ -382,12 +516,18 @@ class Grok1Model(nn.Module):
             ("qkv_proj", "q_proj", "q"),
             ("qkv_proj", "k_proj", "k"),
             ("qkv_proj", "v_proj", "v"),
+            ("mlp.gate_up_proj", "mlp.gate_proj", 0),
+            ("mlp.gate_up_proj", "mlp.up_proj", 1),
         ]
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         expert_params_mapping = self.get_expert_mapping()
         for name, loaded_weight in weights:
+            if ".self_attn." in name:
+                name = name.replace(".self_attn.", ".attn.")
+            if ".block_sparse_moe." in name:
+                name = name.replace(".block_sparse_moe.", ".moe_block.")
             if self.quant_config is not None and (
                 scale_name := self.quant_config.get_cache_scale(name)
             ):
@@ -418,6 +558,8 @@ class Grok1Model(nn.Module):
                     name = maybe_remap_kv_scale_name(name, params_dict)
                     if name is None:
                         continue
+                if name not in params_dict:
+                    continue
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
@@ -464,6 +606,8 @@ class Grok1Model(nn.Module):
                     if "norm.scale" in name:
                         name = name.replace("scale", "weight")
 
+                    if name not in params_dict:
+                        continue
                     param = params_dict[name]
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
@@ -481,6 +625,10 @@ class Grok1ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
             "q_proj",
             "k_proj",
             "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
         ],
     }
 
@@ -512,7 +660,9 @@ class Grok1ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
             config, "output_multiplier_scale", DEFAULT_OUTPUT_MULTIPLIER_SCALE
         )
         self.logits_processor = LogitsProcessor(
-            config.vocab_size, scale=self.output_multiplier_scale
+            config.vocab_size,
+            scale=self.output_multiplier_scale,
+            soft_cap=getattr(config, "final_logit_softcapping", None),
         )
 
         self.make_empty_intermediate_tensors = (

--- a/vllm/model_executor/models/grok1.py
+++ b/vllm/model_executor/models/grok1.py
@@ -176,7 +176,7 @@ class Grok1MoE(nn.Module):
         top_k: int,
         hidden_size: int,
         intermediate_size: int,
-        router_logit_soft_cap: float | None = None,
+        router_logit_soft_cap: float = 0.0,
         params_dtype: torch.dtype | None = None,
         quant_config: QuantizationConfig | None = None,
         tp_size: int | None = None,
@@ -217,7 +217,7 @@ class Grok1MoE(nn.Module):
         hidden_states = hidden_states.view(-1, self.hidden_size)
         # router_logits: (num_tokens, n_experts)
         router_logits, _ = self.gate(hidden_states)
-        if self.router_logit_soft_cap is not None and self.router_logit_soft_cap > 0:
+        if self.router_logit_soft_cap > 0:
             router_logits = self.router_logit_soft_cap * F.tanh(
                 router_logits / self.router_logit_soft_cap
             )

--- a/vllm/model_executor/models/grok1.py
+++ b/vllm/model_executor/models/grok1.py
@@ -283,9 +283,7 @@ class Grok1Attention(nn.Module):
             is_neox_style=True,
         )
 
-        attn_logits_soft_cap = max(
-            getattr(config, "attn_logit_softcapping", 30.0), 0.0
-        )
+        attn_logits_soft_cap = max(getattr(config, "attn_logit_softcapping", 30.0), 0.0)
         attn_logit_softcapping_method = getattr(
             config, "attn_logit_softcapping_method", None
         )

--- a/vllm/model_executor/models/grok1.py
+++ b/vllm/model_executor/models/grok1.py
@@ -36,6 +36,7 @@ from vllm.attention.layer import Attention
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
+from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import GeluAndMul
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -66,7 +67,6 @@ from .utils import (
     make_layers,
     maybe_prefix,
 )
-from vllm.logger import init_logger
 
 # Default Grok1-specific constants, overridden by config values if present
 DEFAULT_ATTN_OUTPUT_MULTIPLIER = 0.08838834764831845

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -120,6 +120,7 @@ _TEXT_GENERATION_MODELS = {
     "GraniteMoeSharedForCausalLM": ("granitemoeshared", "GraniteMoeSharedForCausalLM"),  # noqa: E501
     "GritLM": ("gritlm", "GritLM"),
     "Grok1ModelForCausalLM": ("grok1", "Grok1ForCausalLM"),
+    "Grok1ForCausalLM": ("grok1", "Grok1ForCausalLM"),
     "HunYuanMoEV1ForCausalLM": ("hunyuan_v1", "HunYuanMoEV1ForCausalLM"),
     "HunYuanDenseV1ForCausalLM": ("hunyuan_v1", "HunYuanDenseV1ForCausalLM"),
     "HCXVisionForCausalLM": ("hyperclovax_vision", "HCXVisionForCausalLM"),

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -119,8 +119,8 @@ _TEXT_GENERATION_MODELS = {
     "GraniteMoeHybridForCausalLM": ("granitemoehybrid", "GraniteMoeHybridForCausalLM"),  # noqa: E501
     "GraniteMoeSharedForCausalLM": ("granitemoeshared", "GraniteMoeSharedForCausalLM"),  # noqa: E501
     "GritLM": ("gritlm", "GritLM"),
-    "Grok1ModelForCausalLM": ("grok1", "Grok1ForCausalLM"),
-    "Grok1ForCausalLM": ("grok1", "Grok1ForCausalLM"),
+    "Grok1ModelForCausalLM": ("grok1", "GrokForCausalLM"),
+    "Grok1ForCausalLM": ("grok1", "GrokForCausalLM"),
     "HunYuanMoEV1ForCausalLM": ("hunyuan_v1", "HunYuanMoEV1ForCausalLM"),
     "HunYuanDenseV1ForCausalLM": ("hunyuan_v1", "HunYuanDenseV1ForCausalLM"),
     "HCXVisionForCausalLM": ("hyperclovax_vision", "HCXVisionForCausalLM"),

--- a/vllm/tokenizers/grok2.py
+++ b/vllm/tokenizers/grok2.py
@@ -18,10 +18,11 @@ from huggingface_hub.utils import (
 from transformers import BatchEncoding
 from transformers.utils import chat_template_utils as hf_chat_utils
 
+from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
 from vllm.logger import init_logger
 from vllm.transformers_utils.repo_utils import file_or_path_exists
 
-from .protocol import ChatCompletionMessageParam, TokenizerLike
+from .protocol import TokenizerLike
 
 logger = init_logger(__name__)
 

--- a/vllm/tokenizers/grok2.py
+++ b/vllm/tokenizers/grok2.py
@@ -21,7 +21,7 @@ from transformers.utils import chat_template_utils as hf_chat_utils
 from vllm.logger import init_logger
 from vllm.transformers_utils.repo_utils import file_or_path_exists
 
-from .protocol import TokenizerLike
+from .protocol import ChatCompletionMessageParam, TokenizerLike
 
 logger = init_logger(__name__)
 
@@ -421,7 +421,7 @@ class Grok2Tokenizer(TokenizerLike):
 
     def apply_chat_template(
         self,
-        conversation: list[dict[str, Any]],
+        messages: list[ChatCompletionMessageParam],
         tools: list[dict[str, Any]] | None = None,
         chat_template: str | None = None,
         tokenize: bool = False,
@@ -433,7 +433,7 @@ class Grok2Tokenizer(TokenizerLike):
                 "No chat template available. Provide `chat_template` explicitly."
             )
         prompt = hf_chat_utils.apply_chat_template(
-            conversation=conversation,
+            conversation=messages,
             chat_template=template,
             tools=tools,
             **kwargs,

--- a/vllm/tokenizers/grok2.py
+++ b/vllm/tokenizers/grok2.py
@@ -1,0 +1,425 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tokenizer for Grok-2 .tok.json format."""
+
+from __future__ import annotations
+
+import functools
+import json
+from pathlib import Path
+from typing import AbstractSet, Any, Collection, Literal, overload
+
+from huggingface_hub import hf_hub_download
+from transformers import BatchEncoding
+from transformers.utils import chat_template_utils as hf_chat_utils
+
+from vllm.logger import init_logger
+from vllm.transformers_utils.repo_utils import file_or_path_exists
+
+from .protocol import TokenizerLike
+
+logger = init_logger(__name__)
+
+PAD = "<|pad|>"
+EOS = "<|eos|>"
+SEP = "<|separator|>"
+RESERVED_TOKEN_TEXTS = [f"<|reserved_{i}|>" for i in range(3, 128)]
+CONTROL_TOKEN_TEXTS = [f"<|control{i}|>" for i in range(1, 705)]
+DEFAULT_SPECIAL_TOKENS = [PAD, SEP, EOS]
+DEFAULT_CONTROL_TOKENS = {"pad": PAD, "sep": SEP, "eos": EOS}
+DEFAULT_CHAT_TEMPLATE = (
+    "{% for message in messages %}"
+    "{% if message['role'] == 'user' %}"
+    "{{ 'Human: ' + message['content'].strip() + '<|separator|>\\n\\n' }}"
+    "{% elif message['role'] == 'system' %}"
+    "{{ 'System: ' + message['content'].strip() + '<|separator|>\\n\\n' }}"
+    "{% elif message['role'] == 'assistant' %}"
+    "{{ 'Assistant: ' + message['content'] + '<|separator|>\\n\\n' }}"
+    "{% endif %}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}"
+    "{{ 'Assistant:' }}"
+    "{% endif %}"
+)
+
+# Default + separate each single digit.
+PAT_STR_B = (
+    r"""(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}|"""
+    r""" ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+"""
+)
+
+
+def _maybe_load_tokenizer_config(
+    model_path: Path,
+    *,
+    repo_id: str | None,
+    revision: str | None,
+    download_dir: str | None,
+) -> dict[str, Any]:
+    config_path = model_path / "tokenizer_config.json"
+    if config_path.is_file():
+        with config_path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+
+    if repo_id is None:
+        return {}
+
+    try:
+        config_file = hf_hub_download(
+            repo_id=repo_id,
+            filename="tokenizer_config.json",
+            revision=revision,
+            cache_dir=download_dir,
+        )
+    except Exception:
+        return {}
+
+    try:
+        with Path(config_file).open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def _load_tiktoken_encoding(
+    vocab_file: Path,
+) -> tuple[Any, dict[str, int]]:
+    try:
+        import tiktoken
+    except ImportError as exc:
+        raise ImportError(
+            "Grok-2 tokenizer requires the `tiktoken` package."
+        ) from exc
+
+    with vocab_file.open("rb") as f:
+        xtok_dict = json.load(f)
+
+    mergeable_ranks = {
+        bytes(item["bytes"]): item["token"]
+        for item in xtok_dict.get("regular_tokens", [])
+    }
+    special_tokens = {
+        bytes(item["bytes"]).decode("utf-8", errors="replace"): item["token"]
+        for item in xtok_dict.get("special_tokens", [])
+    }
+
+    if xtok_dict.get("word_split") == "V1":
+        pat_str = PAT_STR_B
+    else:
+        raise ValueError(
+            f"Unknown word_split: {xtok_dict.get('word_split')!r}"
+        )
+
+    pat_str = xtok_dict.get("pat_str", pat_str)
+
+    kwargs = {
+        "name": str(vocab_file),
+        "pat_str": pat_str,
+        "mergeable_ranks": mergeable_ranks,
+        "special_tokens": special_tokens,
+    }
+
+    if "vocab_size" in xtok_dict:
+        kwargs["explicit_n_vocab"] = xtok_dict["vocab_size"]
+
+    tokenizer = tiktoken.Encoding(**kwargs)
+
+    default_allowed_special: set[str] | None = None
+    if "default_allowed_special" in xtok_dict:
+        default_allowed_special = {
+            bytes(bytes_list).decode("utf-8", errors="replace")
+            for bytes_list in xtok_dict["default_allowed_special"]
+        }
+
+    tokenizer._default_allowed_special = default_allowed_special or set()
+    tokenizer._control_tokens = DEFAULT_CONTROL_TOKENS
+
+    def encode_patched(
+        self,
+        text: str,
+        *,
+        allowed_special: Literal["all"] | AbstractSet[str] = set(),
+        disallowed_special: Literal["all"] | Collection[str] = "all",
+    ) -> list[int]:
+        del disallowed_special
+        if isinstance(allowed_special, set):
+            allowed_special |= self._default_allowed_special
+        return tiktoken.Encoding.encode(
+            self,
+            text,
+            allowed_special=allowed_special,
+            disallowed_special=(),
+        )
+
+    tokenizer.encode = functools.partial(encode_patched, tokenizer)
+    tokenizer._default_allowed_special |= set(DEFAULT_CONTROL_TOKENS.values())
+    tokenizer._default_allowed_special |= set(
+        CONTROL_TOKEN_TEXTS + RESERVED_TOKEN_TEXTS
+    )
+
+    return tokenizer, special_tokens
+
+
+class Grok2Tokenizer(TokenizerLike):
+    @classmethod
+    def from_pretrained(
+        cls,
+        path_or_repo_id: str | Path,
+        *args,
+        trust_remote_code: bool = False,
+        revision: str | None = None,
+        download_dir: str | None = None,
+        **kwargs,
+    ) -> "Grok2Tokenizer":
+        if args:
+            logger.debug_once("Ignoring extra positional args for Grok2Tokenizer.")
+
+        path = Path(path_or_repo_id)
+        if path.is_file():
+            vocab_file = path
+            model_path = path.parent
+            repo_id = None
+        elif path.is_dir():
+            vocab_file = path / "tokenizer.tok.json"
+            model_path = path
+            repo_id = None
+        else:
+            vocab_file = Path(
+                hf_hub_download(
+                    repo_id=str(path_or_repo_id),
+                    filename="tokenizer.tok.json",
+                    revision=revision,
+                    cache_dir=download_dir,
+                )
+            )
+            model_path = vocab_file.parent
+            repo_id = str(path_or_repo_id)
+
+        if not vocab_file.is_file():
+            raise FileNotFoundError(
+                f"tokenizer.tok.json not found at {vocab_file}."
+            )
+
+        config = _maybe_load_tokenizer_config(
+            model_path,
+            repo_id=repo_id,
+            revision=revision,
+            download_dir=download_dir,
+        )
+
+        return cls(
+            vocab_file=vocab_file,
+            name_or_path=str(path_or_repo_id),
+            truncation_side=kwargs.get("truncation_side", "left"),
+            chat_template=config.get("chat_template"),
+            init_kwargs=config,
+        )
+
+    def __init__(
+        self,
+        *,
+        vocab_file: Path,
+        name_or_path: str,
+        truncation_side: str,
+        chat_template: str | None,
+        init_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__()
+        self.name_or_path = name_or_path
+        self._truncation_side = truncation_side
+        self.init_kwargs = init_kwargs or {}
+        self._chat_template = chat_template or DEFAULT_CHAT_TEMPLATE
+
+        self._tokenizer, self._special_tokens = _load_tiktoken_encoding(
+            vocab_file
+        )
+
+        self._token_to_id: dict[str, int] = {}
+        self._id_to_token: dict[int, str] = {}
+        for token, token_id in self._tokenizer._mergeable_ranks.items():
+            token_str = token.decode("utf-8", errors="replace")
+            self._token_to_id[token_str] = token_id
+            self._id_to_token[token_id] = token_str
+
+        for token, token_id in self._special_tokens.items():
+            self._token_to_id[token] = token_id
+            self._id_to_token[token_id] = token
+
+        self._bos_token_id = self._special_tokens.get(SEP)
+        if self._bos_token_id is None:
+            self._bos_token_id = self._special_tokens.get(PAD)
+        if self._bos_token_id is None:
+            self._bos_token_id = self._special_tokens.get(EOS, 0)
+
+        self._eos_token_id = self._special_tokens.get(EOS, self._bos_token_id)
+        self._pad_token_id = self._special_tokens.get(PAD, self._eos_token_id)
+        self._unk_token_id = self._pad_token_id
+
+    def num_special_tokens_to_add(self) -> int:
+        return 0
+
+    @property
+    def all_special_tokens(self) -> list[str]:
+        return list(self._special_tokens.keys())
+
+    @property
+    def all_special_ids(self) -> list[int]:
+        return list(self._special_tokens.values())
+
+    @property
+    def bos_token_id(self) -> int:
+        return int(self._bos_token_id)
+
+    @property
+    def eos_token_id(self) -> int:
+        return int(self._eos_token_id)
+
+    @property
+    def pad_token_id(self) -> int:
+        return int(self._pad_token_id)
+
+    @property
+    def is_fast(self) -> bool:
+        return False
+
+    @property
+    def vocab_size(self) -> int:
+        return self._tokenizer.n_vocab
+
+    @property
+    def max_token_id(self) -> int:
+        return self._tokenizer.n_vocab - 1
+
+    @property
+    def truncation_side(self) -> str:
+        return self._truncation_side
+
+    def get_vocab(self) -> dict[str, int]:
+        return dict(self._token_to_id)
+
+    def get_added_vocab(self) -> dict[str, int]:
+        return dict(self._special_tokens)
+
+    def _maybe_truncate(self, tokens: list[int], max_length: int | None) -> list[int]:
+        if max_length is None or len(tokens) <= max_length:
+            return tokens
+        if self.truncation_side == "left":
+            return tokens[-max_length:]
+        return tokens[:max_length]
+
+    def encode(
+        self,
+        text: str,
+        truncation: bool | None = None,
+        max_length: int | None = None,
+        add_special_tokens: bool = True,
+    ) -> list[int]:
+        del add_special_tokens
+        tokens = self._tokenizer.encode(text)
+        if truncation:
+            tokens = self._maybe_truncate(tokens, max_length)
+        return tokens
+
+    def decode(self, ids: list[int] | int, skip_special_tokens: bool = False) -> str:
+        if isinstance(ids, int):
+            ids = [ids]
+        if skip_special_tokens:
+            ids = [token_id for token_id in ids
+                   if token_id not in self._special_tokens.values()]
+        return self._tokenizer.decode(ids)
+
+    @overload
+    def convert_tokens_to_ids(self, tokens: str) -> int: ...
+
+    @overload
+    def convert_tokens_to_ids(self, tokens: list[str]) -> list[int]: ...
+
+    def convert_tokens_to_ids(self, tokens: str | list[str]) -> int | list[int]:
+        if isinstance(tokens, str):
+            return self._token_to_id.get(tokens, self._unk_token_id)
+        return [
+            self._token_to_id.get(token, self._unk_token_id)
+            for token in tokens
+        ]
+
+    def convert_ids_to_tokens(
+        self, ids: list[int], skip_special_tokens: bool = False
+    ) -> list[str]:
+        tokens = []
+        for token_id in ids:
+            if skip_special_tokens and token_id in self._special_tokens.values():
+                continue
+            tokens.append(self._id_to_token.get(token_id, "<|unk|>"))
+        return tokens
+
+    def convert_tokens_to_string(self, tokens: list[str]) -> str:
+        token_ids = self.convert_tokens_to_ids(tokens)
+        return self.decode(token_ids, skip_special_tokens=False)
+
+    def __call__(
+        self,
+        text: str | list[str],
+        text_pair: str | None = None,
+        add_special_tokens: bool = True,
+        truncation: bool = False,
+        max_length: int | None = None,
+    ) -> BatchEncoding:
+        if text_pair is not None:
+            raise NotImplementedError("text_pair is not supported for Grok2Tokenizer.")
+
+        if isinstance(text, list):
+            input_ids = [
+                self.encode(
+                    item,
+                    truncation=truncation,
+                    max_length=max_length,
+                    add_special_tokens=add_special_tokens,
+                )
+                for item in text
+            ]
+            attention_mask = [[1] * len(ids) for ids in input_ids]
+        else:
+            input_ids = self.encode(
+                text,
+                truncation=truncation,
+                max_length=max_length,
+                add_special_tokens=add_special_tokens,
+            )
+            attention_mask = [1] * len(input_ids)
+
+        return BatchEncoding(
+            {"input_ids": input_ids, "attention_mask": attention_mask}
+        )
+
+    def get_chat_template(
+        self, chat_template: str | None, tools: list[dict[str, Any]] | None = None
+    ) -> str | None:
+        del tools
+        return chat_template or self._chat_template
+
+    def apply_chat_template(
+        self,
+        conversation: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        chat_template: str | None = None,
+        tokenize: bool = False,
+        **kwargs,
+    ) -> str | list[int]:
+        template = self.get_chat_template(chat_template, tools=tools)
+        if template is None:
+            raise ValueError(
+                "No chat template available. Provide `chat_template` explicitly."
+            )
+        prompt = hf_chat_utils.apply_chat_template(
+            conversation=conversation,
+            chat_template=template,
+            tools=tools,
+            **kwargs,
+        )
+        if tokenize:
+            return self.encode(prompt, add_special_tokens=False)
+        return prompt
+
+
+def supports_grok2_tokenizer(model_path: str | Path, revision: str | None) -> bool:
+    return file_or_path_exists(model_path, "tokenizer.tok.json", revision)

--- a/vllm/tokenizers/grok2.py
+++ b/vllm/tokenizers/grok2.py
@@ -20,7 +20,6 @@ from transformers.utils import chat_template_utils as hf_chat_utils
 
 from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
 from vllm.logger import init_logger
-from vllm.transformers_utils.repo_utils import file_or_path_exists
 
 from .protocol import TokenizerLike
 
@@ -442,7 +441,3 @@ class Grok2Tokenizer(TokenizerLike):
         if tokenize:
             return self.encode(prompt, add_special_tokens=False)
         return prompt
-
-
-def supports_grok2_tokenizer(model_path: str | Path, revision: str | None) -> bool:
-    return file_or_path_exists(model_path, "tokenizer.tok.json", revision)

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -31,6 +31,7 @@ logger = init_logger(__name__)
 
 _VLLM_TOKENIZERS = {
     "deepseek_v32": ("deepseek_v32", "DeepseekV32Tokenizer"),
+    "grok2": ("grok2", "Grok2Tokenizer"),
     "hf": ("hf", "CachedHfTokenizer"),
     "mistral": ("mistral", "MistralTokenizer"),
 }
@@ -150,6 +151,17 @@ def resolve_tokenizer_args(
         )
         if len(files_list) > 0:
             tokenizer_mode = "mistral"
+
+    # Try to use Grok2 tiktoken tokenizer if possible
+    if tokenizer_mode == "auto":
+        allow_patterns = ["tokenizer.tok.json"]
+        files_list = list_filtered_repo_files(
+            model_name_or_path=str(tokenizer_name),
+            allow_patterns=allow_patterns,
+            revision=revision,
+        )
+        if len(files_list) > 0:
+            tokenizer_mode = "grok2"
 
     # Fallback to HF tokenizer
     if tokenizer_mode == "auto":


### PR DESCRIPTION
## Purpose

Add first-class vLLM support for **Grok-2** models by extending tokenizer support, model registry resolution, execution wiring, tests, and documentation.

This change is not a config-only enablement. It introduces a tiktoken-based Grok-2 tokenizer with `.tok.json` loading and Grok-style chat templates, wires Grok-family model configurations into the vLLM loading and execution paths, and ensures compatibility with existing inference behavior.

Targeted tests and documentation updates are included to validate correctness and make Grok-2 usable in vLLM without downstream patches.

## Test Plan
- `pytest tests/models/language/generation/test_grok.py -k grok`
- `pytest tests/tokenizers_/test_registry.py -k grok2`

## Test Result
- Pass


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>


