### PR TITLE
[ROCm][CI] Handle missing vision_config in Isaac model attention patch

### DIFF
--- a/tests/models/multimodal/generation/vlm_utils/model_utils.py
+++ b/tests/models/multimodal/generation/vlm_utils/model_utils.py
@@ -5,7 +5,9 @@ for manipulating the input / output of HF & vLLM test runners, which are
 typically specific to a small subset of models.
 """
 
+import logging
 import types
+import warnings
 from pathlib import PosixPath
 
 import numpy as np
@@ -30,6 +32,8 @@ from vllm.utils.collection_utils import is_list_of
 
 from .....conftest import HfRunner, ImageAsset, ImageTestAssets
 from .types import RunnerOutput
+
+logger = logging.getLogger(__name__)
 
 
 ####### vLLM output processors functions
@@ -580,19 +584,27 @@ def isaac_patch_hf_runner(hf_model: HfRunner) -> HfRunner:
     # accuracy issues: https://github.com/vllm-project/vllm/issues/30167
     # TODO: Remove once ROCm SDP accuracy issues are resolved on HuggingFace
     # ----------------------------
-    import warnings
-
     from ...conftest import patch_hf_vision_attn_for_rocm
 
     try:
         patch_hf_vision_attn_for_rocm(hf_model.model)
     except AttributeError as e:
-        warnings.warn(
-            f"Skipping ROCm vision attention patch for Isaac model: {e}. "
-            "This may be expected for models without vision_config in "
-            "attention layers.",
-            stacklevel=2,
-        )
+        if "vision_config" in str(e):
+            warnings.warn(
+                f"Skipping ROCm vision attention patch for Isaac model: {e}. "
+                "This is expected for models without vision_config in "
+                "attention layers (e.g., Siglip2VariableLengthAttention).",
+                stacklevel=2,
+            )
+        else:
+            logger.error(
+                "Unexpected AttributeError during ROCm vision attention patch: %s. "
+                "Model type: %s. Inner model type: %s.",
+                e,
+                type(hf_model.model).__name__,
+                type(getattr(hf_model.model, "model", None)).__name__,
+            )
+            raise
 
     def patched_forward(
         self,

--- a/tests/models/multimodal/generation/vlm_utils/model_utils.py
+++ b/tests/models/multimodal/generation/vlm_utils/model_utils.py
@@ -580,9 +580,19 @@ def isaac_patch_hf_runner(hf_model: HfRunner) -> HfRunner:
     # accuracy issues: https://github.com/vllm-project/vllm/issues/30167
     # TODO: Remove once ROCm SDP accuracy issues are resolved on HuggingFace
     # ----------------------------
+    import warnings
+
     from ...conftest import patch_hf_vision_attn_for_rocm
 
-    patch_hf_vision_attn_for_rocm(hf_model.model)
+    try:
+        patch_hf_vision_attn_for_rocm(hf_model.model)
+    except AttributeError as e:
+        warnings.warn(
+            f"Skipping ROCm vision attention patch for Isaac model: {e}. "
+            "This may be expected for models without vision_config in "
+            "attention layers.",
+            stacklevel=2,
+        )
 
     def patched_forward(
         self,


### PR DESCRIPTION
Follow-up to #32233. Adds error handling to `isaac_patch_hf_runner` for models that don't have the expected `vision_config` attribute in their attention layers.

## Problem

Isaac-0.1 (`PerceptronAI/Isaac-0.1`) uses `Siglip2VariableLengthAttention` which doesn't have a `vision_config` attribute, causing test failures:
```
AttributeError: 'Siglip2VariableLengthAttention' object has no attribute 'vision_config'
```

The newer Isaac-0.2-2B-Preview has this attribute, but Isaac-0.1 does not.

## Solution

Wrap the `patch_hf_vision_attn_for_rocm` call in a try-except block that:
- Catches `AttributeError` when `vision_config` is missing
- Logs a warning instead of failing silently
- Allows the test to proceed (the patch may not be needed for all model variants)

This follows the "fail informatively, not silently" principle discussed in #32233, while still allowing tests to run for models with different attention implementations.

## Related

I have also posted an issue on ISAAC repo, so that their code becomes more transformers API compliant and such "hacks" are not necessary: https://github.com/perceptron-ai-inc/perceptron/issues/43