### PR TITLE
[Frontend] Add `reasoning_effort` to `OpenAIServing._preprocess_chat()`

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -318,6 +318,7 @@ class OpenAIServingChat(OpenAIServing):
                     default_chat_template_kwargs=self.default_chat_template_kwargs,
                     tool_parser=tool_parser,
                     add_special_tokens=request.add_special_tokens,
+                    reasoning_effort=request.reasoning_effort,
                 )
             else:
                 # For GPT-OSS.

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -304,6 +304,10 @@ class OpenAIServingChat(OpenAIServing):
                 )
                 if error_check_ret is not None:
                     return error_check_ret
+
+                chat_template_kwargs = request.chat_template_kwargs or {}
+                chat_template_kwargs.update(reasoning_effort=request.reasoning_effort)
+
                 conversation, engine_prompts = await self._preprocess_chat(
                     request,
                     tokenizer,
@@ -314,11 +318,10 @@ class OpenAIServingChat(OpenAIServing):
                     continue_final_message=request.continue_final_message,
                     tool_dicts=tool_dicts,
                     documents=request.documents,
-                    chat_template_kwargs=request.chat_template_kwargs,
+                    chat_template_kwargs=chat_template_kwargs,
                     default_chat_template_kwargs=self.default_chat_template_kwargs,
                     tool_parser=tool_parser,
                     add_special_tokens=request.add_special_tokens,
-                    reasoning_effort=request.reasoning_effort,
                 )
             else:
                 # For GPT-OSS.

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncGenerator, Callable, Iterable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from http import HTTPStatus
-from typing import Any, ClassVar, Generic, TypeAlias, TypeVar
+from typing import Any, ClassVar, Generic, Literal, TypeAlias, TypeVar
 
 import numpy as np
 from fastapi import Request
@@ -1173,6 +1173,8 @@ class OpenAIServing:
         default_chat_template_kwargs: dict[str, Any] | None = None,
         tool_parser: Callable[[TokenizerLike], ToolParser] | None = None,
         add_special_tokens: bool = False,
+        reasoning_effort: Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+        | None = None,
     ) -> tuple[list[ConversationMessage], list[TokensPrompt]]:
         model_config = self.model_config
 
@@ -1195,6 +1197,7 @@ class OpenAIServing:
             continue_final_message=continue_final_message,
             tools=tool_dicts,
             documents=documents,
+            reasoning_effort=reasoning_effort,
         )
         _chat_template_kwargs |= self._prepare_extra_chat_template_kwargs(
             chat_template_kwargs,

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncGenerator, Callable, Iterable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from http import HTTPStatus
-from typing import Any, ClassVar, Generic, Literal, TypeAlias, TypeVar
+from typing import Any, ClassVar, Generic, TypeAlias, TypeVar
 
 import numpy as np
 from fastapi import Request
@@ -1173,8 +1173,6 @@ class OpenAIServing:
         default_chat_template_kwargs: dict[str, Any] | None = None,
         tool_parser: Callable[[TokenizerLike], ToolParser] | None = None,
         add_special_tokens: bool = False,
-        reasoning_effort: Literal["none", "minimal", "low", "medium", "high", "xhigh"]
-        | None = None,
     ) -> tuple[list[ConversationMessage], list[TokensPrompt]]:
         model_config = self.model_config
 
@@ -1197,7 +1195,6 @@ class OpenAIServing:
             continue_final_message=continue_final_message,
             tools=tool_dicts,
             documents=documents,
-            reasoning_effort=reasoning_effort,
         )
         _chat_template_kwargs |= self._prepare_extra_chat_template_kwargs(
             chat_template_kwargs,

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -574,6 +574,9 @@ class OpenAIServingResponses(OpenAIServing):
             tool_parser=self.tool_parser,
             chat_template=self.chat_template,
             chat_template_content_format=self.chat_template_content_format,
+            reasoning_effort=None
+            if request.reasoning is None
+            else request.reasoning.effort,
         )
         return messages, engine_prompts
 

--- a/vllm/entrypoints/openai/serving_responses.py
+++ b/vllm/entrypoints/openai/serving_responses.py
@@ -566,6 +566,13 @@ class OpenAIServingResponses(OpenAIServing):
             prev_msg=self.msg_store.get(prev_response.id) if prev_response else None,
             prev_response_output=prev_response.output if prev_response else None,
         )
+
+        chat_template_kwargs = dict(
+            reasoning_effort=None
+            if request.reasoning is None
+            else request.reasoning.effort
+        )
+
         _, engine_prompts = await self._preprocess_chat(
             request,
             tokenizer,
@@ -574,9 +581,7 @@ class OpenAIServingResponses(OpenAIServing):
             tool_parser=self.tool_parser,
             chat_template=self.chat_template,
             chat_template_content_format=self.chat_template_content_format,
-            reasoning_effort=None
-            if request.reasoning is None
-            else request.reasoning.effort,
+            chat_template_kwargs=chat_template_kwargs,
         )
         return messages, engine_prompts
 


### PR DESCRIPTION
## Purpose
I suggest adding `reasoning_effort` to `OpenAIServing._preprocess_chat()` to make it used in chat template.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 9fa980d64d4fd9cc4d48d16e9544cc0a08eb4282. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
