### PR TITLE
[MTP][GLM][Bugfix] Fixed .weight_scale loading logic that dropped MTP prediction accuracy with fp8+mtp

### DIFF
--- a/vllm/model_executor/models/glm4_moe_mtp.py
+++ b/vllm/model_executor/models/glm4_moe_mtp.py
@@ -268,11 +268,6 @@ class Glm4MoeMTP(nn.Module, SupportsPP, Glm4MixtureOfExperts):
                 if spec_layer is None:
                     continue
                 name = self._rewrite_spec_layer_name(spec_layer, name)
-            # Some checkpoints include weight scale tensors for the LM head even
-            # when the quantized head isn't built. Skip them if the model does
-            # not expose a matching parameter to avoid KeyError during load.
-            if name.endswith(".weight_scale") and name not in params_dict:
-                continue
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 # Skip non-stacked layers and experts (experts handled below).
                 if weight_name not in name:
@@ -314,6 +309,12 @@ class Glm4MoeMTP(nn.Module, SupportsPP, Glm4MixtureOfExperts):
                 else:
                     # Skip loading extra bias for GPTQ models.
                     if name.endswith(".bias") and name not in params_dict:
+                        continue
+                    # Some checkpoints include weight scale tensors for the
+                    # LM head even when the quantized head isn't built. Skip
+                    # them if the model does not expose a matching parameter
+                    # to avoid KeyError during load.
+                    if name.endswith(".weight_scale") and name not in params_dict:
                         continue
 
                     # According to DeepSeek-V3 Technical Report, MTP modules


### PR DESCRIPTION
## Purpose

Fix FP8 checkpoint loading for GLM-4.5/4.6/4.7 MTP (Multi-Token Prediction) model by properly skipping weight scale tensors. Some FP8 checkpoints include `weight_scale` tensors for the LM head even when the quantized head isn't built. Without this fix, loading such checkpoints would cause a `KeyError` when  trying to access non-existent parameters.


Specifically, this pr is to fix a previous [PR](https://github.com/vllm-project/vllm/pull/31757) which had an incorrect logic that skips loading the non-present ".weight_scale" tensors directly before name remappings, which cause some actually meaningful "weight_scale" not loaded properly and led to MTP prediction quality drop.

## Test Plan

Load GLM-4.6-FP8/GLM-4.7-FP8 MTP model with FP8 checkpoint and verify:
1. No `KeyError` during weight loading
2. MTP prediction accuracy is preserved (~90% acceptance rate)

## Test Result
- Before the problematic [PR](https://github.com/vllm-project/vllm/pull/31757): Unable to load GLM-4.5-FP8/GLM-4.6-FP8 when turning on MTP as `KeyError: 'model.layers.92.shared_head.head.weight_scale'` will occur.
- Before this fix: ~1% draft acceptance rate for GLM-4.6-fp8/GLM-4.7-fp8. ~90% when using original bf16 checkpoints.
- After this fix: MTP accuracy ~90%, back to normal.


---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c00464d56342defa84bbc6b953b010023c1cea57. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Fixes FP8 checkpoint loading for GLM-4.x MTP by moving and guarding the `.weight_scale` skip logic inside `load_weights`.
> 
> - Relocates the check for `*.weight_scale` to the fallback load path and skips only when the param is absent in `params_dict`, after name remapping and stacked/expert handling
> - Maintains existing bias-skip for GPTQ and shared-embedding handling for MTP layers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c00464d56342defa84bbc6b953b010023c1cea57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
