### PR TITLE
[ROCm][CI] Disable async scheduling on ROCm for test_structured_output[meta-llama/Meta-Llama-3.1-8B-Instruct-xgrammar-auto-speculative_config9]

### DIFF
--- a/tests/v1/entrypoints/llm/test_struct_output_generate.py
+++ b/tests/v1/entrypoints/llm/test_struct_output_generate.py
@@ -35,6 +35,7 @@ EAGLE_SPEC_CONFIG = {
     "method": "eagle",
     "model": "yuhuili/EAGLE-LLaMA3.1-Instruct-8B",
     "num_speculative_tokens": 5,
+    "async_scheduling": False,
 }
 
 PARAMS_MODELS_BACKENDS_TOKENIZER_MODE = [
@@ -87,6 +88,10 @@ PARAMS_MODELS_TOKENIZER_MODE = [
     ("Qwen/Qwen2.5-1.5B-Instruct", "auto"),
 ]
 
+platform_args = {}
+if current_platform.is_rocm():
+    platform_args["async_scheduling"] = False
+
 
 class CarType(str, Enum):
     sedan = "sedan"
@@ -134,6 +139,7 @@ def test_structured_output(
         load_format="auto" if not model_name.startswith("mistralai/") else "hf",
         config_format="auto" if not model_name.startswith("mistralai/") else "hf",
         speculative_config=speculative_config,
+        **platform_args,
     )
 
     #
@@ -649,6 +655,7 @@ def test_structured_output_with_reasoning_matrices(
         ),
         tokenizer_mode=tokenizer_mode,
         speculative_config=speculative_config,
+        **({"async_scheduling": False} if current_platform.is_rocm() else {}),
         async_scheduling=async_scheduling,
     )
     tokenizer = llm.get_tokenizer()

--- a/tests/v1/entrypoints/llm/test_struct_output_generate.py
+++ b/tests/v1/entrypoints/llm/test_struct_output_generate.py
@@ -35,7 +35,6 @@ EAGLE_SPEC_CONFIG = {
     "method": "eagle",
     "model": "yuhuili/EAGLE-LLaMA3.1-Instruct-8B",
     "num_speculative_tokens": 5,
-    "async_scheduling": False,
 }
 
 PARAMS_MODELS_BACKENDS_TOKENIZER_MODE = [
@@ -655,7 +654,6 @@ def test_structured_output_with_reasoning_matrices(
         ),
         tokenizer_mode=tokenizer_mode,
         speculative_config=speculative_config,
-        **({"async_scheduling": False} if current_platform.is_rocm() else {}),
         async_scheduling=async_scheduling,
     )
     tokenizer = llm.get_tokenizer()


### PR DESCRIPTION
<!-- markdownlint-disable -->
**Problem**

The issue was exposed in the V1 Test entrypoints test group in AMD CI after https://github.com/vllm-project/vllm/pull/31998 enabled async scheduling by default with spec decoding. The test group has been failing ever since that PR was merged(e.g. in [build#2803](https://buildkite.com/vllm/amd-ci/builds/2803/steps/canvas?jid=019bb8eb-2c9d-4f84-8953-924632dcf649)). It passes if you set async_scheduling=False. The failure can be reproduced with this command:
`pytest -v -s tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output[meta-llama/Meta-Llama-3.1-8B-Instruct-xgrammar-auto-speculative_config9]`.

To unblock AMD CI, I am proposing that we disable async scheduling for this test case until we are able to track down and fix the underlying issue.