### PR TITLE
[Feature] add dp coordinaator heartbeat timeout check

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -132,6 +132,12 @@ class ParallelConfig:
     between local data parallel ranks, but an external LB balances
     between vLLM nodes/replicas. Set explicitly in conjunction with
     --data-parallel-start-rank."""
+
+    data_parallel_heartbeat: bool = False
+    """Whether to enable heartbeat messages for data parallel
+    communication. This can help detect failed data parallel ranks
+    more quickly."""
+
     is_moe_model: bool | None = None
     """Whether the deployed model is MoE (if known)."""
     enable_expert_parallel: bool = False

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -402,6 +402,7 @@ class EngineArgs:
     data_parallel_rpc_port: int | None = None
     data_parallel_hybrid_lb: bool = False
     data_parallel_external_lb: bool = False
+    data_parallel_heartbeat: bool = False
     data_parallel_backend: str = ParallelConfig.data_parallel_backend
     enable_expert_parallel: bool = ParallelConfig.enable_expert_parallel
     all2all_backend: str = ParallelConfig.all2all_backend
@@ -847,6 +848,11 @@ class EngineArgs:
             "--data-parallel-external-lb",
             "-dpe",
             **parallel_kwargs["data_parallel_external_lb"],
+        )
+        parallel_group.add_argument(
+            "--data-parallel-heartbeat",
+            "-dphb",
+            **parallel_kwargs["data_parallel_heartbeat"],
         )
         parallel_group.add_argument(
             "--enable-expert-parallel",
@@ -1585,6 +1591,7 @@ class EngineArgs:
             data_parallel_size=self.data_parallel_size,
             data_parallel_rank=self.data_parallel_rank or 0,
             data_parallel_external_lb=data_parallel_external_lb,
+            data_parallel_heartbeat=self.data_parallel_heartbeat,
             data_parallel_size_local=data_parallel_size_local,
             master_addr=self.master_addr,
             master_port=self.master_port,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -619,6 +619,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_ENGINE_READY_TIMEOUT_S": lambda: int(
         os.environ.get("VLLM_ENGINE_READY_TIMEOUT_S", "600")
     ),
+    # Interval in seconds for DP coordinator heartbeat messages.
+    "VLLM_DP_COORDINATOR_HEARTBEAT_INTERVAL_S": lambda: float(
+        os.environ.get("VLLM_DP_COORDINATOR_HEARTBEAT_INTERVAL_S", "2")
+    ),
+    # Timeout in seconds before engines exit if DP coordinator is unreachable.
+    "VLLM_DP_COORDINATOR_HEARTBEAT_TIMEOUT_S": lambda: float(
+        os.environ.get("VLLM_DP_COORDINATOR_HEARTBEAT_TIMEOUT_S", "10")
+    ),
     # API key for vLLM API server
     "VLLM_API_KEY": lambda: os.environ.get("VLLM_API_KEY", None),
     # Whether to log responses from API Server for debugging

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -205,6 +205,8 @@ class EngineCoreRequestType(enum.Enum):
     UTILITY = b"\x03"
     # Sentinel used within EngineCoreProc.
     EXECUTOR_FAILED = b"\x04"
+    # DP headless process heartbeat.
+    HEARTBEAT = b"\x05"
 
 
 class ReconfigureDistributedRequest(msgspec.Struct):

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -227,7 +227,9 @@ class DPCoordinatorProc:
                         (EngineCoreRequestType.HEARTBEAT.value, b"")
                     )
                     last_heartbeat_time = now
-                    logger.info("Send HEARTBEAT multipart to engines from coordinator.")
+                    logger.debug(
+                        "Send HEARTBEAT multipart to engines from coordinator."
+                    )
 
                 events = poller.poll(timeout=max(min_timeout, wait_for - elapsed))
                 if not events:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix: https://github.com/vllm-project/vllm/issues/32136

## Test Plan

## Test Result

1. Start head DP: `CUDA_VISIBLE_DEVICES=0,1 vllm serve /home/jovyan/qwen3-30b-a3b --gpu_memory_utilization=0.9 --enable-expert-parallel --data-parallel-size=4 --api-server-count 2 --data-parallel-address 127.0.0.1 --data-parallel-size-local 2 --data-parallel-start-rank 0 `
2. Start headless DP : `CUDA_VISIBLE_DEVICES=4,5 vllm serve /home/jovyan/qwen3-30b-a3b --gpu_memory_utilization=0.9 --enable-expert-parallel --data-parallel-size=4 --data-parallel-address 127.0.0.1 --data-parallel-size-local 2 --data-parallel-start-rank 2 --headless --data-parallel-heartbeat`

3. Manual stop head dp serve.
4. Watch headless DP can it exit automatically?

```

[rank2]:[W112 01:48:44.277417495 ProcessGroupNCCL.cpp:1771] [PG ID 0 PG GUID 0 Rank 2] Failed to check the "should dump" flag on TCPStore, (maybe TCPStore server has shut down too early), with error: Broken pipe
[rank3]:[W112 01:48:44.275482640 TCPStore.cpp:106] [c10d] sendBytes failed on SocketImpl(fd=83, addr=[localhost]:38648, remote=[localhost]:38381): Broken pipe
Exception raised from sendBytes at /pytorch/torch/csrc/distributed/c10d/Utils.hpp:653 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7f40dd57cb80 in /opt/conda/lib/python3.11/site-packages/torch/lib/libc10.so)
frame #1: <unknown function> + 0x5ffc5b1 (0x7f411f8da5b1 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so)
frame #2: <unknown function> + 0x5ffce42 (0x7f411f8dae42 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so)
frame #3: <unknown function> + 0x5ffe94e (0x7f411f8dc94e in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so)
frame #4: c10d::TCPStore::check(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) + 0x30e (0x7f411f8d726e in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cpu.so)
frame #5: c10d::ProcessGroupNCCL::HeartbeatMonitor::runLoop() + 0x3c8 (0x7f40de455868 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #6: <unknown function> + 0xd3b6d (0x7f41352f1b6d in /opt/conda/bin/../lib/libstdc++.so.6)
frame #7: <unknown function> + 0x9caa4 (0x7f413d873aa4 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #8: <unknown function> + 0x129c3c (0x7f413d900c3c in /usr/lib/x86_64-linux-gnu/libc.so.6)

[rank3]:[W112 01:48:44.292320781 ProcessGroupNCCL.cpp:1771] [PG ID 0 PG GUID 0 Rank 3] Failed to check the "should dump" flag on TCPStore, (maybe TCPStore server has shut down too early), with error: Broken pipe
(EngineCore_DP2 pid=366835) ERROR 01-12 01:48:45 [core.py:1092] DP coordinator heartbeat timed out (>10.0s); exiting.
(EngineCore_DP3 pid=367037) ERROR 01-12 01:48:45 [core.py:1092] DP coordinator heartbeat timed out (>10.0s); exiting.
INFO 01-12 01:48:45 [serve.py:162] Shutting down.
/opt/conda/lib/python3.11/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 2 leaked semaphore objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

