### PR TITLE
[Docs] Clarify structured outputs configuration for Qwen3 reasoning mode

### DIFF
--- a/docs/features/structured_outputs.md
+++ b/docs/features/structured_outputs.md
@@ -210,6 +210,12 @@ Note that you can use reasoning with any provided structured outputs feature. Th
 
 See also: [full example](../examples/online_serving/structured_outputs.md)
 
+!!! note
+    When using Qwen3 Coder models with reasoning enabled, structured outputs might become disabled if the reasoning content does not get parsed into of the `reasoning` field separately (v0.11.2+).
+    To use both features together, you must explicitly enable structured outputs in reasoning mode.
+    To do so, add the following flag when starting the vLLM server: `--structured-outputs-config.enable_in_reasoning=1`.
+    See also: [Reasoning Outputs](reasoning_outputs.md) documentation.
+
 ## Experimental Automatic Parsing (OpenAI API)
 
 This section covers the OpenAI beta wrapper over the `client.chat.completions.create()` method that provides richer integrations with Python specific types.

--- a/docs/features/structured_outputs.md
+++ b/docs/features/structured_outputs.md
@@ -211,9 +211,9 @@ Note that you can use reasoning with any provided structured outputs feature. Th
 See also: [full example](../examples/online_serving/structured_outputs.md)
 
 !!! note
-    When using Qwen3 Coder models with reasoning enabled, structured outputs might become disabled if the reasoning content does not get parsed into of the `reasoning` field separately (v0.11.2+).
+    When using Qwen3 Coder models with reasoning enabled, structured outputs might become disabled if the reasoning content does not get parsed into the `reasoning` field separately (v0.11.2+).
     To use both features together, you must explicitly enable structured outputs in reasoning mode.
-    To do so, add the following flag when starting the vLLM server: `--structured-outputs-config.enable_in_reasoning=1`.
+    To do so, add the following flag when starting the vLLM server: `--structured-outputs-config.enable_in_reasoning=True`.
     See also: [Reasoning Outputs](reasoning_outputs.md) documentation.
 
 ## Experimental Automatic Parsing (OpenAI API)


### PR DESCRIPTION
<!-- markdownlint-disable -->
Adding important caveats to the structured output documentation for qwen3 coder models.

## Purpose
This PR improves documentation for using structured outputs with Qwen3 Coder models when reasoning is enabled, addressing an undocumented configuration requirement.

Qwen3 Coder output on vllm v0.11.0, v0.11.2, and v0.12.0 all fail to produce structured outputs with requests that have `response_format`. This does not match the documentation. It sees reasoning has not ended and skips applying the xgrammar backend because enable_in_reasoning is not set. This documentation update will save future users the time digging for this fix. This issue is reproducible on multiple providers of the qwen3 coder models the presumably use vllm as their backend.

## Test Plan
Run docs to ensure builds properly: https://docs.vllm.ai/en/latest/contributing/#documentation

## Test Result
<img width="824" height="180" alt="image" src="https://github.com/user-attachments/assets/d3b7fed9-1135-4334-8c35-3f10f263d45b" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

