### PR TITLE
[CI] [Bugfix] Fix unbounded variable in `run-multi-node-test.sh`

### DIFF
--- a/.buildkite/scripts/run-multi-node-test.sh
+++ b/.buildkite/scripts/run-multi-node-test.sh
@@ -7,7 +7,7 @@ set -euox pipefail
 if [ -e /dev/kfd ] || \
     [ -d /opt/rocm ] || \
     command -v rocm-smi &> /dev/null || \
-    [ -n "$ROCM_HOME" ]; then
+    [ -n "${ROCM_HOME:-}" ]; then
     IS_ROCM=1
 else
     IS_ROCM=0

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -1104,6 +1104,7 @@ steps:
   - vllm/model_executor/models/
   - tests/distributed/
   - tests/examples/offline_inference/data_parallel.py
+  - .buildkite/scripts/run-multi-node-test.sh
   commands:
   - # the following commands are for the first node, with ip 192.168.10.10 (ray environment already set up)
     - VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed'


### PR DESCRIPTION

## Purpose

Fix the issue `./.buildkite/scripts/run-multi-node-test.sh: line 10: ROCM_HOME: unbound variable` after PR https://github.com/vllm-project/vllm/pull/31922 .

https://buildkite.com/vllm/ci/builds/46115/steps/canvas?sid=019b9d2c-bfc3-4c47-b214-3bf7def2f86a

Add `.buildkite/scripts/run-multi-node-test.sh` into `test-pipeline.yml` to trigger during CI.

## Test Plan

Pass CI.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

