### PR TITLE
[Bugfix][MTP] Fix for tool calling performance degradation on GLM models with MTP on

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1203,6 +1203,7 @@ class OpenAIServingChat(OpenAIServing):
 
                             # GLM 4 parsers with MTP on won't work properly if 
                             # falling back to the original autocomplete logic.
+                            actual_call = tool_parser.streamed_args_for_tool[index]
                             remaining_call = ""
                             if "Glm4" not in type(tool_parser).__name__:
                                 expected_call = json.dumps(
@@ -1211,13 +1212,8 @@ class OpenAIServingChat(OpenAIServing):
                                     ),
                                     ensure_ascii=False,
                                 )
-
-                                # get what we've streamed so far for arguments
-                                # for the current tool
-                                actual_call = tool_parser.streamed_args_for_tool[index]
                                 if latest_delta_len > 0:
                                     actual_call = actual_call[:-latest_delta_len]
-
                                 # check to see if there's anything left
                                 remaining_call = expected_call.replace(
                                     actual_call, "", 1
@@ -1225,9 +1221,6 @@ class OpenAIServingChat(OpenAIServing):
                             else:
                                 # Parser doesn't need autocomplete - just send
                                 # the remaining portion of what was streamed
-                                actual_call = (
-                                    tool_parser.streamed_args_for_tool[index]
-                                )
                                 if latest_delta_len > 0:
                                     remaining_call = actual_call[-latest_delta_len:]
 

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1201,7 +1201,7 @@ class OpenAIServingChat(OpenAIServing):
                                     delta_message.tool_calls[0].function.arguments
                                 )
 
-                            # GLM 4 parsers with MTP on won't work properly if 
+                            # GLM 4 parsers with MTP on won't work properly if
                             # falling back to the original autocomplete logic.
                             actual_call = tool_parser.streamed_args_for_tool[index]
                             remaining_call = ""


### PR DESCRIPTION
## Purpose

This PR fixes an issue where GLM-4 MoE series (4.5/4.6/4.7) tool calling streaming would fail or produce incorrect output when turning on Multi-Token Prediction.

The existing logic in `OpenAIServingChat` assumes a JSON autocomplete/diffing strategy to determine the next argument delta to stream. This approach is incompatible with how GLM-4 tool parsers handle streaming (specifically with MTP enabled), leading to issues where arguments were not streamed correctly.

This change adds a check to identify GLM-4 tool parsers and bypasses the JSON autocomplete logic for them, enabling the server to send the streamed argument delta directly as received from the parser.

## Test Plan
- Validated that the specific codepath for GLM-4 is only triggered when the tool parser type includes "Glm4".
- Ran internal benchmarks before & after this change and verified that this PR recovers the model's performance comparing to MTP-off scenarios.

## Benchmark Result
Running with GLM-4.7 on a subset of open-game-eval https://github.com/Roblox/open-game-eval

1. Before PR, No MTP -- 51% pass rate, 5.6 avg tool calls
2. Before PR, MTP --
3. After PR, No MTP -- 51% pass rate, 5.6 avg tool calls
4. After PR, MTP -- 50% pass rate, 5.5 avg tool calls