### PR TITLE
[Model Runner V2] Skip building deprecated fields in attn metadata

### DIFF
--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -3,7 +3,6 @@
 from collections.abc import Sequence
 from typing import Any, cast
 
-import numpy as np
 import torch
 
 from vllm.config import VllmConfig, get_layers_from_vllm_config
@@ -147,16 +146,13 @@ def build_attn_metadata(
     query_start_loc_gpu: torch.Tensor,
     query_start_loc_cpu: torch.Tensor,
     seq_lens: torch.Tensor,
-    seq_lens_np: np.ndarray,
-    num_computed_tokens_cpu: torch.Tensor | None,
+    max_seq_len: int,
     block_tables: Sequence[torch.Tensor],
     slot_mappings: torch.Tensor,
     kv_cache_config: KVCacheConfig,
 ) -> dict[str, Any]:
     max_query_len = int(query_start_loc_cpu.max())
     seq_lens = seq_lens[:num_reqs]
-    seq_lens_cpu = torch.from_numpy(seq_lens_np)
-    max_seq_len = int(seq_lens_np.max())
 
     attn_metadata: dict[str, Any] = {}
     kv_cache_groups = kv_cache_config.kv_cache_groups
@@ -168,9 +164,7 @@ def build_attn_metadata(
             query_start_loc=query_start_loc_gpu,
             query_start_loc_cpu=query_start_loc_cpu,
             seq_lens=seq_lens,
-            _seq_lens_cpu=seq_lens_cpu,
             max_seq_len=max_seq_len,
-            _num_computed_tokens_cpu=num_computed_tokens_cpu,
             num_reqs=num_reqs,
             num_actual_tokens=num_tokens,
             max_query_len=max_query_len,

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -232,11 +232,9 @@ def prepare_inputs_to_capture(
     query_start_loc.np[: num_reqs + 1] = np.arange(num_reqs + 1) * num_tokens_per_req
     query_start_loc.np[num_reqs:] = num_tokens
     query_start_loc.copy_to_gpu()
-    seq_lens_np = np.full(num_reqs, max_model_len, dtype=np.int32)
+
     # HACK(woosuk): For faster warmup, we set seq_lens (GPU) to num_tokens
-    # rather than max_model_len. This introduces a discrepancy between
-    # seq_lens (on GPU) and seq_lens_np (on CPU), which may cause issues for
-    # certain attention backends.
+    # rather than max_model_len.
     input_buffers.seq_lens[:num_reqs] = num_tokens
     input_buffers.seq_lens[num_reqs:] = 0
 
@@ -250,8 +248,7 @@ def prepare_inputs_to_capture(
         query_start_loc_gpu=query_start_loc.gpu[: num_reqs + 1],
         query_start_loc_cpu=query_start_loc.cpu[: num_reqs + 1],
         seq_lens=input_buffers.seq_lens,
-        seq_lens_np=seq_lens_np,
-        num_computed_tokens_cpu=None,  # FIXME
+        max_seq_len=max_model_len,
         block_tables=input_block_tables,
         slot_mappings=slot_mappings,
         kv_cache_config=kv_cache_config,

--- a/vllm/v1/worker/gpu/input_batch.py
+++ b/vllm/v1/worker/gpu/input_batch.py
@@ -70,7 +70,6 @@ class InputBatch:
     query_start_loc_np: np.ndarray
     # [num_reqs]
     seq_lens: torch.Tensor
-    seq_lens_np: np.ndarray
 
     # [num_tokens_after_padding]
     input_ids: torch.Tensor
@@ -109,8 +108,6 @@ class InputBatch:
         query_start_loc_np = input_buffers.query_start_loc.np[: num_reqs + 1]
         query_start_loc = input_buffers.query_start_loc.copy_to_gpu()[: num_reqs + 1]
         # seq_len equals to query_len
-        seq_lens_np = np.full(num_reqs, num_tokens // num_reqs, dtype=np.int32)
-        seq_lens_np[-1] += num_tokens % num_reqs
         input_buffers.seq_lens[:num_reqs] = num_tokens // num_reqs
         input_buffers.seq_lens[num_reqs - 1] += num_tokens % num_reqs
         input_buffers.seq_lens[num_reqs:] = 0
@@ -133,7 +130,6 @@ class InputBatch:
             query_start_loc=query_start_loc,
             query_start_loc_np=query_start_loc_np,
             seq_lens=seq_lens,
-            seq_lens_np=seq_lens_np,
             input_ids=input_ids,
             positions=positions,
             attn_metadata=None,  # type: ignore

--- a/vllm/v1/worker/gpu/spec_decode/eagle.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle.py
@@ -288,8 +288,6 @@ class EagleSpeculator:
         # Run eager mode.
         query_start_loc.np[: num_reqs + 1] = np.arange(num_reqs + 1)
         query_start_loc_cpu = query_start_loc.cpu[: num_reqs + 1]
-        # HACK(woosuk)
-        seq_lens_np = np.full(num_reqs, self.max_model_len, dtype=np.int32)
         block_tables = [x[:num_reqs] for x in self.block_tables.input_block_tables]
 
         # FIXME(woosuk): This is UNSAFE!!
@@ -300,8 +298,7 @@ class EagleSpeculator:
             query_start_loc_gpu=query_start_loc_gpu,
             query_start_loc_cpu=query_start_loc_cpu,
             seq_lens=self.input_buffers.seq_lens[:num_reqs],
-            seq_lens_np=seq_lens_np,
-            num_computed_tokens_cpu=None,  # FIXME
+            max_seq_len=self.max_model_len,
             block_tables=block_tables,
             slot_mappings=slot_mappings,
             kv_cache_config=self.kv_cache_config,


### PR DESCRIPTION
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit ca8d31a4984d48d87213927ce22fb078580b222d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Streamlines attention metadata construction and removes unused CPU-side fields.
> 
> - `build_attn_metadata` now takes `max_seq_len` and no longer uses `seq_lens_np` or `num_computed_tokens_cpu`; dropped NumPy dependency in `attn_utils.py`
> - Updated callers in `cudagraph_utils.prepare_inputs_to_capture`, `model_runner` (dummy and runtime paths), and EAGLE spec decode to match the new interface
> - Simplified `InputBatch` by removing `seq_lens_np`; adjusted dummy batch creation accordingly
> - Minor comment cleanups and padding logic retained for CUDA graphs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca8d31a4984d48d87213927ce22fb078580b222d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
