### PR TITLE
feature: support eagle3 for HunyuanOCR & Qwen3VLMoe & Qwen2Audio

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -620,7 +620,7 @@ class SpeculativeConfig:
                 f"{self.disable_by_batch_size=}"
             )
 
-        eagle3_target_supported = ["llama", "qwen", "minicpm", "gpt_oss"]
+        eagle3_target_supported = ["llama", "qwen", "minicpm", "gpt_oss", "hunyuan_vl"]
         if (
             self.method == "eagle3"
             and self.target_model_config

--- a/vllm/model_executor/models/hunyuan_v1.py
+++ b/vllm/model_executor/models/hunyuan_v1.py
@@ -66,7 +66,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionType
 
-from .interfaces import MixtureOfExperts, SupportsLoRA, SupportsPP
+from .interfaces import MixtureOfExperts, SupportsEagle3, SupportsLoRA, SupportsPP
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
@@ -630,6 +630,7 @@ class HunYuanModel(nn.Module):
             self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         else:
             self.norm = PPMissingLayer()
+        self.aux_hidden_state_layers = tuple[int, ...]()
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
@@ -654,9 +655,13 @@ class HunYuanModel(nn.Module):
 
         cla_factor = _get_cla_factor(self.config)
         prev_kv_states = None
+        aux_hidden_states = []
         for i, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer)
         ):
+            if i in self.aux_hidden_state_layers:
+                aux_hidden_states.append(hidden_states + residual)
+
             hidden_states, residual, kv_states = layer(
                 positions,
                 hidden_states,
@@ -675,6 +680,9 @@ class HunYuanModel(nn.Module):
             )
 
         hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
         return hidden_states
 
     def _split_qkv_weight(self, qkv: torch.Tensor):
@@ -897,7 +905,7 @@ class HunYuanModel(nn.Module):
         return loaded_params
 
 
-class HunyuanV1ModelBase(nn.Module, SupportsLoRA, SupportsPP):
+class HunyuanV1ModelBase(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle3):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",

--- a/vllm/model_executor/models/hunyuan_vision.py
+++ b/vllm/model_executor/models/hunyuan_vision.py
@@ -84,6 +84,7 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from .interfaces import (
     MultiModalEmbeddings,
+    SupportsEagle3,
     SupportsLoRA,
     SupportsMultiModal,
     SupportsPP,
@@ -792,6 +793,7 @@ class HunYuanVLForConditionalGeneration(
     SupportsPP,
     SupportsQuant,
     SupportsXDRoPE,
+    SupportsEagle3,
 ):
     # To ensure correct weight loading and mapping.
     hf_to_vllm_mapper = WeightsMapper(
@@ -1009,6 +1011,13 @@ class HunYuanVLForConditionalGeneration(
             inputs_embeds=inputs_embeds,
         )
         return hidden_states
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        self.language_model.model.aux_hidden_state_layers = layers
+
+    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        num_layers = len(self.language_model.model.layers)
+        return (2, num_layers // 2, num_layers - 3)
 
     def compute_logits(
         self,

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -310,6 +310,11 @@ class EagleProposer:
             num_tokens_across_dp[self.dp_rank] = num_input_tokens
 
         # copy inputs to buffer for cudagraph
+        if self.uses_mrope:
+            target_positions = target_positions[:3]
+        elif target_positions.ndim > 1:
+            target_positions = target_positions[0]
+
         self._set_positions(num_tokens, target_positions)
         self.hidden_states[:num_tokens] = target_hidden_states
 
@@ -1040,8 +1045,16 @@ class EagleProposer:
             if self.get_model_name(target_model) in [
                 "Qwen2_5_VLForConditionalGeneration",
                 "Qwen3VLForConditionalGeneration",
+                "Qwen3VLMoeForConditionalGeneration",
+                "HunYuanVLForConditionalGeneration",
             ]:
                 self.model.config.image_token_index = target_model.config.image_token_id
+            elif self.get_model_name(target_model) in [
+                "Qwen2AudioForConditionalGeneration",
+            ]:
+                self.model.config.image_token_index = (
+                    target_model.config.audio_token_index
+                )
             elif self.get_model_name(target_model) == "PixtralForConditionalGeneration":
                 self.model.config.image_token_index = (
                     target_model.config.vision_config.image_token_id


### PR DESCRIPTION
## Purpose

Eagle3 models: https://huggingface.co/collections/AngelSlim/eagle3

## Test Plan

## Test Result

[AngelSlim Speculative-Decoding](https://github.com/Tencent/AngelSlim?tab=readme-ov-file#1-speculative-decoding)

### Qwen3-VL Series Models


| Model                         | Method  | **GSM8K**                 |                   | **Alpaca**                |                   | **HumanEval**             |                   | **MT-bench**              |                   | **MATH-500**              |                   | **MMMU**                  |                   | **MMStar**                |                   | **Mean**                  |                   |
|-------------------------------|---------|---------------------------|-------------------|---------------------------|-------------------|---------------------------|-------------------|---------------------------|-------------------|---------------------------|-------------------|---------------------------|-------------------|---------------------------|-------------------|---------------------------|-------------------|
|                               |         | **throughput (tokens/s)** | **accept length** | **throughput (tokens/s)** | **accept length** | **throughput (tokens/s)** | **accept length** | **throughput (tokens/s)** | **accept length** | **throughput (tokens/s)** | **accept length** | **throughput (tokens/s)** | **accept length** | **throughput (tokens/s)** | **accept length** | **throughput (tokens/s)** | **accept length** |
| **Qwen3-VL-2B-Instruct**      | Vanilla |                    348.55 |                 1 |                     350.9 |                 1 |                    346.07 |                 1 |                    346.31 |                 1 |                     82.96 |                 1 |                     83.27 |                 1 |                     81.63 |                 1 |                    234.24 |                 1 |
|                               | Eagle3  |                    511.52 |              2.11 |                    560.55 |              2.26 |                    826.01 |              3.39 |                    555.22 |              2.29 |                    163.09 |              2.57 |                    154.18 |              2.55 |                    139.73 |              2.31 |                    415.76 |               2.5 |
| **Qwen3-VL-4B-Instruct**      | Vanilla |                    212.87 |                 1 |                    213.24 |                 1 |                    211.69 |                 1 |                     212.1 |                 1 |                     67.96 |                 1 |                     65.88 |                 1 |                     67.75 |                 1 |                    150.21 |                 1 |
|                               | Eagle3  |                    415.29 |              2.57 |                    372.89 |              2.26 |                    459.37 |              2.82 |                    382.33 |              2.34 |                    141.87 |              2.72 |                    104.44 |              2.05 |                    107.07 |               2.1 |                    283.32 |              2.41 |
| **Qwen3-VL-30B-A3B-Instruct** | Vanilla |                    179.94 |                 1 |                     184.6 |                 1 |                    168.68 |                 1 |                    180.57 |                 1 |                     31.08 |                 1 |                     31.51 |                 1 |                     30.93 |                 1 |                    115.33 |                 1 |
|                               | Eagle3  |                    281.93 |              2.82 |                    241.42 |              2.13 |                    223.05 |              2.57 |                    240.47 |              2.19 |                     75.31 |              2.79 |                     48.47 |              1.78 |                     52.57 |              1.94 |                    166.17 |              2.32 |

### HunyuanOCR Model

| Model       | Method  | OmniDocBench          |               |
|-------------|---------|-----------------------|---------------|
|             |         | **throughput (tokens/s)** | **accept length** |
| **Hunyuan-OCR** | Vanilla |                 70.12 |             1 |
|             | Eagle3  |                 108.1 |          2.08 |

### Qwen2-Audio Model

| Model           | Method  | LibriSpeech               |                   |
|-----------------|---------|---------------------------|-------------------|
|                 |         | **throughput (tokens/s)** | **accept length** |
| **Qwen2-Audio** | Vanilla |                     78.76 |                 1 |
|                 | Eagle3  |                    146.66 |              3.51 |

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 7a76acd07b65a5460511a765d7dddaf6552f6a62. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Enables EAGLE3 speculation for key multimodal models and wires required auxiliary hidden-state outputs.
> 
> - Add `SupportsEagle3` and aux hidden-state support to `HunYuan*`, `Qwen3VLMoe*`, and `Qwen2Audio*` models; introduce `aux_hidden_state_layers`, return `(hidden_states, aux_hidden_states)` when requested, and expose `set_aux_hidden_state_layers`/`get_eagle3_aux_hidden_state_layers`
> - Extend EAGLE3 target support to `hunyuan_vl` in `SpeculativeConfig`
> - Update EAGLE proposer to handle M-RoPE position shapes, and set multimodal token indices for `Qwen3VLMoeForConditionalGeneration`, `HunYuanVLForConditionalGeneration`, and `Qwen2AudioForConditionalGeneration` (uses audio token index)
> - Minor: integrate aux HS collection into layer loops in Hunyuan and Qwen3-VL-MoE LLM forward paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a76acd07b65a5460511a765d7dddaf6552f6a62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
