### PR TITLE
[Build] Relax anthropic version pin from ==0.71.0 to >=0.71.0

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -48,7 +48,7 @@ cbor2 # Required for cross-language serialization of hashable objects
 ijson # Required for mistral streaming tool parser
 setproctitle # Used to set process names for better debugging and monitoring
 openai-harmony >= 0.0.3  # Required for gpt-oss
-anthropic == 0.71.0
+anthropic >= 0.71.0
 model-hosting-container-standards >= 0.1.10, < 1.0.0
 mcp
 grpcio>=1.76.0


### PR DESCRIPTION
### Summary

Relaxes the `anthropic` package version constraint from an exact pin to a minimum version.

### Changes

```diff
- anthropic == 0.71.0
+ anthropic >= 0.71.0
```

### Motivation

The exact pin creates dependency conflicts with packages that require newer `anthropic` versions. For example, `pydantic-ai` requires `anthropic>=0.75.0`, making it impossible to install alongside vLLM.

The `anthropic` package is now at version 0.76.0 and there doesn't appear to be a specific incompatibility with newer versions.

Fixes #32288