### PR TITLE
Fix Attention when query dim=4 [batch_size, num_tokens, heads, head_dim]

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -359,9 +359,13 @@ class Attention(nn.Module, AttentionLayerBase):
             if output_shape is None:
                 # Handle both 2D [num_tokens, hidden] and
                 # 3D [num_tokens, heads, head_dim] query
-                num_tokens = query.shape[0]
+                # and 4D [batch_size, num_tokens, heads, head_dim] query
+                if query.dim() == 4:
+                    prefix = query.shape[:2]
+                else:
+                    prefix = query.shape[:1]
                 output_shape = torch.Size(
-                    (num_tokens, self.num_heads * self.head_size_v)
+                    (*prefix, self.num_heads * self.head_size_v)
                 )
             output_shape = output_shape if output_shape is not None else query.shape
             output = torch.empty(output_shape, dtype=output_dtype, device=query.device)


### PR DESCRIPTION
Summary:
The breakage was introduced in D89937241(#28775) and D90045073(#31596). We will see reshaping errors with the return values of the attention layer.

When the query shape is 4D, [batch_size, num_tokens, num_heads, head_dim], the output shape will be composed as [batch_size, num_heads * head_dim] however the correct shape should be [batch_size, num_tokens, num_heads * head_dim] instead.

Test Plan: Patched this diff and tested vllm local services, it worked with no issue.

Differential Revision: D90600898


