### PR TITLE
[OpenAI] Extend VLLMValidationError to additional validation parameters

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -911,7 +911,7 @@ def build_app(args: Namespace) -> FastAPI:
 
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(_: Request, exc: RequestValidationError):
-        from vllm.entrypoints.openai.protocol import VLLMValidationError
+        from vllm.exceptions import VLLMValidationError
 
         param = None
         for error in exc.errors():

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -72,6 +72,7 @@ from pydantic import (
 )
 
 from vllm.entrypoints.chat_utils import ChatCompletionMessageParam, make_tool_call_id
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.logprobs import Logprob
 from vllm.sampling_params import (
@@ -129,36 +130,6 @@ class ErrorInfo(OpenAIBaseModel):
 
 class ErrorResponse(OpenAIBaseModel):
     error: ErrorInfo
-
-
-class VLLMValidationError(ValueError):
-    """vLLM-specific validation error for request validation failures.
-
-    Args:
-        message: The error message describing the validation failure.
-        parameter: Optional parameter name that failed validation.
-        value: Optional value that was rejected during validation.
-    """
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        parameter: str | None = None,
-        value: Any = None,
-    ) -> None:
-        super().__init__(message)
-        self.parameter = parameter
-        self.value = value
-
-    def __str__(self):
-        base = super().__str__()
-        extras = []
-        if self.parameter is not None:
-            extras.append(f"parameter={self.parameter}")
-        if self.value is not None:
-            extras.append(f"value={self.value}")
-        return f"{base} ({', '.join(extras)})" if extras else base
 
 
 class ModelPermission(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -140,16 +140,16 @@ class OpenAIServingCompletion(OpenAIServing):
             )
         except ValueError as e:
             logger.exception("Error in preprocessing prompt inputs")
-            return self.create_error_response(str(e))
+            return self.create_error_response(e)
         except TypeError as e:
             logger.exception("Error in preprocessing prompt inputs")
-            return self.create_error_response(str(e))
+            return self.create_error_response(e)
         except RuntimeError as e:
             logger.exception("Error in preprocessing prompt inputs")
-            return self.create_error_response(str(e))
+            return self.create_error_response(e)
         except jinja2.TemplateError as e:
             logger.exception("Error in preprocessing prompt inputs")
-            return self.create_error_response(str(e))
+            return self.create_error_response(e)
 
         # Extract data_parallel_rank from header (router can inject it)
         data_parallel_rank = self._get_data_parallel_rank(raw_request)

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -754,7 +754,7 @@ class OpenAIServing:
         if isinstance(message, Exception):
             exc = message
 
-            from vllm.entrypoints.openai.protocol import VLLMValidationError
+            from vllm.exceptions import VLLMValidationError
 
             if isinstance(exc, VLLMValidationError):
                 err_type = "BadRequestError"

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -373,7 +373,7 @@ class OpenAIServingResponses(OpenAIServing):
             NotImplementedError,
         ) as e:
             logger.exception("Error in preprocessing prompt inputs")
-            return self.create_error_response(f"{e} {e.__cause__}")
+            return self.create_error_response(e)
 
         request_metadata = RequestResponseMetadata(request_id=request.request_id)
         if raw_request:

--- a/vllm/entrypoints/renderer.py
+++ b/vllm/entrypoints/renderer.py
@@ -12,7 +12,7 @@ import torch
 from pydantic import Field
 
 from vllm.config import ModelConfig
-from vllm.entrypoints.openai.protocol import VLLMValidationError
+from vllm.exceptions import VLLMValidationError
 from vllm.inputs.data import EmbedsPrompt, TextPrompt, TokensPrompt
 from vllm.inputs.parse import get_prompt_components, parse_raw_prompts
 from vllm.tokenizers import TokenizerLike

--- a/vllm/exceptions.py
+++ b/vllm/exceptions.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Custom exceptions for vLLM."""
+
+from typing import Any
+
+
+class VLLMValidationError(ValueError):
+    """vLLM-specific validation error for request validation failures.
+
+    Args:
+        message: The error message describing the validation failure.
+        parameter: Optional parameter name that failed validation.
+        value: Optional value that was rejected during validation.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        parameter: str | None = None,
+        value: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.parameter = parameter
+        self.value = value
+
+    def __str__(self):
+        base = super().__str__()
+        extras = []
+        if self.parameter is not None:
+            extras.append(f"parameter={self.parameter}")
+        if self.value is not None:
+            extras.append(f"value={self.value}")
+        return f"{base} ({', '.join(extras)})" if extras else base

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -11,6 +11,7 @@ from typing import Annotated, Any
 import msgspec
 from pydantic.dataclasses import dataclass
 
+from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.logits_process import LogitsProcessor
 from vllm.tokenizers import TokenizerLike
@@ -393,11 +394,17 @@ class SamplingParams(
                 f"{self.repetition_penalty}."
             )
         if self.temperature < 0.0:
-            raise ValueError(
-                f"temperature must be non-negative, got {self.temperature}."
+            raise VLLMValidationError(
+                f"temperature must be non-negative, got {self.temperature}.",
+                parameter="temperature",
+                value=self.temperature,
             )
         if not 0.0 < self.top_p <= 1.0:
-            raise ValueError(f"top_p must be in (0, 1], got {self.top_p}.")
+            raise VLLMValidationError(
+                f"top_p must be in (0, 1], got {self.top_p}.",
+                parameter="top_p",
+                value=self.top_p,
+            )
         # quietly accept -1 as disabled, but prefer 0
         if self.top_k < -1:
             raise ValueError(
@@ -410,7 +417,11 @@ class SamplingParams(
         if not 0.0 <= self.min_p <= 1.0:
             raise ValueError(f"min_p must be in [0, 1], got {self.min_p}.")
         if self.max_tokens is not None and self.max_tokens < 1:
-            raise ValueError(f"max_tokens must be at least 1, got {self.max_tokens}.")
+            raise VLLMValidationError(
+                f"max_tokens must be at least 1, got {self.max_tokens}.",
+                parameter="max_tokens",
+                value=self.max_tokens,
+            )
         if self.min_tokens < 0:
             raise ValueError(
                 f"min_tokens must be greater than or equal to 0, got {self.min_tokens}."
@@ -421,24 +432,30 @@ class SamplingParams(
                 f"max_tokens={self.max_tokens}, got {self.min_tokens}."
             )
         if self.logprobs is not None and self.logprobs != -1 and self.logprobs < 0:
-            raise ValueError(
-                f"logprobs must be non-negative or -1, got {self.logprobs}."
+            raise VLLMValidationError(
+                f"logprobs must be non-negative or -1, got {self.logprobs}.",
+                parameter="logprobs",
+                value=self.logprobs,
             )
         if (
             self.prompt_logprobs is not None
             and self.prompt_logprobs != -1
             and self.prompt_logprobs < 0
         ):
-            raise ValueError(
+            raise VLLMValidationError(
                 f"prompt_logprobs must be non-negative or -1, got "
-                f"{self.prompt_logprobs}."
+                f"{self.prompt_logprobs}.",
+                parameter="prompt_logprobs",
+                value=self.prompt_logprobs,
             )
         if self.truncate_prompt_tokens is not None and (
             self.truncate_prompt_tokens == 0 or self.truncate_prompt_tokens < -1
         ):
-            raise ValueError(
+            raise VLLMValidationError(
                 f"truncate_prompt_tokens must be an integer >= 1 or -1, "
-                f"got {self.truncate_prompt_tokens}"
+                f"got {self.truncate_prompt_tokens}",
+                parameter="truncate_prompt_tokens",
+                value=self.truncate_prompt_tokens,
             )
         assert isinstance(self.stop_token_ids, list)
         if not all(isinstance(st_id, int) for st_id in self.stop_token_ids):
@@ -516,12 +533,14 @@ class SamplingParams(
             if token_id < 0 or token_id > tokenizer.max_token_id
         ]
         if len(invalid_token_ids) > 0:
-            raise ValueError(
+            raise VLLMValidationError(
                 f"The model vocabulary size is {tokenizer.max_token_id + 1},"
                 f" but the following tokens"
                 f" were specified as bad: {invalid_token_ids}."
                 f" All token id values should be integers satisfying:"
-                f" 0 <= token_id <= {tokenizer.max_token_id}."
+                f" 0 <= token_id <= {tokenizer.max_token_id}.",
+                parameter="bad_words",
+                value=self.bad_words,
             )
 
     @cached_property

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any, Literal, cast
 
 from vllm.config import VllmConfig
+from vllm.exceptions import VLLMValidationError
 from vllm.inputs import ProcessorInputs, PromptType, SingletonInputs
 from vllm.inputs.parse import split_enc_dec_inputs
 from vllm.inputs.preprocess import InputPreprocessor
@@ -83,9 +84,11 @@ class InputProcessor:
             if num_logprobs == -1:
                 num_logprobs = self.model_config.get_vocab_size()
             if num_logprobs > max_logprobs:
-                raise ValueError(
+                raise VLLMValidationError(
                     f"Requested sample logprobs of {num_logprobs}, "
-                    f"which is greater than max allowed: {max_logprobs}"
+                    f"which is greater than max allowed: {max_logprobs}",
+                    parameter="logprobs",
+                    value=num_logprobs,
                 )
 
         # Validate prompt logprobs.
@@ -94,9 +97,11 @@ class InputProcessor:
             if num_prompt_logprobs == -1:
                 num_prompt_logprobs = self.model_config.get_vocab_size()
             if num_prompt_logprobs > max_logprobs:
-                raise ValueError(
+                raise VLLMValidationError(
                     f"Requested prompt logprobs of {num_prompt_logprobs}, "
-                    f"which is greater than max allowed: {max_logprobs}"
+                    f"which is greater than max allowed: {max_logprobs}",
+                    parameter="prompt_logprobs",
+                    value=num_prompt_logprobs,
                 )
 
     def _validate_sampling_params(
@@ -134,9 +139,11 @@ class InputProcessor:
                 invalid_token_ids.append(token_id)
 
         if invalid_token_ids:
-            raise ValueError(
+            raise VLLMValidationError(
                 f"token_id(s) {invalid_token_ids} in logit_bias contain "
-                f"out-of-vocab token ids. Vocabulary size: {vocab_size}"
+                f"out-of-vocab token ids. Vocabulary size: {vocab_size}",
+                parameter="logit_bias",
+                value=invalid_token_ids,
             )
 
     def _validate_supported_sampling_params(


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Extend existing VLLMValidationError implementation to populate the param field for additional validation scenarios.

Changes:
- Add `_ValueError` in sampling_params.py to avoid circular imports with protocol.py
- Update sampling parameter validations to use _ValueError with parameter metadata: temperature, top_p, logprobs, prompt_logprobs, truncate_prompt_tokens, bad_words
- Update V1 engine input_processor.py validations: logprobs, prompt_logprobs, logit_bias
- Extend error handling in serving_engine.py to use duck-typing for _ValueError
- Pass exception objects (not strings) to create_error_response to preserve metadata

New validations now populate the `param` field:
- temperature, top_p, logprobs, prompt_logprobs, logit_bias, truncate_prompt_tokens

## Test Plan
1. Build vLLM image and run the server
2. Send curl Requests to the server using a script
## Test Result
1. Starting of server
```
rehankhan@Rehans-MacBook-Pro vllm % docker run --rm --env VLLM_USE_V1=1 -p 8000:8000 local  --model=gpt2 --port=8000
INFO 01-06 13:26:11 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
WARNING 01-06 13:26:14 [argparse_utils.py:195] With `vllm serve`, you should provide the model as a positional argument or in a config file instead of via the `--model` option. The `--model` option will be removed in v0.13.
(APIServer pid=1) INFO 01-06 13:26:14 [api_server.py:1278] vLLM API server version 0.14.0rc1.dev284+g6ebb66cce.d20260106
(APIServer pid=1) INFO 01-06 13:26:14 [utils.py:253] non-default args: {'model_tag': 'gpt2', 'model': 'gpt2'}
(APIServer pid=1) INFO 01-06 13:26:19 [model.py:522] Resolved architecture: GPT2LMHeadModel
(APIServer pid=1) INFO 01-06 13:26:20 [model.py:1816] Downcasting torch.float32 to torch.bfloat16.
(APIServer pid=1) INFO 01-06 13:26:20 [model.py:1508] Using max model len 1024
(APIServer pid=1) WARNING 01-06 13:26:20 [cpu.py:157] VLLM_CPU_KVCACHE_SPACE not set. Using 11.72 GiB for KV cache.
(APIServer pid=1) INFO 01-06 13:26:20 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=2048.
(APIServer pid=1) INFO 01-06 13:26:20 [vllm.py:635] Disabling NCCL for DP synchronization when using async scheduling.
(APIServer pid=1) INFO 01-06 13:26:20 [vllm.py:640] Asynchronous scheduling is enabled.
INFO 01-06 13:26:27 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
(EngineCore_DP0 pid=60) INFO 01-06 13:26:28 [core.py:96] Initializing a V1 LLM engine (v0.14.0rc1.dev284+g6ebb66cce.d20260106) with config: model='gpt2', speculative_config=None, tokenizer='gpt2', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=1024, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=True, quantization=None, enforce_eager=False, kv_cache_dtype=auto, device_config=cpu, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False), seed=0, served_model_name=gpt2, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.DYNAMO_TRACE_ONCE: 2>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': None, 'compile_ranges_split_points': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'dce': True, 'size_asserts': False, 'nan_asserts': False, 'epilogue_fusion': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': None, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False}, 'local_cache_dir': None}
(EngineCore_DP0 pid=60) INFO 01-06 13:26:29 [parallel_state.py:1214] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.17.0.2:47969 backend=gloo
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore_DP0 pid=60) INFO 01-06 13:26:29 [parallel_state.py:1425] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A
(EngineCore_DP0 pid=60) INFO 01-06 13:26:29 [cpu_model_runner.py:55] Starting to load model gpt2...
(EngineCore_DP0 pid=60) INFO 01-06 13:26:52 [weight_utils.py:510] Time spent downloading weights for gpt2: 20.850118 seconds
(EngineCore_DP0 pid=60) INFO 01-06 13:26:52 [weight_utils.py:550] No model.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  5.07it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  5.07it/s]
(EngineCore_DP0 pid=60) 
(EngineCore_DP0 pid=60) INFO 01-06 13:26:52 [default_loader.py:308] Loading weights took 0.20 seconds
(EngineCore_DP0 pid=60) INFO 01-06 13:26:52 [kv_cache_utils.py:1305] GPU KV cache size: 341,248 tokens
(EngineCore_DP0 pid=60) INFO 01-06 13:26:52 [kv_cache_utils.py:1310] Maximum concurrency for 1,024 tokens per request: 333.25x
(EngineCore_DP0 pid=60) INFO 01-06 13:26:55 [cpu_model_runner.py:65] Warming up model for the compilation...
(EngineCore_DP0 pid=60) INFO 01-06 13:27:05 [cpu_model_runner.py:75] Warming up done.
(EngineCore_DP0 pid=60) INFO 01-06 13:27:05 [core.py:273] init engine (profile, create kv cache, warmup model) took 12.64 seconds
(EngineCore_DP0 pid=60) INFO 01-06 13:27:07 [vllm.py:640] Asynchronous scheduling is disabled.
(EngineCore_DP0 pid=60) WARNING 01-06 13:27:07 [vllm.py:671] Inductor compilation was disabled by user settings,Optimizations settings that are only active duringInductor compilation will be ignored.
(EngineCore_DP0 pid=60) WARNING 01-06 13:27:07 [cpu.py:157] VLLM_CPU_KVCACHE_SPACE not set. Using 11.72 GiB for KV cache.
(APIServer pid=1) INFO 01-06 13:27:07 [api_server.py:1020] Supported tasks: ['generate']
(APIServer pid=1) INFO 01-06 13:27:08 [serving_chat.py:180] Warming up chat template processing...
(APIServer pid=1) INFO 01-06 13:27:11 [chat_utils.py:599] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=1) ERROR 01-06 13:27:11 [serving_chat.py:220] Chat template warmup failed
(APIServer pid=1) ERROR 01-06 13:27:11 [serving_chat.py:220] Traceback (most recent call last):
(APIServer pid=1) ERROR 01-06 13:27:11 [serving_chat.py:220]   File "/opt/venv/lib/python3.12/site-packages/vllm/entrypoints/openai/serving_chat.py", line 199, in warmup
(APIServer pid=1) ERROR 01-06 13:27:11 [serving_chat.py:220]     await self._preprocess_chat(
(APIServer pid=1) ERROR 01-06 13:27:11 [serving_chat.py:220]   File "/opt/venv/lib/python3.12/site-packages/vllm/entrypoints/openai/serving_engine.py", line 1233, in _preprocess_chat
(APIServer pid=1) ERROR 01-06 13:27:11 [serving_chat.py:220]     request_prompt = apply_hf_chat_template(
(APIServer pid=1) ERROR 01-06 13:27:11 [serving_chat.py:220]                      ^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1) ERROR 01-06 13:27:11 [serving_chat.py:220]   File "/opt/venv/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 1826, in apply_hf_chat_template
(APIServer pid=1) ERROR 01-06 13:27:11 [serving_chat.py:220]     raise ChatTemplateResolutionError(
(APIServer pid=1) ERROR 01-06 13:27:11 [serving_chat.py:220] vllm.entrypoints.chat_utils.ChatTemplateResolutionError: As of transformers v4.44, default chat template is no longer allowed, so you must provide a chat template if the tokenizer does not define one.
(APIServer pid=1) /opt/venv/lib/python3.12/site-packages/vllm/entrypoints/openai/serving_chat.py:220: RuntimeWarning: coroutine 'AsyncMultiModalItemTracker.all_mm_data' was never awaited
(APIServer pid=1)   logger.exception("Chat template warmup failed")
(APIServer pid=1) RuntimeWarning: Enable tracemalloc to get the object allocation traceback
(APIServer pid=1) INFO 01-06 13:27:12 [api_server.py:1352] Starting vLLM API server 0 on http://0.0.0.0:8000
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:38] Available routes are:
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /redoc, Methods: GET, HEAD
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /pause, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /resume, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /is_paused, Methods: GET
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /v1/audio/transcriptions, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /v1/audio/translations, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /classify, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /v1/embeddings, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /score, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /v1/score, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /rerank, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /v1/rerank, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /v2/rerank, Methods: POST
(APIServer pid=1) INFO 01-06 13:27:12 [launcher.py:46] Route: /pooling, Methods: POST
(APIServer pid=1) INFO:     Started server process [1]
(APIServer pid=1) INFO:     Waiting for application startup.
(APIServer pid=1) INFO:     Application startup complete.
```
2. curl requests
```
[Test 1] Invalid logprobs - should have 'param': 'logprobs'
{
    "error": {
        "message": "Requested sample logprobs of 25, which is greater than max allowed: 20 (parameter=logprobs, value=25)",
        "type": "BadRequestError",
        "param": "logprobs",
        "code": 400
    }
}

[Test 2] Invalid temperature - should have 'param': 'temperature'
{
    "error": {
        "message": "temperature must be non-negative, got -1.0.",
        "type": "BadRequestError",
        "param": "temperature",
        "code": 400
    }
}

[Test 3] Stream options without stream - should have 'param': 'stream_options'
{
    "error": {
        "message": "1 validation error:\n  {'type': 'value_error', 'loc': ('body',), 'msg': 'Value error, Stream options can only be defined when `stream=True`. (parameter=stream_options)', 'input': {'model': 'gpt2', 'prompt': 'Hello', 'stream': False, 'stream_options': {'include_usage': True}}, 'ctx': {'error': VLLMValidationError('Stream options can only be defined when `stream=True`.')}}\n\n  File \"/opt/venv/lib/python3.12/site-packages/vllm/entrypoints/utils.py\", line 517, in create_completion\n    POST /v1/completions [{'type': 'value_error', 'loc': ('body',), 'msg': 'Value error, Stream options can only be defined when `stream=True`. (parameter=stream_options)', 'input': {'model': 'gpt2', 'prompt': 'Hello', 'stream': False, 'stream_options': {'include_usage': True}}, 'ctx': {'error': VLLMValidationError('Stream options can only be defined when `stream=True`.')}}]",
        "type": "Bad Request",
        "param": "stream_options",
        "code": 400
    }
}

[Test 4] Too many input tokens - should have 'param': 'input_tokens'
{
    "error": {
        "message": "This model's maximum context length is 1008 tokens. However, your request has 10002 input tokens. Please reduce the length of the input messages. (parameter=input_tokens, value=10002)",
        "type": "BadRequestError",
        "param": "input_tokens",
        "code": 400
    }
}

[Test 5] Invalid top_p - should have 'param': 'top_p'
{
    "error": {
        "message": "top_p must be in (0, 1], got 2.0.",
        "type": "BadRequestError",
        "param": "top_p",
        "code": 400
    }
}

[Test 6] Invalid logprobs (negative) - should have 'param': 'logprobs'
{
    "error": {
        "message": "1 validation error:\n  {'type': 'value_error', 'loc': ('body',), 'msg': 'Value error, `logprobs` must be a positive value. (parameter=logprobs, value=-5)', 'input': {'model': 'gpt2', 'prompt': 'Hello', 'logprobs': -5}, 'ctx': {'error': VLLMValidationError('`logprobs` must be a positive value.')}}\n\n  File \"/opt/venv/lib/python3.12/site-packages/vllm/entrypoints/utils.py\", line 517, in create_completion\n    POST /v1/completions [{'type': 'value_error', 'loc': ('body',), 'msg': 'Value error, `logprobs` must be a positive value. (parameter=logprobs, value=-5)', 'input': {'model': 'gpt2', 'prompt': 'Hello', 'logprobs': -5}, 'ctx': {'error': VLLMValidationError('`logprobs` must be a positive value.')}}]",
        "type": "Bad Request",
        "param": "logprobs",
        "code": 400
    }
}

[Test 7] Invalid prompt_logprobs - should have 'param': 'prompt_logprobs'
{
    "error": {
        "message": "1 validation error:\n  {'type': 'value_error', 'loc': ('body',), 'msg': 'Value error, `prompt_logprobs` must be a positive value or -1. (parameter=prompt_logprobs, value=-3)', 'input': {'model': 'gpt2', 'prompt': 'Hello', 'prompt_logprobs': -3}, 'ctx': {'error': VLLMValidationError('`prompt_logprobs` must be a positive value or -1.')}}\n\n  File \"/opt/venv/lib/python3.12/site-packages/vllm/entrypoints/utils.py\", line 517, in create_completion\n    POST /v1/completions [{'type': 'value_error', 'loc': ('body',), 'msg': 'Value error, `prompt_logprobs` must be a positive value or -1. (parameter=prompt_logprobs, value=-3)', 'input': {'model': 'gpt2', 'prompt': 'Hello', 'prompt_logprobs': -3}, 'ctx': {'error': VLLMValidationError('`prompt_logprobs` must be a positive value or -1.')}}]",
        "type": "Bad Request",
        "param": "prompt_logprobs",
        "code": 400
    }
}

[Test 8] Invalid logit_bias - should have 'param': 'logit_bias'
{
    "error": {
        "message": "token_id(s) [999999] in logit_bias contain out-of-vocab token ids. Vocabulary size: 50257 (parameter=logit_bias, value=[999999])",
        "type": "BadRequestError",
        "param": "logit_bias",
        "code": 400
    }
}
```

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

