### PR TITLE
Add back missing DeepEP LL params

### DIFF
--- a/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
@@ -295,6 +295,8 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
             self.max_tokens_per_rank,
             num_experts,
             use_fp8=self.use_fp8_dispatch,
+            round_scale=self.use_ue8m0_dispatch,
+            use_ue8m0=self.use_ue8m0_dispatch,
             **(dict(use_nvfp4=True) if use_nvfp4 else dict()),
             **(
                 dict(x_global_scale=qc_a1_gscale_or_scale)


### PR DESCRIPTION

Addresses  #31844 introduced by a regression in f72a817.

Before:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7809|±  |0.0114|
|     |       |strict-match    |     5|exact_match|↑  |0.7801|±  |0.0114|
```

After:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8620|±  |0.0095|
|     |       |strict-match    |     5|exact_match|↑  |0.8855|±  |0.0088|
```

which matches the HT case now

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8757|±  |0.0091|
|     |       |strict-match    |     5|exact_match|↑  |0.8999|±  |0.0083|
```

## Purpose

## Test Plan

```
MODEL_BLOCK := "Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8"
GPUS := "2"
PORT := "8001"
PORT0 := "8001"
PORT1 := "8002"

launch_dp_ep_deepep_ll_no_em80:
  CUDA_VISIBLE_DEVICES=0,1 VLLM_USE_DEEP_GEMM_E8M0=0 VLLM_USE_DEEP_GEMM=1 VLLM_USE_DEEP_GEMM_MOE=1 \
  vllm serve {{MODEL_BLOCK}} -dp {{GPUS}} --port {{PORT}} --enforce-eager --all2all-backend --enable-expert-parallel

launch_dp_ep_deepep_ll:
  CUDA_VISIBLE_DEVICES=0,1 VLLM_USE_DEEP_GEMM=1 VLLM_USE_DEEP_GEMM_MOE=1 \
  vllm serve {{MODEL_BLOCK}} -dp {{GPUS}} --port {{PORT0}} --enforce-eager --all2all-backend deepep_low_latency --enable-expert-parallel

launch_dp_ep_deepep_ht:
  CUDA_VISIBLE_DEVICES=2,3 VLLM_USE_DEEP_GEMM=1 VLLM_USE_DEEP_GEMM_MOE=1 \
  vllm serve {{MODEL_BLOCK}} -dp {{GPUS}} --port {{PORT1}} --enforce-eager --all2all-backend deepep_high_throughput --enable-expert-parallel

eval_block port:
  lm_eval \
    --model local-completions \
    --tasks gsm8k \
    --batch_size 1 \
    --num_fewshot 5 \
    --model_args "model={{MODEL_BLOCK}},base_url=http://localhost/:{{port}}/v1/completions,num_concurrent=512,tokenized_requests=False"
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

