### PR TITLE
[Bugfix]some time rank mapping error when use ray in pp

### DIFF
--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -208,8 +208,11 @@ class WorkerWrapperBase:
         It is only used during the initialization of the executor,
         to adjust the rpc_rank of workers after we create all workers.
         """
-        if self.rpc_rank in rank_mapping:
-            self.rpc_rank = rank_mapping[self.rpc_rank]
+        old_rank = self.rpc_rank
+        if old_rank in rank_mapping:
+            self.rpc_rank = rank_mapping[old_rank]
+            if self.global_rank == old_rank:
+                self.global_rank = rank_mapping[old_rank]
 
     def update_environment_variables(
         self,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

## Test Plan

FIX: https://github.com/vllm-project/vllm/issues/31903

fix after can use this command to start serve.
```
$ vllm serve DeepSeek-V3.2 -tp=8 -pp=4 --distributed-executor-backend ray
```

Because in ray distributed it adjust rank, but not adjust global rank value, but in `initialize_from_config` method it need use global rank to get kv cache config, but global rank value is not right.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

