### PR TITLE
[BugFix] Fix spec decoding edge case bugs

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -775,6 +775,7 @@ class Scheduler(SchedulerInterface):
         self.encoder_cache_manager.free(request)
         request.status = RequestStatus.PREEMPTED
         request.num_computed_tokens = 0
+        request.spec_token_ids.clear()
         request.num_preemptions += 1
         if self.log_stats:
             request.record_event(EngineCoreEventType.PREEMPTED, timestamp)


### PR DESCRIPTION
There are a couple of edge case issues:
- Since https://github.com/vllm-project/vllm/pull/29821, it's again possible to hit the issue described in https://github.com/vllm-project/vllm/pull/30916. Our test does cover it but it's not guaranteed to trigger so was missed and is manifesting as a flake now. The fix here is to clear the request's `spec_token_ids` in the scheduler when it is preempted.
- There's also an issue related to a case where the request can be excluded from the batch temporarily (but not preempted). The "paused" request may still have valid drafted spec tokens but these aren't properly handled upon resumption in the model runner `_update_states` method since they are treated as new requests and the spec token handling isn't on that path.