### PR TITLE
[Perf] Optimize Context Parallel by disable NCCL_GRAPH_MIXING_SUPPORT

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -247,6 +247,15 @@ class CudaPlatformBase(Platform):
             )
             scheduler_config.disable_chunked_mm_input = True
 
+        if (
+            vllm_config.parallel_config.decode_context_parallel_size > 1
+            or vllm_config.parallel_config.prefill_context_parallel_size > 1
+        ) and os.environ.get("NCCL_GRAPH_MIXING_SUPPORT", None) is None:
+            logger.info(
+                "For optimal performance with context parallel, "
+                "consider setting NCCL_GRAPH_MIXING_SUPPORT=0"
+            )
+
     @classmethod
     def get_current_memory_usage(
         cls, device: torch.types.Device | None = None

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -247,14 +247,18 @@ class CudaPlatformBase(Platform):
             )
             scheduler_config.disable_chunked_mm_input = True
 
+        # NCCL_GRAPH_MIXING_SUPPORT has a significant impact on the performance of
+        # context parallelism. Reference: https://github.com/vllm-project/vllm/pull/32106.
         if (
             vllm_config.parallel_config.decode_context_parallel_size > 1
             or vllm_config.parallel_config.prefill_context_parallel_size > 1
         ) and os.environ.get("NCCL_GRAPH_MIXING_SUPPORT", None) is None:
             logger.info(
-                "For optimal performance with context parallel, "
-                "consider setting NCCL_GRAPH_MIXING_SUPPORT=0"
+                "Setting NCCL_GRAPH_MIXING_SUPPORT=0 for optimal performance with "
+                "context parallel. To override this, please set the "
+                "NCCL_GRAPH_MIXING_SUPPORT environment variable."
             )
+            os.environ["NCCL_GRAPH_MIXING_SUPPORT"] = "0"
 
     @classmethod
     def get_current_memory_usage(


### PR DESCRIPTION
## Purpose
I found that the NCCL environment variable `NCCL_GRAPH_MIXING_SUPPORT` has a significant impact (~1ms TPOT) on decode context parallelism. After profiling, I discovered that setting `NCCL_GRAPH_MIXING_SUPPORT=0` reduces bubbles before the all-gather (for Q/LSE) and reduce-scatter (for attn_out) operations within the CUDA graph. 

According to the [discussions](https://discuss.pytorch.org/t/unexplained-gaps-in-execution-before-nccl-operations-when-using-cuda-graphs/197818/15), the possible reason is that setting `NCCL_GRAPH_MIXING_SUPPORT=0` avoids unnecessary `EVENT_WAIT`. 

This PR set this environment variable and adds a log message to remind users.
## Test Plan
```shell
# serve
NCCL_GRAPH_MIXING_SUPPORT=0 vllm serve deepseek-ai/DeepSeek-R1 --gpu-memory-utilization 0.9 --tensor-parallel-size 8 --decode-context-parallel-size 8
```

### Accuracy
Evaluate the accuracy of DeepSeek-R1 on the GSM8K dataset.

### Benchmark
Test the impact of `NCCL_GRAPH_MIXING_SUPPORT` on DeepSeek performance on H20 using 4K/1.5K sequence.

```
# benchmark
vllm bench serve --backend vllm  --model deepseek-ai/DeepSeek-R1  --endpoint /v1/completions   --dataset-name random   --random-input 4096   --random-output 1536   --max-concurrency 1  --num-prompt 10 --ignore-eos --metric-percentiles "50,90,99"
```

## Test Result
### Accuracy
- Default
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9393|±  |0.0046|
|     |       |strict-match    |     5|exact_match|↑  |0.9340|±  |0.0048|
```

- Set NCCL_GRAPH_MIXING_SUPPORT=0
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9367|±  |0.0047|
|     |       |strict-match    |     5|exact_match|↑  |0.9329|±  |0.0049|
```

### Benchmark
- Default
```
============ Serving Benchmark Result ============
Successful requests:                     10        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  346.18    
Total input tokens:                      40950     
Total generated tokens:                  15360     
Request throughput (req/s):              0.03      
Output token throughput (tok/s):         44.37     
Peak output token throughput (tok/s):    45.00     
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          162.66    
---------------Time to First Token----------------
Mean TTFT (ms):                          410.49    
Median TTFT (ms):                        423.53    
P50 TTFT (ms):                           423.53    
P90 TTFT (ms):                           425.07    
P99 TTFT (ms):                           426.52    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          22.29     
Median TPOT (ms):                        22.28     
P50 TPOT (ms):                           22.28     
P90 TPOT (ms):                           22.29     
P99 TPOT (ms):                           22.30     
---------------Inter-token Latency----------------
Mean ITL (ms):                           22.29     
Median ITL (ms):                         22.28     
P50 ITL (ms):                            22.28     
P90 ITL (ms):                            22.37     
P99 ITL (ms):                            23.04     
==================================================
```
- Set NCCL_GRAPH_MIXING_SUPPORT=0
```
============ Serving Benchmark Result ============
Successful requests:                     10        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  331.10    
Total input tokens:                      40950     
Total generated tokens:                  15360     
Request throughput (req/s):              0.03      
Output token throughput (tok/s):         46.39     
Peak output token throughput (tok/s):    47.00     
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          170.07    
---------------Time to First Token----------------
Mean TTFT (ms):                          404.84    
Median TTFT (ms):                        418.23    
P50 TTFT (ms):                           418.23    
P90 TTFT (ms):                           419.83    
P99 TTFT (ms):                           421.17    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          21.31     
Median TPOT (ms):                        21.30     
P50 TPOT (ms):                           21.30     
P90 TPOT (ms):                           21.31     
P99 TPOT (ms):                           21.33     
---------------Inter-token Latency----------------
Mean ITL (ms):                           21.31     
Median ITL (ms):                         21.30     
P50 ITL (ms):                            21.30     
P90 ITL (ms):                            21.39     
P99 ITL (ms):                            21.96     
==================================================
```

## Profiling
Through the profiling file, we can identify the source of the performance difference.
- Default
<img width="1684" height="736" alt="image" src="https://github.com/user-attachments/assets/fcdbde06-3aab-4c48-ad78-64b936f70fc4" />

- Set NCCL_GRAPH_MIXING_SUPPORT=0
<img width="2562" height="670" alt="image" src="https://github.com/user-attachments/assets/79ba5a23-b707-4d69-b616-ef099477d1f8" />



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 4e64001783e0297fe8352e91ac090cd491fca779. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
