### PR TITLE
[Doc] Add note to docker.md on --model arg #32292

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -32,7 +32,7 @@ You can add any other [engine-args](../configuration/engine_args.md) you need af
 !!! warning
     Make sure to use the `--model` flag to specify the model in your command.
 
-    Passing the model as a positional argument (without the flag) can cause vLLM to silently fall back to a default model instead, which may not be what you intend.
+    Passing the model as a positional argument (without the flag) will cause vLLM to silently fall back to a default model instead, which may not be what you intend.
 
 !!! note
     You can either use the `ipc=host` flag or `--shm-size` flag to allow the

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -29,6 +29,11 @@ podman run --device nvidia.com/gpu=all \
 
 You can add any other [engine-args](../configuration/engine_args.md) you need after the image tag (`vllm/vllm-openai:latest`).
 
+!!! warning
+    Make sure to use the `--model` flag to specify the model in your command.
+
+    Passing the model as a positional argument (without the flag) can cause vLLM to silently fall back to a default model instead, which may not be what you intend.
+
 !!! note
     You can either use the `ipc=host` flag or `--shm-size` flag to allow the
     container to access the host's shared memory. vLLM uses PyTorch, which uses shared


### PR DESCRIPTION
**Change in this PR**
Adds a short note emphasizing that Docker usage should pass the model via `--model` (not as a positional argument), to prevent accidental fallback to the default model. 

---

Many `vllm serve` examples pass the model as a positional argument, but the same pattern is easy to copy into Docker and fails in a subtle way as the container will start successfully, but it won’t users intended model. Instead, it silently falls back to the image’s default model unless --model is explicitly provided.

**Example**

```bash
MODEL=Qwen/Qwen2.5-1.5B-Instruct
NAME=qwen

# Works: positional MODEL is accepted by `vllm serve`
vllm serve $MODEL --served-model-name $NAME
```

```bash
# Pitfall: container runs, but will fall back to default model i.e Qwen/Qwen3-0.6B
docker run -d vllm/vllm-openai:latest $MODEL --served-model-name $NAME
```

```bash
# Correct: explicitly specify the model flag in Docker
docker run -d vllm/vllm-openai:latest --model $MODEL --served-model-name $NAME
```