### PR TITLE
[Model] Enable LoRA support for internvl2

### DIFF
--- a/vllm/model_executor/models/internvl.py
+++ b/vllm/model_executor/models/internvl.py
@@ -1086,9 +1086,8 @@ class InternVLChatModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA)
         image_size = config.force_image_size or config.vision_config.image_size
         patch_size = config.vision_config.patch_size
         self.patch_size = patch_size
-        self.num_image_token = int(
-            (image_size // patch_size) ** 2 * (config.downsample_ratio**2)
-        )
+        self.patch_tokens = (image_size // patch_size) ** 2
+        self.num_image_token = int(self.patch_tokens * (config.downsample_ratio**2))
         self.downsample_ratio = config.downsample_ratio
         self.ps_version = config.ps_version
 
@@ -1430,3 +1429,17 @@ class InternVLChatModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA)
             connector="mlp1",
             tower_model="vision_model",
         )
+
+    def get_num_mm_encoder_tokens(self, num_image_tokens: int) -> int:
+        if num_image_tokens <= 0 or self.num_image_token <= 0:
+            return 0
+
+        num_patches = num_image_tokens // self.num_image_token
+        return num_patches * (self.patch_tokens + 1)
+
+    def get_num_mm_connector_tokens(self, num_vision_tokens: int) -> int:
+        if num_vision_tokens <= 0 or self.num_image_token <= 0:
+            return 0
+
+        num_patches = num_vision_tokens // (self.patch_tokens + 1)
+        return num_patches * self.num_image_token


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Enable dynamic LoRA adapters on InternVL2 vision tower + connector (part of #31479) by implementing:

- `get_num_mm_encoder_tokens()`

- `get_num_mm_connector_tokens()`
## Technical Details
InternVL2 has a CLS token and pixel-shuffle downsampling (downsample_ratio), so LM <IMG_CONTEXT> tokens (post-downsample) don’t match tower tokens (pre-downsample). These helpers map token counts correctly between LM and tower/connector.

Part of https://github.com/vllm-project/vllm/issues/31479.
