### PR TITLE
[Bugfix] Abort engine requests on client disconnect

### DIFF
--- a/tests/entrypoints/openai/test_abort_on_disconnect.py
+++ b/tests/entrypoints/openai/test_abort_on_disconnect.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _cancelled_async_iter():
+    async def gen():
+        raise asyncio.CancelledError()
+        if False:
+            yield None
+
+    return gen()
+
+
+@pytest.mark.asyncio
+async def test_completion_stream_generator_aborts_on_disconnect():
+    from vllm.entrypoints.openai.completion.serving import OpenAIServingCompletion
+
+    serving = OpenAIServingCompletion.__new__(OpenAIServingCompletion)
+    serving.engine_client = MagicMock()
+    serving.engine_client.abort = AsyncMock()
+
+    request = SimpleNamespace(n=None, stream_options=None, echo=False, max_tokens=1)
+    request_prompts = ["hi"]  # won't be used (we cancel immediately)
+
+    gen = serving.completion_stream_generator(
+        request=request,
+        request_prompts=request_prompts,
+        result_generator=_cancelled_async_iter(),
+        request_id="cmpl-123",
+        created_time=0,
+        model_name="m",
+        num_prompts=1,
+        tokenizer=MagicMock(),
+        request_metadata=MagicMock(),
+        enable_force_include_usage=False,
+    )
+
+    async for _ in gen:
+        pass
+
+    serving.engine_client.abort.assert_called_once_with("cmpl-123")
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_stream_generator_aborts_on_disconnect():
+    from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+
+    serving = OpenAIServingChat.__new__(OpenAIServingChat)
+    serving.engine_client = MagicMock()
+    serving.engine_client.abort = AsyncMock()
+
+    # minimal request fields used before the async-for
+    request = SimpleNamespace(
+        n=None,
+        stream_options=None,
+    )
+
+    gen = serving.chat_completion_stream_generator(
+        request=request,
+        result_generator=_cancelled_async_iter(),
+        request_id="chat-123",
+        created_time=0,
+        model_name="m",
+        tokenizer=MagicMock(),
+        request_metadata=MagicMock(),
+    )
+
+    async for _ in gen:
+        pass
+
+    serving.engine_client.abort.assert_called_once_with("chat-123")
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_generator_aborts_on_disconnect():
+    from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+
+    serving = OpenAIServingResponses.__new__(OpenAIServingResponses)
+    serving.engine_client = MagicMock()
+    serving.engine_client.abort = AsyncMock()
+
+    request = SimpleNamespace(request_id="resp-123")
+
+    gen = serving.responses_stream_generator(
+        request=request,
+        sampling_params=MagicMock(),
+        result_generator=_cancelled_async_iter(),
+        context=MagicMock(),
+        model_name="m",
+        tokenizer=MagicMock(),
+        request_metadata=MagicMock(),
+        created_time=0,
+    )
+
+    async for _ in gen:
+        pass
+
+    serving.engine_client.abort.assert_called_once_with("resp-123")
+
+
+@pytest.mark.asyncio
+async def test_speech_to_text_stream_generator_aborts_on_disconnect():
+    from vllm.entrypoints.openai.speech_to_text import OpenAISpeechToText
+
+    serving = OpenAISpeechToText.__new__(OpenAISpeechToText)
+    serving.engine_client = MagicMock()
+    serving.engine_client.abort = AsyncMock()
+    serving.task_type = "transcribe"
+
+    request = SimpleNamespace(model="m")
+
+    gen = serving._speech_to_text_stream_generator(
+        request=request,
+        list_result_generator=[_cancelled_async_iter()],
+        request_id="transcribe-123",
+        request_metadata=MagicMock(),
+        audio_duration_s=1.0,
+        chunk_object_type="transcription.chunk",
+        response_stream_choice_class=MagicMock(),
+        stream_response_class=MagicMock(),
+    )
+
+    async for _ in gen:
+        pass
+
+    serving.engine_client.abort.assert_called_once_with("transcribe-123")

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -69,12 +69,19 @@ async def _generate(request_dict: dict, raw_request: Request) -> Response:
 
     # Streaming case
     async def stream_results() -> AsyncGenerator[bytes, None]:
-        async for request_output in results_generator:
-            prompt = request_output.prompt
-            assert prompt is not None
-            text_outputs = [prompt + output.text for output in request_output.outputs]
-            ret = {"text": text_outputs}
-            yield (json.dumps(ret) + "\n").encode("utf-8")
+        try:
+            async for request_output in results_generator:
+                prompt = request_output.prompt
+                assert prompt is not None
+                text_outputs = [
+                    prompt + output.text for output in request_output.outputs
+                ]
+                ret = {"text": text_outputs}
+                yield (json.dumps(ret) + "\n").encode("utf-8")
+        except asyncio.CancelledError:
+            # Client disconnected, abort request to free resources.
+            await engine.abort(request_id)
+            raise
 
     if stream:
         return StreamingResponse(stream_results())
@@ -85,6 +92,8 @@ async def _generate(request_dict: dict, raw_request: Request) -> Response:
         async for request_output in results_generator:
             final_output = request_output
     except asyncio.CancelledError:
+        # Client disconnected, abort request to free resources.
+        await engine.abort(request_id)
         return Response(status_code=499)
 
     assert final_output is not None

--- a/vllm/entrypoints/openai/translations/speech_to_text.py
+++ b/vllm/entrypoints/openai/translations/speech_to_text.py
@@ -542,6 +542,8 @@ class OpenAISpeechToText(OpenAIServing):
                     )
             return final_response
         except asyncio.CancelledError:
+            # Client disconnected, abort request to free resources.
+            await self.engine_client.abort(request_id)
             return self.create_error_response("Client disconnected")
         except ValueError as e:
             return self.create_error_response(e)
@@ -653,6 +655,10 @@ class OpenAISpeechToText(OpenAIServing):
                 total_tokens=num_prompt_tokens + completion_tokens,
             )
 
+        except asyncio.CancelledError:
+            # Client disconnected, abort request to free resources.
+            await self.engine_client.abort(request_id)
+            return
         except Exception as e:
             logger.exception("Error in %s stream generator.", self.task_type)
             data = self.create_streaming_error_response(e)

--- a/vllm/entrypoints/serve/disagg/serving.py
+++ b/vllm/entrypoints/serve/disagg/serving.py
@@ -166,6 +166,8 @@ class ServingTokens(OpenAIServing):
             async for res in result_generator:
                 final_res = res
         except asyncio.CancelledError:
+            # Client disconnected, abort request to free resources.
+            await self.engine_client.abort(request_id)
             return self.create_error_response("Client disconnected")
         except ValueError as e:
             return self.create_error_response(str(e))


### PR DESCRIPTION
## Purpose
  Abort in-flight engine requests on client disconnect (asyncio.CancelledError) so resources (KV cache / scheduler slots) aren't held until completion.

  Adds `abort()` handling across OpenAI serving (chat/completions/responses), API server streaming, disagg serving, and speech-to-text translation.

  Fixes #24584

  ## Test Plan
  - `python -m pytest tests/entrypoints/openai/test_abort_on_disconnect.py -q`

  ## Test Results
  - 4 passed:
    - completion_stream aborts on disconnect
    - chat_completion_stream aborts on disconnect
    - responses_stream aborts on disconnect
    - speech_to_text_stream aborts on disconnect

