### PR TITLE
[BUGFIX] Add missed remaping of the names of fp8 kv-scale

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -64,6 +64,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.model_executor.model_loader.weight_utils import (
     default_weight_loader,
+    maybe_remap_kv_scale_name,
     sharded_weight_loader,
 )
 from vllm.model_executor.models.qwen2_moe import Qwen2MoeMLP as Qwen3NextMLP
@@ -1064,6 +1065,12 @@ class Qwen3NextModel(nn.Module):
 
             if name.startswith("mtp."):
                 continue
+
+            # Remapping the name of FP8 kv-scale.
+            if name.endswith("scale"):
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
 
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:


### PR DESCRIPTION
Qwen3-Next-NVFP4 checkpoint produced a lot of the following warnings

```
$ vllm serve nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4 -tp 2 
...
Parameter layers.3.self_attn.qkqkv_proj.k_scale not found in params_dict, skip loading
Parameter layers.3.self_attn.qkv_proj.v_scale not found in params_dict, skip loading
...
```

caused by missed call of `maybe_remap_kv_scale_name`. 

Fix it. 

---

> [!NOTE]
> Ensures FP8 KV-scale tensors from checkpoints are correctly mapped to model parameter names during load to prevent skip/missing warnings.
> 
> - Import `maybe_remap_kv_scale_name` from `weight_utils`
> - In `Qwen3NextModel.load_weights`, detect names ending with `scale`, remap via `maybe_remap_kv_scale_name`, and skip when unmapped
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9102638503424e9f8eb5ee646d3199ceebc466e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
