### PR TITLE
[responsesAPI] allow reasoning parser to output multiple reasoning items

### DIFF
--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -251,6 +251,59 @@ class TestBaseThinkingReasoningParserExtraction:
         assert reasoning_list == []
         assert content is None
 
+    def test_extract_multiple_reasoning_blocks(self, test_tokenizer):
+        """Test extraction of multiple reasoning blocks."""
+        parser = TestThinkingReasoningParser(test_tokenizer)
+        request = ChatCompletionRequest(messages=[], model="test-model")
+
+        model_output = (
+            "<test:think>First reasoning</test:think>"
+            "<test:think>Second reasoning</test:think>"
+            "Final content"
+        )
+        reasoning_list, content = parser.extract_reasoning(model_output, request)
+
+        assert reasoning_list == ["First reasoning", "Second reasoning"]
+        assert content == "Final content"
+
+    def test_extract_multiple_reasoning_blocks_with_intermediate_content(
+        self, test_tokenizer
+    ):
+        """Test extraction of multiple reasoning blocks with content between them."""
+        parser = TestThinkingReasoningParser(test_tokenizer)
+        request = ChatCompletionRequest(messages=[], model="test-model")
+
+        # When there's content between reasoning blocks, the first content
+        # triggers another search for reasoning blocks
+        model_output = (
+            "<test:think>First reasoning</test:think>"
+            "Some middle content"
+            "<test:think>Second reasoning</test:think>"
+            "Final content"
+        )
+        reasoning_list, content = parser.extract_reasoning(model_output, request)
+
+        # The parser should find both reasoning blocks
+        # TODO: modify this unit test when we support interleaved thinking
+        assert reasoning_list == ["First reasoning", "Second reasoning"]
+        assert content == "Final content"
+
+    def test_extract_three_reasoning_blocks(self, test_tokenizer):
+        """Test extraction of three reasoning blocks."""
+        parser = TestThinkingReasoningParser(test_tokenizer)
+        request = ChatCompletionRequest(messages=[], model="test-model")
+
+        model_output = (
+            "<test:think>First</test:think>"
+            "<test:think>Second</test:think>"
+            "<test:think>Third</test:think>"
+            "Done"
+        )
+        reasoning_list, content = parser.extract_reasoning(model_output, request)
+
+        assert reasoning_list == ["First", "Second", "Third"]
+        assert content == "Done"
+
 
 class TestBaseThinkingReasoningParserStreaming:
     """Test streaming functionality of BaseThinkingReasoningParser."""

--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -202,9 +202,9 @@ class TestBaseThinkingReasoningParserExtraction:
         request = ChatCompletionRequest(messages=[], model="test-model")
 
         model_output = "<test:think>This is reasoning</test:think>This is content"
-        reasoning, content = parser.extract_reasoning(model_output, request)
+        reasoning_list, content = parser.extract_reasoning(model_output, request)
 
-        assert reasoning == "This is reasoning"
+        assert reasoning_list == ["This is reasoning"]
         assert content == "This is content"
 
     def test_extract_reasoning_only_end_token(self, test_tokenizer):
@@ -213,9 +213,9 @@ class TestBaseThinkingReasoningParserExtraction:
         request = ChatCompletionRequest(messages=[], model="test-model")
 
         model_output = "This is reasoning</test:think>This is content"
-        reasoning, content = parser.extract_reasoning(model_output, request)
+        reasoning_list, content = parser.extract_reasoning(model_output, request)
 
-        assert reasoning == "This is reasoning"
+        assert reasoning_list == ["This is reasoning"]
         assert content == "This is content"
 
     def test_extract_reasoning_no_end_token(self, test_tokenizer):
@@ -224,9 +224,9 @@ class TestBaseThinkingReasoningParserExtraction:
         request = ChatCompletionRequest(messages=[], model="test-model")
 
         model_output = "This is just content"
-        reasoning, content = parser.extract_reasoning(model_output, request)
+        reasoning_list, content = parser.extract_reasoning(model_output, request)
 
-        assert reasoning == "This is just content"
+        assert reasoning_list == ["This is just content"]
         assert content is None
 
     def test_extract_reasoning_empty_output(self, test_tokenizer):
@@ -235,9 +235,9 @@ class TestBaseThinkingReasoningParserExtraction:
         request = ChatCompletionRequest(messages=[], model="test-model")
 
         model_output = ""
-        reasoning, content = parser.extract_reasoning(model_output, request)
+        reasoning_list, content = parser.extract_reasoning(model_output, request)
 
-        assert reasoning == ""
+        assert reasoning_list == []
         assert content is None
 
     def test_extract_reasoning_only_tokens(self, test_tokenizer):
@@ -246,9 +246,9 @@ class TestBaseThinkingReasoningParserExtraction:
         request = ChatCompletionRequest(messages=[], model="test-model")
 
         model_output = "<test:think></test:think>"
-        reasoning, content = parser.extract_reasoning(model_output, request)
+        reasoning_list, content = parser.extract_reasoning(model_output, request)
 
-        assert reasoning == ""
+        assert reasoning_list == []
         assert content is None
 
 

--- a/tests/reasoning/test_deepseekv3_reasoning_parser.py
+++ b/tests/reasoning/test_deepseekv3_reasoning_parser.py
@@ -46,10 +46,10 @@ def test_identity_reasoning_parser_basic(tokenizer):
     # Test extract_content_ids returns all input_ids
     assert parser.extract_content_ids(input_ids) == input_ids
 
-    # Test extract_reasoning returns (None, model_output)
+    # Test extract_reasoning returns ([], model_output)
     request = ChatCompletionRequest(model="test-model", messages=[], temperature=1.0)
-    reasoning, content = parser.extract_reasoning(input_text, request)
-    assert reasoning is None
+    reasoning_list, content = parser.extract_reasoning(input_text, request)
+    assert reasoning_list == []
     assert content == input_text
 
     # Test extract_reasoning_streaming returns DeltaMessage or None

--- a/tests/reasoning/utils.py
+++ b/tests/reasoning/utils.py
@@ -91,9 +91,13 @@ def run_reasoning_extraction_nonstreaming(
     request: ChatCompletionRequest | None = None,
 ) -> tuple[str | None, str | None]:
     request = request or ChatCompletionRequest(messages=[], model="test-model")
-    return reasoning_parser.extract_reasoning(
+    reasoning_list, content = reasoning_parser.extract_reasoning(
         model_output="".join(model_output), request=request
     )
+    # Join reasoning list into single string for backwards compatibility
+    # with existing tests
+    reasoning = "\n".join(reasoning_list) if reasoning_list else None
+    return reasoning, content
 
 
 def run_reasoning_extraction_streaming(

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1485,9 +1485,12 @@ class OpenAIServingChat(OpenAIServing):
                     return self.create_error_response(str(e))
                 # If the reasoning parser is enabled,
                 # tool calls are extracted exclusively from the content.
-                reasoning, content = reasoning_parser.extract_reasoning(
+                reasoning_list, content = reasoning_parser.extract_reasoning(
                     output.text, request=request
                 )
+                # Join multiple reasoning blocks into a single string
+                # for backwards compatibility with ChatMessage
+                reasoning = "\n".join(reasoning_list) if reasoning_list else None
                 if not request.include_reasoning:
                     reasoning = None
             else:

--- a/vllm/entrypoints/openai/parser/responses_parser.py
+++ b/vllm/entrypoints/openai/parser/responses_parser.py
@@ -61,10 +61,11 @@ class ResponsesParser:
         # Store the finish_reason from the output
         self.finish_reason = output.finish_reason
 
-        reasoning_content, content = self.reasoning_parser_instance.extract_reasoning(
+        reasoning_list, content = self.reasoning_parser_instance.extract_reasoning(
             output.text, request=self.request
         )
-        if reasoning_content:
+        # Add multiple reasoning items, one for each reasoning block
+        for reasoning_content in reasoning_list:
             self.response_messages.append(
                 ResponseReasoningItem(
                     type="reasoning",

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -109,12 +109,15 @@ class ReasoningParser:
         self,
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
-    ) -> tuple[str | None, str | None]:
+    ) -> tuple[list[str], str | None]:
         """
         Extract reasoning content from a complete model-generated string.
 
         Used for non-streaming responses where we have the entire model response
         available before sending to the client.
+
+        The extraction is recursive - after finding the first reasoning block,
+        it looks inside the remaining content to find additional reasoning blocks.
 
         Parameters:
         model_output: str
@@ -124,8 +127,9 @@ class ReasoningParser:
             The request object that was used to generate the model_output.
 
         Returns:
-        tuple[Optional[str], Optional[str]]
-            A tuple containing the reasoning content and the content.
+        tuple[list[str], Optional[str]]
+            A tuple containing a list of reasoning content strings and the
+            final content. The list may be empty if no reasoning was found.
         """
 
     @abstractmethod

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -182,8 +182,11 @@ class BaseThinkingReasoningParser(ReasoningParser):
                     # No start token was found either
                     # If we already found some reasoning, remaining is content
                     # Otherwise, it's just content with no reasoning
-                    final_content = remaining if remaining else None
-                    return reasoning_list, final_content
+                    if not reasoning_list:
+                        if remaining:
+                            reasoning_list.append(remaining)
+                        return reasoning_list, None
+                    return reasoning_list, remaining or None
             else:
                 # End token found - extract this reasoning block
                 reasoning, _, after_end = remaining.partition(self.end_token)

--- a/vllm/reasoning/deepseek_v3_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_v3_reasoning_parser.py
@@ -50,7 +50,7 @@ class DeepSeekV3ReasoningParser(ReasoningParser):
 
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest
-    ) -> tuple[str | None, str | None]:
+    ) -> tuple[list[str], str | None]:
         return self._parser.extract_reasoning(model_output, request)
 
     def extract_reasoning_streaming(

--- a/vllm/reasoning/ernie45_reasoning_parser.py
+++ b/vllm/reasoning/ernie45_reasoning_parser.py
@@ -145,7 +145,7 @@ class Ernie45ReasoningParser(BaseThinkingReasoningParser):
 
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest
-    ) -> tuple[str | None, str | None]:
+    ) -> tuple[list[str], str | None]:
         """
         Extract reasoning content from the model output.
         The Ernie45 thinking model ouput format is
@@ -154,9 +154,9 @@ class Ernie45ReasoningParser(BaseThinkingReasoningParser):
         - 'abc' goes to reasoning
         - 'def' goes to content
         Returns:
-            tuple[Optional[str], Optional[str]]: reasoning content and content
+            tuple[list[str], Optional[str]]: list of reasoning content and content
         """
-        reasoning, content = super().extract_reasoning(model_output, request)
+        reasoning_list, content = super().extract_reasoning(model_output, request)
         if content:
             start_idx = content.find(self.response_start_token)
             end_idx = content.rfind(self.response_end_token)
@@ -165,4 +165,4 @@ class Ernie45ReasoningParser(BaseThinkingReasoningParser):
                 content = content[start_idx + len(self.response_start_token) : end_idx]
         final_content = content or None
 
-        return reasoning, final_content
+        return reasoning_list, final_content

--- a/vllm/reasoning/gptoss_reasoning_parser.py
+++ b/vllm/reasoning/gptoss_reasoning_parser.py
@@ -140,7 +140,7 @@ class GptOssReasoningParser(ReasoningParser):
         self,
         model_output: str,
         request: ChatCompletionRequest,
-    ) -> tuple[str | None, str | None]:
+    ) -> tuple[list[str], str | None]:
         raise NotImplementedError(
             "gpt-oss has a special branch for parsing reasoning in non-streaming mode. This method shouldn't be used."  # noqa: E501
         )

--- a/vllm/reasoning/granite_reasoning_parser.py
+++ b/vllm/reasoning/granite_reasoning_parser.py
@@ -54,7 +54,7 @@ class GraniteReasoningParser(ReasoningParser):
 
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest
-    ) -> tuple[str | None, str | None]:
+    ) -> tuple[list[str], str | None]:
         """Extract the reasoning content & content sections, respectively.
         If the sequence doesn't match what we expect, i.e., the model generates
         something else, all content is considered non-reasoning content.
@@ -64,16 +64,16 @@ class GraniteReasoningParser(ReasoningParser):
             request (ChatCompletionRequest): Request being processed.
 
         Returns:
-            tuple[Optional[str], Optional[str]]: Tuple pair containing the
-            reasoning content and non-reasoning content.
+            tuple[list[str], Optional[str]]: Tuple pair containing the
+            list of reasoning content strings and non-reasoning content.
         """
         re_match = self.reasoning_regex.findall(model_output)
         if not re_match:
-            return None, model_output
+            return [], model_output
         reasoning, response_content = re_match[0]
         if not response_content:
-            return reasoning, None
-        return reasoning, response_content
+            return [reasoning] if reasoning else [], None
+        return [reasoning] if reasoning else [], response_content
 
     def extract_reasoning_streaming(
         self,

--- a/vllm/reasoning/holo2_reasoning_parser.py
+++ b/vllm/reasoning/holo2_reasoning_parser.py
@@ -70,7 +70,7 @@ class Holo2ReasoningParser(ReasoningParser):
 
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest
-    ) -> tuple[str | None, str | None]:
+    ) -> tuple[list[str], str | None]:
         return self._parser.extract_reasoning(model_output, request)
 
     def extract_reasoning_streaming(

--- a/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
+++ b/vllm/reasoning/hunyuan_a13b_reasoning_parser.py
@@ -91,7 +91,7 @@ class HunyuanA13BReasoningParser(ReasoningParser):
 
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest
-    ) -> tuple[str | None, str | None]:
+    ) -> tuple[list[str], str | None]:
         """Extract the reasoning content & content sections, respectively.
         If the sequence doesn't match what we expect, i.e., the model generates
         something else, all content is considered non-reasoning content.
@@ -101,18 +101,16 @@ class HunyuanA13BReasoningParser(ReasoningParser):
             request (ChatCompletionRequest): Request being processed.
 
         Returns:
-            tuple[Optional[str], Optional[str]]: Tuple pair containing the
-            reasoning content and non-reasoning content.
+            tuple[list[str], Optional[str]]: Tuple pair containing the
+            list of reasoning content strings and non-reasoning content.
         """
 
         re_match = self.full_match_reasoning_regex.findall(model_output)
         if re_match:
             reasoning, response_content = re_match[0]
-            if len(reasoning) == 0:
-                reasoning = None
-            if len(response_content) == 0:
-                response_content = None
-            return reasoning, response_content
+            reasoning_list = [reasoning] if reasoning else []
+            final_content = response_content if response_content else None
+            return reasoning_list, final_content
 
         fallback_regex = self.half_match_reasoning_regex
         fallback_match = fallback_regex.findall(model_output)
@@ -122,14 +120,12 @@ class HunyuanA13BReasoningParser(ReasoningParser):
             if response_content.endswith(self.response_end_expr):
                 response_content = response_content[: -len(self.response_end_expr)]
 
-            if len(reasoning) == 0:
-                reasoning = None
-            if len(response_content) == 0:
-                response_content = None
+            reasoning_list = [reasoning] if reasoning else []
+            final_content = response_content if response_content else None
 
-            return reasoning, response_content
+            return reasoning_list, final_content
 
-        return None, model_output
+        return [], model_output
 
     def _is_strict_increasing_subsequence(
         self, subsequence: Sequence[int], sequence: Sequence[int]

--- a/vllm/reasoning/identity_reasoning_parser.py
+++ b/vllm/reasoning/identity_reasoning_parser.py
@@ -60,7 +60,7 @@ class IdentityReasoningParser(ReasoningParser):
 
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest
-    ) -> tuple[str | None, str | None]:
-        # No reasoning separation: return None for reasoning,
+    ) -> tuple[list[str], str | None]:
+        # No reasoning separation: return empty list for reasoning,
         # and full model_output as content
-        return None, model_output
+        return [], model_output

--- a/vllm/reasoning/minimax_m2_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m2_reasoning_parser.py
@@ -110,5 +110,5 @@ class MiniMaxM2AppendThinkReasoningParser(ReasoningParser):
 
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest | ResponsesRequest
-    ) -> tuple[str | None, str | None]:
-        return None, "<think>" + model_output
+    ) -> tuple[list[str], str | None]:
+        return [], "<think>" + model_output

--- a/vllm/reasoning/mistral_reasoning_parser.py
+++ b/vllm/reasoning/mistral_reasoning_parser.py
@@ -113,12 +113,12 @@ class MistralReasoningParser(BaseThinkingReasoningParser):
 
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest | ResponsesRequest
-    ) -> tuple[str | None, str | None]:
+    ) -> tuple[list[str], str | None]:
         """
         Extract reasoning content from the model output.
         """
         if not model_output:
-            return (None, "")
+            return ([], "")
 
         # Check if the start token is present in the model output, remove it
         # if it is present.
@@ -135,11 +135,15 @@ class MistralReasoningParser(BaseThinkingReasoningParser):
             prev_eot_token, _, post_eot_token = post_bot_token.partition(self.end_token)
             # If model is well prompted and trained prev_bot_token should be ""
             content = prev_bot_token + post_eot_token
-            return prev_eot_token, content if content else None
+            return [
+                prev_eot_token
+            ] if prev_eot_token else [], content if content else None
         # 2. Only BOT token
         elif has_bot_token:
             # If model is well prompted and trained prev_bot_token should be ""
-            return post_bot_token, prev_bot_token if prev_bot_token else None
+            return [
+                post_bot_token
+            ] if post_bot_token else [], prev_bot_token if prev_bot_token else None
         # 3. EOT token has been outputted without BOT or neither has been outputted
         else:
             has_non_valid_eot_token = self.end_token in prev_bot_token
@@ -150,7 +154,7 @@ class MistralReasoningParser(BaseThinkingReasoningParser):
                 prev_eot_token, _, post_eot_token = prev_bot_token.partition(
                     self.end_token
                 )
-                return None, prev_eot_token + post_eot_token
+                return [], prev_eot_token + post_eot_token
             # 3.b neither BOT or EOT have been outputted
             else:
-                return None, prev_bot_token
+                return [], prev_bot_token

--- a/vllm/reasoning/olmo3_reasoning_parser.py
+++ b/vllm/reasoning/olmo3_reasoning_parser.py
@@ -257,7 +257,7 @@ class Olmo3ReasoningParser(ReasoningParser):
         self,
         model_output: str,
         request: ChatCompletionRequest | ResponsesRequest,
-    ) -> tuple[str | None, str | None]:
+    ) -> tuple[list[str], str | None]:
         """Extract the reasoning content & content sections, respectively.
         If the sequence doesn't match what we expect, i.e., the model generates
         something else, all content is considered non-reasoning content.
@@ -268,18 +268,18 @@ class Olmo3ReasoningParser(ReasoningParser):
                 processed.
 
         Returns:
-            tuple[Optional[str], Optional[str]]: Tuple pair containing the
-            reasoning content and non-reasoning content.
+            tuple[list[str], Optional[str]]: Tuple pair containing the
+            list of reasoning content strings and non-reasoning content.
         """
 
         re_match = self.reasoning_regex.match(model_output)
         if re_match:
             reasoning = re_match.group("reasoning") or None
             content = re_match.group("content") or None
-            return reasoning, content
+            return [reasoning] if reasoning else [], content
 
         # no reasoning content
-        return None, model_output
+        return [], model_output
 
     def extract_reasoning_streaming(
         self,

--- a/vllm/reasoning/step3_reasoning_parser.py
+++ b/vllm/reasoning/step3_reasoning_parser.py
@@ -82,11 +82,11 @@ class Step3ReasoningParser(ReasoningParser):
 
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest
-    ) -> tuple[str | None, str | None]:
+    ) -> tuple[list[str], str | None]:
         # Check if the model output contains the </think> token
         if self.think_end_token not in model_output:
             # If no </think> token, everything is reasoning content
-            return model_output, None
+            return [model_output] if model_output else [], None
         else:
             # Find the first occurrence of </think>
             end_index = model_output.find(self.think_end_token)
@@ -95,10 +95,9 @@ class Step3ReasoningParser(ReasoningParser):
             # Content after </think> token
             content = model_output[end_index + len(self.think_end_token) :]
 
-            if len(content) == 0:
-                content = None
+            final_content = content if content else None
 
-            return reasoning, content
+            return [reasoning] if reasoning else [], final_content
 
     def is_reasoning_end(self, input_ids: list[int]) -> bool:
         return self.think_end_token_id in input_ids

--- a/vllm/tool_parsers/__init__.py
+++ b/vllm/tool_parsers/__init__.py
@@ -20,6 +20,9 @@ Example:
     )
 """
 
+# TODO: if I want to pass in an external flag where the tool parser isn't in vLLM
+# how should I do that?
+
 
 _TOOL_PARSERS_TO_REGISTER = {
     "deepseek_v3": (  # name
@@ -70,7 +73,7 @@ _TOOL_PARSERS_TO_REGISTER = {
         "jamba_tool_parser",
         "JambaToolParser",
     ),
-    "kimi_k2": (
+    "kimi_k2": (  # look here
         "kimi_k2_tool_parser",
         "KimiK2ToolParser",
     ),

--- a/vllm/tool_parsers/__init__.py
+++ b/vllm/tool_parsers/__init__.py
@@ -20,9 +20,6 @@ Example:
     )
 """
 
-# TODO: if I want to pass in an external flag where the tool parser isn't in vLLM
-# how should I do that?
-
 
 _TOOL_PARSERS_TO_REGISTER = {
     "deepseek_v3": (  # name
@@ -73,7 +70,7 @@ _TOOL_PARSERS_TO_REGISTER = {
         "jamba_tool_parser",
         "JambaToolParser",
     ),
-    "kimi_k2": (  # look here
+    "kimi_k2": (
         "kimi_k2_tool_parser",
         "KimiK2ToolParser",
     ),


### PR DESCRIPTION
## Purpose
To support interleaved reasoning, we shouldn't confine a reasoning parser to only output a single reasoning item, allow the flexibility for multiple.

Right now in responsesAPI we expect a model to have output [reasoning, tool call / output], but we should have flexibility with an arbitrary array of {reasoning, tool call, output }.

## Test Plan
Added unit tests and unit tests pass

## Test Result
