### PR TITLE
[Doc] Fix: Correct vLLM announcing blog post link in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ vLLM is flexible and easy to use with:
 
 For more information, check out the following:
 
-- [vLLM announcing blog post](https://vllm.ai) (intro to PagedAttention)
+- [vLLM announcing blog post](https://blog.vllm.ai/2023/06/20/vllm.html) (intro to PagedAttention)
 - [vLLM paper](https://arxiv.org/abs/2309.06180) (SOSP 2023)
 - [How continuous batching enables 23x throughput in LLM inference while reducing p50 latency](https://www.anyscale.com/blog/continuous-batching-llm-inference) by Cade Daniel et al.
 - [vLLM Meetups](community/meetups.md)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix incorrect link for the vLLM announcing blog post in the documentation homepage.
The link was pointing to https://vllm.ai (the main website) instead of the actual blog post at https://blog.vllm.ai/2023/06/20/vllm.html which introduces PagedAttention.
## Test Plan
No testing required for documentation link fixes. The change can be verified by:
1. Visiting the documentation at https://docs.vllm.ai
2. Clicking on the "vLLM announcing blog post" link
3. Confirming it navigates to the correct blog post URL
## Test Result
Link now correctly points to https://blog.vllm.ai/2023/06/20/vllm.html

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

