### PR TITLE
[Model] Avoid hardcoding pooling type

### DIFF
--- a/vllm/model_executor/models/bert.py
+++ b/vllm/model_executor/models/bert.py
@@ -25,11 +25,11 @@ from vllm.model_executor.layers.pooler import (
     PoolingParamsUpdate,
 )
 from vllm.model_executor.layers.pooler.seqwise import (
-    CLSPool,
     SequencePooler,
     SequencePoolerHeadOutput,
     SequencePoolerOutput,
     SequencePoolingMethodOutput,
+    get_seq_pooling_method,
 )
 from vllm.model_executor.layers.pooler.tokwise import (
     pooler_for_token_classify,
@@ -94,9 +94,9 @@ class BertEmbedding(nn.Module):
 
 
 class BertPooler(SequencePooler):
-    def __init__(self, config: BertConfig):
+    def __init__(self, config: BertConfig, seq_pooling_type: str):
         super().__init__(
-            pooling=CLSPool(),
+            pooling=get_seq_pooling_method(seq_pooling_type),
             head=self.head,
         )
 
@@ -450,7 +450,11 @@ class BertPoolingModel(BertModel):
         )
 
         config = vllm_config.model_config.hf_config
-        self.pooler = BertPooler(config)
+
+        pooler_config = vllm_config.model_config.pooler_config
+        assert pooler_config is not None
+
+        self.pooler = BertPooler(config, pooler_config.seq_pooling_type)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         other_weights, loaded_stacked_params = self._load_weights(weights)
@@ -711,6 +715,8 @@ class BertSpladeSparseEmbeddingModel(BertEmbeddingModel):
                 layer_norm_eps=getattr(cfg, "layer_norm_eps", 1e-12),
             )
 
+        # None of vLLM's built-in sequence pooling types are
+        # applicable so it is overwritten by SPLADESparsePooler
         pooling_mode = getattr(self, "_splade_pooling", "max")
 
         cls_id = getattr(cfg, "cls_token_id", None)

--- a/vllm/model_executor/models/bert.py
+++ b/vllm/model_executor/models/bert.py
@@ -454,7 +454,7 @@ class BertPoolingModel(BertModel):
         pooler_config = vllm_config.model_config.pooler_config
         assert pooler_config is not None
 
-        self.pooler = BertPooler(config, pooler_config.seq_pooling_type)
+        self.pooler = BertPooler(config, pooler_config)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         other_weights, loaded_stacked_params = self._load_weights(weights)

--- a/vllm/model_executor/models/bert.py
+++ b/vllm/model_executor/models/bert.py
@@ -94,9 +94,9 @@ class BertEmbedding(nn.Module):
 
 
 class BertPooler(SequencePooler):
-    def __init__(self, config: BertConfig, seq_pooling_type: str):
+    def __init__(self, config: BertConfig, pooler_config: PoolerConfig):
         super().__init__(
-            pooling=get_seq_pooling_method(seq_pooling_type),
+            pooling=get_seq_pooling_method(pooler_config.seq_pooling_type),
             head=self.head,
         )
 

--- a/vllm/model_executor/models/bert_with_rope.py
+++ b/vllm/model_executor/models/bert_with_rope.py
@@ -453,6 +453,7 @@ class BertWithRope(nn.Module, SupportsQuant):
         add_pooling_layer: bool = False,
     ):
         super().__init__()
+
         self.vllm_config = vllm_config
         self.add_pooling_layer = add_pooling_layer
         self.config = vllm_config.model_config.hf_config
@@ -463,7 +464,12 @@ class BertWithRope(nn.Module, SupportsQuant):
             rotary_kwargs=self.config.rotary_kwargs,
             prefix=f"{prefix}.encoder",
         )
-        self.pooler = BertPooler(self.config) if add_pooling_layer else None
+
+        if add_pooling_layer:
+            pooler_config = vllm_config.model_config.pooler_config
+            assert pooler_config is not None
+
+            self.pooler = BertPooler(self.config, pooler_config.seq_pooling_type)
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embeddings(input_ids)

--- a/vllm/model_executor/models/bert_with_rope.py
+++ b/vllm/model_executor/models/bert_with_rope.py
@@ -470,6 +470,8 @@ class BertWithRope(nn.Module, SupportsQuant):
             assert pooler_config is not None
 
             self.pooler = BertPooler(self.config, pooler_config.seq_pooling_type)
+        else:
+            self.pooler = None
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embeddings(input_ids)

--- a/vllm/model_executor/models/bert_with_rope.py
+++ b/vllm/model_executor/models/bert_with_rope.py
@@ -469,7 +469,7 @@ class BertWithRope(nn.Module, SupportsQuant):
             pooler_config = vllm_config.model_config.pooler_config
             assert pooler_config is not None
 
-            self.pooler = BertPooler(self.config, pooler_config.seq_pooling_type)
+            self.pooler = BertPooler(self.config, pooler_config)
         else:
             self.pooler = None
 

--- a/vllm/model_executor/models/gritlm.py
+++ b/vllm/model_executor/models/gritlm.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.pooler.seqwise import (
     SequencePoolerHeadOutput,
     SequencePoolingMethod,
     SequencePoolingMethodOutput,
+    pooler_for_embed,
 )
 from vllm.model_executor.layers.pooler.tokwise import pooler_for_token_embed
 from vllm.model_executor.models.llama import LlamaForCausalLM
@@ -235,6 +236,10 @@ class GritLM(LlamaForCausalLM):
             self.pooler = DispatchPooler(
                 {
                     "token_embed": pooler_for_token_embed(pooler_config),
-                    "embed": GritLMPooler(vllm_config.model_config),
+                    "embed": (
+                        GritLMPooler(vllm_config.model_config)
+                        if pooler_config.seq_pooling_type == "MEAN"
+                        else pooler_for_embed(pooler_config)
+                    ),
                 }
             )

--- a/vllm/model_executor/models/gritlm.py
+++ b/vllm/model_executor/models/gritlm.py
@@ -17,7 +17,7 @@ from vllm.model_executor.layers.pooler.seqwise import (
     SequencePoolerHeadOutput,
     SequencePoolingMethod,
     SequencePoolingMethodOutput,
-    pooler_for_embed,
+    get_seq_pooling_method,
 )
 from vllm.model_executor.layers.pooler.tokwise import pooler_for_token_embed
 from vllm.model_executor.models.llama import LlamaForCausalLM
@@ -178,9 +178,13 @@ class GritLMMeanPool(SequencePoolingMethod):
 
 
 class GritLMPooler(SequencePooler):
-    def __init__(self, model_config: ModelConfig):
+    def __init__(self, model_config: ModelConfig, seq_pooling_type: str):
         super().__init__(
-            pooling=GritLMMeanPool(model_config),
+            pooling=(
+                GritLMMeanPool(model_config)
+                if seq_pooling_type == "MEAN"
+                else get_seq_pooling_method(seq_pooling_type)
+            ),
             head=self.head,
         )
 
@@ -236,10 +240,9 @@ class GritLM(LlamaForCausalLM):
             self.pooler = DispatchPooler(
                 {
                     "token_embed": pooler_for_token_embed(pooler_config),
-                    "embed": (
-                        GritLMPooler(vllm_config.model_config)
-                        if pooler_config.seq_pooling_type == "MEAN"
-                        else pooler_for_embed(pooler_config)
+                    "embed": GritLMPooler(
+                        vllm_config.model_config,
+                        pooler_config.seq_pooling_type,
                     ),
                 }
             )

--- a/vllm/model_executor/models/modernbert.py
+++ b/vllm/model_executor/models/modernbert.py
@@ -284,14 +284,12 @@ class ModernBertModel(nn.Module):
 class ModernBertPooler(SequencePooler):
     def __init__(self, config: ModernBertConfig, pooler_config: PoolerConfig):
         hf_pooling_type = config.classifier_pooling.upper()
-        vllm_pooling_type = pooler_config.seq_pooling_type
-        assert hf_pooling_type == vllm_pooling_type, (
-            f"Found inconsistent sequence pooling type: {hf_pooling_type=!r} "
-            f"vs. {vllm_pooling_type=!r}"
-        )
+        # vllm_pooling_type = pooler_config.seq_pooling_type
+        # Currently we don't have a way to see if the user set the pooling type
+        # explicitly or not, so we always use the HF pooling type for now.
 
         super().__init__(
-            pooling=get_seq_pooling_method(pooler_config.seq_pooling_type),
+            pooling=get_seq_pooling_method(hf_pooling_type),
             head=self.head,
         )
 

--- a/vllm/model_executor/models/roberta.py
+++ b/vllm/model_executor/models/roberta.py
@@ -9,7 +9,6 @@ from transformers import RobertaConfig
 
 from vllm.config import ModelConfig, VllmConfig
 from vllm.model_executor.layers.pooler import DispatchPooler
-from vllm.model_executor.layers.pooler.seqwise import CLSPool
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.model_executor.models.bert import (
     TOKEN_TYPE_SHIFT,
@@ -86,7 +85,7 @@ class RobertaClassificationHead(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # CLSPool has already been applied in `pooling`
+        # Token extraction has already been applied in `pooler.pooling`
         x = self.dense(x)
         x = torch.tanh(x)
         x = self.out_proj(x)
@@ -194,7 +193,6 @@ class RobertaForSequenceClassification(nn.Module, SupportsCrossEncoding):
 
         self.pooler = DispatchPooler.for_seq_cls(
             pooler_config,
-            pooling=CLSPool(),
             classifier=self.classifier,
         )
 

--- a/vllm/model_executor/models/transformers/pooling.py
+++ b/vllm/model_executor/models/transformers/pooling.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 
 class EmbeddingMixin(VllmModelForPooling):
-    default_pooling_type = "CLS"
+    default_seq_pooling_type = "CLS"
 
     def __init__(self, *, vllm_config: "VllmConfig", prefix: str = ""):
         # Skip VllmModelForPooling.__init__ and call the next class in MRO
@@ -46,7 +46,7 @@ class EmbeddingMixin(VllmModelForPooling):
 
 
 class SequenceClassificationMixin(SupportsCrossEncoding, VllmModelForPooling):
-    default_pooling_type = "CLS"
+    default_seq_pooling_type = "CLS"
 
     def __init__(self, *, vllm_config: "VllmConfig", prefix: str = ""):
         # Skip VllmModelForPooling.__init__ and call the next class in MRO


### PR DESCRIPTION
## Purpose

Gracefully handle user-specified pooling types where possible, instead of silently ignoring them.

In the next PR, we will work on passing `EmbeddingPoolerHead` to `head` argument so that pooling params are applied correctly.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Enables user-configurable sequence pooling types instead of hardcoded defaults and aligns pooler construction across models.
> 
> - BERT/BertWithRope: `BertPooler` now takes `seq_pooling_type` (via `get_seq_pooling_method`); pooling initialized from `pooler_config`.
> - ModernBert: `ModernBertPooler` uses configured `seq_pooling_type` and validates against HF `classifier_pooling`; sequence classification uses this pooler.
> - RoBERTa and Transformers mixins: remove explicit `CLSPool` usage; `DispatchPooler.for_seq_cls/for_embedding` handle token extraction; minor comment clarifications.
> - GritLM: use custom `GritLMPooler` only for `MEAN`; otherwise defer to generic `pooler_for_embed`.
> - SPLADE embedding: note that built-in sequence pooling is overridden by `SPLADESparsePooler`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecb0656c9d588648a910173d013d93696bd75ad0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Enables configurable sequence pooling and aligns pooler construction across models.
> 
> - **BERT/BertWithRope**: `BertPooler` now accepts `seq_pooling_type` and uses `get_seq_pooling_method`; `BertPoolingModel`/`BertWithRope` initialize pooler from `pooler_config`.
> - **ModernBert**: `ModernBertPooler` uses provided `seq_pooling_type`; `ModernBertForSequenceClassification` validates HF `classifier_pooling` vs. configured type and wires pooling into `DispatchPooler.for_seq_cls`.
> - **RoBERTa + transformers mixins**: Remove explicit `CLSPool`; rely on `DispatchPooler.for_seq_cls/for_embedding` for token extraction; clarify comments.
> - **GritLM**: Use custom `GritLMMeanPool` only when `seq_pooling_type == "MEAN"`; otherwise defer to `get_seq_pooling_method`.
> - **SPLADE embedding**: Note built-in sequence pooling is overridden by `SPLADESparsePooler`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c25d15dcbddfd9b16e3b8a3da807b2dfc135fb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 5d5064e1e13388b8bbc2390bfff84ac433f79598. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit ce4cef5ef0581d6b212ad0c5f790e0d53f3ef6bb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 69c8fde4aea45239d303afbd532d84a1506d7e20. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Makes sequence pooling user-configurable and standardizes pooler construction.
> 
> - BERT/BertWithRope: `BertPooler` now takes `PoolerConfig` and uses `get_seq_pooling_method`; pooling instantiated from `pooler_config` in `BertPoolingModel` and `BertWithRope` (when present)
> - ModernBert: new `ModernBertPooler(config, pooler_config)` (uses HF `classifier_pooling`); `ModernBertForSequenceClassification` wires this through `DispatchPooler.for_seq_cls`
> - RoBERTa + transformers mixins: remove explicit `CLSPool`; rely on `DispatchPooler.for_seq_cls/for_embedding` for token extraction; update default attribute to `default_seq_pooling_type`
> - GritLM: `GritLMPooler` uses custom `GritLMMeanPool` only for `MEAN`, otherwise defers to `get_seq_pooling_method`; updates `DispatchPooler` wiring
> - SPLADE embedding: note that built-in sequence pooling is overridden by `SPLADESparsePooler`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69c8fde4aea45239d303afbd532d84a1506d7e20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
