### PR TITLE
[MoE Recator] Remove CustomOp from UnquantizedFusedMoEMethod

### DIFF
--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -209,7 +209,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase):
                 use_prepack=True,
                 experts_start_id=ep_rank_start,
             )
-            # self.apply = self.apply_xpu
 
         elif current_platform.is_cpu():
             from vllm.model_executor.layers.fused_moe import cpu_fused_moe
@@ -242,8 +241,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase):
                     self.cpu_fused_moe = cpu_fused_moe.CPUFusedMOE(layer)
             else:
                 self.cpu_fused_moe = cpu_fused_moe.CPUFusedMOE(layer)
-
-            # self.apply = self.apply_cpu
 
         elif current_platform.is_cuda_alike():
             self.moe_quant_config = self.get_fused_moe_quant_config(layer)
@@ -285,8 +282,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase):
                     TritonExperts(self.moe_quant_config),
                     shared_experts=None,
                 )
-
-            # self.apply = self.apply_cuda
 
     def apply(
         self,

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Callable
 
 import torch
 import torch.nn.functional as F
@@ -236,7 +237,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase):
                     )
                     assert packed_w2_weight.size() == layer.w2_weight.size()
                     layer.w2_weight.copy_(packed_w2_weight)
-                    self.cpu_fused_moe = cpu_fused_moe.SGLFusedMOE(layer)
+                    self.cpu_fused_moe: Callable = cpu_fused_moe.SGLFusedMOE(layer)
                 else:
                     self.cpu_fused_moe = cpu_fused_moe.CPUFusedMOE(layer)
             else:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -115,7 +115,7 @@ class CompressedTensorsMoEMethod(FusedMoEMethodBase):
         quant_config: "CompressedTensorsConfig",  # type: ignore # noqa E501
         layer: torch.nn.Module,
         layer_name: str,
-    ) -> "CompressedTensorsMoEMethod":
+    ) -> FusedMoEMethodBase:
         # FusedMoE was made by combining multiple Linears so need to
         # make sure quantization config for Linear can target it
         quant_config._add_fused_moe_to_target_scheme_map()


### PR DESCRIPTION
## Purpose
Remove CustomOp from UnquantizedFusedMoEMethod to make MoE runner refactoring simpler.

## Test Plan
CI
MoE Refactor integration tests

## Test Result

cc @robertgshaw2-redhat , @mgoin , @ProExpertProg , @WoosukKwon 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---

> [!NOTE]
> Simplifies the MoE method by removing `CustomOp` and restructuring execution entry points.
> 
> - Removes `@CustomOp.register` and `CustomOp` base from `UnquantizedFusedMoEMethod`
> - Replaces `forward_*` with platform-specific `apply_*` (`apply_cuda`, `apply_cpu`, `apply_xpu`) and sets `apply` alias based on platform
> - Changes `supports_eplb` to return false on CPU/XPU (`True` only on CUDA-like)
> - Moves fused execution handles from the layer to the method: `layer.ipex_fusion` → `self.ipex_fusion`, `layer.cpu_fused_moe` → `self.cpu_fused_moe`
> - Updates call sites to use `self.{cpu_fused_moe, ipex_fusion}` and removes CPU/XPU `NotImplementedError` checks in per-platform apply paths
> - Keeps CUDA path using modular kernel (`FusedMoEModularKernel`) with AITer/FlashInfer/Triton as before
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0c4dfb1cedc7ab01eb5ff008a4d7a32daf59580. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Streamlines the unquantized MoE method by removing `CustomOp` and unifying execution under an `apply` API with per-platform implementations.
> 
> - Remove `CustomOp` import/inheritance/registration from `UnquantizedFusedMoEMethod`
> - Replace `forward_*` with `apply_*` (cuda/cpu/xpu) and assign `apply` at import time; base `apply` now raises if not initialized
> - Move fused backend handles from `layer.*` to `self.*` (`cpu_fused_moe`, `ipex_fusion`)
> - Update `supports_eplb` to return false on CPU/XPU
> - Preserve existing weight prep and backend selection (ROCm aiter, FlashInfer CUTLASS, Triton) with minor naming/return cleanups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0c4dfb1cedc7ab01eb5ff008a4d7a32daf59580. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Refactors the unquantized MoE method to remove the `CustomOp` framework and standardize execution entry points.
> 
> - Drops `@CustomOp.register` and `CustomOp` base; `UnquantizedFusedMoEMethod` now extends only `FusedMoEMethodBase`
> - Replaces `forward_*` with platform-specific `apply_*` (`apply_cuda`, `apply_cpu`, `apply_xpu`) and assigns `apply` per platform; default `apply` now errors if uninitialized
> - Moves fused execution objects from the layer to the method: `layer.ipex_fusion` → `self.ipex_fusion`, `layer.cpu_fused_moe` → `self.cpu_fused_moe`, and updates call sites
> - Updates `supports_eplb` to be disabled on CPU/XPU (enabled only on CUDA-like)
> - Keeps CUDA path using modular kernel (AITer/FlashInfer/Triton) with minor return cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0c4dfb1cedc7ab01eb5ff008a4d7a32daf59580. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Streamlines unquantized MoE execution by dropping `CustomOp` and consolidating per-platform entry points.
> 
> - Removes `@CustomOp.register` and `CustomOp` inheritance from `UnquantizedFusedMoEMethod`
> - Replaces `forward_*` with `apply_*` (`apply_cuda`, `apply_cpu`, `apply_xpu`) and sets `apply` alias based on platform; base `apply` now guards with an error if unset
> - Updates `supports_eplb` to return false on CPU/XPU (true only on CUDA-like)
> - Moves fused backend handles from layer to method: `layer.ipex_fusion` → `self.ipex_fusion`, `layer.cpu_fused_moe` → `self.cpu_fused_moe`; call sites updated
> - Keeps CUDA path using `FusedMoEModularKernel` (AITer/FlashInfer/Triton) with minor cleanup and weight prep retained
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0c4dfb1cedc7ab01eb5ff008a4d7a32daf59580. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Streamlines unquantized MoE execution and decouples from CustomOp.
> 
> - Remove `@CustomOp.register` and `CustomOp` inheritance from `UnquantizedFusedMoEMethod`
> - Replace `forward_*` with `apply_*` (`apply_cuda`, `apply_cpu`, `apply_xpu`) and set `apply` alias per platform; base `apply` now errors if unset
> - Move fused backend handles from layer to method (`layer.ipex_fusion` → `self.ipex_fusion`, `layer.cpu_fused_moe` → `self.cpu_fused_moe`)
> - Update `supports_eplb` to return false on CPU/XPU (enabled only on CUDA-like)
> - Preserve CUDA modular-kernel paths (AITer/FlashInfer/Triton) with minor cleanup
> - Narrow change in `compressed_tensors_moe.get_moe_method` return type to `FusedMoEMethodBase`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf3c2687c1fbdd1b0d282e11657913479e8bf7e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit d57668f79f42f422c9e8ff0ad38da194f30e4ff9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
