### PR TITLE
fix(examples): replace unsafe eval() with safe math evaluator in xLAM tool examples

### DIFF
--- a/examples/online_serving/openai_chat_completion_client_with_tools_xlam.py
+++ b/examples/online_serving/openai_chat_completion_client_with_tools_xlam.py
@@ -71,7 +71,13 @@ def calculate_expression(expression: str):
         tree = ast.parse(expression, mode="eval")
         result = safe_eval(tree)
         return f"The result of {expression} is {result}"
-    except (ValueError, SyntaxError) as e:
+    except (
+        ValueError,
+        SyntaxError,
+        RecursionError,
+        ZeroDivisionError,
+        OverflowError,
+    ) as e:
         return f"Could not calculate {expression}: {e}"
 
 

--- a/examples/online_serving/openai_chat_completion_client_with_tools_xlam_streaming.py
+++ b/examples/online_serving/openai_chat_completion_client_with_tools_xlam_streaming.py
@@ -14,7 +14,9 @@ vllm serve --model Salesforce/xLAM-2-3b-fc-r --enable-auto-tool-choice --tool-ca
 This example demonstrates streaming tool calls with xLAM models.
 """
 
+import ast
 import json
+import operator
 import time
 
 from openai import OpenAI
@@ -30,10 +32,48 @@ def get_weather(location: str, unit: str):
 
 
 def calculate_expression(expression: str):
+    """Safely evaluate a mathematical expression.
+
+    Uses ast.parse to ensure only safe numeric operations are performed,
+    preventing arbitrary code execution.
+    """
+    # Define allowed operators for safe math evaluation
+    allowed_operators = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+        ast.Pow: operator.pow,
+        ast.USub: operator.neg,
+        ast.UAdd: operator.pos,
+    }
+
+    def safe_eval(node):
+        if isinstance(node, ast.Constant):  # Numbers
+            if isinstance(node.value, (int, float)):
+                return node.value
+            raise ValueError(f"Unsupported constant: {node.value}")
+        elif isinstance(node, ast.BinOp):  # Binary operations
+            if type(node.op) not in allowed_operators:
+                raise ValueError(f"Unsupported operator: {type(node.op).__name__}")
+            left = safe_eval(node.left)
+            right = safe_eval(node.right)
+            return allowed_operators[type(node.op)](left, right)
+        elif isinstance(node, ast.UnaryOp):  # Unary operations (-x, +x)
+            if type(node.op) not in allowed_operators:
+                raise ValueError(f"Unsupported operator: {type(node.op).__name__}")
+            operand = safe_eval(node.operand)
+            return allowed_operators[type(node.op)](operand)
+        elif isinstance(node, ast.Expression):
+            return safe_eval(node.body)
+        else:
+            raise ValueError(f"Unsupported expression type: {type(node).__name__}")
+
     try:
-        result = eval(expression)
+        tree = ast.parse(expression, mode="eval")
+        result = safe_eval(tree)
         return f"The result of {expression} is {result}"
-    except Exception as e:
+    except (ValueError, SyntaxError) as e:
         return f"Could not calculate {expression}: {e}"
 
 

--- a/examples/online_serving/openai_chat_completion_client_with_tools_xlam_streaming.py
+++ b/examples/online_serving/openai_chat_completion_client_with_tools_xlam_streaming.py
@@ -73,7 +73,13 @@ def calculate_expression(expression: str):
         tree = ast.parse(expression, mode="eval")
         result = safe_eval(tree)
         return f"The result of {expression} is {result}"
-    except (ValueError, SyntaxError) as e:
+    except (
+        ValueError,
+        SyntaxError,
+        RecursionError,
+        ZeroDivisionError,
+        OverflowError,
+    ) as e:
         return f"Could not calculate {expression}: {e}"
 
 


### PR DESCRIPTION
## Summary

This PR fixes a **Remote Code Execution (RCE) vulnerability** in the xLAM tool calling examples.

### The Problem

The `calculate_expression()` function in both `openai_chat_completion_client_with_tools_xlam.py` and `openai_chat_completion_client_with_tools_xlam_streaming.py` used Python's `eval()` directly on LLM-generated expressions:

```python
def calculate_expression(expression: str):
    result = eval(expression)  # Vulnerable!
```

An attacker could manipulate the LLM (via prompt injection) to call this function with malicious code:
```python
"__import__('os').system('rm -rf /')"
```

### The Fix

Replaced `eval()` with a safe AST-based math evaluator that:
- Only allows numeric constants (`int`, `float`)
- Only permits basic math operators (`+`, `-`, `*`, `/`, `**`)
- Rejects any other Python expressions (function calls, imports, attribute access, etc.)

This prevents arbitrary code execution while maintaining full calculator functionality for the intended use case.

### Security Impact

- **Before**: Arbitrary Python code execution possible
- **After**: Only safe numeric math operations allowed

### Testing

The fix maintains backward compatibility - all valid math expressions like `25 * 17 + 31` still work correctly.

---

*Identified using [aisentry](https://aisentry.co), an AI/LLM security scanner for OWASP LLM Top 10 vulnerabilities.*

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 17cd103324d1efbdfdcc9c0548ef782f3024a3cb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Strengthens safety of xLAM tool-calling examples by eliminating code execution risk.
> 
> - Replaces `eval()` in `calculate_expression` with an AST-validated evaluator allowing only numeric constants and operators (`+`, `-`, `*`, `/`, `**`, unary `+/-`) and rejects all other nodes
> - Updates error handling to catch `ValueError`/`SyntaxError`; adds `ast`/`operator` imports and brief docstring
> - Applies consistently to both `openai_chat_completion_client_with_tools_xlam.py` and `..._xlam_streaming.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17cd103324d1efbdfdcc9c0548ef782f3024a3cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Strengthens safety of xLAM tool-calling examples by eliminating code execution risk.
> 
> - Replaces `eval()` in `calculate_expression` with an AST-validated evaluator allowing only numeric constants and operators (`+`, `-`, `*`, `/`, `**`, unary `+/-`)
> - Adds `ast`/`operator` imports, brief docstring, and narrows error handling to `ValueError`/`SyntaxError`
> - Applies the same change to both `openai_chat_completion_client_with_tools_xlam.py` and `openai_chat_completion_client_with_tools_xlam_streaming.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0cff8cc8522629f6abc101574d1d4236f99f19d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Updates `calculate_expression` in `openai_chat_completion_client_with_tools_xlam.py` and `..._xlam_streaming.py` to use an AST-validated evaluator instead of `eval`.
> 
> - Adds `ast`/`operator` imports and a brief safety docstring
> - Implements `safe_eval` allowing only numeric constants and basic operators; parses with `ast.parse(..., mode="eval")`
> - Narrows exceptions to `ValueError`/`SyntaxError` and adjusts return messages accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65797c5144625ae2bc3c07f5d4f8f1f3148a4112. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Strengthens safety of xLAM tool-calling examples by eliminating code execution risk.
> 
> - Implements `safe_eval` using `ast.parse(..., mode="eval")` allowing only numeric constants and basic operators (`+`, `-`, `*`, `/`, `**`, unary `+/-`); removes direct `eval()`
> - Adds `ast`/`operator` imports, brief safety docstrings, and narrows exception handling (e.g., `ValueError`, `SyntaxError`, `ZeroDivisionError`, etc.)
> - Applies changes to both `openai_chat_completion_client_with_tools_xlam.py` and `openai_chat_completion_client_with_tools_xlam_streaming.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffd503976c0cdc0099888fd4625db252c67399a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Enhances safety of xLAM tool-calling examples by eliminating code execution risk in math evaluation.
> 
> - Replaces `eval()` in `calculate_expression` with an AST-validated `safe_eval` allowing only numeric constants and basic operators (`+`, `-`, `*`, `/`, `**`, unary `+/-`)
> - Adds `ast`/`operator` imports and brief safety docstrings; parses input via `ast.parse(..., mode="eval")`
> - Narrows/expands exception handling to explicit safe errors (e.g., `ValueError`, `SyntaxError`, `ZeroDivisionError`, etc.)
> - Applies identical changes to both `openai_chat_completion_client_with_tools_xlam.py` and `openai_chat_completion_client_with_tools_xlam_streaming.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c86c39e2675e56412ce360b5ff1dbf7f94a6fc91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
