### PR TITLE
[AOT compilation] cached inductor artifacts benchmark #32043

### DIFF
--- a/vllm/benchmarks/startup.py
+++ b/vllm/benchmarks/startup.py
@@ -6,6 +6,7 @@ This script measures total startup time (including model loading, compilation,
 and cache operations) for both cold and warm scenarios:
 - Cold startup: Fresh start with no caches (temporary cache directories)
 - Warm startup: Using cached compilation and model info
+- AOT compile mode: Measures serialization of compiled artifacts to disk
 """
 
 import argparse
@@ -55,14 +56,66 @@ def cold_startup():
             os.environ.pop("VLLM_CACHE_ROOT", None)
 
 
-def run_startup_in_subprocess(engine_args, result_queue):
+@contextmanager
+def aot_warm_startup(cache_dir: str, mega_aot_artifact: bool = False):
+    """
+    Context manager for warm startup with AOT compile artifacts.
+    Uses the provided cache directory (which should contain pre-compiled artifacts).
+    """
+    original_cache_root = os.environ.get("VLLM_CACHE_ROOT")
+    original_aot_compile = os.environ.get("VLLM_USE_AOT_COMPILE")
+    original_standalone = os.environ.get("VLLM_USE_STANDALONE_COMPILE")
+    original_mega_aot = os.environ.get("VLLM_USE_MEGA_AOT_ARTIFACT")
+
+    try:
+        os.environ["VLLM_CACHE_ROOT"] = cache_dir
+        os.environ["VLLM_USE_AOT_COMPILE"] = "1"
+        os.environ["VLLM_USE_STANDALONE_COMPILE"] = "1"
+        if mega_aot_artifact:
+            os.environ["VLLM_USE_MEGA_AOT_ARTIFACT"] = "1"
+        yield
+    finally:
+        if original_cache_root:
+            os.environ["VLLM_CACHE_ROOT"] = original_cache_root
+        else:
+            os.environ.pop("VLLM_CACHE_ROOT", None)
+        if original_aot_compile:
+            os.environ["VLLM_USE_AOT_COMPILE"] = original_aot_compile
+        else:
+            os.environ.pop("VLLM_USE_AOT_COMPILE", None)
+        if original_standalone:
+            os.environ["VLLM_USE_STANDALONE_COMPILE"] = original_standalone
+        else:
+            os.environ.pop("VLLM_USE_STANDALONE_COMPILE", None)
+        if original_mega_aot:
+            os.environ["VLLM_USE_MEGA_AOT_ARTIFACT"] = original_mega_aot
+        else:
+            os.environ.pop("VLLM_USE_MEGA_AOT_ARTIFACT", None)
+
+
+def get_directory_size(path: str) -> int:
+    """Calculate total size of all files in a directory recursively."""
+    total_size = 0
+    for dirpath, _, filenames in os.walk(path):
+        for filename in filenames:
+            filepath = os.path.join(dirpath, filename)
+            if os.path.isfile(filepath):
+                total_size += os.path.getsize(filepath)
+    return total_size
+
+
+def run_startup_in_subprocess(
+    engine_args, result_queue, measure_artifact_size=False, measure_inference=False
+):
     """
     Run LLM startup in a subprocess and return timing metrics via a queue.
     This ensures complete isolation between iterations.
     """
+    import traceback
+
     try:
         # Import inside the subprocess to avoid issues with forking
-        from vllm import LLM
+        from vllm import LLM, SamplingParams
 
         # Measure total startup time
         start_time = time.perf_counter()
@@ -81,16 +134,41 @@ def run_startup_in_subprocess(engine_args, result_queue):
             ):
                 compilation_time = vllm_config.compilation_config.compilation_time
 
+        artifact_size = 0
+        if measure_artifact_size:
+            cache_root = os.environ.get("VLLM_CACHE_ROOT", "")
+            aot_dir = os.path.join(cache_root, "torch_aot_compile")
+            if os.path.exists(aot_dir):
+                artifact_size = get_directory_size(aot_dir)
+
+        inference_tokens_per_sec = 0.0
+        if measure_inference:
+            sampling_params = SamplingParams(temperature=0.0, max_tokens=64)
+            prompt = "The quick brown fox jumps over the lazy dog."
+
+            _ = llm.generate([prompt], sampling_params)
+
+            inference_start = time.perf_counter()
+            outputs = llm.generate([prompt], sampling_params)
+            inference_time = time.perf_counter() - inference_start
+
+            total_tokens = sum(len(o.outputs[0].token_ids) for o in outputs)
+            if inference_time > 0:
+                inference_tokens_per_sec = total_tokens / inference_time
+
         result_queue.put(
             {
                 "total_startup_time": total_startup_time,
                 "compilation_time": compilation_time,
+                "artifact_size": artifact_size,
+                "inference_tokens_per_sec": inference_tokens_per_sec,
             }
         )
 
     except Exception as e:
         result_queue.put(None)
-        result_queue.put(str(e))
+        error_msg = f"{type(e).__name__}: {e}\n{traceback.format_exc()}"
+        result_queue.put(error_msg)
 
 
 def save_to_pytorch_benchmark_format(
@@ -154,6 +232,37 @@ def save_to_pytorch_benchmark_format(
             f"{base_name}.warm_compilation.pytorch.json", warm_compilation_records
         )
 
+    if "avg_aot_cold_startup_time" in results:
+        aot_cold_records = convert_to_pytorch_benchmark_format(
+            args=args,
+            metrics={
+                "avg_aot_cold_startup_time": results["avg_aot_cold_startup_time"],
+            },
+            extra_info={
+                "aot_cold_startup_times": results["aot_cold_startup_times"],
+                "aot_cold_startup_percentiles": results["aot_cold_startup_percentiles"],
+            },
+        )
+        if aot_cold_records:
+            write_to_json(
+                f"{base_name}.aot_cold_startup.pytorch.json", aot_cold_records
+            )
+
+        aot_warm_records = convert_to_pytorch_benchmark_format(
+            args=args,
+            metrics={
+                "avg_aot_warm_startup_time": results["avg_aot_warm_startup_time"],
+            },
+            extra_info={
+                "aot_warm_startup_times": results["aot_warm_startup_times"],
+                "aot_warm_startup_percentiles": results["aot_warm_startup_percentiles"],
+            },
+        )
+        if aot_warm_records:
+            write_to_json(
+                f"{base_name}.aot_warm_startup.pytorch.json", aot_warm_records
+            )
+
 
 def add_cli_args(parser: argparse.ArgumentParser):
     parser.add_argument(
@@ -175,6 +284,23 @@ def add_cli_args(parser: argparse.ArgumentParser):
         help="Number of warm startup iterations.",
     )
     parser.add_argument(
+        "--aot-compile",
+        action="store_true",
+        help="Enable AOT compile mode to benchmark serialization of "
+        "compiled artifacts.",
+    )
+    parser.add_argument(
+        "--mega-aot-artifact",
+        action="store_true",
+        help="Enable mega AOT artifact mode (bundles all compiled artifacts). "
+        "Requires --aot-compile.",
+    )
+    parser.add_argument(
+        "--measure-inference",
+        action="store_true",
+        help="Measure inference performance (tokens/sec) after startup.",
+    )
+    parser.add_argument(
         "--output-json",
         type=str,
         default=None,
@@ -185,14 +311,28 @@ def add_cli_args(parser: argparse.ArgumentParser):
     return parser
 
 
+def format_size(size_bytes: int) -> str:
+    """Format bytes as human-readable string."""
+    for unit in ["B", "KB", "MB", "GB"]:
+        if size_bytes < 1024:
+            return f"{size_bytes:.2f} {unit}"
+        size_bytes /= 1024
+    return f"{size_bytes:.2f} TB"
+
+
 def main(args: argparse.Namespace):
+    if args.mega_aot_artifact and not args.aot_compile:
+        raise ValueError("--mega-aot-artifact requires --aot-compile")
+
     # Set multiprocessing start method to 'spawn' for clean process isolation
     # This ensures each subprocess starts fresh without inheriting state
     multiprocessing.set_start_method("spawn", force=True)
 
     engine_args = EngineArgs.from_cli_args(args)
 
-    def create_llm_and_measure_startup():
+    def create_llm_and_measure_startup(
+        measure_artifact_size=False, measure_inference=False
+    ):
         """
         Create LLM instance in a subprocess and measure startup time.
         Returns timing metrics, using subprocess for complete isolation.
@@ -205,10 +345,22 @@ def main(args: argparse.Namespace):
             args=(
                 engine_args,
                 result_queue,
+                measure_artifact_size,
+                measure_inference,
             ),
         )
         process.start()
         process.join()
+
+        if process.exitcode != 0:
+            error_msg = "Unknown error"
+            if not result_queue.empty():
+                result = result_queue.get()
+                if result is None and not result_queue.empty():
+                    error_msg = result_queue.get()
+            raise RuntimeError(
+                f"Subprocess failed with exit code {process.exitcode}: {error_msg}"
+            )
 
         if not result_queue.empty():
             result = result_queue.get()
@@ -220,7 +372,9 @@ def main(args: argparse.Namespace):
                     raise RuntimeError("Subprocess failed with unknown error")
             return result
         else:
-            raise RuntimeError("Subprocess did not return a result")
+            raise RuntimeError(
+                f"Subprocess did not return a result (exit code: {process.exitcode})"
+            )
 
     os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
     print("Setting VLLM_ENABLE_V1_MULTIPROCESSING=0 to collect startup metrics.\n")
@@ -242,10 +396,80 @@ def main(args: argparse.Namespace):
     print("\nMeasuring warm startup time...\n")
     warm_startup_times = []
     warm_compilation_times = []
+    warm_inference_speeds = []
     for i in tqdm(range(args.num_iters_warm), desc="Warm startup iterations"):
-        metrics = create_llm_and_measure_startup()
+        metrics = create_llm_and_measure_startup(
+            measure_inference=args.measure_inference
+        )
         warm_startup_times.append(metrics["total_startup_time"])
         warm_compilation_times.append(metrics["compilation_time"])
+        if args.measure_inference:
+            warm_inference_speeds.append(metrics["inference_tokens_per_sec"])
+
+    aot_cold_startup_times = []
+    aot_cold_compilation_times = []
+    aot_warm_startup_times = []
+    aot_warm_compilation_times = []
+    aot_warm_inference_speeds = []
+    aot_artifact_sizes = []
+
+    if args.aot_compile:
+        print("\n" + "=" * 60)
+        print("AOT COMPILE BENCHMARKING")
+        if args.mega_aot_artifact:
+            print("(with MEGA AOT ARTIFACT enabled)")
+        print("=" * 60)
+
+        aot_cache_dir = tempfile.mkdtemp(prefix="vllm_startup_bench_aot_")
+
+        try:
+            print("\nMeasuring AOT cold startup (compile + serialize)...\n")
+            for i in tqdm(
+                range(args.num_iters_cold), desc="AOT cold startup iterations"
+            ):
+                if os.path.exists(aot_cache_dir):
+                    shutil.rmtree(aot_cache_dir)
+                os.makedirs(aot_cache_dir, exist_ok=True)
+
+                with aot_warm_startup(aot_cache_dir, args.mega_aot_artifact):
+                    from torch._inductor.utils import fresh_cache
+
+                    with fresh_cache():
+                        metrics = create_llm_and_measure_startup(
+                            measure_artifact_size=True
+                        )
+                        aot_cold_startup_times.append(metrics["total_startup_time"])
+                        aot_cold_compilation_times.append(metrics["compilation_time"])
+                        aot_artifact_sizes.append(metrics["artifact_size"])
+
+            print("\nPopulating AOT cache for warm measurements...\n")
+            if os.path.exists(aot_cache_dir):
+                shutil.rmtree(aot_cache_dir)
+            os.makedirs(aot_cache_dir, exist_ok=True)
+
+            with aot_warm_startup(aot_cache_dir, args.mega_aot_artifact):
+                from torch._inductor.utils import fresh_cache
+
+                with fresh_cache():
+                    create_llm_and_measure_startup(measure_artifact_size=True)
+
+            print("\nMeasuring AOT warm startup (load from cache)...\n")
+            for i in tqdm(
+                range(args.num_iters_warm), desc="AOT warm startup iterations"
+            ):
+                with aot_warm_startup(aot_cache_dir, args.mega_aot_artifact):
+                    metrics = create_llm_and_measure_startup(
+                        measure_inference=args.measure_inference
+                    )
+                    aot_warm_startup_times.append(metrics["total_startup_time"])
+                    aot_warm_compilation_times.append(metrics["compilation_time"])
+                    if args.measure_inference:
+                        aot_warm_inference_speeds.append(
+                            metrics["inference_tokens_per_sec"]
+                        )
+
+        finally:
+            shutil.rmtree(aot_cache_dir, ignore_errors=True)
 
     # Calculate statistics
     cold_startup_array = np.array(cold_startup_times)
@@ -290,32 +514,171 @@ def main(args: argparse.Namespace):
     for percentage, percentile in zip(percentages, warm_compilation_percentiles):
         print(f"  {percentage}%: {percentile:.2f} seconds")
 
+    # Prepare results dict
+    results = {
+        "avg_cold_startup_time": float(avg_cold_startup),
+        "avg_cold_compilation_time": float(avg_cold_compilation),
+        "cold_startup_times": cold_startup_times,
+        "cold_compilation_times": cold_compilation_times,
+        "cold_startup_percentiles": dict(
+            zip(percentages, cold_startup_percentiles.tolist())
+        ),
+        "cold_compilation_percentiles": dict(
+            zip(percentages, cold_compilation_percentiles.tolist())
+        ),
+        "avg_warm_startup_time": float(avg_warm_startup),
+        "avg_warm_compilation_time": float(avg_warm_compilation),
+        "warm_startup_times": warm_startup_times,
+        "warm_compilation_times": warm_compilation_times,
+        "warm_startup_percentiles": dict(
+            zip(percentages, warm_startup_percentiles.tolist())
+        ),
+        "warm_compilation_percentiles": dict(
+            zip(percentages, warm_compilation_percentiles.tolist())
+        ),
+    }
+
+    if args.aot_compile and aot_cold_startup_times:
+        aot_cold_startup_array = np.array(aot_cold_startup_times)
+        aot_cold_compilation_array = np.array(aot_cold_compilation_times)
+        aot_warm_startup_array = np.array(aot_warm_startup_times)
+        aot_warm_compilation_array = np.array(aot_warm_compilation_times)
+        aot_artifact_array = np.array(aot_artifact_sizes)
+
+        avg_aot_cold_startup = np.mean(aot_cold_startup_array)
+        avg_aot_cold_compilation = np.mean(aot_cold_compilation_array)
+        avg_aot_warm_startup = np.mean(aot_warm_startup_array)
+        avg_aot_warm_compilation = np.mean(aot_warm_compilation_array)
+        avg_artifact_size = np.mean(aot_artifact_array)
+
+        aot_cold_startup_percentiles = np.percentile(
+            aot_cold_startup_array, percentages
+        )
+        aot_cold_compilation_percentiles = np.percentile(
+            aot_cold_compilation_array, percentages
+        )
+        aot_warm_startup_percentiles = np.percentile(
+            aot_warm_startup_array, percentages
+        )
+        aot_warm_compilation_percentiles = np.percentile(
+            aot_warm_compilation_array, percentages
+        )
+
+        print("\n" + "-" * 60)
+        print("AOT COMPILE RESULTS")
+        print("-" * 60)
+
+        print("\nAOT COLD STARTUP (compile + serialize):")
+        print(f"Avg total startup time: {avg_aot_cold_startup:.2f} seconds")
+        print(f"Avg compilation time:   {avg_aot_cold_compilation:.2f} seconds")
+        print(f"Avg artifact size:      {format_size(avg_artifact_size)}")
+        print("Startup time percentiles:")
+        for percentage, percentile in zip(percentages, aot_cold_startup_percentiles):
+            print(f"  {percentage}%: {percentile:.2f} seconds")
+
+        print("\nAOT WARM STARTUP (load from cache):")
+        print(f"Avg total startup time: {avg_aot_warm_startup:.2f} seconds")
+        print(f"Avg compilation time:   {avg_aot_warm_compilation:.2f} seconds")
+        print("Startup time percentiles:")
+        for percentage, percentile in zip(percentages, aot_warm_startup_percentiles):
+            print(f"  {percentage}%: {percentile:.2f} seconds")
+
+        speedup = avg_aot_cold_startup / avg_aot_warm_startup
+        time_saved = avg_aot_cold_startup - avg_aot_warm_startup
+        print(f"\nAOT Speedup: {speedup:.2f}x ({time_saved:.2f}s saved)")
+
+        print("\n" + "-" * 60)
+        print("COMPARISON: AOT Warm vs Regular Warm")
+        print("-" * 60)
+        warm_vs_aot_improvement = avg_warm_startup - avg_aot_warm_startup
+        warm_vs_aot_speedup = avg_warm_startup / avg_aot_warm_startup
+        print(f"Regular warm startup: {avg_warm_startup:.2f}s")
+        print(f"AOT warm startup:     {avg_aot_warm_startup:.2f}s")
+        if warm_vs_aot_improvement > 0:
+            print(
+                f"Improvement:          {warm_vs_aot_improvement:.2f}s faster "
+                f"({warm_vs_aot_speedup:.2f}x)"
+            )
+        else:
+            slowdown = 1 / warm_vs_aot_speedup
+            print(
+                f"Regression:           {-warm_vs_aot_improvement:.2f}s slower "
+                f"({slowdown:.2f}x)"
+            )
+
+        avg_warm_inference = 0.0
+        avg_aot_warm_inference = 0.0
+        if (
+            args.measure_inference
+            and warm_inference_speeds
+            and aot_warm_inference_speeds
+        ):
+            avg_warm_inference = np.mean(warm_inference_speeds)
+            avg_aot_warm_inference = np.mean(aot_warm_inference_speeds)
+            inference_diff_pct = (
+                (avg_aot_warm_inference - avg_warm_inference) / avg_warm_inference * 100
+                if avg_warm_inference > 0
+                else 0
+            )
+            print("\nInference Performance:")
+            print(f"Regular warm: {avg_warm_inference:.1f} tokens/sec")
+            print(f"AOT warm:     {avg_aot_warm_inference:.1f} tokens/sec")
+            if abs(inference_diff_pct) < 5:
+                print(f"Difference:   {inference_diff_pct:+.1f}% (within noise)")
+            elif inference_diff_pct > 0:
+                print(f"Improvement:  {inference_diff_pct:+.1f}%")
+            else:
+                print(f"Regression:   {inference_diff_pct:+.1f}%")
+
+        results.update(
+            {
+                "avg_aot_cold_startup_time": float(avg_aot_cold_startup),
+                "avg_aot_cold_compilation_time": float(avg_aot_cold_compilation),
+                "aot_cold_startup_times": aot_cold_startup_times,
+                "aot_cold_compilation_times": aot_cold_compilation_times,
+                "aot_cold_startup_percentiles": dict(
+                    zip(percentages, aot_cold_startup_percentiles.tolist())
+                ),
+                "aot_cold_compilation_percentiles": dict(
+                    zip(percentages, aot_cold_compilation_percentiles.tolist())
+                ),
+                "avg_aot_warm_startup_time": float(avg_aot_warm_startup),
+                "avg_aot_warm_compilation_time": float(avg_aot_warm_compilation),
+                "aot_warm_startup_times": aot_warm_startup_times,
+                "aot_warm_compilation_times": aot_warm_compilation_times,
+                "aot_warm_startup_percentiles": dict(
+                    zip(percentages, aot_warm_startup_percentiles.tolist())
+                ),
+                "aot_warm_compilation_percentiles": dict(
+                    zip(percentages, aot_warm_compilation_percentiles.tolist())
+                ),
+                "avg_artifact_size_bytes": float(avg_artifact_size),
+                "artifact_sizes": aot_artifact_sizes,
+                "aot_speedup": float(speedup),
+                "warm_vs_aot_improvement_seconds": float(warm_vs_aot_improvement),
+                "warm_vs_aot_speedup": float(warm_vs_aot_speedup),
+            }
+        )
+
+        if (
+            args.measure_inference
+            and warm_inference_speeds
+            and aot_warm_inference_speeds
+        ):
+            results.update(
+                {
+                    "avg_warm_inference_tokens_per_sec": float(avg_warm_inference),
+                    "avg_aot_warm_inference_tokens_per_sec": float(
+                        avg_aot_warm_inference
+                    ),
+                    "warm_inference_tokens_per_sec": warm_inference_speeds,
+                    "aot_warm_inference_tokens_per_sec": aot_warm_inference_speeds,
+                }
+            )
+
     print("=" * 60)
 
-    # Output JSON results if specified
     if args.output_json:
-        results = {
-            "avg_cold_startup_time": float(avg_cold_startup),
-            "avg_cold_compilation_time": float(avg_cold_compilation),
-            "cold_startup_times": cold_startup_times,
-            "cold_compilation_times": cold_compilation_times,
-            "cold_startup_percentiles": dict(
-                zip(percentages, cold_startup_percentiles.tolist())
-            ),
-            "cold_compilation_percentiles": dict(
-                zip(percentages, cold_compilation_percentiles.tolist())
-            ),
-            "avg_warm_startup_time": float(avg_warm_startup),
-            "avg_warm_compilation_time": float(avg_warm_compilation),
-            "warm_startup_times": warm_startup_times,
-            "warm_compilation_times": warm_compilation_times,
-            "warm_startup_percentiles": dict(
-                zip(percentages, warm_startup_percentiles.tolist())
-            ),
-            "warm_compilation_percentiles": dict(
-                zip(percentages, warm_compilation_percentiles.tolist())
-            ),
-        }
         with open(args.output_json, "w") as f:
             json.dump(results, f, indent=4)
         save_to_pytorch_benchmark_format(args, results)


### PR DESCRIPTION
benchmark for https://github.com/vllm-project/vllm/pull/25205
## Purpose

## Test Plan

## Test Result
```
vllm bench startup --model Qwen/Qwen3-32B --aot-compile --num-iters-cold 1 --num-iters-warm 1 --measure-inference --mega-aot-artifact

============================================================
STARTUP TIME BENCHMARK RESULTS
============================================================

COLD STARTUP:
Avg total startup time: 68.47 seconds
Avg compilation time:   30.69 seconds
Startup time percentiles:
  10%: 68.47 seconds
  25%: 68.47 seconds
  50%: 68.47 seconds
  75%: 68.47 seconds
  90%: 68.47 seconds
  99%: 68.47 seconds
Compilation time percentiles:
  10%: 30.69 seconds
  25%: 30.69 seconds
  50%: 30.69 seconds
  75%: 30.69 seconds
  90%: 30.69 seconds
  99%: 30.69 seconds

WARM STARTUP:
Avg total startup time: 43.91 seconds
Avg compilation time:   14.95 seconds
Startup time percentiles:
  10%: 43.91 seconds
  25%: 43.91 seconds
  50%: 43.91 seconds
  75%: 43.91 seconds
  90%: 43.91 seconds
  99%: 43.91 seconds
Compilation time percentiles:
  10%: 14.95 seconds
  25%: 14.95 seconds
  50%: 14.95 seconds
  75%: 14.95 seconds
  90%: 14.95 seconds
  99%: 14.95 seconds

------------------------------------------------------------
AOT COMPILE RESULTS
------------------------------------------------------------

AOT COLD STARTUP (compile + serialize):
Avg total startup time: 72.81 seconds
Avg compilation time:   29.41 seconds
Avg artifact size:      30.91 MB
Startup time percentiles:
  10%: 72.81 seconds
  25%: 72.81 seconds
  50%: 72.81 seconds
  75%: 72.81 seconds
  90%: 72.81 seconds
  99%: 72.81 seconds

AOT WARM STARTUP (load from cache):
Avg total startup time: 29.47 seconds
Avg compilation time:   0.00 seconds
Startup time percentiles:
  10%: 29.47 seconds
  25%: 29.47 seconds
  50%: 29.47 seconds
  75%: 29.47 seconds
  90%: 29.47 seconds
  99%: 29.47 seconds

AOT Speedup: 2.47x (43.34s saved)

------------------------------------------------------------
COMPARISON: AOT Warm vs Regular Warm
------------------------------------------------------------
Regular warm startup: 43.91s
AOT warm startup:     29.47s
Improvement:          14.44s faster (1.49x)

Inference Performance:
Regular warm: 76.1 tokens/sec
AOT warm:     75.7 tokens/sec
Difference:   -0.4% (within noise)
============================================================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Adds a standalone benchmark `benchmarks/compile/benchmark_inductor_compiled_artifacts.py` to measure vLLM inductor compiled‑artifacts cache performance across models.
> 
> - Runs cold vs warm starts (and optional baseline AOT without cache), recording `load_time`, `inference_time`, `total_tokens`, `tokens_per_second`, and computing speedups
> - Manages env vars and caches (`VLLM_CACHE_ROOT`, `VLLM_USE_BACKEND_WITH_INDUCTOR_COMPILED_ARTIFACTS`, `VLLM_USE_AOT_COMPILE`, `VLLM_USE_STANDALONE_COMPILE`; clears vLLM/torchinductor caches and GPU memory between runs)
> - CLI supports model selection/listing, prompt/max tokens/batch size, `--compile-sizes`, `--compile-ranges-split-points`, `--cache-dir`, `--include-baseline`, and JSON output via `--output`
> - Prints per‑model results and a summary comparing groups with formatted timings and speedups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e737acd986d043410faef677b91ae34ffc20fe3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Adds `benchmarks/compile/benchmark_inductor_compiled_artifacts.py` to measure cache impact across models.
> 
> - Runs grouped cold/warm starts for the inductor cache, plus optional baseline AOT without cache; records `load_time`, `inference_time`, `total_tokens`, `tokens_per_second`, and computes speedups
> - Manages env vars and cache hygiene (`VLLM_CACHE_ROOT`, `VLLM_USE_BACKEND_WITH_INDUCTOR_COMPILED_ARTIFACTS`, `VLLM_USE_AOT_COMPILE`, `VLLM_USE_STANDALONE_COMPILE`; clears vLLM/torchinductor caches and GPU memory)
> - CLI: model selection/listing, prompt/max tokens/batch size, `--compile-sizes`, `--compile-ranges-split-points`, `--cache-dir`, `--include-baseline`, and JSON results via `--output`
> - Prints per-model results and a summary comparing groups with formatted timings and speedups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35007a8ea0a0960fce09acdb835d5b7e62f07fd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
