### PR TITLE
[Frontend] Fix Flaky MCP Streaming Test

### DIFF
--- a/tests/entrypoints/openai/responses/test_harmony.py
+++ b/tests/entrypoints/openai/responses/test_harmony.py
@@ -925,7 +925,7 @@ async def test_mcp_code_interpreter_streaming(client: OpenAI, model_name: str, s
         }
     ]
     input_text = (
-        "Calculate 15 * 32 using python. "
+        "Calculate 123 * 456 using python. "
         "The python interpreter is not stateful and you must print to see the output."
     )
 


### PR DESCRIPTION
## Purpose
test_mcp_code_interpreter_streaming is occasionally failing due to inconsistent behavior of whether it decides to trigger a tool call. Since the math question is too simple, a tool call isn't always triggered. A more complicated math problem like "123 * 456" consistently triggers the MCP tool call 


## Test Plan

pytest entrypoints/openai/responses/test_harmony.py::test_mcp_code_interpreter_streaming

## Test Result

Consistently passes unit test

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 3d2756b59c16887fb25d17757f57c51791ca38c8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
