### PR TITLE
[Bugfix] Use a large enough aiohttp read_bufsize to avoid ContentLengthError

### DIFF
--- a/vllm/connections.py
+++ b/vllm/connections.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 import aiohttp
 import requests
 
+import vllm.envs as envs
 from vllm.version import __version__ as VLLM_VERSION
 
 
@@ -32,7 +33,12 @@ class HTTPConnection:
     # required, so that the client is only accessible inside async event loop
     async def get_async_client(self) -> aiohttp.ClientSession:
         if self._async_client is None or not self.reuse_client:
-            self._async_client = aiohttp.ClientSession(trust_env=True)
+            # Use a large enough HTTP stream buffer in aiohttp to avoid
+            # ContentLengthError when downloading image/video/audio.
+            self._async_client = aiohttp.ClientSession(
+                trust_env=True,
+                read_bufsize=envs.VLLM_AIOHTTP_READ_BUFSIZE_MB * 1024 * 1024,
+            )
 
         return self._async_client
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
     VLLM_WORKER_MULTIPROC_METHOD: Literal["fork", "spawn"] = "fork"
     VLLM_ASSETS_CACHE: str = os.path.join(VLLM_CACHE_ROOT, "assets")
     VLLM_ASSETS_CACHE_MODEL_CLEAN: bool = False
+    VLLM_AIOHTTP_READ_BUFSIZE_MB: int = 4
     VLLM_IMAGE_FETCH_TIMEOUT: int = 5
     VLLM_VIDEO_FETCH_TIMEOUT: int = 30
     VLLM_AUDIO_FETCH_TIMEOUT: int = 10
@@ -757,6 +758,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # this path $VLLM_ASSETS_CACHE/model_streamer/$model_name
     "VLLM_ASSETS_CACHE_MODEL_CLEAN": lambda: bool(
         int(os.getenv("VLLM_ASSETS_CACHE_MODEL_CLEAN", "0"))
+    ),
+    # Read buffer size in MB for aiohttp when downloading media files.
+    # Default is 4 MB
+    "VLLM_AIOHTTP_READ_BUFSIZE_MB": lambda: int(
+        os.getenv("VLLM_AIOHTTP_READ_BUFSIZE_MB", "4")
     ),
     # Timeout for fetching images when serving multimodal models
     # Default is 5 seconds


### PR DESCRIPTION
## Purpose
This PR fixes the ContentLengthError when downloading large multimedia files through HTTPConnection by increasing aiohttp's read buffer size from the default [64KB](https://github.com/aio-libs/aiohttp/blob/v3.13.3/aiohttp/client.py#L303) to 4MB. The original buffer size is insufficient and unsafe for handling large media files, often causing failures during download.

With this change, multimodal models can reliably process remote media files that exceed the previous buffer limit. Our tests confirm that 2MB is the minimum buffer size to avoid the error. To ensure robustness and add a safety margin, we have set the default buffer size to 4MB.

<img width="3712" height="1560" alt="image" src="https://github.com/user-attachments/assets/5960ff56-fbd8-4ffe-b63d-31763d467b6e" />

## Test Plan
1. Test downloading large image files (>10MB) through the HTTPConnection async methods
2. Test downloading video files to ensure the buffer size is sufficient

## Test Result
1. ✅
2. ✅
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>
