### PR TITLE
[V1][Core] Rename engine_core to engine_core_client for clarity

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -148,8 +148,8 @@ class AsyncLLM(EngineClient):
             tracing_enabled=tracing_endpoint is not None,
         )
 
-        # EngineCore (starts the engine in background process).
-        self.engine_core = EngineCoreClient.make_async_mp_client(
+        # EngineCoreClient (gets EngineCoreRequests and gives EngineCoreOutputs)
+        self.engine_core_client = EngineCoreClient.make_async_mp_client(
             vllm_config=vllm_config,
             executor_class=executor_class,
             log_stats=self.log_stats,
@@ -158,12 +158,15 @@ class AsyncLLM(EngineClient):
             client_index=client_index,
         )
 
+        # Backward compatibility alias.
+        self.engine_core = self.engine_core_client
+
         # Loggers.
         self.logger_manager: StatLoggerManager | None = None
         if self.log_stats:
             self.logger_manager = StatLoggerManager(
                 vllm_config=vllm_config,
-                engine_idxs=self.engine_core.engine_ranks_managed,
+                engine_idxs=self.engine_core_client.engine_ranks_managed,
                 custom_stat_loggers=custom_stat_loggers,
                 enable_default_loggers=log_stats,
                 client_count=client_count,
@@ -270,8 +273,8 @@ class AsyncLLM(EngineClient):
         if renderer := getattr(self, "renderer", None):
             renderer.shutdown()
 
-        if engine_core := getattr(self, "engine_core", None):
-            engine_core.shutdown()
+        if engine_core_client := getattr(self, "engine_core_client", None):
+            engine_core_client.shutdown()
 
         handler = getattr(self, "output_handler", None)
         if handler is not None:
@@ -280,7 +283,9 @@ class AsyncLLM(EngineClient):
     async def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         if not hasattr(self, "_supported_tasks"):
             # Cache the result
-            self._supported_tasks = await self.engine_core.get_supported_tasks_async()
+            self._supported_tasks = (
+                await self.engine_core_client.get_supported_tasks_async()
+            )
 
         return self._supported_tasks
 
@@ -413,7 +418,7 @@ class AsyncLLM(EngineClient):
         self.output_processor.add_request(request, prompt, parent_req, index, queue)
 
         # Add the EngineCoreRequest to EngineCore (separate process).
-        await self.engine_core.add_request_async(request)
+        await self.engine_core_client.add_request_async(request)
 
         if self.log_requests:
             logger.info("Added request %s.", request.request_id)
@@ -643,7 +648,7 @@ class AsyncLLM(EngineClient):
 
         # Ensure that the task doesn't have a circular ref back to the AsyncLLM
         # object, or else it won't be garbage collected and cleaned up properly.
-        engine_core = self.engine_core
+        engine_core_client = self.engine_core_client
         output_processor = self.output_processor
         log_stats = self.log_stats
         logger_manager = self.logger_manager
@@ -654,7 +659,7 @@ class AsyncLLM(EngineClient):
             try:
                 while True:
                     # 1) Pull EngineCoreOutputs from the EngineCore.
-                    outputs = await engine_core.get_output_async()
+                    outputs = await engine_core_client.get_output_async()
                     num_outputs = len(outputs.outputs)
 
                     iteration_stats = (
@@ -681,7 +686,7 @@ class AsyncLLM(EngineClient):
 
                         # 3) Abort any reqs that finished due to stop strings.
                         if processed_outputs.reqs_to_abort:
-                            await engine_core.abort_requests_async(
+                            await engine_core_client.abort_requests_async(
                                 processed_outputs.reqs_to_abort
                             )
 
@@ -712,7 +717,7 @@ class AsyncLLM(EngineClient):
             (request_id,) if isinstance(request_id, str) else as_list(request_id)
         )
         all_request_ids = self.output_processor.abort_requests(request_ids, internal)
-        await self.engine_core.abort_requests_async(all_request_ids)
+        await self.engine_core_client.abort_requests_async(all_request_ids)
 
         if self.log_requests:
             logger.info("Aborted request(s) %s.", ",".join(request_ids))
@@ -751,15 +756,17 @@ class AsyncLLM(EngineClient):
                 stacklevel=2,
             )
             mode = "wait"
-        await self.engine_core.pause_scheduler_async(mode=mode, clear_cache=clear_cache)
+        await self.engine_core_client.pause_scheduler_async(
+            mode=mode, clear_cache=clear_cache
+        )
 
     async def resume_generation(self) -> None:
         """Resume generation after :meth:`pause_generation`."""
-        await self.engine_core.resume_scheduler_async()
+        await self.engine_core_client.resume_scheduler_async()
 
     async def is_paused(self) -> bool:
         """Return whether the engine is currently paused."""
-        return await self.engine_core.is_scheduler_paused_async()
+        return await self.engine_core_client.is_scheduler_paused_async()
 
     async def encode(
         self,
@@ -864,63 +871,63 @@ class AsyncLLM(EngineClient):
             raise self.dead_error
 
     async def start_profile(self, profile_prefix: str | None = None) -> None:
-        coros = [self.engine_core.profile_async(True, profile_prefix)]
+        coros = [self.engine_core_client.profile_async(True, profile_prefix)]
         if self.profiler is not None:
             coros.append(asyncio.to_thread(self.profiler.start))
         await asyncio.gather(*coros)
 
     async def stop_profile(self) -> None:
-        coros = [self.engine_core.profile_async(False)]
+        coros = [self.engine_core_client.profile_async(False)]
         if self.profiler is not None:
             coros.append(asyncio.to_thread(self.profiler.stop))
         await asyncio.gather(*coros)
 
     async def reset_mm_cache(self) -> None:
         self.renderer.clear_mm_cache()
-        await self.engine_core.reset_mm_cache_async()
+        await self.engine_core_client.reset_mm_cache_async()
 
     async def reset_prefix_cache(
         self, reset_running_requests: bool = False, reset_connector: bool = False
     ) -> bool:
-        return await self.engine_core.reset_prefix_cache_async(
+        return await self.engine_core_client.reset_prefix_cache_async(
             reset_running_requests, reset_connector
         )
 
     async def reset_encoder_cache(self) -> None:
-        await self.engine_core.reset_encoder_cache_async()
+        await self.engine_core_client.reset_encoder_cache_async()
 
     async def sleep(self, level: int = 1) -> None:
         if level > 0:
             await self.reset_prefix_cache()
-        await self.engine_core.sleep_async(level)
+        await self.engine_core_client.sleep_async(level)
 
         if self.logger_manager is not None:
             self.logger_manager.record_sleep_state(1, level)
 
     async def wake_up(self, tags: list[str] | None = None) -> None:
-        await self.engine_core.wake_up_async(tags)
+        await self.engine_core_client.wake_up_async(tags)
 
         if self.logger_manager is not None:
             self.logger_manager.record_sleep_state(0, 0)
 
     async def is_sleeping(self) -> bool:
-        return await self.engine_core.is_sleeping_async()
+        return await self.engine_core_client.is_sleeping_async()
 
     async def add_lora(self, lora_request: LoRARequest) -> bool:
         """Load a new LoRA adapter into the engine for future requests."""
-        return await self.engine_core.add_lora_async(lora_request)
+        return await self.engine_core_client.add_lora_async(lora_request)
 
     async def remove_lora(self, lora_id: int) -> bool:
         """Remove an already loaded LoRA adapter."""
-        return await self.engine_core.remove_lora_async(lora_id)
+        return await self.engine_core_client.remove_lora_async(lora_id)
 
     async def list_loras(self) -> set[int]:
         """List all registered adapters."""
-        return await self.engine_core.list_loras_async()
+        return await self.engine_core_client.list_loras_async()
 
     async def pin_lora(self, lora_id: int) -> bool:
         """Prevent an adapter from being evicted."""
-        return await self.engine_core.pin_lora_async(lora_id)
+        return await self.engine_core_client.pin_lora_async(lora_id)
 
     async def collective_rpc(
         self,
@@ -932,7 +939,7 @@ class AsyncLLM(EngineClient):
         """
         Perform a collective RPC call to the given path.
         """
-        return await self.engine_core.collective_rpc_async(
+        return await self.engine_core_client.collective_rpc_async(
             method, timeout, args, kwargs
         )
 
@@ -940,7 +947,7 @@ class AsyncLLM(EngineClient):
         """Wait for all requests to be drained."""
         start_time = time.time()
         while time.time() - start_time < drain_timeout:
-            if not self.engine_core.dp_engines_running():
+            if not self.engine_core_client.dp_engines_running():
                 logger.info("Engines are idle, requests have been drained")
                 return
 
@@ -979,7 +986,7 @@ class AsyncLLM(EngineClient):
             "Requests have been drained, proceeding with scale to %s engines",
             new_data_parallel_size,
         )
-        await self.engine_core.scale_elastic_ep(new_data_parallel_size)
+        await self.engine_core_client.scale_elastic_ep(new_data_parallel_size)
         self.vllm_config.parallel_config.data_parallel_size = new_data_parallel_size
 
         # recreate stat loggers
@@ -1005,7 +1012,7 @@ class AsyncLLM(EngineClient):
 
     @property
     def errored(self) -> bool:
-        return self.engine_core.resources.engine_dead or not self.is_running
+        return self.engine_core_client.resources.engine_dead or not self.is_running
 
     @property
     def dead_error(self) -> BaseException:

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -77,7 +77,7 @@ class LLMEngine:
             parallel_config.data_parallel_size > 1
             and executor_backend == "external_launcher"
         )
-        # important: init dp group before init the engine_core
+        # important: init dp group before init the engine_core_client
         # In the decoupled engine case this is handled in EngineCoreProc.
         if (
             not multiprocess_mode


### PR DESCRIPTION
Renames `engine_core` → `engine_core_client`. A backward compatibility alias (`self.engine_core`) is preserved to avoid breaking existing code.

## Purpose
`self.engine_core` is actually a *client* abstraction created via `EngineCoreClient.make_client()`, but the current name suggests it's the actual `EngineCore`, causing confusion.

For [example](https://github.com/vllm-project/vllm/pull/32513/files#diff-3a65fbeb7245598eee4e39b5119893fd8a5d07c5cade5f91692ceda2d90e7236L127):

```python
self.model_executor = self.engine_core.engine_core.model_executor  # type: ignore
```

Renaming to `engine_core_client` makes the abstraction explicit.

```python
self.model_executor = self.engine_core_client.engine_core.model_executor  # type: ignore
```
