### PR TITLE
[Bugfix] Fix Granite Vision / Don't use Siglip Pooling Head Nested Models by Default 

### DIFF
--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -397,6 +397,14 @@ VLM_TEST_SETTINGS = {
         vllm_runner_kwargs={"mm_processor_kwargs": {"do_pan_and_scan": True}},
         patch_hf_runner=model_utils.gemma3_patch_hf_runner,
     ),
+    "granite_vision": VLMTestInfo(
+        models=["ibm-granite/granite-vision-3.3-2b"],
+        test_type=(VLMTestType.IMAGE),
+        prompt_formatter=lambda img_prompt: f"<|user|>\n{img_prompt}\n<|assistant|>\n",
+        max_model_len=8192,
+        auto_cls=AutoModelForImageTextToText,
+        vllm_output_post_proc=model_utils.llava_image_vllm_to_hf_output,
+    ),
     "glm4v": VLMTestInfo(
         models=["zai-org/glm-4v-9b"],
         test_type=VLMTestType.IMAGE,

--- a/tests/models/multimodal/generation/vlm_utils/model_utils.py
+++ b/tests/models/multimodal/generation/vlm_utils/model_utils.py
@@ -124,8 +124,10 @@ def _llava_vllm_to_hf_output(
         if token_id != mm_token_id or output_ids[idx - 1] != mm_token_id
     ]
 
-    assert output_str[0] == " "
-    hf_output_str = output_str[1:]
+    # output_str[0] is not " " in some cases, e.g., Granite Vision,
+    # but for most llava based models, this is the case
+    hf_output_str = output_str[1:] if output_str[0] == " " else output_str
+
     if hf_output_ids[-1] == eos_token_id:
         hf_output_str = hf_output_str + tokenizer.decode(eos_token_id)
 

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -692,6 +692,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
         trust_remote_code=True,
         min_transformers_version="5.0",
     ),
+    "GraniteVision": _HfExamplesInfo("ibm-granite/granite-vision-3.3-2b"),
     "GraniteSpeechForConditionalGeneration": _HfExamplesInfo(
         "ibm-granite/granite-speech-3.3-2b"
     ),

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Callable, Iterable, Mapping
-from functools import cached_property
+from functools import cached_property, partial
 from typing import Annotated, Literal
 
 import torch
@@ -705,7 +705,7 @@ class SiglipVisionTransformer(nn.Module):
         num_hidden_layers_override: int | None = None,
         require_post_norm: bool | None = None,
         prefix: str = "",
-        is_standalone: bool = False,
+        use_head: bool | None = False,
     ) -> None:
         super().__init__()
 
@@ -739,22 +739,30 @@ class SiglipVisionTransformer(nn.Module):
         else:
             self.post_layernorm = None
 
-        # if this model is initialized as the visual encoder of a VLM, we want
-        # the hidden states and should not default to enabling the pooling head.
-        # However, we still allow the attribute to be defined to prevent potential
-        # issues with weight loading for now.
-        self.is_standalone = is_standalone
+        # Fall back to the config if a bool is not provided explicitly;
+        # note that many config types, including SiglipVisionConfig,
+        # do not have vision_use_head as a defined attribute.
+        if isinstance(use_head, bool):
+            self.use_head = use_head
+        else:
+            self.use_head = (
+                True
+                if not hasattr(config, "vision_use_head")
+                else config.vision_use_head
+            )
 
-        self.use_head = (
-            True if not hasattr(config, "vision_use_head") else config.vision_use_head
-        )
-        if self.use_head:
-            self.head = SiglipMultiheadAttentionPoolingHead(
+        # Only create and load the head weights if we actually need them
+        self.head = (
+            SiglipMultiheadAttentionPoolingHead(
                 config=config,
                 quant_config=quant_config,
                 multimodal_config=multimodal_config,
                 prefix=f"{prefix}.head",
             )
+            if self.use_head
+            else None
+        )
+        self.last_hs_proc = partial(self.maybe_layer_norm_and_apply_head)
 
     @property
     def dtype(self):
@@ -783,34 +791,36 @@ class SiglipVisionTransformer(nn.Module):
             return_all_hidden_states=select_layers is not None,
         )
 
-        if isinstance(encoder_outputs, torch.Tensor):
-            encoder_outputs = self.maybe_norm_and_pool(encoder_outputs)
-        else:
-            encoder_outputs[-1] = self.maybe_norm_and_pool(encoder_outputs[-1])
-
         # In the case that we have multiple feature layers,
         # we stack and concatenate them into a tensor.
+        # NOTE: post layer norm and the attention pooling head
+        # are handled by last_hs_proc, which runs before applying
+        # the vision feature selection strategy.
         encoder_outputs = resolve_visual_encoder_outputs(
             encoder_outputs,
             None,
             select_layers=select_layers,
             max_possible_layers=self.config.num_hidden_layers,
+            last_hs_proc=self.last_hs_proc,
             feature_select_strategy=feature_select_strategy,
         )
 
         return encoder_outputs
 
-    def maybe_norm_and_pool(self, last_hidden_state: torch.Tensor):
-        """Given the last hidden states, apply post layer normalization if
-        we have it. Then, only potentially apply the pooling head if it's
-        running as a standalone model since we generally just want the
-        hidden states when running inside a VLM.
+    def maybe_layer_norm_and_apply_head(
+        self, encoder_outputs: torch.Tensor
+    ) -> torch.Tensor:
+        """Apply the post layer norm and head if they are enabled,
+        given the last hidden states tensor.
+
+        args:
+            encoder_outputs: The last hidden states from the visual encoder.
         """
         if self.post_layernorm is not None:
-            last_hidden_state = self.post_layernorm(last_hidden_state)
-        if self.use_head and self.is_standalone:
-            last_hidden_state = self.head(last_hidden_state)
-        return last_hidden_state
+            encoder_outputs = self.post_layernorm(encoder_outputs)
+        if self.head is not None:
+            encoder_outputs = self.head(encoder_outputs)
+        return encoder_outputs
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         stacked_params_mapping = [
@@ -826,6 +836,11 @@ class SiglipVisionTransformer(nn.Module):
         for name, loaded_weight in weights:
             # post_layernorm is not needed in SiglipVisionTransformer
             if name.startswith("post_layernorm") and self.post_layernorm is None:
+                continue
+
+            # if the model configuration is not going to use
+            # the pooling head for inference, don't load its weights
+            if self.head is None and name.startswith("head"):
                 continue
 
             # omit layers when num_hidden_layers_override is set
@@ -860,7 +875,7 @@ class SiglipVisionModel(nn.Module):
         num_hidden_layers_override: int | None = None,
         require_post_norm: bool | None = None,
         prefix: str = "",
-        is_standalone: bool = False,
+        use_head: bool | None = False,
     ) -> None:
         super().__init__()
 
@@ -872,7 +887,7 @@ class SiglipVisionModel(nn.Module):
             num_hidden_layers_override=num_hidden_layers_override,
             require_post_norm=require_post_norm,
             prefix=f"{prefix}.vision_model",
-            is_standalone=is_standalone,
+            use_head=use_head,
         )
 
     def get_input_embeddings(self) -> nn.Module:
@@ -917,6 +932,11 @@ class SiglipVisionModel(nn.Module):
                 name.startswith("vision_model.post_layernorm")
                 and self.vision_model.post_layernorm is None
             ):
+                continue
+
+            # if the model configuration is not going to use
+            # the pooling head for inference, don't load its weights
+            if self.vision_model.head is None and name.startswith("vision_model.head"):
                 continue
 
             # omit layers when num_hidden_layers_override is set
@@ -1069,7 +1089,7 @@ class SiglipEmbeddingModel(nn.Module, SupportsMultiModal, SupportsQuant):
                 quant_config=quant_config,
                 multimodal_config=multimodal_config,
                 prefix=maybe_prefix(prefix, "vision_model"),
-                is_standalone=True,
+                use_head=None,  # Allows potential pooling head
             )
 
         pooler_config = vllm_config.model_config.pooler_config

--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -154,6 +154,7 @@ def resolve_visual_encoder_outputs(
     *,
     select_layers: list[int] | None = None,
     max_possible_layers: int | None = None,
+    last_hs_proc: Callable[[torch.Tensor], torch.Tensor] | None = None,
     feature_select_strategy: VisionFeatureSelectStrategy | None = None,
 ) -> torch.Tensor:
     """Given the outputs a visual encoder module that may correspond to the
@@ -166,6 +167,11 @@ def resolve_visual_encoder_outputs(
         select_layers: Optional layer indices to grab from the encoder
             outputs; if provided, encoder outputs must be a list.
         max_possible_layers: Total layers in the fully loaded visual encoder.
+        last_hs_proc: Optional callable to be applied to the last layer if it
+            is used, e.g., pooling head for Siglip. This is done prior to
+            feature selection and layer normalization. If select_layers are
+            provided, last_hs_proc must be able to be concatenated with the
+            other select_layers along the last dimension.
         feature_select_strategy: Defines how to select the hidden states
             from each layer.
     """
@@ -175,6 +181,11 @@ def resolve_visual_encoder_outputs(
                 "Expected only a single encoder output when "
                 "`select_layers` is not provided"
             )
+
+        # Preprocess the encoder outputs as needed, e.g., map head
+        # and layer norm for siglip, which runs before feature selection
+        if last_hs_proc is not None:
+            encoder_outputs = last_hs_proc(encoder_outputs)
 
         if feature_select_strategy is not None:
             select_features = _get_vision_feature_selector(feature_select_strategy)
@@ -205,12 +216,15 @@ def resolve_visual_encoder_outputs(
         for layer_idx in select_layers
     ]
 
+    uses_last_layer = select_layers[-1] in (max_possible_layers - 1, -1)
+    if last_hs_proc is not None and uses_last_layer:
+        hs_pool[-1] = last_hs_proc(hs_pool[-1])
+
     if feature_select_strategy is not None:
         select_features = _get_vision_feature_selector(feature_select_strategy)
         hs_pool = [select_features(hs) for hs in hs_pool]
 
     # Apply post-norm on the final hidden state if we are using it
-    uses_last_layer = select_layers[-1] in (max_possible_layers - 1, -1)
     if post_layer_norm is not None and uses_last_layer:
         hs_pool[-1] = post_layer_norm(hs_pool[-1])
 

--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -170,8 +170,8 @@ def resolve_visual_encoder_outputs(
         last_hs_proc: Optional callable to be applied to the last layer if it
             is used, e.g., pooling head for Siglip. This is done prior to
             feature selection and layer normalization. If select_layers are
-            provided, last_hs_proc must be able to be concatenated with the
-            other select_layers along the last dimension.
+            provided, the output of last_hs_proc must be able to be
+            concatenated with the other select_layers along the last dimension.
         feature_select_strategy: Defines how to select the hidden states
             from each layer.
     """


### PR DESCRIPTION
## Purpose
I noticed that granite vision (Llava Next arch with multiple vision feature layers + siglip as the visual encoder) is currently broken due to some changes that were made to siglip when it was exposed as a standalone embedding model.  It blows up as shown when running the vision encoder:

```
(EngineCore_DP0 pid=2274868)   File "/u/abrooks9944/vllm/vllm/model_executor/models/siglip.py", line 783, in forward
(EngineCore_DP0 pid=2274868)     encoder_outputs = self.head(encoder_outputs)
(EngineCore_DP0 pid=2274868)                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
...
(EngineCore_DP0 pid=2274868)   File "/u/abrooks9944/vllm/vllm/model_executor/models/siglip.py", line 682, in forward
(EngineCore_DP0 pid=2274868)     batch_size = hidden_state.size(0)
(EngineCore_DP0 pid=2274868)                  ^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=2274868) AttributeError: 'list' object has no attribute 'size'
```

I think there are 2 issues:

- The one causing the crash, which is that if we have multiple feature layers, we pass a list to the pooling head, which breaks since it expects a tensor
- Most models that I am aware of do not use the pooling head in composite models; in Transformers, the vision encoder can return the hidden states and the pooling head output together, but most models use the hidden states.

This PR:
- Adds a multimodal model test for granite vision in case we hit a similar case in the future
- Fixes the layer norm / pooling for multiple feature layers by only applying it to the last layer if multiple are provided, which is done prior to concatenation
- Adds a guard that disables the pooling head by default unless it's running as a standalone model to keep the model interface well aligned with CLIP etc; this will ensure composite models generally just get the hidden states without changing the behavior for Siglip running by itself.

## Test Plan
- Add model test for granite vision
- Best effort check to make sure no models in vLLM that wrap siglip actually expect pooled outputs instead of hidden states

## Test Result
- Test passes
- I took a quick pass and didn't see any models that are using the pooling head outputs in composite VLMs, so hopefully this change is safe assuming tests pass; list of refs below.
  - aya vision [ref](https://github.com/huggingface/transformers/blob/main/src/transformers/models/aya_vision/modular_aya_vision.py#L149)
  - bagel [ref](https://github.com/ByteDance-Seed/Bagel/blob/main/modeling/bagel/siglip_navit.py#L370) - doesn't have the pooling head in its own copied implementation
  - cohere2 [ref](https://github.com/huggingface/transformers/blob/main/src/transformers/models/cohere2_vision/modeling_cohere2_vision.py#L348) (idx 0 correspondes to hidden states, not pooled output [here](https://github.com/huggingface/transformers/blob/main/src/transformers/models/siglip/modeling_siglip.py#L664))
  - gemma3 [ref](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma3/modeling_gemma3.py#L849)
  - gemma3n [ref](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma3n/modeling_gemma3n.py#L1943)
  - hyperclovax [ref](https://huggingface.co/naver-hyperclovax/HyperCLOVAX-SEED-Vision-Instruct-3B/blob/main/modeling_hyperclovax.py#L756)
   In vLLM, keye has its own implementation of Siglip components, so won't be affected by this changeME (Alex): curre
  - llava [ref](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llava/modeling_llava.py#L190)
  - llava next [ref](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llava_next/modeling_llava_next.py#L403)
  - llava next video [ref](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llava_next_video/modeling_llava_next_video.py#L455)
  - llava one vision: [ref](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llava_onevision/modeling_llava_onevision.py#L426)
  - Minimax VL [ref](https://huggingface.co/MiniMaxAI/MiniMax-VL-01/blob/main/modeling_minimax_vl_01.py#L771) - this one uses clip instead of siglip, but in vLLM we add support for siglip too
  - Ovis [ref](https://huggingface.co/AIDC-AI/Ovis1.6-Gemma2-9B/blob/main/modeling_ovis.py#L200)
  - In vLLM, Paddle OCR has its own implementation of Siglip components, so won't be affected by this change
  - Paligemma [ref](https://github.com/huggingface/transformers/blob/main/src/transformers/models/paligemma/modeling_paligemma.py#L272), does not use the pooled outputs.
  - Phi4MM [ref](https://huggingface.co/microsoft/Phi-4-multimodal-instruct/blob/main/modeling_phi4mm.py#L191)
  - Tarsier is llava based [ref](https://huggingface.co/omni-research/Tarsier-34b/blob/main/config.json#L11), so should have the same behavior as llava


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

