### PR TITLE
[BugFix] Fix flakiness in test_eagle_dp for PyTorch 2.10

### DIFF
--- a/tests/v1/distributed/test_eagle_dp.py
+++ b/tests/v1/distributed/test_eagle_dp.py
@@ -47,7 +47,9 @@ async def test_run_eagle_dp(monkeypatch: pytest.MonkeyPatch):
     )
 
     prompt = "This is a test of data parallel with eagle"
-    num_expected_tokens = 100
+    # This test might be flaky, see
+    # https://github.com/vllm-project/vllm/issues/31913
+    num_expected_tokens = 20
     sampling_params = SamplingParams(
         min_tokens=num_expected_tokens,
         max_tokens=num_expected_tokens,


### PR DESCRIPTION
## Purpose

Fix flakiness in this test for PyTorch 2.10. The test can fail in PyTorch 2.9 too, see https://github.com/vllm-project/vllm/issues/31913 for explanation.

## Test Plan

Ran `TP_SIZE=2 DP_SIZE=2 pytest tests/v1/distributed/test_eagle_dp.py::test_run_eagle_dp` on 2x L4 and verified it passed.

## Test Result

Pass
