### PR TITLE
[Bugfix] Fix GLM-4.7 tool parser for tool call without arguments

### DIFF
--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -113,9 +113,9 @@ class Glm4MoeModelToolParser(ToolParser):
             tool_calls = []
             for match in matched_tool_calls:
                 tc_detail = self.func_detail_regex.search(match)
-                tc_name = tc_detail.group(1)
+                tc_name = tc_detail.group(1).strip()
                 tc_args = tc_detail.group(2)
-                pairs = self.func_arg_regex.findall(tc_args)
+                pairs = self.func_arg_regex.findall(tc_args or "")
                 arg_dct = {}
                 for key, value in pairs:
                     arg_key = key.strip()


### PR DESCRIPTION
## Purpose

The difference in the tool parser for GLM-4.7 (i.e. `Glm47MoeModelToolParser` compared to `Glm4MoeModelToolParser`) leads to tool calls for tools without arguments to fail, so a model output like `<tool_call>get_current_time</tool_call>` is not parsed correctly. Instead, it causes a `TypeError`.

## Test Plan

`pytest -v tests/tool_parsers/test_glm4_moe_tool_parser.py -k test_extract_tool_calls_empty_arguments`

## Test Result

Before fix:

```
tests/tool_parsers/test_glm4_moe_tool_parser.py::test_extract_tool_calls_empty_arguments[glm4_moe_tool_parser] PASSED                                                                                          [ 50%]
tests/tool_parsers/test_glm4_moe_tool_parser.py::test_extract_tool_calls_empty_arguments[glm47_moe_tool_parser] FAILED                                                                                         [100%]

====================================================================================================== FAILURES ======================================================================================================
___________________________________________________________________________ test_extract_tool_calls_empty_arguments[glm47_moe_tool_parser] ___________________________________________________________________________

request = <FixtureRequest for <Function test_extract_tool_calls_empty_arguments[glm47_moe_tool_parser]>>, tool_parser_name = 'glm47_moe_tool_parser'

    @pytest.mark.parametrize(
        "tool_parser_name",
        ["glm4_moe_tool_parser", "glm47_moe_tool_parser"],
    )
    def test_extract_tool_calls_empty_arguments(request, tool_parser_name):
        """Test tool calls with no arguments."""
        tool_parser = request.getfixturevalue(tool_parser_name)
        model_output = """<tool_call>get_current_time
    </tool_call>"""

        extracted_tool_calls = tool_parser.extract_tool_calls(model_output, request=None)  # type: ignore[arg-type]

>       assert extracted_tool_calls.tools_called
E       AssertionError: assert False
E        +  where False = ExtractedToolCallInformation(tools_called=False, tool_calls=[], content='<tool_call>get_current_time\n</tool_call>').tools_called

tests/tool_parsers/test_glm4_moe_tool_parser.py:289: AssertionError
------------------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------------------
ERROR 01-10 19:49:21 [glm4_moe_tool_parser.py:137] Failed to extract tool call spec
ERROR 01-10 19:49:21 [glm4_moe_tool_parser.py:137] Traceback (most recent call last):
ERROR 01-10 19:49:21 [glm4_moe_tool_parser.py:137]   File "/tmp/vllm/vllm/tool_parsers/glm4_moe_tool_parser.py", line 118, in extract_tool_calls
ERROR 01-10 19:49:21 [glm4_moe_tool_parser.py:137]     pairs = self.func_arg_regex.findall(tc_args)
ERROR 01-10 19:49:21 [glm4_moe_tool_parser.py:137]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-10 19:49:21 [glm4_moe_tool_parser.py:137] TypeError: expected string or buffer
```
After fix:

```
tests/tool_parsers/test_glm4_moe_tool_parser.py::test_extract_tool_calls_empty_arguments[glm4_moe_tool_parser] PASSED                                                                                          [ 50%]
tests/tool_parsers/test_glm4_moe_tool_parser.py::test_extract_tool_calls_empty_arguments[glm47_moe_tool_parser] PASSED                                                                                         [100%]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Improves robustness of GLM tool call parsing and adds coverage for GLM-4.7.
> 
> - In `glm4_moe_tool_parser.py`, trim function names (`tc_name.strip()`) and safely handle missing/empty args by running arg regex on `tc_args or ""`, preventing TypeError; resulting empty args serialize to `{}`.
> - Tests: add `Glm47MoeModelToolParser` fixture and parametrize the empty-arguments test to run for both GLM-4 and GLM-4.7 parsers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab23e63af1cbf642059d53e1542a1c63b699b45e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
