### PR TITLE
make assume_32_bit_indexing configurable

### DIFF
--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -504,7 +504,9 @@ def _support_torch_compile(
         # assume_32bit_indexing is only available in torch 2.10.0.dev+
         inductor_config_patches = {}
         if is_torch_equal_or_newer("2.10.0.dev"):
-            inductor_config_patches["assume_32bit_indexing"] = True
+            inductor_config_patches["assume_32bit_indexing"] = (
+                self.compilation_config.dynamic_shapes_config.assume_32_bit_indexing
+            )
 
         with (
             patch.object(

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -275,7 +275,11 @@ class DynamicShapesConfig:
     artifacts also.
     When type is backed, aot_compile must be disabled for this mode to work.
     until this change picked up https://github.com/pytorch/pytorch/pull/169239.
+    """
 
+    assume_32_bit_indexing: bool = True
+    """
+    whether all tensor sizes can use 32 bit indexing.
     """
 
     def compute_hash(self) -> str:
@@ -636,6 +640,7 @@ class CompilationConfig:
             "compilation_time",
             "static_forward_context",
             "pass_config",  # handled separately below
+            "dynamic_shapes_config",  # handled separately below
         }
 
         from vllm.config.utils import get_hash_factors, hash_factors
@@ -643,6 +648,7 @@ class CompilationConfig:
         factors = get_hash_factors(self, ignored_factors)
 
         factors["pass_config"] = self.pass_config.compute_hash()
+        factors["dynamic_shapes_config"] = self.dynamic_shapes_config.compute_hash()
         return hash_factors(factors)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Some meta internal models requires 64 bit indexing for compilation! , this way allow them to override the default config.
also address compilation config hashing issue reported by AI? 

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 106dbf229af2a5584e9968aaa238e0b3a8f7e636. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces a config toggle for Inductor indexing assumptions and wires it into the compile path.
> 
> - Adds `assume_32_bit_indexing: bool` to `DynamicShapesConfig` (defaults to True)
> - In `decorators.py`, sets `torch._inductor.config.assume_32bit_indexing` from `dynamic_shapes_config.assume_32_bit_indexing` when Torch ≥ 2.10.0.dev
> - Minor docstring fix in `DynamicShapesConfig` comments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b42a4fe2397e9a7de2211105aa8a6877589963f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 5b42a4fe2397e9a7de2211105aa8a6877589963f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces a toggle to control Inductor’s indexing width and wires it through the compile path.
> 
> - Adds `assume_32_bit_indexing: bool` (default `True`) to `DynamicShapesConfig` with docs
> - In `decorators.py`, sets `torch._inductor.config.assume_32bit_indexing` from `dynamic_shapes_config.assume_32_bit_indexing` when Torch ≥ `2.10.0.dev`
> - Minor docstring fix in `DynamicShapesConfig` comments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b42a4fe2397e9a7de2211105aa8a6877589963f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
