### PR TITLE
[Bugfix] Fix OpenAPI schema test failures

### DIFF
--- a/tests/entrypoints/openai/test_openai_schema.py
+++ b/tests/entrypoints/openai/test_openai_schema.py
@@ -90,7 +90,10 @@ def before_generate_case(context: schemathesis.hooks.HookContext, strategy):
                         if (
                             isinstance(content, list)
                             and len(content) > 0
-                            and any(item.get("type") == "file" for item in content)
+                            and any(
+                                isinstance(item, dict) and item.get("type") == "file"
+                                for item in content
+                            )
                         ):
                             return False
 
@@ -139,6 +142,7 @@ def test_openapi_stateless(case: schemathesis.Case):
     timeout = {
         # requires a longer timeout
         ("POST", "/v1/chat/completions"): LONG_TIMEOUT_SECONDS,
+        ("POST", "/v1/completions"): LONG_TIMEOUT_SECONDS,
     }.get(key, DEFAULT_TIMEOUT_SECONDS)
 
     # No need to verify SSL certificate for localhost

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1060,7 +1060,9 @@ class CompletionRequest(OpenAIBaseModel):
     min_tokens: int = 0
     skip_special_tokens: bool = True
     spaces_between_special_tokens: bool = True
-    truncate_prompt_tokens: Annotated[int, Field(ge=-1)] | None = None
+    truncate_prompt_tokens: Annotated[int, Field(ge=-1, le=_LONG_INFO.max)] | None = (
+        None
+    )
     allowed_token_ids: list[int] | None = None
     prompt_logprobs: int | None = None
     # --8<-- [end:completion-sampling-params]

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -577,7 +577,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
     min_tokens: int = 0
     skip_special_tokens: bool = True
     spaces_between_special_tokens: bool = True
-    truncate_prompt_tokens: Annotated[int, Field(ge=-1)] | None = None
+    truncate_prompt_tokens: Annotated[int, Field(ge=-1, le=_LONG_INFO.max)] | None = (
+        None
+    )
     prompt_logprobs: int | None = None
     allowed_token_ids: list[int] | None = None
     bad_words: list[str] = Field(default_factory=list)


### PR DESCRIPTION
This PR fixes issues causing OpenAPI schema test failures:

## Changes

### 1. Add upper bound validation to `truncate_prompt_tokens` (`protocol.py`)

The `truncate_prompt_tokens` field only had a lower bound (`ge=-1`) but no upper bound. When schemathesis generates extremely large integers, the server crashed instead of returning a proper 400 validation error.

Added `le=_LONG_INFO.max` constraint to match the `seed` field's validation.

**Example failure:**
```
curl -X POST -H 'Content-Type: application/json' \
  -d '{"messages": [{"content": [{"text": "", "type": "text"}], "role": "developer"}], "truncate_prompt_tokens": 18446744073709551616}' \
  http://127.0.0.1:57049/v1/chat/completions

[500] Internal Server Error:
{"error":{"message":"int too big to convert","type":"Internal Server Error","param":null,"code":500}}
```

### 2. Fix content type check in test filter (`test_openapi_schema.py`)

The test filter assumed all items in message content lists were dicts, but content can also contain strings. Added `isinstance(item, dict)` check before calling `.get()`.

**Example failure:**
```
AttributeError: 'str' object has no attribute 'get'
```

### 3. Add timeout for `/v1/completions` endpoint (`test_openapi_schema.py`)

The `/v1/completions` endpoint can take longer than the default 10s timeout. Added it to the long timeout mapping alongside `/v1/chat/completions`.

**Example failure:**
```
curl -X POST -H 'Content-Type: application/json' -d '{"prompt": [0]}' http://127.0.0.1:56849/v1/completions

Response timeout: The server failed to respond within the specified limit of 10000.00ms
```