### PR TITLE
Update torchao CI tests

### DIFF
--- a/.buildkite/test_areas/quantization.yaml
+++ b/.buildkite/test_areas/quantization.yaml
@@ -9,14 +9,10 @@ steps:
   - vllm/model_executor/layers/quantization
   - tests/quantization
   commands:
-  # temporary install here since we need nightly, will move to requirements/test.in
-  # after torchao 0.12 release, and pin a working version of torchao nightly here
-
-  # since torchao nightly is only compatible with torch nightly currently
-  # https://github.com/pytorch/ao/issues/2919, we'll have to skip new torchao tests for now
-  # we can only upgrade after this is resolved
-  # TODO(jerryzh168): resolve the above comment
-  - uv pip install --system torchao==0.13.0 --index-url https://download.pytorch.org/whl/cu129
+  # we'll test most recent stable torchao release corresponding to the
+  # current torch version used in vllm (torch 2.9.1 -- torchao 0.15.0)
+  # based on the compatiblity table: https://github.com/pytorch/ao/issues/2919
+  - uv pip install --system torchao==0.15.0
   - uv pip install --system conch-triton-kernels
   - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
 


### PR DESCRIPTION
Summary:
Trying to resolve issue: https://github.com/pytorch/pytorch/issues/170419, https://github.com/pytorch/pytorch/issues/164872, https://github.com/pytorch/ao/issues/3487

We workaround the issue in torchao with https://github.com/pytorch/ao/pull/3488
Also remove/skipped some outdated tests for now, we can re-enable tests in torchao 0.16.0

I tried creating weights under inference_mode: https://github.com/pytorch/pytorch/issues/170419#issuecomment-3656315408 but still requires the transpose fix right now, can investigate later

Test Plan:
Tested with local environment, we'll make sure to have it in next release

pytest tests/quantization/test_torchao.py

Reviewers:

Subscribers:

Tasks:

Tags:

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 6bcd3b186879414175fafb81763febfc5cac1df7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures torchao weight loading is safe under inference by avoiding version-counter mutations.
> 
> - Load `torchao`-quantized weights inside `torch.inference_mode()` when `torchao>=0.16.0` in `default_loader.py`
> - Keep `safetensors_load_strategy="torchao"` when applicable (no behavioral change elsewhere)
> - Tests: gate with `torchao_version_at_least("0.16.0")`, update pre-quantized model reference, wrap generation in `torch.inference_mode()`, and skip outdated tests pending v2 configs
> - CI: pin quantization pipeline to `torchao==0.15.0` (stable matching current torch)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bcd3b186879414175fafb81763febfc5cac1df7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 02af85ecfbedcc781069c5ae051996781db8c3b0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures safe torchao weight loading and aligns tests/CI with supported versions.
> 
> - In `default_loader.py`, load weights inside `torch.inference_mode()` when `quantization == "torchao"` and `torchao >= 0.16.0`; keep `safetensors_load_strategy="torchao"` when applicable
> - Tests: gate with `torchao_version_at_least("0.16.0")`, update pre-quantized model reference, wrap generation in `torch.inference_mode()`, and skip outdated tests pending v2 configs
> - CI: Quantization pipeline now installs `torchao==0.15.0` to match current torch release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02af85ecfbedcc781069c5ae051996781db8c3b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 37b9e715ef0113a817f8316ab4b4bcf32eabf72a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures safe torchao weight loading and updates tests/CI for version compatibility.
> 
> - In `default_loader.py`, wrap `model.load_weights(...)` in `torch.inference_mode()` when `quantization=="torchao"` and `torchao>=0.16.0`; retain `safetensors_load_strategy="torchao"` for serialized checkpoints (>=0.15.0)
> - Tests: require `torchao>=0.16.0`, update pre-quantized model ID, wrap generation in `torch.inference_mode()`, and skip outdated cases pending v2 configs
> - CI: Buildkite quantization pipeline now installs `torchao==0.15.0` to match current torch
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37b9e715ef0113a817f8316ab4b4bcf32eabf72a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 217c6490dd7173dc8cb7318b4a12e7e74126519f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Aligns CI and tests with supported torchao versions.
> 
> - **CI**: Quantization pipeline installs `torchao==0.15.0` matching the current torch release
> - **Tests**: Replace `TORCHAO_AVAILABLE` checks with `torchao_version_at_least("0.16.0")`, update pre-quantized model to `opt-125m-Float8WeightOnlyConfig-v2-0.15.0`, and skip/remove outdated tests pending v2 configs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 217c6490dd7173dc8cb7318b4a12e7e74126519f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Aligns CI and tests with supported torchao versions.
> 
> - **CI**: Quantization pipeline installs `torchao==0.15.0` in `.buildkite/test_areas/quantization.yaml` to match current torch
> - **Tests**: Gate with `torchao_version_at_least("0.16.0")`, update pre-quantized model to `opt-125m-Float8WeightOnlyConfig-v2-0.15.0`, keep/skip outdated tests pending v2 configs, and retain online-quantization/reload tests using config dict/file
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b80d488772f281cec162b36ed728d186bbb2ee78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
