### PR TITLE
[Kernel] Change get_min_capability to is_supported

### DIFF
--- a/tests/kernels/quantization/test_mixed_precision_kernel_selection.py
+++ b/tests/kernels/quantization/test_mixed_precision_kernel_selection.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for MixedPrecision kernel selection logic (CPU-only)
+
+Run `pytest tests/kernels/quantization/test_mixed_precision_kernel_selection.py`.
+"""
+
+import inspect
+from abc import ABC
+
+import pytest
+
+from vllm.model_executor.layers.quantization.kernels.mixed_precision import (
+    _POSSIBLE_KERNELS,
+)
+from vllm.model_executor.layers.quantization.kernels.mixed_precision.allspark import (  # noqa: E501
+    AllSparkLinearKernel,
+)
+from vllm.model_executor.layers.quantization.kernels.mixed_precision.bitblas import (  # noqa: E501
+    BitBLASLinearKernel,
+)
+from vllm.model_executor.layers.quantization.kernels.mixed_precision.conch import (  # noqa: E501
+    ConchLinearKernel,
+)
+from vllm.model_executor.layers.quantization.kernels.mixed_precision.MPLinearKernel import (  # noqa: E501
+    MPLinearKernel,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_is_supported_is_abstract():
+    """Test that is_supported() is properly defined as abstract."""
+    assert issubclass(MPLinearKernel, ABC)
+    assert hasattr(MPLinearKernel, "is_supported")
+
+
+def test_all_kernels_implement_is_supported_implemented():
+    """Test that all kernels implement is_supported() method."""
+    for kernel in _POSSIBLE_KERNELS:
+        assert hasattr(kernel, "is_supported"), (
+            f"{kernel.__name__} missing is_supported() method"
+        )
+        # Verify it's a classmethod by checking if it can be called with the class
+        # and by checking the method type
+        assert inspect.ismethod(kernel.is_supported) or inspect.isfunction(
+            kernel.is_supported
+        ), f"{kernel.__name__}.is_supported() should be a classmethod"
+        # Verify it can be called as a classmethod
+        result, reason = kernel.is_supported()
+        assert isinstance(result, bool), "is_supported() should return a bool"
+        assert reason is None or isinstance(reason, str), "reason should be str or None"
+
+
+def test_compute_capability_check():
+    """Test that is_supported() correctly checks compute capability."""
+    for kernel in [
+        AllSparkLinearKernel,
+        BitBLASLinearKernel,
+        ConchLinearKernel,
+    ]:
+        result, reason = kernel.is_supported(compute_capability=0)
+        assert result is False
+        assert reason is not None and "capability" in reason.lower()
+
+        result, reason = kernel.is_supported(compute_capability=100)
+        assert result is True
+        assert reason is None

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/MPLinearKernel.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/MPLinearKernel.py
@@ -26,7 +26,9 @@ class MPLinearLayerConfig:
 class MPLinearKernel(ABC):
     @classmethod
     @abstractmethod
-    def get_min_capability(cls) -> int:
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
         raise NotImplementedError
 
     @classmethod
@@ -43,6 +45,7 @@ class MPLinearKernel(ABC):
         w_gidx_param_name: str | None = None,
     ) -> None:
         assert self.can_implement(c)
+        assert self.is_supported()
         self.config = c
         self.w_q_name = w_q_param_name
         self.w_s_name = w_s_param_name

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/__init__.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/__init__.py
@@ -88,24 +88,18 @@ def choose_mp_linear_kernel(
                 f" {kernel.__name__} disabled by environment variable"
             )
             continue
-        if (
-            compute_capability is not None
-            and kernel.get_min_capability() > compute_capability
-        ):
-            failure_reasons.append(
-                f"{kernel.__name__} requires capability "
-                f"{kernel.get_min_capability()}, current compute "
-                f" capability is {compute_capability}"
-            )
+
+        is_supported, reason = kernel.is_supported(compute_capability)
+        if not is_supported:
+            failure_reasons.append(f"{kernel.__name__}: {reason}")
             continue
 
-        can_implement, failure_reason = kernel.can_implement(config)
-        if can_implement:
-            return kernel
-        else:
-            failure_reasons.append(
-                f" {kernel.__name__} cannot implement due to: {failure_reason}"
-            )
+        can_implement, reason = kernel.can_implement(config)
+        if not can_implement:
+            failure_reasons.append(f"{kernel.__name__}: {reason}")
+            continue
+
+        return kernel
 
     raise ValueError(
         "Failed to find a kernel that can implement the "

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/conch.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/conch.py
@@ -7,6 +7,7 @@ from typing import Final
 import torch
 
 from vllm.model_executor.parameter import BasevLLMParameter, permute_param_layout_
+from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 
 from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
@@ -22,8 +23,21 @@ _CONCH_SUPPORTED_GROUP_SIZES: Final = [-1, 128]
 
 class ConchLinearKernel(MPLinearKernel):
     @classmethod
-    def get_min_capability(cls) -> int:
-        return 80
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        if compute_capability is None:
+            _cc = current_platform.get_device_capability()
+            if _cc is not None:
+                compute_capability = _cc.major * 10 + _cc.minor
+
+        if compute_capability is not None and compute_capability < 80:
+            return (
+                False,
+                f"requires capability >= 80, got {compute_capability}",
+            )
+
+        return True, None
 
     @classmethod
     def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/conch.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/conch.py
@@ -6,8 +6,10 @@ from typing import Final
 
 import torch
 
+from vllm.model_executor.layers.quantization.utils import (
+    is_compute_capability_supported,
+)
 from vllm.model_executor.parameter import BasevLLMParameter, permute_param_layout_
-from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 
 from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
@@ -26,18 +28,9 @@ class ConchLinearKernel(MPLinearKernel):
     def is_supported(
         cls, compute_capability: int | None = None
     ) -> tuple[bool, str | None]:
-        if compute_capability is None:
-            _cc = current_platform.get_device_capability()
-            if _cc is not None:
-                compute_capability = _cc.major * 10 + _cc.minor
-
-        if compute_capability is not None and compute_capability < 80:
-            return (
-                False,
-                f"requires capability >= 80, got {compute_capability}",
-            )
-
-        return True, None
+        return is_compute_capability_supported(
+            min_capability=80, compute_capability=compute_capability
+        )
 
     @classmethod
     def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/cpu.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/cpu.py
@@ -18,14 +18,15 @@ _CPUWNA16_SUPPORTED_QUANT_TYPES = (scalar_types.uint4, scalar_types.uint4b8)
 
 class CPUWNA16LinearKernel(MPLinearKernel):
     @classmethod
-    def get_min_capability(cls) -> int:
-        return -1
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        if not current_platform.is_cpu():
+            return False, "requires CPU"
+        return True, None
 
     @classmethod
     def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
-        if not current_platform.is_cpu():
-            return False, "CPUWNA16 only supported on CPU"
-
         if c.weight_type not in _CPUWNA16_SUPPORTED_QUANT_TYPES:
             return (
                 False,

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/dynamic_4bit.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/dynamic_4bit.py
@@ -15,13 +15,15 @@ class Dynamic4bitLinearKernel(MPLinearKernel):
     SUPPORTED_QUANT_TYPES = [scalar_types.int4]
 
     @classmethod
-    def get_min_capability(cls) -> int:
-        return 1
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        if not current_platform.is_cpu():
+            return False, "requires CPU"
+        return True, None
 
     @classmethod
     def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
-        if not current_platform.is_cpu():
-            return False, "Only CPU is supported"
         if c.weight_type not in cls.SUPPORTED_QUANT_TYPES:
             return False, f"Unsupported quant type {c.weight_type}"
         if (

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/exllama.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/exllama.py
@@ -21,17 +21,15 @@ class ExllamaLinearKernel(MPLinearKernel):
     # currently untested so not added to the list
 
     @classmethod
-    def get_min_capability(cls) -> int:
-        return 60
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        if not current_platform.is_cuda_alike():
+            return False, "requires ROCm or CUDA"
+        return True, None
 
     @classmethod
     def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
-        if not current_platform.is_cuda_alike():
-            return (
-                False,
-                "Exllama is only supported on CUDA and ROCm",
-            )
-
         if c.has_g_idx and c.partition_weight_shape[0] != c.full_weight_shape[0]:
             return (
                 False,

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/marlin.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/marlin.py
@@ -29,15 +29,28 @@ from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
 
 class MarlinLinearKernel(MPLinearKernel):
     @classmethod
-    def get_min_capability(cls) -> int:
-        return 75
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        # Marlin uses inline PTX, so it can only be compatible with Nvidia
+        if not current_platform.is_cuda():
+            return False, "requires CUDA"
+
+        if compute_capability is None:
+            _cc = current_platform.get_device_capability()
+            if _cc is not None:
+                compute_capability = _cc.major * 10 + _cc.minor
+
+        if compute_capability is not None and compute_capability < 75:
+            return (
+                False,
+                f"requires capability >= 75, got {compute_capability}",
+            )
+
+        return True, None
 
     @classmethod
     def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
-        # Marlin uses inline PTX, so it can only be compatible with Nvidia
-        if not current_platform.is_cuda():
-            return False, "Marlin only supported on CUDA"
-
         quant_types = query_marlin_supported_quant_types(c.zero_points)
         if c.weight_type not in quant_types:
             return (

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/xpu.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/xpu.py
@@ -11,14 +11,15 @@ from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
 
 class XPUwNa16LinearKernel(MPLinearKernel):
     @classmethod
-    def get_min_capability(cls) -> int:
-        return 0
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        if not current_platform.is_xpu():
+            return False, "requires XPU/CPU devices"
+        return True, None
 
     @classmethod
     def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
-        if not current_platform.is_xpu():
-            return False, "IPEX wNa16 only supported on XPU/CPU devices"
-
         # TODO: (yiliu30) relax these restrictions in later PRs
         if c.zero_points:
             return False, "Zero points not supported for Now"

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/aiter.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/aiter.py
@@ -20,7 +20,7 @@ class AiterScaledMMLinearKernel(CutlassScaledMMLinearKernel):
         if not current_platform.is_rocm():
             return (
                 False,
-                "AiterScaledMMLinearKernel requires `aiter` which is not "
+                "requires `aiter` which is not "
                 + "currently supported on non-ROCm platform.",
             )
         if compute_capability is None:
@@ -28,7 +28,7 @@ class AiterScaledMMLinearKernel(CutlassScaledMMLinearKernel):
             if _cc is not None:
                 compute_capability = _cc.major * 10 + _cc.minor
         if compute_capability is not None and compute_capability < 90:
-            return False, f"requires capability 90, got {compute_capability}"
+            return False, f"requires capability >= 90, got {compute_capability}"
 
         try:
             import aiter  # noqa: F401 # deliberately attempt to import aiter

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/aiter.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/aiter.py
@@ -6,6 +6,9 @@ import torch
 
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
+from vllm.model_executor.layers.quantization.utils import (
+    is_compute_capability_supported,
+)
 from vllm.platforms import current_platform
 
 from .cutlass import CutlassScaledMMLinearKernel
@@ -23,12 +26,14 @@ class AiterScaledMMLinearKernel(CutlassScaledMMLinearKernel):
                 "requires `aiter` which is not "
                 + "currently supported on non-ROCm platform.",
             )
-        if compute_capability is None:
-            _cc = current_platform.get_device_capability()
-            if _cc is not None:
-                compute_capability = _cc.major * 10 + _cc.minor
-        if compute_capability is not None and compute_capability < 90:
-            return False, f"requires capability >= 90, got {compute_capability}"
+
+        res, err = is_compute_capability_supported(
+            min_capability=90,
+            compute_capability=compute_capability,
+        )
+
+        if not res:
+            return res, err
 
         try:
             import aiter  # noqa: F401 # deliberately attempt to import aiter

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/cpu.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/cpu.py
@@ -23,7 +23,7 @@ class CPUScaledMMLinearKernel(ScaledMMLinearKernel):
         cls, compute_capability: int | None = None
     ) -> tuple[bool, str | None]:
         if not current_platform.is_cpu():
-            return False, "Requires CPU."
+            return False, "requires CPU"
         return True, None
 
     @classmethod

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/cutlass.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/cutlass.py
@@ -20,13 +20,14 @@ class CutlassScaledMMLinearKernel(ScaledMMLinearKernel):
         cls, compute_capability: int | None = None
     ) -> tuple[bool, str | None]:
         if not current_platform.is_cuda():
-            return False, "Requires CUDA."
+            return False, "requires CUDA"
+
         if compute_capability is None:
             _cc = current_platform.get_device_capability()
             if _cc is not None:
                 compute_capability = _cc.major * 10 + _cc.minor
         if compute_capability is not None and compute_capability < 75:
-            return False, f"requires capability 75, got {compute_capability}"
+            return False, f"requires capability >= 75, got {compute_capability}"
         return True, None
 
     @classmethod

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/cutlass.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/cutlass.py
@@ -5,7 +5,10 @@
 import torch
 
 from vllm import _custom_ops as ops
-from vllm.model_executor.layers.quantization.utils import replace_parameter
+from vllm.model_executor.layers.quantization.utils import (
+    is_compute_capability_supported,
+    replace_parameter,
+)
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     convert_to_channelwise,
 )
@@ -22,13 +25,9 @@ class CutlassScaledMMLinearKernel(ScaledMMLinearKernel):
         if not current_platform.is_cuda():
             return False, "requires CUDA"
 
-        if compute_capability is None:
-            _cc = current_platform.get_device_capability()
-            if _cc is not None:
-                compute_capability = _cc.major * 10 + _cc.minor
-        if compute_capability is not None and compute_capability < 75:
-            return False, f"requires capability >= 75, got {compute_capability}"
-        return True, None
+        return is_compute_capability_supported(
+            min_capability=75, compute_capability=compute_capability
+        )
 
     @classmethod
     def can_implement(cls, c: ScaledMMLinearLayerConfig) -> tuple[bool, str | None]:

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/triton.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/triton.py
@@ -21,7 +21,7 @@ class TritonScaledMMLinearKernel(ScaledMMLinearKernel):
     ) -> tuple[bool, str | None]:
         if current_platform.is_cuda_alike():
             return True, None
-        return False, "Requires ROCm or CUDA."
+        return False, "requires ROCm or CUDA"
 
     @classmethod
     def can_implement(cls, c: ScaledMMLinearLayerConfig) -> tuple[bool, str | None]:

--- a/vllm/model_executor/layers/quantization/utils/__init__.py
+++ b/vllm/model_executor/layers/quantization/utils/__init__.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from .kernel_utils import is_compute_capability_supported
 from .layer_utils import replace_parameter, update_tensor_inplace
 
-__all__ = ["update_tensor_inplace", "replace_parameter"]
+__all__ = [
+    "update_tensor_inplace",
+    "replace_parameter",
+    "is_compute_capability_supported",
+]

--- a/vllm/model_executor/layers/quantization/utils/kernel_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/kernel_utils.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from vllm.platforms import current_platform
+
+
+def is_compute_capability_supported(
+    min_capability: int,
+    compute_capability: int | None = None,
+    max_capability: int | None = None,
+) -> tuple[bool, str | None]:
+    """Utility function to check if the current platform's compute capability
+    meets the minimum required capability.
+
+    Args:
+        min_capability (int): The minimum required compute capability.
+        compute_capability (int | None): The compute capability to check.
+            If None, it will be obtained from the current platform.
+        max_capability (int | None): The maximum allowed compute capability.
+            If None, no upper bound check is performed.
+
+    Returns:
+        tuple[bool, str | None]: A tuple where the first element indicates
+        whether the capability is supported, and the second element is an
+        optional error message if not supported.
+    """
+    if compute_capability is None:
+        _cc = current_platform.get_device_capability()
+        if _cc is not None:
+            compute_capability = _cc.major * 10 + _cc.minor
+
+    if compute_capability is not None and compute_capability < min_capability:
+        return (
+            False,
+            f"requires capability >= {min_capability}, got {compute_capability}",
+        )
+
+    if (
+        compute_capability is not None
+        and max_capability is not None
+        and compute_capability > max_capability
+    ):
+        return (
+            False,
+            f"requires capability <= {max_capability}, got {compute_capability}",
+        )
+
+    return True, None


### PR DESCRIPTION
## Purpose
Closes #31821 

- Implements `is_supported()` checks for mixed precision kernel selection

## Test Plan
- Added unit test `test_mixed_precision_kernel_selection.py`

---

> [!NOTE]
> Standardizes kernel capability checks and selection.
> 
> - Replace `get_min_capability()` with `is_supported()` on `MPLinearKernel`; implement across AllSpark, BitBLAS, Conch, CUTLASS W4A8, Marlin, Machete, Exllama, CPU/XPU, Dynamic4bit, and ScaledMM (cutlass/triton/aiter/cpu)
> - Add `is_compute_capability_supported()` helper in `quantization/utils/kernel_utils.py` and export from `utils/__init__.py`
> - Update `choose_mp_linear_kernel()` to call `is_supported()` and aggregate failure reasons; constructor now `assert self.is_supported()`
> - Add CPU-only tests `test_mixed_precision_kernel_selection.py` for abstract method presence and compute capability behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 468ec1bc08b9182618ca6708f6708284da535b5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
