### PR TITLE
[Feature] Add flag to disable FlashInfer autotune

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -241,6 +241,8 @@ class VllmConfig:
     performance, with -O0 having the best startup time and -O3 having the best
     performance. -02 is used by defult. See  OptimizationLevel for full
     description."""
+    disable_flashinfer_autotune: bool = False
+    """If True, skip FlashInfer autotuning during kernel warmup."""
 
     def compute_hash(self) -> str:
         """

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -570,6 +570,7 @@ class EngineArgs:
 
     kv_sharing_fast_prefill: bool = CacheConfig.kv_sharing_fast_prefill
     optimization_level: OptimizationLevel = VllmConfig.optimization_level
+    disable_flashinfer_autotune: bool = VllmConfig.disable_flashinfer_autotune
 
     kv_offloading_size: float | None = CacheConfig.kv_offloading_size
     kv_offloading_backend: KVOffloadingBackend | None = (
@@ -1164,6 +1165,10 @@ class EngineArgs:
         vllm_group.add_argument(
             "--optimization-level", **vllm_kwargs["optimization_level"]
         )
+        vllm_group.add_argument(
+            "--disable-flashinfer-autotune",
+            **vllm_kwargs["disable_flashinfer_autotune"],
+        )
 
         # Other arguments
         parser.add_argument(
@@ -1756,6 +1761,7 @@ class EngineArgs:
             profiler_config=self.profiler_config,
             additional_config=self.additional_config,
             optimization_level=self.optimization_level,
+            disable_flashinfer_autotune=self.disable_flashinfer_autotune,
         )
 
         return config

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -36,8 +36,13 @@ def kernel_warmup(worker: "Worker"):
         max_tokens = worker.scheduler_config.max_num_batched_tokens
         deep_gemm_warmup(model, max_tokens)
 
+    disable_flashinfer_autotune = getattr(
+        worker.vllm_config, "disable_flashinfer_autotune", False
+    )
     # FlashInfer autotune for Hopper (SM 9.0) and Blackwell (SM 10.0) GPUs
-    if has_flashinfer() and current_platform.has_device_capability(90):
+    if disable_flashinfer_autotune:
+        logger.info("Skipping FlashInfer autotune because it is disabled.")
+    elif has_flashinfer() and current_platform.has_device_capability(90):
         flashinfer_autotune(worker.model_runner)
 
     # FlashInfer attention warmup


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

FlashInfer autotuning can sometimes take a long time to complete during initialization. This PR introduces a flag to disable it, allowing users to bypass this step if they are okay with skipping optimization to speed up startup.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

