### PR TITLE
[ROCm][CI] Fix HuggingFace flash_attention_2 accuracy issue in Isaac vision encoder

### DIFF
--- a/tests/models/multimodal/generation/vlm_utils/model_utils.py
+++ b/tests/models/multimodal/generation/vlm_utils/model_utils.py
@@ -576,6 +576,14 @@ def isaac_patch_hf_runner(hf_model: HfRunner) -> HfRunner:
     # ----------------------------
     isaac_model = hf_model.model.model
 
+    # [ROCm] Disable Flash/MemEfficient SDP on ROCm to avoid HF Transformers
+    # accuracy issues: https://github.com/vllm-project/vllm/issues/30167
+    # TODO: Remove once ROCm SDP accuracy issues are resolved on HuggingFace
+    # ----------------------------
+    from ...conftest import patch_hf_vision_attn_for_rocm
+
+    patch_hf_vision_attn_for_rocm(hf_model.model)
+
     def patched_forward(
         self,
         input_ids=None,


### PR DESCRIPTION
Fixes Isaac model test failures on ROCm by forcing SDPA (Scaled Dot-Product Attention) for the vision encoder. HuggingFace's `flash_attention_2` implementation produces incorrect results on ROCm, causing vision embeddings to diverge significantly from CUDA.

## Problem

Isaac model tests were failing on ROCm with completely different outputs compared to CUDA:

| Platform | Output |
|----------|--------|
| CUDA | "This image captures a vibrant street scene in what appears to be a Chinatown district" |
| ROCm | "The image depicts a scene with a central figure, a man, who is dressed" |

## Root Cause

Through systematic tensor comparison between ROCm and CUDA, the divergence was traced to the vision encoder's attention layers:

| Stage | ROCm | CUDA | Match |
|-------|------|------|-------|
| Image input | -958529.0 | -958529.0 | YES |
| Patch embedding | -16596.3 | -16596.3 | YES |
| Q projection | -250937.7 | -250937.1 | YES |
| K projection | -137268.9 | -137268.7 | YES |
| V projection | 2085.7 | 2085.7 | YES |
| **self_attn output** | **-10642.1** | **-9478.6** | NO |
| Final embeddings | -2272.1 | 5632.5 | NO |

The bug is in HuggingFace's `flash_attention_2` implementation which bypasses `torch.backends.cuda` settings and directly calls the flash_attn library.

## Solution

1. Added `patch_hf_vision_attn_for_rocm()` utility in `tests/models/multimodal/generation/conftest.py`
2. This forces `_attn_implementation = "sdpa"` for vision encoder layers on ROCm
3. SDPA then uses `math_sdp` backend (already configured in conftest)

<details>

<summary>Verification: SDPA produces identical results</summary>

**With flash_attention_2 (broken on ROCm):**
```
ROCm  inputs_embeds: sum=-2272.1099, mean=-0.000956
CUDA  inputs_embeds: sum=5632.5000, mean=0.002371
```

**With SDPA (fixed):**
```
ROCm  inputs_embeds: sum=5632.5361, mean=0.002371
CUDA  inputs_embeds: sum=5632.5068, mean=0.002371
```

Both platforms now produce identical tokens:
```
[151667, 271, 151668, 271, 1986, 2168, 40155, 264, 32976, 8592, ...]
```
</details>

## Related Issues

- Related to: https://github.com/vllm-project/vllm/issues/30167 (ROCm SDP accuracy issues)

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 74afc4e7b3583d0d56ff5be812cb5707bbdc2a0d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

---

> [!NOTE]
> Addresses ROCm-specific accuracy issues in HF vision attention.
> 
> - Adds `patch_hf_vision_attn_for_rocm()` in `tests/models/multimodal/conftest.py` to force HF vision encoder layers’ `_attn_implementation` to `"sdpa"` on ROCm
> - Invokes this patch in `isaac_patch_hf_runner()` (`model_utils.py`) so Isaac HF runs use SDPA (and thus `math_sdp` per existing backend settings), aligning ROCm results with CUDA
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74afc4e7b3583d0d56ff5be812cb5707bbdc2a0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
