### PR TITLE
[BugFix][Model]: Pass indexer_rotary_emb to MLA modules

### DIFF
--- a/vllm/model_executor/models/kimi_linear.py
+++ b/vllm/model_executor/models/kimi_linear.py
@@ -255,6 +255,7 @@ class KimiMLAAttention(nn.Module):
             q_b_proj=None,
             q_proj=self.q_proj,
             indexer=None,
+            indexer_rotary_emb=None,
             is_sparse=False,
             topk_indices_buffer=None,
         )

--- a/vllm/model_executor/models/openpangu.py
+++ b/vllm/model_executor/models/openpangu.py
@@ -384,6 +384,7 @@ class OpenPanguMLAAttention(nn.Module):
             q_b_proj=self.q_b_proj if self.q_lora_rank is not None else None,
             q_proj=self.q_proj if self.q_lora_rank is None else None,
             indexer=None,
+            indexer_rotary_emb=None,
             is_sparse=False,
             topk_indices_buffer=None,
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
to fix issues: https://github.com/vllm-project/vllm/issues/31889

- pass `indexer_rotary_emb` into `MLAModules` for KimiMLAAttention to match the updated constructor
- do the same for OpenPangu MLA to prevent the same init-time crash
- keep MLA init aligned across models that don’t use sparse indexing

## Test Plan
``` python
vllm serve moonshotai/Kimi-Linear-48B-A3B-Instruct --trust-remote-code --host 0.0.0.0 --port 8999  --tensor-parallel-size 4 --max-model-len 1048576 --no-enable-prefix-caching
```

## Test Result
server launch success

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

