### PR TITLE
[Doc] Clarify comment regarding partial block loading

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -207,7 +207,7 @@ class OffloadingConnectorScheduler:
 
         full_block_tokens = self.offloaded_block_size * num_blocks
         if full_block_tokens - num_computed_tokens < self.offloaded_block_size:
-            # we can load less than a block, skip
+            # Cannot load partial offloaded blocks; skip.
             return 0, False
 
         start_block_idx = num_computed_tokens // self.offloaded_block_size


### PR DESCRIPTION
## Purpose

Clarify an ambiguous comment in `OffloadingConnectorScheduler`.
The implementation only supports block-granularity loads.

The original comment:
`# we can load less than a block, skip`

The updated comment:
`# Cannot load partial offloaded blocks; skip.`

## Test Plan

This is a **comment-only change**, does not affect behavior.

## Test Result

N/A

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

* [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
* [x] The test plan, such as providing test command.
* [x] The test results, such as pasting the results comparison before and after, or e2e results
* [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
* [ ] (Optional) Release notes update.

</details>