### PR TITLE
[CI] Fix OOM in Hopper Fusion E2E Tests (H100)

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -1064,7 +1064,7 @@ steps:
   - tests/compile/test_fusion_attn.py
   commands:
     - export VLLM_TEST_CLEAN_GPU_MEMORY=1
-    - pytest -v -s tests/compile/test_fusion_attn.py
+    - pytest -v -s tests/compile/test_fusion_attn.py -k 'not Llama-4'
 
 - label: Hopper Fusion Distributed E2E Tests (2xH100)  # 70min
   timeout_in_minutes: 70

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -1064,6 +1064,7 @@ steps:
   - tests/compile/test_fusion_attn.py
   commands:
     - export VLLM_TEST_CLEAN_GPU_MEMORY=1
+    # skip Llama-4 since it does not fit on this device
     - pytest -v -s tests/compile/test_fusion_attn.py -k 'not Llama-4'
 
 - label: Hopper Fusion Distributed E2E Tests (2xH100)  # 70min


### PR DESCRIPTION
Fix OOM in "Hopper Fusion E2E Tests (H100)" by excluding Llama-4 (broken by https://github.com/vllm-project/vllm/pull/30499)