### PR TITLE
[Bugfix][Tool Parser] Fix Hermes parser losing closing braces in tool calls

### DIFF
--- a/tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py
@@ -458,3 +458,109 @@ def test_hermes_parser_non_streaming_tool_call_invalid_json(
 
     assert tool_call is not None
     assert not tool_call.tools_called
+
+
+def test_hermes_parser_streaming_parameterless_tool(
+    qwen_tokenizer: TokenizerLike,
+    hermes_parser: Hermes2ProToolParser,
+    any_chat_request: ChatCompletionRequest,
+) -> None:
+    """Test streaming tool call with empty arguments {} (issue #22885).
+
+    Parameterless tools have empty arguments, and the parser should
+    correctly stream "{}" instead of dropping it.
+    """
+    text = """<tool_call>
+{"name": "switch_led_on", "arguments": {}}
+</tool_call>"""
+    tokens = qwen_tokenizer.encode(text)
+    previous_text = ""
+    delta_messages = []
+    for token in tokens:
+        text = qwen_tokenizer.decode([token])
+        current_text = previous_text + text
+        delta = hermes_parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=text,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=any_chat_request,
+        )
+        previous_text = current_text
+        if delta is not None:
+            delta_messages.append(delta)
+
+    # Should have at least one delta with tool call info
+    assert len(delta_messages) > 0
+    assert delta_messages[0].tool_calls[0].function.name == "switch_led_on"
+
+    # The key assertion: empty arguments should be streamed as "{}"
+    tool_call_args = "".join(
+        delta.tool_calls[0].function.arguments or "" for delta in delta_messages
+    )
+    assert tool_call_args == "{}"
+
+
+def test_hermes_parser_non_streaming_parameterless_tool(
+    hermes_parser: Hermes2ProToolParser,
+    any_chat_request: ChatCompletionRequest,
+) -> None:
+    """Test non-streaming tool call with empty arguments {} (issue #22885)."""
+    text = """<tool_call>
+{"name": "switch_led_on", "arguments": {}}
+</tool_call>"""
+    tool_call = hermes_parser.extract_tool_calls(
+        model_output=text,
+        request=any_chat_request,
+    )
+
+    assert tool_call is not None
+    assert tool_call.tools_called
+    assert tool_call.tool_calls[0].function.name == "switch_led_on"
+    assert tool_call.tool_calls[0].function.arguments == "{}"
+
+
+def test_hermes_parser_streaming_nested_object_arguments(
+    qwen_tokenizer: TokenizerLike,
+    hermes_parser: Hermes2ProToolParser,
+    any_chat_request: ChatCompletionRequest,
+) -> None:
+    """Test streaming tool call with nested object arguments (issue #22885).
+
+    Arguments with nested objects have multiple closing braces, and all
+    should be correctly streamed without losing any.
+    """
+    text = """<tool_call>
+{"name": "search", "arguments": {"query": {"nested": "value"}}}
+</tool_call>"""
+    tokens = qwen_tokenizer.encode(text)
+    previous_text = ""
+    delta_messages = []
+    for token in tokens:
+        text = qwen_tokenizer.decode([token])
+        current_text = previous_text + text
+        delta = hermes_parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=text,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=any_chat_request,
+        )
+        previous_text = current_text
+        if delta is not None:
+            delta_messages.append(delta)
+
+    assert len(delta_messages) > 0
+    assert delta_messages[0].tool_calls[0].function.name == "search"
+
+    # The key assertion: nested object arguments should have all closing braces
+    tool_call_args = "".join(
+        delta.tool_calls[0].function.arguments or "" for delta in delta_messages
+    )
+    # Parse and verify the JSON is valid and complete
+    parsed = json.loads(tool_call_args)
+    assert parsed == {"query": {"nested": "value"}}


### PR DESCRIPTION
## Summary
Fixes issue #22885 - The Hermes tool parser was losing closing braces `}` in tool call arguments during streaming.

**Root causes:**
1. The "tool call closing" case only handled string-ending arguments by checking for the `'"}` pattern. Arguments ending with numbers, booleans, objects, or arrays would have their closing braces dropped.
2. Truthiness checks (`not cur_arguments`) fail for empty dicts `{}`, causing parameterless tool calls to be incorrectly handled.

**This fix:**
- Replaces the `'"}` pattern check with proper diff calculation based on what has been streamed vs. what should be streamed
- Uses `is None` checks instead of truthiness for argument comparisons
- Adds a fallback brace-counting mechanism for edge cases with formatting differences

## Test Plan
Added unit tests for:
- Streaming parameterless tools with empty arguments `{}`
- Non-streaming parameterless tools
- Streaming nested object arguments with multiple closing braces

Run the tests with:
```bash
pytest tests/entrypoints/openai/tool_parsers/test_hermes_tool_parser.py -v
```

## Related Issues
- Closes #22885