### PR TITLE
fp8 online quant: split out Fp8OnlineLinearMethod

### DIFF
--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -133,7 +133,7 @@ def test_kv_cache_model_load_and_run(
 @pytest.mark.parametrize(
     "use_rocm_aiter", [True, False] if current_platform.is_rocm() else [False]
 )
-def test_load_fp16_model(
+def test_online_quantization(
     vllm_runner,
     kv_cache_dtype: str,
     force_marlin: bool,
@@ -190,6 +190,9 @@ def test_load_fp16_model(
                 )
 
         llm.apply_model(check_model)
+
+        outputs = llm.generate_greedy(["Hello my name is"], max_tokens=4)
+        print(outputs[0][1])
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Summary:

Split out `Fp8OnlineLinearMethod` from `Fp8LinearMethod` to more clearly separate online quant from offline quant logic, following a similar PR recently landed for `Fp8OnlineMoEMethod`.

In the same PR, beef up testing for online quant in integration tests a bit so we can depend on tests for testing future functionality for online quant.  Specifically, extend the online fp8 quant test to also include a small moe model, and also extend it to run inference with a couple of tokens.

Test Plan:

```
// on a NVIDIA B200
// run online quant test (dense + moe smoke tests)
with-proxy pytest tests/quantization/test_fp8.py -s -x -k online_quantization
// run entire fp8.py test suite
with-proxy pytest tests/quantization/test_fp8.py -s -x
```

Reviewers:

Subscribers:

Tasks:

Tags:


## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit d209af298f5d6601a9328c21c252c4fc11de1911. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Cleanly separates online FP8 linear quantization from offline (serialized) flow and strengthens smoke test coverage.
> 
> - Adds `Fp8OnlineLinearMethod` that patches weight loading to quantize fp16/bf16 weights on-the-fly via `ops.scaled_fp8_quant`, with optional Marlin preparation
> - Updates `Fp8Config.get_quant_method` to choose `Fp8OnlineLinearMethod` vs `Fp8LinearMethod` based on `is_checkpoint_fp8_serialized`; simplifies `Fp8LinearMethod` to the serialized-FP8 path
> - Keeps MoE split (`Fp8OnlineMoEMethod`/`Fp8MoEMethod`) unchanged, integrates with selection logic
> - Expands tests: new `test_online_quantization` runs on `facebook/opt-125m` and `Qwen/Qwen1.5-MoE-A2.7B`, parameterizes KV cache (`auto`/`fp8`) and Marlin/ROCm flags, and performs short greedy generation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d209af298f5d6601a9328c21c252c4fc11de1911. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Cleanly separates online FP8 linear quantization from the serialized (offline) flow and strengthens smoke test coverage.
> 
> - Adds `Fp8OnlineLinearMethod` that patches weight loading to quantize fp16/bf16 weights via `ops.scaled_fp8_quant`, with optional Marlin prep
> - Updates `Fp8Config.get_quant_method` to choose `Fp8OnlineLinearMethod` vs `Fp8LinearMethod` based on `is_checkpoint_fp8_serialized`; `Fp8LinearMethod` now focuses on fp8-serialized path
> - Keeps MoE split (`Fp8OnlineMoEMethod`/`Fp8MoEMethod`) and integrates it into the same selection logic
> - Expands `test_online_quantization`: runs on `facebook/opt-125m` and `Qwen/Qwen1.5-MoE-A2.7B`, parameterizes KV cache (`auto`/`fp8`) and Marlin/ROCm flags, and validates a short greedy generation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9d2f36f55819d195b00afd8efabf99ab9824a22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
