### PR TITLE
[Perf] Optimize async scheduling placeholder using empty

### DIFF
--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -31,6 +31,9 @@ from vllm.v1.metrics.stats import (
     SchedulerStats,
 )
 
+# shared empty CPU tensor used as a placeholder pooling output
+EMPTY_CPU_TENSOR = torch.empty(0, device="cpu")
+
 
 class RequestOutputCollector:
     """
@@ -426,7 +429,7 @@ class OutputProcessor:
                         new_token_ids=[],
                         # Set pooling_output is not None to
                         # correctly enter the abort pooling branch
-                        pooling_output=torch.empty(0, device="cpu")
+                        pooling_output=EMPTY_CPU_TENSOR
                         if req_state.detokenizer is None
                         else None,
                         finish_reason=FinishReason.ABORT,

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -426,7 +426,7 @@ class OutputProcessor:
                         new_token_ids=[],
                         # Set pooling_output is not None to
                         # correctly enter the abort pooling branch
-                        pooling_output=torch.randn(0, device="cpu")
+                        pooling_output=torch.empty(0, device="cpu")
                         if req_state.detokenizer is None
                         else None,
                         finish_reason=FinishReason.ABORT,


### PR DESCRIPTION
## Purpose

Here for a placeholder tensor, no need to use `rand`, empty is good enough

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 3462afd4a5afeda39c35c85d50e394211106a38f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Minor perf cleanup in abort handling.
> 
> - In `vllm/v1/engine/output_processor.py`, replace zero-length placeholder `pooling_output` from `torch.randn(0, device="cpu")` to `torch.empty(0, device="cpu")` when emitting final abort outputs for pooling requests, avoiding unnecessary random initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3462afd4a5afeda39c35c85d50e394211106a38f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Minor performance cleanup in abort handling.
> 
> - Define `EMPTY_CPU_TENSOR = torch.empty(0, device="cpu")` in `output_processor.py`
> - Use it as the placeholder `pooling_output` in `abort_requests` instead of `torch.randn(0, device="cpu")` to avoid unnecessary initialization
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f0d331c4125f06b4817a13547e27708757584c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
