### PR TITLE
[Refactor] Move MXFP4/MXFP6 logic from fused_experts to Quark

### DIFF
--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -181,29 +181,12 @@ def _mxfp4_quantize(
     block_shape: list[int] | None = None,
 ) -> tuple[torch.Tensor, None]:
     assert block_shape is None
+    # TODO: native mxfp4 is currently not integrated in vllm,
+    # so simulating even on devices supporting this data type natively.
+    # Once integrated, `current_platform.supports_mx()` should be used to
+    # control quantize+dequantize, or simply quantize here down to mxfp4.
     A = quant_dequant_mxfp4(A)
-    return A, None
 
-
-def _mxfp6_e3m2_quantize(
-    A: torch.Tensor,
-    A_scale: torch.Tensor | None,
-    per_act_token_quant: bool,
-    block_shape: list[int] | None = None,
-) -> tuple[torch.Tensor, None]:
-    assert block_shape is None
-    A = quant_dequant_mxfp6(A, quant_dtype="fp6_e3m2")
-    return A, None
-
-
-def _mxfp6_e2m3_quantize(
-    A: torch.Tensor,
-    A_scale: torch.Tensor | None,
-    per_act_token_quant: bool,
-    block_shape: list[int] | None = None,
-) -> tuple[torch.Tensor, None]:
-    assert block_shape is None
-    A = quant_dequant_mxfp6(A, quant_dtype="fp6_e2m3")
     return A, None
 
 
@@ -217,6 +200,40 @@ def _mxfp8_e4m3_quantize(
     assert not per_act_token_quant
     assert block_shape is None
     return mxfp8_e4m3_quantize(A)
+
+
+def _mxfp6_e3m2_quantize(
+    A: torch.Tensor,
+    A_scale: torch.Tensor | None,
+    per_act_token_quant: bool,
+    block_shape: list[int] | None = None,
+) -> tuple[torch.Tensor, None]:
+    assert block_shape is None
+
+    # TODO: native mxfp6 is currently not integrated in vllm,
+    # so simulating even on devices supporting this data type natively.
+    # Eventually, there should be a check based on
+    # `current_platform.supports_mx()` here.
+    A = quant_dequant_mxfp6(A, quant_dtype="fp6_e3m2")
+
+    return A, None
+
+
+def _mxfp6_e2m3_quantize(
+    A: torch.Tensor,
+    A_scale: torch.Tensor | None,
+    per_act_token_quant: bool,
+    block_shape: list[int] | None = None,
+) -> tuple[torch.Tensor, None]:
+    assert block_shape is None
+
+    # TODO: native mxfp6 is currently not integrated in vllm,
+    # so simulating even on devices supporting this data type natively.
+    # Eventually, there should be a check based on
+    # `current_platform.supports_mx()` here.
+    A = quant_dequant_mxfp6(A, quant_dtype="fp6_e2m3")
+
+    return A, None
 
 
 def moe_kernel_quantize_input(
@@ -235,14 +252,14 @@ def moe_kernel_quantize_input(
         return _nvfp4_quantize(A, A_scale, is_sf_swizzled_layout=is_fp4_scale_swizzled)
     elif quant_dtype == "mxfp4":
         return _mxfp4_quantize(A, A_scale, per_act_token_quant, block_shape)
-    elif quant_dtype == "mxfp6_e3m2":
-        return _mxfp6_e3m2_quantize(A, A_scale, per_act_token_quant, block_shape)
-    elif quant_dtype == "mxfp6_e2m3":
-        return _mxfp6_e2m3_quantize(A, A_scale, per_act_token_quant, block_shape)
     elif quant_dtype == "mxfp8":
         # TODO: `quant_dtype == "mxfp8"` is ambiguous,
         # should be fp8_e4m3. OCP MX also defines `fp8_e5m2`.
         return _mxfp8_e4m3_quantize(A, A_scale, per_act_token_quant, block_shape)
+    elif quant_dtype == "mxfp6_e3m2":
+        return _mxfp6_e3m2_quantize(A, A_scale, per_act_token_quant, block_shape)
+    elif quant_dtype == "mxfp6_e2m3":
+        return _mxfp6_e2m3_quantize(A, A_scale, per_act_token_quant, block_shape)
     else:
         return A, A_scale
 


### PR DESCRIPTION

Fixes #30621

## Purpose
Refactors MXFP4/MXFP6 quantization logic from the generic MoE layer into the Quark-specific quantization layer as mentioned in #30621

## Motivation
The generic `fused_experts` kernel should not contain Quark-specific quantization logic. This PR moves all MXFP-related code into `quark_moe.py`, improving separation of concerns and making both the MoE kernel and quantization layer easier to maintain independently.

## Changes 
**Added to `quark_moe.py`:**
- `_dequantize_weights()` - handles MXFP4/MXFP6 weight dequantization for all 5 OCP MX schemes
- `_quantize_activations()` - handles activation quantization using QDQ emulation
- Updated `apply()` to pre-process weights and activations before calling `fused_experts`
- Modified `get_fused_moe_quant_config()` to return `None` for emulation mode

**Removed from `fused_moe.py`:**
- ~34 lines of MXFP4/MXFP6 weight dequantization code
- MXFP4/MXFP6 imports and corresponding type checks

**Removed from `utils.py`:**
- `_mxfp4_quantize()`, `_mxfp6_e3m2_quantize()`, `_mxfp6_e2m3_quantize()` functions
- MXFP branches from `moe_kernel_quantize_input()`

To test locally with AMD hardware:
```bash
pytest tests/quantization/test_quark.py -v -k "mxfp" --tb=short
```
Implements @fxmarty-amd's suggestion from #30621 to handle quantization in `apply()` rather than `process_weights_after_loading()`, preserving on-the-fly dequantization behavior for devices without native MXFP instruction support.

This is an internal refactoring. All 5 OCP MX schemes continue to function as before.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Separates OCP MX logic from the generic MoE kernel and consolidates it in Quark.
> 
> - **Quark (`quark_moe.py`)**: Adds `_dequantize_weights()` and `_quantize_activations()`; updates `QuarkOCP_MX_MoEMethod.apply()` to pre-dequantize weights and QDQ activations for emulation, and returns `None` from `get_fused_moe_quant_config()` in emulation; retains native AITER path handling; keeps support for all MX schemes.
> - **Generic MoE (`fused_moe.py`)**: Removes MXFP4/MXFP6 imports and dequantization branches from `fused_experts_impl`; `_get_config_quant_dtype()` no longer returns MXFP strings; simplifies quant handling to FP8/INT8 only.
> - **Utils (`fused_moe/utils.py`)**: Deletes MXFP4/MXFP6 quantization helpers and their branches from `moe_kernel_quantize_input()`; keeps NVFP4/MXFP8 paths.
> 
> Overall: MXFP responsibilities live in Quark, reducing coupling and making `fused_experts` backend-agnostic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7637104e05cf5e4a3211ebc60d43cb68906ff738. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Refactors MXFP4/MXFP6 handling out of the generic MoE path and into Quark’s OCP MX method, simplifying `fused_experts` and MoE utils.
> 
> - **Quark (`quark_moe.py`)**: Adds `_dequantize_weights()` and `_quantize_activations()`; in emulation mode `apply()` dequantizes MX weights and QDQ-quantizes activations before calling `fused_experts`; `get_fused_moe_quant_config()` sets weight scales to `None` in emulation; keeps native ROCm AITER path for supported configs
> - **Generic MoE (`fused_moe.py`)**: Removes MXFP4/MXFP6 imports and dequantization branch from `fused_experts_impl`
> - **Utils (`fused_moe/utils.py`)**: Deletes MXFP4/MXFP6 helpers and prunes MX branches from `moe_kernel_quantize_input()` (keeps NVFP4/MXFP8/FP8/INT8)
> 
> Result: MXFP logic is isolated to Quark; the generic MoE kernel focuses on FP8/INT8/NVFP4/MXFP8 quant paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05d397ace99660eba766b7991c2a1ef3ce05d93b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 53c35cc4748b9e63ee60856e03581c6688799f0b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Separates OCP MX (MXFP4/MXFP6) logic from the generic MoE path and consolidates it in Quark.
> 
> - **Quark (`quark_moe.py`)**: Adds `_dequantize_weights()` for all OCP MX schemes; in emulation mode, `apply()` dequantizes MX weights and calls `fused_experts`; `get_fused_moe_quant_config()` sets weight scales to `None` in emulation; retains native ROCm AITER path when available
> - **Generic MoE (`fused_moe.py`)**: Removes MXFP imports and in-kernel dequantization; tightens size checks to only treat weights as packed when `ocp_mx_scheme` and scales are provided; keeps activation quantization via `moe_kernel_quantize_input`
> - **Utils (`fused_moe/utils.py`)**: Streamlines MX quant helpers and routing in `moe_kernel_quantize_input` (explicit mxfp4/mxfp6 variants; mxfp8 routed after others)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53c35cc4748b9e63ee60856e03581c6688799f0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
