### PR TITLE
[Misc] Add `--use-flashinfer-rope` to control the RoPE kernel for cuda

### DIFF
--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -17,6 +17,9 @@ class KernelConfig:
     enable_flashinfer_autotune: bool = Field(default=None)
     """If True, run FlashInfer autotuning during kernel warmup."""
 
+    use_flashinfer_rope: bool = Field(default=False)
+    """If True, use FlashInfer's rotary embedding kernel."""
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -785,6 +785,14 @@ class VllmConfig:
                 "KernelConfig.enable_flashinfer_autotune must be set after applying "
                 "optimization level defaults."
             )
+        if (
+            self.kernel_config.use_flashinfer_rope
+            and not self.compilation_config.is_custom_op_enabled("rotary_embedding")
+        ):
+            logger.warning(
+                "rotary_embedding custom op is not enabled, "
+                "use_flashinfer_rope will have no effect."
+            )
 
         if (
             self.compilation_config.cudagraph_mode.requires_piecewise_compilation()

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -540,6 +540,7 @@ class EngineArgs:
     enable_flashinfer_autotune: bool = get_field(
         KernelConfig, "enable_flashinfer_autotune"
     )
+    use_flashinfer_rope: bool = get_field(KernelConfig, "use_flashinfer_rope")
     worker_cls: str = ParallelConfig.worker_cls
     worker_extension_cls: str = ParallelConfig.worker_extension_cls
 
@@ -1181,6 +1182,10 @@ class EngineArgs:
             "--enable-flashinfer-autotune",
             **kernel_kwargs["enable_flashinfer_autotune"],
         )
+        kernel_group.add_argument(
+            "--use-flashinfer-rope",
+            **kernel_kwargs["use_flashinfer_rope"],
+        )
 
         # vLLM arguments
         vllm_kwargs = get_kwargs(VllmConfig)
@@ -1757,6 +1762,8 @@ class EngineArgs:
                     "are mutually exclusive"
                 )
             kernel_config.enable_flashinfer_autotune = self.enable_flashinfer_autotune
+        if self.use_flashinfer_rope is not None:
+            kernel_config.use_flashinfer_rope = self.use_flashinfer_rope
 
         load_config = self.create_load_config()
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -232,7 +232,6 @@ if TYPE_CHECKING:
     VLLM_DEBUG_MFU_METRICS: bool = False
     VLLM_DISABLE_LOG_LOGO: bool = False
     VLLM_LORA_DISABLE_PDL: bool = False
-    VLLM_USE_FLASHINFER_ROPE: bool = False
 
 
 def get_default_cache_root():
@@ -1548,10 +1547,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Disable PDL for LoRA, as enabling PDL with LoRA on SM100 causes
     # Triton compilation to fail.
     "VLLM_LORA_DISABLE_PDL": lambda: bool(int(os.getenv("VLLM_LORA_DISABLE_PDL", "0"))),
-    # If set to 1, use the FlashInfer's rotary embedding kernel
-    "VLLM_USE_FLASHINFER_ROPE": lambda: bool(
-        int(os.getenv("VLLM_USE_FLASHINFER_ROPE", "0"))
-    ),
 }
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -232,6 +232,7 @@ if TYPE_CHECKING:
     VLLM_DEBUG_MFU_METRICS: bool = False
     VLLM_DISABLE_LOG_LOGO: bool = False
     VLLM_LORA_DISABLE_PDL: bool = False
+    VLLM_USE_FLASHINFER_ROPE: bool = False
 
 
 def get_default_cache_root():
@@ -1547,6 +1548,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Disable PDL for LoRA, as enabling PDL with LoRA on SM100 causes
     # Triton compilation to fail.
     "VLLM_LORA_DISABLE_PDL": lambda: bool(int(os.getenv("VLLM_LORA_DISABLE_PDL", "0"))),
+    # If set to 1, use the FlashInfer's rotary embedding kernel
+    "VLLM_USE_FLASHINFER_ROPE": lambda: bool(
+        int(os.getenv("VLLM_USE_FLASHINFER_ROPE", "0"))
+    ),
 }
 
 

--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -73,7 +73,6 @@ class OAIAttention(nn.Module):
         self.rotary_emb = get_rope(
             self.head_dim,
             max_position=config.max_position_embeddings,
-            dtype=torch.float32,
             rope_parameters={
                 "rope_theta": config.rope_parameters["rope_theta"],
                 "rope_type": "yarn",


### PR DESCRIPTION

## Purpose

Related PRs:
#21126 integrated the Flashinfer RoPE kernel.
#25299 disabled it by default due to CI failures.
#30729 enabled it by default for Deepseek RoPE.

This PR adds `--use-flashinfer-rope` env so that we can easily enable Flashinfer RoPE kernel.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

