### PR TITLE
[Misc] Hash keys only when value is `None` in kwargs

### DIFF
--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -98,6 +98,8 @@ class MultiModalHasher:
         key: str,
         obj: object,
     ) -> Iterable[bytes | memoryview]:
+        if obj is None:
+            return
         # Recursive cases
         if isinstance(obj, (list, tuple)):
             for i, elem in enumerate(obj):

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -99,6 +99,7 @@ class MultiModalHasher:
         obj: object,
     ) -> Iterable[bytes | memoryview]:
         if obj is None:
+            yield key.encode("utf-8")
             return
         # Recursive cases
         if isinstance(obj, (list, tuple)):


### PR DESCRIPTION
## Purpose
It's not guaranteed that multimodal kwargs always have non-`None` values. When this happens every request will produce serialization warning which isn't helpful. This PR modifies so that the hasher hashes keys only for such key-value pairs when value is `None`

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Ignores `None` values during multimodal kwargs hashing to prevent noisy serialization warnings.
> 
> - Update `MultiModalHasher.iter_item_to_bytes` to return early when `obj is None`, effectively excluding such entries from hashing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2150c32515e90ed491e7ac237a31bb6ba5436dba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Adjusts multimodal kwargs hashing to gracefully handle `None` values and avoid serialization warnings.
> 
> - In `MultiModalHasher.iter_item_to_bytes`, short-circuits when `obj is None`, yielding only the `key` bytes and skipping value serialization
> - Changes confined to `vllm/multimodal/hasher.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37e2d389cb79df241048cadda62971ddba226f5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
