### PR TITLE
[Bugfix] Pass in missing tp_size to get_port_offset() for MORI IO Connector

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -167,7 +167,7 @@ def get_moriio_mode() -> MoRIIOMode:
         return MoRIIOMode.WRITE
 
 
-def get_port_offset(dp_rank: int, tp_rank: int, tp_size: int = 1) -> int:
+def get_port_offset(dp_rank: int, tp_rank: int, tp_size: int) -> int:
     return (dp_rank) * tp_size + tp_rank
 
 
@@ -208,7 +208,7 @@ class MoRIIOConfig:
         base_notify_port = int(extra_config["notify_port"])
         dp_size = vllm_config.parallel_config.data_parallel_size
         tp_size = get_tensor_model_parallel_world_size()
-        port_offset = get_port_offset(dp_rank, tp_rank)
+        port_offset = get_port_offset(dp_rank, tp_rank, tp_size)
 
         return cls(
             local_ip=get_ip(),

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
@@ -304,7 +304,7 @@ class MoRIIOWriter:
             self.worker.moriio_wrapper.waiting_for_transfer_complete()
 
             remote_port = task.remote_notify_port + get_port_offset(
-                request_info.decode_dp_rank, self.worker.tp_rank
+                request_info.decode_dp_rank, self.worker.tp_rank, self.worker.tp_size
             )
             # Consider using RDMA immediate data in decode side
             # to eliminate the need for this notification.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The original code uses default tp_size = 1 to compute port offset, which is incorrect.
This PR fixes it.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

