### PR TITLE
[Bugfix] Fix missing scale passing for encoder Triton Attention implementation 

### DIFF
--- a/examples/offline_inference/basic/embed.py
+++ b/examples/offline_inference/basic/embed.py
@@ -4,10 +4,7 @@
 from argparse import Namespace
 
 from vllm import LLM, EngineArgs
-from vllm.config import AttentionConfig
-from vllm.platforms import current_platform
 from vllm.utils.argparse_utils import FlexibleArgumentParser
-from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 
 def parse_args():
@@ -23,11 +20,6 @@ def parse_args():
 
 
 def main(args: Namespace):
-    if current_platform.is_rocm():
-        args.attention_config = AttentionConfig(
-            backend=AttentionBackendEnum.FLEX_ATTENTION
-        )
-
     # Sample prompts.
     prompts = [
         "Hello, my name is",

--- a/examples/offline_inference/basic/score.py
+++ b/examples/offline_inference/basic/score.py
@@ -4,10 +4,7 @@
 from argparse import Namespace
 
 from vllm import LLM, EngineArgs
-from vllm.config import AttentionConfig
-from vllm.platforms import current_platform
 from vllm.utils.argparse_utils import FlexibleArgumentParser
-from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 
 def parse_args():
@@ -23,11 +20,6 @@ def parse_args():
 
 
 def main(args: Namespace):
-    if current_platform.is_rocm():
-        args.attention_config = AttentionConfig(
-            backend=AttentionBackendEnum.FLEX_ATTENTION
-        )
-
     # Sample prompts.
     text_1 = "What is the capital of France?"
     texts_2 = [

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -573,6 +573,7 @@ class TritonAttentionImpl(AttentionImpl):
             b_seq_len=seq_lens,
             max_input_len=max_query_len,
             is_causal=False,  # Encoder attention is bidirectional
+            softmax_scale=self.scale,
             sliding_window_q=self.sliding_window[0],
             sliding_window_k=self.sliding_window[1],
         )

--- a/vllm/v1/attention/ops/triton_prefill_attention.py
+++ b/vllm/v1/attention/ops/triton_prefill_attention.py
@@ -211,16 +211,17 @@ def get_block_size(dtype: torch.dtype) -> int:
 
 
 def context_attention_fwd(
-    q,
-    k,
-    v,
-    o,
-    b_start_loc,
-    b_seq_len,
-    max_input_len,
-    is_causal=True,
-    sliding_window_q=None,
-    sliding_window_k=None,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    o: torch.Tensor,
+    b_start_loc: torch.Tensor,
+    b_seq_len: torch.Tensor,
+    max_input_len: int,
+    is_causal: bool = True,
+    softmax_scale: float | None = None,
+    sliding_window_q: int | None = None,
+    sliding_window_k: int | None = None,
 ):
     """
     q, k, v: [b * s, head, head_dim]
@@ -232,7 +233,7 @@ def context_attention_fwd(
 
     Lq, Lk, _ = q.shape[-1], k.shape[-1], v.shape[-1]
 
-    sm_scale = 1.0 / (Lq**0.5)
+    sm_scale = 1.0 / (Lq**0.5) if softmax_scale is None else softmax_scale
     batch, head = b_seq_len.shape[0], q.shape[1]
     kv_group_num = q.shape[1] // k.shape[1]
 


### PR DESCRIPTION

## Purpose
- A small fix for Triton Encoder only attention, otherwise `TritonAttentionImpl.scale` won't take effect exactly.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Ensures encoder Triton attention applies the configured softmax scale.
> 
> - Passes `softmax_scale=self.scale` when invoking `context_attention_fwd` in encoder path of `triton_attn.py`
> - Extends `context_attention_fwd` signature in `triton_prefill_attention.py` with types and optional `softmax_scale` (defaults to `1/sqrt(d)`), preserving kernel behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23857e3be4be21ae033d6f79cb278f3d99b70f2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures encoder-side Triton attention applies the configured softmax scale and updates the prefill attention API.
> 
> - Passes `softmax_scale=self.scale` when calling `context_attention_fwd` in `triton_attn.py` (encoder path)
> - Extends `context_attention_fwd` in `triton_prefill_attention.py` with types and optional `softmax_scale` (defaulting to `1/sqrt(d)`), and threads it to the kernel
> - Simplifies `examples/offline_inference/basic/{embed.py,score.py}` by removing ROCm-specific attention backend imports and overrides
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3340862b455ba867e21aa1bd26d20e36a6435b33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
