### PR TITLE
[1/x][Frontend] A graceful shutdown implementation as per RFC #24885

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -583,6 +583,9 @@ class EngineArgs:
     )
     tokens_only: bool = False
 
+    enable_graceful_shutdown: bool = False
+    drain_timeout: int = 120  # seconds to wait for in-flight requests
+
     def __post_init__(self):
         # support `EngineArgs(compilation_config={...})`
         # without having to manually construct a
@@ -1196,6 +1199,21 @@ class EngineArgs:
             help="Log aggregate rather than per-engine statistics "
             "when using data parallelism.",
         )
+
+        parser.add_argument(
+            "--enable-graceful-shutdown",
+            action="store_true",
+            default=False,
+            help="Enable graceful shutdown with request draining on SIGTERM.",
+        )
+        parser.add_argument(
+            "--drain-timeout",
+            type=int,
+            default=120,
+            help="Seconds to wait for in-flight requests to complete "
+            "during graceful shutdown (default: 120).",
+        )
+
         return parser
 
     @classmethod

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -173,6 +173,11 @@ class EngineClient(ABC):
         """Return whether the engine is currently paused."""
         ...
 
+    @abstractmethod
+    def get_num_unfinished_requests(self) -> int:
+        """Return the number of in-flight requests."""
+        ...
+
     async def scale_elastic_ep(
         self, new_data_parallel_size: int, drain_timeout: int = 300
     ) -> None:

--- a/vllm/entrypoints/launcher.py
+++ b/vllm/entrypoints/launcher.py
@@ -95,7 +95,11 @@ async def serve_http(
         if not enable_graceful:
             return
 
-        model_name = engine_client.model_config.served_model_name
+        served_name = engine_client.model_config.served_model_name
+        if isinstance(served_name, list):
+            model_name = served_name[0] if served_name else "unknown"
+        else:
+            model_name = served_name or "unknown"
         inflight_count = engine_client.get_num_unfinished_requests()
         logger.info(
             "Graceful shutdown: starting drain (timeout=%ds), in-flight requests: %d",

--- a/vllm/entrypoints/launcher.py
+++ b/vllm/entrypoints/launcher.py
@@ -4,6 +4,7 @@
 import asyncio
 import signal
 import socket
+import time
 from http import HTTPStatus
 from typing import Any
 
@@ -16,10 +17,12 @@ from vllm.entrypoints.constants import (
     H11_MAX_HEADER_COUNT_DEFAULT,
     H11_MAX_INCOMPLETE_EVENT_SIZE_DEFAULT,
 )
+from vllm.entrypoints.serve.middleware import set_server_unavailable
 from vllm.entrypoints.ssl import SSLCertRefresher
 from vllm.logger import init_logger
 from vllm.utils.network_utils import find_process_using_port
 from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
+from vllm.v1.metrics.prometheus import set_server_draining
 
 logger = init_logger(__name__)
 
@@ -81,6 +84,59 @@ async def serve_http(
         )
     )
 
+    async def graceful_drain() -> None:
+        """Perform graceful drain before shutdown."""
+        args = getattr(app.state, "args", None)
+        engine_client: EngineClient = app.state.engine_client
+
+        enable_graceful = getattr(args, "enable_graceful_shutdown", False)
+        drain_timeout = getattr(args, "drain_timeout", 120)
+
+        if not enable_graceful:
+            return
+
+        model_name = engine_client.model_config.served_model_name
+        inflight_count = engine_client.get_num_unfinished_requests()
+        logger.info(
+            "Graceful shutdown: starting drain (timeout=%ds), in-flight requests: %d",
+            drain_timeout,
+            inflight_count,
+        )
+
+        # reject new requests at the HTTP layer
+        set_server_unavailable(True)
+
+        # expose draining state via prometheus for external load balancers
+        set_server_draining(model_name, draining=True)
+
+        start_time = time.monotonic()
+        try:
+            # pause generation and wait for in-flight requests
+            await asyncio.wait_for(
+                engine_client.pause_generation(
+                    wait_for_inflight_requests=True,
+                    clear_cache=False,
+                ),
+                timeout=drain_timeout,
+            )
+            elapsed = time.monotonic() - start_time
+            logger.info(
+                "Graceful shutdown: drain complete, drained %d requests in %.1fs",
+                inflight_count,
+                elapsed,
+            )
+        except asyncio.TimeoutError:
+            elapsed = time.monotonic() - start_time
+            remaining = engine_client.get_num_unfinished_requests()
+            logger.warning(
+                "Graceful shutdown: drain timed out after %.1fs, "
+                "%d requests remaining, proceeding with shutdown",
+                elapsed,
+                remaining,
+            )
+        except Exception as e:
+            logger.warning("Graceful shutdown: drain failed: %s", e)
+
     def signal_handler() -> None:
         # prevents the uvicorn signal handler to exit early
         server_task.cancel()
@@ -88,11 +144,24 @@ async def serve_http(
         if ssl_cert_refresher:
             ssl_cert_refresher.stop()
 
+    async def graceful_signal_handler() -> None:
+        """Async wrapper for graceful shutdown."""
+        await graceful_drain()
+        signal_handler()
+
+    def on_signal() -> None:
+        """Signal callback that spawns the graceful shutdown task."""
+        args = getattr(app.state, "args", None)
+        if getattr(args, "enable_graceful_shutdown", False):
+            loop.create_task(graceful_signal_handler())
+        else:
+            signal_handler()
+
     async def dummy_shutdown() -> None:
         pass
 
-    loop.add_signal_handler(signal.SIGINT, signal_handler)
-    loop.add_signal_handler(signal.SIGTERM, signal_handler)
+    loop.add_signal_handler(signal.SIGINT, on_signal)
+    loop.add_signal_handler(signal.SIGTERM, on_signal)
 
     try:
         await server_task

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -980,7 +980,12 @@ async def init_app_state(
     state.args = args
 
     # initialize draining metric to 0 so it's scrapeable from startup
-    get_server_draining_gauge(engine_client.model_config.served_model_name)
+    served_name = engine_client.model_config.served_model_name
+    if isinstance(served_name, list):
+        draining_model_name = served_name[0] if served_name else "unknown"
+    else:
+        draining_model_name = served_name or "unknown"
+    get_server_draining_gauge(draining_model_name)
 
     supported_tasks = await engine_client.get_supported_tasks()
     logger.info("Supported tasks: %s", supported_tasks)

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -75,9 +75,7 @@ from vllm.entrypoints.pooling.embed.serving import OpenAIServingEmbedding
 from vllm.entrypoints.pooling.pooling.serving import OpenAIServingPooling
 from vllm.entrypoints.pooling.score.serving import ServingScores
 from vllm.entrypoints.serve.disagg.serving import ServingTokens
-from vllm.entrypoints.serve.elastic_ep.middleware import (
-    ScalingMiddleware,
-)
+from vllm.entrypoints.serve.middleware import ScalingMiddleware
 from vllm.entrypoints.serve.tokenize.serving import OpenAIServingTokenization
 from vllm.entrypoints.tool_server import DemoToolServer, MCPToolServer, ToolServer
 from vllm.entrypoints.utils import (
@@ -99,6 +97,7 @@ from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.gc_utils import freeze_gc_heap
 from vllm.utils.network_utils import is_valid_ipv6_address
 from vllm.utils.system_utils import decorate_logs, set_ulimit
+from vllm.v1.metrics.prometheus import get_server_draining_gauge
 from vllm.version import __version__ as VLLM_VERSION
 
 prometheus_multiproc_dir: tempfile.TemporaryDirectory
@@ -979,6 +978,10 @@ async def init_app_state(
     state.log_stats = not args.disable_log_stats
     state.vllm_config = vllm_config
     state.args = args
+
+    # initialize draining metric to 0 so it's scrapeable from startup
+    get_server_draining_gauge(engine_client.model_config.served_model_name)
+
     supported_tasks = await engine_client.get_supported_tasks()
     logger.info("Supported tasks: %s", supported_tasks)
 

--- a/vllm/entrypoints/serve/elastic_ep/api_router.py
+++ b/vllm/entrypoints/serve/elastic_ep/api_router.py
@@ -13,9 +13,9 @@ from vllm.entrypoints.openai.api_server import validate_json_request
 from vllm.entrypoints.openai.engine.protocol import (
     ErrorResponse,
 )
-from vllm.entrypoints.serve.elastic_ep.middleware import (
-    get_scaling_elastic_ep,
-    set_scaling_elastic_ep,
+from vllm.entrypoints.serve.middleware import (
+    is_server_unavailable,
+    set_server_unavailable,
 )
 from vllm.logger import init_logger
 
@@ -65,7 +65,7 @@ async def scale_elastic_ep(raw_request: Request):
         )
 
     # Set scaling flag to prevent new requests
-    set_scaling_elastic_ep(True)
+    set_server_unavailable(True)
     client = engine_client(raw_request)
     try:
         await client.scale_elastic_ep(new_data_parallel_size, drain_timeout)
@@ -84,12 +84,12 @@ async def scale_elastic_ep(raw_request: Request):
         logger.error("Scale failed: %s", e)
         raise HTTPException(status_code=500, detail="Scale failed") from e
     finally:
-        set_scaling_elastic_ep(False)
+        set_server_unavailable(False)
 
 
 @router.post("/is_scaling_elastic_ep")
 async def is_scaling_elastic_ep(raw_request: Request):
-    return JSONResponse({"is_scaling_elastic_ep": get_scaling_elastic_ep()})
+    return JSONResponse({"is_scaling_elastic_ep": is_server_unavailable()})
 
 
 def attach_router(app: FastAPI):

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -614,6 +614,10 @@ class AsyncLLM(EngineClient):
         async with self._pause_cond:
             return self._paused
 
+    def get_num_unfinished_requests(self) -> int:
+        """Return the number of in-flight requests."""
+        return self.output_processor.get_num_unfinished_requests()
+
     async def encode(
         self,
         prompt: PromptType,


### PR DESCRIPTION
- Add new optional signal handler for the API server on SIGINT and SIGTERM that waits for all running requests to complete before shutting down
- Update /health endpoint behavior to report unhealthy/not ready during drain, add new `/live` endpoint with same semantics of old /health endpoint
- Expose new gauge metrics so ELBs can intuit the server is in a draining state and route traffic around it

Uses the same engine internals and middleware implementation that EPLB relies on, could use some review there cc @tlrmchlsmth 

**Note:** Needs a follow up stacked PR to also add the KVConnection drain-wait semantics @markmc calls out in #24885, this will require more plumbing of state from the KCConnector workers back up to the API server and signal handler.