### PR TITLE
[Refactor] Move top-level dummy data generation to registry

### DIFF
--- a/tests/models/multimodal/processing/test_mllama4.py
+++ b/tests/models/multimodal/processing/test_mllama4.py
@@ -24,7 +24,7 @@ def test_profiling(model_id: str, max_model_len: int):
         limit_mm_per_prompt=mm_counts,
     )
 
-    mm_inputs = MULTIMODAL_REGISTRY.get_dummy_mm_data(
+    mm_inputs = MULTIMODAL_REGISTRY.get_dummy_mm_inputs(
         ctx.model_config,
         mm_counts=mm_counts,
     )

--- a/tests/models/multimodal/processing/test_mllama4.py
+++ b/tests/models/multimodal/processing/test_mllama4.py
@@ -24,32 +24,20 @@ def test_profiling(model_id: str, max_model_len: int):
         limit_mm_per_prompt=mm_counts,
     )
 
-    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
-    decoder_dummy_data = processor.dummy_inputs.get_decoder_dummy_data(
-        processor,
-        max_model_len,
-        mm_counts=mm_counts,
-    )
-    dummy_mm_data = processor.dummy_inputs.get_dummy_processor_inputs(
-        max_model_len,
+    mm_inputs = MULTIMODAL_REGISTRY.get_dummy_mm_data(
+        ctx.model_config,
         mm_counts=mm_counts,
     )
 
     hf_config = ctx.get_hf_config(Llama4Config)
-
-    mm_inputs = processor.apply(
-        prompt=dummy_mm_data.prompt,
-        mm_data=dummy_mm_data.mm_data,
-        hf_processor_mm_kwargs=dict(),
-    )
-    mm_data = mm_inputs["mm_kwargs"].get_data()
-
     image_size = hf_config.vision_config.image_size
     patch_size = hf_config.vision_config.patch_size
     downsample_ratio = int(
         round(1.0 / (hf_config.vision_config.pixel_shuffle_ratio**2))
     )
     tokens_per_patch = ((image_size // patch_size) ** 2) // downsample_ratio
+
+    mm_data = mm_inputs["mm_kwargs"].get_data()
     chunks_per_image = prod(mm_data["patches_per_image"])
     total_num_patches = chunks_per_image * tokens_per_patch
     num_tiles = (
@@ -63,6 +51,5 @@ def test_profiling(model_id: str, max_model_len: int):
         item.get_num_embeds for item in mm_inputs["mm_placeholders"]["image"]
     )
     assert total_tokens == sum(
-        placeholder.length
-        for placeholder in decoder_dummy_data.multi_modal_placeholders["image"]
+        placeholder.length for placeholder in mm_inputs["mm_placeholders"]["image"]
     )

--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -926,7 +926,7 @@ def test_limit_mm_per_prompt_dummy(model_id, limit, num_supported, is_valid):
     exc_ctx = nullcontext() if is_valid else pytest.raises(ValueError, match="At most")
 
     with exc_ctx:
-        MULTIMODAL_REGISTRY.get_dummy_mm_data(
+        MULTIMODAL_REGISTRY.get_dummy_mm_inputs(
             model_config,
             mm_counts=limit_mm_per_prompt,
             processor=processor,

--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -926,10 +926,10 @@ def test_limit_mm_per_prompt_dummy(model_id, limit, num_supported, is_valid):
     exc_ctx = nullcontext() if is_valid else pytest.raises(ValueError, match="At most")
 
     with exc_ctx:
-        processor.dummy_inputs.get_decoder_dummy_data(
-            processor,
-            model_config.max_model_len,
+        MULTIMODAL_REGISTRY.get_dummy_mm_data(
+            model_config,
             mm_counts=limit_mm_per_prompt,
+            processor=processor,
         )
 
 

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -50,6 +50,7 @@ from .parse import (
     MultiModalDataItems,
     MultiModalDataParser,
 )
+from .profiling import BaseDummyInputsBuilder
 
 if TYPE_CHECKING:
     from transformers.configuration_utils import PretrainedConfig
@@ -59,7 +60,6 @@ if TYPE_CHECKING:
     from vllm.config import ModelConfig, ObservabilityConfig
 
     from .cache import BaseMultiModalProcessorCache
-    from .profiling import BaseDummyInputsBuilder
 else:
     PretrainedConfig = object
     BatchFeature = object

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -176,7 +176,7 @@ class MultiModalRegistry:
                 if mm_counts.get(modality, 0) > 0
             }
 
-        mm_inputs = self.get_dummy_mm_data(
+        mm_inputs = self.get_dummy_mm_inputs(
             model_config,
             mm_counts=mm_counts,
             processor=processor,
@@ -294,7 +294,7 @@ class MultiModalRegistry:
 
         return factories.build_processor(ctx, cache=cache)
 
-    def get_dummy_mm_data(
+    def get_dummy_mm_inputs(
         self,
         model_config: "ModelConfig",
         mm_counts: Mapping[str, int] | None = None,

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -10,15 +10,13 @@ from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike, cached_tokenizer_from_config
 
 from .cache import BaseMultiModalProcessorCache
+from .inputs import MultiModalInputs
 from .processing import (
     BaseMultiModalProcessor,
     BaseProcessingInfo,
     InputProcessingContext,
 )
-from .profiling import (
-    BaseDummyInputsBuilder,
-    DummyDecoderData,
-)
+from .profiling import BaseDummyInputsBuilder
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, ObservabilityConfig
@@ -160,7 +158,6 @@ class MultiModalRegistry:
             model_config, observability_config, cache=cache
         )
 
-        seq_len = model_config.max_model_len
         if profiler_limits is None:
             profiler_limits = processor.allowed_mm_limits
 
@@ -169,7 +166,7 @@ class MultiModalRegistry:
         }
 
         max_tokens_per_item = processor.info.get_mm_max_tokens_per_item(
-            seq_len=seq_len,
+            seq_len=model_config.max_model_len,
             mm_counts=mm_counts,
         )
         if max_tokens_per_item is not None:
@@ -179,11 +176,10 @@ class MultiModalRegistry:
                 if mm_counts.get(modality, 0) > 0
             }
 
-        mm_inputs = processor.dummy_inputs.get_dummy_mm_inputs(
-            processor,
-            seq_len,
+        mm_inputs = self.get_dummy_mm_data(
+            model_config,
             mm_counts=mm_counts,
-            mm_options=self._extract_mm_options(model_config),
+            processor=processor,
         )
 
         return {
@@ -298,39 +294,47 @@ class MultiModalRegistry:
 
         return factories.build_processor(ctx, cache=cache)
 
-    def get_decoder_dummy_data(
+    def get_dummy_mm_data(
         self,
         model_config: "ModelConfig",
-        seq_len: int,
         mm_counts: Mapping[str, int] | None = None,
         *,
         cache: BaseMultiModalProcessorCache | None = None,
         observability_config: ObservabilityConfig | None = None,
-    ) -> DummyDecoderData:
+        processor: BaseMultiModalProcessor | None = None,
+    ) -> MultiModalInputs:
         """
         Create dummy data for profiling the memory usage of a model.
 
         The model is identified by `model_config`.
         """
-        processor = self.create_processor(
-            model_config, observability_config, cache=cache
-        )
-        dummy_data = processor.dummy_inputs.get_decoder_dummy_data(
-            processor,
-            seq_len,
+        seq_len = model_config.max_model_len
+
+        if processor is None:
+            processor = self.create_processor(
+                model_config, observability_config, cache=cache
+            )
+        if mm_counts is None:
+            mm_counts = processor.allowed_mm_limits
+
+        processor_inputs = processor.dummy_inputs.get_dummy_processor_inputs(
+            seq_len=seq_len,
             mm_counts=mm_counts,
             mm_options=self._extract_mm_options(model_config),
         )
+        mm_inputs = processor.apply(
+            prompt=processor_inputs.prompt,
+            mm_data=processor_inputs.mm_data,
+            hf_processor_mm_kwargs=processor_inputs.hf_processor_mm_kwargs,
+            tokenization_kwargs=processor_inputs.tokenization_kwargs,
+        )
 
-        # Having more tokens is over-conservative but otherwise fine
-        token_ids = dummy_data.prompt_token_ids
-        if len(token_ids) < seq_len:
-            raise AssertionError(
-                f"Expected at least {seq_len} dummy tokens for profiling, "
-                f"but found {len(token_ids)} tokens instead."
-            )
+        prompt_token_ids = mm_inputs["prompt_token_ids"]
+        total_len = len(prompt_token_ids)
+        if total_len < seq_len:
+            prompt_token_ids.extend([0] * (seq_len - total_len))
 
-        return dummy_data
+        return mm_inputs
 
     def get_encdec_max_encoder_len(self, model_config: "ModelConfig") -> int:
         """

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4192,13 +4192,12 @@ class GPUModelRunner(
         """Dummy data for profiling and precompiling multimodal models."""
         assert self.mm_budget is not None
 
-        dummy_decoder_data = self.mm_registry.get_decoder_dummy_data(
-            model_config=self.model_config,
-            seq_len=self.max_model_len,
+        dummy_decoder_data = self.mm_registry.get_dummy_mm_data(
+            self.model_config,
             mm_counts={modality: 1},
             cache=self.mm_budget.cache,
         )
-        dummy_mm_data = dummy_decoder_data.multi_modal_data
+        dummy_mm_data = dummy_decoder_data["mm_kwargs"].require_data()
 
         # Result in the maximum GPU consumption of the model
         dummy_mm_item = dummy_mm_data[modality][0]

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4192,15 +4192,14 @@ class GPUModelRunner(
         """Dummy data for profiling and precompiling multimodal models."""
         assert self.mm_budget is not None
 
-        dummy_decoder_data = self.mm_registry.get_dummy_mm_data(
+        dummy_mm_inputs = self.mm_registry.get_dummy_mm_inputs(
             self.model_config,
             mm_counts={modality: 1},
             cache=self.mm_budget.cache,
         )
-        dummy_mm_data = dummy_decoder_data["mm_kwargs"].require_data()
 
         # Result in the maximum GPU consumption of the model
-        dummy_mm_item = dummy_mm_data[modality][0]
+        dummy_mm_item = dummy_mm_inputs["mm_kwargs"][modality][0]
         dummy_mm_items = [dummy_mm_item] * max_items_per_batch
 
         return next(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4203,7 +4203,7 @@ class GPUModelRunner(
 
         # We use the cache so that the item is saved to the cache,
         # but not read from the cache
-        assert dummy_mm_item is not None, "Item should not be cached"
+        assert dummy_mm_item is not None, "Item should not already be cached"
 
         dummy_mm_items = [dummy_mm_item] * max_items_per_batch
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4200,6 +4200,11 @@ class GPUModelRunner(
 
         # Result in the maximum GPU consumption of the model
         dummy_mm_item = dummy_mm_inputs["mm_kwargs"][modality][0]
+
+        # We use the cache so that the item is saved to the cache,
+        # but not read from the cache
+        assert dummy_mm_item is not None, "Item should not be cached"
+
         dummy_mm_items = [dummy_mm_item] * max_items_per_batch
 
         return next(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4192,13 +4192,12 @@ class GPUModelRunner(
         """Dummy data for profiling and precompiling multimodal models."""
         assert self.mm_budget is not None
 
+        # Don't use `max_items_per_batch` here to avoid redundant computation
         dummy_mm_inputs = self.mm_registry.get_dummy_mm_inputs(
             self.model_config,
             mm_counts={modality: 1},
             cache=self.mm_budget.cache,
         )
-
-        # Result in the maximum GPU consumption of the model
         dummy_mm_item = dummy_mm_inputs["mm_kwargs"][modality][0]
 
         # We use the cache so that the item is saved to the cache,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

- Untangle the circular dependency between `MultiModalProcessor` and `DummyInputsBuilder`.
- Remove redundant `DummyEncoderData` and `DummyDecoderData`. Use `MultiModalInputs` instead.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

