### PR TITLE
[BugFix] Fix DeepSeek-V3.1 + DeepGEMM incompatible scale shapes

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -299,6 +299,9 @@ def get_and_maybe_dequant_weights(
     if (
         isinstance(layer.quant_method, Fp8LinearMethod)
         and not layer.quant_method.use_marlin
+        # DeepGEMM transforms the scales using `transform_sf_into_required_layout` into
+        # a layout that is not compatible with `scaled_dequantize`.
+        and not layer.quant_method.use_deep_gemm
     ):
         weight_scales = get_attribute_fallback(
             layer, ["weight_scale", "weight_scale_inv"]


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/29867 broke

```
pytest tests/quantization/test_blackwell_moe.py -k "test_deepseek_fp8_block_moe_deep_gemm" -s -v --tb=short
```

with 
```
"/home/eldarkurtic/github/eldarkurtic/for_debug/vllm/vllm/model_executor/layers/quantization/utils/quant_utils.py", line 271, in scaled_dequantize
(EngineCore_DP0 pid=2746729) ERROR 01-14 12:15:22 [core.py:936]     assert x_s.shape[-1] == x_q.shape[-1] // group_shape[1]
(EngineCore_DP0 pid=2746729) ERROR 01-14 12:15:22 [core.py:936]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

For DeepGEMM revert to the behavior before https://github.com/vllm-project/vllm/pull/29867 

Credit to: Eldar Kurtić <8884008+eldarkurtic@users.noreply.github.com> for running this down 
Co-authored-by: Eldar Kurtić <8884008+eldarkurtic@users.noreply.github.com>

