### PR TITLE
[Misc][PD] Fix `get_attn_backend` usage in transfer connectors

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -1439,7 +1439,7 @@ def test_register_kv_caches(default_vllm_config, dist_init, attn_backend):
         patch(f"{nixl_module}.NixlWrapper") as mock_nixl_wrapper,
         patch(f"{nixl_module}.threading.Event"),
         patch(f"{nixl_module}.threading.Thread") as mock_thread,
-        patch(f"{nixl_module}.get_attn_backend") as mock_get_attn_backend,
+        patch(f"{nixl_module}.get_current_attn_backend") as mock_get_attn_backend,
     ):
         # Ensure get_attn_backend returns the correct value due to
         # _cached_get_attn_backend returning the backend from previous

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -6,14 +6,15 @@ KV cache helper for store.
 
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import torch
 
-from vllm.config import get_current_vllm_config
+from vllm.attention.backends.abstract import AttentionBackend
+from vllm.config import VllmConfig, get_current_vllm_config, get_layers_from_vllm_config
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
 from vllm.logger import init_logger
-from vllm.v1.attention.backend import AttentionBackend
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.outputs import KVConnectorOutput, ModelRunnerOutput
 
 if TYPE_CHECKING:
@@ -433,3 +434,26 @@ class TpKVTopology:
     ) -> list[int]:
         remote_tp_size = self.remote_tp_size[remote_engine_id]
         return self.get_target_remote_ranks(remote_tp_size)
+
+
+def get_current_attn_backend(vllm_config: VllmConfig):
+    layer_type = cast(type[Any], AttentionLayerBase)
+    layers = get_layers_from_vllm_config(vllm_config, layer_type, None)
+    if layers:
+        backend = next(iter(layers.values())).get_attn_backend()
+    else:
+        # Fallback for tests, when static_forward_context is empty.
+        logger.debug(
+            "No layers found in the vLLM config. "
+            "Falling back to default attention backend."
+        )
+        from vllm.attention.selector import get_attn_backend
+
+        backend = get_attn_backend(
+            head_size=vllm_config.model_config.get_head_size(),
+            dtype=vllm_config.model_config.dtype,
+            kv_cache_dtype=vllm_config.cache_config.cache_dtype,
+            block_size=vllm_config.cache_config.block_size,
+            use_mla=vllm_config.model_config.use_mla,
+        )
+    return backend

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -10,11 +10,11 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 import torch
 
-from vllm.attention.backends.abstract import AttentionBackend
 from vllm.config import VllmConfig, get_current_vllm_config, get_layers_from_vllm_config
 from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.outputs import KVConnectorOutput, ModelRunnerOutput
 
 if TYPE_CHECKING:
@@ -447,7 +447,7 @@ def get_current_attn_backend(vllm_config: VllmConfig):
             "No layers found in the vLLM config. "
             "Falling back to default attention backend."
         )
-        from vllm.attention.selector import get_attn_backend
+        from vllm.v1.attention.selector import get_attn_backend
 
         backend = get_attn_backend(
             head_size=vllm_config.model_config.get_head_size(),

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
@@ -482,7 +482,7 @@ class MooncakeConnectorWorker:
         # NOTE (NickLucche) models with multiple backends are not supported yet
         layer_type = cast(type[Any], AttentionLayerBase)
         layers = get_layers_from_vllm_config(vllm_config, layer_type, None)
-        backend = layers[next(iter(layers.keys()))].get_attn_backend()
+        backend = next(iter(layers.values())).get_attn_backend()
         self.backend_name = backend.get_name()
         self.kv_cache_layout = get_kv_cache_layout()
         logger.debug("Detected attention backend %s", self.backend_name)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
@@ -16,7 +16,6 @@ import zmq
 import zmq.asyncio
 
 from vllm import envs
-from vllm.attention.backends.abstract import AttentionMetadata
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import (
     TpKVTopology,
@@ -37,7 +36,6 @@ from vllm.logger import init_logger
 from vllm.utils.network_utils import get_ip, make_zmq_path, make_zmq_socket
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.utils import get_kv_cache_layout
-from vllm.v1.attention.selector import get_attn_backend
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.request import RequestStatus
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -20,15 +20,14 @@ import torch
 import zmq
 
 from vllm import envs
-from vllm.attention.backends.abstract import AttentionMetadata
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import (
     EngineId,
     TpKVTopology,
+    get_current_attn_backend,
     kv_postprocess_blksize_and_layout_on_receive,
     kv_postprocess_blksize_on_receive,
     kv_postprocess_layout_on_receive,
-    get_current_attn_backend,
     yield_req_data,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
@@ -55,7 +54,6 @@ from vllm.platforms import current_platform
 from vllm.utils.network_utils import make_zmq_path, make_zmq_socket
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.utils import get_kv_cache_layout
-from vllm.v1.attention.selector import get_attn_backend
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.worker.block_table import BlockTable
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -963,7 +963,7 @@ class NixlConnectorWorker:
         # NOTE (NickLucche) models with multiple backends are not supported yet
         layer_type = cast(type[Any], AttentionLayerBase)
         layers = get_layers_from_vllm_config(vllm_config, layer_type, None)
-        backend = layers[next(iter(layers.keys()))].get_attn_backend()
+        backend = next(iter(layers.values())).get_attn_backend()
 
         self.backend_name = backend.get_name()
         self.kv_cache_layout = get_kv_cache_layout()


### PR DESCRIPTION
This PR fixes the use of `get_attn_backend` in the context discussed here https://vllm-dev.slack.com/archives/C07R5Q1Q2BB/p1767810349936949.
In particular, it turns out that modification to the interface of this shared function can cause unintended backend retrieval (as a partial configuration was passed in), leading to cases such as
```
VLLM_LOGGING_LEVEL=DEBUG vllm serve google/gemma-3-4b-it --port 8004 --enforce-eager --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
...
# Nixl wrongly selects FA for gemma3 instead of TritonATTN
distributed/.../v1/nixl_connector.py:319] NixlConnector setting KV cache layout to HND for better xfer performance.
(EngineCore_DP0 pid=2826069) DEBUG 01-07 18:52:37 [distributed/.../v1/nixl_connector.py:967] Detected attention backend FLASH_ATTN
```
with this PR
```
# POST PR
(EngineCore_DP0 pid=4094511) 2026-01-08 17:47:09 NIXL INFO    _api.py:251 Initialized NIXL agent: dc963518-8898-4e91-a89a-9d67d8489a89
(EngineCore_DP0 pid=4094511) INFO 01-08 17:47:09 [distributed/.../v1/nixl_connector.py:320] NixlConnector setting KV cache layout to HND for better xfer performance.
(EngineCore_DP0 pid=4094511) DEBUG 01-08 17:47:09 [distributed/.../v1/nixl_connector.py:977] Detected attention backend TRITON_ATTN
(EngineCore_DP0 pid=4094511) DEBUG 01-08 17:47:09 [distributed/.../v1/nixl_connector.py:978] Detected kv cache layout HND
``` 


Note, there are other instances where `get_attn_backend` is called without supplying the all list of args. I don't have enough context into eg `StaticSinkAttention` right now, so focusing on fixing the PD stuff.

---

> [!NOTE]
> Ensures connectors pick the correct attention backend based on the instantiated model layer rather than reconstructing from partial config.
> 
> - Replace `get_attn_backend(...)` with layer-derived backend: obtain layers via `get_layers_from_vllm_config` and call `get_attn_backend()` on the first `AttentionLayerBase` in both `nixl_connector.py` and `mooncake_connector.py`
> - Update imports to include `cast`, `get_layers_from_vllm_config`, and `AttentionLayerBase`
> - Logically unchanged elsewhere; backend name and KV cache layout logging remain
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba740ca460fcb2339edfbeaea1877caea76453bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures KV-transfer connectors choose the correct attention backend based on the initialized model layer rather than recomputing from partial config.
> 
> - Add `get_current_attn_backend(vllm_config)` in `utils.py` to fetch the backend from the first `AttentionLayerBase`; includes a test-only fallback to selector `get_attn_backend`
> - Switch `NixlConnector` and `MooncakeConnector` to use `get_current_attn_backend` and keep existing backend/layout logging
> - Update test `test_register_kv_caches` to mock `get_current_attn_backend` accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be3f6e62fca54c92687a7771c489fcb49a240970. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures KV-transfer connectors select the correct attention backend from the instantiated model layers instead of recomputing from partial config.
> 
> - Add `get_current_attn_backend(vllm_config)` in `utils.py` to fetch backend from the first `AttentionLayerBase`; includes a test-only fallback to selector `get_attn_backend`
> - Switch `NixlConnector` and `MooncakeConnector` to use `get_current_attn_backend` and keep existing backend/layout logging
> - Update unit test `test_register_kv_caches` to mock `get_current_attn_backend`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f321c48d6e3a2e957599def7a96e3148a57c2339. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Align backend selection with the instantiated model layers to avoid mismatches from partially specified configs.
> 
> - Add `get_current_attn_backend(vllm_config)` in `utils.py` to fetch backend from the first `AttentionLayerBase`; includes a test-only fallback to selector `get_attn_backend`
> - Replace direct `get_attn_backend(...)` calls in `v1/nixl_connector.py` and `v1/mooncake_connector.py` with `get_current_attn_backend`, and adjust imports
> - Update unit test `test_register_kv_caches` to mock `get_current_attn_backend` instead of `get_attn_backend`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6eeb35f39186eb19c31edb2eb1354941b7f25764. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
