### PR TITLE
[Refactor] Remove `get_encoder_dummy_data`

### DIFF
--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -605,6 +605,10 @@ class NemotronParseProcessingInfo(BaseProcessingInfo):
             **kwargs,
         )
 
+    @property
+    def skip_prompt_length_check(self) -> bool:
+        return True  # Because the encoder prompt is padded
+
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
         return {"image": 1}
 
@@ -622,10 +626,6 @@ class NemotronParseProcessingInfo(BaseProcessingInfo):
     ) -> Mapping[str, int] | None:
         image_tokens = self.get_num_image_tokens()
         return {"image": image_tokens}
-
-    @property
-    def skip_prompt_length_check(self) -> bool:
-        return True  # Because the encoder prompt is padded
 
 
 class NemotronParseDummyInputsBuilder(

--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -623,6 +623,10 @@ class NemotronParseProcessingInfo(BaseProcessingInfo):
         image_tokens = self.get_num_image_tokens()
         return {"image": image_tokens}
 
+    @property
+    def skip_prompt_length_check(self) -> bool:
+        return True  # Because the encoder prompt is padded
+
 
 class NemotronParseDummyInputsBuilder(
     BaseDummyInputsBuilder[NemotronParseProcessingInfo]
@@ -656,10 +660,6 @@ class NemotronParseMultiModalProcessor(
         mm_data: MultiModalDataDict,
     ) -> str | list[int]:
         return [0]
-
-    @property
-    def pad_dummy_encoder_prompt(self) -> bool:
-        return True
 
     def _call_hf_processor(
         self,

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -681,6 +681,10 @@ class WhisperProcessingInfo(BaseProcessingInfo):
     def get_hf_config(self) -> WhisperConfig:
         return self.ctx.get_hf_config(WhisperConfig)
 
+    @property
+    def skip_prompt_length_check(self) -> bool:
+        return True  # Because the encoder prompt is padded
+
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
         return {"audio": 1}
 
@@ -696,10 +700,6 @@ class WhisperProcessingInfo(BaseProcessingInfo):
 
     def get_num_audio_tokens(self) -> int:
         return self.get_hf_config().max_source_positions
-
-    @property
-    def skip_prompt_length_check(self) -> bool:
-        return True  # Because the encoder prompt is padded
 
 
 class WhisperDummyInputsBuilder(BaseDummyInputsBuilder[WhisperProcessingInfo]):

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -697,6 +697,10 @@ class WhisperProcessingInfo(BaseProcessingInfo):
     def get_num_audio_tokens(self) -> int:
         return self.get_hf_config().max_source_positions
 
+    @property
+    def skip_prompt_length_check(self) -> bool:
+        return True  # Because the encoder prompt is padded
+
 
 class WhisperDummyInputsBuilder(BaseDummyInputsBuilder[WhisperProcessingInfo]):
     def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
@@ -732,10 +736,6 @@ class WhisperMultiModalProcessor(EncDecMultiModalProcessor[WhisperProcessingInfo
             target_sr=feature_extractor.sampling_rate,
             target_channels=self.info.get_target_channels(),
         )
-
-    @property
-    def pad_dummy_encoder_prompt(self) -> bool:
-        return True
 
     def create_encoder_prompt(
         self,

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -1525,10 +1525,6 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
     def allowed_mm_limits(self):
         return self._allowed_mm_limits
 
-    @property
-    def skip_prompt_length_check(self) -> bool:
-        return False
-
     def __call__(
         self,
         prompt: str,

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -1396,6 +1396,10 @@ class BaseProcessingInfo:
         """
         return self.ctx.get_hf_processor(**kwargs)
 
+    @property
+    def skip_prompt_length_check(self) -> bool:
+        return False
+
     @abstractmethod
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
         """
@@ -1520,6 +1524,10 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
     @property
     def allowed_mm_limits(self):
         return self._allowed_mm_limits
+
+    @property
+    def skip_prompt_length_check(self) -> bool:
+        return False
 
     def __call__(
         self,
@@ -2402,10 +2410,6 @@ class EncDecMultiModalProcessor(BaseMultiModalProcessor[_I]):
         this prompt during profiling and generation.
         """
         raise NotImplementedError
-
-    @property
-    def pad_dummy_encoder_prompt(self) -> bool:
-        return False
 
     def create_decoder_prompt(
         self,

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -18,7 +18,6 @@ from .processing import (
 from .profiling import (
     BaseDummyInputsBuilder,
     DummyDecoderData,
-    DummyEncoderData,
     MultiModalProfiler,
 )
 
@@ -313,43 +312,6 @@ class MultiModalRegistry:
             raise AssertionError(
                 f"Expected at least {seq_len} dummy tokens for profiling, "
                 f"but found {len(token_ids)} tokens instead."
-            )
-
-        return dummy_data
-
-    def get_encoder_dummy_data(
-        self,
-        model_config: "ModelConfig",
-        seq_len: int,
-        mm_counts: Mapping[str, int] | None = None,
-        *,
-        cache: BaseMultiModalProcessorCache | None = None,
-        observability_config: ObservabilityConfig | None = None,
-    ) -> DummyEncoderData:
-        """
-        Create dummy data for profiling the memory usage of a model.
-
-        The model is identified by `model_config`.
-        """
-        processor = self.create_processor(
-            model_config, observability_config, cache=cache
-        )
-        profiler: MultiModalProfiler = MultiModalProfiler(processor)
-
-        # Extract configurable options from multimodal config.
-        # Only include modalities that use advanced option types so legacy
-        # count-only behavior remains unchanged.
-        mm_options = self._extract_mm_options(model_config)
-
-        dummy_data = profiler.get_encoder_dummy_data(seq_len, mm_counts, mm_options)
-
-        # Having more tokens is over-conservative but otherwise fine
-        token_ids = dummy_data.prompt_token_ids
-        if len(token_ids) < seq_len:
-            logger.warning_once(
-                "Expected at least %d dummy encoder tokens for profiling, but found %d tokens instead.",  # noqa: E501
-                seq_len,
-                len(token_ids),
             )
 
         return dummy_data


### PR DESCRIPTION
## Purpose

`get_encoder_dummy_data` is not used in V1 so we can remove it.

This lets us move `EncDecMultiModalProcessor.pad_dummy_encoder_prompt -> ProcessingInfo.skip_prompt_length_check`
to avoid creating the whole processor for this check.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

