### PR TITLE
[Benchmark][2/2] Use spline interpolation to tune SLA variables

### DIFF
--- a/docs/benchmarking/sweeps.md
+++ b/docs/benchmarking/sweeps.md
@@ -129,10 +129,10 @@ vllm bench sweep serve_sla \
 
 The algorithm for adjusting the SLA variable is as follows:
 
-1. Run the benchmark with infinite QPS, and use the corresponding metrics to determine the initial value of the variable.
-    - For example, the initial request rate is set to the concurrency under infinite QPS.
-2. If the SLA is still satisfied, keep doubling the value until the SLA is no longer satisfied. This gives a relatively narrow window that contains the point where the SLA is barely satisfied.
-3. Apply binary search over the window to find the maximum value that still satisfies the SLA.
+1. Run the benchmark once with maximum possible QPS, and once with minimum possible QPS. For each run, calculate the distance of the SLA metrics from their targets, resulting in data points of QPS vs SLA distance.
+2. Perform spline interpolation between the data points to estimate the QPS that results in zero SLA distance.
+3. Run the benchmark with the estimated QPS and add the resulting data point to the history.
+4. Repeat Steps 2 and 3 until the estimated QPS is the same as that from the previous iteration.
 
 !!! important
     SLA tuning is applied over each combination of `--serve-params`, `--bench-params`, and `--sla-params`.

--- a/docs/benchmarking/sweeps.md
+++ b/docs/benchmarking/sweeps.md
@@ -132,7 +132,7 @@ The algorithm for adjusting the SLA variable is as follows:
 1. Run the benchmark once with maximum possible QPS, and once with minimum possible QPS. For each run, calculate the distance of the SLA metrics from their targets, resulting in data points of QPS vs SLA distance.
 2. Perform spline interpolation between the data points to estimate the QPS that results in zero SLA distance.
 3. Run the benchmark with the estimated QPS and add the resulting data point to the history.
-4. Repeat Steps 2 and 3 until the estimated QPS is the same as that from the previous iteration.
+4. Repeat Steps 2 and 3 until the maximum QPS that passes SLA and the minimum QPS that fails SLA in the history are close enough to each other.
 
 !!! important
     SLA tuning is applied over each combination of `--serve-params`, `--bench-params`, and `--sla-params`.

--- a/tests/benchmarks/sweep/test_serve_sla.py
+++ b/tests/benchmarks/sweep/test_serve_sla.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from vllm.benchmarks.sweep.param_sweep import ParameterSweepItem
-from vllm.benchmarks.sweep.serve_sla import _estimate_sla_bounds, _find_sla_value
+from vllm.benchmarks.sweep.serve_sla import solve_sla
 from vllm.benchmarks.sweep.server import ServerProcess
 from vllm.benchmarks.sweep.sla_sweep import (
     SLACriterionBase,
@@ -39,18 +39,69 @@ def _set_return_value(
     return patch("vllm.benchmarks.sweep.serve_sla.run_sla", side_effect=mock_run_sla)
 
 
-def _var2metric_identity(bench_comb):
-    return [{"request_throughput": float(bench_comb["request_rate"])}]
+def _var2metric_linear():
+    def wrapped(bench_comb):
+        x = float(bench_comb["request_rate"])
+        y = x
+        return [{"request_throughput": y}]
+
+    return wrapped
 
 
-def _run_estimate_sla_bounds(
+def _var2metric_concave(elbow_point: float):
+    def wrapped(bench_comb):
+        x = float(bench_comb["request_rate"])
+        if x < elbow_point:
+            y = 0.5 * (x - elbow_point) + elbow_point
+        else:
+            y = 1.5 * (x - elbow_point) + elbow_point
+
+        return [{"request_throughput": y}]
+
+    return wrapped
+
+
+def _var2metric_convex(elbow_point: float):
+    def wrapped(bench_comb):
+        x = float(bench_comb["request_rate"])
+        if x < elbow_point:
+            y = 1.5 * (x - elbow_point) + elbow_point
+        else:
+            y = 0.5 * (x - elbow_point) + elbow_point
+
+        return [{"request_throughput": y}]
+
+    return wrapped
+
+
+def _var2metric_quadratic(y_intercept: float):
+    def wrapped(bench_comb):
+        x = float(bench_comb["request_rate"])
+        y = y_intercept + 0.1 * x**2
+
+        return [{"request_throughput": y}]
+
+    return wrapped
+
+
+def _var2metric_sqrt(y_intercept: float):
+    def wrapped(bench_comb):
+        x = float(bench_comb["request_rate"])
+        y = y_intercept + 10 * x**0.5
+
+        return [{"request_throughput": y}]
+
+    return wrapped
+
+
+def _run_solve_sla(
     var2metric: Callable[[ParameterSweepItem], list[dict[str, float]]],
     criterion: SLACriterionBase,
-    init_value: int,
-    max_value: int,
+    min_value: int = 1,
+    max_value: int = 100,
 ):
     with _set_return_value(var2metric):
-        return _estimate_sla_bounds(
+        result = solve_sla(
             server=None,
             bench_cmd=[],
             serve_comb=ParameterSweepItem(),
@@ -60,143 +111,129 @@ def _run_estimate_sla_bounds(
             num_runs=1,
             dry_run=False,
             sla_variable="request_rate",
-            init_value=init_value,
-            max_value=max_value,
+            sla_min_value=min_value,
+            sla_max_value=max_value,
         )
+        assert result is not None
+
+        return result
 
 
-def test_estimate_sla_bounds_le():
-    sla_data, (max_passing, min_failing), history = _run_estimate_sla_bounds(
-        _var2metric_identity,
+def test_solve_linear_sla_le():
+    sla_data, history = _run_solve_sla(
+        _var2metric_linear(),
         SLALessThanOrEqualTo(target=32),
-        init_value=1,
-        max_value=100,
     )
 
-    assert max_passing == 32
-    assert min_failing == 64
+    assert history.get_max_passing() == 32
 
     assert {val: margin <= 0 for val, margin in history.items()} == {
+        100: False,
         1: True,
-        2: True,
-        4: True,
-        8: True,
-        16: True,
         32: True,
-        64: False,
+        33: False,
     }
 
 
-def test_estimate_sla_bounds_lt():
-    sla_data, (max_passing, min_failing), history = _run_estimate_sla_bounds(
-        _var2metric_identity,
+def test_solve_linear_sla_lt():
+    sla_data, history = _run_solve_sla(
+        _var2metric_linear(),
         SLALessThan(target=32),
-        init_value=1,
-        max_value=100,
     )
 
-    assert max_passing == 16
-    assert min_failing == 32
+    assert history.get_max_passing() == 31
 
     assert {val: margin <= 0 for val, margin in history.items()} == {
+        100: False,
         1: True,
-        2: True,
-        4: True,
-        8: True,
-        16: True,
+        31: True,
         32: False,
     }
 
 
-def test_estimate_sla_bounds_oob():
-    sla_data, (max_passing, min_failing), history = _run_estimate_sla_bounds(
-        _var2metric_identity,
+def test_solve_linear_sla_oob():
+    sla_data, history = _run_solve_sla(
+        _var2metric_linear(),
         SLALessThanOrEqualTo(target=32),
-        init_value=64,
-        max_value=128,
-    )
-
-    assert max_passing == 0
-    assert min_failing == 64
-
-    assert {val: margin <= 0 for val, margin in history.items()} == {
-        64: False,
-    }
-
-
-def _run_test_find_sla_value_le(
-    var2metric: Callable[[ParameterSweepItem], list[dict[str, float]]],
-    criterion: SLACriterionBase,
-    min_value: int,
-    max_value: int,
-):
-    with _set_return_value(var2metric):
-        return _find_sla_value(
-            server=None,
-            bench_cmd=[],
-            serve_comb=ParameterSweepItem(),
-            bench_comb=ParameterSweepItem(),
-            sla_comb=SLASweepItem({"request_throughput": criterion}),
-            base_path=Path(""),
-            num_runs=1,
-            dry_run=False,
-            sla_variable="request_rate",
-            min_value=min_value,
-            max_value=max_value,
-        )
-
-
-def test_find_sla_value_le():
-    sla_data, sla_value, history = _run_test_find_sla_value_le(
-        _var2metric_identity,
-        SLALessThanOrEqualTo(target=50.0),
-        min_value=32,
-        max_value=64,
-    )
-
-    assert sla_value == 50
-    assert {val: margin <= 0 for val, margin in history.items()} == {
-        48: True,
-        56: False,
-        52: False,
-        50: True,
-        51: False,
-    }
-
-
-def test_find_sla_value_lt():
-    sla_data, sla_value, history = _run_test_find_sla_value_le(
-        _var2metric_identity,
-        SLALessThan(target=50.0),
-        min_value=32,
-        max_value=64,
-    )
-
-    assert sla_value == 49
-    assert {val: margin <= 0 for val, margin in history.items()} == {
-        48: True,
-        56: False,
-        52: False,
-        50: False,
-        49: True,
-    }
-
-
-def test_find_sla_value_oob():
-    sla_data, sla_value, history = _run_test_find_sla_value_le(
-        _var2metric_identity,
-        SLALessThanOrEqualTo(target=50.0),
         min_value=64,
-        max_value=128,
     )
 
-    assert sla_value == 64
+    assert history.get_max_passing() == 64
+    assert history.get_min_failing() == 64
+
     assert {val: margin <= 0 for val, margin in history.items()} == {
-        96: False,
-        80: False,
-        72: False,
-        68: False,
-        66: False,
-        65: False,
+        100: False,
         64: False,
+    }
+
+
+def test_solve_concave_sla_le():
+    sla_data, history = _run_solve_sla(
+        _var2metric_concave(elbow_point=32),
+        SLALessThanOrEqualTo(target=24),
+    )
+
+    assert history.get_max_passing() == 16
+
+    assert {val: margin <= 0 for val, margin in history.items()} == {
+        100: False,
+        1: True,
+        7: True,
+        13: True,
+        15: True,
+        16: True,
+        17: False,
+    }
+
+
+def test_solve_convex_sla_le():
+    sla_data, history = _run_solve_sla(
+        _var2metric_convex(elbow_point=32),
+        SLALessThanOrEqualTo(target=24),
+    )
+
+    assert history.get_max_passing() == 26
+
+    assert {val: margin <= 0 for val, margin in history.items()} == {
+        100: False,
+        1: True,
+        48: False,
+        30: False,
+        24: True,
+        26: True,
+        27: False,
+    }
+
+
+def test_solve_quadratic_sla_le():
+    sla_data, history = _run_solve_sla(
+        _var2metric_quadratic(y_intercept=10),
+        SLALessThanOrEqualTo(target=50),
+    )
+
+    assert history.get_max_passing() == 20
+
+    assert {val: margin <= 0 for val, margin in history.items()} == {
+        100: False,
+        1: True,
+        4: True,
+        20: True,
+        21: False,
+    }
+
+
+def test_solve_sqrt_sla_le():
+    sla_data, history = _run_solve_sla(
+        _var2metric_sqrt(y_intercept=10),
+        SLALessThanOrEqualTo(target=100),
+    )
+
+    assert history.get_max_passing() == 81
+
+    assert {val: margin <= 0 for val, margin in history.items()} == {
+        100: False,
+        1: True,
+        89: False,
+        81: True,
+        82: False,
     }

--- a/tests/benchmarks/sweep/test_serve_sla.py
+++ b/tests/benchmarks/sweep/test_serve_sla.py
@@ -43,6 +43,7 @@ def _var2metric_linear():
     def wrapped(bench_comb):
         x = float(bench_comb["request_rate"])
         y = x
+
         return [{"request_throughput": y}]
 
     return wrapped

--- a/vllm/benchmarks/sweep/serve_sla.py
+++ b/vllm/benchmarks/sweep/serve_sla.py
@@ -149,7 +149,7 @@ def solve_sla(
     dry_run: bool,
     sla_variable: SLAVariable,
     sla_min_value: int = 1,
-    sla_max_value: int = 65536,  # The value that represents infinite QPS
+    sla_max_value: int = 8192,  # The value that represents infinite QPS
 ):
     sla_data = list[dict[str, object]]()
     history = SLAHistory(min_value=sla_min_value, max_value=sla_max_value)

--- a/vllm/benchmarks/sweep/serve_sla.py
+++ b/vllm/benchmarks/sweep/serve_sla.py
@@ -155,7 +155,7 @@ def solve_sla(
     sla_data = list[dict[str, object]]()
     history = SLAHistory(min_value=sla_min_value, max_value=sla_max_value)
 
-    while history.get_min_failing() - history.get_max_passing() > 1:
+    while history.get_max_passing() + 1 < history.get_min_failing():
         if len(history) == 0:
             val = sla_max_value
         elif len(history) == 1:

--- a/vllm/benchmarks/sweep/serve_sla.py
+++ b/vllm/benchmarks/sweep/serve_sla.py
@@ -3,13 +3,12 @@
 import argparse
 import contextlib
 import json
-import math
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import ClassVar, Literal, get_args
 
-from typing_extensions import assert_never
+from scipy.interpolate import PchipInterpolator
 
 from vllm.utils.import_utils import PlaceholderModule
 
@@ -118,18 +117,28 @@ def run_sla(
 SLAVariable = Literal["request_rate", "max_concurrency"]
 
 
-def _estimate_sla_value(run_data: dict[str, object], sla_variable: SLAVariable):
-    request_throughput = float(run_data["request_throughput"])  # type: ignore
-    if sla_variable == "request_rate":
-        return request_throughput
-    if sla_variable == "max_concurrency":
-        mean_latency_ms = float(run_data["mean_e2el_ms"])  # type: ignore
-        return request_throughput * mean_latency_ms / 1000
+class SLAHistory(dict[int, float]):
+    def __init__(self, min_value: int, max_value: int) -> None:
+        super().__init__()
 
-    assert_never(sla_variable)
+        self.min_value = min_value
+        self.max_value = max_value
+
+    def get_max_passing(self) -> float:
+        return max(
+            (val for val, margin in self.items() if margin <= 0),
+            default=self.min_value,
+        )
+
+    def get_min_failing(self) -> float:
+        return min(
+            (val for val, margin in self.items() if margin > 0),
+            default=self.max_value,
+        )
 
 
-def _estimate_sla_bounds(
+# NOTE: The SLA variable is assumed to have positive correlation w.r.t. the margin
+def solve_sla(
     server: ServerProcess | None,
     bench_cmd: list[str],
     *,
@@ -140,17 +149,33 @@ def _estimate_sla_bounds(
     num_runs: int,
     dry_run: bool,
     sla_variable: SLAVariable,
-    init_value: int,
-    max_value: int,
+    sla_min_value: int = 1,
+    sla_max_value: int = 65536,  # The value that represents infinite QPS
 ):
     sla_data = list[dict[str, object]]()
+    history = SLAHistory(min_value=sla_min_value, max_value=sla_max_value)
 
-    val: int = init_value
-    assert val > 0
+    while history.get_min_failing() - history.get_max_passing() > 1:
+        if len(history) == 0:
+            val = sla_max_value
+        elif len(history) == 1:
+            val = sla_min_value
+        else:
+            xs = list[int]()
+            ys = list[float]()
+            for x, y in sorted(history.items()):
+                xs.append(x)
+                ys.append(y)
 
-    history = dict[int, float]()
+            spl = PchipInterpolator(xs, ys, extrapolate=False)
+            spl_roots = spl.solve()
+            val = int(next(iter(spl_roots)))
 
-    while True:
+            if val in history:
+                val += 1  # Cover both sides (floor and ceil) of the root
+
+        unclamped_val = val
+        val = max(sla_min_value, min(val, sla_max_value))
         print(f"Testing {sla_variable}: {val} req/s")
 
         iter_data = run_sla(
@@ -162,8 +187,9 @@ def _estimate_sla_bounds(
             num_runs=num_runs,
             dry_run=dry_run,
         )
+        if iter_data is None:
+            return None
 
-        assert iter_data is not None
         sla_data.extend(iter_data)
 
         iter_data_mean = {
@@ -175,92 +201,17 @@ def _estimate_sla_bounds(
             criterion.print_and_compute_margin(iter_data_mean, k)
             for k, criterion in sla_comb.items()
         ]
-        margin = max(sla_margins)
-        history[val] = margin
+        history[val] = margin = max(sla_margins)
 
         if margin <= 0:
-            print("SLA criteria are met.")
-            val *= 2
+            print(f"SLA criteria are met. ({margin=:.2f})")
         else:
-            print("SLA criteria are not met.")
+            print(f"SLA criteria are not met. ({margin=:.2f})")
+
+        if unclamped_val != val:
             break
 
-        if val >= max_value:
-            break
-
-    max_passing = max(
-        (val for val, margin in history.items() if margin <= 0),
-        default=0,
-    )
-    min_failing = min(
-        (val for val, margin in history.items() if margin > 0),
-        default=max_value,
-    )
-
-    return sla_data, (max_passing, min_failing), history
-
-
-def _find_sla_value(
-    server: ServerProcess | None,
-    bench_cmd: list[str],
-    *,
-    serve_comb: ParameterSweepItem,
-    bench_comb: ParameterSweepItem,
-    sla_comb: SLASweepItem,
-    base_path: Path,
-    num_runs: int,
-    dry_run: bool,
-    sla_variable: SLAVariable,
-    min_value: int,
-    max_value: int,
-):
-    sla_data = list[dict[str, object]]()
-
-    left: int = min_value
-    right: int = max_value
-
-    history = dict[int, float]()
-
-    while True:
-        val = (left + right) // 2
-        print(f"Testing {sla_variable}: {val} req/s")
-
-        iter_data = run_sla(
-            server,
-            bench_cmd,
-            serve_comb=serve_comb,
-            bench_comb=bench_comb | {sla_variable: val},
-            iter_path=_get_sla_iter_path(base_path, sla_comb, sla_variable, val),
-            num_runs=num_runs,
-            dry_run=dry_run,
-        )
-
-        assert iter_data is not None
-        sla_data.extend(iter_data)
-
-        iter_data_mean = {
-            k: sum(float(run_data[k]) for run_data in iter_data) / len(iter_data)  # type: ignore
-            for k in sla_comb
-        }
-
-        sla_margins = [
-            criterion.print_and_compute_margin(iter_data_mean, k)
-            for k, criterion in sla_comb.items()
-        ]
-        margin = max(sla_margins)
-        history[val] = margin
-
-        if margin <= 0:
-            print("SLA criteria are met.")
-            left = val
-        else:
-            print("SLA criteria are not met.")
-            right = val
-
-        if right - left <= 1 and left in history:
-            break
-
-    return sla_data, left, history
+    return sla_data, history
 
 
 def search_sla(
@@ -271,7 +222,6 @@ def search_sla(
     bench_comb: ParameterSweepItem,
     sla_comb: SLASweepItem,
     sla_variable: SLAVariable,
-    sla_inf_value: int = 65536,  # The value that represents infinite QPS
     base_path: Path,
     num_runs: int,
     dry_run: bool,
@@ -279,57 +229,25 @@ def search_sla(
     print("[SLA START]")
     print(f"SLA criteria: {sla_comb.as_text()}")
 
-    sla_data_0 = run_sla(
+    result = solve_sla(
         server,
         bench_cmd,
         serve_comb=serve_comb,
-        bench_comb=bench_comb | {sla_variable: sla_inf_value},
-        iter_path=_get_sla_iter_path(base_path, sla_comb, sla_variable, sla_inf_value),
+        bench_comb=bench_comb,
+        sla_comb=sla_comb,
+        base_path=base_path,
         num_runs=num_runs,
         dry_run=dry_run,
+        sla_variable=sla_variable,
     )
-    if sla_data_0 is None:
+    if result is None:
         assert dry_run
         print("Omitting SLA search.")
         print("[SLA END]")
-        return None
+        return
 
-    sla_init_value = math.ceil(
-        sum(_estimate_sla_value(item, sla_variable) for item in sla_data_0)
-        / len(sla_data_0)
-    )
-    print(f"Initial {sla_variable} to search: {sla_init_value} req/s.")
-
-    sla_data_1, (sla_min, sla_max), _ = _estimate_sla_bounds(
-        server,
-        bench_cmd,
-        serve_comb=serve_comb,
-        bench_comb=bench_comb,
-        sla_comb=sla_comb,
-        base_path=base_path,
-        num_runs=num_runs,
-        dry_run=dry_run,
-        sla_variable=sla_variable,
-        init_value=sla_init_value,
-        max_value=sla_inf_value,
-    )
-    print(f"Range of {sla_variable} to search: [{sla_min}, {sla_max}] req/s.")
-
-    sla_data_2, sla_value, _ = _find_sla_value(
-        server,
-        bench_cmd,
-        serve_comb=serve_comb,
-        bench_comb=bench_comb,
-        sla_comb=sla_comb,
-        base_path=base_path,
-        num_runs=num_runs,
-        dry_run=dry_run,
-        sla_variable=sla_variable,
-        min_value=sla_min,
-        max_value=sla_max,
-    )
-
-    sla_data = sla_data_0 + sla_data_1 + sla_data_2
+    sla_data, sla_history = result
+    sla_value = sla_history.get_max_passing()
     print(f"Maximum {sla_variable} for SLA: {sla_value} req/s.")
 
     with _get_sla_iter_path(

--- a/vllm/benchmarks/sweep/serve_sla.py
+++ b/vllm/benchmarks/sweep/serve_sla.py
@@ -169,7 +169,11 @@ def solve_sla(
 
             spl = PchipInterpolator(xs, ys, extrapolate=False)
             spl_roots = spl.solve()
-            val = int(next(iter(spl_roots)))
+            if len(spl_roots) == 0:
+                # Fallback to binary search
+                val = (history.get_max_passing() + history.get_min_failing()) // 2
+            else:
+                val = int(spl_roots[0])
 
             if val in history:
                 # Cover both sides (floor and ceil) of the root to be sure

--- a/vllm/benchmarks/sweep/serve_sla.py
+++ b/vllm/benchmarks/sweep/serve_sla.py
@@ -155,6 +155,7 @@ def solve_sla(
     sla_data = list[dict[str, object]]()
     history = SLAHistory(min_value=sla_min_value, max_value=sla_max_value)
 
+    # NOTE: We don't use equality here to be more robust against noisy results
     while history.get_max_passing() + 1 < history.get_min_failing():
         if len(history) == 0:
             val = sla_max_value

--- a/vllm/benchmarks/sweep/serve_sla.py
+++ b/vllm/benchmarks/sweep/serve_sla.py
@@ -27,7 +27,7 @@ except ImportError:
     PchipInterpolator = (
         PlaceholderModule("scipy")
         .placeholder_attr("interpolate")
-        .placeholder_attr("PlaceholderModule")
+        .placeholder_attr("PchipInterpolator")
     )
 
 

--- a/vllm/benchmarks/sweep/serve_sla.py
+++ b/vllm/benchmarks/sweep/serve_sla.py
@@ -172,7 +172,9 @@ def solve_sla(
             val = int(next(iter(spl_roots)))
 
             if val in history:
-                val += 1  # Cover both sides (floor and ceil) of the root
+                # Cover both sides (floor and ceil) of the root to be sure
+                # that it is indeed the target value
+                val += 1
 
         unclamped_val = val
         val = max(sla_min_value, min(val, sla_max_value))

--- a/vllm/benchmarks/sweep/serve_sla.py
+++ b/vllm/benchmarks/sweep/serve_sla.py
@@ -137,7 +137,6 @@ class SLAHistory(dict[int, float]):
         )
 
 
-# NOTE: The SLA variable is assumed to have positive correlation w.r.t. the margin
 def solve_sla(
     server: ServerProcess | None,
     bench_cmd: list[str],


### PR DESCRIPTION
## Purpose

Use spline interpolation to search for the maximum QPS that barely satisfies the SLA requirements. Compared to the previous algorithm that adopts a two-stage approach (scanning min/max boundaries before applying binary search), the new algorithm only has one stage and converges faster especially for large QPS values: binary search is forced to pick the midpoint between left/right pointers, while interpolation allows for choosing other candidates between the two pointers.

Follow-up to #32075

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 1ff2d18b77e9a99f4d793d1447148b7e42e86f00. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 2b1c2916e29a23c77f56cd1f4de300fc9a6b28db. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces an interpolation-based SLA search for faster convergence and simpler flow.
> 
> - Replace two-stage scan + binary search with `solve_sla` using `PchipInterpolator` and `SLAHistory`; refactor `search_sla` to consume the new solver
> - Update docs to describe iterative min/max runs + spline interpolation loop for SLA tuning
> - Rewrite tests to validate `solve_sla` on linear, concave/convex, quadratic, and sqrt relationships; remove legacy bound/value estimators
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b1c2916e29a23c77f56cd1f4de300fc9a6b28db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces an interpolation-based SLA solver for faster convergence and simpler flow in serve sweeps.
> 
> - Add `solve_sla` using `PchipInterpolator` with `SLAHistory` to iteratively estimate the SLA root from past runs; refactor `search_sla` to consume the new solver
> - Remove legacy `_estimate_sla_bounds`/`_find_sla_value` logic and associated math/assert imports
> - Update `docs/benchmarking/sweeps.md` to describe the new min/max runs + spline interpolation loop
> - Rewrite tests in `tests/benchmarks/sweep/test_serve_sla.py` to validate `solve_sla` across linear, concave/convex, quadratic, and sqrt relationships; adjust expectations to `SLAHistory.get_max_passing()`/`get_min_failing()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac8f79452522003209b2eb2ef0148b8055a04fb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces an interpolation-based SLA search that simplifies flow and improves convergence in serve sweeps.
> 
> - Add `solve_sla` leveraging `scipy.interpolate.PchipInterpolator` and `SLAHistory` to iteratively estimate the zero-margin point; refactor `search_sla` to consume it
> - Remove legacy `_estimate_sla_bounds`/`_find_sla_value` logic and related imports; simplify control flow in `serve_sla.py`
> - Update `docs/benchmarking/sweeps.md` to describe the new min/max runs + spline interpolation loop for SLA tuning
> - Rewrite `tests/benchmarks/sweep/test_serve_sla.py` to validate `solve_sla` across linear, concave/convex, quadratic, and sqrt cases; assert via `SLAHistory.get_max_passing()`/`get_min_failing()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddbe69d384914181e1d48488a0bd1ad8b24f6e03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces an interpolation-driven SLA search that converges faster and simplifies flow.
> 
> - Replace bound-scan + binary search with `solve_sla` using `PchipInterpolator` and `SLAHistory`; refactor `search_sla` to consume the new solver
> - Remove legacy `_estimate_sla_bounds`/`_find_sla_value` logic and related imports
> - Update `docs/benchmarking/sweeps.md` to describe min/max runs + spline interpolation loop for tuning
> - Rewrite tests in `tests/benchmarks/sweep/test_serve_sla.py` to validate linear, concave/convex, quadratic, and sqrt cases; assert via `history.get_max_passing()`/`get_min_failing()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a796892f2cead4cb31b19bd693342209248beb88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces an interpolation-driven SLA search for faster, single-stage convergence.
> 
> - Add `solve_sla` using `PchipInterpolator` and `SLAHistory`; refactor `search_sla` to consume it
> - Remove legacy `_estimate_sla_bounds`/`_find_sla_value` logic and related imports
> - Update `docs/benchmarking/sweeps.md` to describe min/max runs + spline interpolation loop
> - Rewrite `tests/benchmarks/sweep/test_serve_sla.py` to validate linear, concave/convex, quadratic, and sqrt cases using `history.get_max_passing()/get_min_failing()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92638336f25a528ffef9ebeeca18fe61bbdb8ca2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces a single-stage, interpolation-based SLA tuner for serve sweeps.
> 
> - Add `solve_sla` leveraging `scipy.interpolate.PchipInterpolator` with `SLAHistory` to estimate the zero-margin point; refactor `search_sla` to use it
> - Remove legacy `_estimate_sla_bounds` and `_find_sla_value` paths and related imports; simplify control flow and dry-run handling
> - Update `docs/benchmarking/sweeps.md` to describe min/max runs + spline interpolation loop for SLA tuning
> - Rewrite `tests/benchmarks/sweep/test_serve_sla.py` to validate linear, concave/convex, quadratic, and sqrt relationships via `history.get_max_passing()`/`get_min_failing()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13bf6f556f830c2304e6802c34b66f043d1d1807. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces an interpolation-driven SLA solver for faster, single-stage convergence in serve sweeps.
> 
> - Add `solve_sla` using `scipy.interpolate.PchipInterpolator` with `SLAHistory` to estimate the zero-margin point; refactor `search_sla` to use it and simplify dry-run handling
> - Remove legacy `_estimate_sla_bounds`/`_find_sla_value` paths and related code
> - Update `docs/benchmarking/sweeps.md` to describe min/max runs + spline interpolation loop for tuning
> - Rewrite `tests/benchmarks/sweep/test_serve_sla.py` to validate linear, concave/convex, quadratic, and sqrt cases using `history.get_max_passing()`/`get_min_failing()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 660130b6db1fdb6241fbe88b7e7b33039a4bf64a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces a single-stage, interpolation-based SLA tuner for serve sweeps, replacing the prior bound-scan + binary search with faster convergence and simpler flow.
> 
> - Adds `solve_sla` using `scipy.interpolate.PchipInterpolator` with `SLAHistory` to estimate the zero-margin point; refactors `search_sla` to use it and simplifies dry-run handling
> - Removes legacy `_estimate_sla_bounds`/`_find_sla_value` logic and related imports
> - Updates `docs/benchmarking/sweeps.md` to document min/max seeding and spline interpolation loop
> - Rewrites `tests/benchmarks/sweep/test_serve_sla.py` to validate linear, concave/convex, quadratic, and sqrt relationships via `history.get_max_passing()`/`get_min_failing()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 712b3c102f0c24dc69b0fa93cc0a5544b7769aaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces a single-stage, interpolation-based SLA tuner for serve sweeps.
> 
> - Add `solve_sla` using `scipy.interpolate.PchipInterpolator` with `SLAHistory` to iteratively estimate the zero-margin point; refactor `search_sla` to consume it and simplify dry-run handling
> - Remove legacy `_estimate_sla_bounds`/`_find_sla_value` logic and related imports; streamline result aggregation and output
> - Update `docs/benchmarking/sweeps.md` to document min/max seeding + spline interpolation loop
> - Rewrite `tests/benchmarks/sweep/test_serve_sla.py` to validate linear, concave/convex, quadratic, and sqrt relationships using `history.get_max_passing()`/`get_min_failing()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8df2901c4542fed0e9cf8542a02dcd6a1f8b23cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
