### PR TITLE
[doc] fix broken links

### DIFF
--- a/docs/design/paged_attention.md
+++ b/docs/design/paged_attention.md
@@ -139,18 +139,14 @@ token data.
 const scalar_t* q_ptr = q + seq_idx * q_stride + head_idx * HEAD_SIZE;
 ```
 
-<p align="center">
-  <img src="../assets/design/paged_attention/query.png" alt="query" width="70%" />
-</p>
+![query](../assets/design/paged_attention/query.png)
 
 Each thread defines its own `q_ptr` which points to the assigned
 query token data on global memory. For example, if `VEC_SIZE` is 4
 and `HEAD_SIZE` is 128, the `q_ptr` points to data that contains
 total of 128 elements divided into 128 / 4 = 32 vecs.
 
-<p align="center">
-  <img src="../assets/design/paged_attention/q_vecs.png" alt="q_vecs" width="70%" />
-</p>
+![q_vecs](../assets/design/paged_attention/q_vecs.png)
 
 ```cpp
 __shared__ Q_vec q_vecs[THREAD_GROUP_SIZE][NUM_VECS_PER_THREAD];
@@ -187,9 +183,7 @@ key token at different iterations. As shown above, that `k_ptr`
 points to key token data based on `k_cache` at assigned block,
 assigned head and assigned token.
 
-<p align="center">
-  <img src="../assets/design/paged_attention/key.png" alt="key" width="70%" />
-</p>
+![key](../assets/design/paged_attention/key.png)
 
 The diagram above illustrates the memory layout for key data. It
 assumes that the `BLOCK_SIZE` is 16, `HEAD_SIZE` is 128, `x` is
@@ -202,9 +196,7 @@ iterations. Inside each rectangle, there are a total 32 vecs (128
 elements for one token) that will be processed by 2 threads (one
 thread group) separately.
 
-<p align="center">
-  <img src="../assets/design/paged_attention/k_vecs.png" alt="k_vecs" width="70%" />
-</p>
+![k_vecs](../assets/design/paged_attention/k_vecs.png)
 
 ```cpp
 K_vec k_vecs[NUM_VECS_PER_THREAD]
@@ -361,17 +353,11 @@ later steps. Now, it should store the normalized softmax result of
 
 ## Value
 
-<p align="center">
-  <img src="../assets/design/paged_attention/value.png" alt="value" width="70%" />
-</p>
+![value](../assets/design/paged_attention/value.png)
 
-<p align="center">
-  <img src="../assets/design/paged_attention/logits_vec.png" alt="logits_vec" width="50%" />
-</p>
+![logits_vec](../assets/design/paged_attention/logits_vec.png)
 
-<p align="center">
-  <img src="../assets/design/paged_attention/v_vec.png" alt="v_vec" width="70%" />
-</p>
+![v_vec](../assets/design/paged_attention/v_vec.png)
 
 Now we need to retrieve the value data and perform dot multiplication
 with `logits`. Unlike query and key, there is no thread group


### PR DESCRIPTION

## Purpose

Images were using HTML `<img>` tags with relative paths. MkDocs doesn't process relative paths in HTML tags, causing incorrect URLs.

<img width="772" height="616" alt="Clipboard_Screenshot_1768207949" src="https://github.com/user-attachments/assets/efd01e54-7d2c-40a3-9485-81c3b30cb863" />


## Test Plan

NA

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit df4aace545c831174f37f60348999c5ee3faf2ee. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Converts image embeds in `docs/design/paged_attention.md` from HTML `img` tags to Markdown image syntax so MkDocs resolves relative paths correctly.
> 
> - Replaces HTML image blocks with Markdown images for diagrams (`query`, `q_vecs`, `key`, `k_vecs`, `value`, `logits_vec`, `v_vec`)
> - Pure docs formatting change; no code or content logic modified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df4aace545c831174f37f60348999c5ee3faf2ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
