### PR TITLE
[Misc] Add VLLM Config to Prometheus Logger

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -194,11 +194,6 @@ class CacheConfig:
         factors = get_hash_factors(self, ignored_factors)
         return hash_factors(factors)
 
-    def metrics_info(self):
-        # convert cache_config to dict(key: str, value: str) for prometheus
-        # metrics info
-        return {key: str(value) for key, value in self.__dict__.items()}
-
     @field_validator("cache_dtype", mode="after")
     @classmethod
     def _validate_cache_dtype(cls, cache_dtype: CacheDType) -> CacheDType:

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -63,7 +63,13 @@ def config(cls: ConfigT) -> ConfigT:
                     for sub_key, sub_value in value.metrics_info().items():
                         metrics_info_dict[f"{key}_{sub_key}"] = str(sub_value)
                 else:
-                    metrics_info_dict[key] = str(value)
+                    # Using `repr()` handles objects likeQuantizationConfig that
+                    # implement __repr__ but not metrics_info
+                    metrics_info_dict[key] = (
+                        repr(value)
+                        if not isinstance(value, (str, int, float, bool))
+                        else str(value)
+                    )
             return metrics_info_dict
 
         cls.metrics_info = metrics_info

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -44,7 +44,30 @@ def config(cls: ConfigT) -> ConfigT:
 
     Config validation is performed by the tools/pre_commit/validate_config.py
     script, which is invoked during the pre-commit checks.
+
+    Injects a `metrics_info` method that converts the config to a
+    dict[str, str] for prometheus metrics.
     """
+    # Only inject metrics_info if the class doesn't already have it
+    if not hasattr(cls, "metrics_info"):
+
+        def metrics_info(self) -> dict[str, str]:
+            """
+            If a nested config has a `metrics_info` method, it will be called
+            recursively and keys will be prefixed with the field name. Otherwise,
+            all fields will be converted to strings automatically.
+            """
+            metrics_info_dict = {}
+            for key, value in self.__dict__.items():
+                if hasattr(value, "metrics_info"):
+                    for sub_key, sub_value in value.metrics_info().items():
+                        metrics_info_dict[f"{key}_{sub_key}"] = str(sub_value)
+                else:
+                    metrics_info_dict[key] = str(value)
+            return metrics_info_dict
+
+        cls.metrics_info = metrics_info
+
     return cls
 
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1377,21 +1377,6 @@ class VllmConfig:
             )
         return self
 
-    def metrics_info(self):
-        """
-        Convert VllmConfig to dict(key: str, value: str) for prometheus metrics info.
-        If a config is missing a metrics_info method, all of its fields will be
-        converted to strings automatically.
-        """
-        metrics_info = {}
-        for key, value in self.__dict__.items():
-            if hasattr(value, "metrics_info"):
-                for sub_key, sub_value in value.metrics_info().items():
-                    metrics_info[f"{key}_{sub_key}"] = str(sub_value)
-            else:
-                metrics_info[key] = str(value)
-        return metrics_info
-
 
 _current_vllm_config: VllmConfig | None = None
 _current_prefix: str | None = None

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1377,6 +1377,20 @@ class VllmConfig:
             )
         return self
 
+    def metrics_info(self):
+        """
+        Convert VllmConfig to dict(key: str, value: str) for prometheus metrics info.
+        If a config is missing a metrics_info method, all of its fields will be
+        converted to strings automatically.
+        """
+        metrics_info = {}
+        for key, value in self.__dict__.items():
+            if hasattr(value, "metrics_info"):
+                metrics_info[key] = value.metrics_info()
+            else:
+                metrics_info[key] = str(value)
+        return metrics_info
+
 
 _current_vllm_config: VllmConfig | None = None
 _current_prefix: str | None = None

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1386,7 +1386,8 @@ class VllmConfig:
         metrics_info = {}
         for key, value in self.__dict__.items():
             if hasattr(value, "metrics_info"):
-                metrics_info[key] = value.metrics_info()
+                for sub_key, sub_value in value.metrics_info().items():
+                    metrics_info[f"{key}_{sub_key}"] = str(sub_value)
             else:
                 metrics_info[key] = str(value)
         return metrics_info

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -168,3 +168,31 @@ class QuantizationConfig(ABC):
         Interface to update values after config initialization.
         """
         pass
+
+    def __repr__(self) -> str:
+        """
+        Provide a string representation (used for metrics or logging).
+        """
+        # Get the quantization method name
+        try:
+            name = self.get_name()
+        except Exception:
+            name = self.__class__.__name__
+
+        # Collect relevant attributes
+        attrs = []
+        for key, value in sorted(self.__dict__.items()):
+            # Format the value appropriately
+            if (
+                value is None
+                or isinstance(value, (list, tuple, dict))
+                and len(value) == 0
+            ):
+                continue
+            else:
+                attrs.append(f"{key}={value!r}")
+
+        if attrs:
+            return f"{self.__class__.__name__}(name={name!r}, {', '.join(attrs)})"
+        else:
+            return f"{self.__class__.__name__}(name={name!r})"

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -175,22 +175,15 @@ class QuantizationConfig(ABC):
         """
         # Get the quantization method name
         try:
-            name = self.get_name()
+            name: str = str(self.get_name())
         except Exception:
             name = self.__class__.__name__
 
-        # Collect relevant attributes
         attrs = []
         for key, value in sorted(self.__dict__.items()):
-            # Format the value appropriately
-            if (
-                value is None
-                or isinstance(value, (list, tuple, dict))
-                and len(value) == 0
-            ):
+            if value is None:
                 continue
-            else:
-                attrs.append(f"{key}={value!r}")
+            attrs.append(f"{key}={value!r}")
 
         if attrs:
             return f"{self.__class__.__name__}(name={name!r}, {', '.join(attrs)})"

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -5,7 +5,7 @@ import logging
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import TypeAlias
+from typing import TypeAlias, cast
 
 from prometheus_client import Counter, Gauge, Histogram
 
@@ -1190,8 +1190,14 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             self.gauge_engine_sleep_state["awake"][engine_idx].set(awake)
 
     def log_engine_initialized(self):
-        self.log_metrics_info("cache_config", self.vllm_config.cache_config)
-        self.log_metrics_info("vllm_config", self.vllm_config)
+        # Use cast to make mypy happy (the @config decorator injects
+        # metrics_info method at runtime).
+        self.log_metrics_info(
+            "cache_config", cast(SupportsMetricsInfo, self.vllm_config.cache_config)
+        )
+        self.log_metrics_info(
+            "vllm_config", cast(SupportsMetricsInfo, self.vllm_config)
+        )
 
 
 PromMetric: TypeAlias = Gauge | Counter | Histogram

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1007,6 +1007,9 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         if type == "cache_config":
             name = "vllm:cache_config_info"
             documentation = "Information of the LLMEngine CacheConfig"
+        elif type == "vllm_config":
+            name = "vllm:vllm_config_info"
+            documentation = "Information of the LLMEngine VllmConfig"
         assert name is not None, f"Unknown metrics info type {type}"
 
         # Info type metrics are syntactic sugar for a gauge permanently set to 1
@@ -1188,6 +1191,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
 
     def log_engine_initialized(self):
         self.log_metrics_info("cache_config", self.vllm_config.cache_config)
+        self.log_metrics_info("vllm_config", self.vllm_config)
 
 
 PromMetric: TypeAlias = Gauge | Counter | Histogram


### PR DESCRIPTION
## Purpose
It's helpful to have all the vllm configs device in prometheus.

The metrics are published similar to the cache config information. Both are published once at initialization time.

I have also created https://github.com/vllm-project/vllm/pull/32435 that adds NVIDIA GPU info to the device config.
I will resolve the possible conflicts between the two PRs.

## Test Plan
I tested this via Grafana.

## Test Result
<img width="1592" height="786" alt="image" src="https://github.com/user-attachments/assets/43fb4954-4f45-4e58-8b7e-58f5b7be4bec" />
