### PR TITLE
[Misc] Make `scipy` as optional audio/benchmark dependency 

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -42,7 +42,6 @@ depyf==0.20.0 # required for profiling and debugging with compilation config
 cloudpickle # allows pickling lambda functions in model_executor/models/registry.py
 watchfiles # required for http server to monitor the updates of TLS files
 python-json-logger # Used by logging as per examples/others/logging_configuration.md
-scipy # Required for phi-4-multimodal-instruct
 ninja # Required for xgrammar, rocm, tpu, xpu
 pybase64 # fast base64 implementation
 cbor2 # Required for cross-language serialization of hashable objects

--- a/setup.py
+++ b/setup.py
@@ -978,15 +978,16 @@ setup(
     ext_modules=ext_modules,
     install_requires=get_requirements(),
     extras_require={
-        "bench": ["pandas", "matplotlib", "seaborn", "datasets"],
-        "tensorizer": ["tensorizer==2.10.1"],
-        "fastsafetensors": ["fastsafetensors >= 0.1.10"],
-        "runai": ["runai-model-streamer[s3,gcs] >= 0.15.3"],
         "audio": [
             "librosa",
+            "scipy",
             "soundfile",
             "mistral_common[audio]",
         ],  # Required for audio processing
+        "bench": ["pandas", "matplotlib", "seaborn", "datasets", "scipy"],
+        "tensorizer": ["tensorizer==2.10.1"],
+        "fastsafetensors": ["fastsafetensors >= 0.1.10"],
+        "runai": ["runai-model-streamer[s3,gcs] >= 0.15.3"],
         "video": [],  # Kept for backwards compatibility
         "flashinfer": [],  # Kept for backwards compatibility
         # Optional deps for AMD FP4 quantization support

--- a/setup.py
+++ b/setup.py
@@ -978,16 +978,16 @@ setup(
     ext_modules=ext_modules,
     install_requires=get_requirements(),
     extras_require={
+        "bench": ["pandas", "matplotlib", "seaborn", "datasets", "scipy"],
+        "tensorizer": ["tensorizer==2.10.1"],
+        "fastsafetensors": ["fastsafetensors >= 0.1.10"],
+        "runai": ["runai-model-streamer[s3,gcs] >= 0.15.3"],
         "audio": [
             "librosa",
             "scipy",
             "soundfile",
             "mistral_common[audio]",
         ],  # Required for audio processing
-        "bench": ["pandas", "matplotlib", "seaborn", "datasets", "scipy"],
-        "tensorizer": ["tensorizer==2.10.1"],
-        "fastsafetensors": ["fastsafetensors >= 0.1.10"],
-        "runai": ["runai-model-streamer[s3,gcs] >= 0.15.3"],
         "video": [],  # Kept for backwards compatibility
         "flashinfer": [],  # Kept for backwards compatibility
         # Optional deps for AMD FP4 quantization support

--- a/vllm/multimodal/audio.py
+++ b/vllm/multimodal/audio.py
@@ -27,6 +27,12 @@ try:
 except ImportError:
     soundfile = PlaceholderModule("soundfile")  # type: ignore[assignment]
 
+
+try:
+    import scipy.signal as scipy_signal
+except ImportError:
+    scipy_signal = PlaceholderModule("scipy").placeholder_attr("signal")  # type: ignore[assignment]
+
 # ============================================================
 
 
@@ -173,13 +179,10 @@ def resample_audio_scipy(
     orig_sr: float,
     target_sr: float,
 ):
-    # lazy import scipy.signal, otherwise it will crash doc build.
-    import scipy.signal
-
     if orig_sr > target_sr:
-        return scipy.signal.resample_poly(audio, 1, orig_sr // target_sr)
+        return scipy_signal.resample_poly(audio, 1, orig_sr // target_sr)
     elif orig_sr < target_sr:
-        return scipy.signal.resample_poly(audio, target_sr // orig_sr, 1)
+        return scipy_signal.resample_poly(audio, target_sr // orig_sr, 1)
     return audio
 
 


### PR DESCRIPTION

## Purpose
- `scipy` is only used for Phi4-MM's audio resampling. 
- So we can mark it as audio optional dependency together with `librosa` etc to slim common requirements.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c5efc411100cbeee4d141b7517b0bca040d0e4dd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Makes `scipy` an optional dependency and updates audio code to handle its absence.
> 
> - Remove `scipy` from `requirements/common.txt`; add to `extras_require` for `audio` and `bench` in `setup.py`
> - In `vllm/multimodal/audio.py`, import `scipy.signal` via a placeholder alias (`scipy_signal`) and use it in `resample_audio_scipy`, eliminating the in-function import
> - Keeps `librosa`/`soundfile` behavior unchanged; only the SciPy resampling path depends on the optional extra
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5efc411100cbeee4d141b7517b0bca040d0e4dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
