### PR TITLE
fix(rocm): Enable non-gated MoE (is_act_and_mul=False) support on ROCm

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -448,9 +448,13 @@ class FusedMoE(CustomOp):
         )
 
         # ROCm aiter shared experts fusion
-        self.rocm_aiter_fmoe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
+        # AITER only supports gated activations (silu/gelu), so disable it
+        # for non-gated MoE (is_act_and_mul=False)
+        self.rocm_aiter_fmoe_enabled = (
+            rocm_aiter_ops.is_fused_moe_enabled() and is_act_and_mul
+        )
         self.aiter_fmoe_shared_expert_enabled = (
-            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled() and is_act_and_mul
         )
 
         self.num_fused_shared_experts = (
@@ -619,9 +623,9 @@ class FusedMoE(CustomOp):
         # for heuristic purposes, so it must be initialized first.
         self.quant_method: FusedMoEMethodBase = _get_quant_method()
 
-        if not self.moe_config.is_act_and_mul and not current_platform.is_cuda():
+        if not self.moe_config.is_act_and_mul and not current_platform.is_cuda_alike():
             raise NotImplementedError(
-                "is_act_and_mul=False is supported only for CUDA for now"
+                "is_act_and_mul=False is supported only for CUDA and ROCm for now"
             )
 
         if self.enable_eplb and not self.quant_method.supports_eplb:


### PR DESCRIPTION
## Purpose
Models like NemotronH use non-gated MoE with activations like relu2_no_mul. Previously, this was blocked on ROCm because the platform check only allowed CUDA.

- Updates platform check from is_cuda() to is_cuda_alike() to allow ROCm
- Disables AITER kernel for non-gated MoE since AITER only supports gated activations (silu/gelu)
- Falls back to Triton implementation which properly handles non-gated activations via apply_moe_activation()

## Test Plan
Tested on AMD MI210 GPU with NemotronH model.

## Test Result
Model loads and serves successfully.