### PR TITLE
[Bugfix][chat_completion] ensure tokenizer eos_token_id is added to stop_token_ids

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -385,7 +385,15 @@ class OpenAIServingChat(OpenAIServing):
                         self.logits_processors,
                         sampling_params,
                     )
-
+                # Ensure the model's EOS token is always treated as a stop token.
+                # This fixes infinite generation for models (like Qwen3) that rely on 
+                # specific EOS tokens not explicitly passed by the client.
+                if tokenizer is not None and tokenizer.eos_token_id is not None:
+                    if not sampling_params.stop_token_ids:
+                        sampling_params.stop_token_ids = []
+                    if tokenizer.eos_token_id not in sampling_params.stop_token_ids:
+                        sampling_params.stop_token_ids.append(tokenizer.eos_token_id)
+                
                 self._log_inputs(
                     sub_request_id,
                     engine_prompt,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -385,15 +385,17 @@ class OpenAIServingChat(OpenAIServing):
                         self.logits_processors,
                         sampling_params,
                     )
-                # Ensure the model's EOS token is always treated as a stop token.
-                # This fixes infinite generation for models (like Qwen3) that rely on 
-                # specific EOS tokens not explicitly passed by the client.
-                if tokenizer is not None and tokenizer.eos_token_id is not None:
-                    if not sampling_params.stop_token_ids:
-                        sampling_params.stop_token_ids = []
-                    if tokenizer.eos_token_id not in sampling_params.stop_token_ids:
-                        sampling_params.stop_token_ids.append(tokenizer.eos_token_id)
-                
+                    # Ensure the model's EOS token is always treated as a stop token.
+                    # This fixes infinite generation for models (like Qwen3)
+                    # that rely on specific EOS tokens not explicitly passed
+                    # by the client.
+                    if tokenizer is not None and tokenizer.eos_token_id is not None:
+                        stop_token_ids = sampling_params.stop_token_ids or []
+                        if tokenizer.eos_token_id not in stop_token_ids:
+                            sampling_params.stop_token_ids = stop_token_ids + [
+                                tokenizer.eos_token_id
+                            ]
+
                 self._log_inputs(
                     sub_request_id,
                     engine_prompt,


### PR DESCRIPTION
## Purpose
This PR fixes a critical issue where chat completion requests could hang indefinitely or until timeout for models that rely on specific EOS tokens (e.g., `Qwen3`, `Qwen2.5-AWQ`) when the client does not explicitly provide stop tokens.

**Fixes #30589**

**Root Cause:**
Previously, stop_token_ids in SamplingParams was initialized as an empty list if not provided by the user. This caused the engine to ignore the model's native eos_token_id during generation, leading to infinite generation loops for models that output the EOS token but are not instructed to stop by the engine.

## Test Plan
**Environment:**
- GPU: RTX A4000
- Model: `Qwen/Qwen3-8B-AWQ`

## Test Result

### Before Fix
Potential problems: Server log showing empty stop tokens despite valid tokenizer EOS

```
(APIServer pid=15286) Model: ./models/Qwen3-8B-AWQ
(APIServer pid=15286) Original Stop Token IDs: [] 
(APIServer pid=15286) Tokenizer EOS ID: 151645 
```

### After Fix
The tokenizer.eos_token_id (e.g., `151645` for Qwen3) is correctly added to stop_token_ids. The request now completes successfully upon generating the EOS token.

```
(APIServer pid=16591) Model: ./models/Qwen3-8B-AWQ
(APIServer pid=16591) Original Stop Token IDs: [151645]
(APIServer pid=16591) Tokenizer EOS ID: 151645
```