### PR TITLE
[Speculators][Speculative Decoding] Add EAGLE-3 Speculative Decoding Support for DeepSeek V3/V3.2

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -620,7 +620,14 @@ class SpeculativeConfig:
                 f"{self.disable_by_batch_size=}"
             )
 
-        eagle3_target_supported = ["llama", "qwen", "minicpm", "gpt_oss"]
+        eagle3_target_supported = [
+            "llama",
+            "qwen",
+            "minicpm",
+            "gpt_oss",
+            "deepseek_v3",
+            "deepseek_v32",
+        ]
         if (
             self.method == "eagle3"
             and self.target_model_config


### PR DESCRIPTION
## Purpose

This PR adds EAGLE-3 speculative decoding support for DeepSeek V3 and V3.2 models, enabling faster inference through speculative decoding with EAGLE-3 draft models.

For details on EAGLE-3, see: https://github.com/SafeAILab/EAGLE

**Changes:**

1. **`vllm/config/speculative.py`**: Added `deepseek_v3` and `deepseek_v32` to the `eagle3_target_supported` list.

2. **`vllm/model_executor/models/deepseek_v2.py`**:
   - Added `SupportsEagle3` interface to `DeepseekV2ForCausalLM` class.
   - Implemented EAGLE-3 interface methods:
     - `set_aux_hidden_state_layers()`: Configures which layers output auxiliary hidden states.
     - `get_eagle3_aux_hidden_state_layers()`: Returns default layer indices for auxiliary hidden states (early, middle, late layers).
   - Modified `DeepseekV2Model.forward()` to capture auxiliary hidden states when configured.
   - Added `aux_hidden_state_layers` attribute to `DeepseekV2Model` for tracking which layers to capture.

## Test Plan

```bash
vllm serve deepseek-ai/DeepSeek-V3.2 \
    --speculative-config '{"method": "eagle3", "model": "/path/to/eagle3", "num_speculative_tokens": 3}'
```

## Test Result

Tested with:
- DeepSeek V3.2 target model (`model_type: deepseek_v32`)
- Custom EAGLE-3 draft model trained for DeepSeek V3.2

The implementation correctly captures auxiliary hidden states from the target model and passes them to the EAGLE-3 draft model for improved token prediction.

These defaults can be overridden by the EAGLE-3 draft model config via `eagle_aux_hidden_state_layer_ids`.

### Draft Model Config Example

The EAGLE-3 draft model for DeepSeek V3/V3.2 uses a config like:

```json
{
  "architectures": [
    "LlamaForCausalLMEagle3"
  ],
  "attention_bias": false,
  "attention_dropout": 0.0,
  "bos_token_id": 0,
  "draft_vocab_size": 32000,
  "dtype": "bfloat16",
  "eagle_config": {
    "eagle_aux_hidden_state_layer_ids": [
      1,
      29,
      57
    ],
    "use_aux_hidden_state": true
  },
  "eos_token_id": 1,
  "head_dim": 56,
  "hidden_act": "silu",
  "hidden_size": 7168,
  "initializer_range": 0.02,
  "intermediate_size": 18432,
  "max_position_embeddings": 163840,
  "mlp_bias": false,
  "model_type": "llama",
  "num_attention_heads": 128,
  "num_hidden_layers": 1,
  "num_key_value_heads": 128,
  "pad_token_id": 0,
  "pretraining_tp": 1,
  "rms_norm_eps": 1e-06,
  "rope_scaling": {
    "beta_fast": 32.0,
    "beta_slow": 1.0,
    "factor": 40.0,
    "mscale": 1.0,
    "mscale_all_dim": 1.0,
    "original_max_position_embeddings": 4096,
    "rope_type": "yarn",
    "type": "yarn"
  },
  "rope_theta": 10000,
  "tie_word_embeddings": false,
  "transformers_version": "4.57.1",
  "use_cache": true,
  "vocab_size": 129280
}
```

---

- [x] The purpose of the PR is clearly stated.
- [x] The test plan is provided.
- [x] The test results are described.
- [ ] (Optional) Documentation update - N/A for this PR.
- [ ] (Optional) Release notes update - This is a new model feature.

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 491fe598a0a6f106c52de5c521466f33598c119f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
