### PR TITLE
[Feature] Add command-line argument support to basic.py example

### DIFF
--- a/examples/offline_inference/basic/basic.py
+++ b/examples/offline_inference/basic/basic.py
@@ -54,16 +54,14 @@ def main():
         max_tokens=args.max_tokens
     )
     
-    import sys
-    
     # Create an LLM.
-    print(f"Loading model: {args.model}", file=sys.stderr)
+    print(f"Loading model: {args.model}")
     llm = LLM(model=args.model)
     
     # Generate texts from the prompts.
     # The output is a list of RequestOutput objects
     # that contain the prompt, generated text, and other information.
-    print("Generating text...", file=sys.stderr)
+    print("Generating text...")
     outputs = llm.generate(prompts, sampling_params)
     
     # Print the outputs.

--- a/examples/offline_inference/basic/basic.py
+++ b/examples/offline_inference/basic/basic.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import argparse
 from vllm import LLM, SamplingParams
 
 # Sample prompts.
@@ -10,17 +11,59 @@ prompts = [
     "The capital of France is",
     "The future of AI is",
 ]
-# Create a sampling params object.
-sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Basic vLLM text generation example")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="facebook/opt-125m",
+        help="Name or path of the model to use"
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.8,
+        help="Temperature for sampling"
+    )
+    parser.add_argument(
+        "--top-p",
+        type=float,
+        default=0.95,
+        help="Top-p for sampling"
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=100,
+        help="Maximum number of tokens to generate"
+    )
+    return parser.parse_args()
 
 
 def main():
+    # Parse command line arguments
+    args = parse_args()
+    
+    # Create a sampling params object.
+    sampling_params = SamplingParams(
+        temperature=args.temperature,
+        top_p=args.top_p,
+        max_tokens=args.max_tokens
+    )
+    
     # Create an LLM.
-    llm = LLM(model="facebook/opt-125m")
+    print(f"Loading model: {args.model}")
+    llm = LLM(model=args.model)
+    
     # Generate texts from the prompts.
     # The output is a list of RequestOutput objects
     # that contain the prompt, generated text, and other information.
+    print("Generating text...")
     outputs = llm.generate(prompts, sampling_params)
+    
     # Print the outputs.
     print("\nGenerated Outputs:\n" + "-" * 60)
     for output in outputs:

--- a/examples/offline_inference/basic/basic.py
+++ b/examples/offline_inference/basic/basic.py
@@ -54,14 +54,16 @@ def main():
         max_tokens=args.max_tokens
     )
     
+    import sys
+    
     # Create an LLM.
-    print(f"Loading model: {args.model}")
+    print(f"Loading model: {args.model}", file=sys.stderr)
     llm = LLM(model=args.model)
     
     # Generate texts from the prompts.
     # The output is a list of RequestOutput objects
     # that contain the prompt, generated text, and other information.
-    print("Generating text...")
+    print("Generating text...", file=sys.stderr)
     outputs = llm.generate(prompts, sampling_params)
     
     # Print the outputs.

--- a/examples/offline_inference/basic/basic.py
+++ b/examples/offline_inference/basic/basic.py
@@ -15,55 +15,46 @@ prompts = [
 
 def parse_args():
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description="Basic vLLM text generation example")
-    parser.add_argument(
-        "--model",
-        type=str,
-        default="facebook/opt-125m",
-        help="Name or path of the model to use"
-    )
-    parser.add_argument(
-        "--temperature",
-        type=float,
-        default=0.8,
-        help="Temperature for sampling"
-    )
-    parser.add_argument(
-        "--top-p",
-        type=float,
-        default=0.95,
-        help="Top-p for sampling"
-    )
-    parser.add_argument(
-        "--max-tokens",
-        type=int,
-        default=100,
-        help="Maximum number of tokens to generate"
-    )
+    parser = argparse.ArgumentParser(
+        description="Basic vLLM text generation example")
+    parser.add_argument("--model",
+                        type=str,
+                        default="facebook/opt-125m",
+                        help="Name or path of the model to use")
+    parser.add_argument("--temperature",
+                        type=float,
+                        default=0.8,
+                        help="Temperature for sampling")
+    parser.add_argument("--top-p",
+                        type=float,
+                        default=0.95,
+                        help="Top-p for sampling")
+    parser.add_argument("--max-tokens",
+                        type=int,
+                        default=100,
+                        help="Maximum number of tokens to generate")
     return parser.parse_args()
 
 
 def main():
     # Parse command line arguments
     args = parse_args()
-    
+
     # Create a sampling params object.
-    sampling_params = SamplingParams(
-        temperature=args.temperature,
-        top_p=args.top_p,
-        max_tokens=args.max_tokens
-    )
-    
+    sampling_params = SamplingParams(temperature=args.temperature,
+                                     top_p=args.top_p,
+                                     max_tokens=args.max_tokens)
+
     # Create an LLM.
     print(f"Loading model: {args.model}")
     llm = LLM(model=args.model)
-    
+
     # Generate texts from the prompts.
     # The output is a list of RequestOutput objects
     # that contain the prompt, generated text, and other information.
     print("Generating text...")
     outputs = llm.generate(prompts, sampling_params)
-    
+
     # Print the outputs.
     print("\nGenerated Outputs:\n" + "-" * 60)
     for output in outputs:


### PR DESCRIPTION
<!-- markdownlint-disable --> 
 
 ## Purpose 
 Add command-line argument support to the `examples/offline_inference/basic/basic.py` example, allowing users to customize model and sampling parameters without modifying code. This enhances the example's flexibility and user-friendliness for new users. 
 
 ## Test Plan 
 1. Run the example with default parameters to ensure backward compatibility:
    ```bash
    python examples/offline_inference/basic/basic.py
    ```
 2. Test with custom model parameter:
    ```bash
    python examples/offline_inference/basic/basic.py --model gpt2
    ```
 3. Test with custom sampling parameters:
    ```bash
    python examples/offline_inference/basic/basic.py --temperature 0.7 --top-p 0.9 --max-tokens 50
    ```
 4. Test with all parameters combined:
    ```bash
    python examples/offline_inference/basic/basic.py --model gpt2 --temperature 0.6 --top-p 0.85 --max-tokens 75
    ```
 
 ## Test Result 
 1. Default parameters: Example runs successfully with the default model and parameters, generating text as expected.
 2. Custom model: Example successfully loads and uses the specified model (gpt2).
 3. Custom sampling parameters: Generated text reflects the adjusted temperature and top-p values, with appropriate length based on max-tokens.
 4. Combined parameters: Example works correctly with all custom parameters applied simultaneously.

 <details> 
 <summary> Essential Elements of an Effective PR Description Checklist </summary> 
 
 - [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)". 
 - [x] The test plan, such as providing test command. 
 - [x] The test results, such as pasting the results comparison before and after, or e2e results 
 - [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. 
 - [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the `https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0` . 
 </details> 
 
