### PR TITLE
[Model Runner V2] Support structured outputs + spec decoding

### DIFF
--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -72,6 +72,7 @@ class InputBatch:
     logits_indices: torch.Tensor
     # [num_reqs + 1]
     cu_num_logits: torch.Tensor
+    cu_num_logits_np: np.ndarray
 
     @classmethod
     def make_dummy(
@@ -110,6 +111,7 @@ class InputBatch:
         # attn_metadata = defaultdict(lambda: None)
         logits_indices = query_start_loc[1:] - 1
         cu_num_logits = torch.arange(num_reqs + 1, device=device, dtype=torch.int32)
+        cu_num_logits_np = np.arange(num_reqs + 1, dtype=np.int32)
         return cls(
             req_ids=req_ids,
             num_reqs=num_reqs,
@@ -129,6 +131,7 @@ class InputBatch:
             attn_metadata=None,  # type: ignore
             logits_indices=logits_indices,
             cu_num_logits=cu_num_logits,
+            cu_num_logits_np=cu_num_logits_np,
         )
 
 

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -4,38 +4,67 @@ import numpy as np
 import torch
 
 from vllm.triton_utils import tl, triton
-from vllm.v1.worker.gpu.input_batch import InputBuffers
+from vllm.utils.math_utils import cdiv
+from vllm.v1.worker.gpu.buffer_utils import UvaBufferPool
+from vllm.v1.worker.gpu.input_batch import InputBatch
 
 
-def apply_grammar_bitmask(
-    logits: torch.Tensor,
-    req_ids: list[str],
-    grammar_req_ids: list[str],
-    grammar_bitmask: np.ndarray,
-    input_buffers: InputBuffers,
-) -> None:
-    input_buffers.grammar_bitmask.np[: grammar_bitmask.shape[0]] = grammar_bitmask
-    input_buffers.grammar_bitmask.copy_to_gpu(grammar_bitmask.shape[0])
+class StructuredOutputsWorker:
+    def __init__(
+        self,
+        max_num_logits: int,
+        vocab_size: int,
+        device: torch.device,
+    ):
+        # NOTE(woosuk): Here, we use UvaBufferPool instead of UvaBackedTensor
+        # to save a CPU-to-CPU copy.
+        self.logits_indices = UvaBufferPool(max_num_logits, torch.int32, device)
+        self.grammar_bitmask = UvaBufferPool(
+            (max_num_logits, cdiv(vocab_size, 32)), torch.int32, device
+        )
 
-    batch_size = logits.shape[0]
-    grammar_req_id_to_idx = {req_id: i for i, req_id in enumerate(grammar_req_ids)}
-    # logits -> bitmask mapping
-    mapping = [grammar_req_id_to_idx.get(req_id, -1) for req_id in req_ids]
-    input_buffers.bitmask_indices.np[:batch_size] = mapping
-    input_buffers.bitmask_indices.copy_to_gpu(batch_size)
+    def apply_grammar_bitmask(
+        self,
+        logits: torch.Tensor,
+        input_batch: InputBatch,
+        grammar_req_ids: list[str],
+        grammar_bitmask: np.ndarray,
+    ) -> None:
+        if not grammar_req_ids:
+            return
 
-    vocab_size = logits.shape[-1]
-    BLOCK_SIZE = 8192
-    grid = (batch_size, triton.cdiv(vocab_size, BLOCK_SIZE))
-    _apply_grammar_bitmask_kernel[grid](
-        logits,
-        logits.stride(0),
-        input_buffers.grammar_bitmask.gpu,
-        input_buffers.grammar_bitmask.gpu.stride(0),
-        input_buffers.bitmask_indices.gpu,
-        vocab_size,
-        BLOCK_SIZE=BLOCK_SIZE,
-    )
+        # Copy bitmask to GPU
+        bitmask = self.grammar_bitmask.copy_to_gpu(grammar_bitmask)
+
+        # Construct bitmask -> logits mapping
+        mapping: list[int] = []
+        req_ids = input_batch.req_ids
+        cu_num_logits_np = input_batch.cu_num_logits_np
+        req_id_to_idx = {req_id: i for i, req_id in enumerate(req_ids)}
+        req_id_to_cnt = {req_id: 0 for req_id in req_ids}
+        for grammar_req_id in grammar_req_ids:
+            req_idx = req_id_to_idx[grammar_req_id]
+            req_cnt = req_id_to_cnt[grammar_req_id]
+            logits_start_idx = cu_num_logits_np[req_idx]
+            mapping.append(logits_start_idx + req_cnt)
+            req_id_to_cnt[grammar_req_id] = req_cnt + 1
+        # Copy mapping to GPU
+        mapping_np = np.array(mapping, dtype=np.int32)
+        logits_indices = self.logits_indices.copy_to_gpu(mapping_np)
+
+        num_masks = bitmask.shape[0]
+        vocab_size = logits.shape[-1]
+        BLOCK_SIZE = 8192
+        grid = (num_masks, triton.cdiv(vocab_size, BLOCK_SIZE))
+        _apply_grammar_bitmask_kernel[grid](
+            logits,
+            logits.stride(0),
+            logits_indices,
+            bitmask,
+            bitmask.stride(0),
+            vocab_size,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
 
 
 # Adapted from
@@ -44,17 +73,14 @@ def apply_grammar_bitmask(
 def _apply_grammar_bitmask_kernel(
     logits_ptr,
     logits_stride,
+    logits_indices_ptr,
     bitmask_ptr,
     bitmask_stride,
-    bitmask_indices_ptr,
     vocab_size,
     BLOCK_SIZE: tl.constexpr,
 ):
-    logits_idx = tl.program_id(0)
-    bitmask_idx = tl.load(bitmask_indices_ptr + logits_idx)
-    if bitmask_idx == -1:
-        # No bitmask to apply.
-        return
+    bitmask_idx = tl.program_id(0)
+    logits_idx = tl.load(logits_indices_ptr + bitmask_idx)
 
     # Load the bitmask.
     block_id = tl.program_id(1)


### PR DESCRIPTION
> [!NOTE]
> Enables structured outputs to work with speculative decoding by introducing a dedicated worker and updating batching metadata.
> 
> - Adds `StructuredOutputsWorker` to apply grammar bitmasks in-place on logits using a new Triton kernel that maps bitmasks to specific logits via `logits_indices`
> - Integrates worker into `GPUModelRunner.sample`, replacing prior helper and supporting multiple logits per request (spec decoding)
> - Extends `InputBatch` with `cu_num_logits_np` and wires its population in `prepare_inputs` and dummy paths to support accurate logits mapping
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdd44357294ad753ba3691a0de040637dc0f39a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Introduces structured outputs compatibility with speculative decoding and updates batching metadata for accurate logits mapping.
> 
> - Adds `StructuredOutputsWorker` with a Triton kernel applying grammar bitmasks in-place to `logits` via `logits_indices`
> - Integrates worker into `GPUModelRunner.sample`, replacing prior helper and handling multiple logits per request
> - Extends `InputBatch` with `cu_num_logits_np`; populates it in `make_dummy` and `prepare_inputs` (both no-draft and draft paths)
> - Computes `cu_num_logits`/`expanded_idx_mapping` appropriately for spec decoding and uses them to build the bitmask→logits mapping
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79e4cfc640165ab46d0cc6b9be16b3b99c4db428. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
