### PR TITLE
[Refactor] Simplify FusedMoEParallelConfig.make() logic and remove redundant assert

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -959,6 +959,12 @@ class FusedMoEParallelConfig:
         )
 
         if use_ep:
+            # Expert Parallelism (EP) mode: DP + EP / TP + EP / DP + TP + EP
+            #
+            # In EP, each device owns a disjoint set of experts fully.
+            # There is no tensor parallelism within experts. Instead, experts
+            # are distributed across devices. We convert the TP dimensions
+            # (which were flattened across DP and PCP) into EP dimensions.
             ep_size, ep_rank = tp_size, tp_rank
             tp_size, tp_rank = 1, 0
         else:


### PR DESCRIPTION

## Purpose
This PR refactors the `FusedMoEParallelConfig.make()` method to improve code maintainability by:

- Removing a redundant `assert use_ep` statement

- Consolidating two separate return statements into a single unified return

- Simplifying the control flow logic

## Test Plan

## Test Result

