### PR TITLE
[ROCm][CI] Pin transformers 4.57.3 to fix jina test failures

### DIFF
--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -90,3 +90,5 @@ perceptron==0.1.4
 timm==1.0.17
 # Required for plugins test
 albumentations==1.4.6
+# Pin transformers version
+transformers==4.57.3


### PR DESCRIPTION
This PR pins the `transformers` dependency to version `4.57.3` to resolve test failures introduced in `transformers==4.57.5`.

## Problem

The following tests fail with `transformers>=4.57.5`:

- `tests/models/multimodal/pooling/test_jinavl_reranker.py::test_model_text_image`
- `tests/models/multimodal/pooling/test_jinavl_reranker.py::test_model_text_text`
- `tests/models/multimodal/pooling/test_jinavl_reranker.py::test_model_image_text`
- `tests/models/multimodal/pooling/test_jinavl_reranker.py::test_model_image_image`
- `tests/models/multimodal/pooling/test_jinavl_reranker.py::test_model_text_mixed_documents`

Two distinct errors occur:

1. **`AttributeError: Qwen2TokenizerFast has no attribute tokenizer`**
   
   The Jina model's custom modeling code accesses `self._processor.tokenizer`, but changes to `__getattr__` in `tokenization_utils_base.py` now raise an `AttributeError` for attributes not in `__dict__`.

2. **`TypeError: PreTrainedTokenizerFast._batch_encode_plus() got an unexpected keyword argument 'images'`**
   
   The model passes `images` to the processor/tokenizer, but the updated `_batch_encode_plus()` no longer accepts this argument.

## Root Cause

This is a regression in `transformers==4.57.5`. An upstream issue has been filed: [huggingface/transformers#43295](https://github.com/huggingface/transformers/issues/43295)

## Solution

Pin `transformers==4.57.3` until the upstream regression is resolved.

## Testing

All 5 failing tests pass with `transformers==4.57.3`.