### PR TITLE
[BugFix] Fix `assert x_s.shape[-1] == x_q.shape[-1] // group_shape[1]` in Blackwell Quantized MoE Test

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -246,10 +246,8 @@ def scaled_dequantize(
     if group_shape is not None:
         group_shape = _normalize_quant_group_shape(x_q, group_shape)
 
-    if x_s.ndim == 0:  # scalar
-        x_s = x_s.unsqueeze(-1).unsqueeze(-1)  # convert to (1, 1) tensor
     if x_s.numel() == 1:  # scalar
-        x_s = x_s.unsqueeze(0)
+        x_s = x_s.reshape(1, 1)  # normalize all scalar-like tensors to (1, 1)
     if x_s.ndim == 1:
         if group_shape is None:
             raise AssertionError(

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -248,6 +248,8 @@ def scaled_dequantize(
 
     if x_s.ndim == 0:  # scalar
         x_s = x_s.unsqueeze(-1).unsqueeze(-1)  # convert to (1, 1) tensor
+    if x_s.numel() == 1:  # scalar
+        x_s = x_s.unsqueeze(0)
     if x_s.ndim == 1:
         if group_shape is None:
             raise AssertionError(


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/32361 broke:

```
python -m pytest tests/compile/fullgraph/test_full_graph.py::test_fp8_kv_scale_compile[deepseek-ai/DeepSeek-V2-Lite-AttentionBackendEnum.FLASHINFER_MLA-0]
```

Add more robust handling of scalar weights to fix it