### PR TITLE
[Feature] Support async scheduling + PP with constraints

### DIFF
--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -9,6 +9,7 @@ from vllm.config import (
     ECTransferConfig,
     KVTransferConfig,
     ModelConfig,
+    ParallelConfig,
     SchedulerConfig,
     SpeculativeConfig,
     VllmConfig,
@@ -53,6 +54,7 @@ def create_scheduler(
     num_speculative_tokens: int | None = None,
     skip_tokenizer_init: bool = False,
     async_scheduling: bool = False,
+    pipeline_parallel_size: int = 1,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
 ) -> Scheduler | AsyncScheduler:
@@ -133,6 +135,7 @@ def create_scheduler(
         scheduler_config=scheduler_config,
         model_config=model_config,
         cache_config=cache_config,
+        parallel_config=ParallelConfig(pipeline_parallel_size=pipeline_parallel_size),
         kv_transfer_config=kv_transfer_config,
         speculative_config=speculative_config,
         ec_transfer_config=ec_transfer_config,

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -563,11 +563,6 @@ class VllmConfig:
 
         if self.scheduler_config.async_scheduling:
             # Async scheduling explicitly enabled, hard fail any incompatibilities.
-            if self.parallel_config.pipeline_parallel_size > 1:
-                raise ValueError(
-                    "Async scheduling is not yet compatible with "
-                    "pipeline_parallel_size > 1."
-                )
             # Currently, async scheduling only support eagle speculative
             # decoding.
             if self.speculative_config is not None:
@@ -589,14 +584,7 @@ class VllmConfig:
                 )
         elif self.scheduler_config.async_scheduling is None:
             # Enable async scheduling unless there is an incompatible option.
-            if self.parallel_config.pipeline_parallel_size > 1:
-                logger.warning_once(
-                    "Async scheduling is not yet supported with "
-                    "pipeline_parallel_size > 1 and will be disabled.",
-                    scope="local",
-                )
-                self.scheduler_config.async_scheduling = False
-            elif (
+            if (
                 self.speculative_config is not None
                 and self.speculative_config.method not in get_args(EagleModelTypes)
             ):

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -283,6 +283,13 @@ class Scheduler(SchedulerInterface):
         while req_index < len(self.running) and token_budget > 0:
             request = self.running[req_index]
 
+            # do not schedule another step for the same request while it still has
+            # output placeholders for PP.
+            # TODO: support PP + async scheduling without this limit
+            if self.use_pp and request.num_output_placeholders > 0:
+                req_index += 1
+                continue
+
             if (
                 request.num_output_placeholders > 0
                 # This is (num_computed_tokens + 1) - (num_output_placeholders - 1).

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -411,9 +411,11 @@ class MultiprocExecutor(Executor):
 
     @cached_property
     def max_concurrent_batches(self) -> int:
+        # PP requires PP-size concurrent batches to fill the pipeline.
+        pp_size = self.parallel_config.pipeline_parallel_size
         if self.scheduler_config.async_scheduling:
-            return 2
-        return self.parallel_config.pipeline_parallel_size
+            return pp_size if pp_size > 1 else 2
+        return pp_size
 
     def _get_output_rank(self) -> int:
         # Only returns ModelRunnerOutput from TP rank=0 and PP rank=-1

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -413,9 +413,7 @@ class MultiprocExecutor(Executor):
     def max_concurrent_batches(self) -> int:
         # PP requires PP-size concurrent batches to fill the pipeline.
         pp_size = self.parallel_config.pipeline_parallel_size
-        if self.scheduler_config.async_scheduling:
-            return pp_size if pp_size > 1 else 2
-        return pp_size
+        return 2 if pp_size <= 1 and self.scheduler_config.async_scheduling else pp_size
 
     def _get_output_rank(self) -> int:
         # Only returns ModelRunnerOutput from TP rank=0 and PP rank=-1

--- a/vllm/v1/executor/ray_executor.py
+++ b/vllm/v1/executor/ray_executor.py
@@ -112,9 +112,7 @@ class RayDistributedExecutor(Executor):
         meaning that it allows PP size batches to be executed concurrently.
         """
         pp_size = self.parallel_config.pipeline_parallel_size
-        if self.scheduler_config.async_scheduling:
-            return pp_size if pp_size > 1 else 2
-        return pp_size
+        return 2 if pp_size <= 1 and self.scheduler_config.async_scheduling else pp_size
 
     def shutdown(self) -> None:
         if logger:

--- a/vllm/v1/executor/ray_executor.py
+++ b/vllm/v1/executor/ray_executor.py
@@ -111,9 +111,10 @@ class RayDistributedExecutor(Executor):
         """Ray distributed executor supports pipeline parallelism,
         meaning that it allows PP size batches to be executed concurrently.
         """
+        pp_size = self.parallel_config.pipeline_parallel_size
         if self.scheduler_config.async_scheduling:
-            return 2
-        return self.parallel_config.pipeline_parallel_size
+            return pp_size if pp_size > 1 else 2
+        return pp_size
 
     def shutdown(self) -> None:
         if logger:


### PR DESCRIPTION
## Purpose

Thanks for the context from @njhill !

Support async scheduling + PP, currently we ban the case where two tokens in one request got scheduled together

Following up:
- Support `num_output_placeholders` with PP

## Test

`export MODEL="Qwen/Qwen3-30B-A3B-Thinking-2507-FP8"`

`vllm serve $MODEL -pp 4 --port 9256 --max-num-seqs 128  --async-scheduling`
vs
`vllm serve $MODEL -pp 4 --port 9256 --max-num-seqs 128 -no-async-scheduling`

### Acc

`lm_eval --model local-completions --model_args "base_url=http://127.0.0.1:9256/v1/completions,model=$MODEL,num_concurrent=1024" --tasks gsm8k`

```bash
# with async
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6361|±  |0.0133|
|     |       |strict-match    |     5|exact_match|↑  |0.7817|±  |0.0114|
# without
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6262|±  |0.0133|
|     |       |strict-match    |     5|exact_match|↑  |0.7779|±  |0.0114|
```

### Perf

`vllm bench serve --model $MODEL  --dataset-name random --host 127.0.0.1  --random-input-len 2 --random-output-len 256 --num-prompts 128 --port 9256    --num-warmups 16`

```bash
# with
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Benchmark duration (s):                  9.61      
Total input tokens:                      256       
Total generated tokens:                  32768     
Request throughput (req/s):              13.32     
Output token throughput (tok/s):         3411.04   
Peak output token throughput (tok/s):    4184.00   
Peak concurrent requests:                128.00    
Total token throughput (tok/s):          3437.68   
---------------Time to First Token----------------
Mean TTFT (ms):                          190.00    
Median TTFT (ms):                        194.15    
P99 TTFT (ms):                           223.50    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          36.68     
Median TPOT (ms):                        36.70     
P99 TPOT (ms):                           36.76     
---------------Inter-token Latency----------------
Mean ITL (ms):                           36.68     
Median ITL (ms):                         36.96     
P99 ITL (ms):                            46.99     
==================================================
# without
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Benchmark duration (s):                  9.88      
Total input tokens:                      256       
Total generated tokens:                  32768     
Request throughput (req/s):              12.95     
Output token throughput (tok/s):         3315.57   
Peak output token throughput (tok/s):    4136.00   
Peak concurrent requests:                128.00    
Total token throughput (tok/s):          3341.47   
---------------Time to First Token----------------
Mean TTFT (ms):                          207.60    
Median TTFT (ms):                        208.96    
P99 TTFT (ms):                           242.69    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          37.70     
Median TPOT (ms):                        37.74     
P99 TPOT (ms):                           37.77     
---------------Inter-token Latency----------------
Mean ITL (ms):                           37.71     
Median ITL (ms):                         37.11     
P99 ITL (ms):                            50.74     
==================================================
```