### PR TITLE
[Ignore] Emulate contiguous blocks

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -196,6 +196,7 @@ if TYPE_CHECKING:
     VLLM_MQ_MAX_CHUNK_BYTES_MB: int = 16
     VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: int = 300
     VLLM_KV_CACHE_LAYOUT: Literal["NHD", "HND"] | None = None
+    VLLM_CONTIGUOUS_BLOCKS: bool = False
     VLLM_COMPUTE_NANS_IN_LOGITS: bool = False
     VLLM_USE_NVFP4_CT_EMULATIONS: bool = False
     VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: Literal[
@@ -1373,6 +1374,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # implement and support a subset of all possible layouts.
     "VLLM_KV_CACHE_LAYOUT": env_with_choices(
         "VLLM_KV_CACHE_LAYOUT", None, ["NHD", "HND"]
+    ),
+    # Force contiguous block allocation for KV cache (disables paged
+    # attention benefits). This introduces memory fragmentation and is
+    # useful for demonstrating the performance benefits of paged attention.
+    "VLLM_CONTIGUOUS_BLOCKS": lambda: bool(
+        int(os.getenv("VLLM_CONTIGUOUS_BLOCKS", "0"))
     ),
     # Enable checking whether the generated logits contain NaNs,
     # indicating corrupted output. Useful for debugging low level bugs

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -307,10 +307,16 @@ class BlockPool:
         Returns:
             A list of new block.
         """
+        from vllm import envs
+
         if num_blocks > self.get_num_free_blocks():
             raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
 
-        ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+        if envs.VLLM_CONTIGUOUS_BLOCKS:
+            ret = self.free_block_queue.popleft_contiguous_n(num_blocks)
+            assert ret is not None
+        else:
+            ret = self.free_block_queue.popleft_n(num_blocks)
 
         # In order to only iterate the list once, we duplicated code a bit
         if self.enable_caching:
@@ -459,8 +465,14 @@ class BlockPool:
         """Get the number of free blocks in the pool.
 
         Returns:
-            The number of free blocks.
+            The number of free blocks. When VLLM_CONTIGUOUS_BLOCKS is set,
+            returns the largest contiguous region instead (to reflect
+            actual allocatable capacity under fragmentation).
         """
+        from vllm import envs
+
+        if envs.VLLM_CONTIGUOUS_BLOCKS:
+            return self.free_block_queue.get_largest_contiguous()
         return self.free_block_queue.num_free_blocks
 
     def get_usage(self) -> float:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -363,6 +363,32 @@ class FreeKVCacheBlockQueue:
             curr_block = curr_block.next_free_block
         return ret
 
+    def get_largest_contiguous(self) -> int:
+        """Get size of largest contiguous free region."""
+        free = self.get_all_free_blocks()
+        if not free:
+            return 0
+        ids = sorted(b.block_id for b in free)
+        max_run = cur_run = 1
+        for i in range(1, len(ids)):
+            cur_run = cur_run + 1 if ids[i] == ids[i - 1] + 1 else 1
+            max_run = max(max_run, cur_run)
+        return max_run
+
+    def popleft_contiguous_n(self, n: int) -> list[KVCacheBlock] | None:
+        """Pop n blocks with consecutive block_ids, or None if not possible."""
+        if n <= 0:
+            return []
+        if n > self.num_free_blocks:
+            return None
+        free = sorted(self.get_all_free_blocks(), key=lambda b: b.block_id)
+        for i in range(len(free) - n + 1):
+            if free[i + n - 1].block_id - free[i].block_id == n - 1:
+                for b in free[i : i + n]:
+                    self.remove(b)
+                return free[i : i + n]
+        return None  # No contiguous region (fragmentation)
+
 
 def need_extra_keys(request: Request) -> bool:
     """Check whether the blocks allocated to this request need extra hash keys.


### PR DESCRIPTION
<!-- markdownlint-disable -->

With `VLLM_CONTIGUOUS_BLOCKS=1`, requests require contiguous block IDs. As sequences complete and leave "holes", the scheduler sees reduced capacity and makes new requests wait rather than crash. This demonstrates fragmentation degrading throughput compared to the paged block allocation.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

