### PR TITLE
[Docker][Hotfix] CUDA compatibility enablement

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,7 +119,7 @@ RUN gcc --version
 
 # Workaround for triton/pytorch issues
 # This temporarily adds the CUDA compatibility libraries to the ldconfig cache.
-RUN ldconfig /usr/local/cuda-$(echo "$CUDA_VERSION" | cut -d. -f1,2)/compat/
+RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
 
 # ============================================================
 # SLOW-CHANGING DEPENDENCIES BELOW
@@ -456,7 +456,7 @@ ENV UV_LINK_MODE=copy
 
 # Workaround for triton/pytorch issues
 # This temporarily adds the CUDA compatibility libraries to the ldconfig cache.
-RUN ldconfig /usr/local/cuda-$(echo "$CUDA_VERSION" | cut -d. -f1,2)/compat/
+RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
 
 # ============================================================
 # SLOW-CHANGING DEPENDENCIES BELOW

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -118,7 +118,6 @@ ENV UV_LINK_MODE=copy
 RUN gcc --version
 
 # Workaround for triton/pytorch issues
-# This temporarily adds the CUDA compatibility libraries to the ldconfig cache.
 RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
 
 # ============================================================
@@ -455,7 +454,6 @@ ENV UV_INDEX_STRATEGY="unsafe-best-match"
 ENV UV_LINK_MODE=copy
 
 # Workaround for triton/pytorch issues
-# This temporarily adds the CUDA compatibility libraries to the ldconfig cache.
 RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
 
 # ============================================================
@@ -556,10 +554,6 @@ RUN --mount=type=bind,from=build,src=/tmp/ep_kernels_workspace/dist,target=/vllm
 # consistently from the host (see https://github.com/vllm-project/vllm/issues/18859).
 # Until then, add /usr/local/nvidia/lib64 before the image cuda path to allow override.
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
-
-# Add CUDA compatibility libraries to the end of LD_LIBRARY_PATH.
-# This ensures they are used as a fallback if the host driver is too old.
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/compat
 
 # Copy examples and benchmarks at the end to minimize cache invalidation
 COPY examples examples

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -117,8 +117,8 @@ ENV UV_LINK_MODE=copy
 # Verify GCC version
 RUN gcc --version
 
-# Ensure CUDA compatibility library is loaded
-RUN echo "/usr/local/cuda-$(echo "$CUDA_VERSION" | cut -d. -f1,2)/compat/" > /etc/ld.so.conf.d/00-cuda-compat.conf && ldconfig
+# Workaround for triton/pytorch issues
+RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
 
 # ============================================================
 # SLOW-CHANGING DEPENDENCIES BELOW
@@ -453,8 +453,8 @@ ENV UV_HTTP_TIMEOUT=500
 ENV UV_INDEX_STRATEGY="unsafe-best-match"
 ENV UV_LINK_MODE=copy
 
-# Ensure CUDA compatibility library is loaded
-RUN echo "/usr/local/cuda-$(echo "$CUDA_VERSION" | cut -d. -f1,2)/compat/" > /etc/ld.so.conf.d/00-cuda-compat.conf && ldconfig
+# Workaround for triton/pytorch issues
+RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
 
 # ============================================================
 # SLOW-CHANGING DEPENDENCIES BELOW

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,7 +119,7 @@ RUN gcc --version
 
 # Workaround for triton/pytorch issues
 # This temporarily adds the CUDA compatibility libraries to the ldconfig cache.
-RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
+RUN ldconfig /usr/local/cuda-$(echo "$CUDA_VERSION" | cut -d. -f1,2)/compat/
 
 # ============================================================
 # SLOW-CHANGING DEPENDENCIES BELOW
@@ -456,7 +456,7 @@ ENV UV_LINK_MODE=copy
 
 # Workaround for triton/pytorch issues
 # This temporarily adds the CUDA compatibility libraries to the ldconfig cache.
-RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
+RUN ldconfig /usr/local/cuda-$(echo "$CUDA_VERSION" | cut -d. -f1,2)/compat/
 
 # ============================================================
 # SLOW-CHANGING DEPENDENCIES BELOW

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -118,6 +118,7 @@ ENV UV_LINK_MODE=copy
 RUN gcc --version
 
 # Workaround for triton/pytorch issues
+# This temporarily adds the CUDA compatibility libraries to the ldconfig cache.
 RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
 
 # ============================================================
@@ -454,6 +455,7 @@ ENV UV_INDEX_STRATEGY="unsafe-best-match"
 ENV UV_LINK_MODE=copy
 
 # Workaround for triton/pytorch issues
+# This temporarily adds the CUDA compatibility libraries to the ldconfig cache.
 RUN ldconfig /usr/local/cuda-$(echo $CUDA_VERSION | cut -d. -f1,2)/compat/
 
 # ============================================================
@@ -554,6 +556,10 @@ RUN --mount=type=bind,from=build,src=/tmp/ep_kernels_workspace/dist,target=/vllm
 # consistently from the host (see https://github.com/vllm-project/vllm/issues/18859).
 # Until then, add /usr/local/nvidia/lib64 before the image cuda path to allow override.
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
+
+# Add CUDA compatibility libraries to the end of LD_LIBRARY_PATH.
+# This ensures they are used as a fallback if the host driver is too old.
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/compat
 
 # Copy examples and benchmarks at the end to minimize cache invalidation
 COPY examples examples


### PR DESCRIPTION
A change in #30784 was introduced to ensure CUDA compatibility libraries remained available even after an `ldconfig` cache update (which happens when `apt-get` is called for example). However, this caused a regression on systems where compatibility libraries are not required (when the host driver is newer than the container's CUDA version), as reported in #32373.

This PR reverts the change to `/etc/ld.so.conf.d` and implements a safer strategy by appending the compatibility path to `LD_LIBRARY_PATH`. This ensures that compatibility libraries persist after an `ldconfig` cache reset but are only used as a fallback.

Fixes #32373