### PR TITLE
[Tracing] Support OTEL_TRACES_EXPORTER env var and multiple exporters

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -59,3 +59,7 @@ terratorch @ git+https://github.com/IBM/terratorch.git@1.1.rc3 # required for Pr
 gpt-oss >= 0.0.7; python_version > '3.11'
 
 perceptron # required for isaac test
+
+# OpenTelemetry tracing
+opentelemetry-sdk
+opentelemetry-exporter-otlp

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -283,7 +283,10 @@ google-crc32c==1.7.1
 google-resumable-media==2.7.2
     # via google-cloud-storage
 googleapis-common-protos==1.70.0
-    # via google-api-core
+    # via
+    #   google-api-core
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
 gpt-oss==0.0.8
     # via -r requirements/test.in
 graphene==3.4.3
@@ -298,7 +301,9 @@ graphql-relay==3.2.0
 greenlet==3.2.3
     # via sqlalchemy
 grpcio==1.76.0
-    # via ray
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   ray
 gunicorn==23.0.0
     # via mlflow
 h11==0.14.0
@@ -644,16 +649,35 @@ opencv-python-headless==4.11.0.86
 opentelemetry-api==1.35.0
     # via
     #   mlflow-skinny
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-exporter-prometheus
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp==1.35.0
+    # via -r requirements/test.in
+opentelemetry-exporter-otlp-proto-common==1.35.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.35.0
+    # via opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.35.0
+    # via opentelemetry-exporter-otlp
 opentelemetry-exporter-prometheus==0.56b0
     # via ray
-opentelemetry-proto==1.36.0
-    # via ray
+opentelemetry-proto==1.35.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   ray
 opentelemetry-sdk==1.35.0
     # via
+    #   -r requirements/test.in
     #   mlflow-skinny
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-exporter-prometheus
     #   ray
 opentelemetry-semantic-conventions==0.56b0
@@ -947,6 +971,7 @@ requests==2.32.3
     #   mistral-common
     #   mlflow-skinny
     #   mteb
+    #   opentelemetry-exporter-otlp-proto-http
     #   pooch
     #   ray
     #   responses
@@ -1258,6 +1283,8 @@ typing-extensions==4.15.0
     #   mlflow-skinny
     #   mteb
     #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
     #   pqdm


### PR DESCRIPTION

## Purpose

The current tracing implementation hardcodes OTLP exporter and doesn't respect the OTEL_TRACES_EXPORTER environment variable defined in the OpenTelemetry specification.

This PR:

- Adds support for OTEL_TRACES_EXPORTER env var with values: otlp, console, none
- Supports comma-separated multiple exporters (e.g., console,otlp) for debugging scenarios where you want both terminal output and collector export
- Uses SimpleSpanProcessor for ConsoleSpanExporter to ensure immediate output


## Test Plan

`tests/v1/tracing/test_tracing.py`

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Introduces flexible OpenTelemetry trace exporting and updates dependencies.
> 
> - Implement `get_span_exporters` honoring `OTEL_TRACES_EXPORTER` (supports `otlp` [default], `console`, `none`, and comma-separated combos; `none` takes precedence; case-insensitive) and wire into `init_tracer` using `SimpleSpanProcessor` for `ConsoleSpanExporter` and `BatchSpanProcessor` otherwise
> - Add `_get_otlp_span_exporter` that respects `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` (grpc/http) with clearer errors and logging
> - Add unit tests in `tests/v1/tracing/test_tracing.py` covering defaults, console, none, multiple values, spacing, invalid values, and case-insensitivity
> - Update `requirements/test.in/.txt` to include `opentelemetry-sdk`, `opentelemetry-exporter-otlp` and related pinned packages (e.g., `opentelemetry-proto==1.35.0`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60ce021bc040c046ced304f7ef5ed21c49d295d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces flexible OpenTelemetry tracing configuration and aligns dependencies.
> 
> - Implement `get_span_exporters` honoring `OTEL_TRACES_EXPORTER` (`otlp` default, `console`, `none`, comma-separated; `none` takes precedence; case-insensitive) and use in `init_tracer` with `SimpleSpanProcessor` for `ConsoleSpanExporter` and `BatchSpanProcessor` otherwise
> - Add `_get_otlp_span_exporter` that respects `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` (`grpc` or `http/protobuf`) with clearer errors and logging
> - Add unit tests in `tests/v1/tracing/test_tracing.py` covering defaults, console, none, multiple values/spacing, invalid values, and case-insensitivity
> - Update `requirements/test.in` and compiled `requirements/test.txt` to include `opentelemetry-sdk`, `opentelemetry-exporter-otlp`, and pin related packages (e.g., `opentelemetry-proto==1.35.0`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98479fa7a14e3db108ae6078438dcc540a0dd59f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces configurable OpenTelemetry trace exporting and aligns dependencies.
> 
> - Implements `get_span_exporters` honoring `OTEL_TRACES_EXPORTER` (`otlp` default, `console`, `none`, comma-separated; `none` takes precedence; case-insensitive) and wires into `init_tracer` using `SimpleSpanProcessor` for `ConsoleSpanExporter` and `BatchSpanProcessor` otherwise
> - Adds `_get_otlp_span_exporter` that respects `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` (`grpc` or `http/protobuf`) with clearer errors and logging
> - Adds unit tests in `tests/v1/tracing/test_tracing.py` covering defaults, console, none, multiple values/spacing, invalid values, case-insensitivity, and deduplication
> - Updates `requirements/test.in` and compiled `requirements/test.txt` to include `opentelemetry-sdk`, `opentelemetry-exporter-otlp`, and adjust related pins (e.g., `opentelemetry-proto==1.35.0`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70a79ae2d9afb84d2f3c8da0020bb728a5d89d03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
