### PR TITLE
[BugFix] scheduler: Fix ordering preserving of skipped requests

### DIFF
--- a/vllm/v1/core/sched/request_queue.py
+++ b/vllm/v1/core/sched/request_queue.py
@@ -71,11 +71,6 @@ class RequestQueue(ABC):
         """Iterate over the queue according to the policy."""
         pass
 
-    @abstractmethod
-    def __reversed__(self) -> Iterator[Request]:
-        """Iterate over the queue in reverse order."""
-        pass
-
 
 class FCFSRequestQueue(deque[Request], RequestQueue):
     """A first-come-first-served queue that supports deque operations."""
@@ -100,8 +95,12 @@ class FCFSRequestQueue(deque[Request], RequestQueue):
 
     def prepend_requests(self, requests: RequestQueue) -> None:
         """Prepend all requests from another queue to the front of this
-        queue."""
-        self.extendleft(reversed(requests))
+        queue.
+
+        Note: The requests will be prepended in reverse order of their
+        appearance in the `requests` queue.
+        """
+        self.extendleft(requests)
 
     def remove_request(self, request: Request) -> None:
         """Remove a specific request from the queue."""
@@ -127,10 +126,6 @@ class FCFSRequestQueue(deque[Request], RequestQueue):
     def __iter__(self) -> Iterator[Request]:
         """Iterate over the queue according to FCFS policy."""
         return super().__iter__()
-
-    def __reversed__(self) -> Iterator[Request]:
-        """Iterate over the queue in reverse order."""
-        return super().__reversed__()
 
 
 class PriorityRequestQueue(RequestQueue):
@@ -201,10 +196,6 @@ class PriorityRequestQueue(RequestQueue):
         heap_copy = self._heap[:]
         while heap_copy:
             yield heapq.heappop(heap_copy)
-
-    def __reversed__(self) -> Iterator[Request]:
-        """Iterate over the queue in reverse priority order."""
-        return reversed(list(self))
 
 
 def create_request_queue(policy: SchedulingPolicy) -> RequestQueue:


### PR DESCRIPTION
This PR fixes the order preserving of requests skipped by the scheduler.
A unit test is added to verify the fix.

I came across this bug while testing #29087, and the test there requires this fix.

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 8c08c30fef37d620043c4221960e04d6704ba1dc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Fixes request ordering when skipped requests are re-queued.
> 
> - Update `FCFSRequestQueue.prepend_requests` to `extendleft(requests)` (remove reverse) to maintain original order when prepending
> - Remove unused `__reversed__` definitions from request queues
> - Add `test_prepend_skipped_requests_order` to verify waiting order is preserved when some requests wait for remote KVs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c08c30fef37d620043c4221960e04d6704ba1dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures scheduler preserves request order when skipped requests are re-queued.
> 
> - Update `FCFSRequestQueue.prepend_requests` to prepend without reversing to maintain original order
> - Remove unused `__reversed__` definitions from `RequestQueue`, `FCFSRequestQueue`, and `PriorityRequestQueue`
> - Add `test_prepend_skipped_requests_order` to verify waiting order is preserved when some requests wait for remote KVs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc525fcc2dbb1c060a48b593dfab8d93d2d8697b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Ensures the scheduler preserves waiting order when skipped requests are re-queued.
> 
> - Update `FCFSRequestQueue.prepend_requests` to prepend without reversing to maintain original waiting order
> - Remove unused `__reversed__` from `RequestQueue`, `FCFSRequestQueue`, and `PriorityRequestQueue`
> - Add `test_prepend_skipped_requests_order` to verify waiting order is preserved when some requests wait for remote KVs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43019fa47b6e32a6d9b921b8328c9143fe3dcc23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
