### PR TITLE
[Model] Cleanup: Remove redundant manual definition of `make_empty_intermediate_tensors` in GLM-4-MoE

### DIFF
--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -478,20 +478,6 @@ class Glm4MoeModel(nn.Module):
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
 
-    def make_empty_intermediate_tensors(
-        self, batch_size: int, dtype: torch.dtype, device: torch.device
-    ) -> IntermediateTensors:
-        return IntermediateTensors(
-            {
-                "hidden_states": torch.zeros(
-                    (batch_size, self.config.hidden_size), dtype=dtype, device=device
-                ),
-                "residual": torch.zeros(
-                    (batch_size, self.config.hidden_size), dtype=dtype, device=device
-                ),
-            }
-        )
-
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)


### PR DESCRIPTION

## Purpose
This PR removes a redundant manual implementation of make_empty_intermediate_tensors in Glm4MoeModel.

### Details
In Glm4MoeModel, the method make_empty_intermediate_tensors is already dynamically created and assigned to the instance via `make_empty_intermediate_tensors_factory` in the `__init__` constructor.
### Changes
Deleted the `make_empty_intermediate_tensors` class method in `vllm/model_executor/models/glm4_moe.py` (lines 480-492).
## Test Plan

## Test Result

