### PR TITLE
[Misc] Change log level for batch queue log

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -183,7 +183,7 @@ class EngineCore:
             deque[tuple[Future[ModelRunnerOutput], SchedulerOutput, Future[Any]]] | None
         ) = None
         if self.batch_queue_size > 1:
-            logger.info("Batch queue is enabled with size %d", self.batch_queue_size)
+            logger.debug("Batch queue is enabled with size %d", self.batch_queue_size)
             self.batch_queue = deque(maxlen=self.batch_queue_size)
 
         self.is_ec_producer = (


### PR DESCRIPTION
As per https://vllm-dev.slack.com/archives/C07R5Q1Q2BB/p1768224082041559

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit e0bdb779a0d93b90afb5f791188ae2bcc3139364. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Lowers log verbosity for batch queue initialization to reduce noise in standard logs.
> 
> - Changes `logger.info` to `logger.debug` for "Batch queue is enabled with size %d" in `vllm/v1/engine/core.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0bdb779a0d93b90afb5f791188ae2bcc3139364. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
