### PR TITLE
nixl_connector: export UCX_MEM_MMAP_HOOK_MODE=none to avoid a UCX memory leak

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -98,6 +98,10 @@ try:
                 "Please set UCX_MEM_MMAP_HOOK_MODE to 'none' manually."
             )
         else:
+            logger.info(
+                "Setting UCX_MEM_MMAP_HOOK_MODE to 'none' to avoid a rare "
+                "memory leak in UCX when using NIXL."
+            )
             os.environ["UCX_MEM_MMAP_HOOK_MODE"] = "none"
 
     if not current_platform.is_rocm():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -4,7 +4,9 @@ import contextlib
 import copy
 import logging
 import math
+import os
 import queue
+import sys
 import threading
 import time
 import uuid
@@ -87,6 +89,17 @@ logger = init_logger(__name__)
 
 # Lazy import nixl_wrapper to avoid loading nixl_bindings if nixl is not used
 try:
+    if "UCX_MEM_MMAP_HOOK_MODE" not in os.environ:
+        # avoid a memory leak in UCX when using NIXL on some models
+        # see: https://github.com/vllm-project/vllm/issues/24264
+        if "nixl" in sys.modules or "rixl" in sys.modules:
+            logger.warning(
+                "NIXL was already imported, we can't disable UCX mmap hooks. "
+                "Please set UCX_MEM_MMAP_HOOK_MODE to 'none' manually."
+            )
+        else:
+            os.environ["UCX_MEM_MMAP_HOOK_MODE"] = "none"
+
     if not current_platform.is_rocm():
         from nixl._api import nixl_agent as NixlWrapper
         from nixl._bindings import nixlXferTelemetry


### PR DESCRIPTION
Implementation of the fix described here: https://github.com/vllm-project/vllm/issues/24264#issuecomment-3710305796

---

> [!NOTE]
>
>Mitigates a UCX memory leak when using NIXL by configuring UCX mmap hooks before loading NIXL bindings.
>
> -  If `UCX_MEM_MMAP_HOOK_MODE` is unset, set it to `none` prior to importing `nixl/rixl`; log a warning if `nixl` or `rixl` was already imported
> -  Adds `os`/`sys` imports; retains ROCm vs CUDA import paths and existing availability logging in `nixl_connector.py`
>
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2816c0f177d927c2d9e55f7348b274a1eb576858. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

