### PR TITLE
[Bugfix] Fix Harmony preamble visibility in Responses API

### DIFF
--- a/tests/entrypoints/openai/responses/test_harmony.py
+++ b/tests/entrypoints/openai/responses/test_harmony.py
@@ -712,15 +712,14 @@ async def test_function_calling_required(client: OpenAI, model_name: str):
 async def test_system_message_with_tools(client: OpenAI, model_name: str):
     from vllm.entrypoints.openai.parser.harmony_utils import get_system_message
 
-    # Test with custom tools enabled - commentary channel should be available
-    sys_msg = get_system_message(with_custom_tools=True)
-    valid_channels = sys_msg.content[0].channel_config.valid_channels
-    assert "commentary" in valid_channels
-
-    # Test with custom tools disabled - commentary channel should be removed
-    sys_msg = get_system_message(with_custom_tools=False)
-    valid_channels = sys_msg.content[0].channel_config.valid_channels
-    assert "commentary" not in valid_channels
+    # Commentary channel should always be present (needed for preambles)
+    # regardless of whether custom tools are enabled
+    for with_tools in (True, False):
+        sys_msg = get_system_message(with_custom_tools=with_tools)
+        valid_channels = sys_msg.content[0].channel_config.valid_channels
+        assert "commentary" in valid_channels, (
+            f"commentary channel missing when with_custom_tools={with_tools}"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/responses/test_mcp_tools.py
+++ b/tests/entrypoints/openai/responses/test_mcp_tools.py
@@ -172,13 +172,13 @@ class TestMCPEnabled:
             recipient = message.get("recipient")
             if recipient and recipient.startswith("python"):
                 tool_call_found = True
-                assert message.get("channel") == "analysis"
+                assert message.get("channel") == "commentary"
             author = message.get("author", {})
             if author.get("role") == "tool" and (author.get("name") or "").startswith(
                 "python"
             ):
                 tool_response_found = True
-                assert message.get("channel") == "analysis"
+                assert message.get("channel") == "commentary"
 
         assert tool_call_found, (
             f"No Python tool call found. "

--- a/tests/entrypoints/openai/test_serving_chat_stream_harmony.py
+++ b/tests/entrypoints/openai/test_serving_chat_stream_harmony.py
@@ -180,20 +180,13 @@ class TestExtractHarmonyStreamingDelta:
 
         assert delta_message.tool_calls[0].index == 1
 
-    @pytest.mark.parametrize(
-        "channel,recipient",
-        [
-            ("commentary", None),
-            ("commentary", "browser.search"),
-        ],
-    )
-    def test_returns_tool_call_preambles(self, channel, recipient):
-        """Test that invalid tool recipient on commentary is treated as content."""
+    def test_returns_preambles_as_content(self):
+        """Test that commentary with no recipient (preamble) is user content."""
         parser = MockStreamableParser()
         delta_text = "some text"
 
         token_states = [
-            TokenState(channel=channel, recipient=recipient, text=delta_text)
+            TokenState(channel="commentary", recipient=None, text=delta_text)
         ]
 
         delta_message, tools_streamed = extract_harmony_streaming_delta(
@@ -211,6 +204,7 @@ class TestExtractHarmonyStreamingDelta:
         [
             (None, None),
             ("unknown_channel", None),
+            ("commentary", "browser.search"),
         ],
     )
     def test_returns_none_for_invalid_inputs(self, channel, recipient):

--- a/tests/entrypoints/openai/test_serving_responses.py
+++ b/tests/entrypoints/openai/test_serving_responses.py
@@ -26,6 +26,9 @@ from vllm.entrypoints.openai.responses.serving import (
     _extract_allowed_tools_from_mcp_requests,
     extract_tool_types,
 )
+from vllm.entrypoints.openai.responses.streaming_events import (
+    HarmonyStreamingState,
+)
 from vllm.inputs.data import TokensPrompt
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import SamplingParams
@@ -439,3 +442,115 @@ class TestExtractAllowedToolsFromMcpRequests:
             "server1": ["tool1"],
             "server2": ["tool2"],
         }
+
+
+class TestHarmonyPreambleStreaming:
+    """Tests for preamble (commentary with no recipient) streaming events."""
+
+    @staticmethod
+    def _make_ctx(*, channel, recipient, delta="hello"):
+        """Build a lightweight mock StreamingHarmonyContext."""
+        ctx = MagicMock()
+        ctx.last_content_delta = delta
+        ctx.parser.current_channel = channel
+        ctx.parser.current_recipient = recipient
+        return ctx
+
+    @staticmethod
+    def _make_previous_item(*, channel, recipient, text="preamble text"):
+        """Build a lightweight mock previous_item (openai_harmony Message)."""
+        content_part = MagicMock()
+        content_part.text = text
+        item = MagicMock()
+        item.channel = channel
+        item.recipient = recipient
+        item.content = [content_part]
+        return item
+
+    def test_preamble_delta_emits_text_events(self) -> None:
+        """commentary + recipient=None should emit output_text.delta events."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_content_delta_events,
+        )
+
+        ctx = self._make_ctx(channel="commentary", recipient=None)
+        state = HarmonyStreamingState()
+
+        events = emit_content_delta_events(ctx, state)
+
+        type_names = [e.type for e in events]
+        assert "response.output_text.delta" in type_names
+        assert "response.output_item.added" in type_names
+
+    def test_preamble_delta_second_token_no_added(self) -> None:
+        """Second preamble token should emit delta only, not added again."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_content_delta_events,
+        )
+
+        ctx = self._make_ctx(channel="commentary", recipient=None, delta="w")
+        state = HarmonyStreamingState()
+        state.sent_output_item_added = True
+        state.current_item_id = "msg_test"
+        state.current_content_index = 0
+
+        events = emit_content_delta_events(ctx, state)
+
+        type_names = [e.type for e in events]
+        assert "response.output_text.delta" in type_names
+        assert "response.output_item.added" not in type_names
+
+    def test_commentary_with_function_recipient_not_preamble(self) -> None:
+        """commentary + recipient='functions.X' must NOT use preamble path."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_content_delta_events,
+        )
+
+        ctx = self._make_ctx(
+            channel="commentary",
+            recipient="functions.get_weather",
+        )
+        state = HarmonyStreamingState()
+
+        events = emit_content_delta_events(ctx, state)
+
+        type_names = [e.type for e in events]
+        assert "response.output_text.delta" not in type_names
+
+    def test_preamble_done_emits_text_done_events(self) -> None:
+        """Completed preamble should emit text done + content_part done +
+        output_item done, same shape as final channel."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_previous_item_done_events,
+        )
+
+        previous = self._make_previous_item(channel="commentary", recipient=None)
+        state = HarmonyStreamingState()
+        state.current_item_id = "msg_test"
+        state.current_output_index = 0
+        state.current_content_index = 0
+
+        events = emit_previous_item_done_events(previous, state)
+
+        type_names = [e.type for e in events]
+        assert "response.output_text.done" in type_names
+        assert "response.content_part.done" in type_names
+        assert "response.output_item.done" in type_names
+
+    def test_commentary_with_recipient_no_preamble_done(self) -> None:
+        """commentary + recipient='functions.X' should route to function call
+        done, not preamble done."""
+        from vllm.entrypoints.openai.responses.streaming_events import (
+            emit_previous_item_done_events,
+        )
+
+        previous = self._make_previous_item(
+            channel="commentary", recipient="functions.get_weather"
+        )
+        state = HarmonyStreamingState()
+        state.current_item_id = "fc_test"
+
+        events = emit_previous_item_done_events(previous, state)
+
+        type_names = [e.type for e in events]
+        assert "response.output_text.done" not in type_names

--- a/tests/entrypoints/openai/test_serving_responses.py
+++ b/tests/entrypoints/openai/test_serving_responses.py
@@ -27,7 +27,7 @@ from vllm.entrypoints.openai.responses.serving import (
     extract_tool_types,
 )
 from vllm.entrypoints.openai.responses.streaming_events import (
-    HarmonyStreamingState,
+    StreamingState,
 )
 from vllm.inputs.data import TokensPrompt
 from vllm.outputs import CompletionOutput, RequestOutput
@@ -474,7 +474,7 @@ class TestHarmonyPreambleStreaming:
         )
 
         ctx = self._make_ctx(channel="commentary", recipient=None)
-        state = HarmonyStreamingState()
+        state = StreamingState()
 
         events = emit_content_delta_events(ctx, state)
 
@@ -489,7 +489,7 @@ class TestHarmonyPreambleStreaming:
         )
 
         ctx = self._make_ctx(channel="commentary", recipient=None, delta="w")
-        state = HarmonyStreamingState()
+        state = StreamingState()
         state.sent_output_item_added = True
         state.current_item_id = "msg_test"
         state.current_content_index = 0
@@ -510,7 +510,7 @@ class TestHarmonyPreambleStreaming:
             channel="commentary",
             recipient="functions.get_weather",
         )
-        state = HarmonyStreamingState()
+        state = StreamingState()
 
         events = emit_content_delta_events(ctx, state)
 
@@ -525,7 +525,7 @@ class TestHarmonyPreambleStreaming:
         )
 
         previous = self._make_previous_item(channel="commentary", recipient=None)
-        state = HarmonyStreamingState()
+        state = StreamingState()
         state.current_item_id = "msg_test"
         state.current_output_index = 0
         state.current_content_index = 0
@@ -547,7 +547,7 @@ class TestHarmonyPreambleStreaming:
         previous = self._make_previous_item(
             channel="commentary", recipient="functions.get_weather"
         )
-        state = HarmonyStreamingState()
+        state = StreamingState()
         state.current_item_id = "fc_test"
 
         events = emit_previous_item_done_events(previous, state)

--- a/vllm/entrypoints/openai/chat_completion/stream_harmony.py
+++ b/vllm/entrypoints/openai/chat_completion/stream_harmony.py
@@ -147,7 +147,7 @@ def extract_harmony_streaming_delta(
                         function=DeltaFunctionCall(arguments=group.text),
                     )
                 )
-        elif group.channel == "commentary":
+        elif group.channel == "commentary" and group.recipient is None:
             # Tool call preambles meant to be shown to the user
             combined_content += group.text
             content_encountered = True

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -26,7 +26,6 @@ from openai.types.responses.response_reasoning_item import (
 from openai.types.responses.tool import Tool
 from openai_harmony import (
     Author,
-    ChannelConfig,
     Conversation,
     DeveloperContent,
     HarmonyEncodingName,
@@ -126,13 +125,6 @@ def get_system_message(
         sys_msg_content = sys_msg_content.with_tools(python_description)
     if container_description is not None:
         sys_msg_content = sys_msg_content.with_tools(container_description)
-    if not with_custom_tools:
-        channel_config = sys_msg_content.channel_config
-        invalid_channel = "commentary"
-        new_config = ChannelConfig.require_channels(
-            [c for c in channel_config.valid_channels if c != invalid_channel]
-        )
-        sys_msg_content = sys_msg_content.with_channel_config(new_config)
     sys_msg = Message.from_role_and_content(Role.SYSTEM, sys_msg_content)
     return sys_msg
 

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -540,8 +540,12 @@ class HarmonyContext(ConversationContext):
         self.first_tok_of_message = True  # For streaming support
 
     def _update_num_reasoning_tokens(self):
-        # Count all analysis and commentary channels as reasoning tokens
-        if self.parser.current_channel in {"analysis", "commentary"}:
+        channel = self.parser.current_channel
+        if channel == "analysis":
+            self.num_reasoning_tokens += 1
+        elif channel == "commentary" and self.parser.current_recipient is not None:
+            # Tool interactions (python/browser/container) are hidden.
+            # Preambles (recipient=None) are visible user text.
             self.num_reasoning_tokens += 1
 
     def append_output(self, output: RequestOutput) -> None:

--- a/vllm/entrypoints/openai/responses/streaming_events.py
+++ b/vllm/entrypoints/openai/responses/streaming_events.py
@@ -563,7 +563,9 @@ def emit_content_delta_events(
     channel = ctx.parser.current_channel
     recipient = ctx.parser.current_recipient
 
-    if channel == "final" and recipient is None:
+    if channel in ("final", "commentary") and recipient is None:
+        # Preambles (commentary with no recipient) and final messages
+        # are both user-visible text.
         return emit_text_delta_events(delta, state)
     elif channel == "analysis" and recipient is None:
         return emit_reasoning_delta_events(delta, state)
@@ -607,7 +609,9 @@ def emit_previous_item_done_events(
             return emit_mcp_completion_events(previous_item.recipient, text, state)
     elif previous_item.channel == "analysis":
         return emit_reasoning_done_events(text, state)
-    elif previous_item.channel == "final":
+    elif previous_item.channel in ("commentary", "final"):
+        # Preambles (commentary with no recipient) and final messages
+        # are both user-visible text.
         return emit_text_output_done_events(text, state)
     return []
 


### PR DESCRIPTION
## Summary

Per the [Harmony spec](https://developers.openai.com/cookbook/articles/openai-harmony), preambles (commentary channel messages with no recipient) are *"intended to be shown to end-users"*. vLLM was incorrectly treating them as hidden reasoning across multiple code paths.

This PR fixes preamble visibility in 6 code paths across 3 files:

**Parser (`harmony_utils.py`):**
- `parse_output_message()`: route preambles to `ResponseOutputMessage` instead of `ResponseReasoningItem`
- `parse_remaining_state()`: return visible `ResponseOutputMessage` (streaming) instead of hidden reasoning
- `parse_chat_output()`: include preambles in `final_texts` (Chat Completions API), exclude tool call JSON that was leaking into visible content

**Streaming events (`streaming_events.py`):**
- `emit_content_delta_events()`: emit `response.output_text.delta` for preamble tokens (were silently dropped)
- `emit_previous_item_done_events()`: emit text done events for completed preambles

**Token counting (`context.py`):**
- `_update_num_reasoning_tokens()`: exclude preamble tokens from `reasoning_tokens` count

**Channel config (`harmony_utils.py`):**
- `get_system_message()`: stop stripping `commentary` from valid channels when `with_custom_tools=False`. The spec always declares all 3 channels; without `commentary` the model cannot generate preambles in built-in-tool-only sessions (web_search, code_interpreter).

### Before/After

The model generates a **preamble** to preview an upcoming tool call:

```
<|channel|>commentary
<|message|>I'll search for the weather in SF.<|end|>
<|start|>assistant to=functions.web_search
<|channel|>commentary
<|message|>{"query": "weather in SF"}<|end|>
```

**Responses API — before:**
```json
{"type": "reasoning", "content": [{"type": "reasoning_text", "text": "I'll search for the weather in SF."}]}
```
Preamble hidden as reasoning — user never sees it.

**Responses API — after:**
```json
{"type": "message", "content": [{"type": "output_text", "text": "I'll search for the weather in SF."}]}
```
Preamble visible as a message.

**Streaming — before:** Preamble tokens emitted no SSE events (silently dropped).
**Streaming — after:** Preamble tokens emit `response.output_text.delta` events, same as final channel text.

**Chat Completions — before:** `content` included tool call JSON (`{"query": "weather in SF"}`) because the filter was `channel != "analysis"`.
**Chat Completions — after:** `content` only includes preambles and final text; tool call payloads excluded.

**Token counting — before:** Preamble tokens counted as `reasoning_tokens`.
**Token counting — after:** Preamble tokens counted as regular output tokens.

**Channel config — before:** `commentary` stripped from valid channels when no custom tools — model can't generate preambles at all.
**Channel config — after:** All 3 channels always present per spec.

---

> [!NOTE]
> Makes Harmony preambles user-visible and adjusts parser behavior accordingly.
> 
> - Parse `commentary` with no `recipient` as `ResponseOutputMessage` (visible `content`) rather than `ResponseReasoningItem` (hidden `reasoning_content`)
> - Update `parse_remaining_state` to emit `message` (status `incomplete`) for commentary preambles; keep `analysis` as reasoning
> - Clarify built-in tools (`python`, `browser`, `container`) return reasoning; non-builtin recipients become MCP calls; functions remain `function_call`
> - Tests updated to expect `ResponseOutputMessage` for preambles, single message with multiple contents, and streaming status; added coverage for parser edge cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50cc9b144534f3a83a9b18b739254e9bc3763dfe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Makes Harmony preambles visible to users and aligns commentary parsing with the Harmony spec.
> 
> - Commentary with no `recipient` now emits a `ResponseOutputMessage` (visible `content`) rather than `ResponseReasoningItem`; analysis remains reasoning
> - Streaming parser updated: commentary preambles return a `message` with `status="incomplete"`; built-in tools (`python`, `browser`, `container`) explicitly return reasoning; MCP parsing unchanged
> - Tests updated/added to cover preamble visibility, multi-content aggregation into a single message, and streaming states
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8711d3df75eaf8887e155da050e420e89c0e47b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
