### PR TITLE
[Refactor] Remove numpy split in async scheduling

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -511,14 +511,11 @@ class AsyncLLM(EngineClient):
                     # event loop for too long.
                     engine_core_outputs = outputs.outputs
                     for start in range(0, num_outputs, chunk_size):
-                        end = min(start + chunk_size, num_outputs)
+                        end = start + chunk_size
+                        outputs_slice = engine_core_outputs[start:end]
                         # 2) Process EngineCoreOutputs.
                         processed_outputs = output_processor.process_outputs(
-                            engine_core_outputs,
-                            outputs.timestamp,
-                            iteration_stats,
-                            start_idx=start,
-                            end_idx=end,
+                            outputs_slice, outputs.timestamp, iteration_stats
                         )
                         # NOTE: RequestOutputs are pushed to their queues.
                         assert not processed_outputs.request_outputs

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -9,7 +9,6 @@ from collections.abc import AsyncGenerator, Iterable, Mapping
 from copy import copy
 from typing import Any, cast
 
-import numpy as np
 import torch
 
 import vllm.envs as envs
@@ -32,7 +31,6 @@ from vllm.transformers_utils.config import maybe_register_config_serialize_by_va
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.async_utils import cancel_task_threadsafe
 from vllm.utils.collection_utils import as_list
-from vllm.utils.math_utils import cdiv
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.core_client import EngineCoreClient
 from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
@@ -510,15 +508,11 @@ class AsyncLLM(EngineClient):
                     # Split outputs into chunks of at most
                     # VLLM_V1_OUTPUT_PROC_CHUNK_SIZE, so that we don't block the
                     # event loop for too long.
-                    if num_outputs <= envs.VLLM_V1_OUTPUT_PROC_CHUNK_SIZE:
-                        slices = (outputs.outputs,)
-                    else:
-                        slices = np.array_split(
-                            outputs.outputs,
-                            cdiv(num_outputs, envs.VLLM_V1_OUTPUT_PROC_CHUNK_SIZE),
-                        )
-
-                    for i, outputs_slice in enumerate(slices):
+                    chunk_size = envs.VLLM_V1_OUTPUT_PROC_CHUNK_SIZE
+                    engine_core_outputs = outputs.outputs
+                    for start in range(0, num_outputs, chunk_size):
+                        end = start + chunk_size
+                        outputs_slice = engine_core_outputs[start:end]
                         # 2) Process EngineCoreOutputs.
                         processed_outputs = output_processor.process_outputs(
                             outputs_slice, outputs.timestamp, iteration_stats
@@ -527,7 +521,7 @@ class AsyncLLM(EngineClient):
                         assert not processed_outputs.request_outputs
 
                         # Allow other asyncio tasks to run between chunks
-                        if i + 1 < len(slices):
+                        if end < num_outputs:
                             await asyncio.sleep(0)
 
                         # 3) Abort any reqs that finished due to stop strings.


### PR DESCRIPTION
## Purpose

Remove numpy split in async scheduling and got performance improvement a little bit

## Test

`export MODEL="zai-org/GLM-4.7-FP8"`

`vllm serve $MODEL -tp 8   --port 9256 --enable-expert-parallel --max_num_seqs 128`

`lm_eval --model local-completions --model_args "base_url=http://127.0.0.1:9256/v1/completions,model=$MODEL,num_concurrent=1024" --tasks gsm8k`

```bash
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9447|±  |0.0063|
|     |       |strict-match    |     5|exact_match|↑  |0.9424|±  |0.0064|
```

Doesn't affect too much for E2E throughput

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 5f7bd8757a5b2f1eee94b3e1f729a2f4e7f328e5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Simplifies async output processing by removing NumPy-based chunking.
> 
> - Replaces `np.array_split` and `cdiv` with a `for` loop over `range(0, num_outputs, chunk_size)` using Python slicing in `AsyncLLM._run_output_handler`
> - Drops `numpy` and `cdiv` imports
> - Maintains chunked processing behavior and cooperative `await asyncio.sleep(0)` between chunks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f7bd8757a5b2f1eee94b3e1f729a2f4e7f328e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Refactors the async output handling hot path to avoid NumPy for chunking.
> 
> - In `AsyncLLM._run_output_handler`, iterate over `range(0, num_outputs, chunk_size)` and pass `start_idx`/`end_idx` to `output_processor.process_outputs`, using `chunk_size = envs.VLLM_V1_OUTPUT_PROC_CHUNK_SIZE`.
> - Removes `numpy` and `cdiv` usage/imports; maintains cooperative `await asyncio.sleep(0)` between chunks.
> 
> This change reduces dependencies and keeps chunked processing behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b69497f47efa10031e024e893b345b057b45e3de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Simplifies async output processing by removing NumPy-based chunking.
> 
> - Refactors `AsyncLLM._run_output_handler` to iterate `range(0, num_outputs, chunk_size)` and slice `outputs` instead of using `np.array_split`/`cdiv`
> - Introduces local `chunk_size = envs.VLLM_V1_OUTPUT_PROC_CHUNK_SIZE`; preserves cooperative `await asyncio.sleep(0)` between chunks
> - Removes `numpy` and `cdiv` imports from `async_llm.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c59c31620abe9281a8604cdf3cfa40910812b26e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
