### PR TITLE
[Bugfix] Fix Fp8 Triton for non-gated MoE (Nemotron)

### DIFF
--- a/tests/evals/gsm8k/configs/moe-refactor/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16-triton.yaml
+++ b/tests/evals/gsm8k/configs/moe-refactor/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16-triton.yaml
@@ -1,0 +1,5 @@
+model_name: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
+accuracy_threshold: 0.85
+num_questions: 1319
+num_fewshot: 10
+server_args: "--enforce-eager --max-model-len 8192 --tensor-parallel-size 2"

--- a/tests/evals/gsm8k/configs/moe-refactor/config-b200.txt
+++ b/tests/evals/gsm8k/configs/moe-refactor/config-b200.txt
@@ -11,3 +11,4 @@ Qwen3-30B-A3B-NvFp4-ModelOpt-marlin.yaml
 Qwen3-30B-A3B-NvFp4-ModelOpt-fi-trtllm.yaml
 Qwen3-30B-A3B-NvFp4-ModelOpt-fi-cutlass.yaml
 Qwen3-30B-A3B-NvFp4-ModelOpt-fi-cutlass-dp-ep.yaml
+NVIDIA-Nemotron-3-Nano-30B-A3B-BF16-triton.yaml

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -733,6 +733,7 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
             block_quant=False,
             tp_size=moe_config.moe_parallel_config.tp_size,
             with_lora_support=self.moe.is_lora_enabled,
+            is_act_and_mul=self.moe.is_act_and_mul,
         )
         self.kernel: mk.FusedMoEModularKernel | None = None
 


### PR DESCRIPTION
## Purpose
vLLM serve command that fails:
```
export MODEL_PATH=/my_home/hf_models/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8/

export VLLM_USE_FLASHINFER_MOE_FP8=0

vllm serve $MODEL_PATH --served-model-name my_model \
--trust-remote-code --async-scheduling --kv-cache-dtype fp8 --tensor-parallel-size 1
```

The following backend should be used:
```
Detected ModelOpt fp8 checkpoint (quant_algo=FP8).
Using Triton backend for FP8 MoE
```

But vLLM fails:
```
(EngineCore_DP0 pid=49841)   File "/my_home/workspace/my_vllm/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 603, in activation
(EngineCore_DP0 pid=49841)     assert output.size(-1) == input.size(-1)
```

### Note
Backend `VLLM_USE_FLASHINFER_MOE_FP8=1` was fixed in this PR:
https://github.com/vllm-project/vllm/pull/31960

## Test Plan
Run basic `lm_eval` test with two configs:

Config based on recipe (https://docs.vllm.ai/projects/recipes/en/latest/NVIDIA/Nemotron-3-Nano-30B-A3B.html#launch-the-vllm-server):
```
VLLM_USE_FLASHINFER_MOE_FP8=1
VLLM_FLASHINFER_MOE_BACKEND=throughput
```

And with Triton:
```
VLLM_USE_FLASHINFER_MOE_FP8=0
```

Results should be similiar to an older commit that did not fail/crash (1ab055efe6b7f9abdd8774ed64ead1b83dd00253).

## Test Result
Test results are OK.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Ensures FP8 MoE works for non-gated (no gate-up fusion) paths and fixes Triton execution shape assumptions.
> 
> - Plumbs `is_act_and_mul` into `fp8_w8a8_moe_quant_config`, `make_fp8_moe_quant_config`, and `select_fp8_moe_backend` so kernels/quant config align with gated vs non-gated layouts
> - ModelOpt FP8 MoE: passes `is_act_and_mul` into backend selection and quant-config creation to avoid mismatched dimensions at runtime
> - Adds `NVIDIA-Nemotron-3-Nano-30B-A3B-BF16-triton.yaml` and references it in `config-b200.txt` for GSM8K evals
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed92436863414a4572046962938013b858a8b51e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures FP8 MoE handles non-gated paths correctly and avoids kernel shape mismatches.
> 
> - Plumbs `is_act_and_mul` into `select_fp8_moe_backend` and `make_fp8_moe_quant_config` via `ModelOptFp8MoEMethod` (constructor and quant-config), aligning backend choice and scales for gated vs non-gated MoE
> - Updates `fp8.py` quant-config API to accept `is_act_and_mul`
> - Adds `NVIDIA-Nemotron-3-Nano-30B-A3B-BF16-triton.yaml` and references it in `config-b200.txt` for GSM8K evals
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4533a693dd9967ada13043ab43b0f1a93f74a2be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures FP8 MoE handles non‑gated (no gate-up fusion) paths correctly and avoids Triton kernel shape mismatches.
> 
> - Plumbs `is_act_and_mul` into `select_fp8_moe_backend` and `make_fp8_moe_quant_config` via `ModelOptFp8MoEMethod` (constructor and quant-config), aligning backend selection and scales for gated vs non‑gated MoE
> - Adds `NVIDIA-Nemotron-3-Nano-30B-A3B-BF16-triton.yaml` and references it in `config-b200.txt` for GSM8K evals
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85de95e27264d6c17ecdcc05a96b98dce062a041. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 360a708cab806d79e792e0a50383849be21589a6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
