### PR TITLE
[CI] fix `test_concat_and_cache_mla_rope_fused`

### DIFF
--- a/tests/kernels/core/test_rotary_embedding_mla_cache_fused.py
+++ b/tests/kernels/core/test_rotary_embedding_mla_cache_fused.py
@@ -13,7 +13,7 @@ from tests.kernels.allclose_default import get_default_atol, get_default_rtol
 from tests.kernels.utils import DEFAULT_OPCHECK_TEST_UTILS, opcheck
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
-from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
 
 
 @pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16, torch.float])
@@ -31,6 +31,7 @@ from vllm.platforms import current_platform
 )
 @torch.inference_mode()
 def test_concat_and_cache_mla_rope_fused(
+    default_vllm_config,
     dtype: torch.dtype,
     is_neox_style: bool,
     seq_len: int,
@@ -45,7 +46,7 @@ def test_concat_and_cache_mla_rope_fused(
     max_position: int = 8192,
     base: float = 10000,
 ) -> None:
-    current_platform.seed_everything(seed)
+    set_random_seed(seed)
     torch.set_default_device(device)
 
     rope = RotaryEmbedding(


### PR DESCRIPTION

## Purpose

`test_concat_and_cache_mla_rope_fused` failed in https://buildkite.com/vllm/ci/builds/46560/steps/canvas?sid=019babdb-d9fb-43f3-a42c-203bb4696684

## Test Plan
```
pytest -s -v kernels/core/test_rotary_embedding_mla_cache_fused.py
```
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> **Tests**
> 
> - Update `tests/kernels/core/test_rotary_embedding_mla_cache_fused.py` to use `set_random_seed(seed)` from `vllm.utils.torch_utils` instead of `current_platform.seed_everything` and remove the `current_platform` import.
> - Add `default_vllm_config` fixture parameter to `test_concat_and_cache_mla_rope_fused` (no functional changes to test logic).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39557dbd1d48e9b854f5882cd45c6a3cf2f17b03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
