### PR TITLE
[Bugfix] interleaved multimodal feature concatenation

### DIFF
--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -203,9 +203,7 @@ class PlaceholderRange:
 
         return embeds_start_idx, embeds_end_idx
 
-    def extract_embeds_range(
-        self, start_idx: int | None = None, end_idx: int | None = None
-    ) -> list[tuple[int, int]]:
+    def extract_embeds_range(self) -> list[tuple[int, int]]:
         """Extract the start and end indices of the embedded region in prompt.
 
         For example, given `PlaceholderRange(offset=2, length=5)` and
@@ -219,10 +217,8 @@ class PlaceholderRange:
         """
         if self.is_embed is None:
             return [(self.offset, self.offset + self.length - 1)]
-        if start_idx is not None and end_idx is not None:
-            mask_i = self.is_embed[start_idx:end_idx].int()
-        else:
-            mask_i = self.is_embed.int()
+
+        mask_i = self.is_embed.int()
         starts = torch.nonzero(
             torch.diff(mask_i, prepend=mask_i.new_zeros(1)) == 1
         ).flatten()

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -203,7 +203,9 @@ class PlaceholderRange:
 
         return embeds_start_idx, embeds_end_idx
 
-    def extract_embeds_range(self) -> list[tuple[int, int]]:
+    def extract_embeds_range(
+        self, start_idx: int | None = None, end_idx: int | None = None
+    ) -> list[tuple[int, int]]:
         """Extract the start and end indices of the embedded region in prompt.
 
         For example, given `PlaceholderRange(offset=2, length=5)` and
@@ -217,8 +219,10 @@ class PlaceholderRange:
         """
         if self.is_embed is None:
             return [(self.offset, self.offset + self.length - 1)]
-
-        mask_i = self.is_embed.int()
+        if start_idx is not None and end_idx is not None:
+            mask_i = self.is_embed[start_idx:end_idx].int()
+        else:
+            mask_i = self.is_embed.int()
         starts = torch.nonzero(
             torch.diff(mask_i, prepend=mask_i.new_zeros(1)) == 1
         ).flatten()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2429,7 +2429,8 @@ class GPUModelRunner(
                         list(torch.split(mm_embeds_item, split_size_or_sections, dim=0))
                     )
                 else:
-                    mm_embeds_req.append([mm_embeds_item, (start_idx, end_idx)])
+                    mm_embeds_ranges.append((start_idx, end_idx))
+                    mm_embeds_req.append([mm_embeds_item])
 
             mm_embeds_req = [
                 x


### PR DESCRIPTION
## Purpose
Corrects an issue where interleaved multimodal features were misordered during concatenation. 
One example scenario is inference with Omni models (e.g., Qwen3-Omni-30B-A3B-Instruct) 
when `use_audio_in_video` is enabled, producing sequences like video-audio-video-audio. 
This fix ensures proper ordering and alignment of cross-modal features.
## Test Plan
The video data is from Video-MME datasets
```python
from vllm import LLM, SamplingParams
from transformers import Qwen3OmniMoeProcessor
from qwen_omni_utils import process_mm_info

MODEL_PATH="/mnt/models/Qwen3-Omni-30B-A3B-Instruct"
use_audio_in_video=True
llm = LLM(
        model=MODEL_PATH,
        max_num_seqs=8,
        limit_mm_per_prompt={"image": 3, "video": 3, "audio": 3},
        tensor_parallel_size=1,
        enable_expert_parallel=True,
        seed=0,
        gpu_memory_utilization=0.9,
        trust_remote_code=True
)
processor = Qwen3OmniMoeProcessor.from_pretrained(MODEL_PATH)
messages=[
    {
        'role': 'user', 
        'content': [
            {'type': 'video', 'video': 'https://www.youtube.com/watch?v=0ay2Qy3wBe8', 'nframes': 8},
            {'type': 'text', 'text': '\nThese are the frames of a video. Select the best answer to the following multiple-choice question based on the video. Respond with only the letter (A, B, C, or D) of the correct option.\n'}, 
            {'type': 'text', 'text': 'Question: How is the smoke generated by the man depicted in the video?\nA. By burning a piece of cloth.\nB. By lighting a torch.\nC. By smoking.\nD. By lighting a bonefire.\nAnswer: '}
        ]
    }
]

text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
audios, image_inputs, video_inputs = process_mm_info(messages, use_audio_in_video=use_audio_in_video)

sampling_params = SamplingParams(
            temperature=0.6,
            max_tokens=1024,
            top_p=0.95,
            top_k=20
        )

mm_data = {}
if image_inputs is not None:
    mm_data['image'] = image_inputs
if video_inputs is not None:
    mm_data['video'] = video_inputs
if 'audios' in locals() and audios is not None:
    mm_data['audio'] = audios

req = {'prompt': text}
if mm_data:
    req['multi_modal_data'] = mm_data
req['mm_processor_kwargs'] = {"use_audio_in_video": use_audio_in_video}

outputs = llm.generate([req], sampling_params=sampling_params)
for o in outputs:
    generated_text = o.outputs[0].text
    print(f"response: {generated_text}")
```

## Test Result


Main:
```
response:  
And the eval result of Video-MME is 39.9
```
This PR:
```
response:  D
And the eval result of Video-MME is 691
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

