### PR TITLE
[Core] Use weights_only=True with torch.load

### DIFF
--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -762,7 +762,7 @@ def tensorize_lora_adapter(lora_path: str, tensorizer_config: TensorizerConfig):
     if tensor_path.endswith(".safetensors"):
         tensors = safetensors.torch.load_file(tensor_path)
     elif tensor_path.endswith(".bin"):
-        tensors = torch.load(tensor_path)
+        tensors = torch.load(tensor_path, weights_only=True)
     else:
         raise ValueError("Unsupported file: %s", tensor_path)
 


### PR DESCRIPTION
This code neglected to use `weights_only=True` with `torch.load()`.
This is unsafe if used on potentially untrusted model data. We should
always be using `weights_only=True` unless necessary.

It turns out that the default changed to `True` as of PyTorch 2.6, so
this isn't a security vulnerability, but we explicitly set it to
`True` everywhere else, so change it here for consistency. This also
prevents it from getting flagged by security scanners, which is how I
came aware of it via a private report.

https://docs.pytorch.org/docs/stable/notes/serialization.html#weights-only

Signed-off-by: Russell Bryant <rbryant@redhat.com>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 359c21590e22abfa488c2b5d0e28351bb615b8b5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Hardens LoRA adapter tensorization by restricting PyTorch deserialization to weights only.
> 
> - In `tensorizer.py` (`tensorize_lora_adapter`), `torch.load()` for `.bin` files now uses `weights_only=True` to avoid unpickling arbitrary code during weight load
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 359c21590e22abfa488c2b5d0e28351bb615b8b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Hardens LoRA adapter deserialization.
> 
> - In `tensorizer.py` (`tensorize_lora_adapter`), `.bin` adapter loads now call `torch.load(..., weights_only=True)`, reducing unpickling risk and aligning with other usages
> - `.safetensors` path unchanged; no other files modified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 392dd25705850920ee9a3f67c454d06a55e2ba7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
