### PR TITLE
[Frontend] reimplement beam-search reference transformers

### DIFF
--- a/tests/samplers/test_beam_search.py
+++ b/tests/samplers/test_beam_search.py
@@ -221,5 +221,73 @@ def test_beam_search_passes_multimodal_data(
             assert filtered_hf_output_ids == filtered_vllm_output_ids
 
 
+# Our results are very similar to hf, but not exactly the same as. so we chose
+# Levenshtein distance as a simple test metric. When `dist <= 10`, we thought
+# the result is correct.
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("dtype", ["half"])
+@pytest.mark.parametrize("max_tokens", MAX_TOKENS)
+@pytest.mark.parametrize("beam_width", BEAM_WIDTHS)
+def test_beam_search_by_levenshtein(
+    hf_runner,
+    vllm_runner,
+    example_prompts,
+    model: str,
+    dtype: str,
+    max_tokens: int,
+    beam_width: int,
+) -> None:
+    import importlib
+    from collections.abc import Hashable, Sequence
+
+    try:
+        importlib.import_module("rapidfuzz")
+        from rapidfuzz.distance import Levenshtein
+    except ImportError:
+        return
+
+    def levenshtein_dist(a: Sequence[Hashable], b: Sequence[Hashable]) -> int:
+        """
+        Levenshtein distance of two token lists.
+        """
+
+        if a is b:
+            return 0
+        if not a:
+            return len(b)
+        if not b:
+            return len(a)
+        return Levenshtein.distance(a, b)
+
+    dist_threshold = 10
+    example_prompts = example_prompts[:1]
+    with hf_runner(model, dtype=dtype) as hf_model:
+        hf_outputs = hf_model.generate_beam_search(
+            example_prompts, beam_width, max_tokens
+        )
+
+    with vllm_runner(model, dtype=dtype, enable_prefix_caching=False) as vllm_model:
+        vllm_outputs = vllm_model.generate_beam_search(
+            example_prompts, beam_width, max_tokens
+        )
+
+    for i in range(len(example_prompts)):
+        hf_output_ids, hf_output_texts = hf_outputs[i]
+        vllm_output_ids, vllm_output_texts = vllm_outputs[i]
+        for j, (hf_text, vllm_text) in enumerate(
+            zip(hf_output_texts, vllm_output_texts)
+        ):
+            print(f">>>{j}-th hf output:")
+            print(hf_text)
+            print(f">>>{j}-th vllm output:")
+            print(vllm_text)
+        assert len(hf_output_ids) == len(vllm_output_ids)
+        for j, (hf_ids, vllm_ids) in enumerate(zip(hf_output_ids, vllm_output_ids)):
+            assert len(hf_ids) == len(vllm_ids)
+            assert levenshtein_dist(hf_ids, vllm_ids) <= dist_threshold, (
+                f"Test{i} output{j}:\nHF: {hf_ids}\nvLLM: {vllm_ids}"
+            )  # use levenshtein distance to check
+
+
 # NOTE: encoder/decoder tests are currently located under
 # tests/models/multimodal/generation/test_whisper.py

--- a/vllm/beam_search.py
+++ b/vllm/beam_search.py
@@ -165,30 +165,6 @@ def create_sort_beams_key_function(eos_token_id: int, length_penalty: float):
     return sort_beams_key
 
 
-def _get_token_prompts(tensor: torch.Tensor, pad_token_id: int) -> list[TokensPrompt]:
-    """
-    Vectorized removal of leading padding and returns TokensPrompt list.
-    tensor: [batch*num_beams, seq_len] on the model device (torch.Tensor)
-    """
-    mask = tensor.ne(pad_token_id)
-    any_nonpad = mask.any(dim=1)
-    first_nonpad = torch.where(
-        any_nonpad,
-        mask.float().argmax(dim=1),
-        torch.full(
-            (tensor.size(0),), tensor.size(1), device=tensor.device, dtype=torch.long
-        ),
-    )
-
-    result_prompts = []
-    for i in range(tensor.size(0)):
-        start = int(first_nonpad[i].item())
-        # all-pads -> empty sequence
-        processed = [] if start >= tensor.size(1) else tensor[i, start:].tolist()
-        result_prompts.append(TokensPrompt(prompt_token_ids=processed))
-    return result_prompts
-
-
 def _flatten_beam_dim(tensor: torch.Tensor) -> torch.Tensor:
     """[batch_size, num_beams, ...] -> [batch_size * num_beams, ...]"""
     shape = list(tensor.shape)

--- a/vllm/beam_search.py
+++ b/vllm/beam_search.py
@@ -307,7 +307,7 @@ def _get_top_k_continuations(
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     output_log_probs = torch.full(
         (batch_size * num_beams, logprobs_size),
-        1e-9,
+        -1.0e9,
         dtype=torch.float32,
         device=running_sequences.device,
     )

--- a/vllm/beam_search.py
+++ b/vllm/beam_search.py
@@ -10,7 +10,6 @@ from vllm.inputs import (
     EncoderDecoderInput,
     MultiModalInput,
     TokensInput,
-    TokensPrompt,
     mm_input,
     tokens_input,
 )

--- a/vllm/beam_search.py
+++ b/vllm/beam_search.py
@@ -3,11 +3,14 @@
 
 from dataclasses import dataclass
 
+import torch
+
 from vllm.inputs import (
     DecoderOnlyEngineInput,
     EncoderDecoderInput,
     MultiModalInput,
     TokensInput,
+    TokensPrompt,
     mm_input,
     tokens_input,
 )
@@ -160,3 +163,305 @@ def create_sort_beams_key_function(eos_token_id: int, length_penalty: float):
         )
 
     return sort_beams_key
+
+
+def _get_token_prompts(tensor: torch.Tensor, pad_token_id: int) -> list[TokensPrompt]:
+    """
+    Vectorized removal of leading padding and returns TokensPrompt list.
+    tensor: [batch*num_beams, seq_len] on the model device (torch.Tensor)
+    """
+    mask = tensor.ne(pad_token_id)
+    any_nonpad = mask.any(dim=1)
+    first_nonpad = torch.where(
+        any_nonpad,
+        mask.float().argmax(dim=1),
+        torch.full(
+            (tensor.size(0),), tensor.size(1), device=tensor.device, dtype=torch.long
+        ),
+    )
+
+    result_prompts = []
+    for i in range(tensor.size(0)):
+        start = int(first_nonpad[i].item())
+        # all-pads -> empty sequence
+        processed = [] if start >= tensor.size(1) else tensor[i, start:].tolist()
+        result_prompts.append(TokensPrompt(prompt_token_ids=processed))
+    return result_prompts
+
+
+def _flatten_beam_dim(tensor: torch.Tensor) -> torch.Tensor:
+    """[batch_size, num_beams, ...] -> [batch_size * num_beams, ...]"""
+    shape = list(tensor.shape)
+    return torch.reshape(tensor, [shape[0] * shape[1]] + shape[2:])
+
+
+def _unflatten_beam_dim(
+    tensor: torch.Tensor, batch_size: int, num_beams: int
+) -> torch.Tensor:
+    """[batch_size * num_beams, ...] -> [batch_size, num_beams, ...]"""
+    shape = list(tensor.shape)
+    return torch.reshape(tensor, [batch_size, num_beams] + shape[1:])
+
+
+def _gather_beams(tensor: torch.Tensor, beam_indices: torch.Tensor) -> torch.Tensor:
+    """Gathers the beam slices indexed by beam_indices into new beam array."""
+    while len(beam_indices.shape) < len(tensor.shape):
+        beam_indices = beam_indices.unsqueeze(-1)
+    gathered_tensor = torch.take_along_dim(input=tensor, indices=beam_indices, dim=1)
+    return gathered_tensor
+
+
+def _check_early_stop_heuristic(
+    is_early_stop_heuristic_unsatisfied: torch.Tensor,
+    running_beam_scores: torch.Tensor,
+    beam_scores: torch.Tensor,
+    is_sent_finished: torch.Tensor,
+    cur_len: int,
+    max_length: int,
+    decoder_prompt_len: int,
+    early_stopping: bool | str,
+    length_penalty: float,
+):
+    """
+    Determine whether early stopping is possible by checking if the best possible
+    score of running beams could still improve upon the finished ones.
+
+    Mechanism:
+    - Without a length penalty, beam scores typically decrease as more tokens are
+    generated. So, if the *best possible* score from any running beam is already
+    worse than the *worst* finished beam, we can safely stop early.
+    - With a length penalty, scores may increase with longer sequences. In this
+    case, we use heuristics to estimate the best possible score — though this estimate
+    may not always be correct — and stop if no further improvement seems likely.
+
+    We apply different heuristics depending on the value of `early_stopping`:
+    1. `early_stopping == False`:
+    -> Use a heuristic that assumes the best score comes from the current length
+    minus the decoder prompt length.
+    -> See detailed discussion:
+    https://github.com/huggingface/transformers/pull/20901#issuecomment-1369845565
+
+    2. `early_stopping == "never"`:
+    -> Estimate the best score using either `max_length` or `cur_len`, depending
+    on the sign of `length_penalty`.
+    -> A positive length penalty favors longer sequences, so we use `max_length`
+    in that case.
+
+    NOTE: the canonical beam search implementation can be replicated with
+    `early_stopping="never"` and `length_penalty=0.0`, which are NOT the default
+    flags. The default behavior was empirically found to produce better sequences
+    (prior to 2022), and changing it is BC breaking.
+    """
+    if early_stopping == "never" and length_penalty > 0.0:
+        best_hypothetical_length = max_length - decoder_prompt_len
+    else:
+        best_hypothetical_length = cur_len - decoder_prompt_len
+    best_possible_running_score = running_beam_scores[:, :1] / (
+        best_hypothetical_length**length_penalty
+    )
+    worst_finished_score = torch.where(
+        is_sent_finished, torch.min(beam_scores, dim=1, keepdim=True)[0], -1.0e9
+    )
+    return is_early_stop_heuristic_unsatisfied & torch.any(
+        best_possible_running_score > worst_finished_score, dim=-1, keepdim=True
+    )
+
+
+def _beam_search_has_unfinished_sequences(
+    is_early_stop_heuristic_unsatisfied: torch.Tensor,
+    is_sent_finished: torch.Tensor,
+    next_token_hits_stopping_criteria: torch.Tensor,
+    early_stopping: bool | str,
+):
+    """
+    Beam Search stopping condition -- halts the generation loop if any of these
+    conditions becomes False
+    """
+    # a. Can the open beams improve the top completed scores?
+    improvement_possible = torch.any(is_early_stop_heuristic_unsatisfied)
+
+    # b. Is there still a beam without fully completed sequences? This is only
+    # relevant if early_stopping is enabled, where we want to finish as soon as
+    # all beams have a completed sequence.
+    exists_open_beam = ~(torch.all(is_sent_finished) & (early_stopping is True))
+
+    # c. Have we hit a stopping criteria with all running sequences and have no
+    # way to continue? e.g. we have reached `max_length``
+    valid_continuations = ~torch.all(next_token_hits_stopping_criteria)
+
+    return improvement_possible & exists_open_beam & valid_continuations
+
+
+def _get_top_k_continuations(
+    model_outputs,
+    running_sequences: torch.Tensor,
+    running_beam_indices: torch.Tensor,
+    running_beam_scores: torch.Tensor,
+    cur_len: int,
+    decoder_prompt_len: int,
+    beams_to_keep: int,
+    num_beams: int,
+    batch_size: int,
+    logprobs_size: int,
+    is_first_step: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    output_log_probs = torch.full(
+        (batch_size * num_beams, logprobs_size),
+        1e-9,
+        dtype=torch.float32,
+        device=running_sequences.device,
+    )
+    output_token_ids = torch.zeros(
+        (batch_size * num_beams, logprobs_size),
+        dtype=torch.long,
+        device=running_sequences.device,
+    )
+
+    if is_first_step:
+        output_log_probs = _unflatten_beam_dim(output_log_probs, batch_size, num_beams)
+        output_token_ids = _unflatten_beam_dim(output_token_ids, batch_size, num_beams)
+        for idx in range(batch_size):
+            out = model_outputs[idx]
+            lp_map = out.outputs[0].logprobs[0]
+            for item_idx, (token_id, logprob_obj) in enumerate(lp_map.items()):
+                # token_id might be string or int (be defensive)
+                output_token_ids[
+                    idx, item_idx // logprobs_size, item_idx % logprobs_size
+                ] = int(token_id)
+                output_log_probs[
+                    idx, item_idx // logprobs_size, item_idx % logprobs_size
+                ] = float(logprob_obj.logprob)
+    else:
+        for idx in range(batch_size * num_beams):
+            out = model_outputs[idx]
+            lp_map = out.outputs[0].logprobs[0]
+            for item_idx, (token_id, logprob_obj) in enumerate(lp_map.items()):
+                # token_id might be string or int (be defensive)
+                output_token_ids[idx, item_idx] = int(token_id)
+                output_log_probs[idx, item_idx] = float(logprob_obj.logprob)
+        output_log_probs = _unflatten_beam_dim(output_log_probs, batch_size, num_beams)
+        output_token_ids = _unflatten_beam_dim(output_token_ids, batch_size, num_beams)
+
+    # accumulate
+    output_log_probs = output_log_probs + running_beam_scores[:, :, None]
+    # flatten to [batch, num_beams * logprobs_size]
+    output_log_probs = torch.reshape(
+        output_log_probs, (batch_size, num_beams * logprobs_size)
+    )
+    output_token_ids = torch.reshape(
+        output_token_ids, (batch_size, num_beams * logprobs_size)
+    )
+
+    topk_log_probs, topk_indices = torch.topk(output_log_probs, k=beams_to_keep, dim=-1)
+
+    # Gather K top beams, recover the beam index by floor division and token id
+    # by modulo division
+    topk_ids = torch.gather(output_token_ids, dim=-1, index=topk_indices)
+    topk_current_beam_indices = topk_indices // logprobs_size
+    topk_running_beam_indices = _gather_beams(
+        running_beam_indices, topk_current_beam_indices
+    )
+    topk_running_sequences = _gather_beams(running_sequences, topk_current_beam_indices)
+
+    # Update sequences for the K top-k new sequences.
+    topk_running_sequences[:, :, cur_len] = topk_ids
+
+    # we want to store the beam indices with batch information ->
+    # real beam index = beam index % num beams
+    batch_offset = (
+        torch.arange(batch_size, device=topk_ids.device).view(-1, 1) * num_beams
+    )
+    batch_modified_indices = topk_current_beam_indices + batch_offset
+    topk_running_beam_indices[:, :, cur_len - decoder_prompt_len] = (
+        batch_modified_indices
+    )
+
+    return topk_log_probs, topk_running_sequences, topk_running_beam_indices
+
+
+def _get_running_beams_for_next_iteration(
+    topk_log_probs: torch.Tensor,
+    topk_running_sequences: torch.Tensor,
+    topk_running_beam_indices: torch.Tensor,
+    next_token_hits_stopping_criteria: torch.Tensor,
+    num_beams: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Given the top-K continuations, their scores, and whether they hit a stopping
+    criteria, select the best non-finished beams to continue beam search in the
+    next iteration.
+    """
+    # To prevent these just finished sequences from being used in subsequent
+    # iterations, set their log probs to a very large negative value
+    topk_running_log_probs = (
+        topk_log_probs + next_token_hits_stopping_criteria.to(torch.float32) * -1.0e9
+    )
+
+    next_topk_indices = torch.topk(topk_running_log_probs, k=num_beams)[1]
+    running_sequences = _gather_beams(topk_running_sequences, next_topk_indices)
+    running_beam_scores = _gather_beams(topk_running_log_probs, next_topk_indices)
+    running_beam_indices = _gather_beams(topk_running_beam_indices, next_topk_indices)
+    return running_sequences, running_beam_scores, running_beam_indices
+
+
+def _update_finished_beams(
+    sequences: torch.Tensor,
+    topk_running_sequences: torch.Tensor,
+    beam_scores: torch.Tensor,
+    topk_log_probs: torch.Tensor,
+    beam_indices: torch.Tensor,
+    topk_running_beam_indices: torch.Tensor,
+    is_early_stop_heuristic_unsatisfied: torch.Tensor,
+    is_sent_finished: torch.Tensor,
+    next_token_hits_stopping_criteria: torch.Tensor,
+    top_num_beam_mask: torch.Tensor,
+    num_beams: int,
+    cur_len: int,
+    decoder_prompt_len: int,
+    length_penalty: float,
+    early_stopping: bool | str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Updates the finished beams if (and only if) there are new completed sequences
+    that have a higher score than the current finished sequences.
+    """
+    # Only the top `num_beam` sequences can be considered for the final returned
+    # sequences. Remember: the remaining sequences only exist as a backup to ensure
+    # that we have at least `num_beams` sequences to continue.
+    did_top_num_beams_just_finished = (
+        next_token_hits_stopping_criteria & top_num_beam_mask[None, :]
+    )
+
+    # Further process topk logits for the finished beams
+    # - add length penalty
+    topk_log_probs = topk_log_probs / (
+        (cur_len + 1 - decoder_prompt_len) ** length_penalty
+    )
+    # - make sure no scores can be added anymore if beam is full and early stopping
+    # is on
+    beams_in_batch_are_full = torch.all(is_sent_finished, axis=-1, keepdims=True) & (
+        early_stopping is True
+    )
+    topk_log_probs += beams_in_batch_are_full.to(torch.float32) * -1.0e9
+    # - make sure no scores can be added anymore if improvement is not possible
+    topk_log_probs += (~is_early_stop_heuristic_unsatisfied).to(torch.float32) * -1.0e9
+
+    # - make sure still running sequences cannot be chosen as finalized beam
+    topk_log_probs += (~did_top_num_beams_just_finished) * -1.0e9
+
+    # Get finalized  `num_beam` sequences for the next generation step -- combine the
+    # previous finalized data with the new finalized sequences (if any, non-finalized
+    # sequences have a very large negative score in this step), and keep the best
+    # `num_beams` sequences.
+    merged_sequences = torch.cat((sequences, topk_running_sequences), dim=1)
+    merged_scores = torch.cat((beam_scores, topk_log_probs), dim=1)
+    merged_beam_indices = torch.cat((beam_indices, topk_running_beam_indices), dim=1)
+    merged_is_sent_finished = torch.cat(
+        (is_sent_finished, did_top_num_beams_just_finished), dim=1
+    )
+    topk_merged_indices = torch.topk(merged_scores, k=num_beams)[1]
+    sequences = _gather_beams(merged_sequences, topk_merged_indices)
+    beam_scores = _gather_beams(merged_scores, topk_merged_indices)
+    beam_indices = _gather_beams(merged_beam_indices, topk_merged_indices)
+    is_sent_finished = _gather_beams(merged_is_sent_finished, topk_merged_indices)
+    return sequences, beam_scores, beam_indices, is_sent_finished

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -4,19 +4,26 @@
 import itertools
 from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import cloudpickle
+import torch
 import torch.nn as nn
 from pydantic import ValidationError
 from tqdm.auto import tqdm
 from typing_extensions import TypeVar, overload
 
 from vllm.beam_search import (
-    BeamSearchInstance,
     BeamSearchOutput,
     BeamSearchSequence,
-    create_sort_beams_key_function,
+    _beam_search_has_unfinished_sequences,
+    _check_early_stop_heuristic,
+    _flatten_beam_dim,
+    _get_running_beams_for_next_iteration,
+    _get_token_prompts,
+    _get_top_k_continuations,
+    _unflatten_beam_dim,
+    _update_finished_beams,
 )
 from vllm.config import (
     AttentionConfig,
@@ -678,6 +685,25 @@ class LLM:
         """
         return self.llm_engine.apply_model(func)
 
+    def _get_beam_search_lora_requests(
+        self,
+        lora_request: list[LoRARequest] | LoRARequest | None,
+        prompts: list[TokensPrompt | TextPrompt],
+        beam_width: int,
+    ) -> list[LoRARequest | None]:
+        """Get the optional lora request corresponding to each prompt."""
+        if isinstance(lora_request, Sequence):
+            if len(lora_request) != len(prompts):
+                raise ValueError(
+                    "Lora request list should be the same length as the prompts"
+                )
+            return [[lr] * beam_width for lr in lora_request]
+
+        if lora_request is None or isinstance(lora_request, LoRARequest):
+            return [lora_request] * beam_width * len(prompts)
+
+        raise TypeError(f"Invalid lora_request type {type(lora_request)}")
+
     def beam_search(
         self,
         prompts: list[TokensPrompt | TextPrompt],
@@ -695,144 +721,286 @@ class LLM:
             params: The beam search parameters.
             lora_request: LoRA request to use for generation, if any.
             use_tqdm: Whether to use tqdm to display the progress bar.
-            concurrency_limit: The maximum number of concurrent requests.
-                If None, the number of concurrent requests is unlimited.
+            concurrency_limit: Not used
         """
-        # TODO: how does beam search work together with length penalty,
-        # frequency, penalty, and stopping criteria, etc.?
-        beam_width = params.beam_width
-        max_tokens = params.max_tokens
+        tokenizer = self.get_tokenizer()
+
+        # 1. init beam_search values
         temperature = params.temperature
         ignore_eos = params.ignore_eos
+        early_stopping = params.early_stopping
         length_penalty = params.length_penalty
-
-        tokenizer = self.renderer.get_tokenizer()
-        eos_token_id = tokenizer.eos_token_id
-        sort_beams_key = create_sort_beams_key_function(eos_token_id, length_penalty)
-
-        engine_inputs = self._preprocess_cmpl(prompts)
-        lora_requests = self._lora_request_to_seq(lora_request, len(engine_inputs))
-
-        if use_tqdm and concurrency_limit is not None:
-            logger.warning(
-                "Progress bar is not supported when using concurrency_limit. "
-                "Disabling progress bar."
-            )
-            use_tqdm = False
-
-        if concurrency_limit is None:
-            concurrency_limit = len(engine_inputs)
-
-        # generate 2 * beam_width candidates at each step
-        # following the huggingface transformers implementation
-        # at https://github.com/huggingface/transformers/blob/e15687fffe5c9d20598a19aeab721ae0a7580f8a/src/transformers/generation/beam_search.py#L534 # noqa
-        sampling_params = SamplingParams(
-            logprobs=2 * beam_width,
-            max_tokens=1,
-            temperature=temperature,
-            skip_clone=True,  # Internal beam search, safe to skip clone
+        max_tokens = params.max_tokens
+        num_beams = params.beam_width
+        num_return_sequences = (
+            params.num_return_sequences
+            if params.num_return_sequences is not None
+            else num_beams
         )
-        instances: list[BeamSearchInstance] = []
+        max_logprobs_size = self.model_config.max_logprobs
+        pad_token_id = (
+            params.pad_token_id
+            if params.pad_token_id is not None
+            else tokenizer.pad_token_id
+        )
+        eos_token_id = (
+            params.eos_token_id
+            if params.eos_token_id is not None
+            else tokenizer.eos_token_id
+        )
+        device = "cpu"  # use tensor on cpu
+        batch_size = len(prompts)
+        beam_lora_requests = self._get_beam_search_lora_requests(
+            lora_request, prompts, num_beams
+        )
 
-        for lora_req, prompt in zip(lora_requests, engine_inputs):
-            if prompt["type"] == "embeds":
-                raise NotImplementedError(
-                    "Embedding prompt not supported for beam search"
-                )
+        # At each beam search step, we want to keep top K
+        # [K = (number of EOS tokens + 1) * `num_beams`] candidates # with the
+        # highest log-probabilities, or sample K continuations without replacement.
+        # We gather the top K (as opposed to `num_beams`, or any number lower than K)
+        # so that we have at least `num_beams` sequences non-finished to continue
+        # the live beam search, in case the top `num_beams` all select an EOS token.
+        n_eos_tokens = len(eos_token_id) if isinstance(eos_token_id, list) else 1
+        beams_to_keep = max(2, 1 + n_eos_tokens) * num_beams
+        top_num_beam_mask = torch.cat(
+            (
+                torch.ones((num_beams), dtype=torch.bool),
+                torch.zeros((beams_to_keep - num_beams), dtype=torch.bool),
+            ),
+            dim=0,
+        ).to(device)
 
-            instances.append(
-                BeamSearchInstance(
-                    prompt,
-                    lora_request=lora_req,
-                    logprobs=None,
-                ),
+        # 2. encode prompts
+        token_prompts: list[TokensPrompt] = [
+            TokensPrompt(prompt_token_ids=tokenizer.encode(prompt["prompt"]))
+            if "prompt_token_ids" not in prompt
+            else cast(TokensPrompt, prompt)  # Needed for mypy
+            for prompt in prompts
+        ]
+        prompt_max_len = max(len(seq["prompt_token_ids"]) for seq in token_prompts)
+        max_length = prompt_max_len + max_tokens
+        input_ids = torch.full(
+            (batch_size, prompt_max_len), pad_token_id, dtype=torch.long, device=device
+        )
+        for i, seq in enumerate(token_prompts):
+            token_ids = seq["prompt_token_ids"]
+            token_tensor = torch.tensor(
+                token_ids, dtype=torch.long, device=input_ids.device
+            )
+            input_ids[i, prompt_max_len - len(token_ids) : prompt_max_len] = (
+                token_tensor
             )
 
-        for prompt_start in range(0, len(instances), concurrency_limit):
-            instances_batch = instances[prompt_start : prompt_start + concurrency_limit]
+        input_ids = input_ids.repeat_interleave(
+            num_beams, dim=0
+        )  # [batch*num_beams, prompt_len]
+        cur_len = input_ids.shape[1]
+        decoder_prompt_len = cur_len
 
-            token_iter = range(max_tokens)
-            if use_tqdm:
-                token_iter = tqdm(
-                    token_iter, desc="Beam search", unit="token", unit_scale=False
+        # 3. init running tensors and static-shaped placeholders
+        output_fill_value = (
+            pad_token_id
+            or (
+                eos_token_id[0]
+                if isinstance(eos_token_id, (list, tuple))
+                else eos_token_id
+            )
+            if eos_token_id is not None
+            else -1
+        )
+        running_sequences = torch.full(
+            (batch_size, num_beams, max_length),
+            fill_value=output_fill_value,
+            dtype=torch.long,
+            device=device,
+        )
+        running_sequences[:, :, :cur_len] = _unflatten_beam_dim(
+            input_ids, batch_size, num_beams
+        )
+        sequences = running_sequences.detach().clone()
+
+        # per batch, beam-item score, logprobs
+        # initialise score of first beam with 0 and the rest with -1e9. This
+        # makes sure that only tokens of the first beam are considered to avoid
+        # sampling the exact same tokens across all beams.
+        running_beam_scores = torch.zeros(
+            (batch_size, num_beams), dtype=torch.float, device=device
+        )
+        running_beam_scores[:, 1:] = -1e9
+        beam_scores = torch.full(
+            (batch_size, num_beams), fill_value=-1e9, dtype=torch.float, device=device
+        )
+
+        # per batch, beam-item state bit indicating if sentence has finished.
+        is_sent_finished = torch.zeros(
+            (batch_size, num_beams), dtype=torch.bool, device=device
+        )
+
+        # per batch state bit indicating if there is a possibility to improve
+        # the best finished sentence.
+        is_early_stop_heuristic_unsatisfied = torch.ones(
+            (batch_size, 1), dtype=torch.bool, device=device
+        )
+
+        # per batch, beam-item state bit indicating if there are valid continuations.
+        next_token_hits_stopping_criteria = torch.zeros(
+            (batch_size, num_beams), dtype=torch.bool, device=device
+        )
+
+        # per batch selected beam indices
+        running_beam_indices = torch.full(
+            (batch_size, num_beams, max_length - cur_len),
+            fill_value=-1,
+            dtype=torch.int32,
+            device=device,
+        )
+        beam_indices = running_beam_indices.detach().clone()
+
+        # 4. run the generation loop
+        token_iter = range(cur_len, max_length)
+        if not early_stopping and use_tqdm:
+            token_iter = tqdm(
+                token_iter, desc="Beam search", unit="token", unit_scale=False
+            )
+            logger.warning(
+                "The progress bar shows the upper bound on token steps and "
+                "may finish early due to stopping conditions. It does not "
+                "reflect instance-level progress."
+            )
+        for _ in token_iter:
+            if cur_len == 67:
+                _ = 1
+
+            # a. Forward current tokens, obtain the logits
+            is_first_step = cur_len == decoder_prompt_len
+
+            # for the first step, all sequences are the same, so only use one
+            # to generate
+            flat_running_sequences = (
+                running_sequences[:, 0, :cur_len]
+                if is_first_step
+                else _flatten_beam_dim(running_sequences[:, :, :cur_len])
+            )
+            model_inputs = _get_token_prompts(flat_running_sequences, pad_token_id)
+            model_outputs = self.generate(
+                prompts=model_inputs,
+                sampling_params=SamplingParams(
+                    logprobs=max_logprobs_size, max_tokens=1, temperature=temperature
+                ),
+                use_tqdm=False,
+                lora_request=lora_request if is_first_step else beam_lora_requests,
+            )
+
+            # b. Compute log probs. Not needed
+
+            # c. Retrieve top-K continuations, i.e. select the next token
+            # (greedy or sampling) and then keep the best continuations among
+            # all beams based on the accumulated scores.
+            topk_log_probs, topk_running_sequences, topk_running_beam_indices = (
+                _get_top_k_continuations(
+                    model_outputs,
+                    running_sequences=running_sequences,
+                    running_beam_indices=running_beam_indices,
+                    running_beam_scores=running_beam_scores,
+                    cur_len=cur_len,
+                    decoder_prompt_len=decoder_prompt_len,
+                    beams_to_keep=beams_to_keep,
+                    num_beams=num_beams,
+                    batch_size=batch_size,
+                    logprobs_size=max_logprobs_size,
+                    is_first_step=is_first_step,
                 )
-                logger.warning(
-                    "The progress bar shows the upper bound on token steps and "
-                    "may finish early due to stopping conditions. It does not "
-                    "reflect instance-level progress."
-                )
-            for _ in token_iter:
-                all_beams: list[BeamSearchSequence] = list(
-                    sum((instance.beams for instance in instances_batch), [])
-                )
-                pos = [0] + list(
-                    itertools.accumulate(
-                        len(instance.beams) for instance in instances_batch
-                    )
-                )
-                instance_start_and_end: list[tuple[int, int]] = list(
-                    zip(pos[:-1], pos[1:])
+            )
+
+            # d. Check which running sequences have finished
+            if not ignore_eos:
+                next_token_hits_stopping_criteria = (
+                    topk_running_sequences[:, :, cur_len] == eos_token_id
                 )
 
-                if len(all_beams) == 0:
-                    break
-
-                # only runs for one step
-                # we don't need to use tqdm here
-                output = self._render_and_run_requests(
-                    prompts=(beam.get_prompt() for beam in all_beams),
-                    params=self._params_to_seq(sampling_params, len(all_beams)),
-                    output_type=RequestOutput,
-                    lora_requests=[beam.lora_request for beam in all_beams],
-                    use_tqdm=False,
+            # e. Get the non-finished running `num_beams` sequences for the
+            # next generation step
+            running_sequences, running_beam_scores, running_beam_indices = (
+                _get_running_beams_for_next_iteration(
+                    topk_log_probs=topk_log_probs,
+                    topk_running_sequences=topk_running_sequences,
+                    topk_running_beam_indices=topk_running_beam_indices,
+                    next_token_hits_stopping_criteria=next_token_hits_stopping_criteria,
+                    num_beams=num_beams,
                 )
+            )
 
-                for (start, end), instance in zip(
-                    instance_start_and_end, instances_batch
-                ):
-                    instance_new_beams = []
-                    for i in range(start, end):
-                        current_beam = all_beams[i]
-                        result = output[i]
+            # f. Update the completed beams if a new high score in a finished
+            # sequence is found
+            sequences, beam_scores, beam_indices, is_sent_finished = (
+                _update_finished_beams(
+                    sequences=sequences,
+                    topk_running_sequences=topk_running_sequences,
+                    beam_scores=beam_scores,
+                    topk_log_probs=topk_log_probs,
+                    beam_indices=beam_indices,
+                    topk_running_beam_indices=topk_running_beam_indices,
+                    is_early_stop_heuristic_unsatisfied=is_early_stop_heuristic_unsatisfied,
+                    is_sent_finished=is_sent_finished,
+                    next_token_hits_stopping_criteria=next_token_hits_stopping_criteria,
+                    top_num_beam_mask=top_num_beam_mask,
+                    num_beams=num_beams,
+                    cur_len=cur_len,
+                    decoder_prompt_len=decoder_prompt_len,
+                    length_penalty=length_penalty,
+                    early_stopping=early_stopping,
+                )
+            )
 
-                        if result.outputs[0].logprobs is not None:
-                            # if `result.outputs[0].logprobs` is None, it means
-                            # the sequence is completed because of the
-                            # max-model-len or abortion. we don't need to add
-                            # it to the new beams.
-                            logprobs = result.outputs[0].logprobs[0]
-                            for token_id, logprob_obj in logprobs.items():
-                                new_beam = BeamSearchSequence(
-                                    current_beam.orig_prompt,
-                                    tokens=current_beam.tokens + [token_id],
-                                    logprobs=current_beam.logprobs + [logprobs],
-                                    lora_request=current_beam.lora_request,
-                                    cum_logprob=current_beam.cum_logprob
-                                    + logprob_obj.logprob,
-                                )
+            # g. Prepare remaining data for the next iteration, including computing
+            # the stopping condition for beam search as a whole (as opposed to
+            # individual beams, i.e. `stopping_criteria`)
+            cur_len = cur_len + 1
+            is_early_stop_heuristic_unsatisfied = _check_early_stop_heuristic(
+                is_early_stop_heuristic_unsatisfied=is_early_stop_heuristic_unsatisfied,
+                running_beam_scores=running_beam_scores,
+                beam_scores=beam_scores,
+                is_sent_finished=is_sent_finished,
+                cur_len=cur_len,
+                max_length=max_length,
+                decoder_prompt_len=decoder_prompt_len,
+                early_stopping=early_stopping,
+                length_penalty=length_penalty,
+            )
 
-                                if token_id == eos_token_id and not ignore_eos:
-                                    instance.completed.append(new_beam)
-                                else:
-                                    instance_new_beams.append(new_beam)
-                    sorted_beams = sorted(
-                        instance_new_beams, key=sort_beams_key, reverse=True
-                    )
-                    instance.beams = sorted_beams[:beam_width]
+            if not _beam_search_has_unfinished_sequences(
+                is_early_stop_heuristic_unsatisfied,
+                is_sent_finished,
+                next_token_hits_stopping_criteria,
+                early_stopping,
+            ):
+                break
+
+        # 5. prepare outputs
+        sequences = _flatten_beam_dim(sequences[:, :num_return_sequences, :])
+        beam_scores = _flatten_beam_dim(beam_scores[:, :num_return_sequences])
 
         outputs = []
-        for instance in instances:
-            instance.completed.extend(instance.beams)
-            sorted_completed = sorted(
-                instance.completed, key=sort_beams_key, reverse=True
-            )
-            best_beams = sorted_completed[:beam_width]
+        seq_token_lists = [seq.tolist() for seq in sequences]
+        decoded_texts = [
+            tokenizer.decode(seq, skip_special_tokens=True) for seq in seq_token_lists
+        ]
 
-            for beam in best_beams:
-                beam.text = tokenizer.decode(beam.tokens)
-
-            outputs.append(BeamSearchOutput(sequences=best_beams))
-
+        for i in range(batch_size):
+            batch_outputs = []
+            for j in range(num_return_sequences):
+                idx = i * num_return_sequences + j
+                seq = seq_token_lists[idx]
+                score = beam_scores[idx].item() if idx < len(beam_scores) else 0.0
+                batch_outputs.append(
+                    BeamSearchSequence(
+                        text=decoded_texts[idx],
+                        logprobs=[],
+                        tokens=seq,
+                        cum_logprob=score,
+                    )
+                )
+            outputs.append(BeamSearchOutput(sequences=batch_outputs))
         return outputs
 
     def _preprocess_cmpl(

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -690,8 +690,11 @@ class LLM:
         lora_request: list[LoRARequest] | LoRARequest | None,
         prompts: list[TokensPrompt | TextPrompt],
         beam_width: int,
-    ) -> list[LoRARequest | None]:
+    ) -> list[LoRARequest] | None:
         """Get the optional lora request corresponding to each prompt."""
+        if lora_request is None:
+            return None
+
         if isinstance(lora_request, Sequence):
             if len(lora_request) != len(prompts):
                 raise ValueError(
@@ -699,7 +702,7 @@ class LLM:
                 )
             return [lr for lr in lora_request for _ in range(beam_width)]
 
-        if lora_request is None or isinstance(lora_request, LoRARequest):
+        if isinstance(lora_request, LoRARequest):
             return [lora_request] * beam_width * len(prompts)
 
         raise TypeError(f"Invalid lora_request type {type(lora_request)}")
@@ -782,8 +785,8 @@ class LLM:
         input_ids = torch.full(
             (batch_size, prompt_max_len), pad_token_id, dtype=torch.long, device=device
         )
-        for i, seq in enumerate(token_prompts):
-            token_ids = seq["prompt_token_ids"]
+        for i, token_prompt in enumerate(token_prompts):
+            token_ids = token_prompt["prompt_token_ids"]
             token_tensor = torch.tensor(
                 token_ids, dtype=torch.long, device=input_ids.device
             )
@@ -987,13 +990,13 @@ class LLM:
             batch_outputs = []
             for j in range(num_return_sequences):
                 idx = i * num_return_sequences + j
-                seq = seq_token_lists[idx]
+                seq_tokens = seq_token_lists[idx]
                 score = beam_scores[idx].item() if idx < len(beam_scores) else 0.0
                 batch_outputs.append(
                     BeamSearchSequence(
                         text=decoded_texts[idx],
                         logprobs=[],
-                        tokens=seq,
+                        tokens=seq_tokens,
                         cum_logprob=score,
                     )
                 )

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -697,7 +697,7 @@ class LLM:
                 raise ValueError(
                     "Lora request list should be the same length as the prompts"
                 )
-            return [[lr] * beam_width for lr in lora_request]
+            return [lr for lr in lora_request for _ in range(beam_width)]
 
         if lora_request is None or isinstance(lora_request, LoRARequest):
             return [lora_request] * beam_width * len(prompts)
@@ -868,9 +868,6 @@ class LLM:
                 "reflect instance-level progress."
             )
         for _ in token_iter:
-            if cur_len == 67:
-                _ = 1
-
             # a. Forward current tokens, obtain the logits
             is_first_step = cur_len == decoder_prompt_len
 

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import itertools
 from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -753,7 +752,9 @@ class LLM:
         )
         device = "cpu"  # use tensor on cpu
         batch_size = len(prompts)
-        lora_requests = self._lora_request_to_seq(lora_request, len(prompts) * num_beams)
+        lora_requests = self._lora_request_to_seq(
+            lora_request, len(prompts) * num_beams
+        )
 
         if use_tqdm and concurrency_limit is not None:
             logger.warning(

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -20,7 +20,6 @@ from vllm.beam_search import (
     _check_early_stop_heuristic,
     _flatten_beam_dim,
     _get_running_beams_for_next_iteration,
-    _get_token_prompts,
     _get_top_k_continuations,
     _unflatten_beam_dim,
     _update_finished_beams,
@@ -724,7 +723,8 @@ class LLM:
             params: The beam search parameters.
             lora_request: LoRA request to use for generation, if any.
             use_tqdm: Whether to use tqdm to display the progress bar.
-            concurrency_limit: Not used
+            concurrency_limit: The maximum number of concurrent requests.
+                If None, the number of concurrent requests is unlimited.
         """
         tokenizer = self.get_tokenizer()
 
@@ -753,9 +753,17 @@ class LLM:
         )
         device = "cpu"  # use tensor on cpu
         batch_size = len(prompts)
-        beam_lora_requests = self._get_beam_search_lora_requests(
-            lora_request, prompts, num_beams
-        )
+        lora_requests = self._lora_request_to_seq(lora_request, len(prompts) * num_beams)
+
+        if use_tqdm and concurrency_limit is not None:
+            logger.warning(
+                "Progress bar is not supported when using concurrency_limit. "
+                "Disabling progress bar."
+            )
+            use_tqdm = False
+
+        if concurrency_limit is None:
+            concurrency_limit = len(prompts) * num_beams
 
         # At each beam search step, we want to keep top K
         # [K = (number of EOS tokens + 1) * `num_beams`] candidates # with the
@@ -860,6 +868,12 @@ class LLM:
         beam_indices = running_beam_indices.detach().clone()
 
         # 4. run the generation loop
+        sampling_params = SamplingParams(
+            logprobs=max_logprobs_size,
+            max_tokens=1,
+            temperature=temperature,
+            skip_clone=True,  # Internal beam search, safe to skip clone
+        )
         token_iter = range(cur_len, max_length)
         if not early_stopping and use_tqdm:
             token_iter = tqdm(
@@ -881,14 +895,13 @@ class LLM:
                 if is_first_step
                 else _flatten_beam_dim(running_sequences[:, :, :cur_len])
             )
-            model_inputs = _get_token_prompts(flat_running_sequences, pad_token_id)
-            model_outputs = self.generate(
-                prompts=model_inputs,
-                sampling_params=SamplingParams(
-                    logprobs=max_logprobs_size, max_tokens=1, temperature=temperature
-                ),
+            engine_inputs = self._preprocess_cmpl(flat_running_sequences.tolist())
+            model_outputs = self._render_and_run_requests(
+                prompts=engine_inputs,
+                params=self._params_to_seq(sampling_params, len(engine_inputs)),
+                output_type=RequestOutput,
+                lora_requests=lora_request if is_first_step else lora_requests,
                 use_tqdm=False,
-                lora_request=lora_request if is_first_step else beam_lora_requests,
             )
 
             # b. Compute log probs. Not needed
@@ -994,6 +1007,7 @@ class LLM:
                 score = beam_scores[idx].item() if idx < len(beam_scores) else 0.0
                 batch_outputs.append(
                     BeamSearchSequence(
+                        orig_prompt=prompts[i],
                         text=decoded_texts[idx],
                         logprobs=[],
                         tokens=seq_tokens,
@@ -1001,6 +1015,7 @@ class LLM:
                     )
                 )
             outputs.append(BeamSearchOutput(sequences=batch_outputs))
+
         return outputs
 
     def _preprocess_cmpl(

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -920,3 +920,7 @@ class BeamSearchParams(
     temperature: float = 0.0
     length_penalty: float = 1.0
     include_stop_str_in_output: bool = False
+    num_return_sequences: int | None = None
+    early_stopping: bool = False
+    pad_token_id: int | None = None
+    eos_token_id: int | None = None

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -923,4 +923,4 @@ class BeamSearchParams(
     num_return_sequences: int | None = None
     early_stopping: bool = False
     pad_token_id: int | None = None
-    eos_token_id: int | None = None
+    eos_token_id: list[int] | int | None = None


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Reimplement beam-search reference transformers v4.57.3 [_beam_search](https://github.com/huggingface/transformers/blob/47b0e478f324b54f177ea7998a0791870fdd0324/src/transformers/generation/utils.py#L3111) function. 

- Partially solves performance issues because of removing beam-search from core. #14426, #20316
- We removed old beam search, so #31081 is supposed to be solved. But this issue do not provide any test so we haven't test yet.

## Test Plan

We briefly test our beam-search on `Qwen/Qwen2-0.5B` and dataset `google/wmt24pp`, and also provide a simple test case in `<project_root>/tests/samplers/test_beam_search.py`

- script

```python
# test script of `google/wmt24pp`
import argparse
import time
import torch

from datasets import load_dataset
# Importing Scarebleu for BLEU score calculation
from sacrebleu import corpus_bleu

from vllm import LLM, TextPrompt
from vllm.sampling_params import BeamSearchParams

MODEL_NAME = "Qwen/Qwen2-0.5B"


class TestParams:
    enable_prefix_cache = True
    enable_early_stopping = True
    max_tokens = 2048  # 1024
    beam_num = 2
    samples_num = 1000
    prompt_template = "Translate the following text from {src_lang} to {tgt_lang} (Only output the translation, don't include any other text):\n\n{src_text}.\n\n"


def run_beam_search(wmt_datasets, print_text):
    """run LLM.beam_search_by_transformers_vectoring

    version: move from transformer _beam_search
    """
    from vllm import LLM, TextPrompt
    from vllm.sampling_params import BeamSearchParams, SamplingParams

    prefix_cached_llm = LLM(
        model=MODEL_NAME,
        gpu_memory_utilization=0.8,
        swap_space=8,
        trust_remote_code=True,
        tensor_parallel_size=1,
        dtype=torch.bfloat16,
        enable_prefix_caching=TestParams.enable_prefix_cache
    )
    params = BeamSearchParams(
        beam_width=TestParams.beam_num, 
        max_tokens=TestParams.max_tokens, 
        temperature=0.0, 
        early_stopping=TestParams.enable_early_stopping,
    )
    beam_search_func = getattr(prefix_cached_llm, f"beam_search")
    generate_func = getattr(prefix_cached_llm, f"generate")
    generate_params = SamplingParams(
        max_tokens=TestParams.max_tokens,
        temperature=0.0,
        top_p=1.0,
        top_k=-1,
    )

    infer_time = 0
    references = []  # Store target texts
    hypotheses = [[], []]  # Store generated texts
    for i in range(min(TestParams.samples_num, len(wmt_datasets))):
        item = wmt_datasets[i]
        src_text = item["source"]
        tgt_text = item["target"]

        prompt_text = TestParams.prompt_template.format(
            src_lang="english", tgt_lang="chinese", src_text=src_text)
        prompts = [TextPrompt({"prompt": prompt_text})]

        t1 = time.time()
        outputs = beam_search_func(prompts, params)
        infer_time += time.time() - t1
        generate_output = generate_func(prompts, generate_params)

        _text1, _text2 = outputs[-1].sequences[0].text, outputs[-1].sequences[1].text
        _infer1, _infer2 = _text1.removeprefix(
            prompt_text), _text2.removeprefix(prompt_text)

        # Append to references and hypotheses
        references.append([tgt_text])
        hypotheses[0].append(_infer1)
        hypotheses[1].append(_infer2)

        if print_text:
            print(f"\nPrompt {i+1}:")
            print(f"Source: {src_text}")
            print(f"Target: {tgt_text}")
            print(f"generate: {generate_output[0].outputs[0].text}")
            print(f"Beam 1: {_infer1}")
            print(f"Beam 2: {_infer2}")

    # Calculate BLEU score after the loop
    print(f"\nInfer Time(s): {infer_time}")
    for i in range(TestParams.beam_num):
        bleu_score = corpus_bleu(hypotheses[i], references)
        print(f"Beam {i}: {bleu_score}")


def run(args):
    TestParams.enable_prefix_cache = args.prefix_caching
    TestParams.enable_early_stopping = args.early_stopping

    # solve datasets
    dataset_wmt24pp = load_dataset(
        "google/wmt24pp", "en-zh_CN", split="train")

    run_beam_search(dataset_wmt24pp, args.print_text)


if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument("--prefix-caching",
                        action="store_true", help="enable prefix-caching")
    parser.add_argument("--early-stopping",
                        action="store_true", help="enable early-stopping")
    parser.add_argument("--print-text",
                        action="store_true", help="print text result")
    args = parser.parse_args()
    run(args)
```

## Test Result

- `wmt24pp` result

```
Infer Time(s): 1625.854460477829
Beam 0: BLEU = 61.48 71.4/66.7/60.0/50.0 (BP = 1.000 ratio = 1.000 hyp_len = 7 ref_len = 7)
Beam 1: BLEU = 54.11 75.0/57.1/50.0/40.0 (BP = 1.000 ratio = 1.000 hyp_len = 8 ref_len = 8)
```

The old function will take a lot of time and lower the BLEU score because it will always execute to the max length.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

