### PR TITLE
MXFP8 Online Quantization for Linear

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -773,7 +773,7 @@ steps:
   # TODO(jerryzh168): resolve the above comment
   - uv pip install --system torchao==0.14.1
   - uv pip install --system conch-triton-kernels
-  - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
+  - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py --ignore quantization/test_mxfp8.py
 
 - label: LM Eval Small Models # 53min
   timeout_in_minutes: 75

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -725,7 +725,7 @@ steps:
   # TODO(jerryzh168): resolve the above comment
   - uv pip install --system torchao==0.14.1 --index-url https://download.pytorch.org/whl/cu129
   - uv pip install --system conch-triton-kernels
-  - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
+  - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py --ignore quantization/test_mxfp8.py
 
 - label: LM Eval Small Models # 53min
   timeout_in_minutes: 75
@@ -1169,6 +1169,16 @@ steps:
   - vllm/v1/attention/backends/flashinfer.py
   commands:
     - pytest -s -v tests/quantization/test_blackwell_moe.py
+
+- label: Blackwell Quantized Linear Test
+  timeout_in_minutes: 30
+  working_dir: "/vllm-workspace/"
+  gpu: b200
+  source_file_dependencies:
+  - tests/quantization/test_mxfp8.py
+  - vllm/model_executor/layers/quantization/mxfp8.py
+  commands:
+    - pytest -s -v tests/quantization/test_mxfp8.py
 
 - label: Blackwell LM Eval Small Models
   timeout_in_minutes: 120

--- a/.buildkite/test_areas/quantization.yaml
+++ b/.buildkite/test_areas/quantization.yaml
@@ -18,7 +18,7 @@ steps:
   # TODO(jerryzh168): resolve the above comment
   - uv pip install --system torchao==0.13.0 --index-url https://download.pytorch.org/whl/cu129
   - uv pip install --system conch-triton-kernels
-  - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py
+  - VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py --ignore quantization/test_mxfp8.py
 
 - label: Quantized MoE Test (B200)
   timeout_in_minutes: 60
@@ -36,6 +36,16 @@ steps:
   - vllm/v1/attention/backends/flashinfer.py
   commands:
     - pytest -s -v tests/quantization/test_blackwell_moe.py
+
+- label: Quantized Linear Test (B200)
+  timeout_in_minutes: 30
+  working_dir: "/vllm-workspace/"
+  gpu: b200
+  source_file_dependencies:
+  - tests/quantization/test_mxfp8.py
+  - vllm/model_executor/layers/quantization/mxfp8.py
+  commands:
+    - pytest -s -v tests/quantization/test_mxfp8.py
 
 - label: Quantized Models Test
   timeout_in_minutes: 60

--- a/tests/quantization/test_mxfp8.py
+++ b/tests/quantization/test_mxfp8.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for MXFP8 (Microscaling FP8) online quantization.
+
+Run `pytest tests/quantization/test_mxfp8.py --forked`.
+"""
+
+import pytest
+import torch
+
+from tests.quantization.utils import is_quant_method_supported
+from vllm.model_executor.layers.quantization.mxfp8 import Mxfp8LinearMethod
+
+
+def compute_sqnr(output: torch.Tensor, ref_output: torch.Tensor) -> float:
+    """Compute Signal-to-Quantization-Noise Ratio (SQNR) in dB.
+
+    SQNR = 10 * log10(signal_power / noise_power)
+
+    Args:
+        output: Quantized output tensor.
+        ref_output: Reference (full precision) output tensor.
+
+    Returns:
+        SQNR in dB.
+    """
+    noise = output - ref_output
+    signal_power = (ref_output**2).mean()
+    noise_power = (noise**2).mean()
+    return 10 * torch.log10(signal_power / noise_power).item()
+
+
+@pytest.mark.skipif(
+    not is_quant_method_supported("mxfp8"),
+    reason="MXFP8 is not supported on this GPU type (requires SM100+/Blackwell).",
+)
+@pytest.mark.parametrize("enforce_eager", [True, False])
+def test_load_bf16_model(vllm_runner, monkeypatch, enforce_eager: bool) -> None:
+    """Test loading a BF16 model with MXFP8 online quantization."""
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+    monkeypatch.setenv("VLLM_USE_COMPILE_CACHE", "1")
+
+    with vllm_runner(
+        "facebook/opt-125m",
+        quantization="mxfp8",
+        enforce_eager=enforce_eager,
+        dtype="bfloat16",
+    ) as llm:
+
+        def check_model(model):
+            fc1 = model.model.decoder.layers[0].fc1
+            assert isinstance(fc1.quant_method, Mxfp8LinearMethod)
+            # Weights should be quantized to FP8
+            assert fc1.weight.dtype == torch.float8_e4m3fn
+
+        llm.apply_model(check_model)
+
+        # Basic generation test
+        outputs = llm.generate_greedy(["Hello my name is"], max_tokens=4)
+        print(outputs[0][1])
+
+
+@pytest.mark.skipif(
+    not is_quant_method_supported("mxfp8"),
+    reason="MXFP8 is not supported on this GPU type (requires SM100+/Blackwell).",
+)
+@pytest.mark.parametrize("use_bias", [True, False])
+def test_mxfp8_linear_method_apply(dist_init, use_bias: bool) -> None:
+    """Test Mxfp8LinearMethod.apply produces numerically reasonable results."""
+    from vllm.model_executor.layers.quantization.mxfp8 import Mxfp8Config
+    from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+    config = Mxfp8Config()
+    method = Mxfp8LinearMethod(config)
+
+    # Create layer and weights
+    # Use sizes that are multiples of 128 for proper blocking
+    layer = torch.nn.Module()
+    input_size = 256  # Must be multiple of 32 (block size)
+    output_size = 128
+
+    with torch.device("cuda"):
+        method.create_weights(
+            layer=layer,
+            input_size_per_partition=input_size,
+            output_partition_sizes=[output_size],
+            input_size=input_size,
+            output_size=output_size,
+            params_dtype=torch.bfloat16,
+            weight_loader=default_weight_loader,
+        )
+
+        # Initialize weights
+        weight_ref = torch.randn(output_size, input_size, dtype=torch.bfloat16)
+        layer.weight.data.copy_(weight_ref)
+
+        # Process weights (quantize)
+        method.process_weights_after_loading(layer)
+
+        # Create input and optional bias
+        x = torch.randn(4, input_size, dtype=torch.bfloat16, device="cuda")
+        bias = (
+            torch.randn(output_size, dtype=torch.bfloat16, device="cuda")
+            if use_bias
+            else None
+        )
+
+        # Run MXFP8 forward pass
+        output = method.apply(layer, x, bias=bias)
+
+        # Reference: BF16 linear
+        ref_output = torch.nn.functional.linear(x, weight_ref.cuda(), bias)
+
+        # Check outputs using SQNR (Signal-to-Quantization-Noise Ratio)
+        sqnr = compute_sqnr(output, ref_output)
+        assert sqnr > 15, f"SQNR {sqnr:.2f} dB is too low (expected > 15 dB)"

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -33,6 +33,7 @@ QuantizationMethods = Literal[
     "torchao",
     "inc",
     "mxfp4",
+    "mxfp8",
     "petit_nvfp4",
     "cpu_awq",
 ]
@@ -134,6 +135,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
     from .modelopt import ModelOptFp8Config, ModelOptNvFp4Config
     from .moe_wna16 import MoeWNA16Config
     from .mxfp4 import Mxfp4Config
+    from .mxfp8 import Mxfp8Config
     from .petit import PetitNvFp4Config
     from .ptpc_fp8 import PTPCFp8Config
     from .torchao import TorchAOConfig
@@ -163,6 +165,7 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
         "auto-round": INCConfig,
         "inc": INCConfig,
         "mxfp4": Mxfp4Config,
+        "mxfp8": Mxfp8Config,
         "petit_nvfp4": PetitNvFp4Config,
         "cpu_awq": CPUAWQConfig,
     }

--- a/vllm/model_executor/layers/quantization/mxfp8.py
+++ b/vllm/model_executor/layers/quantization/mxfp8.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+MXFP8 (Microscaling FP8) Quantization for Linear layers.
+
+This module implements online MXFP8 quantization with dynamic activation
+scaling. MXFP8 uses block-based scaling where each block of 32 elements
+shares a single scale factor (torch.float8_e8m0fnu format).
+
+Note: MXFP8 with native cuBLAS MX GEMM requires SM100+ (Blackwell).
+"""
+
+from typing import Any, Optional
+
+import torch
+from torch.nn import Module
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    UnquantizedLinearMethod,
+)
+from vllm.model_executor.layers.quantization import QuantizationMethods
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from vllm.model_executor.layers.quantization.utils.mxfp8_utils import (
+    mxfp8_quantize,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    is_layer_skipped,
+)
+from vllm.model_executor.parameter import ModelWeightParameter
+
+logger = init_logger(__name__)
+
+MIN_M_REQUIRED = 32
+
+
+def _mxfp8_linear_forward_impl(
+    x: torch.Tensor,
+    weight_fp8: torch.Tensor,
+    w_scale_blocked: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> torch.Tensor:
+    """MXFP8 linear forward pass implementation.
+
+    Args:
+        x: Input tensor of shape [..., K] in bfloat16.
+        weight_fp8: Quantized weight tensor of shape [N, K] in float8_e4m3fn.
+        w_scale_blocked: Weight scale in cuBLAS blocked layout.
+        bias: Optional bias tensor of shape [N].
+
+    Returns:
+        Output tensor of shape [..., N] in bfloat16.
+    """
+    orig_shape = x.shape
+    K = orig_shape[-1]
+    M = x.numel() // K
+    N = weight_fp8.shape[0]
+
+    # Reshape input to 2D: [..., K] -> [M, K]
+    x_2d = x.reshape(M, K)
+
+    # PAD M dimension to minimum of 32 for cuBLAS bias support
+    # (cuBLAS MX GEMM with bias requires M >= 17)
+    # Always pad/unpad to keep control flow static for torch.compile/cudagraph
+    padded_M = max(M, MIN_M_REQUIRED)
+    padded_shape = [padded_M, K]
+    padded_x = torch.zeros(padded_shape, device=x_2d.device, dtype=x_2d.dtype)
+    padded_x[0:M, ...].copy_(x_2d)
+
+    # Quantize input activation to MXFP8 with swizzled scale layout
+    x_fp8, x_scale_blocked = mxfp8_quantize(padded_x)
+
+    # Assertions for contiguity (matching torchao pattern)
+    assert x_fp8.is_contiguous(), "Input must be contiguous"
+    assert weight_fp8.is_contiguous(), "Weight must be contiguous"
+
+    # Use torch._scaled_mm with block scales
+    # a (x_fp8): [M_padded, K] row-major (contiguous)
+    # b (weight_fp8.t()): [K, N] column-major (weight_fp8 is [N, K] row-major,
+    #   so weight_fp8.t() is [K, N] with stride [1, K] = column-major)
+    output = torch._scaled_mm(
+        x_fp8,
+        weight_fp8.t(),  # [K, N] column-major
+        x_scale_blocked,
+        w_scale_blocked,
+        bias=bias,
+        out_dtype=torch.bfloat16,
+    )
+
+    # Remove padding from output (always slice to keep control flow static)
+    output = output[0:M, ...]
+
+    output_shape = orig_shape[:-1] + (N,)
+    output = output.view(*output_shape)
+
+    return output
+
+
+class Mxfp8Config(QuantizationConfig):
+    """Config class for MXFP8 (Microscaling FP8) quantization.
+
+    MXFP8 uses block-based quantization where each block of 32 elements
+    shares a single torch.float8_e8m0fnu scale factor. This provides a balance
+    between per-tensor and per-channel quantization granularity.
+
+    Args:
+        ignored_layers: List of layer name patterns to skip quantization.
+    """
+
+    def __init__(
+        self,
+        ignored_layers: list[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self.ignored_layers = ignored_layers or []
+
+    @classmethod
+    def get_name(cls) -> QuantizationMethods:
+        return "mxfp8"
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> list[torch.dtype]:
+        return [torch.bfloat16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        # MXFP8 with native cuBLAS MX GEMM requires SM100+ (Blackwell)
+        return 100
+
+    @classmethod
+    def get_config_filenames(cls) -> list[str]:
+        return []
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "Mxfp8Config":
+        ignored_layers = cls.get_from_keys_or(config, ["ignored_layers"], None)
+        if not ignored_layers:
+            ignored_layers = cls.get_from_keys_or(
+                config, ["modules_to_not_convert"], None
+            )
+        return cls(ignored_layers=ignored_layers)
+
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> Optional["QuantizeMethodBase"]:
+        if isinstance(layer, LinearBase):
+            if is_layer_skipped(
+                prefix=prefix,
+                ignored_layers=self.ignored_layers,
+                fused_mapping=self.packed_modules_mapping,
+            ):
+                return UnquantizedLinearMethod()
+            return Mxfp8LinearMethod(self)
+        return None
+
+
+class Mxfp8LinearMethod(LinearMethodBase):
+    """Linear method for MXFP8 online quantization.
+
+    Implements online (dynamic) MXFP8 quantization where:
+    - Weights are quantized to torch.float8_e4m3fn with block-wise
+      torch.float8_e8m0fnu scales
+    - Activations are dynamically quantized at runtime
+
+    This is the simplest MXFP8 implementation for linear layers.
+
+    Args:
+        quant_config: The MXFP8 quantization config.
+    """
+
+    def __init__(self, quant_config: Mxfp8Config):
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        """Create weight parameters for MXFP8 linear layer.
+
+        For online quantization, weights are stored in the original dtype
+        and quantized after loading.
+
+        Note: This implementation only supports online quantization.
+        Pre-quantized MXFP8 checkpoints are not supported.
+        """
+        # Assert bfloat16 for online quantization
+        assert params_dtype == torch.bfloat16, (
+            "MXFP8 only supports bfloat16 params_dtype for online quantization. "
+            f"Got params_dtype={params_dtype}"
+        )
+
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+        layer.orig_dtype = params_dtype
+
+        # Create weight in original dtype for online quantization
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition,
+                dtype=params_dtype,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight", weight)
+
+    def process_weights_after_loading(self, layer: Module) -> None:
+        """Quantize weights to MXFP8 format after loading.
+
+        Converts weights from original dtype to torch.float8_e4m3fn with
+        block-wise torch.float8_e8m0fnu scale factors. Weight scales are
+        pre-converted to cuBLAS blocked layout for efficient runtime usage.
+
+        Weight is stored as [N, K] row-major. When passed to _scaled_mm,
+        we use weight.t() which gives [K, N] column-major (as required by cuBLAS).
+        """
+        weight = layer.weight.data
+
+        # Ensure weight is contiguous before quantization
+        weight = weight.contiguous()
+
+        # Quantize weight to MXFP8 format with swizzled scale layout
+        weight_fp8, w_scale_blocked = mxfp8_quantize(weight)
+
+        # Store weight as [N, K] row-major (standard contiguous layout)
+        # When we call weight.t() in apply(), we get [K, N] column-major
+        # which is what cuBLAS _scaled_mm expects for the second argument
+        layer.weight = torch.nn.Parameter(weight_fp8, requires_grad=False)
+        # Store pre-blocked weight scale in torch.float8_e8m0fnu format
+        layer.weight_scale = torch.nn.Parameter(w_scale_blocked, requires_grad=False)
+        layer.orig_dtype = layer.orig_dtype
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Apply MXFP8 quantized linear operation.
+
+        Quantizes input activation dynamically and performs FP8 matmul
+        using torch._scaled_mm with block scales.
+
+        Note: Requires SM100+ (Blackwell) for native cuBLAS MX GEMM support.
+
+        Args:
+            layer: The linear layer with quantized weights.
+            x: Input tensor of shape [..., K].
+            bias: Optional bias tensor.
+
+        Returns:
+            Output tensor of shape [..., N].
+        """
+        return _mxfp8_linear_forward_impl(
+            x,
+            layer.weight,
+            layer.weight_scale,
+            bias,
+        )

--- a/vllm/model_executor/layers/quantization/utils/mxfp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp8_utils.py
@@ -1,16 +1,29 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""MXFP8 quantization utilities.
+
+Contains both flashinfer-based quantization (for fused_moe) and
+torch.compile-compatible implementation based on torchao's mx_formats.
+"""
 
 import torch
 
-from vllm.logger import init_logger
+# MXFP8 block size (number of elements sharing one scale)
+MXFP8_BLOCK_SIZE = 32
 
-logger = init_logger(__name__)
+
+def _ceil_div(a: int, b: int) -> int:
+    """Ceiling division."""
+    return (a + b - 1) // b
 
 
 def mxfp8_e4m3_quantize(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize tensor to MXFP8 using flashinfer.
+
+    Used by fused_moe. For torch.compile-compatible version, use mxfp8_quantize.
+    """
     try:
-        from flashinfer import mxfp8_quantize as mxfp8_e4m3_quantize
+        from flashinfer import mxfp8_quantize as flashinfer_mxfp8_quantize
     except ImportError as err:
         raise ImportError(
             "The package `flashinfer` is required to do "
@@ -18,7 +31,184 @@ def mxfp8_e4m3_quantize(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
             "`pip install flashinfer`"
         ) from err
 
-    x_q, x_scales = mxfp8_e4m3_quantize(x, is_sf_swizzled_layout=False)
+    x_q, x_scales = flashinfer_mxfp8_quantize(x, is_sf_swizzled_layout=False)
     if x_scales.ndim == 1:
         x_scales = x_scales.view(x.size(0), -1)
     return x_q, x_scales
+
+
+# from https://github.com/pytorch/ao/blob/21acb9c63f3ae01365821475df7cd2a2a96a5eb8/torchao/prototype/mx_formats/utils.py#L32
+def _to_blocked(input_matrix: torch.Tensor) -> torch.Tensor:
+    """
+    Rearrange scale matrix to cuBLAS blocked layout.
+
+    See: https://docs.nvidia.com/cuda/cublas/index.html#d-block-scaling-factors-layout
+
+    Args:
+        input_matrix: Input tensor of shape (H, W)
+
+    Returns:
+        Rearranged flattened tensor for cuBLAS consumption.
+    """
+    rows, cols = input_matrix.shape
+    n_row_blocks = _ceil_div(rows, 128)
+    n_col_blocks = _ceil_div(cols, 4)
+
+    # Calculate the padded shape
+    padded_rows = n_row_blocks * 128
+    padded_cols = n_col_blocks * 4
+
+    padded = input_matrix
+    # Always create padded tensor when compiling to avoid dynamic shape issues
+    # (This follows torchao's pattern for vLLM compatibility)
+    if torch.compiler.is_compiling() or (rows, cols) != (padded_rows, padded_cols):
+        padded = torch.zeros(
+            (padded_rows, padded_cols),
+            device=input_matrix.device,
+            dtype=input_matrix.dtype,
+        )
+        padded[:rows, :cols] = input_matrix
+
+    # Rearrange the blocks
+    blocks = padded.view(n_row_blocks, 128, n_col_blocks, 4).permute(0, 2, 1, 3)
+    rearranged = blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16)
+    return rearranged.flatten()
+
+
+# torch.float8_e8m0fnu scale format constants
+E8M0_EXPONENT_BIAS = 127
+
+# torch.float8_e4m3fn constants
+F8E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max  # 448.0
+
+
+# from https://github.com/pytorch/ao/blob/c6d21f9b82819a7e3546a267eafb15a5b8cf3951/torchao/prototype/mx_formats/mx_tensor.py#L96
+def _to_mx_rceil(
+    data_hp: torch.Tensor,
+    max_abs: torch.Tensor,
+    max_pos: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    MXFP scale factor derivation method described in
+    https://docs.nvidia.com/cuda/cublas/#d-block-quantization
+
+    Args:
+        data_hp: High precision data.
+        max_abs: Maximum absolute value for data_hp along specified
+            dimension/block_size.
+        max_pos: The maximum value of the low precision data type.
+
+    Returns:
+        exponent: The biased exponent with torch.float8_e8m0fnu dtype in uint8
+            container.
+        data_lp: The targeted low precision data, in high precision container
+            (requires cast to low precision data type).
+    """
+    descale = max_abs / max_pos
+    exponent = torch.where(
+        torch.isnan(descale),
+        0xFF,  # Handle biased exponent for nan
+        (
+            torch.clamp(
+                torch.ceil(torch.log2(descale)),
+                min=-E8M0_EXPONENT_BIAS,
+                max=E8M0_EXPONENT_BIAS,
+            )
+            + E8M0_EXPONENT_BIAS
+        ).to(torch.uint8),
+    )
+
+    descale_fp = torch.where(
+        exponent == 0, 1.0, torch.exp2(E8M0_EXPONENT_BIAS - exponent.to(torch.float32))
+    )
+
+    # scale and saturated cast the data elements to max of target dtype
+    data_lp = torch.clamp(data_hp * descale_fp, min=-1 * max_pos, max=max_pos)
+    return exponent, data_lp
+
+
+# from https://github.com/pytorch/ao/blob/21acb9c63f3ae01365821475df7cd2a2a96a5eb8/torchao/prototype/mx_formats/utils.py#L122
+def _hp_data_dims_to_swizzled_scale_dims_mx(
+    hp_data_M: int,
+    hp_data_K: int,
+) -> tuple[int, int]:
+    """
+    Given the M and K dimensions of a high precision contiguous tensor,
+    returns a 2d tuple of the dims of the swizzled mx scale corresponding to
+    that tensor.
+    """
+    # a 128x128 unpacked or 128x64 packed qdata tile corresponds
+    # to a swizzled 32x16 scale tile
+    scale_M = _ceil_div(hp_data_M, 128) * 32
+    scale_K = _ceil_div(hp_data_K, 128) * 16
+    return scale_M, scale_K
+
+
+# from https://github.com/pytorch/ao/blob/21acb9c63f3ae01365821475df7cd2a2a96a5eb8/torchao/prototype/mx_formats/mx_tensor.py#L144
+# with the `ScaleCalculationMode.RCEIL` branch
+# and the `is_swizzled_scales` branch
+def mxfp8_quantize(
+    data: torch.Tensor,
+    block_size: int = MXFP8_BLOCK_SIZE,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a tensor to MXFP8 format.
+
+    Quantizes to torch.float8_e4m3fn with torch.float8_e8m0fnu block scales.
+    This is a torch.compile-compatible implementation based on the OCP
+    Microscaling spec and torchao's mx_formats.
+
+    Args:
+        data: Input tensor of shape [M, K] where K is divisible by block_size.
+        block_size: Number of elements per scale block (default: 32).
+
+    Returns:
+        Tuple of (quantized_data, scales) where:
+        - quantized_data: torch.float8_e4m3fn tensor of same shape as input
+        - scales: torch.float8_e8m0fnu scale tensor in cuBLAS blocked (swizzled)
+          layout with shape (scale_M, scale_K) where scale_M and scale_K are
+          computed by _hp_data_dims_to_swizzled_scale_dims_mx(M, K)
+    """
+    assert data.dtype == torch.bfloat16, f"Expected bfloat16, got {data.dtype}"
+    assert data.shape[-1] % block_size == 0, (
+        f"Last dim {data.shape[-1]} must be divisible by block_size {block_size}"
+    )
+    assert data.is_contiguous(), "Input must be contiguous"
+
+    orig_shape = data.shape
+    M, K = orig_shape[-2], orig_shape[-1]
+
+    # Reshape to [..., num_blocks, block_size]
+    data = data.reshape(*orig_shape[:-1], orig_shape[-1] // block_size, block_size)
+
+    # Find max absolute value per block
+    max_abs = torch.amax(torch.abs(data), dim=-1, keepdim=True)
+
+    # Cast to float32 for scale calculation
+    data = data.to(torch.float32)
+    max_abs = max_abs.to(torch.float32)
+
+    # Use rceil method for scale derivation
+    scale_e8m0, data_scaled = _to_mx_rceil(data, max_abs, F8E4M3_MAX)
+
+    # Cast to torch.float8_e4m3fn and reshape back to original shape
+    data_fp8 = data_scaled.to(torch.float8_e4m3fn).reshape(orig_shape)
+
+    # Reshape scales: remove the keepdim and get [..., num_blocks]
+    # Convert to torch.float8_e8m0fnu format (view uint8 as e8m0)
+    scale_e8m0 = scale_e8m0.squeeze(-1).view(torch.float8_e8m0fnu)
+
+    # Convert scale to cuBLAS blocked (swizzled) layout for best performance
+    # This matches torchao's is_swizzled_scales=True behavior
+    scale_shape = (M, K // block_size)
+    scale_blocked = _to_blocked(scale_e8m0.view(scale_shape))
+
+    # Reshape to swizzled scale dimensions (matches torchao)
+    # Note: We only support 2D inputs [M, K] currently, so leading_dims is empty.
+    # For batched inputs (e.g., [B, M, K] for MoE), torchao does:
+    #   leading_dims = orig_shape[:-2]
+    #   scale.view(*leading_dims, scale_M, scale_K)
+    # We will add leading_dims support when we add MoE quantization.
+    scale_M, scale_K = _hp_data_dims_to_swizzled_scale_dims_mx(M, K)
+    scale_e8m0_blocked = scale_blocked.view(scale_M, scale_K)
+
+    return data_fp8, scale_e8m0_blocked


### PR DESCRIPTION
Summary:
### 1. vllm/model_executor/layers/quantization/mxfp8.py (NEW)
**Purpose:** Main MXFP8 quantization implementation for linear layers with torch.compile support.
**Key Components:**
| Component | Description |
|-----------|-------------|
| MXFP8_BLOCK_SIZE = 32 | Block size for E8M0 scales |
| E8M0_EXPONENT_BIAS = 127 | E8M0 format exponent bias |
| F8E4M3_MAX_POW2 = 8 | Largest power of 2 in FP8 E4M3 |
| mxfp8_quantize() | torch.compile-compatible quantization using bit manipulation |
| _to_blocked() | Rearranges scale matrix to cuBLAS blocked layout |
| Mxfp8Config | Quantization config class (requires SM100+) |
| Mxfp8LinearMethod | Linear layer quantization method |

**Key Methods:**
- `mxfp8_quantize()` - Quantizes tensor to FP8 E4M3 with E8M0 block scales using bit manipulation (no external dependencies, torch.compile compatible)
- `_to_blocked()` - Converts scale matrix to cuBLAS blocked layout per NVIDIA spec, with `torch.compiler.is_compiling()` check for compile compatibility
- `create_weights()` - Creates weight parameters in bfloat16 for online quantization
- `process_weights_after_loading()` - Quantizes weights to FP8 E4M3 with pre-blocked E8M0 scales
- `apply()` - Dynamically quantizes activations, pads M dimension for bias support, performs matmul via torch._scaled_mm

**Dependencies:**
- torch._scaled_mm with block scales (E8M0 format)
- No external quantization library dependencies (replaced flashinfer with custom implementation)

---

### 2. vllm/model_executor/layers/quantization/__init__.py (MODIFIED)
**Changes:**
- Added "mxfp8" to QuantizationMethods literal type
- Added import: `from .mxfp8 import Mxfp8Config`
- Added mapping: `"mxfp8": Mxfp8Config`

---

### 3. tests/quantization/test_mxfp8.py (NEW)

**Tests:**

| Test | Description |
|------|-------------|
| test_load_bf16_model | End-to-end test loading facebook/opt-125m with MXFP8 quantization |
| test_mxfp8_linear_method_apply | Unit test for Mxfp8LinearMethod.apply() numerical correctness |

**Test Parameters:**
- `test_load_bf16_model` parametrized with `enforce_eager=[True, False]` (tests both eager and compile modes)
- `test_mxfp8_linear_method_apply` parametrized with `use_bias=[False, True]`
- Uses SQNR > 15 dB threshold for numerical correctness validation
- Skip Condition: Tests skip if GPU capability < SM100 (Blackwell)

**Helper Functions:**
- `compute_sqnr()` - Computes Signal-to-Quantization-Noise Ratio in dB
---


### Technical Details

<details>

```
Quantization Flow:
BF16 weights → mxfp8_quantize() → FP8 E4M3 + E8M0 scales
                                          ↓
                    scales → _to_blocked() → cuBLAS blocked layout (pre-computed)
                                          ↓
                    stored as layer.weight (FP8) + layer.weight_scale (blocked E8M0)
BF16 activations → pad M to 32 → mxfp8_quantize() → FP8 E4M3 + E8M0 scales
                                          ↓
                    scales → _to_blocked() → cuBLAS blocked layout (runtime)
                                          ↓
                    torch._scaled_mm(x_fp8, weight_fp8.t(),
                                    x_scale_blocked, w_scale_blocked,
                                    bias=bias, out_dtype=bf16)
                                          ↓
                    output → remove padding → view to original shape
                    
```
                    
Matrix Layout Requirements:
- Input (a): [M_padded, K] row-major (contiguous), M_padded = max(M, 32)
- Weight (b): [N, K] row-major → .t() → [K, N] column-major
- Input scales: [M_padded, K//32] → _to_blocked() → flattened cuBLAS format (runtime)
- Weight scales: [N, K//32] → _to_blocked() → flattened cuBLAS format (pre-computed)
- Bias: Passed directly to _scaled_mm (requires M >= 17, hence padding to 32)


torch.compile Compatibility:
- mxfp8_quantize() uses pure PyTorch ops with bit manipulation
- _to_blocked() has torch.compiler.is_compiling() check for consistent tensor creation
- M padding uses torch.compiler.is_compiling() check for consistent control flow
- Weight scales pre-blocked during loading to avoid runtime blocking under compile

```

</details>


**Requirements:**
- GPU: SM100+ (Blackwell)
- PyTorch: 2.8.0+ (for torch._scaled_mm with E8M0 block scales)
- Input dtype: bfloat16 only
- Online quantization only (no pre-quantized checkpoints)
**Usage:**
```bash
# With FLASH_ATTN backend (recommended for torch.compile)
VLLM_ATTENTION_BACKEND=FLASH_ATTN VLLM_DISABLE_COMPILE_CACHE=1 vllm serve <model> --dtype bfloat16 --quantization mxfp8
# Eager mode (works with any attention backend)
vllm serve <model> --dtype bfloat16 --quantization mxfp8 --enforce-eager
```

---
Test Commands

pytest tests/quantization/test_mxfp8.py

Result

<details>

```
============================= test session starts ==============================
platform linux -- Python 3.12.0, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/jerryzh/local/vllm
configfile: pyproject.toml
plugins: anyio-4.11.0
collected 4 items

tests/quantization/test_mxfp8.py ....                                    [100%]

=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/quantization/test_mxfp8.py::test_load_bf16_model[True]
tests/quantization/test_mxfp8.py::test_load_bf16_model[False]
  /home/jerryzh/.conda/envs/vllm/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=4157396) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 4 passed, 4 warnings in 40.00s ========================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```


```
VLLM_ATTENTION_BACKEND=FLASH_ATTN VLLM_DISABLE_COMPILE_CACHE=1 with-proxy vllm serve facebook/opt-125m --quantization mxfp8 --dtype bfloat16
```

<details>


Note that there are some pre-existing error the default flashinfer (without quantization), that's why we set attention backend to FLASH_ATTN:
```
(EngineCore_DP0 pid=3024207)   File "/home/jerryzh/local/vllm/vllm/v1/attention/backends/flashinfer.py", line 1507, in forward
(EngineCore_DP0 pid=3024207)     assert is_strictly_contiguous(decode_query)
(EngineCore_DP0 pid=3024207) AssertionError
[rank0]:[W114 17:28:57.561665561 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs
/stable/distributed.html#shutdown (function operator())
```

```
...
(APIServer pid=3525388) INFO 01-14 17:41:04 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=3525388) INFO 01-14 17:41:04 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=3525388) INFO 01-14 17:41:04 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=3525388) INFO 01-14 17:41:04 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=3525388) INFO 01-14 17:41:04 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=3525388) INFO 01-14 17:41:04 [launcher.py:46] Route: /classify, Methods: POST
(APIServer pid=3525388) INFO 01-14 17:41:04 [launcher.py:46] Route: /v1/embeddings, Methods: POST
(APIServer pid=3525388) INFO 01-14 17:41:04 [launcher.py:46] Route: /score, Methods: POST
(APIServer pid=3525388) INFO 01-14 17:41:04 [launcher.py:46] Route: /v1/score, Methods: POST
(APIServer pid=3525388) INFO 01-14 17:41:04 [launcher.py:46] Route: /rerank, Methods: POST
(APIServer pid=3525388) INFO 01-14 17:41:04 [launcher.py:46] Route: /v1/rerank, Methods: POST
(APIServer pid=3525388) INFO 01-14 17:41:04 [launcher.py:46] Route: /v2/rerank, Methods: POST
(APIServer pid=3525388) INFO 01-14 17:41:04 [launcher.py:46] Route: /pooling, Methods: POST
(APIServer pid=3525388) INFO:     Started server process [3525388]
(APIServer pid=3525388) INFO:     Waiting for application startup.
(APIServer pid=3525388) INFO:     Application startup complete.
^C[rank0]:[W114 17:41:36.897933262 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
(APIServer pid=3525388) INFO 01-14 17:41:36 [launcher.py:110] Shutting down FastAPI HTTP server.
(APIServer pid=3525388) INFO:     Shutting down
(APIServer pid=3525388) INFO:     Waiting for application shutdown.
(APIServer pid=3525388) INFO:     Application shutdown complete.
```


</details>


Performance

<details>

CUDA_VISIBLE_DEVICES=1 VLLM_ATTENTION_BACKEND=FLASH_ATTN VLLM_DISABLE_COMPILE_CACHE=1 with-proxy vllm bench latency --input-len 1024 --output-len 1024 --model Qwen/Qwen3-8B --batch-size 32 --quantization mxfp8 
Avg latency: 7.114737543479229 seconds
10% percentile latency: 7.090550634596729 seconds
25% percentile latency: 7.095485741025186 seconds
50% percentile latency: 7.100555320997955 seconds
75% percentile latency: 7.107174740507617 seconds
90% percentile latency: 7.116721842222614 seconds
99% percentile latency: 7.380051661875914 seconds


CUDA_VISIBLE_DEVICES=1 VLLM_ATTENTION_BACKEND=FLASH_ATTN VLLM_DISABLE_COMPILE_CACHE=1 with-proxy vllm bench latency --input-len 1024 --output-len 1024 --model Qwen/Qwen3-8B --batch-size 32

Avg latency: 6.2698817714350294 seconds
10% percentile latency: 6.262251399946399 seconds
25% percentile latency: 6.264382338747964 seconds
50% percentile latency: 6.268500665522879 seconds
75% percentile latency: 6.271425302984426 seconds
90% percentile latency: 6.277459568175255 seconds
99% percentile latency: 6.29489082104119 seconds


CUDA_VISIBLE_DEVICES=1 VLLM_ATTENTION_BACKEND=FLASH_ATTN VLLM_DISABLE_COMPILE_CACHE=1 with-proxy vllm bench latency --input-len 1024 --output-len 1024 --model Qwen/Qwen3-8B --batch-size 8

Avg latency: 5.377933108761984 seconds
10% percentile latency: 5.36727682906785 seconds
25% percentile latency: 5.369608670487651 seconds
50% percentile latency: 5.370721633022185 seconds
75% percentile latency: 5.374492640490644 seconds
90% percentile latency: 5.382614015077706 seconds
99% percentile latency: 5.4619856172625445 seconds


CUDA_VISIBLE_DEVICES=1 VLLM_ATTENTION_BACKEND=FLASH_ATTN VLLM_DISABLE_COMPILE_CACHE=1 with-proxy vllm bench latency --input-len 1024 --output-len 1024 --model Qwen/Qwen3-8B --batch-size 8 --quantization mxfp8

Avg latency: 5.8796797158953265 seconds
10% percentile latency: 5.868537089729216 seconds
25% percentile latency: 5.873511790239718 seconds
50% percentile latency: 5.876653404004173 seconds
75% percentile latency: 5.885830606741365 seconds
90% percentile latency: 5.8914141334069425 seconds
99% percentile latency: 5.9247187449870395 seconds
[rank0]:[W204 18:49:56.613028276 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())


——————
CUDA_VISIBLE_DEVICES=1 VLLM_ATTENTION_BACKEND=FLASH_ATTN VLLM_DISABLE_COMPILE_CACHE=1 with-proxy vllm bench latency --input-len 1024 --output-len 1024 --model Qwen/Qwen3-32B --batch-size 256 --quantization mxfp8
Avg latency: 53.336440228034434 seconds
10% percentile latency: 53.07816166278208 seconds
25% percentile latency: 53.27027780821663 seconds
50% percentile latency: 53.39790177551913 seconds
75% percentile latency: 53.4346607557527 seconds
90% percentile latency: 53.45001104929834 seconds
99% percentile latency: 53.49330673501012 seconds

CUDA_VISIBLE_DEVICES=1 VLLM_ATTENTION_BACKEND=FLASH_ATTN VLLM_DISABLE_COMPILE_CACHE=1 with-proxy vllm bench latency --input-len 1024 --output-len 1024 --model Qwen/Qwen3-32B --batch-size 256
Avg latency: 75.82325858416735 seconds
10% percentile latency: 75.72335491161793 seconds
25% percentile latency: 75.74582710850518 seconds
50% percentile latency: 75.86072600752232 seconds
75% percentile latency: 75.88143472374941 seconds
90% percentile latency: 75.89680293400306 seconds
99% percentile latency: 75.91749269683962 seconds
[rank0]:[W204 20:40:52.323331938 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
</details>


---
Usage Example

from vllm import LLM

llm = LLM(
    model="facebook/opt-125m",
    quantization="mxfp8",
    dtype="bfloat16",
)


Generated by claude

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

