### PR TITLE
Fail-fast guard: block MTP on GLM-4.7-FP8 to avoid CUDA illegal access

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -280,7 +280,8 @@ class SpeculativeConfig:
                 # model string may be a path, and matching on the whole string
                 # risks false positives if parent directories contain tokens
                 # like "glm-4.7" or "fp8".
-                model_name = (self.target_model_config.model or "").split("/")[-1].lower()
+                model_str = self.target_model_config.model or ""
+                model_name = model_str.split("/")[-1].lower()
                 if "glm-4.7" in model_name and "fp8" in model_name:
                     raise ValueError(
                         "Speculative decoding method 'mtp' is temporarily disabled "

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -276,8 +276,12 @@ class SpeculativeConfig:
                 # nightlies (CUDA illegal memory access) when using GLM-4.7-FP8
                 # with MTP speculative decoding on H100.
                 # Prefer a deterministic, actionable error over an unsafe CUDA crash.
-                target_id = (self.target_model_config.model or "").lower()
-                if "glm-4.7" in target_id and "fp8" in target_id:
+                # Only match on the model name itself (basename). The full
+                # model string may be a path, and matching on the whole string
+                # risks false positives if parent directories contain tokens
+                # like "glm-4.7" or "fp8".
+                model_name = (self.target_model_config.model or "").split("/")[-1].lower()
+                if "glm-4.7" in model_name and "fp8" in model_name:
                     raise ValueError(
                         "Speculative decoding method 'mtp' is temporarily disabled "
                         "for GLM-4.7-FP8 due to a CUDA illegal memory access regression "

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -285,7 +285,8 @@ class SpeculativeConfig:
                 if "glm-4.7" in model_name and "fp8" in model_name:
                     raise ValueError(
                         "Speculative decoding method 'mtp' is temporarily disabled "
-                        "for GLM-4.7-FP8 due to a CUDA illegal memory access regression "
+                        "for GLM-4.7-FP8 due to a CUDA illegal memory access "
+                        "regression "
                         "(see vllm-project/vllm#32090). Workaround: disable "
                         "`--speculative-config.method mtp` or pin a last-known-good "
                         "nightly image (e.g. nightly-ef96fa3f...)."


### PR DESCRIPTION
This is a mitigation for vllm-project/vllm#32090.

Problem: recent nightlies reported CUDA illegal memory access when running zai-org/GLM-4.7-FP8 with speculative decoding method mtp (often with speculative-config.method=mtp). A last-known-good nightly (nightly-ef96fa3f...) was reported to avoid the crash.

Change:
- Add a fail-fast guard in SpeculativeConfig when method==mtp and target model id contains 'glm-4.7' and 'fp8', raising an actionable error instead of letting it hit an unsafe CUDA crash.
- Add a small unit test to assert the guard triggers.

Workaround message suggests disabling MTP or pinning to a last-known-good nightly.