### PR TITLE
[Misc] Add Device Config to Prometheus Logger

### DIFF
--- a/vllm/config/device.py
+++ b/vllm/config/device.py
@@ -26,9 +26,9 @@ class CudaInfo:
     gpu_name: str | None = None
     """GPU name (e.g., 'NVIDIA A100-SXM4-40GB'). """
     gpu_memory: str | None = None
-    """Total GPU memory in bytes. """
-    gpu_compute_capability: tuple[int, int] | None = None
-    """GPU compute capability as (major, minor) tuple. """
+    """Total GPU memory (e.g., '39.59 GiB'). """
+    gpu_compute_capability: str | None = None
+    """GPU compute capability as a string (e.g., '8.6'). """
     gpu_multi_processor_count: int | None = None
     """Number of streaming multiprocessors (SMs). """
     gpu_device_index: int | None = None
@@ -40,7 +40,7 @@ class CudaInfo:
     gpu_pci_domain_id: int | None = None
     """GPU PCI domain ID. """
     gpu_l2_cache_size: str | None = None
-    """GPU L2 cache size in bytes. """
+    """GPU L2 cache size (e.g., '6.00 MiB'). """
 
     # CPU and platform information
     cpu_count: int | None = None
@@ -54,7 +54,7 @@ class CudaInfo:
     platform_info: str | None = None
     """Platform information string."""
     total_memory: str | None = None
-    """Total system memory in bytes."""
+    """Total system memory (e.g., '15.91 GiB'). """
 
     @classmethod
     def collect(
@@ -97,8 +97,10 @@ class CudaInfo:
             l2_cache_size,
         ) = cuda_get_device_properties(device_index, property_names)
 
-        cuda_info.gpu_memory = f"{gpu_memory / 1024 / 1024 / 1024:.2f} GiB"
-        cuda_info.gpu_l2_cache_size = f"{l2_cache_size / 1024 / 1024:.2f} MiB"
+        if gpu_memory is not None:
+            cuda_info.gpu_memory = f"{gpu_memory / 1024 / 1024 / 1024:.2f} GiB"
+        if l2_cache_size is not None:
+            cuda_info.gpu_l2_cache_size = f"{l2_cache_size / 1024 / 1024:.2f} MiB"
         cuda_info.gpu_compute_capability = (
             f"{major}.{minor}" if major is not None and minor is not None else None
         )
@@ -118,8 +120,11 @@ class CudaInfo:
         # Platform information
         cuda_info.architecture = platform.machine()
         cuda_info.platform_info = platform.platform()
+        total_memory = psutil.virtual_memory().total
         cuda_info.total_memory = (
-            f"{psutil.virtual_memory().total / 1024 / 1024 / 1024:.2f} GiB"
+            f"{total_memory / 1024 / 1024 / 1024:.2f} GiB"
+            if total_memory is not None
+            else None
         )
 
         return cuda_info

--- a/vllm/config/device.py
+++ b/vllm/config/device.py
@@ -1,17 +1,128 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import platform
 from dataclasses import field
 from typing import Any, Literal
 
+import cpuinfo
+import psutil
 import torch
 from pydantic import ConfigDict, SkipValidation
 from pydantic.dataclasses import dataclass
 
 from vllm.config.utils import config
 from vllm.utils.hashing import safe_hash
+from vllm.utils.platform_utils import cuda_get_device_properties
 
 Device = Literal["auto", "cuda", "cpu", "tpu", "xpu"]
+
+
+@dataclass
+class CudaInfo:
+    """CUDA device information including GPU and CPU/platform details."""
+
+    # GPU properties
+    gpu_name: str | None = None
+    """GPU name (e.g., 'NVIDIA A100-SXM4-40GB'). """
+    gpu_memory: str | None = None
+    """Total GPU memory in bytes. """
+    gpu_compute_capability: tuple[int, int] | None = None
+    """GPU compute capability as (major, minor) tuple. """
+    gpu_multi_processor_count: int | None = None
+    """Number of streaming multiprocessors (SMs). """
+    gpu_device_index: int | None = None
+    """GPU device index. """
+    gpu_pci_bus_id: int | None = None
+    """GPU PCI bus ID. """
+    gpu_pci_device_id: int | None = None
+    """GPU PCI device ID. """
+    gpu_pci_domain_id: int | None = None
+    """GPU PCI domain ID. """
+    gpu_l2_cache_size: str | None = None
+    """GPU L2 cache size in bytes. """
+
+    # CPU and platform information
+    cpu_count: int | None = None
+    """Number of CPU cores."""
+    cpu_type: str | None = None
+    """CPU type/brand."""
+    cpu_family_model_stepping: str | None = None
+    """CPU family, model, and stepping as comma-separated string."""
+    architecture: str | None = None
+    """System architecture (e.g., 'x86_64')."""
+    platform_info: str | None = None
+    """Platform information string."""
+    total_memory: str | None = None
+    """Total system memory in bytes."""
+
+    @classmethod
+    def collect(
+        cls,
+        device_type: str,
+        device: torch.device | None,
+        current_platform: Any,
+    ) -> "CudaInfo":
+        """Collect CUDA information. Only collects data if device_type is 'cuda'."""
+        cuda_info = cls()
+
+        if device_type != "cuda" or not current_platform.is_cuda_alike():
+            return cuda_info
+
+        device_index = (
+            device.index if device is not None and device.index is not None else 0
+        )
+
+        # Get all GPU properties
+        property_names = [
+            "name",
+            "total_memory",
+            "major",
+            "minor",
+            "multi_processor_count",
+            "pci_bus_id",
+            "pci_device_id",
+            "pci_domain_id",
+            "L2_cache_size",
+        ]
+        (
+            cuda_info.gpu_name,
+            gpu_memory,
+            major,
+            minor,
+            cuda_info.gpu_multi_processor_count,
+            cuda_info.gpu_pci_bus_id,
+            cuda_info.gpu_pci_device_id,
+            cuda_info.gpu_pci_domain_id,
+            l2_cache_size,
+        ) = cuda_get_device_properties(device_index, property_names)
+
+        cuda_info.gpu_memory = f"{gpu_memory / 1024 / 1024 / 1024:.2f} GiB"
+        cuda_info.gpu_l2_cache_size = f"{l2_cache_size / 1024 / 1024:.2f} MiB"
+        cuda_info.gpu_compute_capability = (
+            f"{major}.{minor}" if major is not None and minor is not None else None
+        )
+        cuda_info.gpu_device_index = device_index
+
+        # Collect CPU and platform information
+        info = cpuinfo.get_cpu_info()
+        cuda_info.cpu_count = info.get("count", None)
+        cuda_info.cpu_type = info.get("brand_raw", "")
+        cpu_family = str(info.get("family", ""))
+        cpu_model = str(info.get("model", ""))
+        cpu_stepping = str(info.get("stepping", ""))
+        cuda_info.cpu_family_model_stepping = ",".join(
+            [cpu_family, cpu_model, cpu_stepping]
+        )
+
+        # Platform information
+        cuda_info.architecture = platform.machine()
+        cuda_info.platform_info = platform.platform()
+        cuda_info.total_memory = (
+            f"{psutil.virtual_memory().total / 1024 / 1024 / 1024:.2f} GiB"
+        )
+
+        return cuda_info
 
 
 @config
@@ -28,6 +139,8 @@ class DeviceConfig:
     device_type: str = field(init=False)
     """Device type from the current platform. This is set in
     `__post_init__`."""
+    cuda_info: CudaInfo = field(init=False)
+    """CUDA device information including GPU and CPU/platform details."""
 
     def compute_hash(self) -> str:
         """
@@ -49,10 +162,10 @@ class DeviceConfig:
         return hash_str
 
     def __post_init__(self):
+        from vllm.platforms import current_platform
+
         if self.device == "auto":
             # Automated device type detection
-            from vllm.platforms import current_platform
-
             self.device_type = current_platform.device_type
             if not self.device_type:
                 raise RuntimeError(
@@ -73,3 +186,19 @@ class DeviceConfig:
         else:
             # Set device with device type
             self.device = torch.device(self.device_type)
+
+        # Collect CUDA information (only populated for CUDA devices)
+        self.cuda_info = CudaInfo.collect(
+            self.device_type, self.device, current_platform
+        )
+
+    def metrics_info(self):
+        result = {}
+        for key, value in self.__dict__.items():
+            if key == "cuda_info":
+                # Flatten cuda_info fields
+                for cuda_key, cuda_value in value.__dict__.items():
+                    result[f"{cuda_key}"] = str(cuda_value)
+            else:
+                result[key] = str(value)
+        return result

--- a/vllm/utils/platform_utils.py
+++ b/vllm/utils/platform_utils.py
@@ -33,10 +33,13 @@ def cuda_get_device_properties(
     device, names: Sequence[str], init_cuda=False
 ) -> tuple[Any, ...]:
     """Get specified CUDA device property values without initializing CUDA in
-    the current process."""
+    the current process.
+
+    If a property name is missing, returns None for that property.
+    """
     if init_cuda or cuda_is_initialized():
         props = torch.cuda.get_device_properties(device)
-        return tuple(getattr(props, name) for name in names)
+        return tuple(getattr(props, name, None) for name in names)
 
     # Run in subprocess to avoid initializing CUDA as a side effect.
     mp_ctx = multiprocessing.get_context("fork")

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1007,6 +1007,9 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         if type == "cache_config":
             name = "vllm:cache_config_info"
             documentation = "Information of the LLMEngine CacheConfig"
+        elif type == "device_config":
+            name = "vllm:device_config_info"
+            documentation = "Information of the LLMEngine DeviceConfig"
         assert name is not None, f"Unknown metrics info type {type}"
 
         # Info type metrics are syntactic sugar for a gauge permanently set to 1
@@ -1188,6 +1191,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
 
     def log_engine_initialized(self):
         self.log_metrics_info("cache_config", self.vllm_config.cache_config)
+        self.log_metrics_info("device_config", self.vllm_config.device_config)
 
 
 PromMetric: TypeAlias = Gauge | Counter | Histogram


### PR DESCRIPTION
## Purpose
It's helpful to have device information in prometheus.

The metrics are published similar to the cache config information. Both are published once at initialization time.

## Test Plan
I have tested this via Grafana on a system with NVIDIA GPUs. 
I have not tested this on other systems such as AMD or TPU.

## Test Result
<img width="1737" height="77" alt="image" src="https://github.com/user-attachments/assets/bada66b6-4a67-4387-85d2-0c36ef2806bf" />