### PR TITLE
[ROCm][CI] Fix attention backend test flakiness from uninitialized KV cache memory

### DIFF
--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -136,7 +136,7 @@ def create_and_prepopulate_kv_cache(
     slot_mapping = common_attn_metadata.slot_mapping
 
     # Create KV cache
-    kv_cache = torch.empty(
+    kv_cache = torch.zeros(
         2, num_blocks, block_size, num_kv_heads, head_size, dtype=dtype, device=device
     )
     kv_cache_flat = kv_cache.view(2, -1, num_kv_heads, head_size)


### PR DESCRIPTION
Fixes intermittent test failures in `test_attention_backends.py` caused by uninitialized memory in the KV cache.

## Problem

The `create_and_prepopulate_kv_cache` function uses `torch.empty()` to allocate the KV cache, which leaves memory uninitialized. Only the blocks actually used by test sequences are populated with valid data.

This manifests as intermittent failures, particularly on ROCm where uninitialized GPU memory is less likely to contain "safe" values compared to CUDA.

## Fix

Replace `torch.empty()` with `torch.zeros()` to ensure all KV cache memory is initialized to valid values.

## Testing

Ran the failing test 100 times locally on ROCm to verify the fix eliminates the intermittent failures.