### PR TITLE
[ROCm][LoRA] Fix MoE accuracy regression by preserving float32 router weight scaling

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -519,6 +519,12 @@ def fused_moe_kernel(
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk
 
+    # Router weight multiplication MUST happen in float32 before precision
+    # conversion for numerical stability (especially critical on ROCm).
+    if MUL_ROUTED_WEIGHT:
+        moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
+        accumulator = accumulator * moe_weight[:, None]
+
     if use_int8_w8a16:
         accumulator = (accumulator * b_scale).to(compute_type)
     elif use_fp8_w8a8 or use_int8_w8a8:
@@ -529,12 +535,10 @@ def fused_moe_kernel(
     else:
         accumulator = accumulator.to(compute_type)
 
-    # Since bias is typically not quantized, it's added after dequantization.
+    # Bias is added AFTER dequantization since bias is typically stored in
+    # the output dtype and should not be scaled by quantization factors.
     if HAS_BIAS:
         accumulator = accumulator + bias[None, :]
-    if MUL_ROUTED_WEIGHT:
-        moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
-        accumulator = accumulator * moe_weight[:, None]
 
     # -----------------------------------------------------------
     # Write back the block of the output


### PR DESCRIPTION
Fixes MoE accuracy regression on ROCm introduced in #31676.

## Problem

PR #31676 reordered post-accumulation operations to add bias after dequantization. However, this also moved `MUL_ROUTED_WEIGHT` after the `.to(compute_type)` precision conversion, causing router weight multiplication to occur in bf16/fp16 instead of float32.

This precision loss causes different outputs on ROCm due to differences in mixed-precision handling between ROCm and CUDA Triton backends. The issue manifests as non-deterministic expert routing, particularly visible in LoRA mixed-adapter tests.

## Root Cause

**Before #31676 (correct):**
```python
accumulator = accumulator * moe_weight  # float32
accumulator = accumulator.to(compute_type)  # float32 to bf16
```

**After #31676 (broken on ROCm):**
```python
accumulator = accumulator.to(compute_type)  # float32 to bf16
accumulator = accumulator * moe_weight  # bf16 x float32
```

## Fix

Restore `MUL_ROUTED_WEIGHT` before precision conversion while preserving the correct bias placement after dequantization:
```python
# Router weights in float32 (before conversion)
if MUL_ROUTED_WEIGHT:
    accumulator = accumulator * moe_weight[:, None]

# Dequantization + precision conversion
accumulator = accumulator.to(compute_type)

# Bias after dequantization (unchanged from #31676)
if HAS_BIAS:
    accumulator = accumulator + bias
```

## Testing

- [x] `test_olmoe_lora_mixed` passes on ROCm

Fixes CI regression from: #31676