### PR TITLE
[Perf] Optimize requests abort

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -506,6 +506,8 @@ class AsyncLLM(EngineClient):
                         IterationStats() if (log_stats and num_outputs) else None
                     )
 
+                    reqs_to_abort: list[str] = []
+
                     # Split outputs into chunks of at most
                     # VLLM_V1_OUTPUT_PROC_CHUNK_SIZE, so that we don't block the
                     # event loop for too long.
@@ -519,15 +521,16 @@ class AsyncLLM(EngineClient):
                         )
                         # NOTE: RequestOutputs are pushed to their queues.
                         assert not processed_outputs.request_outputs
+                        if processed_outputs.reqs_to_abort:
+                            reqs_to_abort.extend(processed_outputs.reqs_to_abort)
 
                         # Allow other asyncio tasks to run between chunks
                         if end < num_outputs:
                             await asyncio.sleep(0)
 
-                        # 3) Abort any reqs that finished due to stop strings.
-                        await engine_core.abort_requests_async(
-                            processed_outputs.reqs_to_abort
-                        )
+                    # 3) Abort any reqs that finished due to stop strings.
+                    if reqs_to_abort:
+                        await engine_core.abort_requests_async(reqs_to_abort)
 
                     output_processor.update_scheduler_stats(outputs.scheduler_stats)
 

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -519,15 +519,16 @@ class AsyncLLM(EngineClient):
                         )
                         # NOTE: RequestOutputs are pushed to their queues.
                         assert not processed_outputs.request_outputs
+
+                        # Allow other asyncio tasks to run between chunks
+                        if end < num_outputs:
+                            await asyncio.sleep(0)
+
                         # 3) Abort any reqs that finished due to stop strings.
                         if processed_outputs.reqs_to_abort:
                             await engine_core.abort_requests_async(
                                 processed_outputs.reqs_to_abort
                             )
-
-                        # Allow other asyncio tasks to run between chunks
-                        if end < num_outputs:
-                            await asyncio.sleep(0)
 
                     output_processor.update_scheduler_stats(outputs.scheduler_stats)
 


### PR DESCRIPTION
## Purpose

Batch reqs_to_abort and do once at the end instead of calling each time, getting a little bit perf improvement

## Test

`export MODEL="zai-org/GLM-4.7-FP8"`
`vllm serve $MODEL -tp 8   --port 9256 --enable-expert-parallel --max_num_seqs 128`
`lm_eval --model local-completions --model_args "base_url=http://127.0.0.1:9256/v1/completions,model=$MODEL,num_concurrent=1024" --tasks gsm8k`

```bash
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.98|±  |0.0141|
|     |       |strict-match    |     5|exact_match|↑  | 0.97|±  |0.0171|
```

---

> [!NOTE]
> Batches request aborts in the `AsyncLLM` output handler to avoid per-chunk abort calls.
> 
> - Collects `reqs_to_abort` across processed output chunks and calls `engine_core.abort_requests_async` once after the loop
> - Removes per-chunk abort invocation; no other logic or interfaces changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 969979d4c24c4e49c03e2ad2e2d9f2cf99bffd22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Minimizes overhead in `AsyncLLM` output handling by avoiding no-op abort calls during chunked processing.
> 
> - In `async_llm.py`, within the output handler loop, call `engine_core.abort_requests_async` only when `processed_outputs.reqs_to_abort` is non-empty and place it before the inter-chunk `await asyncio.sleep(0)`
> - Remove the previous unconditional per-chunk abort invocation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be2bc7aa33534078628dedf570d83b022a9f5565. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Improves output handling performance in `AsyncLLM` by avoiding unnecessary abort calls during chunk processing.
> 
> - In `async_llm.py` output handler, call `engine_core.abort_requests_async` only when `processed_outputs.reqs_to_abort` is non-empty
> - No interface or control-flow changes beyond this conditionalization
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 207f8e0cc8015157f183793504994925a8188bd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Optimizes the `AsyncLLM` output handler by avoiding no-op abort calls during chunk processing.
> 
> - In `async_llm.py`, call `engine_core.abort_requests_async` only when `processed_outputs.reqs_to_abort` is non-empty within the per-chunk loop
> - No interface or control-flow changes beyond this conditionalization
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 207f8e0cc8015157f183793504994925a8188bd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
