### PR TITLE
[Doc] Remove hardcoded Whisper in example openai translation client

### DIFF
--- a/examples/online_serving/openai_translation_client.py
+++ b/examples/online_serving/openai_translation_client.py
@@ -9,11 +9,11 @@ from openai import OpenAI
 from vllm.assets.audio import AudioAsset
 
 
-def sync_openai(audio_path: str, client: OpenAI):
+def sync_openai(audio_path: str, client: OpenAI, model: str):
     with open(audio_path, "rb") as f:
         translation = client.audio.translations.create(
             file=f,
-            model="openai/whisper-large-v3",
+            model=model,
             response_format="json",
             temperature=0.0,
             # Additional params not provided by OpenAI API.
@@ -26,11 +26,13 @@ def sync_openai(audio_path: str, client: OpenAI):
         print("translation result:", translation.text)
 
 
-async def stream_openai_response(audio_path: str, base_url: str, api_key: str):
+async def stream_openai_response(
+    audio_path: str, base_url: str, api_key: str, model: str
+):
     data = {
         "language": "it",
         "stream": True,
-        "model": "openai/whisper-large-v3",
+        "model": model,
     }
     url = base_url + "/audio/translations"
     headers = {"Authorization": f"Bearer {api_key}"}
@@ -66,9 +68,13 @@ def main():
         api_key=openai_api_key,
         base_url=openai_api_base,
     )
-    sync_openai(foscolo, client)
+
+    model = client.models.list().data[0].id
+    print(f"Using model: {model}")
+
+    sync_openai(foscolo, client, model)
     # Run the asynchronous function
-    asyncio.run(stream_openai_response(foscolo, openai_api_base, openai_api_key))
+    asyncio.run(stream_openai_response(foscolo, openai_api_base, openai_api_key, model))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## Purpose
- Avoid hardcoded `openai/whisper-large-v3` in `openai_translation_client.py`, so that we can test other model's translation API easily.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Updates the example to support any available model instead of a fixed Whisper variant.
> 
> - Removes hardcoded `openai/whisper-large-v3`; `sync_openai` and `stream_openai_response` now take a `model` parameter and forward it to requests
> - In `main`, selects the first available model via `client.models.list().data[0].id`, logs it, and passes it to both sync and streaming paths
> - Streaming payload updated to include the provided `model`; no other behavioral changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 695ce7d81b5aefcceef6b7d7ba07c0372db9211f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Makes the example translation client model-agnostic.
> 
> - `sync_openai` and `stream_openai_response` now accept a `model` parameter and forward it to the request/payload
> - `main` selects the first available model via `client.models.list().data[0].id`, logs it, and uses it for both paths
> - Removes hardcoded `openai/whisper-large-v3`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fefd738bbc538ee5fd944c65d4856364e4c17f34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
