### PR TITLE
[ROCm][Bugfix] Fix AITER speculative decoding accuracy issue

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -947,6 +947,7 @@ class AiterFlashAttentionImpl(AttentionImpl):
                         b_loc=attn_metadata.block_table[:num_decodes],
                         b_start_loc=attn_metadata.query_start_loc[: num_decodes + 1],
                         b_seq_len=attn_metadata.seq_lens[:num_decodes],
+                        max_seq_len=attn_metadata.decode_metadata.max_seq_len,
                         max_input_len=attn_metadata.decode_metadata.max_query_len,
                         k_scale=layer._k_scale,
                         v_scale=layer._v_scale,


### PR DESCRIPTION
## Summary

- Fix speculative decoding (query_len > 1) for ROCM_AITER_FA backend
- Fall back to `context_attention_fwd` when decode has multi-token queries
- Resolves 0% accuracy issue reported in #31625

## Problem

The AITER `paged_attention_v1` kernel only supports single-token queries (`query_len = 1`). When speculative decoding is enabled, the decode path receives multi-token queries, causing the kernel to produce incorrect results (0% accuracy on GSM8K benchmark).

## Solution

Detect when `decode_metadata.max_query_len > 1` and use the Triton-based `context_attention_fwd` kernel which supports arbitrary query lengths with paged KV cache. This is the same approach used by `chunked_prefill_paged_decode` in the ROCm attention backend.

## Changes

1. Added import for `context_attention_fwd` from `vllm.attention.ops.prefix_prefill`
2. Added speculative decoding detection (`max_query_len > 1`) before existing decode paths
3. Restructured decode logic to proper `if-elif-else` chain

## Test plan

- [ ] Verify speculative decoding accuracy on ROCm with AITER backend
- [ ] Run GSM8K benchmark with command from issue:
  ```bash
  VLLM_USE_V1=1 VLLM_ROCM_USE_AITER=1 VLLM_ATTENTION_BACKEND=ROCM_AITER_FA \
  vllm serve meta-llama/Llama-3.3-70B-Instruct -tp 4 \
  --speculative-config '{"model": "yuhuili/EAGLE3-LLaMA3.3-Instruct-70B", "num_speculative_tokens": 3, "method":"eagle3", "draft_tensor_parallel_size":1}'
  ```
- [ ] Verify standard (non-speculative) decode still works

Fixes #31625

🤖 Generated with [Claude Code](https://claude.ai/code)

---

> [!NOTE]
> Improves decode handling on ROCm AITER FA to correctly process speculative (multi-token) queries.
> 
> - Detects `decode_metadata.max_query_len > 1` and routes decode to `context_attention_fwd` (supports paged KV with arbitrary query lengths)
> - Retains existing sliding-window `unified_attention` path and standard single-token `paged_attention_v1` path
> - Adds import for `context_attention_fwd` and refactors decode into `if-elif-else` chain to separate multi-token, sliding-window, and single-token cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d7bfe78c8b326acd9c1e913c8d7bfa32149ca94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Addresses speculative decoding correctness on ROCm AITER FA by handling multi-token decode queries.
> 
> - Detects `decode_metadata.max_query_len > 1` and falls back to Triton `context_attention_fwd` (paged KV, arbitrary query lengths)
> - Retains sliding-window `unified_attention` path and standard single-token decode via `aiter.paged_attention_v1`
> - Adds `context_attention_fwd` import and refactors decode logic into `if-elif-else`; other paths unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40c915d4c2a68d2a76e5bf0efcffe33bc1ce8dec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> **Fixes speculative decode correctness on ROCm AITER FA**
> 
> - Detects `decode_metadata.max_query_len > 1` and falls back to `context_attention_fwd` (paged KV, arbitrary query lengths)
> - Preserves sliding-window `unified_attention` and standard single-token decode via `aiter.paged_attention_v1`
> - Adds `context_attention_fwd` import and refactors decode handling into `if-elif-else` with early returns
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54379da0d1a3b30cfcb5d5380d2a4fa1a63759a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures correct decode behavior on ROCm AITER FA when speculative decoding produces multi-token queries.
> 
> - Adds `context_attention_fwd` import and uses it when `decode_metadata.max_query_len > 1` (supports paged KV with arbitrary query lengths)
> - Keeps sliding-window path via `unified_attention` and standard single-token decode via `aiter.paged_attention_v1`
> - Refactors decode logic into clear `if-elif-else` branches with early returns; workspace allocation only in single-token branch
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caae36cb11ace741c6e7e1db221016621eb29aca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
