### PR TITLE
[Docs] Add docs about OOT Quantization Plugins

### DIFF
--- a/docs/features/quantization/README.md
+++ b/docs/features/quantization/README.md
@@ -204,29 +204,4 @@ from vllm import LLM
 llm = LLM(model="your-model", quantization="my_quant")
 ```
 
-### Creating a Distributable Plugin
-
-To distribute your quantization method as a pip-installable package, use Python entry points:
-
-```python
-# setup.py
-from setuptools import setup
-
-setup(
-    name='vllm_my_quant',
-    version='0.1',
-    packages=['vllm_my_quant'],
-    entry_points={
-        'vllm.general_plugins': [
-            "register_my_quant = vllm_my_quant:register"
-        ]
-    }
-)
-
-# vllm_my_quant/__init__.py
-def register():
-    # Import to trigger the @register_quantization_config decorator
-    from vllm_my_quant.my_quant_config import MyQuantConfig
-```
-
 For more information on the plugin system, see the [Plugin System documentation](../../design/plugin_system.md).

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -187,5 +187,6 @@ __all__ = [
     "QuantizationConfig",
     "QuantizationMethods",
     "get_quantization_config",
+    "register_quantization_config",
     "QUANTIZATION_METHODS",
 ]


### PR DESCRIPTION

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Introduces documentation for creating and using custom, out-of-tree quantization methods, including examples, required interfaces, MoE support, and packaging via Python entry points.
> 
> - Adds an "**Out-of-Tree Quantization Plugins**" section to `docs/features/quantization/README.md` with examples for `QuantizationConfig`, `QuantizeMethodBase`, and MoE (`FusedMoEMethodBase`) implementations, plus usage and distribution guidance
> - Exports `register_quantization_config` from `vllm/model_executor/layers/quantization/__init__.py` to enable `from vllm.model_executor.layers.quantization import register_quantization_config`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57d7f93619f853fc5c41ac668c0754e6ab9ed44d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces guidance and API surface for custom, out-of-tree quantization plugins.
> 
> - Adds an **Out-of-Tree Quantization Plugins** section to `docs/features/quantization/README.md` with examples for `QuantizationConfig`, `QuantizeMethodBase`, and MoE (`FusedMoEMethodBase`) integration, plus usage instructions
> - Exports `register_quantization_config` from `vllm/model_executor/layers/quantization/__init__.py` (added to `__all__`) to enable `from vllm.model_executor.layers.quantization import register_quantization_config`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ca663a5335cb69e78130326de5b8a38b49b2155. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Adds documentation and a small API surface tweak enabling custom quantization plugins.
> 
> - New "Out-of-Tree Quantization Plugins" section in `docs/features/quantization/README.md` with examples for `QuantizationConfig`, linear (`UnquantizedLinearMethod`) and MoE (`FusedMoEMethodBase`) implementations, plus usage
> - Exposes `register_quantization_config` via `vllm/model_executor/layers/quantization/__init__.py` (`__all__`), enabling `from vllm.model_executor.layers.quantization import register_quantization_config`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 242516655db29eec8bb7ed80b695b1b31794f31c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
