### PR TITLE
[V1][Spec Decode] Fix outdated RejectionSampler docstring

### DIFF
--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -39,11 +39,10 @@ class RejectionSampler(nn.Module):
     bonus tokens:
         If all proposed tokens are accepted, the bonus token is added to the
         end of the sequence. The bonus token is only sampled from the target
-        probabilities. We pass in the bonus tokens instead of sampling them
-        in the rejection sampler to allow for more flexibility in the
-        sampling process. For example, we can use top_p, top_k sampling for
-        bonus tokens, while spec decode does not support these sampling
-        strategies.
+        probabilities. We compute the bonus tokens with the standard sampler
+        and pass them into the rejection sampling kernels (instead of sampling
+        them inside the kernels) to reuse the regular sampling logic (e.g.,
+        top_p and top_k).
     output tokens:
         Tokens are finally generated with the rejection sampler.
         output tokens = accepted tokens + recovered tokens + bonus tokens


### PR DESCRIPTION
## Purpose

Update the `RejectionSampler` docstring to remove an outdated claim that speculative decoding does not support `top_p`/`top_k`, and clarify that the bonus token is sampled with the standard sampler and passed into the rejection sampling kernels.

## Test Plan

- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile vllm/v1/sample/rejection_sampler.py`

## Test Result

- Pass

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit fc926912ec1efdabb2969c608ebb40761aa5859f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Docs-only update to `RejectionSampler`.
> 
> - Clarifies that bonus tokens are sampled with the standard sampler and passed into rejection sampling kernels to reuse regular sampling logic (`top_p`/`top_k`)
> - Removes outdated claim that speculative decoding doesn’t support `top_p`/`top_k`
> - No functional/code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc926912ec1efdabb2969c608ebb40761aa5859f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
