### PR TITLE
[Misc] Make mem utils can be reused by other platforms

### DIFF
--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -589,7 +589,11 @@ class Platform:
     def __getattr__(self, key: str):
         device = getattr(torch, self.device_type, None)
         if device is not None and hasattr(device, key):
-            return getattr(device, key)
+            attr = getattr(device, key)
+            # NOTE: `hasattr(device, key)=True` can only avoid AttributeError,
+            # but the value of this attr could be `None`.
+            if attr is not None:
+                return attr
         else:
             logger.warning(
                 "Current platform %s does not have '%s' attribute.",

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -594,13 +594,13 @@ class Platform:
             # but the value of this attr could be `None`.
             if attr is not None:
                 return attr
-        else:
-            logger.warning(
-                "Current platform %s does not have '%s' attribute.",
-                self.device_type,
-                key,
-            )
-            return None
+
+        logger.warning(
+            "Current platform %s does not have '%s' attribute.",
+            self.device_type,
+            key,
+        )
+        return None
 
     def get_global_graph_pool(self) -> Any:
         """

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -76,7 +76,6 @@ class MemorySnapshot:
     timestamp: float = 0.0
 
     device: torch.types.Device = None
-    device_name: str = ""
     auto_measure: bool = True
 
     def __post_init__(self) -> None:
@@ -84,7 +83,6 @@ class MemorySnapshot:
             device_fn = current_platform.current_device
             assert device_fn is not None
             self.device_ = torch.device(device_fn())
-            self.device_name = current_platform.device_name
         else:
             self.device_ = torch.device(self.device)
 
@@ -157,7 +155,7 @@ class MemorySnapshot:
             f"torch_peak={format_gib(self.torch_peak)}GiB, "
             f"free_memory={format_gib(self.free_memory)}GiB, "
             f"total_memory={format_gib(self.total_memory)}GiB, "
-            f"{self.device_name}_memory={format_gib(self.cuda_memory)}GiB, "
+            f"{current_platform.device_name}_memory={format_gib(self.cuda_memory)}GiB, "
             f"torch_memory={format_gib(self.torch_memory)}GiB, "
             f"non_torch_memory={format_gib(self.non_torch_memory)}GiB, "
             f"timestamp={self.timestamp}, "

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -11,6 +11,8 @@ import psutil
 import torch
 import torch.types
 
+from vllm.platforms import current_platform
+
 from .mem_constants import GiB_bytes, MiB_bytes
 
 
@@ -45,8 +47,6 @@ class DeviceMemoryProfiler:
 
     def current_memory_usage(self) -> float:
         # Return the memory usage in bytes.
-        from vllm.platforms import current_platform
-
         gc.collect()
         return current_platform.get_current_memory_usage(self.device)
 
@@ -76,15 +76,15 @@ class MemorySnapshot:
     timestamp: float = 0.0
 
     device: torch.types.Device = None
+    device_name: str = ""
     auto_measure: bool = True
 
     def __post_init__(self) -> None:
         if self.device is None:
-            from vllm.platforms import current_platform
-
             device_fn = current_platform.current_device
             assert device_fn is not None
             self.device_ = torch.device(device_fn())
+            self.device_name = current_platform.device_name
         else:
             self.device_ = torch.device(self.device)
 
@@ -92,8 +92,6 @@ class MemorySnapshot:
             self.measure()
 
     def measure(self) -> None:
-        from vllm.platforms import current_platform
-
         device = self.device_
 
         # we measure the torch peak memory usage via allocated_bytes,
@@ -101,11 +99,11 @@ class MemorySnapshot:
         # After `torch.cuda.reset_peak_memory_stats()`,
         # `torch.cuda.memory_reserved()` will keep growing, and only shrink
         # when we call `torch.cuda.empty_cache()` or OOM happens.
-        self.torch_peak = torch.cuda.memory_stats(device).get(
+        self.torch_peak = current_platform.memory_stats(device).get(
             "allocated_bytes.all.peak", 0
         )
 
-        self.free_memory, self.total_memory = torch.cuda.mem_get_info(device)
+        self.free_memory, self.total_memory = current_platform.mem_get_info(device)
         shared_sysmem_device_mem_sms = ((8, 7), (11, 0), (12, 1))  # Orin, Thor, Spark
         if (
             current_platform.is_cuda()
@@ -130,7 +128,7 @@ class MemorySnapshot:
         # torch.cuda.memory_reserved() is how many bytes
         # PyTorch gets from cuda (by calling cudaMalloc, etc.)
         # this is used to measure the non-torch memory usage
-        self.torch_memory = torch.cuda.memory_reserved(device)
+        self.torch_memory = current_platform.memory_reserved(device)
 
         self.non_torch_memory = self.cuda_memory - self.torch_memory
         self.timestamp = time.time()
@@ -159,7 +157,7 @@ class MemorySnapshot:
             f"torch_peak={format_gib(self.torch_peak)}GiB, "
             f"free_memory={format_gib(self.free_memory)}GiB, "
             f"total_memory={format_gib(self.total_memory)}GiB, "
-            f"cuda_memory={format_gib(self.cuda_memory)}GiB, "
+            f"{self.device_name}_memory={format_gib(self.cuda_memory)}GiB, "
             f"torch_memory={format_gib(self.torch_memory)}GiB, "
             f"non_torch_memory={format_gib(self.non_torch_memory)}GiB, "
             f"timestamp={self.timestamp}, "
@@ -254,8 +252,8 @@ def memory_profiling(
     until after profiling to get (c.).
     """
     gc.collect()
-    torch.cuda.empty_cache()
-    torch.cuda.reset_peak_memory_stats(baseline_snapshot.device_)
+    current_platform.empty_cache()
+    current_platform.reset_peak_memory_stats(baseline_snapshot.device_)
 
     result = MemoryProfilingResult(
         before_create=baseline_snapshot,
@@ -268,7 +266,7 @@ def memory_profiling(
     yield result
 
     gc.collect()
-    torch.cuda.empty_cache()
+    current_platform.empty_cache()
 
     result.after_profile.measure()
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -312,9 +312,6 @@ class Worker(WorkerBase):
             logger.info(msg)
             return kv_cache_memory_bytes
 
-        torch.cuda.empty_cache()
-        torch.cuda.reset_peak_memory_stats()
-
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
         with memory_profiling(
@@ -360,7 +357,6 @@ class Worker(WorkerBase):
             format_gib(self.available_kv_cache_memory_bytes),
             scope="local",
         )
-        gc.collect()
 
         return int(self.available_kv_cache_memory_bytes)
 


### PR DESCRIPTION
## Purpose

1. Make profiling utils more general so that other platforms can reuse these codes (using the mechanism introduced in https://github.com/vllm-project/vllm/pull/14411).
2. Remove redundant memory clearing operations in `determine_available_memory()` of GPU worker, which have been done in `memory_profiling()`.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

