### PR TITLE
[ROCm][CI] Skip Qwen3-30B-A3B-MXFP4A16 Eval Test On Non-CUDA Platforms

### DIFF
--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -60,8 +60,8 @@ def test_gsm8k_correctness(config_filename):
         and "Qwen3-30B-A3B-MXFP4A16" in eval_config["model_name"]
     ):
         pytest.skip(
-            "Skipping Qwen3-30B-A3B-MXFP4A16 on ROCm. "
-            "Marlin kernels are not supported on ROCm."
+            "Skipping Qwen3-30B-A3B-MXFP4A16 on non-CUDA platforms. "
+            "Marlin kernels are not supported."
         )
 
     # Parse server arguments from config (use shlex to handle quoted strings)

--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -56,7 +56,7 @@ def test_gsm8k_correctness(config_filename):
     eval_config = yaml.safe_load(config_filename.read_text(encoding="utf-8"))
 
     if (
-        current_platform.is_rocm()
+        not current_platform.is_cuda()
         and "Qwen3-30B-A3B-MXFP4A16" in eval_config["model_name"]
     ):
         pytest.skip(

--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -11,9 +11,11 @@ pytest -s -v tests/evals/gsm8k/test_gsm8k_correctness.py \
 
 import shlex
 
+import pytest
 import yaml
 
 from tests.utils import RemoteOpenAIServer
+from vllm.platforms import current_platform
 
 from .gsm8k_eval import evaluate_gsm8k
 
@@ -52,6 +54,15 @@ def run_gsm8k_eval(eval_config: dict, server_url: str) -> dict:
 def test_gsm8k_correctness(config_filename):
     """Test GSM8K correctness for a given model configuration."""
     eval_config = yaml.safe_load(config_filename.read_text(encoding="utf-8"))
+
+    if (
+        current_platform.is_rocm()
+        and "Qwen3-30B-A3B-MXFP4A16" in eval_config["model_name"]
+    ):
+        pytest.skip(
+            "Skipping Qwen3-30B-A3B-MXFP4A16 on ROCm. "
+            "Marlin kernels are not supported on ROCm."
+        )
 
     # Parse server arguments from config (use shlex to handle quoted strings)
     server_args_str = eval_config.get("server_args", "")


### PR DESCRIPTION
<!-- markdownlint-disable -->
Earlier today, https://github.com/vllm-project/vllm/pull/32285 added a test case to `tests/evals/gsm8k/test_gsm8k_correctness.py` to test Qwen3-30B-A3B-MXFP4A16. However, the MXFP4A16 implementation uses Marlin kernels, which are specific to CUDA. As a result, `LM Eval Small Models (1 Card)` has been failing on AMD CI (e.g. [build 3071](https://buildkite.com/vllm/amd-ci/builds/3071/steps/canvas?sid=019bc3eb-1358-413b-96b2-b4acdd8dab59)). This PR skips the test for non CUDA platforms. 

Now, when running `pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-small.txt`, I am seeing:
```
================================================================================================================================================================= warnings summary ==================================================================================================================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

../../../usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305
  /usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    ref_error: type[Exception] = jsonschema.RefResolutionError,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================================================================== 6 passed, 1 skipped, 3 warnings in 509.13s (0:08:29) ================================================================================================================================================
```