### PR TITLE
[Bugfix] Fix shellcheck hook find command syntax error

### DIFF
--- a/tools/pre_commit/shellcheck.sh
+++ b/tools/pre_commit/shellcheck.sh
@@ -18,5 +18,16 @@ if ! [ -x "$(command -v shellcheck)" ]; then
     export PATH="$PATH:$(pwd)/shellcheck-${scversion}"
 fi
 
-# TODO - fix warnings in .buildkite/scripts/hardware_ci/run-amd-test.sh
-find . -name "*.sh" ".git" -prune -not -path "./.buildkite/scripts/hardware_ci/run-amd-test.sh" -print0 | xargs -0 -I {} sh -c 'git check-ignore -q "{}" || shellcheck -s bash "{}"'
+# TODO - fix shellcheck warnings in excluded directories/files below
+find . -path "./.git" -prune -o -name "*.sh" \
+    -not -path "./.buildkite/*" \
+    -not -path "./benchmarks/*" \
+    -not -path "./examples/*" \
+    -not -path "./tests/v1/ec_connector/integration/*" \
+    -not -path "./tests/v1/kv_connector/nixl_integration/*" \
+    -not -path "./tests/standalone_tests/python_only_compile.sh" \
+    -not -path "./tools/install_deepgemm.sh" \
+    -not -path "./tools/flashinfer-build.sh" \
+    -not -path "./tools/vllm-tpu/build.sh" \
+    -not -path "./tools/ep_kernels/*" \
+    -print0 | xargs -0 -I {} sh -c 'git check-ignore -q "{}" || shellcheck -s bash "{}"'


### PR DESCRIPTION
## Summary

- Fix incorrect `find` command syntax in `tools/pre_commit/shellcheck.sh`
- The `.git` argument was misplaced, causing `find: paths must precede expression` errors
- Changed from `-name "*.sh" ".git" -prune` to `-path "./.git" -prune -o -name "*.sh"`
- Added exclusions for directories/scripts with pre-existing shellcheck warnings

## Problem

The shellcheck pre-commit hook was failing with:
```
find: paths must precede expression: `.git'
find: possible unquoted pattern after predicate `-name'?
```

More critically, subsequent runs would silently pass because the failed `find` command produced an empty file list, making pre-commit believe everything passed when no files were actually linted.

## Fix

1. Use correct `find` syntax with `-path "./.git" -prune -o` to properly exclude the `.git` directory

2. Add exclusions for directories/scripts with pre-existing shellcheck warnings that were not being linted before due to the broken find command:
   - `.buildkite/*`
   - `benchmarks/*`
   - `examples/*`
   - `tests/v1/ec_connector/integration/*`
   - `tests/v1/kv_connector/nixl_integration/*`
   - `tests/standalone_tests/python_only_compile.sh`
   - `tools/install_deepgemm.sh`
   - `tools/flashinfer-build.sh`
   - `tools/vllm-tpu/build.sh`
   - `tools/ep_kernels/*`

These exclusions preserve the previous (unintentional) behavior where these scripts were not being linted. Fixing the shellcheck warnings in these scripts can be addressed in follow-up PRs.

Fixes #32391

## Test plan

- [x] Verified the fixed `find` command works correctly and finds shell scripts
- [x] Verified the old command produces the syntax error mentioned in the issue
- [x] Verified excluded directories/files are properly filtered out