### PR TITLE
[Doc] Update NVIDIA PyTorch Docker image in gpu.cuda.inc.md since it seems outdated

### DIFF
--- a/docs/getting_started/installation/gpu.cuda.inc.md
+++ b/docs/getting_started/installation/gpu.cuda.inc.md
@@ -207,7 +207,7 @@ docker run \
     --gpus all \
     -it \
     --rm \
-    --ipc=host nvcr.io/nvidia/pytorch:23.10-py3
+    --ipc=host nvcr.io/nvidia/pytorch:25.12-py3
 ```
 
 If you don't want to use docker, it is recommended to have a full installation of CUDA Toolkit. You can download and install it from [the official website](https://developer.nvidia.com/cuda-toolkit-archive). After installation, set the environment variable `CUDA_HOME` to the installation path of CUDA Toolkit, and make sure that the `nvcc` compiler is in your `PATH`, e.g.:


### PR DESCRIPTION
The NVIDIA PyTorch Docker image link in `gpu.cuda.inc.md` seems outdated, since when trying this along with `pip install -e .` doesn't work, and results in a `setuptools` error, but when switching to the more recent version, everything works.

---

> [!NOTE]
> Updates the recommended NVIDIA PyTorch Docker image in `gpu.cuda.inc.md` to a newer tag for build troubleshooting.
> 
> - Changes `docker run` example to use `nvcr.io/nvidia/pytorch:25.12-py3` instead of `23.10-py3`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca14c18565c891eba6a3ae5ce02b6163ec918615. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
