### PR TITLE
[KVConnector] OffloadingConnector: Add preemptions-only mode

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -265,7 +265,9 @@ class KVConnectorBase_V1(ABC):
         """
         return
 
-    def handle_preemptions(self, preempted_req_ids: set[str]):
+    def handle_preemptions(
+        self, preempted_req_ids: set[str], connector_metadata: KVConnectorMetadata
+    ):
         """
         Handle preempted requests BEFORE their blocks are overwritten.
         Needed for connectors which use async saves (e.g., OffloadingConnector)

--- a/vllm/v1/kv_offload/spec.py
+++ b/vllm/v1/kv_offload/spec.py
@@ -39,6 +39,10 @@ class OffloadingSpec(ABC):
         self.offloaded_block_size = int(
             self.extra_config.get("block_size", self.gpu_block_size)
         )
+        self.preemptions_only_mode = (
+            str(self.extra_config.get("preemptions_only_mode", "false")).lower()
+            == "true"
+        )
 
         assert self.offloaded_block_size % self.gpu_block_size == 0
 

--- a/vllm/v1/worker/gpu/kv_connector.py
+++ b/vllm/v1/worker/gpu/kv_connector.py
@@ -63,9 +63,13 @@ class ActiveKVConnector(KVConnector):
         if self._disabled:
             return
 
-        if scheduler_output.preempted_req_ids:
-            self.kv_connector.handle_preemptions(scheduler_output.preempted_req_ids)
         assert scheduler_output.kv_connector_metadata is not None
+        if scheduler_output.preempted_req_ids:
+            self.kv_connector.handle_preemptions(
+                scheduler_output.preempted_req_ids,
+                scheduler_output.kv_connector_metadata,
+            )
+
         self.kv_connector.bind_connector_metadata(
             scheduler_output.kv_connector_metadata
         )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3280,8 +3280,10 @@ class GPUModelRunner(
                 logger.error("RoutedExpertsCapturer not initialized.")
 
         if scheduler_output.preempted_req_ids and has_kv_transfer_group():
+            assert scheduler_output.kv_connector_metadata is not None
             get_kv_transfer_group().handle_preemptions(
-                scheduler_output.preempted_req_ids
+                scheduler_output.preempted_req_ids,
+                scheduler_output.kv_connector_metadata,
             )
 
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens


### PR DESCRIPTION
This PR adds a new preemptions-only mode for the OffloadingConnector. In this mode, only preempted requests are offloading, and only requests resumed from preemption are loaded back.
This allows handling preemptions cost-efficiently using minimal CPU usage.

The next step will be to enabling CPU offloading by default with a low memory reservation, just for the sake of handling preemptions.

The change in the OffloadingConnector is relatively small, but turned a big bigger due to some refactoring I included in the `_get_reqs_to_store` function, as well as the unifying of several state-keeping members of `OffloadingConnectorScheduler`.
A change is also needed in the recently added `handle_preemptions` connector API.