### PR TITLE
scheduler: Cache also the last block after KV recving

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1676,12 +1676,13 @@ class Scheduler(SchedulerInterface):
             num_computed_tokens = len(block_ids) * self.block_size
             # Handle the case where num request tokens less than one block.
             num_computed_tokens = min(num_computed_tokens, request.num_tokens)
-            if num_computed_tokens == request.num_tokens:
-                num_computed_tokens -= 1
             # This will cache the blocks iff caching is enabled.
             self.kv_cache_manager.cache_blocks(request, num_computed_tokens)
 
             # Update the request state for scheduling.
+            if num_computed_tokens == request.num_tokens:
+                # need to recompute last token in order to sample the next token
+                num_computed_tokens -= 1
             request.num_computed_tokens = num_computed_tokens
 
         # Return that we are ready.


### PR DESCRIPTION
This PR fixes the scheduler to commit the last full block of KV data that was async received.

@robertgshaw2-redhat this is modifying code you introduced in #17751.
I think it's safe to cache that last block as well, but not sure.
cc @njhill 

BTW, do we really have to re-compute the last token, or can we somehow re-use the KV data that we saved for it?

---

> [!NOTE]
> Ensures KV blocks are fully cached after async KV receive while preserving correct sampling behavior.
> 
> - In `Scheduler._update_waiting_for_remote_kv`, after caching received blocks, sets `num_computed_tokens` to `request.num_tokens - 1` when equal, so the last token is recomputed next step
> - Previously decremented before caching; now the last full block is cached too, improving cache commit behavior for completed blocks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0076065f920f1d42875ba89e1f6e382953d1b6de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
