### PR TITLE
UX: add vLLM env info in '/server_info'

### DIFF
--- a/vllm/entrypoints/serve/instrumentator/server_info.py
+++ b/vllm/entrypoints/serve/instrumentator/server_info.py
@@ -39,9 +39,11 @@ async def show_server_info(
 ):
     vllm_config: VllmConfig = raw_request.app.state.vllm_config
     server_info = {
-        "vllm_config": str(vllm_config)
-        if config_format == "text"
-        else PydanticVllmConfig.dump_python(vllm_config, mode="json", fallback=str),
+        "vllm_config": (
+            str(vllm_config)
+            if config_format == "text"
+            else PydanticVllmConfig.dump_python(vllm_config, mode="json", fallback=str)
+        ),
         # fallback=str is needed to handle e.g. torch.dtype
         "vllm_env": _get_vllm_env_vars(),
     }

--- a/vllm/entrypoints/serve/instrumentator/server_info.py
+++ b/vllm/entrypoints/serve/instrumentator/server_info.py
@@ -19,6 +19,19 @@ router = APIRouter()
 PydanticVllmConfig = pydantic.TypeAdapter(VllmConfig)
 
 
+def _get_vllm_env_vars():
+    from vllm.config.utils import normalize_value
+
+    vllm_envs = {}
+    for key in dir(envs):
+        if key.startswith("VLLM_"):
+            value = getattr(envs, key, None)
+            if value is not None:
+                value = normalize_value(value)
+                vllm_envs[key] = value
+    return vllm_envs
+
+
 @router.get("/server_info")
 async def show_server_info(
     raw_request: Request,
@@ -28,8 +41,9 @@ async def show_server_info(
     server_info = {
         "vllm_config": str(vllm_config)
         if config_format == "text"
-        else PydanticVllmConfig.dump_python(vllm_config, mode="json", fallback=str)
+        else PydanticVllmConfig.dump_python(vllm_config, mode="json", fallback=str),
         # fallback=str is needed to handle e.g. torch.dtype
+        "vllm_env": _get_vllm_env_vars(),
     }
     return JSONResponse(content=server_info)
 

--- a/vllm/entrypoints/serve/instrumentator/server_info.py
+++ b/vllm/entrypoints/serve/instrumentator/server_info.py
@@ -24,7 +24,7 @@ def _get_vllm_env_vars():
 
     vllm_envs = {}
     for key in dir(envs):
-        if key.startswith("VLLM_"):
+        if key.startswith("VLLM_") and "KEY" not in key:
             value = getattr(envs, key, None)
             if value is not None:
                 value = normalize_value(value)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

```bash
VLLM_SERVER_DEV_MODE=1 vllm serve Qwen/Qwen3-0.6B \
     --served-model-name base-model 
```
```python
import requests

respones = requests.get("http://0.0.0.0:8000/server_info")
print(respones.json())
```

<details>
<summary>Expected Result</summary>

```{
  "vllm_config": "model='Qwen/Qwen3-0.6B', speculative_config=None, tokenizer='Qwen/Qwen3-0.6B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=40960, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False), seed=0, served_model_name=base-model, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False}, 'local_cache_dir': None}",
  "vllm_env": {
    "VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE": true,
    "VLLM_ALLOW_INSECURE_SERIALIZATION": false,
    "VLLM_ALLOW_LONG_MAX_MODEL_LEN": false,
    "VLLM_ALLOW_RUNTIME_LORA_UPDATING": false,
    "VLLM_ALLREDUCE_USE_SYMM_MEM": true,
    "VLLM_ASSETS_CACHE": "/root/.cache/vllm/assets",
    "VLLM_ASSETS_CACHE_MODEL_CLEAN": false,
    "VLLM_AUDIO_FETCH_TIMEOUT": 10,
    "VLLM_CACHE_ROOT": "/root/.cache/vllm",
    "VLLM_CI_USE_S3": false,
    "VLLM_COMPILE_CACHE_SAVE_FORMAT": "binary",
    "VLLM_COMPUTE_NANS_IN_LOGITS": false,
    "VLLM_CONFIGURE_LOGGING": true,
    "VLLM_CONFIG_ROOT": "/root/.config/vllm",
    "VLLM_CPU_OMP_THREADS_BIND": "auto",
    "VLLM_CPU_SGL_KERNEL": false,
    "VLLM_CUSTOM_SCOPES_FOR_PROFILING": false,
    "VLLM_DBO_COMM_SMS": 20,
    "VLLM_DEBUG_LOG_API_SERVER_RESPONSE": false,
    "VLLM_DEBUG_MFU_METRICS": false,
    "VLLM_DEBUG_WORKSPACE": false,
    "VLLM_DEEPEPLL_NVFP4_DISPATCH": false,
    "VLLM_DEEPEP_BUFFER_SIZE_MB": 1024,
    "VLLM_DEEPEP_HIGH_THROUGHPUT_FORCE_INTRA_NODE": false,
    "VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL": false,
    "VLLM_DEEP_GEMM_WARMUP": "relax",
    "VLLM_DISABLED_KERNELS": [],
    "VLLM_DISABLE_COMPILE_CACHE": false,
    "VLLM_DISABLE_FLASHINFER_PREFILL": false,
    "VLLM_DISABLE_PYNCCL": false,
    "VLLM_DISABLE_SHARED_EXPERTS_STREAM": false,
    "VLLM_DOCKER_BUILD_CONTEXT": false,
    "VLLM_DO_NOT_TRACK": false,
    "VLLM_DP_MASTER_IP": "127.0.0.1",
    "VLLM_DP_MASTER_PORT": 0,
    "VLLM_DP_RANK": 0,
    "VLLM_DP_RANK_LOCAL": 0,
    "VLLM_DP_SIZE": 1,
    "VLLM_ENABLE_CUDAGRAPH_GC": false,
    "VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING": true,
    "VLLM_ENABLE_INDUCTOR_COORDINATE_DESCENT_TUNING": true,
    "VLLM_ENABLE_INDUCTOR_MAX_AUTOTUNE": true,
    "VLLM_ENABLE_MOE_DP_CHUNK": true,
    "VLLM_ENABLE_RESPONSES_API_STORE": false,
    "VLLM_ENABLE_V1_MULTIPROCESSING": true,
    "VLLM_ENGINE_ITERATION_TIMEOUT_S": 60,
    "VLLM_ENGINE_READY_TIMEOUT_S": 600,
    "VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS": 300,
    "VLLM_FLASHINFER_ALLREDUCE_FUSION_THRESHOLDS_MB": [],
    "VLLM_FLASHINFER_DISABLE_Q_QUANTIZATION": false,
    "VLLM_FLASHINFER_MOE_BACKEND": "latency",
    "VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE": 413138944,
    "VLLM_FLASH_ATTN_MAX_NUM_SPLITS_FOR_CUDA_GRAPH": 32,
    "VLLM_FLOAT32_MATMUL_PRECISION": "highest",
    "VLLM_FORCE_AOT_LOAD": false,
    "VLLM_FUSED_MOE_CHUNK_SIZE": 16384,
    "VLLM_GC_DEBUG": "",
    "VLLM_GPT_OSS_HARMONY_SYSTEM_INSTRUCTIONS": false,
    "VLLM_GPT_OSS_SYSTEM_TOOL_MCP_LABELS": [],
    "VLLM_HAS_FLASHINFER_CUBIN": false,
    "VLLM_HOST_IP": "",
    "VLLM_HTTP_TIMEOUT_KEEP_ALIVE": 5,
    "VLLM_IMAGE_FETCH_TIMEOUT": 5,
    "VLLM_KEEP_ALIVE_ON_ENGINE_DEATH": false,
    "VLLM_KV_EVENTS_USE_INT_BLOCK_HASHES": true,
    "VLLM_LOGGING_COLOR": "auto",
    "VLLM_LOGGING_LEVEL": "INFO",
    "VLLM_LOGGING_PREFIX": "",
    "VLLM_LOGGING_STREAM": "ext://sys.stdout",
    "VLLM_LOG_BATCHSIZE_INTERVAL": -1.0,
    "VLLM_LOG_STATS_INTERVAL": 10.0,
    "VLLM_LOOPBACK_IP": "",
    "VLLM_MAIN_CUDA_VERSION": "12.9",
    "VLLM_MARLIN_USE_ATOMIC_ADD": false,
    "VLLM_MAX_AUDIO_CLIP_FILESIZE_MB": 25,
    "VLLM_MAX_TOKENS_PER_EXPERT_FP4_MOE": 163840,
    "VLLM_MEDIA_CONNECTOR": "http",
    "VLLM_MEDIA_LOADING_THREAD_COUNT": 8,
    "VLLM_MEDIA_URL_ALLOW_REDIRECTS": true,
    "VLLM_MLA_DISABLE": false,
    "VLLM_MOE_DP_CHUNK_SIZE": 256,
    "VLLM_MOE_ROUTING_SIMULATION_STRATEGY": "",
    "VLLM_MOE_USE_DEEP_GEMM": true,
    "VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT": 480,
    "VLLM_MOONCAKE_BOOTSTRAP_PORT": 8998,
    "VLLM_MQ_MAX_CHUNK_BYTES_MB": 16,
    "VLLM_MSGPACK_ZERO_COPY_THRESHOLD": 256,
    "VLLM_NIXL_ABORT_REQUEST_TIMEOUT": 480,
    "VLLM_NIXL_SIDE_CHANNEL_HOST": "localhost",
    "VLLM_NIXL_SIDE_CHANNEL_PORT": 5600,
    "VLLM_NO_USAGE_STATS": false,
    "VLLM_NVTX_SCOPES_FOR_PROFILING": false,
    "VLLM_OBJECT_STORAGE_SHM_BUFFER_NAME": "VLLM_OBJECT_STORAGE_SHM_BUFFER",
    "VLLM_PROCESS_NAME_PREFIX": "VLLM",
    "VLLM_RANDOMIZE_DP_DUMMY_INPUTS": false,
    "VLLM_RAY_BUNDLE_INDICES": "",
    "VLLM_RAY_DP_PACK_STRATEGY": "strict",
    "VLLM_RAY_PER_WORKER_GPUS": 1.0,
    "VLLM_RINGBUFFER_WARNING_INTERVAL": 60,
    "VLLM_ROCM_CUSTOM_PAGED_ATTN": true,
    "VLLM_ROCM_FP8_MFMA_PAGE_ATTN": false,
    "VLLM_ROCM_FP8_PADDING": true,
    "VLLM_ROCM_MOE_PADDING": true,
    "VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16": true,
    "VLLM_ROCM_QUICK_REDUCE_QUANTIZATION": "NONE",
    "VLLM_ROCM_SLEEP_MEM_CHUNK_SIZE": 256,
    "VLLM_ROCM_USE_AITER": false,
    "VLLM_ROCM_USE_AITER_FP4_ASM_GEMM": false,
    "VLLM_ROCM_USE_AITER_FP8BMM": true,
    "VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS": false,
    "VLLM_ROCM_USE_AITER_LINEAR": true,
    "VLLM_ROCM_USE_AITER_MHA": true,
    "VLLM_ROCM_USE_AITER_MLA": true,
    "VLLM_ROCM_USE_AITER_MOE": true,
    "VLLM_ROCM_USE_AITER_PAGED_ATTN": false,
    "VLLM_ROCM_USE_AITER_RMSNORM": true,
    "VLLM_ROCM_USE_AITER_TRITON_GEMM": true,
    "VLLM_ROCM_USE_AITER_TRITON_ROPE": false,
    "VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION": false,
    "VLLM_ROCM_USE_SKINNY_GEMM": true,
    "VLLM_RPC_BASE_PATH": "/tmp",
    "VLLM_RPC_TIMEOUT": 10000,
    "VLLM_SERVER_DEV_MODE": true,
    "VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD": 256,
    "VLLM_SKIP_P2P_CHECK": true,
    "VLLM_SKIP_PRECOMPILED_VERSION_SUFFIX": false,
    "VLLM_SLEEP_WHEN_IDLE": false,
    "VLLM_TARGET_DEVICE": "cuda",
    "VLLM_TEST_FORCE_FP8_MARLIN": false,
    "VLLM_TEST_FORCE_LOAD_FORMAT": "dummy",
    "VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY": false,
    "VLLM_TOOL_PARSE_REGEX_TIMEOUT_SECONDS": 1,
    "VLLM_TPU_BUCKET_PADDING_GAP": 0,
    "VLLM_TPU_USING_PATHWAYS": false,
    "VLLM_TRACE_FUNCTION": 0,
    "VLLM_USAGE_SOURCE": "production",
    "VLLM_USAGE_STATS_SERVER": "https://stats.vllm.ai",
    "VLLM_USE_AOT_COMPILE": false,
    "VLLM_USE_BYTECODE_HOOK": true,
    "VLLM_USE_CUDNN_PREFILL": false,
    "VLLM_USE_DEEP_GEMM": true,
    "VLLM_USE_DEEP_GEMM_E8M0": true,
    "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT": false,
    "VLLM_USE_FBGEMM": false,
    "VLLM_USE_FLASHINFER_MOE_FP16": false,
    "VLLM_USE_FLASHINFER_MOE_FP4": false,
    "VLLM_USE_FLASHINFER_MOE_FP8": false,
    "VLLM_USE_FLASHINFER_MOE_MXFP4_BF16": false,
    "VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8": false,
    "VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS": false,
    "VLLM_USE_FUSED_MOE_GROUPED_TOPK": true,
    "VLLM_USE_MODELSCOPE": false,
    "VLLM_USE_NCCL_SYMM_MEM": false,
    "VLLM_USE_NVFP4_CT_EMULATIONS": false,
    "VLLM_USE_PRECOMPILED": false,
    "VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE": "auto",
    "VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM": false,
    "VLLM_USE_RAY_WRAPPED_PP_COMM": true,
    "VLLM_USE_STANDALONE_COMPILE": true,
    "VLLM_USE_TRITON_AWQ": false,
    "VLLM_USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL": false,
    "VLLM_USE_V2_MODEL_RUNNER": false,
    "VLLM_V1_OUTPUT_PROC_CHUNK_SIZE": 128,
    "VLLM_V1_USE_OUTLINES_CACHE": false,
    "VLLM_V1_USE_PREFILL_DECODE_ATTENTION": false,
    "VLLM_VIDEO_FETCH_TIMEOUT": 30,
    "VLLM_VIDEO_LOADER_BACKEND": "opencv",
    "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
    "VLLM_XGRAMMAR_CACHE_MB": 512,
    "VLLM_XLA_CACHE_PATH": "/root/.cache/vllm/xla_cache",
    "VLLM_XLA_CHECK_RECOMPILATION": false,
    "VLLM_XLA_USE_SPMD": false
  }
}

```
</details>



## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

