### PR TITLE
[Fix] Enable mm_processor_cache with vision LoRA

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1651,19 +1651,6 @@ class EngineArgs:
 
         if (
             lora_config is not None
-            and lora_config.enable_tower_connector_lora
-            and self.mm_processor_cache_gb != 0
-        ):
-            raise ValueError(
-                "Currently, enable_tower_connector_lora is "
-                "incompatible with the multi-modal processor cache. "
-                "When enable_tower_connector_lora is set, "
-                "mm_processor_cache_gb must be 0, got %s",
-                self.mm_processor_cache_gb,
-            )
-
-        if (
-            lora_config is not None
             and speculative_config is not None
             and scheduler_config.max_num_batched_tokens
             < (

--- a/vllm/multimodal/cache.py
+++ b/vllm/multimodal/cache.py
@@ -635,12 +635,17 @@ class BaseMultiModalReceiverCache(
         Update multimodal features with cached encoder outputs.
         Touch all identifier at first before update to avoid
         item in updated list evict during update.
+
+        Uses mm_hash for cache key to share across LoRAs (falls back to
+        identifier for backward compatibility).
         """
         for feature in mm_features:
-            self.touch_receiver_cache_item(feature.identifier, feature.data)
+            cache_key = feature.mm_hash or feature.identifier
+            self.touch_receiver_cache_item(cache_key, feature.data)
 
         for feature in mm_features:
-            feature.data = self.get_and_update_item(feature.data, feature.identifier)
+            cache_key = feature.mm_hash or feature.identifier
+            feature.data = self.get_and_update_item(feature.data, cache_key)
         return mm_features
 
     @abstractmethod

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -330,6 +330,9 @@ class MultiModalFeatureSpec:
     mm_position: PlaceholderRange
     """e.g., PlaceholderRange(offset=2, length=336)"""
 
+    mm_hash: str | None = None
+    """Base mm_hash for processor cache (without LoRA prefix)."""
+
     @staticmethod
     def gather_kwargs(features: list["MultiModalFeatureSpec"], keys: set[str]):
         kwargs = defaultdict[str, list[NestedTensors]](list)

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -562,15 +562,17 @@ class InputProcessor:
 
             mm_features = []
             for modality, idx in sorted_mm_idxs:
+                base_mm_hash = decoder_mm_hashes[modality][idx]
                 mm_features.append(
                     MultiModalFeatureSpec(
                         data=decoder_mm_inputs[modality][idx],
                         modality=modality,
                         identifier=self._get_mm_identifier(
-                            decoder_mm_hashes[modality][idx],
+                            base_mm_hash,
                             lora_request,
                         ),
                         mm_position=decoder_mm_positions[modality][idx],
+                        mm_hash=base_mm_hash,
                     )
                 )
 


### PR DESCRIPTION
## Purpose
Enables multi-modal processor cache when `enable_tower_connector_lora` is active. #26674 prefixes `identifier` with LoRA hash to avoid incorrect encoder cache hits(https://github.com/vllm-project/vllm/pull/26674#discussion_r2636937770) but processor cache should be shared across LoRAs.

 **Solution:**
  - Add `mm_hash` field to `MultiModalFeatureSpec` to store the base hash (without LoRA prefix)
  - Processor cache uses `mm_hash` for cache lookups (shared across LoRAs)
  - Encoder cache continues using `identifier` (LoRA-prefixed, separate per LoRA)