### PR TITLE
apply _validate_input to MistralTokenizer token-id chat prompts

### DIFF
--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -743,7 +743,9 @@ async def test_serving_chat_mistral_token_ids_prompt_is_validated(monkeypatch_mo
     # rendering can return a list[int] (token IDs).
     import vllm.entrypoints.openai.engine.serving as engine_serving
 
-    monkeypatch_module.setattr(engine_serving, "MistralTokenizer", DummyMistralTokenizer)
+    monkeypatch_module.setattr(
+        engine_serving, "MistralTokenizer", DummyMistralTokenizer
+    )
 
     serving_chat = _build_serving_chat(mock_engine)
 
@@ -788,7 +790,9 @@ async def test_serving_chat_mistral_token_ids_prompt_too_long_is_rejected(
 
     import vllm.entrypoints.openai.engine.serving as engine_serving
 
-    monkeypatch_module.setattr(engine_serving, "MistralTokenizer", DummyMistralTokenizer)
+    monkeypatch_module.setattr(
+        engine_serving, "MistralTokenizer", DummyMistralTokenizer
+    )
 
     serving_chat = _build_serving_chat(mock_engine)
 

--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -719,6 +719,97 @@ async def test_serving_chat_should_set_correct_max_tokens():
 
 
 @pytest.mark.asyncio
+async def test_serving_chat_mistral_token_ids_prompt_is_validated(monkeypatch_module):
+    """Regression test: when the Mistral tokenizer path returns token IDs
+    directly, we must still apply input length + max_tokens validation.
+    """
+
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+
+    class DummyMistralTokenizer:
+        def decode(self, token_ids):
+            # Only used for logging/validation error messages.
+            return "dummy"
+
+    dummy_tokenizer = DummyMistralTokenizer()
+    mock_engine.get_tokenizer.return_value = dummy_tokenizer
+
+    # Patch the OpenAI engine serving module to treat our dummy tokenizer
+    # as a MistralTokenizer. This forces the code path where chat template
+    # rendering can return a list[int] (token IDs).
+    import vllm.entrypoints.openai.engine.serving as engine_serving
+
+    monkeypatch_module.setattr(engine_serving, "MistralTokenizer", DummyMistralTokenizer)
+
+    serving_chat = _build_serving_chat(mock_engine)
+
+    # Force the Mistral chat template renderer to return token IDs.
+    # Choose a prompt length that is < max_model_len, but large enough that
+    # adding max_tokens should exceed the model context window.
+    serving_chat._apply_mistral_chat_template_async = AsyncMock(
+        return_value=list(range(95))
+    )
+
+    req = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "what is 1+1?"}],
+        max_tokens=10,
+    )
+
+    resp = await serving_chat.create_chat_completion(req)
+    assert isinstance(resp, ErrorResponse)
+    assert "max_tokens" in resp.error.message
+
+
+@pytest.mark.asyncio
+async def test_serving_chat_mistral_token_ids_prompt_too_long_is_rejected(
+    monkeypatch_module,
+):
+    """Regression test: MistralTokenizer token-id prompts must still enforce
+    the max context length for the input itself (token_num >= max_model_len).
+    """
+
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+
+    class DummyMistralTokenizer:
+        def decode(self, token_ids):
+            return "dummy"
+
+    dummy_tokenizer = DummyMistralTokenizer()
+    mock_engine.get_tokenizer.return_value = dummy_tokenizer
+
+    import vllm.entrypoints.openai.engine.serving as engine_serving
+
+    monkeypatch_module.setattr(engine_serving, "MistralTokenizer", DummyMistralTokenizer)
+
+    serving_chat = _build_serving_chat(mock_engine)
+
+    # prompt_token_ids length == max_model_len should be rejected for
+    # completion-like requests (ChatCompletionRequest).
+    serving_chat._apply_mistral_chat_template_async = AsyncMock(
+        return_value=list(range(mock_engine.model_config.max_model_len))
+    )
+
+    req = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "what is 1+1?"}],
+        max_tokens=1,
+    )
+
+    resp = await serving_chat.create_chat_completion(req)
+    assert isinstance(resp, ErrorResponse)
+    assert "maximum context length" in resp.error.message
+
+
+@pytest.mark.asyncio
 async def test_serving_chat_could_load_correct_generation_config():
     mock_model_config = MockModelConfig()
     mock_model_config.diff_sampling_param = {

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -1277,9 +1277,11 @@ class OpenAIServing:
             assert is_list_of(request_prompt, int), (
                 "Prompt has to be either a string or a list of token ids"
             )
-            prompt_inputs = TokensPrompt(
-                prompt=tokenizer.decode(request_prompt),
-                prompt_token_ids=request_prompt,
+            input_text = tokenizer.decode(request_prompt)
+            prompt_inputs = self._validate_input(
+                request=request,
+                input_ids=request_prompt,
+                input_text=input_text,
             )
 
         engine_prompt = TokensPrompt(prompt_token_ids=prompt_inputs["prompt_token_ids"])


### PR DESCRIPTION
!-- markdownlint-disable -->
## Purpose
Fix inconsistent request validation in the OpenAI-compatible server when using `MistralTokenizer`.

When the Mistral chat template path returns a `list[int]` (token IDs), we previously constructed a `TokensPrompt` directly and **skipped `_validate_input`**, bypassing:
- max context window checks (`max_model_len`)
- `max_tokens` / `max_completion_tokens` overflow checks

This PR routes the Mistral token-id prompt path through `_validate_input` so Mistral behaves consistently with HF-tokenizer prompt handling and fails fast with a clear 400 on invalid requests.

## Test Plan
- Run the two focused regression tests:

```bash
pytest -q tests/entrypoints/openai/test_serving_chat.py -k "mistral_token_ids_prompt_is_validated or mistral_token_ids_prompt_too_long_is_rejected"
```

## Test Result
### Curl repro
```bash
curl -sS http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
    "messages": [
      { "role": "user", "content": "Write a short haiku about GPUs." }
    ],
    "max_tokens": 800000,
    "stream": false
  }'
```

### Before (buggy: request succeeds when it should be rejected)
```json
{
  "id":"chatcmpl-bb41c61182e899f8",
  "object":"chat.completion",
  "created":1768530229,
  "model":"mistralai/Mistral-Small-3.2-24B-Instruct-2506",
  "choices":[{"index":0,"message":{"role":"assistant","content":"**Silicon dreams glow,**\n**lightning in tiny circuits—**\n**worlds rendered in light.**","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null,"reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],
  "service_tier":null,
  "system_fingerprint":null,
  "usage":{"prompt_tokens":12,"total_tokens":35,"completion_tokens":23,"prompt_tokens_details":null},
  "prompt_logprobs":null,
  "prompt_token_ids":null,
  "kv_transfer_params":null
}
```

### After (fixed: rejected early with clear 400)
```json
{
  "error":{
    "message":"'max_tokens' or 'max_completion_tokens' is too large: 800000. This model's maximum context length is 131072 tokens and your request has 12 input tokens (800000 > 131072 - 12). (parameter=max_tokens, value=800000) None",
    "type":"BadRequestError",
    "param":null,
    "code":400
  }
}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

