### PR TITLE
Initial structural_tag support for tool calling

### DIFF
--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -76,17 +76,8 @@ class ToolParser:
 
     def adjust_request(self, request: ChatCompletionRequest) -> ChatCompletionRequest:
         """
-        Adjust the request to add structured output constraints for tool calling.
-
-        This method sets up either:
-        1. Structural tags (preferred) - Constrains only the JSON arguments region
-           while allowing the model to use its native tool call format
-        2. Full JSON schema (fallback) - Constrains the entire output to JSON
-
-        Structural tags are preferred because they:
-        - Allow the model to generate native tool tokens (e.g., <tool_call>)
-        - Enable reasoning/thinking before tool calls
-        - Only constrain the arguments portion to the schema
+        Adjust the request to add structured output constraints for tool calling,
+        either using structural tags or full JSON schema.
         """
         if not request.tools:
             return request

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -75,17 +75,15 @@ class ToolParser:
 
     def adjust_request(self, request: ChatCompletionRequest) -> ChatCompletionRequest:
         """
-        Adjust the request to add structured output constraints for tool calling,
-        either using structural tags or full JSON schema.
+        Adjust the request to add structured output constraints for tool calling.
         """
         if not request.tools:
             return request
 
-        # Try structural tags first
-        if self.supports_structural_tag() and request.tool_choice in (
-            "auto",
-            "required",
-        ):
+        # Try structural tags first, only for "required" mode.
+        # TODO(mgoin): Add support for "auto" mode. It should work with structural tags
+        # but it seems there are side effects with the current implementation.
+        if request.tool_choice == "required" and self.supports_structural_tag():
             import json
 
             structural_tag_config = build_structural_tag_config(

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -80,21 +80,23 @@ class ToolParser:
         if not request.tools:
             return request
 
-        # Try structural tags first, only for "required" mode.
-        # TODO(mgoin): Add support for "auto" mode. It should work with structural tags
-        # but it seems there are side effects with the current implementation.
-        if request.tool_choice == "required" and self.supports_structural_tag():
+        # Try structural tags first
+        # TODO(mgoin): Add support for "auto" tool_choice. It should work with
+        # structural tags but it seems there are side effects.
+        if (
+            isinstance(request, ChatCompletionRequest)
+            and request.tool_choice == "required"
+            and self.supports_structural_tag()
+        ):
             import json
 
             structural_tag_config = build_structural_tag_config(
                 tools=request.tools,
                 get_structure_info=self.get_structure_info,
             )
-            if isinstance(request, ChatCompletionRequest):
-                request.structured_outputs = StructuredOutputsParams()
-                request.structured_outputs.structural_tag = json.dumps(
-                    structural_tag_config
-                )
+            request.structured_outputs = StructuredOutputsParams(
+                structural_tag=json.dumps(structural_tag_config)
+            )
             return request
 
         # Fallback to full JSON schema constraint

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -58,8 +58,7 @@ class ToolParser:
     def get_structure_info(self, tool_name: str) -> StructureInfo | None:
         """
         Return StructureInfo for constrained tool call generation.
-
-        Override this method in subclasses to enable structural tag support.
+        Override this method to enable structural tag support.
 
         Args:
             tool_name: Name of the tool to generate structure info for

--- a/vllm/tool_parsers/hermes_tool_parser.py
+++ b/vllm/tool_parsers/hermes_tool_parser.py
@@ -24,6 +24,7 @@ from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.tool_parsers.abstract_tool_parser import (
     ToolParser,
 )
+from vllm.tool_parsers.structural_tag_utils import StructureInfo
 
 logger = init_logger(__name__)
 
@@ -76,6 +77,13 @@ class Hermes2ProToolParser(ToolParser):
         ]
 
         self.buffered_delta_text = ""
+
+    def get_structure_info(self, tool_name: str) -> StructureInfo:
+        return StructureInfo(
+            trigger=self.tool_call_start_token,
+            begin=f'{self.tool_call_start_token}{{"name": "{tool_name}", "arguments": ',  # noqa: E501
+            end=f"}}{self.tool_call_end_token}",
+        )
 
     # Very simple idea: when encountering tokens like <, tool, _call, >,
     # <, /, tool, _call, >, store them in a buffer.

--- a/vllm/tool_parsers/structural_tag_utils.py
+++ b/vllm/tool_parsers/structural_tag_utils.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Structural Tag Utilities for Tool Calling
+
+This module provides utilities for generating structural tags that enable
+constrained generation of tool calls. Structural tags allow the model to:
+
+1. Generate native tool call tokens (e.g., <tool_call>) freely
+2. Apply JSON schema constraints ONLY within the arguments region
+3. Continue generating freely after the constrained region
+
+This is in contrast to full JSON schema constraints which force the entire
+output to follow a schema, preventing the model from using its native format.
+
+Example (tool_choice="required"):
+    Without structural tags:
+        [{"name": "get_weather", "parameters": {"city": "NYC"}}]
+        Issue: First token forced to '[', bypasses native format
+
+    With structural tags:
+        <tool_call>{"name": "get_weather", "arguments": {"city": "NYC"}}</tool_call>
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from vllm.entrypoints.openai.protocol import ChatCompletionToolsParam
+
+
+@dataclass(frozen=True)
+class StructureInfo:
+    """
+    Defines the structural boundaries for constrained tool call generation.
+
+    The structure works as follows:
+        [free text] [trigger] [begin] [CONSTRAINED JSON] [end] [free text]
+
+    Attributes:
+        trigger: Token sequence that activates constraint checking (e.g., "<tool_call>")
+        begin: Fixed prefix that includes everything up to the constrained region.
+               This can include special tokens AND the function name.
+        end: Fixed suffix after the constrained region.
+        schema_is_args_only: If True, the schema constrains only the arguments JSON.
+                             If False, the schema constrains the full tool object.
+
+    Example formats:
+
+        Name INSIDE JSON (Hermes, Qwen2.5):
+            begin='<tool_call>{"name": "get_weather", "arguments": '
+            end='}</tool_call>'
+            schema_is_args_only=True  # Schema is for {"city": "..."}, not full object
+
+        Name OUTSIDE JSON (DeepSeek, Kimi K2):
+            begin='<|tool▁call▁begin|>get_weather<|tool▁sep|>'
+            end='<|tool▁call▁end|>'
+            schema_is_args_only=True  # Arguments JSON directly follows begin
+
+    TODO(mgoin): Add support for Pythonic/XML-ish formats
+    (e.g., get_weather(city="NYC")) because they cannot use structural tags since
+    the content between begin/end is not JSON. In the future, we should add support
+    for arbitrary EBNF grammars.
+    """
+
+    trigger: str
+    begin: str
+    end: str
+    schema_is_args_only: bool = True  # Most formats only constrain the arguments
+
+
+def build_structural_tag_config(
+    tools: list[ChatCompletionToolsParam],
+    get_structure_info: Callable[[str], StructureInfo],
+) -> dict[str, Any]:
+    """
+    Build a structural tag configuration for constrained tool call generation.
+
+    Args:
+        tools: List of available tools with their schemas
+        get_structure_info: Function (tool_name) -> StructureInfo for each tool
+
+    Returns:
+        A structural tag configuration dict that can be serialized to JSON
+        and passed to the structured outputs backend.
+
+    Example output:
+        {
+            "type": "structural_tag",
+            "structures": [
+                {
+                    "begin": '<tool_call>{"name": "get_weather", "arguments": ',
+                    "schema": {"type": "object", "properties": {"city": {...}}},
+                    "end": "}</tool_call>"
+                }
+            ],
+            "triggers": ["<tool_call>"]
+        }
+    """
+    structures: list[dict[str, Any]] = []
+    triggers: set[str] = set()
+
+    for tool in tools:
+        name = tool.function.name
+        info = get_structure_info(name)
+
+        # Determine schema based on format
+        if info.schema_is_args_only:
+            # Most formats: function name is in begin pattern, only constrain arguments
+            schema = tool.function.parameters or {
+                "type": "object",
+                "properties": {},
+            }
+        else:
+            # Rare case: constrain the full tool object including name selection
+            schema = {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "enum": [name]},
+                    "arguments": tool.function.parameters
+                    or {
+                        "type": "object",
+                        "properties": {},
+                    },
+                },
+                "required": ["name", "arguments"],
+            }
+
+        structures.append(
+            {
+                "begin": info.begin,
+                "schema": schema,
+                "end": info.end,
+            }
+        )
+        triggers.add(info.trigger)
+
+    return {
+        "type": "structural_tag",
+        "structures": structures,
+        "triggers": list(triggers),
+    }


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

My initial start to attempt progress on https://github.com/vllm-project/vllm/issues/32142

Adds structural tag support for tool calling so that `tool_choice="required"` constrains only the JSON arguments region, not the entire output. This allows models to generate their native tool tokens (e.g., `<tool_call>`) and any reasoning before the constrained region. Implemented for Hermes parser as reference; other parsers can override `get_structure_info()`. Currently disabled for `tool_choice="auto"` due to test regressions - needs further investigation into xgrammar trigger behavior.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

