### PR TITLE
[Bugfix] Fix llama4_pythonic tool parser for nested list parameters

### DIFF
--- a/tests/entrypoints/openai/tool_parsers/test_llama4_pythonic_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_llama4_pythonic_tool_parser.py
@@ -61,6 +61,34 @@ ESCAPED_STRING_FUNCTION_CALL = FunctionCall(
 PYTHON_TAG_FUNCTION_OUTPUT = (
     "<|python_start|>[get_weather(city='LA', metric='C')]<|python_end|>"
 )
+# Test case for nested list parameters (GitHub issue #30722)
+NESTED_LIST_FUNCTION_OUTPUT = (
+    '[enterprise_search(query="Benefits enrollment", '
+    'rephrased_queries=["How do I enroll in benefits?", '
+    '"What is the benefits enrollment process?"])]'
+)
+NESTED_LIST_FUNCTION_CALL = FunctionCall(
+    name="enterprise_search",
+    arguments='{"query": "Benefits enrollment", '
+    '"rephrased_queries": ["How do I enroll in benefits?", '
+    '"What is the benefits enrollment process?"]}',
+)
+# Test case with nested list containing mixed types
+NESTED_LIST_MIXED_OUTPUT = (
+    "[process_data(items=[1, 'text', True, None, {'key': 'value'}])]"
+)
+NESTED_LIST_MIXED_CALL = FunctionCall(
+    name="process_data",
+    arguments='{"items": [1, "text", true, null, {"key": "value"}]}',
+)
+# Test case with deeply nested structures
+DEEPLY_NESTED_OUTPUT = (
+    "[analyze(data={'users': [{'name': 'John', 'tags': ['admin', 'user']}]})]"
+)
+DEEPLY_NESTED_CALL = FunctionCall(
+    name="analyze",
+    arguments='{"data": {"users": [{"name": "John", "tags": ["admin", "user"]}]}}',
+)
 
 
 @pytest.mark.parametrize("streaming", [True, False])
@@ -199,6 +227,43 @@ TEST_CASES = [
             FunctionCall(name="register_user", arguments='{"name": "Doe", "age": 9}'),
         ],
         id="parallel_calls_nonstreaming",
+    ),
+    # Test cases for nested list parameters (GitHub issue #30722)
+    pytest.param(
+        True,
+        NESTED_LIST_FUNCTION_OUTPUT,
+        [NESTED_LIST_FUNCTION_CALL],
+        id="nested_list_streaming",
+    ),
+    pytest.param(
+        False,
+        NESTED_LIST_FUNCTION_OUTPUT,
+        [NESTED_LIST_FUNCTION_CALL],
+        id="nested_list_nonstreaming",
+    ),
+    pytest.param(
+        True,
+        NESTED_LIST_MIXED_OUTPUT,
+        [NESTED_LIST_MIXED_CALL],
+        id="nested_list_mixed_streaming",
+    ),
+    pytest.param(
+        False,
+        NESTED_LIST_MIXED_OUTPUT,
+        [NESTED_LIST_MIXED_CALL],
+        id="nested_list_mixed_nonstreaming",
+    ),
+    pytest.param(
+        True,
+        DEEPLY_NESTED_OUTPUT,
+        [DEEPLY_NESTED_CALL],
+        id="deeply_nested_streaming",
+    ),
+    pytest.param(
+        False,
+        DEEPLY_NESTED_OUTPUT,
+        [DEEPLY_NESTED_CALL],
+        id="deeply_nested_nonstreaming",
     ),
 ]
 

--- a/vllm/tool_parsers/llama4_pythonic_tool_parser.py
+++ b/vllm/tool_parsers/llama4_pythonic_tool_parser.py
@@ -45,8 +45,12 @@ class Llama4PythonicToolParser(ToolParser):
     # Neither of these are necessary for e.g. ToolACE, but both would help make
     # Llama3.2 models more reliable.
 
+    # Simplified pattern that detects tool call structure without parsing
+    # individual parameters. This handles nested structures like arrays
+    # and dicts in parameter values. Actual validation is done by ast.parse().
+    # Matches: [funcname(...)] with optional multiple function calls
     TOOL_CALL_REGEX = re.compile(
-        r"\[([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*,\s*)*([a-zA-Z]+\w*=.*\s)?\),\s*)*([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*,\s*)*([a-zA-Z]+\w*=.*\s*)?\)\s*)+\]",
+        r"^\s*\[\s*[a-zA-Z_]\w*\s*\(.*\)\s*\]\s*$",
         re.DOTALL,
     )
 

--- a/vllm/tool_parsers/pythonic_tool_parser.py
+++ b/vllm/tool_parsers/pythonic_tool_parser.py
@@ -48,8 +48,12 @@ class PythonicToolParser(ToolParser):
     # Neither of these are necessary for e.g. ToolACE, but both would help make
     # Llama3.2 models more reliable.
 
+    # Simplified pattern that detects tool call structure without parsing
+    # individual parameters. This handles nested structures like arrays
+    # and dicts in parameter values. Actual validation is done by ast.parse().
+    # Matches: [funcname(...)] with optional multiple function calls
     TOOL_CALL_REGEX = re.compile(
-        r"\[([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*,\s*)*([a-zA-Z]+\w*=.*\s)?\),\s*)*([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*,\s*)*([a-zA-Z]+\w*=.*\s*)?\)\s*)+\]",
+        r"^\s*\[\s*[a-zA-Z_]\w*\s*\(.*\)\s*\]\s*$",
         re.DOTALL,
     )
 


### PR DESCRIPTION
## Summary

Fixes GitHub issue #30722 - The `llama4_pythonic` tool parser fails with SyntaxError on nested list parameters like `rephrased_queries=["...", "..."]`.

**Root Cause:**
The `TOOL_CALL_REGEX` pattern was overly complex and tried to parse individual parameter syntax with patterns like `[a-zA-Z]+\w*=.*,`. The greedy `.*` matching caused failures with nested structures (arrays/dicts in parameter values) because it could match past the intended boundary.

**Fix:**
- Simplified the regex to only detect the basic tool call structure: starts with `[`, has a function name with parentheses, ends with `]`
- This allows the regex to reliably detect potential tool calls while delegating actual syntax validation to `ast.parse()`
- Applied the same fix to `pythonic_tool_parser.py` for consistency

**Changes:**
- `vllm/tool_parsers/llama4_pythonic_tool_parser.py`: Simplified TOOL_CALL_REGEX
- `vllm/tool_parsers/pythonic_tool_parser.py`: Same regex simplification
- `tests/entrypoints/openai/tool_parsers/test_llama4_pythonic_tool_parser.py`: Added test cases for:
  - Nested list parameters (the exact case from issue #30722)
  - Nested lists with mixed types
  - Deeply nested structures (dicts containing arrays containing dicts)

## Test plan

- [x] Added unit tests for nested list parameters that reproduce the issue
- [x] All existing tests pass (46 tests in pythonic and llama4_pythonic parsers)
- [x] Pre-commit checks pass
- [ ] CI checks pass

Fixes: #30722