### PR TITLE
support dynamic resolution image encoding for Nemotron Nano VL

### DIFF
--- a/vllm/model_executor/models/intern_vit.py
+++ b/vllm/model_executor/models/intern_vit.py
@@ -274,8 +274,6 @@ class InternMLP(nn.Module):
 
 
 class InternVisionEncoderLayer(nn.Module):
-    attn_cls: InternParallelAttention = InternParallelAttention
-
     def __init__(
         self,
         config: PretrainedConfig,
@@ -284,12 +282,14 @@ class InternVisionEncoderLayer(nn.Module):
         num_dummy_heads: int = 0,
         prefix: str = "",
         use_data_parallel: bool = False,
+        attn_cls: type[InternParallelAttention] = InternParallelAttention,
     ) -> None:
         super().__init__()
 
         self.embed_dim = config.hidden_size
         self.intermediate_size = config.intermediate_size
         self.norm_type = config.norm_type
+        self.attn_cls = attn_cls
 
         self.attn = self._init_attn(
             config,
@@ -349,8 +349,6 @@ class InternVisionEncoderLayer(nn.Module):
 
 
 class InternVisionEncoder(nn.Module):
-    layer_cls: InternVisionEncoderLayer = InternVisionEncoderLayer
-
     def __init__(
         self,
         config: PretrainedConfig,
@@ -360,10 +358,12 @@ class InternVisionEncoder(nn.Module):
         num_dummy_heads: int = 0,
         prefix: str = "",
         use_data_parallel: bool = False,
+        layer_cls: type[InternVisionEncoderLayer] = InternVisionEncoderLayer,
     ):
         super().__init__()
 
         self.config = config
+        self.layer_cls = layer_cls
 
         if num_hidden_layers_override is None:
             num_hidden_layers = config.num_hidden_layers

--- a/vllm/model_executor/models/radio.py
+++ b/vllm/model_executor/models/radio.py
@@ -504,7 +504,8 @@ class RadioParallelAttention(InternParallelAttention):
 
 
 class RadioVisionEncoderLayer(InternVisionEncoderLayer):
-    attn_cls = RadioParallelAttention
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, attn_cls=RadioParallelAttention, **kwargs)
 
     def forward(
         self,
@@ -522,7 +523,8 @@ class RadioVisionEncoderLayer(InternVisionEncoderLayer):
 
 
 class RadioVisionEncoder(InternVisionEncoder):
-    layer_cls = RadioVisionEncoderLayer
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, layer_cls=RadioVisionEncoderLayer, **kwargs)
 
     def forward(
         self,


### PR DESCRIPTION
Adds dynamic image resolution support for encoding images with Nemotron Nano VL, while preserving static resolution images as-is. This means that images contribute a variable number of tokens to the prompt.  
Dynamic resolution applies to images only; **video remains static resolution**.

Adapted from code and work of, among others:
https://github.com/tylerpoon
https://github.com/trintamaki

Dynamic resolution can be enabled by adding `min_num_patches` and `max_num_patches` to config["vision_config"]["args"].

Aside from adding the dynamic tiler in `vllm/model_executor/models/nano_nemotron_vl.py` processing code, the PR expands `radio.py` and `intern_vit.py` to support a concatenated ragged tensor of images, using manual attention masking so that images don't attend to each other.