### PR TITLE
fused_moe_kernel - cast accumulator after applying router weights

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -520,14 +520,9 @@ def fused_moe_kernel(
         b_ptrs += BLOCK_SIZE_K * stride_bk
 
     if use_int8_w8a16:
-        accumulator = (accumulator * b_scale).to(compute_type)
-    elif use_fp8_w8a8 or use_int8_w8a8:
-        if group_k > 0 and group_n > 0:
-            accumulator = accumulator.to(compute_type)
-        else:
-            accumulator = (accumulator * a_scale * b_scale).to(compute_type)
-    else:
-        accumulator = accumulator.to(compute_type)
+        accumulator = accumulator * b_scale
+    elif (use_fp8_w8a8 or use_int8_w8a8) and not (group_k > 0 and group_n > 0):
+        accumulator = accumulator * a_scale * b_scale
 
     # Since bias is typically not quantized, it's added after dequantization.
     if HAS_BIAS:
@@ -535,6 +530,8 @@ def fused_moe_kernel(
     if MUL_ROUTED_WEIGHT:
         moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
         accumulator = accumulator * moe_weight[:, None]
+
+    accumulator = accumulator.to(compute_type)
 
     # -----------------------------------------------------------
     # Write back the block of the output


### PR DESCRIPTION

## Purpose
The `tests/lora/test_olmoe_tp.py test_olmoe_lora_mixed` test case has been failing since https://github.com/vllm-project/vllm/pull/31676 was merged. Previously the application of `moe_weight` (router weights) to the `accumulator` was performed in `float32`, but after https://github.com/vllm-project/vllm/pull/31676, this computation is now done after `accumulator` has been cast to `compute_type`. 

This change in behavior caused the above test case to begin failing, and introduced a slight accuracy degradation based on lm-eval results on `gsm8k` and `mmlu_pro`. 

Results Before https://github.com/vllm-project/vllm/pull/31676:
```
gsm8k:  0.680
mmlu_pro: 0.2229
```

Results on main:
```
gsm8k:  0.676
mmlu_pro: 0.2218
```

## Test Plan
- Run MoE Tests
- Run Failing LoRA test
- Rerun lm-eval tests

## Test Result

`tests/lora/test_olmoe_tp.py test_olmoe_lora_mixed` is passing now.

lm-eval results after the change in this PR:
```
gsm8k: 0.2229
mmlu_pro: 0.680
```


---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit e78572a0a60b7e39926e61f8064ee7c739d69c80. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Adjusts compute order in the Triton `fused_moe_kernel` to improve numerical behavior.
> 
> - Applies `b_scale`/`a_scale` dequant multipliers without early casting; defers `accumulator.to(compute_type)` until after adding `bias` and multiplying router `moe_weight`
> - Simplifies dequant branches: for `int8_w8a16`, multiply by `b_scale`; for `fp8_w8a8`/`int8_w8a8` tensor-wise or per-channel (non-block-wise), multiply by `a_scale * b_scale`
> - No API changes; affects only internal accumulation/casting order in `vllm/model_executor/layers/fused_moe/fused_moe.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e78572a0a60b7e39926e61f8064ee7c739d69c80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
