### PR TITLE
[Bugfix] fix apiserver crash exist then engine core close

### DIFF
--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -211,6 +211,7 @@ def run_multi_api_server(args: argparse.Namespace):
             stats_update_address=coordinator.get_stats_publish_address()
             if coordinator
             else None,
+            local_engine_manager=local_engine_manager,
         )
 
         # For dp ranks > 0 in external/hybrid DP LB modes, we must delay the


### PR DESCRIPTION

## Purpose

Fix: https://github.com/vllm-project/vllm/issues/32116

## Test Plan

We can set a very small ready timeout value to reproduction it.
```
$ VLLM_ENGINE_READY_TIMEOUT_S=10 CUDA_VISIBLE_DEVICES=0,1 vllm serve /home/jovyan/qwen3-30b-a3b --gpu_memory_utilization=0.9 --enable-expert-parallel --data-parallel-size=2 --api-server-count 2 --data-parallel-address 127.0.0.1 --data-parallel-size-local 2 --data-parallel-start-rank 0
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Links API server worker lifecycle to engine shutdown to avoid orphaned engines/crashes.
> 
> - `APIServerProcessManager` accepts `local_engine_manager` and spawns a monitor thread per worker to `close()` the engine manager when a worker dies
> - Adds `monitor_process` method; imports `threading`/`time`
> - `serve.py` passes `local_engine_manager` into `APIServerProcessManager` during multi-API-server launch
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8142dd77778e9dd24ab27b0a8e5d04aa7c64e3d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
