### PR TITLE
[Model] Remove redundant None check in DeepSeekOCR image input processing

### DIFF
--- a/vllm/model_executor/models/deepseek_ocr.py
+++ b/vllm/model_executor/models/deepseek_ocr.py
@@ -437,19 +437,16 @@ class DeepseekOCRForCausalLM(nn.Module, SupportsMultiModal, SupportsPP, Supports
         if pixel_values is None or torch.sum(pixel_values).item() == 0:
             return None
 
-        if pixel_values is not None:
-            base_size = self.vision_config.image_size
-            return DeepseekOCRImagePixelInputs(
-                type="pixel_values",
-                data=pixel_values,
-                images_crop=images_crop,
-                images_spatial_crop=images_spatial_crop,
-                resolve_bindings={
-                    "base_size": base_size,
-                },
-            )
-
-        raise AssertionError("This line should be unreachable.")
+        base_size = self.vision_config.image_size
+        return DeepseekOCRImagePixelInputs(
+            type="pixel_values",
+            data=pixel_values,
+            images_crop=images_crop,
+            images_spatial_crop=images_spatial_crop,
+            resolve_bindings={
+                "base_size": base_size,
+            },
+        )
 
     def _encode_global_features(self, image_tensor: torch.Tensor) -> torch.Tensor:
         global_features_1 = self.sam_model(image_tensor)


### PR DESCRIPTION

## Purpose
Remove redundant `if pixel_values is not None` check and unreachable assertion in `DeepseekOCRImagePixelInputs._parse_image_pixel_values`.

Line 437-438 already handles the `pixel_values` is None case with an early return

This cleanup improves code readability and removes unnecessary branching


## Test Plan

## Test Result

---

> [!NOTE]
> Cleans up image input handling in `deepseek_ocr.py` for readability.
> 
> - Simplifies `_parse_and_validate_image_input`: early-returns when `pixel_values` is `None` or zeroed; otherwise always builds `DeepseekOCRImagePixelInputs`
> - Deletes unreachable assertion and redundant `if pixel_values is not None` branch to streamline control flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0eaaca2b76c8b7b84b027fef9d3a03f22c8cc27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
