### PR TITLE
[Hardware][SM100] Add TRTLLM Kernel for INT4 W4A16 Kernel.

### DIFF
--- a/tests/kernels/moe/test_marlin_vs_trtllm_mxint4.py
+++ b/tests/kernels/moe/test_marlin_vs_trtllm_mxint4.py
@@ -113,7 +113,12 @@ def marlin_quantize_moe_weights(
     return weights_marlin, scales_marlin
 
 
-@pytest.mark.skipif(current_platform.is_rocm(), reason="Skip for rocm")
+TRTLLM_GEN_AVAILABLE = (
+    current_platform.is_cuda() and current_platform.is_device_capability_family(100)
+)
+
+
+@pytest.mark.skipif(not TRTLLM_GEN_AVAILABLE, reason="Skip for non SM100")
 @pytest.mark.parametrize("m", [1, 33])
 @pytest.mark.parametrize("n", [7168])
 @pytest.mark.parametrize("k", [512])

--- a/tests/kernels/moe/test_marlin_vs_trtllm_mxint4.py
+++ b/tests/kernels/moe/test_marlin_vs_trtllm_mxint4.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test comparing Marlin INT4 MoE vs FlashInfer TRT-LLM MXINT4 MoE."""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
+    fused_marlin_moe,
+)
+from vllm.model_executor.layers.quantization.utils.flashinfer_mxint4_moe import (
+    prepare_static_weights_for_trtllm_mxint4_moe,
+)
+from vllm.platforms import current_platform
+from vllm.scalar_type import scalar_types
+
+
+def noaux_tc_ref(logits, bias, n_group, topk_group, top_k, routed_scaling_factor):
+    """DeepSeek-style no-aux routing reference implementation."""
+    scores = torch.nn.functional.sigmoid(logits)
+    scores_with_bias = scores + bias if bias is not None else scores
+    if n_group > 1:
+        scores_shape = list(scores_with_bias.shape)
+        group_scores = torch.sum(
+            torch.topk(
+                scores_with_bias.view(
+                    scores_shape[:-1] + [n_group, scores_shape[-1] // n_group]
+                ),
+                k=2,
+                dim=-1,
+                largest=True,
+                sorted=True,
+            )[0],
+            dim=-1,
+        )
+        _, group_idx = torch.topk(
+            group_scores, k=topk_group, dim=-1, largest=True, sorted=True
+        )
+        group_mask = torch.zeros_like(group_scores)
+        group_mask.scatter_(-1, group_idx, 1)
+        score_mask = (
+            group_mask.unsqueeze(-1)
+            .expand(scores_shape[:-1] + [n_group, scores_shape[-1] // n_group])
+            .reshape(scores_shape)
+        )
+        scores_with_bias = scores_with_bias * score_mask
+
+    _, topk_idx = torch.topk(
+        scores_with_bias, k=top_k, dim=-1, largest=True, sorted=True
+    )
+    new_mask = torch.zeros_like(scores)
+    new_mask.scatter_(-1, topk_idx, 1)
+    scores = scores * new_mask
+    score_sum = torch.sum(scores, dim=-1, keepdim=True) + 1e-20
+    scores = scores / score_sum * routed_scaling_factor
+    return scores
+
+
+def mxint4_quantize(
+    x: torch.Tensor, sf_vec_size: int = 32
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize BF16 tensor to MXINT4 with block scaling (group_size=sf_vec_size).
+
+    Returns:
+        - uint8 packed (2 INT4/byte): [..., k//2] - stores SIGNED INT4 [-8, 7]
+        - scales in BF16: [..., k//sf_vec_size]
+    """
+    x_reshaped = x.reshape(-1, sf_vec_size)
+    x_max = x_reshaped.max(dim=-1, keepdim=True)[0].to(torch.float32)
+    x_min = x_reshaped.min(dim=-1, keepdim=True)[0].to(torch.float32)
+    x_max = x_max * 8.0 / 7.0
+    amax = torch.where(x_max > -x_min, x_max, -x_min)
+    scales = amax / 8.0
+    x_scaled = x_reshaped * scales.reciprocal()
+    x_int8 = (
+        x_scaled.round().clamp(-8, 7).to(torch.int8).reshape(-1, sf_vec_size // 2, 2)
+    )
+    x_int4 = (x_int8[..., 0] & 0x0F) | ((x_int8[..., 1] & 0x0F) << 4)
+    return (
+        x_int4.to(torch.uint8).reshape(*x.shape[:-1], x.shape[-1] // 2),
+        scales.to(x.dtype).reshape(*x.shape[:-1], x.shape[-1] // sf_vec_size),
+    )
+
+
+def mxint4_quantize_moe_weights(
+    weights_bf16: torch.Tensor, group_size: int = 32
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize MoE weights [e, n, k] to MxInt4 format.
+
+    Args:
+        weights_bf16: BF16 weights of shape [num_experts, out_features, in_features]
+        group_size: Quantization group size (default: 32)
+
+    Returns:
+        - weights_mxint4: Quantized weights [e, n, k//2] uint8
+        - scales_mxint4: Quantization scales [e, n, k//group_size] bf16
+    """
+    e = weights_bf16.shape[0]
+    weight_list = []
+    scale_list = []
+
+    for i in range(e):
+        w_q, w_s = mxint4_quantize(weights_bf16[i], sf_vec_size=group_size)
+        weight_list.append(w_q)
+        scale_list.append(w_s)
+
+    return torch.stack(weight_list), torch.stack(scale_list)
+
+
+__all__ = [
+    "mxint4_quantize",
+    "mxint4_quantize_moe_weights",
+    "marlin_quantize_moe_weights",
+]
+
+
+def marlin_quantize_moe_weights(
+    weights_bf16: torch.Tensor, group_size: int = 32
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize MoE weights [e, n, k] to Marlin INT4 format.
+
+    Args:
+        weights_bf16: BF16 weights of shape [num_experts, out_features, in_features]
+        group_size: Quantization group size (default: 32)
+
+    Returns:
+        - weights_marlin: Marlin quantized weights [e, k//8, n] int32
+        - scales_marlin: Marlin quantization scales [e, k//group_size, n] bf16
+    """
+    from vllm.model_executor.layers.quantization.utils.marlin_utils_test import (
+        marlin_quantize,
+    )
+
+    e, n, k = weights_bf16.shape
+    weight_list = []
+    scale_list = []
+
+    for i in range(e):
+        # Transpose for Marlin: [n, k] → [k, n]
+        w_t = weights_bf16[i].T.contiguous()
+        _, w_q, w_s, _, _, _ = marlin_quantize(
+            w_t, scalar_types.uint4b8, group_size, act_order=False
+        )
+        weight_list.append(w_q)
+        scale_list.append(w_s)
+
+    # Stack to get [e, ...] shape
+    weights_marlin = torch.stack(weight_list)  # [e, k // 8, n]
+    scales_marlin = torch.stack(scale_list)  # [e, k // group_size, n]
+
+    return weights_marlin, scales_marlin
+
+
+@pytest.mark.skipif(current_platform.is_rocm(), reason="Skip for rocm")
+@pytest.mark.parametrize("m", [1, 33])
+@pytest.mark.parametrize("n", [7168])
+@pytest.mark.parametrize("k", [512])
+@pytest.mark.parametrize("e", [384])
+@pytest.mark.parametrize("topk", [8])
+@pytest.mark.parametrize("group_size", [32])
+def test_marlin_vs_trtllm_mxint4_moe_kimik2(monkeypatch, m, n, k, e, topk, group_size):
+    """Compare Marlin INT4 MoE vs FlashInfer TRT-LLM MXINT4 MoE.
+
+    Uses mxint4_quantize() to generate common INT4 weights + BF16 scales,
+    then runs both Marlin and TRT-LLM kernels and compares outputs.
+    """
+    pytest.importorskip("flashinfer")
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_INT4", "1")
+
+    torch.cuda.manual_seed(0)
+
+    dtype = torch.bfloat16
+
+    # DeepSeekV3 routing config (from Kimi-K2-Thinking config.json)
+    n_group = 1  # n_group from model config
+    topk_group = 1  # topk_group from model config
+    routed_scaling = 2.827  # routed_scaling_factor from model config
+
+    # Input - realistic activation range for LLM (after LayerNorm: mean~0, std~1)
+    a = torch.randn((m, k), device="cuda", dtype=dtype) * 0.5
+
+    # Generate routing logits and bias (DeepSeekV3 expects float logits)
+    # Realistic ranges: logits typically [-3, 3], bias [-2, 2]
+    routing_logits = torch.randn((m, e), device="cuda", dtype=torch.float32) * 1.5
+    routing_bias = torch.randn(e, device="cuda", dtype=torch.float32) * 0.8
+
+    # 1. Generate BF16 weights (SHARED between both paths)
+    # Realistic weight initialization: Xavier/Glorot uniform scaling
+    # std = sqrt(2 / (fan_in + fan_out))
+    std_w1 = (2.0 / (k + 2 * n)) ** 0.5
+    std_w2 = (2.0 / (n + k)) ** 0.5
+    w1_bf16 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) * std_w1
+    w2_bf16 = torch.randn((e, k, n), device="cuda", dtype=dtype) * std_w2
+
+    # === Marlin path: Quantize using Marlin's method (UINT4b8) ===
+    w1_marlin, w1_scales_marlin = marlin_quantize_moe_weights(w1_bf16, group_size)
+    w2_marlin, w2_scales_marlin = marlin_quantize_moe_weights(w2_bf16, group_size)
+
+    routing_scores = noaux_tc_ref(
+        routing_logits,
+        routing_bias,
+        n_group,
+        topk_group,
+        topk,
+        routed_scaling,
+    )
+    topk_weights, topk_ids = torch.topk(
+        routing_scores, k=topk, dim=-1, largest=True, sorted=True
+    )
+    topk_weights = topk_weights.float()
+    topk_ids = topk_ids.int()
+
+    marlin_output = fused_marlin_moe(
+        a,
+        w1_marlin,
+        w2_marlin,
+        None,
+        None,
+        w1_scales_marlin,
+        w2_scales_marlin,
+        None,  # gating_output not needed when topk_weights/ids provided
+        topk_weights,
+        topk_ids,
+        global_num_experts=e,
+        expert_map=None,
+        global_scale1=None,
+        global_scale2=None,
+        g_idx1=None,
+        g_idx2=None,
+        input_global_scale1=None,
+        input_global_scale2=None,
+        sort_indices1=None,
+        sort_indices2=None,
+        w1_zeros=None,
+        w2_zeros=None,
+        input_dtype=dtype,
+        quant_type_id=scalar_types.uint4b8.id,
+        is_k_full=True,
+    )
+
+    # === TRT-LLM path: Quantize using MXINT4 method (signed INT4) ===
+    w1_int4, w1_scales = mxint4_quantize_moe_weights(w1_bf16, group_size)
+    w2_int4, w2_scales = mxint4_quantize_moe_weights(w2_bf16, group_size)
+
+    trtllm_weights = prepare_static_weights_for_trtllm_mxint4_moe(
+        gemm1_weights=w1_int4,
+        gemm1_scales=w1_scales,
+        gemm2_weights=w2_int4,
+        gemm2_scales=w2_scales,
+    )
+
+    from flashinfer import RoutingMethodType
+    from flashinfer.fused_moe import trtllm_mxint4_block_scale_moe
+
+    trtllm_output = trtllm_mxint4_block_scale_moe(
+        routing_logits=routing_logits,
+        routing_bias=routing_bias.to(torch.bfloat16),
+        hidden_states=a,
+        gemm1_weights=trtllm_weights["gemm1_weights"],
+        gemm1_weights_scale=trtllm_weights["gemm1_scales"],
+        gemm1_alpha=None,
+        gemm1_beta=None,
+        gemm1_clamp_limit=None,
+        gemm2_weights=trtllm_weights["gemm2_weights"],
+        gemm2_weights_scale=trtllm_weights["gemm2_scales"],
+        num_experts=e,
+        top_k=topk,
+        n_group=n_group,
+        topk_group=topk_group,
+        intermediate_size=n,
+        local_expert_offset=0,
+        local_num_experts=e,
+        routed_scaling_factor=routed_scaling,
+        routing_method_type=RoutingMethodType.DeepSeekV3,
+        enable_pdl=None,
+        output=None,
+        tune_max_num_tokens=8192,
+    ).to(dtype)
+
+    # Sanity check: manually compute BF16 reference for comparison
+    bf16_output = torch.zeros((m, k), device="cuda", dtype=dtype)
+    for token_idx in range(m):
+        for expert_rank in range(topk):
+            expert_id = topk_ids[token_idx, expert_rank].item()
+            weight = topk_weights[token_idx, expert_rank].item()
+            # w1: [2*n, k] @ [k] -> [2*n]
+            up_gate = a[token_idx] @ w1_bf16[expert_id].T  # [2*n]
+            gate, up = up_gate.chunk(2, dim=0)
+            intermediate = torch.nn.functional.silu(gate) * up  # [n]
+            # w2: [k, n] @ [n] -> [k]
+            expert_out = intermediate @ w2_bf16[expert_id].T  # [k]
+            bf16_output[token_idx] += weight * expert_out
+    # Compare against BF16 reference.
+    torch.testing.assert_close(marlin_output, bf16_output, atol=0.2, rtol=0.5)
+    torch.testing.assert_close(trtllm_output, bf16_output, atol=0.2, rtol=0.5)
+
+    # Compare against each other for sanity.
+    torch.testing.assert_close(marlin_output, trtllm_output, atol=0.2, rtol=0.5)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -174,6 +174,7 @@ if TYPE_CHECKING:
     VLLM_USE_FLASHINFER_MOE_FP16: bool = False
     VLLM_USE_FLASHINFER_MOE_FP8: bool = False
     VLLM_USE_FLASHINFER_MOE_FP4: bool = False
+    VLLM_USE_FLASHINFER_MOE_INT4: bool = False
     VLLM_FLASHINFER_MOE_BACKEND: Literal["throughput", "latency", "masked_gemm"] = (
         "latency"
     )
@@ -1240,17 +1241,21 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER": lambda: bool(
         int(os.getenv("VLLM_BLOCKSCALE_FP8_GEMM_FLASHINFER", "0"))
     ),
-    # Allow use of FlashInfer MoE kernels for fused moe ops.
+    # Allow use of FlashInfer BF16 MoE kernels for fused moe ops.
     "VLLM_USE_FLASHINFER_MOE_FP16": lambda: bool(
         int(os.getenv("VLLM_USE_FLASHINFER_MOE_FP16", "0"))
     ),
-    # Allow use of FlashInfer MoE kernels for fused moe ops.
+    # Allow use of FlashInfer FP8 MoE kernels for fused moe ops.
     "VLLM_USE_FLASHINFER_MOE_FP8": lambda: bool(
         int(os.getenv("VLLM_USE_FLASHINFER_MOE_FP8", "0"))
     ),
-    # Allow use of FlashInfer CUTLASS kernels for fused moe ops.
+    # Allow use of FlashInfer NVFP4 MoE kernels for fused moe ops.
     "VLLM_USE_FLASHINFER_MOE_FP4": lambda: bool(
         int(os.getenv("VLLM_USE_FLASHINFER_MOE_FP4", "0"))
+    ),
+    # Allow use of FlashInfer MxInt4 MoE kernels for fused moe ops.
+    "VLLM_USE_FLASHINFER_MOE_INT4": lambda: bool(
+        int(os.getenv("VLLM_USE_FLASHINFER_MOE_INT4", "0"))
     ),
     # If set to 1, use the FlashInfer
     # MXFP8 (activation) x MXFP4 (weight) MoE backend.

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1134,6 +1134,11 @@ class FusedMoE(CustomOp):
             return False if return_success else None
         # Hereafter, `expert_id` is local physical id
 
+        # is_transposed: if the dim to shard the weight
+        # should be flipped. Required by GPTQ, compressed-tensors
+        # should be whatever dimension intermediate_size_per_partition is
+        is_transposed = getattr(param, "is_transposed", False)
+
         # compressed-tensors checkpoints with packed weights are stored flipped
         # TODO (mgoin): check self.quant_method.quant_config.quant_format
         # against known CompressionFormat enum values that have this quality
@@ -1141,13 +1146,10 @@ class FusedMoE(CustomOp):
             "CompressedTensorsWNA16MarlinMoEMethod",
             "CompressedTensorsWNA16MoEMethod",
         ):
-            if (
-                hasattr(self.quant_method, "use_flashinfer_mxint4_moe")
-                and self.quant_method.use_flashinfer_mxint4_moe
-            ):
-                loaded_weight = loaded_weight
-            else:
+            if is_transposed:
                 loaded_weight = loaded_weight.t().contiguous()
+            else:
+                loaded_weight = loaded_weight
 
         if shard_id not in ("w1", "w2", "w3"):
             raise ValueError(f"shard_id must be ['w1','w2','w3'] but got {shard_id}.")
@@ -1185,10 +1187,6 @@ class FusedMoE(CustomOp):
                 )
             return True if return_success else None
 
-        # is_transposed: if the dim to shard the weight
-        # should be flipped. Required by GPTQ, compressed-tensors
-        # should be whatever dimension intermediate_size_per_partition is
-        is_transposed = getattr(param, "is_transposed", False)
         shard_dim = SHARD_ID_TO_SHARDED_DIM[shard_id]
         if is_transposed:
             shard_dim = int(not shard_dim)

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1141,7 +1141,13 @@ class FusedMoE(CustomOp):
             "CompressedTensorsWNA16MarlinMoEMethod",
             "CompressedTensorsWNA16MoEMethod",
         ):
-            loaded_weight = loaded_weight.t().contiguous()
+            if (
+                hasattr(self.quant_method, "use_flashinfer_mxint4_moe")
+                and self.quant_method.use_flashinfer_mxint4_moe
+            ):
+                loaded_weight = loaded_weight
+            else:
+                loaded_weight = loaded_weight.t().contiguous()
 
         if shard_id not in ("w1", "w2", "w3"):
             raise ValueError(f"shard_id must be ['w1','w2','w3'] but got {shard_id}.")

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -1259,6 +1259,13 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
             and self.group_size == 32
             and weight_quant.num_bits == 4
         )
+        if self.use_flashinfer_mxint4_moe:
+            logger.info_once(
+                "Using Flashinfer TRTLLM Kernels for MXINT4 MoE"
+                f"with group size {self.group_size}, "
+                f"and num bits {self.num_bits}",
+                scope="local",
+            )
 
     def get_weight_shape(
         self,
@@ -1340,7 +1347,6 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
         **extra_weight_attrs,
     ):
         intermediate_size_full = extra_weight_attrs.pop("intermediate_size_full")
-        w13_num_shards = 2 if self.moe.is_act_and_mul else 1
 
         # Will transpose the loaded weight along the
         # intermediate and hidden dim sizes. Will
@@ -1689,7 +1695,6 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
         topk_weights: torch.Tensor,
         topk_ids: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        
         if self.use_flashinfer_mxint4_moe:
             return flashinfer_trtllm_mxint4_moe(
                 layer=layer,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -1701,6 +1701,7 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
         x: torch.Tensor,
         router_logits: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        assert self.kernel_backend == "Flashinfer"
         return flashinfer_trtllm_mxint4_moe(
             x=x,
             router_logits=router_logits,
@@ -1742,6 +1743,7 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
             quant_type_id=self.quant_type.id,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             global_num_experts=layer.global_num_experts,
+            activation=layer.activation,
             expert_map=layer.expert_map,
             g_idx1=layer.w13_weight_g_idx,
             g_idx2=layer.w2_weight_g_idx,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -63,9 +63,6 @@ from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
     flashinfer_trtllm_fp4_moe,
     flashinfer_trtllm_fp4_routed_moe,
 )
-from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
-    apply_fi_trtllm_fp8_per_tensor_moe,
-)
 from vllm.model_executor.layers.quantization.utils.flashinfer_mxint4_moe import (
     flashinfer_trtllm_mxint4_moe,
     is_flashinfer_mxint4_moe_available,
@@ -73,7 +70,6 @@ from vllm.model_executor.layers.quantization.utils.flashinfer_mxint4_moe import 
 )
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     apply_fi_trtllm_fp8_per_tensor_moe,
-    build_flashinfer_fp8_cutlass_moe_prepare_finalize,
 )
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     process_fp8_input_tensor_strategy_moe,

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_mxint4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_mxint4_moe.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Utility helpers for MxInt4 + FlashInfer fused-MoE path"""
+
+import functools
+
+import torch
+
+import vllm.envs as envs
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
+
+__all__ = [
+    "prepare_static_weights_for_trtllm_mxint4_moe",
+    "flashinfer_trtllm_mxint4_moe",
+    "is_flashinfer_mxint4_moe_available",
+]
+
+logger = init_logger(__name__)
+
+
+@functools.lru_cache(maxsize=1)
+def is_flashinfer_mxint4_moe_available() -> bool:
+    """Return `True` when FlashInfer MxInt4 kernels can be used."""
+    use_flashinfer_mxint4_moe = (
+        envs.VLLM_USE_FLASHINFER_MOE_INT4
+        and has_flashinfer_trtllm_fused_moe()
+        and current_platform.is_cuda()
+        and current_platform.is_device_capability_family(100)
+    )
+    logger.debug_once(
+        f"Using FlashInfer MxInt4 MoE: {use_flashinfer_mxint4_moe}", scope="local"
+    )
+    return use_flashinfer_mxint4_moe
+
+
+def prepare_static_weights_for_trtllm_mxint4_moe(
+    gemm1_weights,
+    gemm1_scales,
+    gemm2_weights,
+    gemm2_scales,
+):
+    """
+    Prepare MxInt4 weights for TRT-LLM kernel.
+
+    Input:
+        gemm1_weights: [num_experts, 2*intermediate_size, hidden_size//8] int32
+            (checkpoint uint4b8 packed) or uint8 (already packed signed int4)
+        gemm1_scales: [num_experts, 2*intermediate_size, hidden_size//32] bf16
+        gemm2_weights: [num_experts, hidden_size, intermediate_size//8] int32
+            (checkpoint uint4b8 packed) or uint8 (already packed signed int4)
+        gemm2_scales: [num_experts, hidden_size, intermediate_size//32] bf16
+
+    Returns:
+        Tuple of shuffled/packed weights and scales ready for kernel
+    """
+    from flashinfer import block_scale_interleave
+    from flashinfer.fused_moe import (
+        convert_to_block_layout,
+    )
+    from flashinfer.fused_moe.core import (
+        _maybe_get_cached_w3_w1_permute_indices,
+        get_w2_permute_indices_with_cache,
+    )
+
+    from vllm.model_executor.layers.quantization.utils.flashinfer_fp4_moe import (
+        reorder_w1w3_to_w3w1,
+    )
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        convert_packed_uint4b8_to_signed_int4_inplace,
+    )
+
+    device = gemm1_weights.device
+    assert gemm1_weights.ndim == 3, (
+        f"Expected a 3D gemm1_weights tensor, got {gemm1_weights.shape}"
+    )
+    assert gemm1_scales.ndim == 3, (
+        f"Expected a 3D gemm1_scales tensor, got {gemm1_scales.shape}"
+    )
+    assert gemm2_weights.ndim == 3, (
+        f"Expected a 3D gemm2_weights tensor, got {gemm2_weights.shape}"
+    )
+    assert gemm2_scales.ndim == 3, (
+        f"Expected a 3D gemm2_scales tensor, got {gemm2_scales.shape}"
+    )
+
+    # Convert checkpoint format (uint4b8 in int32) to signed int4
+    # Checkpoint stores INT4 as unsigned [0, 15], kernel expects signed [-8, 7]
+    if gemm1_weights.dtype == torch.int32 and gemm2_weights.dtype == torch.int32:
+        convert_packed_uint4b8_to_signed_int4_inplace(gemm1_weights)
+        convert_packed_uint4b8_to_signed_int4_inplace(gemm2_weights)
+
+    gemm1_weights, gemm1_scales = reorder_w1w3_to_w3w1(
+        gemm1_weights, gemm1_scales, dim=-2
+    )
+
+    _cache_permute_indices: dict[torch.Size, torch.Tensor] = {}
+    num_experts = gemm1_weights.shape[0]
+
+    # Convert quantized weights to proper formats -
+    gemm1_weights_mxint4 = gemm1_weights.view(torch.uint8)
+    assert gemm1_scales.dtype == torch.bfloat16
+    gemm2_weights_mxint4 = gemm2_weights.view(torch.uint8)
+    assert gemm2_scales.dtype == torch.bfloat16
+
+    epilogue_tile_m = 128
+    gemm1_weights_mxint4_shuffled = []
+    gemm1_scales_shuffled = []
+    gemm2_weights_mxint4_shuffled = []
+    gemm2_scales_shuffled = []
+
+    for i in range(num_experts):
+        # Calculate the permute indices for the following:
+        # 1. Reorder rows of W1 and scales for fused gated activation
+        # 2. Shuffle weights and scaling factors for transposed mma output
+        # for both w3_w1 and w2 weights and scale factors
+        permute_indices = _maybe_get_cached_w3_w1_permute_indices(
+            _cache_permute_indices,
+            gemm1_weights_mxint4[i],
+            epilogue_tile_m,
+        )
+        gemm1_weights_shuffled = gemm1_weights_mxint4[i][
+            permute_indices.to(gemm1_weights.device)
+        ].contiguous()
+        permute_sf_indices = _maybe_get_cached_w3_w1_permute_indices(
+            _cache_permute_indices,
+            gemm1_scales[i],
+            epilogue_tile_m,
+            num_elts_per_sf=32,
+        ).to(device)
+        gemm1_scales_shuffled.append(
+            block_scale_interleave(gemm1_scales[i][permute_sf_indices].contiguous())
+        )
+
+        permute_indices = get_w2_permute_indices_with_cache(
+            _cache_permute_indices,
+            gemm2_weights_mxint4[i],
+            epilogue_tile_m,
+        )
+        gemm2_weights_shuffled = gemm2_weights_mxint4[i][
+            permute_indices.to(gemm2_weights.device)
+        ].contiguous()
+
+        permute_sf_indices = get_w2_permute_indices_with_cache(
+            _cache_permute_indices,
+            gemm2_scales[i],
+            epilogue_tile_m,
+            num_elts_per_sf=16,
+        )
+        gemm2_scales_shuffled.append(
+            block_scale_interleave(
+                gemm2_scales[i][permute_sf_indices.to(gemm2_scales.device)].contiguous()
+            )
+        )
+
+        block_k = 128
+        gemm1_weights_shuffled = convert_to_block_layout(
+            gemm1_weights_shuffled.view(torch.uint8), block_k
+        )
+        gemm2_weights_shuffled = convert_to_block_layout(
+            gemm2_weights_shuffled.view(torch.uint8), block_k
+        )
+
+        gemm1_weights_mxint4_shuffled.append(gemm1_weights_shuffled)
+        gemm2_weights_mxint4_shuffled.append(gemm2_weights_shuffled)
+
+    gemm1_weights_mxint4_shuffled = torch.stack(gemm1_weights_mxint4_shuffled)
+    gemm2_weights_mxint4_shuffled = torch.stack(gemm2_weights_mxint4_shuffled)
+    gemm1_scales_shuffled = torch.stack(gemm1_scales_shuffled).view(torch.bfloat16)
+    gemm2_scales_shuffled = torch.stack(gemm2_scales_shuffled).view(torch.bfloat16)
+    return {
+        "gemm1_weights": gemm1_weights_mxint4_shuffled,
+        "gemm1_scales": gemm1_scales_shuffled,
+        "gemm2_weights": gemm2_weights_mxint4_shuffled,
+        "gemm2_scales": gemm2_scales_shuffled,
+    }
+
+
+def flashinfer_trtllm_mxint4_moe(
+    layer: torch.nn.Module,
+    x: torch.Tensor,
+    router_logits: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Apply FlashInfer TensorRT-LLM MxInt4 MoE kernel.
+
+    Args:
+        layer: MoE layer with mxint4 weights and BF16 scales
+        x: Input tensor (bf16)
+        router_logits: Router logits for expert selection
+
+    Returns:
+        Output tensor from MoE layer
+    """
+    from flashinfer import RoutingMethodType
+    from flashinfer.fused_moe import trtllm_mxint4_block_scale_moe
+
+    assert x.dtype == torch.bfloat16
+    assert layer.w13_weight_packed.dtype == torch.uint8, (
+        f"w13_weight_packed dtype: {layer.w13_weight_packed.dtype}"
+    )
+    assert layer.w13_weight_scale.dtype == torch.bfloat16, (
+        f"w13_weight_scale dtype: {layer.w13_weight_scale.dtype}"
+    )
+    assert layer.w2_weight_packed.dtype == torch.uint8, (
+        f"w2_weight_packed dtype: {layer.w2_weight_packed.dtype}"
+    )
+    assert layer.w2_weight_scale.dtype == torch.bfloat16, (
+        f"w2_weight_scale dtype: {layer.w2_weight_scale.dtype}"
+    )
+
+    routing_bias = None
+    if layer.e_score_correction_bias is not None:
+        routing_bias = layer.e_score_correction_bias.to(torch.bfloat16)
+
+    if layer.routing_method_type == RoutingMethodType.DeepSeekV3:
+        router_logits = router_logits.to(torch.float32)
+
+    out = trtllm_mxint4_block_scale_moe(
+        routing_logits=router_logits,
+        routing_bias=routing_bias,
+        hidden_states=x,
+        gemm1_weights=layer.w13_weight_packed.data,
+        gemm1_weights_scale=layer.w13_weight_scale.data,
+        gemm1_alpha=layer.gemm1_alpha.data if hasattr(layer, "gemm1_alpha") else None,
+        gemm1_beta=layer.gemm1_beta.data if hasattr(layer, "gemm1_beta") else None,
+        gemm1_clamp_limit=layer.gemm1_clamp_limit.data
+        if hasattr(layer, "gemm1_clamp_limit")
+        else None,
+        gemm2_weights=layer.w2_weight_packed.data,
+        gemm2_weights_scale=layer.w2_weight_scale.data,
+        num_experts=layer.global_num_experts,
+        top_k=layer.top_k,
+        n_group=layer.num_expert_group if layer.num_expert_group is not None else 0,
+        topk_group=layer.topk_group if layer.topk_group is not None else 0,
+        intermediate_size=layer.intermediate_size_per_partition,
+        local_expert_offset=layer.ep_rank * layer.local_num_experts,
+        local_num_experts=layer.local_num_experts,
+        routed_scaling_factor=None,
+        routing_method_type=layer.routing_method_type,
+        enable_pdl=None,
+        output=None,
+        tune_max_num_tokens=8192,
+    ).to(x.dtype)
+
+    return out

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -131,19 +131,9 @@ scaled_fp4_grouped_quantize = _lazy_import_wrapper(
 nvfp4_block_scale_interleave = _lazy_import_wrapper(
     "flashinfer.fp4_quantization", "block_scale_interleave"
 )
-
-block_scale_interleave = _lazy_import_wrapper(
-    "flashinfer.fp4_quantization", "block_scale_interleave"
-)
-
 trtllm_fp4_block_scale_moe = _lazy_import_wrapper(
     "flashinfer", "trtllm_fp4_block_scale_moe"
 )
-
-trtllm_mxintw4a16_block_scale_moe = _lazy_import_wrapper(
-    "flashinfer", "trtllm_mxint4_block_scale_moe"
-)
-
 # Special case for autotune since it returns a context manager
 autotune = _lazy_import_wrapper(
     "flashinfer.autotuner",

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -141,7 +141,7 @@ trtllm_fp4_block_scale_moe = _lazy_import_wrapper(
 )
 
 trtllm_mxintw4a16_block_scale_moe = _lazy_import_wrapper(
-    "flashinfer", "trtllm_mxintw4a16__moe"
+    "flashinfer", "trtllm_mxint4_block_scale_moe"
 )
 
 # Special case for autotune since it returns a context manager

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -129,10 +129,19 @@ scaled_fp4_grouped_quantize = _lazy_import_wrapper(
     "flashinfer", "scaled_fp4_grouped_quantize"
 )
 nvfp4_block_scale_interleave = _lazy_import_wrapper(
-    "flashinfer", "nvfp4_block_scale_interleave"
+    "flashinfer.fp4_quantization", "block_scale_interleave"
 )
+
+block_scale_interleave = _lazy_import_wrapper(
+    "flashinfer.fp4_quantization", "block_scale_interleave"
+)
+
 trtllm_fp4_block_scale_moe = _lazy_import_wrapper(
     "flashinfer", "trtllm_fp4_block_scale_moe"
+)
+
+trtllm_mxintw4a16_block_scale_moe = _lazy_import_wrapper(
+    "flashinfer", "trtllm_mxintw4a16__moe"
 )
 
 # Special case for autotune since it returns a context manager
@@ -196,6 +205,7 @@ def has_flashinfer_trtllm_fused_moe() -> bool:
         ("flashinfer.fused_moe", "trtllm_fp8_block_scale_moe"),
         ("flashinfer.fused_moe", "trtllm_fp8_per_tensor_scale_moe"),
         ("flashinfer.fused_moe", "trtllm_fp4_block_scale_moe"),
+        ("flashinfer.fused_moe", "trtllm_mxint4_block_scale_moe"),
     ]
     for module_name, attr_name in required_functions:
         mod = _get_submodule(module_name)


### PR DESCRIPTION
## Purpose
Adds INT4 W4A16 kernels from trtllm. Use `VLLM_USE_FLASHINFER_MOE_INT4=1` to use the kernel.
 
## Test Plan
Local test, gsm8k

## Test Result
```
vllm serve /tmp/moonshotai-Kimi-K2-Thinking   --tensor-parallel-size 4   --enable-auto-tool-choice   --tool-call-parser kimi_k2   --reasoning-parser kimi_k2    --trust-remote-code
root@gb-nvl-081-compute06:/workspace/pm-vllm# python3 tests/evals/gsm8k/gsm8k_eval.py 
Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/train.jsonl to /tmp/train.jsonl
Downloading from https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl to /tmp/test.jsonl
Running GSM8K evaluation: 1319 questions, 5-shot
Evaluating: 100%|█████████████████████████████████████████████| 1319/1319 [01:23<00:00, 15.77it/s]

Results:
Accuracy: 0.908
Invalid responses: 0.000
Total latency: 83.633 s
Questions per second: 15.771
Total output tokens: 134324
Output tokens per second: 1606.116

VLLM_USE_FLASHINFER_MOE_INT4=1 vllm serve /tmp/moonshotai-Kimi-K2-Thinking   --tensor-parallel-size 4   --enable-auto-tool-choice   --tool-call-parser kimi_k2   --reasoning-parser kimi_k2    --trust-remote-code
root@gb-nvl-081-compute06:/workspace/pm-vllm# python3 tests/evals/gsm8k/gsm8k_eval.py 
Running GSM8K evaluation: 1319 questions, 5-shot
Evaluating: 100%|█████████████████████████████████████████████| 1319/1319 [01:23<00:00, 15.79it/s]

Results:
Accuracy: 0.907
Invalid responses: 0.000
Total latency: 83.560 s
Questions per second: 15.785
Total output tokens: 133733
```

Kernel Benchmarks - https://github.com/vllm-project/vllm/pull/32437#issuecomment-3776142056
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

