### PR TITLE
[Bugfix] Fix Kimi-K2 tool parser streaming regex for multiple tool calls

### DIFF
--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -66,11 +66,15 @@ class KimiK2ToolParser(ToolParser):
             re.DOTALL,
         )
 
+        # Use [^<]+ instead of .+ to prevent greedy matching across tool call
+        # boundaries when multiple tool calls are concatenated without spacing.
+        # This matches the non-streaming regex pattern above (fixes issue #24478).
         self.stream_tool_call_portion_regex = re.compile(
-            r"(?P<tool_call_id>.+:\d+)\s*<\|tool_call_argument_begin\|>\s*(?P<function_arguments>.*)"
+            r"(?P<tool_call_id>[^<]+:\d+)\s*"
+            r"<\|tool_call_argument_begin\|>\s*(?P<function_arguments>.*)"
         )
 
-        self.stream_tool_call_name_regex = re.compile(r"(?P<tool_call_id>.+:\d+)\s*")
+        self.stream_tool_call_name_regex = re.compile(r"(?P<tool_call_id>[^<]+:\d+)\s*")
 
         if not self.model_tokenizer:
             raise ValueError(


### PR DESCRIPTION
## Summary
- Fix the streaming regex patterns in Kimi-K2 tool parser to correctly handle multiple concatenated tool calls
- The bug was that the streaming regexes used `.+` which greedily matched across tool call boundaries, causing multiple tool calls to be incorrectly merged into a single malformed entry
- The fix changes `.+` to `[^<]+` in `stream_tool_call_portion_regex` and `stream_tool_call_name_regex` to match the non-streaming regex behavior

## Related Issue
Fixes #24478

## Root Cause
The streaming tool call regexes used `.+` pattern which matches ANY character including `<`. When multiple tool calls were concatenated without spacing (e.g., `<|tool_call_end|><|tool_call_begin|>`), the greedy `.+` would match across tool call boundaries, capturing content like:

```
functions.get_weather:0<|tool_call_argument_begin|>{"lat":34}<|tool_call_end|><|tool_call_begin|>functions.get_news:1
```

This resulted in a garbled tool call ID and mismatched arguments as shown in the issue.

## Fix
Changed `.+` to `[^<]+` which excludes `<` characters. This ensures the regex stops at the first `<` (the start of the next special marker), preventing over-matching. This matches the behavior of the non-streaming regex which already used `[^<]+`.

## Test Plan
- Added `test_streaming_regex_does_not_match_across_tool_boundaries`: Unit test that directly validates the regex patterns correctly stop at `<` characters
- Added `test_streaming_concatenated_tool_calls_issue_24478`: Regression test that simulates the exact scenario from the bug report

Run tests:
```bash
pytest tests/tool_parsers/test_kimi_k2_tool_parser.py -v
```