### PR TITLE
[ROCm][CI] Add ROCm attention backend support for EAGLE DP tests

### DIFF
--- a/tests/v1/distributed/test_eagle_dp.py
+++ b/tests/v1/distributed/test_eagle_dp.py
@@ -16,7 +16,7 @@ from vllm.v1.engine.async_llm import AsyncLLM
 DP_SIZE = int(os.getenv("DP_SIZE", 2))
 
 if current_platform.is_rocm():
-    ATTN_BACKENDS = ["ROCM_ATTN", "ROCM_AITER_FA", "TRITON_ATTN", "FLEX_ATTENTION"]
+    ATTN_BACKENDS = ["ROCM_ATTN", "TRITON_ATTN", "FLEX_ATTENTION"]
 else:
     ATTN_BACKENDS = ["FLASH_ATTN"]
 


### PR DESCRIPTION
This PR adds ROCm platform support to the EAGLE data parallel tests by parametrizing attention backends based on the detected platform.

## Changes

- Add platform detection using `current_platform.is_rocm()` to select appropriate attention backends
- Parametrize `test_run_eagle_dp` across platform-specific backends:
  - **ROCm**: `ROCM_ATTN`, `ROCM_AITER_FA`, `TRITON_ATTN`, `FLEX_ATTENTION`
  - **CUDA**: `FLASH_ATTN`
- Conditionally apply `VLLM_BATCH_INVARIANT` flag

## Testing

```bash
pytest -v -s tests/v1/distributed/test_eagle_dp.py::test_run_eagle_dp
```