### PR TITLE
[Doc] Add documentation for offline API docs feature

### DIFF
--- a/docs/serving/openai_compatible_server.md
+++ b/docs/serving/openai_compatible_server.md
@@ -173,6 +173,14 @@ with `--enable-request-id-headers`.
     print(completion._request_id)
     ```
 
+## Offline API Documentation
+
+The FastAPI `/docs` endpoint requires an internet connection by default. To enable offline access in air-gapped environments, use the `--enable-offline-docs` flag:
+
+```bash
+vllm serve NousResearch/Meta-Llama-3-8B-Instruct --enable-offline-docs
+```
+
 ## API Reference
 
 ### Completions API


### PR DESCRIPTION
## Summary
Add documentation for offline API docs feature
related :https://github.com/vllm-project/vllm/pull/30184

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 9bcf3bd955c830737300f641b96eadcb63174273. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Adds guidance for air-gapped environments.
> 
> - New **Offline API Documentation** section explaining that FastAPI `/docs` requires internet by default and how to enable offline docs with `--enable-offline-docs`
> - Provides example command: `vllm serve NousResearch/Meta-Llama-3-8B-Instruct --enable-offline-docs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bcf3bd955c830737300f641b96eadcb63174273. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
