### PR TITLE
[misc] remove the magic number in _set_cudagraph_sizes function

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1073,7 +1073,7 @@ class VllmConfig:
         capture as:
 
         ```python
-        max_graph_size = min(max_num_seqs * 2, 512)
+        max_graph_size = min(max_num_seqs * (1 + num_speculative_tokens), 512)
         # 1, 2, 4, then multiples of 8 up to 256 and then multiples of 16
         # up to max_graph_size
         cudagraph_capture_sizes = [1, 2, 4] + list(range(8, 256, 8)) + list(
@@ -1124,7 +1124,7 @@ class VllmConfig:
                 ):
                     decode_query_len += self.speculative_config.num_speculative_tokens
                 max_cudagraph_capture_size = min(
-                    self.scheduler_config.max_num_seqs * decode_query_len * 2, 512
+                    self.scheduler_config.max_num_seqs * decode_query_len, 512
                 )
             max_num_tokens = self.scheduler_config.max_num_batched_tokens
             max_cudagraph_capture_size = min(max_num_tokens, max_cudagraph_capture_size)


### PR DESCRIPTION
## Purpose
Currently, default `max_cudagraph_capture_size` is set to `max_num_seqs * (1 + num_speculative_tokens) * 2` which contains a magic number. This implementation leads to more and larger graph_capture_sizes, further larger VRAM allocation on devices (graph capturing , gemm, dispatch and combine operators cost with larger `max_cudagraph_capture_size`). Apart from the aforementioned drawbacks, this configuration does not provide any decoding performance benefits, except in extreme cases involving sporadic P‑requests with few tokens. So this PR aims to eliminate this magic number.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

