### PR TITLE
Change warning in get_current_vllm_config to report caller's line number

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1444,7 +1444,9 @@ def get_current_vllm_config() -> VllmConfig:
         # in ci, usually when we test custom ops/modules directly,
         # we don't set the vllm config. In that case, we set a default
         # config.
-        logger.warning("Current vLLM config is not set.")
+        # Use stack level 2 so the log contains the line of the caller,
+        # so it's easier to track down the source of the warning.
+        logger.warning("Current vLLM config is not set.", stacklevel=2)
         return VllmConfig()
     return _current_vllm_config
 


### PR DESCRIPTION
Minor thing - pass `stacklevel=2` in the warning log in `get_current_vllm_config` so it's easier to track down an invalid call to that function.