### PR TITLE
[Misc] Assign worker process titles and logging prefix earlier

### DIFF
--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -707,6 +707,14 @@ class WorkerProc:
         signal.signal(signal.SIGTERM, signal_handler)
         signal.signal(signal.SIGINT, signal_handler)
 
+        # Set early process title and log prefix using rank (before full
+        # initialization). This helps with debugging during startup.
+        # The title will be updated later with full parallelism info.
+        rank = kwargs.get("rank", 0)
+        early_name = f"Worker_{rank}"
+        set_process_title(name=early_name)
+        decorate_logs(early_name)
+
         worker = None
         # tuple[Connection, Connection]
         reader, ready_writer = kwargs.pop("ready_pipe")


### PR DESCRIPTION
## Summary
- Set process title and logging prefix early in `worker_main` (before full worker initialization) to help with debugging worker startup issues
- The early title uses just the rank (e.g., "Worker_0"), which is later updated with full parallelism info (DP, PP, TP, EP ranks) after `init_device()` completes
- This provides identifiable process names and log prefixes even before the distributed environment is fully initialized

## Related Issue
Fixes #24476

## Test plan
- [x] Pre-commit checks pass
- [ ] Existing tests should pass (no behavioral changes, just earlier title/log setup)
- Manual verification: Worker processes should show meaningful names even during early startup phase