### PR TITLE
[CI] fix ROCM_HOME: unbound variable

### DIFF
--- a/.buildkite/scripts/run-multi-node-test.sh
+++ b/.buildkite/scripts/run-multi-node-test.sh
@@ -7,7 +7,7 @@ set -euox pipefail
 if [ -e /dev/kfd ] || \
     [ -d /opt/rocm ] || \
     command -v rocm-smi &> /dev/null || \
-    [ -n "$ROCM_HOME" ]; then
+    [ -n "${ROCM_HOME:-}" ]; then
     IS_ROCM=1
 else
     IS_ROCM=0


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/31922 broke the "2 Node Tests (4 GPUs in total)" with 
```
[2026-01-08T07:32:12Z] ./.buildkite/scripts/run-multi-node-test.sh: line 10: ROCM_HOME: unbound variable
```
https://buildkite.com/organizations/vllm/pipelines/ci/builds/46074/jobs/019b9c75-6389-40dc-a23b-5ecd3683d951/log