### PR TITLE
[BugFix] fix FusedMoE.make_expert_params_mapping in EXAONE-MoE

### DIFF
--- a/vllm/model_executor/models/exaone_moe.py
+++ b/vllm/model_executor/models/exaone_moe.py
@@ -338,6 +338,7 @@ class ExaoneMoeModel(nn.Module):
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
         return FusedMoE.make_expert_params_mapping(
+            self,
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",


### PR DESCRIPTION

## Purpose
Added the missing changes.
Related to #31104.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Fixes expert parameter mapping for EXAONE-MoE.
> 
> - Updates `get_expert_mapping` to pass `self` into `FusedMoE.make_expert_params_mapping`, ensuring correct mapping/loading of expert weights (including redundant experts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 370629eaf4bcdfcc5a9ca534745dbd293215f928. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
