### PR TITLE
[Misc] Delay deprecation of CommonAttentionMetadata properties

### DIFF
--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -96,7 +96,7 @@ class CommonAttentionMetadata:
     dcp_local_seq_lens_cpu: torch.Tensor | None = None
     """Sequence lengths of the local rank in decode context parallelism world"""
 
-    # WARNING: Deprecated fields. Will be removed in a future release (v0.14.0)
+    # WARNING: Deprecated fields. Will be removed in a future release (v0.15.0)
     _seq_lens_cpu: torch.Tensor | None = None
     _num_computed_tokens_cpu: torch.Tensor | None = None
 
@@ -107,7 +107,7 @@ class CommonAttentionMetadata:
         """
     Prefer using device seq_lens directly to avoid implicit H<>D sync.
     If a CPU copy is needed, use `seq_lens.cpu()` instead.
-    Will be removed in a future release (v0.14.0)
+    Will be removed in a future release (v0.15.0)
     """
     )
     def seq_lens_cpu(self) -> torch.Tensor:
@@ -121,7 +121,7 @@ class CommonAttentionMetadata:
     Prefer using device seq_lens directly to avoid implicit H<>D sync which breaks full
     async scheduling. If a CPU copy is needed, it can be derived from 
     query_start_loc_cpu and seq_lens.
-    Will be removed in a future release (v0.14.0)
+    Will be removed in a future release (v0.15.0)
     """
     )
     def num_computed_tokens_cpu(self) -> torch.Tensor:


### PR DESCRIPTION
Tracking progress here: https://github.com/vllm-project/vllm/issues/32072

Unfortunately the last 2 PR
- https://github.com/vllm-project/vllm/pull/31852
- https://github.com/vllm-project/vllm/pull/32073

Are a bit trickier and do not appear to be on track to v0.14; delay just in case

---

> [!NOTE]
> Delays removal timeline for deprecated CPU-based fields and accessors in attention metadata.
> 
> - Update deprecation notes/comments in `CommonAttentionMetadata` so `seq_lens_cpu` and `num_computed_tokens_cpu` (and related fields) are marked for removal in v0.15.0 instead of v0.14.0
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 705bc8f0fa2c529cfe3b6cbb7abf75f37bef7df1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
