### PR TITLE
[CI] Allow Deprecated Quantization For LM Eval Tests

### DIFF
--- a/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
+++ b/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
@@ -60,6 +60,7 @@ def launch_lm_eval(eval_config, tp_size):
         f"add_bos_token=true,"
         f"trust_remote_code={trust_remote_code},"
         f"max_model_len={max_model_len},"
+        "allow_deprecated_quantization=True,"
     )
 
     env_vars = eval_config.get("env_vars", None)


### PR DESCRIPTION
Ever since https://github.com/vllm-project/vllm/pull/31688 began the process of deprecating some quantization schemes, the `LM Eval Large Models` test group is failing on main, as seen here for example: https://buildkite.com/vllm/ci/builds/46314/steps/canvas?sid=019ba18f-0a1a-4482-82d8-b8c102fd92c0. The PR updated other relevant tests to allow deprecated quantization types, but skipped `test_lm_eval_correctness.py`, so the `Meta-Llama-3-70B-Instruct-FBGEMM-nonuniform` test case is failing with this error:

```
Value error, ('The quantization method %s is deprecated and will be removed in future versions of vLLM. To bypass, set `--allow-deprecated-quantization`.', 'fbgemm_fp8')
```

This PR updates `test_lm_eval_correctness.py` to match the behavior of other affected tests such as tests/compile/fullgraph/test_full_graph.py. With this change, I am seeing all tests pass:
```
=================== 5 passed, 7 warnings in 475.20s (0:07:55) =======================
```

---

> [!NOTE]
> Enables LM Eval test harness to run models with deprecated quantization schemes.
> 
> - Adds `allow_deprecated_quantization=True` to `model_args` in `test_lm_eval_correctness.py`, aligning behavior with other tests and preventing failures on deprecated quantization (e.g., FBGEMM variants)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e68ff9727fcc935598de7f9ce1e888c22d5c7f69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
