### PR TITLE
[BugFix] Add spec-decode-incompatible request param validation

### DIFF
--- a/tests/v1/distributed/test_eagle_dp.py
+++ b/tests/v1/distributed/test_eagle_dp.py
@@ -51,7 +51,6 @@ async def test_run_eagle_dp(monkeypatch: pytest.MonkeyPatch):
     # https://github.com/vllm-project/vllm/issues/31913
     num_expected_tokens = 20
     sampling_params = SamplingParams(
-        min_tokens=num_expected_tokens,
         max_tokens=num_expected_tokens,
         ignore_eos=True,
         output_kind=RequestOutputKind.FINAL_ONLY,


### PR DESCRIPTION
Some sampling parameters are not yet supported with spec decoding. We log a warning during startup but then effectively silently ignore the parameters if included in requests at runtime.

This adds request-scope validation for this to fail rather than silently ignore.