### PR TITLE
AMD CI Test - unskip moe_sum test and moe_align_block_size tests

### DIFF
--- a/tests/kernels/moe/test_moe.py
+++ b/tests/kernels/moe/test_moe.py
@@ -1161,7 +1161,6 @@ def test_batched_moe_align_block_size_opcheck():
 @pytest.mark.parametrize("topk", TOP_KS)
 @pytest.mark.parametrize("k", [128, 511, 1024])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
-@pytest.mark.skipif(current_platform.is_rocm(), reason="Skip for rocm")
 def test_moe_sum(m: int, topk: int, k: int, dtype: torch.dtype):
     input = torch.randn((m, topk, k), device="cuda", dtype=dtype)
     actual = torch.empty((m, k), device="cuda", dtype=dtype)

--- a/tests/kernels/moe/test_moe_align_block_size.py
+++ b/tests/kernels/moe/test_moe_align_block_size.py
@@ -12,7 +12,6 @@ from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
     batched_moe_align_block_size,
     moe_align_block_size,
 )
-from vllm.platforms import current_platform
 from vllm.utils.math_utils import round_up
 from vllm.utils.torch_utils import set_random_seed
 
@@ -185,7 +184,6 @@ def torch_moe_align_block_size(
 @pytest.mark.parametrize("num_experts", NUM_EXPERTS)
 @pytest.mark.parametrize("block_size", BLOCK_SIZES)
 @pytest.mark.parametrize("pad_sorted_ids", [False, True])
-@pytest.mark.skipif(current_platform.is_rocm(), reason="Skip for rocm")
 def test_moe_align_block_size(
     m: int, topk: int, num_experts: int, block_size: int, pad_sorted_ids: bool
 ):
@@ -245,7 +243,6 @@ def test_moe_align_block_size(
 @pytest.mark.parametrize("topk", [2, 4])
 @pytest.mark.parametrize("num_experts", [8, 64])
 @pytest.mark.parametrize("block_size", [64])
-@pytest.mark.skipif(current_platform.is_rocm(), reason="Skip for rocm")
 def test_moe_align_block_size_with_expert_map(
     m: int, topk: int, num_experts: int, block_size: int
 ):

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -188,6 +188,27 @@ class RocmPlatform(Platform):
         supported_quantization += ["bitsandbytes"]
 
     @classmethod
+    def import_kernels(cls) -> None:
+        """Import ROCm-specific kernels."""
+        import contextlib
+        
+        # Import main C extension
+        try:
+            import vllm._C  # noqa: F401
+        except ImportError as e:
+            from vllm.logger import init_logger
+            logger = init_logger(__name__)
+            logger.warning("Failed to import from vllm._C: %r", e)
+        
+        # Import MOE C extension - ROCm supports MOE operations
+        with contextlib.suppress(ImportError):
+            import vllm._moe_C  # noqa: F401
+        
+        # Import ROCm-specific extension
+        with contextlib.suppress(ImportError):
+            import vllm._rocm_C  # noqa: F401
+
+    @classmethod
     def get_attn_backend_cls(
         cls,
         selected_backend: "AttentionBackendEnum",

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -190,20 +190,10 @@ class RocmPlatform(Platform):
     @classmethod
     def import_kernels(cls) -> None:
         """Import ROCm-specific kernels."""
+        super().import_kernels()
+
         import contextlib
-        
-        # Import main C extension
-        try:
-            import vllm._C  # noqa: F401
-        except ImportError as e:
-            from vllm.logger import init_logger
-            logger = init_logger(__name__)
-            logger.warning("Failed to import from vllm._C: %r", e)
-        
-        # Import MOE C extension - ROCm supports MOE operations
-        with contextlib.suppress(ImportError):
-            import vllm._moe_C  # noqa: F401
-        
+
         # Import ROCm-specific extension
         with contextlib.suppress(ImportError):
             import vllm._rocm_C  # noqa: F401


### PR DESCRIPTION
## Purpose

To test AMD CI by enabling one skipped test.


Summary of Changes
1. Fixed test_moe.py and test_moe_align_block_size.py to unskip it on ROCm
Removed unnecessary @pytest.mark.skipif(current_platform.is_rocm()) from test_moe_sum, test_moe_align_block_size, 
test_moe_align_block_size_with_expert_map

2. Fixed vllm/platforms/rocm.py 
Added import_kernels() method to RocmPlatform class
This ensures _moe_C extension is loaded automatically on ROCm
Matches the pattern used by XPUPlatform and base Platform class

This fixed the error when running the test 
```
 E               AttributeError: '_OpNamespace' '_moe_C' object has no attribute 'moe_sum'
```
## Test Plan

```
 pytest -v -s tests/kernels/moe/test_moe.py::test_moe_sum
```

Output:

```
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-128-2-1] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-128-2-33] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-128-2-222] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-128-6-1] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-128-6-33] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-128-6-222] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-511-2-1] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-511-2-33] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-511-2-222] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-511-6-1] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-511-6-33] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-511-6-222] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-1024-2-1] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-1024-2-33] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-1024-2-222] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-1024-6-1] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-1024-6-33] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype0-1024-6-222] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-128-2-1] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-128-2-33] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-128-2-222] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-128-6-1] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-128-6-33] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-128-6-222] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-511-2-1] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-511-2-33] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-511-2-222] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-511-6-1] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-511-6-33] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-511-6-222] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-1024-2-1] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-1024-2-33] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-1024-2-222] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-1024-6-1] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-1024-6-33] PASSED
tests/kernels/moe/test_moe.py::test_moe_sum[dtype1-1024-6-222] PASSED

========================================= warnings summary ==========================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/kernels/moe/test_moe.py:779
  /workspace/vllm/tests/kernels/moe/test_moe.py:779: PytestUnknownMarkWarning: Unknown pytest.mark.flaky - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.flaky(reruns=2)

tests/kernels/moe/test_moe.py:899
  /workspace/vllm/tests/kernels/moe/test_moe.py:899: PytestUnknownMarkWarning: Unknown pytest.mark.flaky - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.flaky(reruns=2)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================== 36 passed, 4 warnings in 17.53s ==================================

```

and
```
pytest -v -s tests/kernels/moe/test_moe_align_block_size.py
```

```
================================ 429 passed, 2 warnings in 191.65s (0:03:11) ================================
```



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---


> [!NOTE]
> Enables ROCm MOE ops at runtime and validates them in CI.
> 
> - Added `RocmPlatform.import_kernels()` to import ROCm extensions (calls `super().import_kernels()` and conditionally imports `vllm._rocm_C`)
> - Removed ROCm skip from `tests/kernels/moe/test_moe.py::test_moe_sum` to exercise `torch.ops._moe_C.moe_sum` on ROCm
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a961723fa3e3caec8c568c637efe1151ff12fe4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 2f9678ce316add7000fbe90c93b62bce7d0fa138. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures ROCm MOE ops are registered and exercised in CI.
> 
> - Add `RocmPlatform.import_kernels()` to import `vllm._rocm_C` (with `contextlib.suppress`) after calling `super().import_kernels()`
> - Unskip ROCm in `tests/kernels/moe/test_moe.py::test_moe_sum` and `tests/kernels/moe/test_moe_align_block_size.py` (remove `skipif` and unused `current_platform` import)
> - Validates `torch.ops._moe_C.moe_sum` and `moe_align_block_size` run on ROCm
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f9678ce316add7000fbe90c93b62bce7d0fa138. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
