### PR TITLE
[platform] add dp_metadata arg to set_additional_forward_context

### DIFF
--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -324,6 +324,7 @@ def set_forward_context(
         cudagraph_runtime_mode=cudagraph_runtime_mode,
         batch_descriptor=batch_descriptor,
         ubatch_slices=ubatch_slices,
+        dp_metadata=dp_metadata,
     )
 
     forward_context = create_forward_context(

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -319,12 +319,12 @@ def set_forward_context(
         attn_metadata=attn_metadata,
         vllm_config=vllm_config,
         virtual_engine=virtual_engine,
+        dp_metadata=dp_metadata,
         num_tokens=num_tokens,
         num_tokens_across_dp=num_tokens_across_dp,
         cudagraph_runtime_mode=cudagraph_runtime_mode,
         batch_descriptor=batch_descriptor,
         ubatch_slices=ubatch_slices,
-        dp_metadata=dp_metadata,
     )
 
     forward_context = create_forward_context(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
#31674 add `set_additional_forward_context` in set_forward_context, so other platform can add extra fields in forward_context,
but `set_additional_forward_context` lack  the argument `dp_metadata`, other platform will use `num_tokens_across_dp`, but if there is no `dp_medata`, they will call `coordinate_batch_acorss_dp` again, which make some extra communication. 
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

