### PR TITLE
[2/N][Attention] Fix pre-commit errors

### DIFF
--- a/tools/pre_commit/mypy.py
+++ b/tools/pre_commit/mypy.py
@@ -74,8 +74,6 @@ EXCLUDE = [
     "vllm/model_executor/layers/fla/ops",
     # Ignore triton kernels in ops.
     "vllm/v1/attention/ops",
-    # TODO(matt): remove.
-    "vllm/v1/attention/backends/fa_utils.py",
 ]
 
 

--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -7,10 +7,7 @@ from vllm.platforms import current_platform
 logger = init_logger(__name__)
 
 if current_platform.is_cuda():
-    from vllm import _custom_ops
-
-    ops = _custom_ops
-    reshape_and_cache_flash = ops.reshape_and_cache_flash
+    from vllm._custom_ops import reshape_and_cache_flash
     from vllm.vllm_flash_attn import (  # type: ignore[attr-defined]
         flash_attn_varlen_func,
         get_scheduler_metadata,
@@ -19,10 +16,9 @@ if current_platform.is_cuda():
 elif current_platform.is_xpu():
     from vllm._ipex_ops import ipex_ops
 
-    ops = ipex_ops
-    reshape_and_cache_flash = ops.reshape_and_cache_flash
-    flash_attn_varlen_func = ops.flash_attn_varlen_func
-    get_scheduler_metadata = ops.get_scheduler_metadata
+    reshape_and_cache_flash = ipex_ops.reshape_and_cache_flash
+    flash_attn_varlen_func = ipex_ops.flash_attn_varlen_func
+    get_scheduler_metadata = ipex_ops.get_scheduler_metadata
 
 elif current_platform.is_rocm():
     try:

--- a/vllm/v1/attention/ops/paged_attn.py
+++ b/vllm/v1/attention/ops/paged_attn.py
@@ -7,13 +7,9 @@ import torch
 from vllm.platforms import current_platform
 
 if current_platform.is_cuda_alike():
-    from vllm import _custom_ops
-
-    ops = _custom_ops
+    from vllm import _custom_ops as ops
 elif current_platform.is_xpu():
-    from vllm._ipex_ops import ipex_ops
-
-    ops = ipex_ops
+    from vllm._ipex_ops import ipex_ops as ops  # type: ignore[no-redef]
 
 
 class PagedAttention:


### PR DESCRIPTION

## Purpose
Another step in the attention restructuring, #31919 
This PR fixes pre-commit errors which arose when moving files into regions of higher mypy scrutiny

## Test Plan
Pre-commit should pass

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit b9743968bf2e3f20de1e03e51544ccaef025b11f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Focuses on addressing mypy failures introduced by moving attention code under stricter checks.
> 
> - Updates pre-commit mypy `EXCLUDE` to stop excluding `vllm/v1/attention/backends/fa_utils.py`, bringing it under type checking
> - Refactors imports in `fa_utils.py` (CUDA/XPU) to import symbols directly instead of via intermediate `ops`
> - Aligns `paged_attn.py` imports to alias backend ops modules directly (`as ops`) with a targeted `type: ignore`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9743968bf2e3f20de1e03e51544ccaef025b11f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
