### PR TITLE
[Bugfix] Fix Qwen3-VL-Reranker model loading for sequence classification

### DIFF
--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -381,14 +381,13 @@ class SequenceClassificationConfig(VerifyAndUpdateConfig):
         text_config.use_sep_token = use_sep_token
 
 
-def _get_lm_head_parent_and_inner_model(model):
+def _get_lm_head_parent_and_inner_model(
+    model: nn.Module,
+) -> tuple[nn.Module, nn.Module | None, nn.Module | None]:
     """Helper to get lm_head parent and inner_model for text and VL models.
 
     For VL models, lm_head is under language_model (model.language_model.lm_head).
     For text-only models, lm_head is directly on the model (model.lm_head).
-
-    Returns:
-        tuple: (lm_head_parent, inner_model, language_model)
     """
     language_model = getattr(model, "language_model", None)
     if language_model is not None:
@@ -396,7 +395,9 @@ def _get_lm_head_parent_and_inner_model(model):
     return model, getattr(model, "model", None), None
 
 
-def _get_embed_tokens(inner_model, lm_head_parent):
+def _get_embed_tokens(
+    inner_model: nn.Module | None, lm_head_parent: nn.Module
+) -> nn.Module:
     """Helper to get embed_tokens for weight tying.
 
     embed_tokens is the assumed name for input embeddings. If the model does not

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -381,6 +381,37 @@ class SequenceClassificationConfig(VerifyAndUpdateConfig):
         text_config.use_sep_token = use_sep_token
 
 
+def _get_lm_head_parent_and_inner_model(model):
+    """Helper to get lm_head parent and inner_model for text and VL models.
+
+    For VL models, lm_head is under language_model (model.language_model.lm_head).
+    For text-only models, lm_head is directly on the model (model.lm_head).
+
+    Returns:
+        tuple: (lm_head_parent, inner_model, language_model)
+    """
+    language_model = getattr(model, "language_model", None)
+    if language_model is not None:
+        return language_model, getattr(language_model, "model", None), language_model
+    return model, getattr(model, "model", None), None
+
+
+def _get_embed_tokens(inner_model, lm_head_parent):
+    """Helper to get embed_tokens for weight tying.
+
+    embed_tokens is the assumed name for input embeddings. If the model does not
+    have this attribute, we fall back to get_input_embeddings(), which is used by
+    the Transformers modeling backend.
+    """
+    if inner_model is not None:
+        return (
+            inner_model.embed_tokens
+            if hasattr(inner_model, "embed_tokens")
+            else inner_model.get_input_embeddings()
+        )
+    return lm_head_parent.get_input_embeddings()
+
+
 def load_weights_using_from_2_way_softmax(
     model, weights: Iterable[tuple[str, torch.Tensor]]
 ):
@@ -401,24 +432,16 @@ def load_weights_using_from_2_way_softmax(
     tokens = cast(list[int], tokens)
     assert len(tokens) == 2
 
-    model.lm_head = ParallelLMHead(
+    lm_head_parent, inner_model, language_model = _get_lm_head_parent_and_inner_model(
+        model
+    )
+
+    lm_head_parent.lm_head = ParallelLMHead(
         text_config.vocab_size, text_config.hidden_size, quant_config=quant_config
     )
     if text_config.tie_word_embeddings:
-        # embed_tokens is the assumed name for input embeddings. If the model does not
-        # have this attribute, we fall back to get_input_embeddings(), which is used by
-        # the Transformers modeling backend.
-        text_backbone = (
-            model.get_language_model().model
-            if hasattr(model, "get_language_model")
-            else model.model
-        )
-        embed_tokens = (
-            text_backbone.embed_tokens
-            if hasattr(text_backbone, "embed_tokens")
-            else text_backbone.get_input_embeddings()
-        )
-        model.lm_head = model.lm_head.tie_weights(embed_tokens)
+        embed_tokens = _get_embed_tokens(inner_model, lm_head_parent)
+        lm_head_parent.lm_head = lm_head_parent.lm_head.tie_weights(embed_tokens)
 
     # ModelForPooling is dynamically defined inside the _create_pooling_model_cls
     # function, so we need use this hacky method to obtain it.
@@ -438,17 +461,20 @@ def load_weights_using_from_2_way_softmax(
 
     false_id = tokenizer.convert_tokens_to_ids(tokens[0])
     true_id = tokenizer.convert_tokens_to_ids(tokens[1])
-    score_weight = model.lm_head.weight.data[[true_id]].to(
+    score_weight = lm_head_parent.lm_head.weight.data[[true_id]].to(
         torch.float32
-    ) - model.lm_head.weight.data[[false_id]].to(torch.float32)
+    ) - lm_head_parent.lm_head.weight.data[[false_id]].to(torch.float32)
 
     param = model.score.weight
     weight_loader = getattr(param, "weight_loader", default_weight_loader)
     weight_loader(param, score_weight)
 
-    del model.lm_head
+    del lm_head_parent.lm_head
     loaded_weights.add("score.weight")
-    loaded_weights.discard("lm_head.weight")
+    if language_model is not None:
+        loaded_weights.discard("language_model.lm_head.weight")
+    else:
+        loaded_weights.discard("lm_head.weight")
     return loaded_weights
 
 
@@ -464,19 +490,16 @@ def load_weights_no_post_processing(model, weights: Iterable[tuple[str, torch.Te
     tokens = cast(list[int], tokens)
     assert len(tokens) > 0
 
-    model.lm_head = ParallelLMHead(
+    lm_head_parent, inner_model, language_model = _get_lm_head_parent_and_inner_model(
+        model
+    )
+
+    lm_head_parent.lm_head = ParallelLMHead(
         text_config.vocab_size, text_config.hidden_size, quant_config=quant_config
     )
     if text_config.tie_word_embeddings:
-        # embed_tokens is the assumed name for input embeddings. If the model does not
-        # have this attribute, we fall back to get_input_embeddings(), which is used by
-        # the Transformers modeling backend.
-        embed_tokens = (
-            model.model.embed_tokens
-            if hasattr(model.model, "embed_tokens")
-            else model.model.get_input_embeddings()
-        )
-        model.lm_head = model.lm_head.tie_weights(embed_tokens)
+        embed_tokens = _get_embed_tokens(inner_model, lm_head_parent)
+        lm_head_parent.lm_head = lm_head_parent.lm_head.tie_weights(embed_tokens)
 
     # Skip ModelForSequenceClassification in MRO to avoid infinite recursion
     loaded_weights = type(model).__mro__[1].load_weights(model, weights)
@@ -491,15 +514,18 @@ def load_weights_no_post_processing(model, weights: Iterable[tuple[str, torch.Te
     )
 
     token_ids = [tokenizer.convert_tokens_to_ids(t) for t in tokens]
-    score_weight = model.lm_head.weight.data[token_ids]
+    score_weight = lm_head_parent.lm_head.weight.data[token_ids]
 
     param = model.score.weight
     weight_loader = getattr(param, "weight_loader", default_weight_loader)
     weight_loader(param, score_weight)
 
-    del model.lm_head
+    del lm_head_parent.lm_head
     loaded_weights.add("score.weight")
-    loaded_weights.discard("lm_head.weight")
+    if language_model is not None:
+        loaded_weights.discard("language_model.lm_head.weight")
+    else:
+        loaded_weights.discard("lm_head.weight")
     return loaded_weights
 
 

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -448,7 +448,12 @@ def load_weights_using_from_2_way_softmax(
 
     del language_model.lm_head
     loaded_weights.add("score.weight")
-    loaded_weights.discard("lm_head.weight")
+
+    lm_head_name = "lm_head.weight"
+    hf_to_vllm_mapper = getattr(model, "hf_to_vllm_mapper", None)
+    if hf_to_vllm_mapper := getattr(model, "hf_to_vllm_mapper", None):
+        lm_head_name = hf_to_vllm_mapper._map_name(lm_head_name)
+    loaded_weights.discard(lm_head_name)
     return loaded_weights
 
 

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -450,7 +450,6 @@ def load_weights_using_from_2_way_softmax(
     loaded_weights.add("score.weight")
 
     lm_head_name = "lm_head.weight"
-    hf_to_vllm_mapper = getattr(model, "hf_to_vllm_mapper", None)
     if hf_to_vllm_mapper := getattr(model, "hf_to_vllm_mapper", None):
         lm_head_name = hf_to_vllm_mapper._map_name(lm_head_name)
     loaded_weights.discard(lm_head_name)

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -254,7 +254,9 @@ class Qwen3ForSequenceClassificationConfig(VerifyAndUpdateConfig):
             "Try loading the original Qwen3 Reranker?, see: "
             "https://github.com/vllm-project/vllm/tree/main/examples/pooling/score/qwen3_reranker_offline.py"
         )
-        model_config.hf_config.method = "from_2_way_softmax"
+        text_config = config.get_text_config()
+        text_config.method = "from_2_way_softmax"
+        text_config.classifier_from_token = tokens
 
 
 class Qwen3VLForSequenceClassificationConfig(Qwen3ForSequenceClassificationConfig):


### PR DESCRIPTION
## Summary

Fix weight loading failure for Qwen3-VL-Reranker model when using sequence classification mode.

Fixes #32086

## Problem

When running `Qwen/Qwen3-VL-Reranker-8B` with pooling runner:
```bash
  vllm serve /home/rickychen/Desktop/llm/models/Qwen3-VL-Reranker-8B --runner pooling --max-model-len 8192 --hf_overrides '{"architectures": ["Qwen3VLForSequenceClassification"], "classifier_from_token": ["no", "yes"], "is_original_qwen3_reranker": true}'
```

## error:
There is no module or parameter named 'lm_head' in Qwen3LLMForCausalLM

The sequence classification adapter assumes a flat model structure (model.lm_head), but Vision-Language models like Qwen3-VL have a nested structure where lm_head is under language_model (model.language_model.lm_head).

## Solution

- adapters.py: Detect VL models by checking for language_model attribute and access lm_head through the correct parent module
- config.py: Ensure classifier_from_token is set on text_config (not just hf_config) so the weight loading functions can find it

---

> [!NOTE]
> Addresses weight loading failures in VL sequence classification models.
> 
> - Detect VL models via `language_model` and create/tie `lm_head` on the correct parent (`lm_head_parent`) instead of assuming `model.lm_head`
> - Tie word embeddings using `inner_model.embed_tokens` or `get_input_embeddings()` and clean up (`del lm_head_parent.lm_head`) after extracting weights
> - Adjust loaded weight bookkeeping to discard `language_model.lm_head.weight` when applicable
> - In `config.py`, set `text_config.method = "from_2_way_softmax"` and propagate `classifier_from_token` to `text_config` for original Qwen3 reranker
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8795716cd71e54854c313eae315b8edbfc493ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Resolves weight loading failures for VL rerankers by supporting nested language-model structures and proper config placement.
> 
> - Add helpers to locate `lm_head` and input embeddings across text/VL models; create/tie `language_model.lm_head` when present and clean it up after extracting classifier weights
> - Update scoring weight extraction to use the correct parent (`language_model` vs top-level), and adjust loaded-weights bookkeeping (discard `language_model.lm_head.weight` when applicable)
> - In `config.py`, set `text_config.method = "from_2_way_softmax"` and propagate `classifier_from_token` to `text_config` for original Qwen3 reranker
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27eca8f30ac54b136520d94626d38c6c806c248c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Resolves weight-loading failures for VL rerankers by supporting nested language-model structures and proper config placement.
> 
> - Add helpers to locate `lm_head` and input embeddings across text/VL models; create/tie `language_model.lm_head` when present and clean it up after extracting classifier weights
> - Update score-weight extraction to read from the correct parent (`language_model` vs top-level) and adjust loaded-weights bookkeeping (`discard language_model.lm_head.weight` when applicable)
> - In `config.py`, set `text_config.method = "from_2_way_softmax"` and propagate `classifier_from_token` to `text_config` for original Qwen3 reranker
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22e5c5e55b02ce2ba73a3c1cc8ed273d6ab014dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 2c7ef2b5cbbe198b8401a527d693ee0d29acd51d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Resolves weight-loading failures for VL sequence classification models (e.g., Qwen3-VL-Reranker) by supporting nested language-model structures and proper config placement.
> 
> - In `adapters.py`, detect VL models via `language_model`; create/tie `language_model.lm_head`, compute `score.weight` from its vocab rows, then delete it; adjust loaded-weights bookkeeping to discard `lm_head.weight` appropriately
> - Token/method lookup now checks both `hf_config` and `text_config`
> - In `config.py`, for original Qwen3 reranker, set `text_config.method = "from_2_way_softmax"` and propagate `classifier_from_token` to `text_config`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3588d1fcc9de07ea871a4645f29c3181c0cb2c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures VL reranker sequence-classification loads and maps weights correctly.
> 
> - In `adapters.py`, create/tie `language_model.lm_head` (fallback to top-level if absent), compute `score.weight` from its vocab rows, then delete it; update loaded-weights bookkeeping to discard the correct `lm_head.weight` (supports `hf_to_vllm_mapper`).
> - Token/method lookup now checks both `hf_config` and `text_config`.
> - In `config.py`, for original Qwen3 reranker, set `text_config.method = "from_2_way_softmax"` and propagate `classifier_from_token` to `text_config`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15b674b5cfb13968eaedc4636a56203a045c7918. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit f968e1a4563ca709117bea076fce49878151ec93. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures VL reranker models (e.g., Qwen3-VL) load classifier weights correctly in seq-classification mode.
> 
> - In `adapters.py`, detect `language_model`; create/tie `language_model.lm_head`, compute `score.weight` from its vocab rows, then delete it; adjust loaded-weights bookkeeping (supports `hf_to_vllm_mapper`).
> - In `config.py`, for original Qwen3 reranker, set `text_config.method = "from_2_way_softmax"` and propagate `classifier_from_token` to `text_config`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f968e1a4563ca709117bea076fce49878151ec93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
