### PR TITLE
[wip] expose online quantization for linear for compressed-tensors path

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -417,7 +417,7 @@ class ReplicatedLinear(LinearBase):
     def extra_repr(self) -> str:
         s = f"in_features={self.input_size}"
         s += f", output_features={self.output_size}"
-        s += f", bias={self.bias is not None}"
+        s += f", bias={getattr(self, 'bias', None) is not None}"
         return s
 
 
@@ -616,7 +616,7 @@ class ColumnParallelLinear(LinearBase):
     def extra_repr(self) -> str:
         s = f"in_features={self.input_size}"
         s += f", output_features={self.output_size_per_partition}"
-        s += f", bias={self.bias is not None}"
+        s += f", bias={getattr(self, 'bias', None) is not None}"
         s += f", tp_size={self.tp_size}"
         s += f", gather_output={self.gather_output}"
         return s
@@ -1469,7 +1469,7 @@ class RowParallelLinear(LinearBase):
     def extra_repr(self) -> str:
         s = f"in_features={self.input_size_per_partition}"
         s += f", output_features={self.output_size}"
-        s += f", bias={self.bias is not None}"
+        s += f", bias={getattr(self, 'bias', None) is not None}"
         s += f", tp_size={self.tp_size}"
         s += f", reduce_results={self.reduce_results}"
         return s


### PR DESCRIPTION
Summary:

WIP and not ready for review yet

High level, I'd like to work towards enabling online quantization for all the quantization recipes in compressed-tensors.  Ideally we work through a POC for a single recipe and get alignment from vllm team, and then we can parallelize further work if needed.

For now, tested e2e on a tiny dense model (facebook/opt-125m) and float8 rowwise scaling.

tl;dr;
1. enables `CompressedTensorsConfig.from_config_file`, and provides an example config file for float8 rowwise (in test plan, I got this from llm-compressor) which user can pass in with the `--hf_overrides` flag under the `quantization_config_file` key
2. creates `CompressedTensorsOnlineLinearMethod` for linear + online quant + compressed tensors (MoE can be handled in a similar way in a future PR)
3. implements the logic to quantize weights online for the float8 rowwise recipe, for now hardcoding it in `CompressedTensorsOnlineLinearMethod` but to be moved out shortly

Open things to work through:
a. passing a config file (or equialent json) is high-effort, would be nice to have a cleaner command line API for simple cases and resort to config/file for more complicated cases
b. I got the "valid quant json" from llm-compressor example checkpoint, this isn't super scalable, need to find if there is a spec for this / create the spec in compressed-tensors
c. need to align on where to put the "quantize the weights online" logic, likely in children of `CompressedTensorsScheme`

Test Plan:

```
//
// online quantization
//

// contents of config file: https://gist.github.com/vkuzo/62f2b32eabaf858fe78573565e9c53d0
// note that the `is_online_quantization` key in the config enables the
// online quantization logic

VLLM_ENABLE_V1_MULTIPROCESSING=0 with-proxy python3
examples/offline_inference/basic/generate.py --model facebook/opt-125m
--enforce-eager --dtype=bfloat16 --max_model_len=2048
--quantization=compressed-tensors
--hf_overrides="{\"quantization_config_file\":\"/home/vasiliy/local/tmp/20260108_llmc_example_float8_quantization_config_v2.json\"}"

//
// ptq still works (just for reference), run a checkpoint
// with the same recipe created from llm-compressor
//

VLLM_ENABLE_V1_MULTIPROCESSING=0 with-proxy python3
examples/offline_inference/basic/generate.py --model
~/local/pytorch_scripts/hf_torchao_vllm/data/llmcompressor/fp8-opt-125m/
--enforce-eager --dtype=bfloat16 --max_model_len=2048
```

Reviewers:

Subscribers:

Tasks:

Tags:

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

