### PR TITLE
[CI][BugFix][AMD][FP8] Fix test_rms_norm so it runs correctly on ROCm

### DIFF
--- a/tests/kernels/core/test_fused_quant_layernorm.py
+++ b/tests/kernels/core/test_fused_quant_layernorm.py
@@ -18,7 +18,6 @@ from vllm.platforms import current_platform
 
 DTYPES = [torch.bfloat16, torch.float]
 QUANT_DTYPES = [torch.int8, current_platform.fp8_dtype()]
-
 VEC_HIDDEN_SIZES = [1024, 1025, 1027, 1029]
 # Avoid combinatorial explosion with full Cartesian product
 NUM_TOKENS_HIDDEN_SIZES = [

--- a/tests/kernels/core/test_fused_quant_layernorm.py
+++ b/tests/kernels/core/test_fused_quant_layernorm.py
@@ -14,9 +14,11 @@ from vllm.model_executor.layers.quantization.utils.fp8_utils import (
 from vllm.model_executor.layers.quantization.utils.int8_utils import (
     per_token_group_quant_int8,
 )
+from vllm.platforms import current_platform
 
 DTYPES = [torch.bfloat16, torch.float]
-QUANT_DTYPES = [torch.int8, torch.float8_e4m3fn]
+QUANT_DTYPES = [torch.int8, current_platform.fp8_dtype()]
+
 VEC_HIDDEN_SIZES = [1024, 1025, 1027, 1029]
 # Avoid combinatorial explosion with full Cartesian product
 NUM_TOKENS_HIDDEN_SIZES = [
@@ -61,14 +63,14 @@ def ref_dynamic_per_token_or_block_quant(
     group_size: list[int] | None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
     if scale_ub is not None:
-        assert quant_dtype == torch.float8_e4m3fn
+        assert quant_dtype == current_platform.fp8_dtype()
 
     # Norm
     torch_out, residual = ref_rms_norm(rms_norm_layer, x, residual)
 
     # Quant
     if group_size is not None:
-        if quant_dtype == torch.float8_e4m3fn:
+        if quant_dtype == current_platform.fp8_dtype():
             torch_out, scales = per_token_group_quant_fp8(
                 torch_out, group_size=group_size[1], use_ue8m0=False
             )
@@ -78,7 +80,7 @@ def ref_dynamic_per_token_or_block_quant(
                 torch_out, group_size=group_size[1]
             )
     else:
-        if quant_dtype == torch.float8_e4m3fn:
+        if quant_dtype == current_platform.fp8_dtype():
             torch_out, scales = ops.scaled_fp8_quant(
                 torch_out, scale_ub=scale_ub, use_per_token_if_dynamic=True
             )
@@ -162,6 +164,7 @@ def test_rms_norm(
     if torch.cuda.is_available():
         torch.cuda.manual_seed(seed)
     torch.set_default_device(device)
+    torch.cuda.set_device(device)
 
     if group_size is not None and hidden_size % group_size[1] != 0:
         # skip
@@ -171,7 +174,7 @@ def test_rms_norm(
         # blockwise baseline doesn't support scale_ub
         return
 
-    if has_scale_ub and quant_dtype != torch.float8_e4m3fn:
+    if has_scale_ub and quant_dtype != current_platform.fp8_dtype():
         # skip
         return
 


### PR DESCRIPTION

## Purpose
This PR applies changes to `test_fused_quant_layernorm.py::test_rms_norm` so it runs correctly on ROCm:
1. Use` current_platform.fp8_dtype(`) instead of  `torch.float8_e4m3fn`.
2. Ensure that `torch.cuda.set_device` is called as well as` torch.set_default_device` so tensors and kernels both run on the same device, otherwise an illegal memory access will occur.

## Test Plan
`pytest -sv kernels/core/test_fused_quant_layernorm.py`
## Test Result
`1728 passed, 3 warnings`
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ X] The test plan, such as providing test command.
- [ X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

