### PR TITLE
[Misc] Allow enabling NCCL for DP sync when async scheduling

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -2,10 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic.dataclasses import dataclass
 from torch.distributed import ProcessGroup, ReduceOp
 from typing_extensions import Self
@@ -294,6 +295,12 @@ class ParallelConfig:
         This is an internal config that is only valid for and
         should only be set by API server scale-out.
     """
+
+    @field_validator("disable_nccl_for_dp_synchronization", mode="wrap")
+    @classmethod
+    def _skip_none_validation(cls, value: Any, handler: Callable) -> Any:
+        """Skip validation if the value is `None` when initialisation is delayed."""
+        return None if value is None else handler(value)
 
     @model_validator(mode="after")
     def _validate_parallel_config(self) -> Self:

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -182,9 +182,12 @@ class ParallelConfig:
     threshold, microbatching will be used. Otherwise, the request will be
     processed in a single batch."""
 
-    disable_nccl_for_dp_synchronization: bool = False
+    disable_nccl_for_dp_synchronization: bool = Field(default=None)
     """Forces the dp synchronization logic in vllm/v1/worker/dp_utils.py 
-    to use Gloo instead of NCCL for its all reduce"""
+    to use Gloo instead of NCCL for its all reduce.
+
+    Defaults to True when async scheduling is enabled, False otherwise.
+    """
 
     ray_workers_use_nsight: bool = False
     """Whether to profile Ray workers with nsight, see https://docs.ray.io/en/latest/ray-observability/user-guides/profiling.html#profiling-nsight-profiler."""

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -209,9 +209,7 @@ class SchedulerConfig:
     @classmethod
     def _skip_none_validation(cls, value: Any, handler: Callable) -> Any:
         """Skip validation if the value is `None` when initialisation is delayed."""
-        if value is None:
-            return value
-        return handler(value)
+        return None if value is None else handler(value)
 
     def __post_init__(self, max_model_len: int, is_encoder_decoder: bool) -> None:
         if is_encoder_decoder:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -629,19 +629,19 @@ class VllmConfig:
             else:
                 self.scheduler_config.async_scheduling = True
 
-        if (
-            self.scheduler_config.async_scheduling
-            and not self.parallel_config.disable_nccl_for_dp_synchronization
-        ):
-            logger.info_once(
-                "Disabling NCCL for DP synchronization when using async scheduling."
-            )
-            self.parallel_config.disable_nccl_for_dp_synchronization = True
-
         logger.info_once(
             "Asynchronous scheduling is %s.",
             "enabled" if self.scheduler_config.async_scheduling else "disabled",
         )
+
+        if self.parallel_config.disable_nccl_for_dp_synchronization is None:
+            if self.scheduler_config.async_scheduling:
+                logger.info_once(
+                    "Disabling NCCL for DP synchronization when using async scheduling."
+                )
+                self.parallel_config.disable_nccl_for_dp_synchronization = True
+            else:
+                self.parallel_config.disable_nccl_for_dp_synchronization = False
 
         from vllm.platforms import current_platform
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -637,7 +637,9 @@ class VllmConfig:
         if self.parallel_config.disable_nccl_for_dp_synchronization is None:
             if self.scheduler_config.async_scheduling:
                 logger.info_once(
-                    "Disabling NCCL for DP synchronization when using async scheduling."
+                    "Disabling NCCL for DP synchronization "
+                    "when using async scheduling.",
+                    scope="local",
                 )
                 self.parallel_config.disable_nccl_for_dp_synchronization = True
             else:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -413,7 +413,7 @@ class EngineArgs:
     ubatch_size: int = ParallelConfig.ubatch_size
     dbo_decode_token_threshold: int = ParallelConfig.dbo_decode_token_threshold
     dbo_prefill_token_threshold: int = ParallelConfig.dbo_prefill_token_threshold
-    disable_nccl_for_dp_synchronization: bool = (
+    disable_nccl_for_dp_synchronization: bool | None = (
         ParallelConfig.disable_nccl_for_dp_synchronization
     )
     eplb_config: EPLBConfig = get_field(ParallelConfig, "eplb_config")


### PR DESCRIPTION
It's currently disabled by default in this case but we should allow manual override either way.

See https://github.com/vllm-project/vllm/issues/32140

---

> [!NOTE]
> Sets `ParallelConfig.disable_nccl_for_dp_synchronization` to accept `None` and defers defaulting logic to `VllmConfig`.
> 
> - `disable_nccl_for_dp_synchronization` changed to `bool | None` in `ParallelConfig` and CLI args; doc clarifies default behavior
> - Defaulting moved to `vllm/config/vllm.py`: if `None`, auto-set to True when `async_scheduling` is enabled, otherwise False (preserves previous behavior but allows manual override)
> - Removes prior unconditional flip when async scheduling was enabled and adds explicit `None` check before setting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50aa934cecd12be2efb1166e94c6830437fcdf18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit fed08e31b7b3eb55e815b0a5a41ad7ebedc5166d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Enables explicit override of DP synchronization backend while keeping prior defaults.
> 
> - Change `ParallelConfig.disable_nccl_for_dp_synchronization` to `bool | None` with doc update and a validator to accept `None`
> - Move defaulting to `VllmConfig`: when the field is `None`, set to True if `async_scheduling` is enabled, else False; remove prior unconditional flip
> - Update CLI (`EngineArgs`) to accept and pass through `None` for this option
> - Minor refactor to `SchedulerConfig` validator (no functional change)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5ae39454c958e4ddcd4be3b505ef5a3fb666f98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Allows explicit control over DP synchronization backend while preserving prior defaults.
> 
> - Change `ParallelConfig.disable_nccl_for_dp_synchronization` to `bool | None` with a validator to allow `None`; docs clarify behavior
> - Move defaulting to `VllmConfig`: when the field is `None`, set to True if `scheduler_config.async_scheduling` is enabled, else False; remove prior unconditional flip
> - Update CLI (`EngineArgs`) to accept and propagate `None` for this option
> - Minor cleanup: simplify `SchedulerConfig` validator for `None` passthrough
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9a321b4f1f117ac24e6e22a24a523b1943bb29c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
