### PR TITLE
[Feature][Bugfix] Support draft model tp any of speculative decode

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -586,14 +586,6 @@ class SpeculativeConfig:
                 speculative_draft_tensor_parallel_size = (
                     target_parallel_config.tensor_parallel_size
                 )
-        elif speculative_draft_tensor_parallel_size not in (
-            1,
-            target_parallel_config.tensor_parallel_size,
-        ):
-            raise ValueError(
-                f"{speculative_draft_tensor_parallel_size=} cannot be "
-                f"other value than 1 or target model tensor_parallel_size"
-            )
         return speculative_draft_tensor_parallel_size
 
     @staticmethod

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -14,7 +14,7 @@ from vllm.config import (
     VllmConfig,
     get_layers_from_vllm_config,
 )
-from vllm.distributed.parallel_state import get_pp_group
+from vllm.distributed import get_pp_group, get_tp_group
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
@@ -217,6 +217,8 @@ class EagleProposer:
         self.tree_draft_pos_offsets = torch.arange(
             1, len(self.tree_choices) + 1, device=device, dtype=torch.int32
         ).repeat(max_batch_size, 1)
+        # Store original tp group for resharding
+        self.tp_group = get_tp_group()
 
     def _get_positions(self, num_tokens: int):
         if self.uses_mrope:
@@ -1113,9 +1115,22 @@ class EagleProposer:
                 )
 
             if share_embeddings:
-                if hasattr(self.model.model, "embed_tokens"):
-                    del self.model.model.embed_tokens
-                self.model.model.embed_tokens = target_embed_tokens
+                eagle_shape = self.model.model.embed_tokens.weight.shape
+                target_shape = target_embed_tokens.weight.shape
+                if eagle_shape == target_shape:
+                    self.model.model.embed_tokens = target_embed_tokens
+                else:
+                    target_name = (
+                        "embed_tokens"
+                        if hasattr(target_language_model.model, "embed_tokens")
+                        else "embedding"
+                    )
+                    resharded_tensor = self._reshard_draft_tp_tensor(
+                        target_language_model, target_name
+                    )
+                    self.model.model.embed_tokens.weight = nn.Parameter(
+                        resharded_tensor, requires_grad=False
+                    )
         else:
             logger.info(
                 "The draft model's vocab embedding will be loaded separately"
@@ -1162,9 +1177,17 @@ class EagleProposer:
             )
 
         if share_lm_head and hasattr(target_language_model, "lm_head"):
-            if hasattr(self.model, "lm_head"):
-                del self.model.lm_head
-            self.model.lm_head = target_language_model.lm_head
+            eagle_shape = self.model.lm_head.weight.shape
+            target_shape = target_language_model.lm_head.weight.shape
+            if eagle_shape == target_shape:
+                self.model.lm_head = target_language_model.lm_head
+            else:
+                resharded_tensor = self._reshard_draft_tp_tensor(
+                    target_language_model, "lm_head"
+                )
+                self.model.lm_head.weight = nn.Parameter(
+                    resharded_tensor, requires_grad=False
+                )
 
     @torch.inference_mode()
     def dummy_run(
@@ -1306,6 +1329,48 @@ class EagleProposer:
         if num_toks_across_dp is not None:
             num_tokens_dp_padded = int(num_toks_across_dp[self.dp_rank].item())
         return num_tokens_dp_padded, num_toks_across_dp
+
+    def _reshard_draft_tp_tensor(
+        self,
+        target_model: nn.Module,
+        target_name: str,
+    ) -> torch.Tensor:
+        """
+        Support different tp size between main model and draft model.
+        """
+        from vllm.distributed import get_tensor_model_parallel_rank
+
+        tp_rank = get_tensor_model_parallel_rank()
+        sd = target_model.state_dict()
+        dst_tensor = None
+        draft_tp_size = self.speculative_config.draft_tensor_parallel_size
+        for name, param in self.model.named_parameters():
+            if target_name in name:
+                src_tensor = sd[name]
+                if draft_tp_size == self.tp_group.world_size:
+                    return src_tensor
+
+                full_tensor_shape = (
+                    draft_tp_size * param.shape[0],
+                    *param.shape[1:],
+                )
+                full_tensor = torch.empty(
+                    full_tensor_shape, dtype=src_tensor.dtype, device=src_tensor.device
+                )
+                torch.distributed.all_gather_into_tensor(
+                    full_tensor, src_tensor, group=self.tp_group.device_group
+                )
+                dst_tensor = full_tensor[
+                    tp_rank * param.shape[0] : (tp_rank + 1) * param.shape[0]
+                ]
+                logger.debug(
+                    "Draft tp reshard %s, src_tensor:%s, dst_tensor:%s",
+                    target_name,
+                    src_tensor.shape,
+                    dst_tensor.shape,
+                )
+                break
+        return dst_tensor
 
 
 # NOTE(woosuk): Currently, the below code is not used and we always use argmax

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -40,7 +40,9 @@ from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tp_group,
     graph_capture,
+    init_model_parallel_group,
     is_global_first_rank,
+    patch_tensor_parallel_group,
     prepare_communication_buffer_for_model,
 )
 from vllm.forward_context import (
@@ -454,6 +456,19 @@ class GPUModelRunner(
                     f"{self.speculative_config.method}"
                 )
             self.rejection_sampler = RejectionSampler(self.sampler)
+            # Initialize model parallel group for draft tensor parallelism.
+            world_size = torch.distributed.get_world_size()
+            draft_tp_size = (
+                self.speculative_config.draft_tensor_parallel_size
+                if self.speculative_config.draft_tensor_parallel_size is not None
+                else self.vllm_config.parallel_config.tensor_parallel_size
+            )
+            group_ranks = torch.arange(world_size).reshape(-1, draft_tp_size).tolist()
+            local_rank = get_tp_group().local_rank
+            tp_backend = torch.distributed.get_backend(get_tp_group().device_group)
+            self.draft_tp_group = init_model_parallel_group(
+                group_ranks, local_rank, tp_backend
+            )
 
         self.num_spec_tokens = 0
         if self.speculative_config:
@@ -3770,17 +3785,18 @@ class GPUModelRunner(
             else:
                 mm_embed_inputs = None
 
-            draft_token_ids = self.drafter.propose(
-                target_token_ids=target_token_ids,
-                target_positions=target_positions,
-                target_hidden_states=target_hidden_states,
-                next_token_ids=next_token_ids,
-                last_token_indices=token_indices_to_sample,
-                sampling_metadata=sampling_metadata,
-                common_attn_metadata=common_attn_metadata,
-                mm_embed_inputs=mm_embed_inputs,
-                num_rejected_tokens_gpu=num_rejected_tokens_gpu,
-            )
+            with patch_tensor_parallel_group(self.draft_tp_group):
+                draft_token_ids = self.drafter.propose(
+                    target_token_ids=target_token_ids,
+                    target_positions=target_positions,
+                    target_hidden_states=target_hidden_states,
+                    next_token_ids=next_token_ids,
+                    last_token_indices=token_indices_to_sample,
+                    sampling_metadata=sampling_metadata,
+                    common_attn_metadata=common_attn_metadata,
+                    mm_embed_inputs=mm_embed_inputs,
+                    num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+                )
 
         return draft_token_ids
 
@@ -3828,7 +3844,8 @@ class GPUModelRunner(
                     )
                 if hasattr(self, "drafter"):
                     logger.info_once("Loading drafter model...")
-                    self.drafter.load_model(self.model)
+                    with patch_tensor_parallel_group(self.draft_tp_group):
+                        self.drafter.load_model(self.model)
                     if (
                         hasattr(self.drafter, "model")
                         and is_mixture_of_experts(self.drafter.model)
@@ -4490,11 +4507,12 @@ class GPUModelRunner(
                 if self.compilation_config.cudagraph_specialize_lora and activate_lora:
                     use_cudagraphs = False
 
-                self.drafter.dummy_run(
-                    num_tokens,
-                    use_cudagraphs=use_cudagraphs,
-                    is_graph_capturing=is_graph_capturing,
-                )
+                with patch_tensor_parallel_group(self.draft_tp_group):
+                    self.drafter.dummy_run(
+                        num_tokens,
+                        use_cudagraphs=use_cudagraphs,
+                        is_graph_capturing=is_graph_capturing,
+                    )
 
         # We register layerwise NVTX hooks here after the first dynamo tracing is
         # done to avoid nvtx operations in hook functions being traced by


### PR DESCRIPTION
## Purpose
We met a problem that adding `'draft_tensor_parallel_size': 1` or `'draft_tensor_parallel_size': 2` in server script, the draft model tensor parallel size is still same as the main model.
```
Qwen3ForCausalLM(
  (model): Qwen3Model(
    (embed_tokens): VocabParallelEmbedding(num_embeddings=18992, embedding_dim=5120, org_vocab_size=151936, num_embeddings_padded=151936, tp_size=8)
    (layers): ModuleList(
      (0-63): 64 x Qwen3DecoderLayer(
        (self_attn): Qwen3Attention(
          (qkv_proj): QKVParallelLinear(in_features=5120, output_features=1280, bias=False, tp_size=8, gather_output=False)
          (o_proj): RowParallelLinear(in_features=1024, output_features=5120, bias=False, tp_size=8, reduce_results=True)
          (rotary_emb): YaRNScalingRotaryEmbedding(head_size=128, rotary_dim=128, max_position_embeddings=40960, base=1000000, is_neox_style=True)
          (attn): Attention(head_size=128, num_heads=8, num_kv_heads=1, scale=0.08838834764831845, backend=FlashAttentionImpl)
          (q_norm): RMSNorm(hidden_size=128, eps=1e-06)
          (k_norm): RMSNorm(hidden_size=128, eps=1e-06)
        )
        (mlp): Qwen2MLP(
          (gate_up_proj): MergedColumnParallelLinear(in_features=5120, output_features=6400, bias=False, tp_size=8, gather_output=False)
          (down_proj): RowParallelLinear(in_features=3200, output_features=5120, bias=False, tp_size=8, reduce_results=True)
          (act_fn): SiluAndMul()
        )
        (input_layernorm): RMSNorm(hidden_size=5120, eps=1e-06)
        (post_attention_layernorm): RMSNorm(hidden_size=5120, eps=1e-06)
      )
    )
    (norm): RMSNorm(hidden_size=5120, eps=1e-06)
  )
  (lm_head): ParallelLMHead(num_embeddings=18992, embedding_dim=5120, org_vocab_size=151936, num_embeddings_padded=151936, tp_size=8)
  (logits_processor): LogitsProcessor(vocab_size=151936, org_vocab_size=151936, scale=1.0, logits_as_input=False)
)

EagleQwen3ForCausalLM(
  (model): Qwen3Model(
    (embed_tokens): VocabParallelEmbedding(num_embeddings=18992, embedding_dim=5120, org_vocab_size=151936, num_embeddings_padded=151936, tp_size=8)
    (layers): ModuleList(
      (0): Qwen3EalgeDecoderLayer(
        (self_attn): Qwen3Attention(
          (qkv_proj): QKVParallelLinear(in_features=5120, output_features=1280, bias=False, tp_size=8, gather_output=False)
          (o_proj): RowParallelLinear(in_features=1024, output_features=5120, bias=False, tp_size=8, reduce_results=True)
          (rotary_emb): YaRNScalingRotaryEmbedding(head_size=128, rotary_dim=128, max_position_embeddings=40960, base=1000000, is_neox_style=True)
          (attn): Attention(head_size=128, num_heads=8, num_kv_heads=1, scale=0.08838834764831845, backend=FlashAttentionImpl)
          (q_norm): RMSNorm(hidden_size=128, eps=1e-06)
          (k_norm): RMSNorm(hidden_size=128, eps=1e-06)
        )
        (mlp): Qwen3MLP(
          (gate_up_proj): MergedColumnParallelLinear(in_features=5120, output_features=6400, bias=False, tp_size=8, gather_output=False)
          (down_proj): RowParallelLinear(in_features=3200, output_features=5120, bias=False, tp_size=8, reduce_results=True)
          (act_fn): SiluAndMul()
        )
        (post_attention_layernorm): RMSNorm(hidden_size=5120, eps=1e-06)
        (input_layernorm): Identity()
      )
    )
    (fc): Linear(in_features=10240, out_features=5120, bias=False)
  )
  (lm_head): ParallelLMHead(num_embeddings=18992, embedding_dim=5120, org_vocab_size=151936, num_embeddings_padded=151936, tp_size=8)
  (logits_processor): LogitsProcessor(vocab_size=151936, org_vocab_size=151936, scale=1.0, logits_as_input=False)
)
```
Quick start script:
```
nohup python -m vllm.entrypoints.openai.api_server \
    --trust-remote-code \
    --model=$model_path \
    --served-model-name auto \
    --host $host \
    --port $port \
    --tensor-parallel-size $tp \
    --data-parallel-size 1 \
    --no-enforce-eager \
    --max-num-seqs 256  \
    --max-num-batched-tokens 32768 \
    --gpu-memory-utilization 0.90 \
    --speculative_config '{"model": "modelpath", "num_speculative_tokens": 5, "method": "eagle3", "draft_tensor_parallel_size": 2}' \
    --compilation-config '{"cudagraph_capture_sizes": [6,12,24],"cudagraph_mode": "FULL_DECODE_ONLY"}' \
    > run.log &
```
The reason is that draft model shares same communication group with main model. We reuse function `patch_tensor_parallel_group` to deal with the problem.
Possibly related to issue #31345

## Test Plan
Test in server mode, print acceptance length to evaluate draft model accuracy with different tp size.

## Test Result
test in deepseek-v3 with self-data
```
(APIServer pid=79877) INFO 01-13 15:48:00 [metrics.py:100] SpecDecoding metrics: Mean acceptance length: 3.20, Accepted throughput: 31.70 tokens/s, Drafted throughput: 71.99 tokens/s, Accepted: 317 tokens, Drafted: 720 tokens, Per-position acceptance rate: 0.729, 0.549, 0.382, 0.312, 0.229, Avg Draft acceptance rate: 44.0%
```
test in qwen3-235b with self-data
```
(APIServer pid=85341) INFO 01-13 16:29:06 [metrics.py:100] SpecDecoding metrics: Mean acceptance length: 4.12, Accepted throughput: 23.40 tokens/s, Drafted throughput: 52.49 tokens/s, Accepted: 234 tokens, Drafted: 525 tokens, Per-position acceptance rate: 0.787, 0.653, 0.480, 0.387, 0.293, 0.293, 0.227, Avg Draft acceptance rate: 44.6%
```
---

> [!NOTE]
> Adds end-to-end support for draft models using a different tensor-parallel (TP) size than the target model.
> 
> - Relax `SpeculativeConfig._verify_and_get_draft_tp` validation so `draft_tensor_parallel_size` is no longer restricted to `{1, target TP}`
> - In `GPUModelRunner`, initialize a dedicated draft TP process group and run drafter ops under `patch_tensor_parallel_group(...)` (for load, propose, dummy_run)
> - In `EagleProposer`:
>   - Store original `tp_group` and implement `_reshard_draft_tp_tensor(...)` that `all_gather`s shards and slices to match the draft TP partition
>   - When sharing `embed_tokens`/`lm_head`, if shapes differ, reshard target weights to the draft TP shard; otherwise reuse modules directly
>   - Minor import consolidation (`get_pp_group`, `get_tp_group`) and small logging adjustments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 948067ad6de220509d0d1c365ba6a9835b282b22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
