### PR TITLE
[Fix] Qwen3-VL-MoE bitsandbytes 4 bit quant

### DIFF
--- a/vllm/model_executor/model_loader/bitsandbytes_loader.py
+++ b/vllm/model_executor/model_loader/bitsandbytes_loader.py
@@ -1078,7 +1078,8 @@ class BitsAndBytesModelLoader(BaseModelLoader):
                     loaded_weight, "fused_moe_weight_loader", None
                 )
 
-                if fused_moe_weight_loader is not None:
-                    if fused_moe_weight_loader(param, loaded_weight):
-                        bnb_loaded_weights.add(param_name)
+                if fused_moe_weight_loader is not None and fused_moe_weight_loader(
+                    param, loaded_weight
+                ):
+                    bnb_loaded_weights.add(param_name)
                 break

--- a/vllm/model_executor/model_loader/bitsandbytes_loader.py
+++ b/vllm/model_executor/model_loader/bitsandbytes_loader.py
@@ -83,6 +83,8 @@ class BitsAndBytesModelLoader(BaseModelLoader):
         self.pre_quant: bool = False
         self.load_8bit: bool = False
         self.is_pool_model: bool = False
+        # Flag for models with fused 3D MoE weights (e.g., Qwen3-VL-MoE)
+        self.is_3d_moe_weight: bool = False
 
     def _get_weight_files(
         self,
@@ -361,10 +363,124 @@ class BitsAndBytesModelLoader(BaseModelLoader):
                 tp_size = global_tp_size
                 tp_rank = global_tp_rank
 
-            if any(
+            # Check if this is a 3D MoE weight (no .weight suffix)
+            is_3d_moe_target = (
+                self.is_3d_moe_weight
+                and any(
+                    mapped_weight_name == target_module
+                    for target_module in self.target_modules
+                )
+                and len(weight_tensor.shape) == 3
+            )
+
+            is_regular_target = any(
                 target_module in mapped_weight_name
                 for target_module in self.target_modules
-            ) and mapped_weight_name.endswith(".weight"):
+            ) and mapped_weight_name.endswith(".weight")
+
+            if is_3d_moe_target:
+                # Handle 3D fused MoE weights (e.g., Qwen3-VL-MoE)
+                # Checkpoint shape:
+                #   gate_up_proj: [num_experts, intermediate_size*2, hidden_size]
+                #   down_proj: [num_experts, hidden_size, intermediate_size]
+                # But checkpoint has transposed layout:
+                #   gate_up_proj: [128, 2048, 1536] = [n_exp, out_dim*2, in_dim]
+                #   down_proj: [128, 768, 2048] = [n_exp, out_dim, in_dim]
+                #
+                # FusedMoE expects:
+                #   w13_weight: [num_experts, intermediate_size*2, hidden_size]
+                #   w2_weight: [num_experts, hidden_size, intermediate_size]
+                #
+                # First transpose: [n_exp, dim1, dim2] -> [n_exp, dim2, dim1]
+
+                num_experts = weight_tensor.shape[0]
+
+                # Transpose to match FusedMoE expected layout
+                # This mirrors what qwen3_vl_moe.py does: loaded_weight.transpose(-1, -2)
+                weight_tensor = weight_tensor.transpose(-1, -2).contiguous()
+
+                is_gate_up = "gate_up_proj" in mapped_weight_name
+
+                # For gate_up_proj, we need to split into w1 (gate) and w3 (up)
+                # After transpose: [128, 1536, 2048] for gate_up (1536 = hidden_size, 2048 = intermediate_size*2)
+                # Wait, that's still reversed. Let me recalculate.
+                #
+                # Checkpoint gate_up_proj: [128, 2048, 1536]
+                # After transpose: [128, 1536, 2048]
+                #
+                # FusedMoE w13_weight expects_shape: (num_experts, intermediate_size*2, hidden_size)
+                # With intermediate_size=768, hidden_size=2048:
+                #   expected = [128, 1536, 2048] ✓
+                #
+                # Actually the transposed shape [128, 1536, 2048] matches the expected shape!
+
+                # For 3D MoE weights, we need to quantize each expert separately
+                # and store their quant states
+                quantized_experts = []
+                quant_states_list = []
+
+                # Determine sharding:
+                # gate_up (column parallel): shard on output dim (dim 0 of expert slice)
+                # down (row parallel): shard on input dim (dim -1 of expert slice)
+                is_down_proj = "down_proj" in mapped_weight_name
+
+                for expert_id in range(num_experts):
+                    expert_weight = weight_tensor[expert_id]
+                    # After transpose:
+                    # gate_up expert: [1536, 2048] = [hidden_size, intermediate_size*2]
+                    # down expert: [2048, 768] = [intermediate_size, hidden_size]
+                    #
+                    # Hmm wait, FusedMoE weight layout is [intermediate_size, hidden_size]
+                    # See layer.py line 557-561:
+                    #   experts_shape: (num_experts, intermediate_size * 2, hidden_size)
+                    # The first dim (after num_experts) is the output dim (intermediate)
+                    #
+                    # For gate_up (column parallel): output shard on dim 0
+                    # For down (row parallel): input shard on dim -1
+
+                    # Apply TP sharding per expert if needed
+                    if is_down_proj:
+                        # down_proj is row parallel, shard input (dim -1)
+                        total_size = expert_weight.size(-1)
+                        start_index = total_size // tp_size * tp_rank
+                        end_index = total_size // tp_size * (tp_rank + 1)
+                        expert_weight = expert_weight[..., start_index:end_index]
+                    else:
+                        # gate_up is column parallel, shard output (dim 0)
+                        total_size = expert_weight.size(0)
+                        start_index = total_size // tp_size * tp_rank
+                        end_index = total_size // tp_size * (tp_rank + 1)
+                        expert_weight = expert_weight[start_index:end_index, ...]
+
+                    # Move to GPU and make contiguous
+                    if expert_weight.is_cuda:
+                        loaded_weight = expert_weight
+                    else:
+                        loaded_weight = expert_weight.to(
+                            device=current_platform.device_type
+                        )
+
+                    if loaded_weight.is_contiguous() is False:
+                        loaded_weight = loaded_weight.contiguous()
+
+                    # Quantize
+                    with set_default_torch_dtype(torch.float32):
+                        quantized, quant_state = quantize_4bit(
+                            loaded_weight,
+                            compress_statistics=True,
+                            quant_type="nf4",
+                        )
+                    quantized_experts.append(quantized)
+                    quant_states_list.append(quant_state)
+
+                # Stack quantized experts
+                processed_weight = torch.stack(quantized_experts, dim=0)
+
+                # Store quant states as a list for later fusion
+                quant_state_dict[mapped_weight_name] = quant_states_list
+
+
+            elif is_regular_target:
                 # Without sharding
                 if any(
                     check_match(mapped_weight_name, module)
@@ -446,6 +562,7 @@ class BitsAndBytesModelLoader(BaseModelLoader):
                 processed_weight = weight_tensor
             yield org_weight_name, processed_weight
 
+
     def _get_bnb_target_modules(self, model: nn.Module) -> None:
         """
         Identify and collect all modules that support BitsAndBytes
@@ -481,12 +598,25 @@ class BitsAndBytesModelLoader(BaseModelLoader):
                 # Get the corresponding weight name using module name and
                 # expert_params_mapping.
 
-                for exp in self.expert_params_mapping:
-                    weight_name = exp[1]
-                    rep_name = name.replace("experts", "") + weight_name.removesuffix(
-                        "."
-                    )
-                    self.target_modules.append(rep_name)
+                if self.is_3d_moe_weight:
+                    # For fused 3D MoE weights (e.g., Qwen3-VL-MoE), the checkpoint
+                    # has weights like "experts.gate_up_proj" and "experts.down_proj"
+                    # without the ".weight" suffix and without per-expert indices.
+                    # Add these to target modules for proper quantization.
+                    fused_3d_weight_names = ["gate_up_proj", "down_proj"]
+                    for weight_name in fused_3d_weight_names:
+                        # module name is like "model.language_model.layers.0.mlp.experts"
+                        # We need to add "model.language_model.layers.0.mlp.experts.gate_up_proj"
+                        rep_name = f"{name}.{weight_name}"
+                        self.target_modules.append(rep_name)
+                else:
+                    for exp in self.expert_params_mapping:
+                        weight_name = exp[1]
+                        rep_name = name.replace("experts", "") + weight_name.removesuffix(
+                            "."
+                        )
+                        self.target_modules.append(rep_name)
+
 
         assert self.target_modules, (
             "vLLM currently does not support BNB quantization for"
@@ -514,14 +644,20 @@ class BitsAndBytesModelLoader(BaseModelLoader):
             elif isinstance(module, (RowParallelLinear,)):
                 self.column_sharded_weights_modules.append(name)
             elif isinstance(module, FusedMoE):
-                expert_mapping = self.expert_params_mapping
-                for exp in expert_mapping:
-                    if exp[-1] == "w2":
-                        weight_name = exp[1]
-                        rep_name = name.replace(
-                            "experts", ""
-                        ) + weight_name.removesuffix(".")
-                        self.column_sharded_weights_modules.append(rep_name)
+                if self.is_3d_moe_weight:
+                    # For fused 3D MoE weights, down_proj is row parallel (column sharded)
+                    rep_name = f"{name}.down_proj"
+                    self.column_sharded_weights_modules.append(rep_name)
+                else:
+                    expert_mapping = self.expert_params_mapping
+                    for exp in expert_mapping:
+                        if exp[-1] == "w2":
+                            weight_name = exp[1]
+                            rep_name = name.replace(
+                                "experts", ""
+                            ) + weight_name.removesuffix(".")
+                            self.column_sharded_weights_modules.append(rep_name)
+
 
     def _verify_model_compatibility(
         self, model: nn.Module, model_config: ModelConfig
@@ -572,12 +708,15 @@ class BitsAndBytesModelLoader(BaseModelLoader):
 
         if is_moe_model(model):
             self.expert_params_mapping = get_moe_expert_mapping(model)
-            if not self.expert_params_mapping:
+            # Check if model uses fused 3D MoE weights (e.g., Qwen3-VL-MoE)
+            self.is_3d_moe_weight = getattr(model, "is_3d_moe_weight", False)
+            if not self.expert_params_mapping and not self.is_3d_moe_weight:
                 raise AttributeError(
                     f"MoE Model {type(model).__name__} does not support "
                     "BitsAndBytes quantization yet. Ensure this model has "
                     "'get_expert_mapping' method."
                 )
+
         # For some models like Molmo, we need to use hf_to_vllm_mapper
         # to ensure correct loading of weights.
         if hf_to_vllm_mapper := getattr(model, "hf_to_vllm_mapper", None):
@@ -627,6 +766,10 @@ class BitsAndBytesModelLoader(BaseModelLoader):
         fused representations for w13 and w2.
         """
         from bitsandbytes.functional import QuantState
+
+        if self.is_3d_moe_weight:
+            # Handle 3D MoE weights (e.g., Qwen3-VL-MoE)
+            return self._fuse_3d_moe_quant_states(model, quant_states_dict)
 
         if not self.expert_params_mapping:
             return dict()
@@ -698,6 +841,95 @@ class BitsAndBytesModelLoader(BaseModelLoader):
             expert_qs_dict[w13_weight_name] = w13_qs
             expert_qs_dict[w2_weight_name] = w2_qs
         return expert_qs_dict
+
+    def _fuse_3d_moe_quant_states(
+        self, model: nn.Module, quant_states_dict: dict
+    ) -> dict:
+        """
+        Fuse quant states for 3D MoE weights (e.g., Qwen3-VL-MoE).
+
+        For 3D weights, quant_states_dict contains:
+        - "module.experts.gate_up_proj": list of QuantState per expert
+        - "module.experts.down_proj": list of QuantState per expert
+
+        We need to convert these to:
+        - "module.experts.w13_weight": fused QuantState for gate+up
+        - "module.experts.w2_weight": fused QuantState for down
+        """
+        from bitsandbytes.functional import QuantState
+
+        expert_qs_dict = {}
+        for name, module in model.named_modules():
+            if not isinstance(module, FusedMoE):
+                continue
+
+            # Find the corresponding quant states in the dict
+            gate_up_key = f"{name}.gate_up_proj"
+            down_key = f"{name}.down_proj"
+
+            if gate_up_key not in quant_states_dict:
+                continue
+
+            gate_up_states = quant_states_dict[gate_up_key]  # list of QuantState
+            down_states = quant_states_dict[down_key]  # list of QuantState
+
+            # Dequantize nested states
+            for qs in gate_up_states:
+                self._dequantize_dq(qs)
+            for qs in down_states:
+                self._dequantize_dq(qs)
+
+            # For gate_up_proj, each expert's state covers both gate and up
+            # The shape is [intermediate_size * 2, hidden_size] after transpose
+            # We need to split and interleave
+            w13_absmax_lst = []
+            w13_total_dim0 = 0
+            for qs in gate_up_states:
+                # Each gate_up_proj quant state covers both w1 (gate) and w3 (up)
+                # The absmax is for the combined weight
+                w13_absmax_lst.append(qs.absmax)
+                w13_total_dim0 += qs.shape[0]
+
+            w2_absmax_lst = []
+            w2_total_dim0 = 0
+            for qs in down_states:
+                w2_absmax_lst.append(qs.absmax)
+                w2_total_dim0 += qs.shape[0]
+
+            w13_absmax = torch.cat(w13_absmax_lst)
+            w2_absmax = torch.cat(w2_absmax_lst)
+
+            # Create fused quantization state for w13
+            w13_qs = QuantState(
+                absmax=w13_absmax,
+                shape=(w13_total_dim0, gate_up_states[0].shape[1]),
+                code=gate_up_states[0].code,
+                blocksize=gate_up_states[0].blocksize,
+                quant_type="nf4",
+                dtype=gate_up_states[0].dtype,
+            )
+
+            # Create fused quantization state for w2
+            w2_qs = QuantState(
+                absmax=w2_absmax,
+                shape=(w2_total_dim0, down_states[0].shape[1]),
+                code=down_states[0].code,
+                blocksize=down_states[0].blocksize,
+                quant_type="nf4",
+                dtype=down_states[0].dtype,
+            )
+
+            w13_weight_name = name + ".w13_weight"
+            w2_weight_name = name + ".w2_weight"
+            expert_qs_dict[w13_weight_name] = w13_qs
+            expert_qs_dict[w2_weight_name] = w2_qs
+
+            # Remove original keys
+            del quant_states_dict[gate_up_key]
+            del quant_states_dict[down_key]
+
+        return expert_qs_dict
+
 
     def _stack_quantization_states(
         self, model: nn.Module, quant_state_dict: dict

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -242,48 +242,35 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
                     if is_pp_missing_parameter(name_mapped, self):
                         continue
                     if is_fused_expert:
-                        # Check if this is a BNB quantized weight
-                        param = params_dict.get(name_mapped)
-                        is_bnb_quantized = (
-                            param is not None
-                            and getattr(param, "use_bitsandbytes_4bit", False)
-                        )
-
-                        if is_bnb_quantized:
-                            # BNB loader already quantized and properly shaped
-                            # the 3D MoE weights. Just copy directly.
-                            # The weight shape is [num_experts, quantized_size, 1]
-                            param.data.copy_(loaded_weight)
-                            success = True
+                        # For fused expert weights, use standard loading path
+                        # BNB-specific logic is now handled in bitsandbytes_loader.py
+                        loaded_weight = loaded_weight.transpose(-1, -2)  # no bias
+                        if "experts.gate_up_proj" in name:
+                            loaded_weight = loaded_weight.chunk(2, dim=-2)
+                            success_w1 = self.load_fused_expert_weights(
+                                name_mapped,
+                                params_dict,
+                                loaded_weight[0],
+                                "w1",
+                                num_experts,
+                            )
+                            success_w3 = self.load_fused_expert_weights(
+                                name_mapped,
+                                params_dict,
+                                loaded_weight[1],
+                                "w3",
+                                num_experts,
+                            )
+                            success = success_w1 and success_w3
                         else:
-                            # Non-BNB path: transpose and chunk as before
-                            loaded_weight = loaded_weight.transpose(-1, -2)  # no bias
-                            if "experts.gate_up_proj" in name:
-                                loaded_weight = loaded_weight.chunk(2, dim=-2)
-                                success_w1 = self.load_fused_expert_weights(
-                                    name_mapped,
-                                    params_dict,
-                                    loaded_weight[0],
-                                    "w1",
-                                    num_experts,
-                                )
-                                success_w3 = self.load_fused_expert_weights(
-                                    name_mapped,
-                                    params_dict,
-                                    loaded_weight[1],
-                                    "w3",
-                                    num_experts,
-                                )
-                                success = success_w1 and success_w3
-                            else:
-                                # down_proj
-                                success = self.load_fused_expert_weights(
-                                    name_mapped,
-                                    params_dict,
-                                    loaded_weight,
-                                    shard_id,
-                                    num_experts,
-                                )
+                            # down_proj
+                            success = self.load_fused_expert_weights(
+                                name_mapped,
+                                params_dict,
+                                loaded_weight,
+                                shard_id,
+                                num_experts,
+                            )
 
                     else:
                         # Skip loading extra parameters for GPTQ/modelopt models
@@ -359,7 +346,7 @@ class Qwen3MoeLLMForCausalLM(Qwen3MoeForCausalLM):
             quant_config=self.quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
-        if self.config.tie_word_embeddings:
+        if getattr(self.config, "tie_word_embeddings", False):
             self.lm_head.weight = self.model.embed_tokens.weight
         self.logits_processor = LogitsProcessor(self.config.vocab_size)
         self.make_empty_intermediate_tensors = (


### PR DESCRIPTION
## Purpose
Starting the vLLM server with the Qwen/Qwen3-VL-30B-A3B-Instruct using bitsandbytes quantization format seems to fail while loading the weights due to quantization issues. 

FIX https://github.com/vllm-project/vllm/issues/32012
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] Fixes https://github.com/vllm-project/vllm/issues/32012
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Adds end-to-end handling for fused 3D MoE checkpoints (e.g., `Qwen3-VL-MoE`) in the BNB 4-bit loader and model.
> 
> - Introduces `is_3d_moe_weight` flag; detects 3D MoE weights (`experts.gate_up_proj`, `experts.down_proj`) without `.weight` suffix and adds them to `target_modules`.
> - In `bitsandbytes_loader.py` 4-bit path: per-expert transpose, TP-aware sharding (column for `gate_up_proj`, row for `down_proj`), per-expert quantization, stacking, and storage of per-expert quant states.
> - Adds `_fuse_3d_moe_quant_states` to consolidate per-expert `gate_up_proj` and `down_proj` quant states into fused `w13_weight` and `w2_weight`; integrates with existing MoE fusion flow.
> - Updates sharding classification so `experts.down_proj` is treated as column-sharded under 3D MoE.
> - In `qwen3_vl_moe.py`: during weight load, if BNB-quantized fused 3D MoE tensors are present, copy directly to params; otherwise fall back to prior transpose/chunk expert-loading path.
> - Minor plumbing: propagate `is_3d_moe_weight` from model; ensure compatibility checks and target module discovery account for 3D MoE.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5191ee650862f75858721dd5218e76d88488ed1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit ba68ff9216e192a0dffe9bf8d9a7f2d9ea251256. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Adds end-to-end handling of fused 3D MoE checkpoints in the BNB 4-bit path.
> 
> - Introduces `is_3d_moe_weight` and treats `experts.gate_up_proj`/`experts.down_proj` (no `.weight`) as BNB targets; updates sharding classification so `down_proj` is column-sharded
> - In `bitsandbytes_loader.py`: per-expert transpose, TP-aware sharding (column for `gate_up_proj`, row for `down_proj`), per-expert 4-bit quantization, stacking, and storage of per-expert quant states
> - Adds `_fuse_3d_moe_quant_states` to convert per-expert states into fused `w13_weight` and `w2_weight`; integrates with existing MoE fusion flow
> - Propagates model flag and updates compatibility/target-module discovery to account for 3D MoE
> - In `qwen3_vl_moe.py`: when BNB-quantized fused 3D MoE tensors are present, copy directly into params; otherwise fall back to prior transpose/chunk expert-loading logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba68ff9216e192a0dffe9bf8d9a7f2d9ea251256. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Adds end-to-end handling for fused 3D MoE checkpoints in the BNB 4-bit path.
> 
> - Introduces `is_3d_moe_weight` and treats `experts.gate_up_proj`/`experts.down_proj` (no `.weight`) as BNB targets; updates target-module discovery and compatibility checks
> - Implements per-expert transpose, TP-aware sharding (column for `gate_up_proj`, row for `down_proj`), per-expert 4-bit quantization, stacking, and storage of per-expert quant states in `bitsandbytes_loader.py`
> - Adds `_fuse_3d_moe_quant_states` to fuse per-expert states into `w13_weight` and `w2_weight`; integrates with `_fuse_moe_quant_states`
> - Classifies `experts.down_proj` as column-sharded under 3D MoE
> - In `qwen3_vl_moe.py` `load_weights`, directly copies BNB-quantized fused 3D MoE tensors into params; otherwise falls back to previous transpose/chunk expert-loading
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba68ff9216e192a0dffe9bf8d9a7f2d9ea251256. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
