### PR TITLE
[Bugfix] Seed OSS 36B Tool Parsing

### DIFF
--- a/vllm/tool_parsers/seed_oss_tool_parser.py
+++ b/vllm/tool_parsers/seed_oss_tool_parser.py
@@ -108,132 +108,143 @@ class SeedOssToolParser(ToolParser):
         self.json_started = False
         self.json_closed = False
 
+    def _get_arguments_config(
+        self, func_name: str, tools: list[ChatCompletionToolsParam] | None
+    ) -> dict:
+        """Extract argument configuration for a function."""
+        if tools is None:
+            return {}
+        for config in tools:
+            if not hasattr(config, "type") or not (
+                hasattr(config, "function") and hasattr(config.function, "name")
+            ):
+                continue
+            if config.type == "function" and config.function.name == func_name:
+                if not hasattr(config.function, "parameters"):
+                    return {}
+                params = config.function.parameters
+                if isinstance(params, dict) and "properties" in params:
+                    return params["properties"]
+                elif isinstance(params, dict):
+                    return params
+                else:
+                    return {}
+        logger.debug("Tool '%s' is not defined in the tools list.", func_name)
+        return {}
+
+    def _convert_param_value(
+        self, param_value: str, param_name: str, param_config: dict, func_name: str
+    ) -> Any:
+        """Convert parameter value based on its type in the schema."""
+        # Handle null value for any type
+        if param_value.lower() == "null":
+            return None
+
+        if param_name not in param_config:
+            if param_config != {}:
+                logger.debug(
+                    "Parsed parameter '%s' is not defined in the tool "
+                    "parameters for tool '%s', directly returning the "
+                    "string value.",
+                    param_name,
+                    func_name,
+                )
+            return param_value
+
+        if (
+            isinstance(param_config[param_name], dict)
+            and "type" in param_config[param_name]
+        ):
+            param_type = str(param_config[param_name]["type"]).strip().lower()
+        else:
+            param_type = "string"
+        if param_type in ["string", "str", "text", "varchar", "char", "enum"]:
+            return param_value
+        elif (
+            param_type.startswith("int")
+            or param_type.startswith("uint")
+            or param_type.startswith("long")
+            or param_type.startswith("short")
+            or param_type.startswith("unsigned")
+        ):
+            try:
+                return int(param_value)
+            except (ValueError, TypeError):
+                logger.debug(
+                    "Parsed value '%s' of parameter '%s' is not an "
+                    "integer in tool '%s', degenerating to string.",
+                    param_value,
+                    param_name,
+                    func_name,
+                )
+                return param_value
+        elif param_type.startswith("num") or param_type.startswith("float"):
+            try:
+                float_param_value = float(param_value)
+                return (
+                    float_param_value
+                    if float_param_value - int(float_param_value) != 0
+                    else int(float_param_value)
+                )
+            except (ValueError, TypeError):
+                logger.debug(
+                    "Parsed value '%s' of parameter '%s' is not a float "
+                    "in tool '%s', degenerating to string.",
+                    param_value,
+                    param_name,
+                    func_name,
+                )
+                return param_value
+        elif param_type in ["boolean", "bool", "binary"]:
+            param_value = param_value.lower()
+            if param_value not in ["true", "false"]:
+                logger.debug(
+                    "Parsed value '%s' of parameter '%s' is not a boolean "
+                    "(`true` or `false`) in tool '%s', degenerating to "
+                    "false.",
+                    param_value,
+                    param_name,
+                    func_name,
+                )
+            return param_value == "true"
+        else:
+            if (
+                param_type in ["object", "array", "arr"]
+                or param_type.startswith("dict")
+                or param_type.startswith("list")
+            ):
+                try:
+                    param_value = json.loads(param_value)
+                    return param_value
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    logger.debug(
+                        "Parsed value '%s' of parameter '%s' cannot be "
+                        "parsed with json.loads in tool '%s', will try "
+                        "other methods to parse it.",
+                        param_value,
+                        param_name,
+                        func_name,
+                    )
+            try:
+                param_value = ast.literal_eval(param_value)  # safer
+            except (ValueError, SyntaxError, TypeError):
+                logger.debug(
+                    "Parsed value '%s' of parameter '%s' cannot be "
+                    "converted via Python `ast.literal_eval()` in tool "
+                    "'%s', degenerating to string.",
+                    param_value,
+                    param_name,
+                    func_name,
+                )
+            return param_value
+
     def _parse_xml_function_call(
         self, function_call_str: str, tools: list[ChatCompletionToolsParam] | None
     ) -> ToolCall | None:
-        def get_arguments_config(func_name: str) -> dict:
-            if tools is None:
-                return {}
-            for config in tools:
-                if not hasattr(config, "type") or not (
-                    hasattr(config, "function") and hasattr(config.function, "name")
-                ):
-                    continue
-                if config.type == "function" and config.function.name == func_name:
-                    if not hasattr(config.function, "parameters"):
-                        return {}
-                    params = config.function.parameters
-                    if isinstance(params, dict) and "properties" in params:
-                        return params["properties"]
-                    elif isinstance(params, dict):
-                        return params
-                    else:
-                        return {}
-            logger.warning("Tool '%s' is not defined in the tools list.", func_name)
-            return {}
-
-        def convert_param_value(
-            param_value: str, param_name: str, param_config: dict, func_name: str
-        ) -> Any:
-            # Handle null value for any type
-            if param_value.lower() == "null":
-                return None
-
-            if param_name not in param_config:
-                if param_config != {}:
-                    logger.warning(
-                        "Parsed parameter '%s' is not defined in "
-                        "the tool parameters for tool '%s', "
-                        "directly returning the string value.",
-                        param_name,
-                        func_name,
-                    )
-                return param_value
-
-            if (
-                isinstance(param_config[param_name], dict)
-                and "type" in param_config[param_name]
-            ):
-                param_type = str(param_config[param_name]["type"]).strip().lower()
-            else:
-                param_type = "string"
-            if param_type in ["string", "str", "text", "varchar", "char", "enum"]:
-                return param_value
-            elif (
-                param_type.startswith("int")
-                or param_type.startswith("uint")
-                or param_type.startswith("long")
-                or param_type.startswith("short")
-                or param_type.startswith("unsigned")
-            ):
-                try:
-                    param_value = int(param_value)  # type: ignore
-                except (ValueError, TypeError):
-                    logger.warning(
-                        "Parsed value '%s' of parameter '%s' is not an integer in tool "
-                        "'%s', degenerating to string.",
-                        param_value,
-                        param_name,
-                        func_name,
-                    )
-                return param_value
-            elif param_type.startswith("num") or param_type.startswith("float"):
-                try:
-                    float_param_value = float(param_value)
-                    param_value = (
-                        float_param_value  # type: ignore
-                        if float_param_value - int(float_param_value) != 0
-                        else int(float_param_value)  # type: ignore
-                    )
-                except (ValueError, TypeError):
-                    logger.warning(
-                        "Parsed value '%s' of parameter '%s' is not a float in tool "
-                        "'%s', degenerating to string.",
-                        param_value,
-                        param_name,
-                        func_name,
-                    )
-                return param_value
-            elif param_type in ["boolean", "bool", "binary"]:
-                param_value = param_value.lower()
-                if param_value not in ["true", "false"]:
-                    logger.warning(
-                        "Parsed value '%s' of parameter '%s' is not a boolean "
-                        "(`true` of `false`) in tool '%s', degenerating to false.",
-                        param_value,
-                        param_name,
-                        func_name,
-                    )
-                return param_value == "true"
-            else:
-                if param_type == "object" or param_type.startswith("dict"):
-                    try:
-                        param_value = json.loads(param_value)
-                        return param_value
-                    except (ValueError, TypeError, json.JSONDecodeError):
-                        logger.warning(
-                            "Parsed value '%s' of parameter '%s' is not a valid JSON "
-                            "object in tool '%s', will try other methods to parse it.",
-                            param_value,
-                            param_name,
-                            func_name,
-                        )
-                try:
-                    param_value = ast.literal_eval(param_value)
-                except (ValueError, SyntaxError):
-                    logger.warning(
-                        "Parsed value '%s' of parameter '%s' cannot be converted via "
-                        "Python `ast.literal_eval()` in tool '%s', degenerating to string.",
-                        param_value,
-                        param_name,
-                        func_name,
-                    )
-                return param_value
-
         # Extract function name
         end_index = function_call_str.index(">")
         function_name = function_call_str[:end_index]
-        param_config = get_arguments_config(function_name)
+        param_config = self._get_arguments_config(function_name, tools)
         parameters = function_call_str[end_index + 1 :]
         param_dict = {}
         for match in self.tool_call_parameter_regex.findall(parameters):
@@ -247,7 +258,7 @@ class SeedOssToolParser(ToolParser):
             if param_value.endswith("\n"):
                 param_value = param_value[:-1]
 
-            param_dict[param_name] = convert_param_value(
+            param_dict[param_name] = self._convert_param_value(
                 param_value, param_name, param_config, function_name
             )
         return ToolCall(
@@ -639,22 +650,33 @@ class SeedOssToolParser(ToolParser):
                             if param_value.endswith("\n"):
                                 param_value = param_value[:-1]
 
-                            # Build complete JSON fragment for this parameter
+                            # Get parameter configuration for type conversion
+                            param_config = self._get_arguments_config(
+                                self.current_function_name or "",
+                                request.tools if request else None,
+                            )
+
+                            # Convert param value to appropriate type
+                            converted_value = self._convert_param_value(
+                                param_value,
+                                self.current_param_name,
+                                param_config,
+                                self.current_function_name or "",
+                            )
+
+                            # Build JSON fragment based on the converted type
+                            # Use json.dumps to properly serialize the value
+                            serialized_value = json.dumps(
+                                converted_value, ensure_ascii=False
+                            )
+
                             if self.param_count == 0:
                                 json_fragment = (
-                                    '"'
-                                    + self.current_param_name
-                                    + '": "'
-                                    + json.dumps(param_value)[1:-1]
-                                    + '"'
+                                    f'"{self.current_param_name}": {serialized_value}'
                                 )
                             else:
                                 json_fragment = (
-                                    ', "'
-                                    + self.current_param_name
-                                    + '": "'
-                                    + json.dumps(param_value)[1:-1]
-                                    + '"'
+                                    f', "{self.current_param_name}": {serialized_value}'
                                 )
 
                             self.param_count += 1


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes bugs #32352 and #26573 in seed_oss_tool_parser.py.

## Changes

- Lift `_get_arguments_config()` and `_convert_param_value()` functions into their own top-level instance methods
- Properly serialize each tool parameter before building the final JSON fragment
- Assume `is_thinking=False` by default and handle thinking state before parsing any tools
- Add test cases to confirm fixes are effective

## Test Plan

```
uv run pytest -v tests/tool_parsers/test_seed_oss_tool_parser.py
```

## Test Result

```
========================================================== test session starts ===========================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /home/alex/dev/vllm/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/alex/dev/vllm
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 12 items

tests/tool_parsers/test_seed_oss_tool_parser.py::test_extract_tool_calls_no_tools PASSED                                           [  8%]
tests/tool_parsers/test_seed_oss_tool_parser.py::test_extract_tool_calls[tool_call_0_thinking_budget] PASSED                       [ 16%]
tests/tool_parsers/test_seed_oss_tool_parser.py::test_extract_tool_calls[tool_call_512_thinkg_budget] PASSED                       [ 25%]
tests/tool_parsers/test_seed_oss_tool_parser.py::test_extract_tool_calls[tool_call_unlimited_thinking_budget] PASSED               [ 33%]
tests/tool_parsers/test_seed_oss_tool_parser.py::test_streaming_tool_calls_no_tools PASSED                                         [ 41%]
tests/tool_parsers/test_seed_oss_tool_parser.py::test_streaming_tool_calls[tool_call_0_thinking_budget] PASSED                     [ 50%]
tests/tool_parsers/test_seed_oss_tool_parser.py::test_streaming_tool_calls[tool_call_512_thinkg_budget] PASSED                     [ 58%]
tests/tool_parsers/test_seed_oss_tool_parser.py::test_streaming_tool_calls[tool_call_unlimited_thinking_budget] PASSED             [ 66%]
tests/tool_parsers/test_seed_oss_tool_parser.py::test_array_parameter_parsing PASSED                                               [ 75%]
tests/tool_parsers/test_seed_oss_tool_parser.py::test_tool_calls_without_think_tokens PASSED                                       [ 83%]
tests/tool_parsers/test_seed_oss_tool_parser.py::test_streaming_array_parameter PASSED                                             [ 91%]
tests/tool_parsers/test_seed_oss_tool_parser.py::test_streaming_without_think_tokens PASSED                                        [100%]

============================================================ warnings summary ============================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== 12 passed, 2 warnings in 4.48s =====================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

In addition to the unit tests, I've been using this parser in VLLM with Roo Code and everything is working as expected.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] ~~(Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.~~
- [ ] ~~(Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).~~
</details>

