### PR TITLE
[Bugfix] Fix vllm serve failure with Nemotron Nano V3 FP8

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -1619,11 +1619,12 @@ def process_fp8_weight_tensor_strategy_moe(
     """Process moe weights for tensor-wise quantization strategy."""
     max_scales = weight_scales.max(dim=1).values
 
-    # For w1 case (i.e. not w13): just collapse the last dim since
-    # there is already just one scale per expert in this case.
+    # For w1 case (i.e. not w13): there is already just one scale per expert.
     if not is_act_and_mul:
         assert weight_scales.shape[1] == 1
-        return weight, weight_scales.max()
+        # One scale per expert
+        assert max_scales.shape == (num_experts,)
+        return weight, max_scales
 
     # For w13 case (common): require single scale for w13 per expert, but
     # on disk there is a scale for w1 and w3. Use the max to requantize.


### PR DESCRIPTION
## Purpose
Fix bug:
https://github.com/vllm-project/vllm/issues/31957

The fix in file `fp8_utils.py` is required to fix this error (raised from `flashinfer_cutlass_fused_moe`):
```
RuntimeError: Check failed: fc1_dequant.ndim() == 1 (0 vs. 1) : fc1_dequant must be a 1D tensor
```

## Test Plan
vLLM serve should not fail.

Run vLLM serve based on this recipe:
https://docs.vllm.ai/projects/recipes/en/latest/NVIDIA/Nemotron-3-Nano-30B-A3B.html#launch-the-vllm-server

Run basic vLLM test (benchmark, check generated output).

## Test Result

vLLM serve works (single B200 GPU):
```
export VLLM_USE_FLASHINFER_MOE_FP8=1
export VLLM_FLASHINFER_MOE_BACKEND=throughput

export MODEL_PATH=/hf_models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8/

vllm serve $MODEL_PATH --served-model-name my_model \
--trust-remote-code --no-enable-prefix-caching --tensor-parallel-size 1 --kv-cache-dtype fp8
```

The selected backend:
```
[fp8.py:102] Using FlashInfer CUTLASS backend for FP8 MoE
```

### Note:
If I use `VLLM_USE_FLASHINFER_MOE_FP8=0` vLLM fails (`Using Triton backend for FP8 MoE`).
This can be fixed in a separate PR.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

