### PR TITLE
Remove non-aiter quant matching path for rocm_aiter_fusion.py

### DIFF
--- a/vllm/compilation/rocm_aiter_fusion.py
+++ b/vllm/compilation/rocm_aiter_fusion.py
@@ -170,7 +170,7 @@ class AiterRMSFp8GroupQuantPattern(AiterRMSNormQuantPattern):
         epsilon: float,
         quant_dtype: torch.dtype,
         group_shape: GroupShape,
-        symmetric: bool =True,
+        symmetric: bool = True,
     ) -> None:
         scale = ScaleDesc(torch.float32, False, group_shape)
         key = FusedRMSQuantKey(


### PR DESCRIPTION
## Purpose
This path only worked when custom ops and aiter were enabled and is not functional when custom quant_fp8 is disabled due to duplicate patterns being created. When quant_fp8's custom op is disabled, the match_aiter_quant=True path already already matches on the IR.

## Test Plan
tests/compile/test_fusion.py

## Test Result
The same tests pass and fail after this change.