### PR TITLE
Fix optional parameter parsing in MiniMax M2 tool parser #32278

### DIFF
--- a/vllm/tool_parsers/minimax_m2_tool_parser.py
+++ b/vllm/tool_parsers/minimax_m2_tool_parser.py
@@ -217,15 +217,12 @@ class MinimaxM2ToolParser(ToolParser):
         Returns:
             The converted value
         """
-        if value.lower() == "null":
+        # Check if the VALUE itself indicates null (not just if null is allowed)
+        if value.lower() in ("null", "none", "nil"):
             return None
 
         # Normalize types
         normalized_types = [t.lower() for t in param_types]
-
-        # Try null first if it's in the list
-        if "null" in normalized_types or value.lower() in ("null", "none", "nil"):
-            return None
 
         # Try each type in order of preference (most specific first, string as fallback)
         # Priority: integer > number > boolean > object > array > string


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
#32278
 
## Test Plan
```
 CUDA_VISIBLE_DEVICES=0,1,2,3 \
python -m vllm.entrypoints.openai.api_server \
  --model MiniMaxAI/MiniMax-M2 \
  --tensor-parallel-size 4 \
  --gpu-memory-utilization 0.90 \
  --max-model-len 32768 \
  --enable-auto-tool-choice \
  --tool-call-parser minimax_m2 \
  --trust-remote-code \
  --port 8000
```
```
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "MiniMaxAI/MiniMax-M2",
    "messages": [{
      "role": "user",
      "content": "使用 run_shell 工具，command 参数是 date，logfile 参数必须是 /tmp/foo（不是空值）"
    }],
    "tools": [{
      "type": "function",
      "function": {
        "name": "run_shell",
        "description": "执行 shell 命令",
        "parameters": {
          "type": "object",
          "properties": {
            "command": {"type": "string"},
            "logfile": {"type": ["string", "null"]}
          },
          "required": ["command"]
        }
      }
    }],
    "tool_choice": "auto"
  }'
```
## Test Result
main branch:
"logprobs":null,
```
           "command": {"type": "string"},
            "logfile": {"type": ["string", "null"]}
          },
          "required": ["command"]
        }
      }
    }],
    "tool_choice": "auto"
  }'
{"id":"chatcmpl-92af089130f8e5ad","object":"chat.completion","created":1768411489,"model":"MiniMaxAI/MiniMax-M2","choices":[{"index":0,"message":{"role":"assistant","content":"Okay, let's analyze what the user is asking. They want me to execute a shell command using the run_shell tool, and they've specified two parameters:\n1. The command to execute: \"date\" (which displays the current date and time)\n2. The log file where output should be saved: \"/tmp/foo\"\n\nLooking at the run_shell tool description in my system message, I can see it has two parameters:\n- \"command\": A string representing the shell command to execute\n- \"logfile\": A string representing the file where command output should be logged (optional)\n\nThe user has provided values for both parameters, which is good because \"command\" is required and \"logfile\" is optional but they've specified it anyway.\n\nTo execute this request, I need to format a proper tool call using the specified XML format with the tool name and JSON arguments. The tool name is \"run_shell\" and the arguments are the command and logfile parameters.\n\nI'll structure my response as a tool call with:\n- The tool name: \"run_shell\"\n- The arguments: A JSON object containing the command \"date\" and the logfile \"/tmp/foo\"\n\nThis should execute the date command and save its output to the specified log file. The date command typically outputs something like \"Thu Jun 17 14:23:45 UTC 2023\" depending on the system and date/time settings.\n\nSo I'll use the tool_calls format as instructed in my system message to make this request.\n</think>\n\n\n","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[{"id":"chatcmpl-tool-960e310b9581fec6","type":"function","function":{"name":"run_shell","arguments":"{\"command\": \"date\", \"logfile\": null}"}}],"reasoning":null,"reasoning_content":null},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":216,"total_tokens":558,"completion_tokens":342,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}(vllm)  

```

<img width="1161" height="369" alt="image" src="https://github.com/user-attachments/assets/0f954098-9367-4fca-825a-1ef10910ef65" />
\"logfile\": \"/tmp/foo\"}" 
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

