### PR TITLE
[BugFix] Python file source reading can fail on UnicodeDecodeError

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -606,7 +606,7 @@ class VllmBackend:
             try:
                 with open(filepath) as f:
                     hash_content.append(f.read())
-            except OSError:
+            except (OSError, UnicodeDecodeError):
                 logger.warning("Failed to read file %s", filepath)
                 continue
         code_hash = hashlib.sha256("\n".join(hash_content).encode()).hexdigest()


### PR DESCRIPTION
## Purpose

We're running into an issue with
https://github.com/vllm-project/vllm/pull/31616

The two main errors one gets is OSError *and* UnicodeDecodeError, not just OSError.

This PR is a hotfix for this. In a separate, follow-up PR I will try to fix the UnicodeDecodeError issue (I don't want to do it in this PR because it will take a bit longer).

