### PR TITLE
[Quantization] Add W4A16 NVFP4 MoE support for CompressedTensors

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -694,7 +694,7 @@ class CompressedTensorsW4A16Nvfp4MoEMethod(CompressedTensorsMoEMethod):
             1 / layer.w13_weight_global_scale[:, 0], requires_grad=False
         )
         layer.w2_weight_scale_2 = torch.nn.Parameter(
-            1 / layer.w2_weight_global_scale.data, requires_grad=False
+            1 / layer.w2_weight_global_scale, requires_grad=False
         )
 
         # Clean up temporary attributes.


### PR DESCRIPTION
## Purpose

Add W4A16 (weight-only FP4) NVFP4 MoE support for CompressedTensors quantization scheme.

Currently, vLLM's CompressedTensors only supports W4A4 (both weights and activations quantized to FP4) for MoE models. This PR adds support for W4A16, which quantizes only weights to FP4 while keeping activations in original precision (FP16/BF16).

**Advantages of W4A16 over W4A4:**
- No input quantization overhead during inference
- Higher numerical precision (activations remain in original precision)
- Simpler deployment (no need to calibrate input scales)

**Implementation:**
- Added `CompressedTensorsW4A16Nvfp4MoEMethod` class in `compressed_tensors_moe.py`
- Supports Marlin backend only (other backends require input quantization)

## Test Plan

```python
from vllm import LLM, SamplingParams

MODEL_ID = "pe-nlp/Qwen3-30B-A3B-NVFP4A16"
PROMPT = "vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs."

llm = LLM(model=MODEL_ID, trust_remote_code=True)
sampling_params = SamplingParams(temperature=0, max_tokens=128)
outputs = llm.generate([PROMPT], sampling_params)
print(outputs[0].outputs[0].text)
```

## Test Result

```
Prompt: vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs.
Output: It is designed to be fast and efficient, with a focus on both latency and throughput. 
It supports various LLMs, including LLaMA, LLaMA2, and other models. It is built on top of 
the TensorRT library, which allows it to take advantage of the GPU's parallel processing 
capabilities. It also supports multiple GPUs and can scale to large clusters. The engine is 
designed to be easy to use, with a simple API and a variety of tools for monitoring and 
managing the inference process. It is also designed to be compatible with various frameworks 
and platforms, making it easy to integrate into existing systems.
```

---

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update.
