### PR TITLE
[ROCm]Skip test_torchao.py::test_pre_quantized_model on CDNA3 arch

### DIFF
--- a/tests/quantization/test_torchao.py
+++ b/tests/quantization/test_torchao.py
@@ -6,11 +6,17 @@ import importlib.util
 import pytest
 import torch
 
+from vllm.platforms import current_platform
+
 DTYPE = ["bfloat16"]
 
 TORCHAO_AVAILABLE = importlib.util.find_spec("torchao") is not None
 
 
+@pytest.mark.skipif(
+    current_platform.is_rocm() and current_platform.is_fp8_fnuz(),
+    reason="Only fp8_fnuz supported on CDNA3 architecture",
+)
 @pytest.mark.skipif(not TORCHAO_AVAILABLE, reason="torchao is not available")
 def test_pre_quantized_model(vllm_runner):
     with vllm_runner(


### PR DESCRIPTION

## Purpose

Skip UT  `test_torchao.py::test_pre_quantized_model` on CDNA3 arch. On CDNA3 arch, only fp8_e4m3_fnuz is supported, but the tested checkpoints use fp8_e4m3.

## Test Plan

```
pytest -sv tests/quantization/test_torchao.py::test_pre_quantized_model
```

## Test Result

The UT should sikpped on CDNA3 arch, like MI325, MI300X. Example output

```bash
collected 12 items                                                                                                                                 

tests/quantization/test_torchao.py::test_pre_quantized_model SKIPPED (Only fp8_fnuz supported on CDNA3 architecture)
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

