### PR TITLE
[ROCm][CI] Disable Async Scheduling For Qwen3-Next-80B-A3B-Instruct MTP Async EPLB Accuracy Test

### DIFF
--- a/.buildkite/scripts/scheduled_integration_test/qwen3_next_mtp_async_eplb.sh
+++ b/.buildkite/scripts/scheduled_integration_test/qwen3_next_mtp_async_eplb.sh
@@ -18,15 +18,18 @@ wait_for_server() {
 
 MODEL="Qwen/Qwen3-Next-80B-A3B-Instruct"
 
-# Set BACKENDS based on platform
+# Set BACKENDS and platform-specific args based on platform
 if command -v rocm-smi &> /dev/null || [[ -d /opt/rocm ]] || [[ -n "${ROCM_PATH:-}" ]]; then
   # ROCm platform
   BACKENDS=("allgather_reducescatter")
   # Disable MOE padding for ROCm since it is causing eplb to fail
   export VLLM_ROCM_MOE_PADDING=0
+  PLATFORM_ARGS=("--no-async-scheduling")
+  echo "Disabled async scheduling for ROCm platform due to issues with spec decode."
 else
   # Non-ROCm platform (CUDA/other)
   BACKENDS=("deepep_high_throughput" "deepep_low_latency")
+  PLATFORM_ARGS=()
 fi
 
 cleanup() {
@@ -53,8 +56,8 @@ for BACK in "${BACKENDS[@]}"; do
     --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":1}' \
     --trust-remote-code \
     --max-model-len 2048 \
-    --no-async-scheduling \
     --gpu-memory-utilization 0.9 \
+    "${PLATFORM_ARGS[@]}" \
     --port $PORT &
   SERVER_PID=$!
   wait_for_server $PORT

--- a/.buildkite/scripts/scheduled_integration_test/qwen3_next_mtp_async_eplb.sh
+++ b/.buildkite/scripts/scheduled_integration_test/qwen3_next_mtp_async_eplb.sh
@@ -53,8 +53,9 @@ for BACK in "${BACKENDS[@]}"; do
     --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":1}' \
     --trust-remote-code \
     --max-model-len 2048 \
+    --no-async-scheduling \
     --gpu-memory-utilization 0.9 \
-    --port $PORT &
+    --port $PORT & \
   SERVER_PID=$!
   wait_for_server $PORT
 

--- a/.buildkite/scripts/scheduled_integration_test/qwen3_next_mtp_async_eplb.sh
+++ b/.buildkite/scripts/scheduled_integration_test/qwen3_next_mtp_async_eplb.sh
@@ -55,7 +55,7 @@ for BACK in "${BACKENDS[@]}"; do
     --max-model-len 2048 \
     --no-async-scheduling \
     --gpu-memory-utilization 0.9 \
-    --port $PORT & \
+    --port $PORT &
   SERVER_PID=$!
   wait_for_server $PORT
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
https://github.com/vllm-project/vllm/pull/31998 enabled async scheduling by default with spec decoding. This exposed a bug on for the Qwen3-Next-80B-A3B-Instruct MTP Async EPLB Accuracy test, which currently only runs on AMD CI. The test hangs https://buildkite.com/vllm/amd-ci/builds/2766/summary?sid=019bb772-7097-4d58-a3c6-a282068589ed

The test hangs on after evaluating 140 prompts.
```
Evaluating:  11%|█         | 140/1319 [01:10<01:02, 18.73it/s](EngineCore_DP0 pid=606) INFO 01-13 13:52:55 [shm_broadcast.py:542] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
```
Here we disable async scheduling again to unblock CI while we investigate the issue. This should only impact AMD CI.