### PR TITLE
[ROCm][CI] Enable AITER Unified Attention On ROCm For gpt-oss Test

### DIFF
--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -10,6 +10,7 @@ import pytest
 import pytest_asyncio
 from openai import OpenAI
 
+from vllm._aiter_ops import is_aiter_found_and_supported
 from vllm.config.multimodal import MultiModalConfig
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
@@ -23,7 +24,6 @@ from vllm.entrypoints.openai.engine.protocol import (
 from vllm.entrypoints.openai.models.serving import BaseModelPath, OpenAIServingModels
 from vllm.entrypoints.openai.parser.harmony_utils import get_encoding
 from vllm.outputs import CompletionOutput, RequestOutput
-from vllm.platforms import current_platform
 from vllm.tokenizers import get_tokenizer
 from vllm.tool_parsers import ToolParserManager
 from vllm.v1.engine.async_llm import AsyncLLM
@@ -109,13 +109,13 @@ def gptoss_speculative_server(default_server_args: list[str]):
         f'"method": "eagle3", "num_speculative_tokens": 3}}',
         f"--attention-backend={
             'TRITON_ATTN'
-            if not current_platform.is_rocm()
+            if not is_aiter_found_and_supported()
             else 'ROCM_AITER_UNIFIED_ATTN'
         }",
     ]
     # gpt-oss requires AITER unified attention on ROCm
     env_dict = None
-    if current_platform.is_rocm():
+    if is_aiter_found_and_supported():
         env_dict = {"VLLM_ROCM_USE_AITER": "1"}
     with RemoteOpenAIServer(
         GPT_OSS_MODEL_NAME, server_args, env_dict=env_dict

--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -114,6 +114,8 @@ def gptoss_speculative_server(default_server_args: list[str]):
         }",
     ]
     # gpt-oss requires AITER unified attention on ROCm
+    # TODO: Remove after fixing TRITON_ATTN issue on ROCm
+    # https://github.com/vllm-project/vllm/issues/32434
     env_dict = None
     if is_aiter_found_and_supported():
         env_dict = {"VLLM_ROCM_USE_AITER": "1"}


### PR DESCRIPTION
<!-- markdownlint-disable -->
https://github.com/vllm-project/vllm/pull/26291 introduced a gpt-oss test which currently fails on ROCm:
```
pytest -v -s tests/entrypoints/openai/test_serving_chat.py::TestGPTOSSSpeculativeChat::test_gpt_oss_speculative_reasoning_leakage[with_tool_parser-exclude_tools_when_tool_choice_none]
```

On ROCm, gpt-oss requires the `ROCM_AITER_UNIFIED_ATTN` backend to be enabled. It is expected that `TRITON_ATTN` should work, however, so I have filed an issue for this here: https://github.com/vllm-project/vllm/issues/32434.You can see this by running the same test with the correct environment variables, and seeing that it passes:
```
VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1 pytest -v -s tests/entrypoints/openai/test_serving_chat.py::TestGPTOSSSpeculativeChat::test_gpt_oss_speculative_reasoning_leakage[with_tool_parser-exclude_tools_when_tool_choice_none]

Result: =========== 1 passed, 3 warnings in 43.59s ==============
```

This PR enables AITER and sets the `ROCM_AITER_UNIFIED_ATTN` attention backend required to run gpt-oss on ROCm correctly.