### PR TITLE
Add support for compressed-tensors NVFP4 in non-gated MoE layers #31782

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -618,6 +618,9 @@ class FusedMoE(CustomOp):
 
         if not self.moe_config.is_act_and_mul:
             # Avoid circular import
+            from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa: E501
+                CompressedTensorsW4A4Nvfp4MoEMethod,
+            )
             from vllm.model_executor.layers.quantization.modelopt import (
                 ModelOptFp8MoEMethod,
                 ModelOptNvFp4FusedMoE,
@@ -629,11 +632,13 @@ class FusedMoE(CustomOp):
                     UnquantizedFusedMoEMethod,
                     ModelOptFp8MoEMethod,
                     ModelOptNvFp4FusedMoE,
+                    CompressedTensorsW4A4Nvfp4MoEMethod,
                 ),
             ):
                 raise NotImplementedError(
                     "is_act_and_mul=False is supported only for unquantized "
-                    ", ModelOpt FP8, and ModelOpt NvFp4 checkpoints"
+                    ", ModelOpt FP8, ModelOpt NvFp4, and CompressedTensors "
+                    "NvFp4 checkpoints"
                 )
             if not current_platform.is_cuda():
                 raise NotImplementedError(

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -616,35 +616,6 @@ class FusedMoE(CustomOp):
         # for heuristic purposes, so it must be initialized first.
         self.quant_method: FusedMoEMethodBase = _get_quant_method()
 
-        if not self.moe_config.is_act_and_mul:
-            # Avoid circular import
-            from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa: E501
-                CompressedTensorsW4A4Nvfp4MoEMethod,
-            )
-            from vllm.model_executor.layers.quantization.modelopt import (
-                ModelOptFp8MoEMethod,
-                ModelOptNvFp4FusedMoE,
-            )
-
-            if not isinstance(
-                self.quant_method,
-                (
-                    UnquantizedFusedMoEMethod,
-                    ModelOptFp8MoEMethod,
-                    ModelOptNvFp4FusedMoE,
-                    CompressedTensorsW4A4Nvfp4MoEMethod,
-                ),
-            ):
-                raise NotImplementedError(
-                    "is_act_and_mul=False is supported only for unquantized "
-                    ", ModelOpt FP8, ModelOpt NvFp4, and CompressedTensors "
-                    "NvFp4 checkpoints"
-                )
-            if not current_platform.is_cuda():
-                raise NotImplementedError(
-                    "is_act_and_mul=False is supported only for CUDA for now"
-                )
-
         if self.enable_eplb and not self.quant_method.supports_eplb:
             # TODO: Add support for additional quantization methods.
             # The implementation for other quantization methods does not

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -234,6 +234,12 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
     ):
         super().__init__(moe)
         self.group_size = 16
+
+        if not moe.is_act_and_mul and not current_platform.is_cuda():
+            raise NotImplementedError(
+                "is_act_and_mul=False is supported only for CUDA for now"
+            )
+
         if use_marlin:
             if not moe.is_act_and_mul:
                 raise NotImplementedError(


### PR DESCRIPTION

## Purpose
#31782
This PR adds support for **compressed-tensors NVFP4-quantized MoE models** in vLLM, specifically addressing the limitation that prevents initialization of non-gated MoE models (like Nemotron-H / Nemotron-3-Nano-30B-A3B) when using compressed-tensors NVFP4 quantization.


**Solution:**
- Added `CompressedTensorsW4A4Nvfp4MoEMethod` to the allowed quantization methods list in MoE layer initialization (`layer.py` line 635)
- Removed the hard-coded restriction that prevented non-gated MoE (`is_act_and_mul=False`) with compressed-tensors NVFP4
- Added proper global scale sanitization to handle NaN/Inf/non-positive values in quantized weights (extracted `sanitize_global_scale` to shared utility)
- Updated error message to explicitly mention CompressedTensors NvFp4 as a supported format

## Test Plan
https://paste.ubuntu.com/p/DkKD5VsNg6/
## Test Result
<img width="1465" height="364" alt="image" src="https://github.com/user-attachments/assets/37a1c93a-e4e9-4eb4-a1c9-e127a592a7c6" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 947b2f63ab6eed2fb20111dafca3a393bb8a4820. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Adds support for non-gated MoE with compressed-tensors NVFP4 under CUDA, aligning backend and activation constraints, and hardens scale handling.
> 
> - Removes the restriction in `FusedMoE` initialization that blocked `is_act_and_mul=False`; backend/platform checks are enforced in NVFP4 methods
> - Extends `CompressedTensorsW4A4Nvfp4MoEMethod` to non-gated MoE: dynamic `w13`/scale shapes, global-scale tensors sized by global experts when needed, CUDA-only guard, and require `relu2_no_mul` for non-gated activations
> - Introduces `sanitize_global_scale` utility and applies it when loading NVFP4 MoE/global scales and linear NVFP4 (`compressed_tensors_w4a4_nvfp4.py`) to handle NaN/Inf/non-positive values
> - NVFP4 (W4A4) scheme: swizzled-scale padding mirrored in packed weights, honors `output_size_per_partition` for output shaping/slicing, and supports FlashInfer/CUTLASS/FBGEMM paths
> - ModelOpt NVFP4 MoE: refines non-gated checks (CUDA-only and FlashInfer CUTLASS requirement)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 947b2f63ab6eed2fb20111dafca3a393bb8a4820. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
