### PR TITLE
fix: avoid crash on zero-arg tool calls in glm4 parser

### DIFF
--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -115,9 +115,15 @@ class Glm4MoeModelToolParser(ToolParser):
             tool_calls = []
             for match in matched_tool_calls:
                 tc_detail = self.func_detail_regex.search(match)
+                if not tc_detail:
+                    logger.warning(
+                        "Failed to parse tool call details from: %s",
+                        match,
+                    )
+                    continue
                 tc_name = tc_detail.group(1)
                 tc_args = tc_detail.group(2)
-                pairs = self.func_arg_regex.findall(tc_args)
+                pairs = self.func_arg_regex.findall(tc_args) if tc_args else []
                 arg_dct = {}
                 for key, value in pairs:
                     arg_key = key.strip()


### PR DESCRIPTION
## Issue
- Fixes #32213

## Summary
- Guard tool call detail parsing to avoid crashing on unmatched patterns.
- Treat missing arg groups as empty so zero-arg tool calls parse cleanly.

## Motivation
- Zero-argument tool calls can yield `None` for the arg group, which used to
  trigger a `TypeError` and drop tool calls.

## Validation
- Manual: `C:\vllm-venv\Scripts\python -` with `<tool_call>get_current_time</tool_call>`
  using glm47 parser → `tools_called=True`, arguments `{}`.
- Manual: same snippet with glm4 parser → no exception (warning only).
