### PR TITLE
[CI] Skip Qwen-VL in multimodal processing tests due to flaky external dependency

### DIFF
--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -404,6 +404,11 @@ def test_processing_correctness(
         pytest.skip("Fix later")
     if model_id == "jinaai/jina-reranker-m0":
         pytest.skip("Fix later")
+    if model_id in {"Qwen/Qwen-VL", "Qwen/Qwen-VL-Chat"}:
+        pytest.skip(
+            "Qwen-VL tokenizer requires downloading a font file from "
+            "servers that often refuse connections in CI"
+        )
 
     _test_processing_correctness(
         model_id,


### PR DESCRIPTION
The Qwen-VL and Qwen-VL-Chat models are being skipped in `test_processing_correctness` due to intermittent CI failures.

The tokenizer for these models attempts to download a font file from Alibaba's China servers (`qianwen-res.oss-cn-beijing.aliyuncs.com`), which sometimes times out or refuses connections in CI environments.

```
urllib3.exceptions.ConnectTimeoutError: Connection to qianwen-res.oss-cn-beijing.aliyuncs.com timed out
```

Discussed with @ywang96 who confirmed these models can be removed from the test.