### PR TITLE
[Feature] Add FIPS 140-3 compliant hash algorithm option for multimodal hashing

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
     VLLM_MAX_AUDIO_CLIP_FILESIZE_MB: int = 25
     VLLM_VIDEO_LOADER_BACKEND: str = "opencv"
     VLLM_MEDIA_CONNECTOR: str = "http"
+    VLLM_MM_HASHER_ALGORITHM: str = "blake3"
     VLLM_TARGET_DEVICE: str = "cuda"
     VLLM_MAIN_CUDA_VERSION: str = "12.9"
     VLLM_FLOAT32_MATMUL_PRECISION: Literal["highest", "high", "medium"] = "highest"
@@ -806,6 +807,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # imported at runtime.
     # If a non-existing backend is used, an AssertionError will be thrown.
     "VLLM_MEDIA_CONNECTOR": lambda: os.getenv("VLLM_MEDIA_CONNECTOR", "http"),
+    # Hash algorithm for multimodal content hashing.
+    # - "blake3": Default, fast cryptographic hash (not FIPS 140-3 compliant)
+    # - "sha256": FIPS 140-3 compliant, widely supported
+    # - "sha512": FIPS 140-3 compliant, faster on 64-bit systems
+    # Use sha256 or sha512 for FIPS compliance in government/enterprise deployments
+    "VLLM_MM_HASHER_ALGORITHM": env_with_choices(
+        "VLLM_MM_HASHER_ALGORITHM",
+        "blake3",
+        ["blake3", "sha256", "sha512"],
+        case_sensitive=False,
+    ),
     # Path to the XLA persistent cache directory.
     # Only used for XLA devices such as TPUs.
     "VLLM_XLA_CACHE_PATH": lambda: os.path.expanduser(

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import functools
 import hashlib
 import pickle
 import uuid
@@ -18,6 +19,7 @@ from .media import MediaWithBytes
 logger = init_logger(__name__)
 
 
+@functools.lru_cache(maxsize=1)
 def _get_hasher_factory() -> Callable[[], "hashlib._Hash"]:
     """
     Get the hasher factory based on the configured algorithm.

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -4,8 +4,7 @@
 import hashlib
 import pickle
 import uuid
-from collections.abc import Iterable
-from typing import Callable
+from collections.abc import Callable, Iterable
 
 import numpy as np
 import torch
@@ -32,6 +31,7 @@ def _get_hasher_factory() -> Callable[[], "hashlib._Hash"]:
 
     if algorithm == "blake3":
         from blake3 import blake3
+
         return blake3
     elif algorithm == "sha256":
         return hashlib.sha256


### PR DESCRIPTION
## Summary
- Adds configurable hash algorithm for multimodal content hashing via `VLLM_MM_HASHER_ALGORITHM` environment variable
- Enables FIPS 140-3 compliance for government/enterprise deployments
- Maintains backward compatibility (blake3 remains the default)

## Supported Algorithms

| Algorithm | FIPS Compliant | Notes |
|-----------|----------------|-------|
| `blake3` | ❌ No | Default, fastest option |
| `sha256` | ✅ Yes | Widely supported, good performance |
| `sha512` | ✅ Yes | Faster on 64-bit systems |

## Usage

```bash
# For FIPS compliance, set before starting vLLM:
export VLLM_MM_HASHER_ALGORITHM=sha256
# or
export VLLM_MM_HASHER_ALGORITHM=sha512
```

## Changes

1. **vllm/envs.py**: Added `VLLM_MM_HASHER_ALGORITHM` environment variable with validation
2. **vllm/multimodal/hasher.py**: Updated to use configurable hash algorithm via factory function

## Test Plan

Tested locally on macOS M3 Pro:

```python
# All three algorithms tested successfully:
# - blake3: 6a953581d60dbebc9749b56d2383277f...
# - sha256: 916f0027a575074ce72a331777c3478d...
# - sha512: 0e1e21ecf105ec853d24d728867ad706...

# hash_kwargs integration verified with SHA256
# Deterministic hashing confirmed
```

## Related Issue
Fixes #18334

## Background
Blake3 is not listed in NIST SP 800-140Cr2 as a FIPS 140-3 approved algorithm. This blocks vLLM usage in government and enterprise environments requiring FIPS compliance. This PR adds SHA256/SHA512 options which are FIPS approved.