### PR TITLE
[BUGFIX] Fix `test_mla_backends.py`. Scale MLA projection weights to prevent numerical instability 

### DIFF
--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -504,13 +504,15 @@ def test_backend_correctness(
     W_UV = torch.randn(
         kv_lora_rank, num_q_heads, v_head_dim, dtype=dtype, device=device
     )
-    kv_b_proj_weight = torch.cat([W_UK, W_UV], dim=-1)
 
     # Scale weights to produce realistic magnitude outputs.
     # Without scaling, projection output has std ~sqrt(kv_lora_rank) ≈ 22.6,
     # causing extreme attention scores and numerical instability in LSE merging.
     weight_scale = 1.0 / (kv_lora_rank**0.5)
-    kv_b_proj_weight = kv_b_proj_weight * weight_scale
+    W_UK = W_UK * weight_scale
+    W_UV = W_UV * weight_scale
+
+    kv_b_proj_weight = torch.cat([W_UK, W_UV], dim=-1)
 
     for i, backend in enumerate(BACKENDS_TO_TEST):
         all_sdpa_outputs.append([])

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -506,6 +506,12 @@ def test_backend_correctness(
     )
     kv_b_proj_weight = torch.cat([W_UK, W_UV], dim=-1)
 
+    # Scale weights to produce realistic magnitude outputs.
+    # Without scaling, projection output has std ~sqrt(kv_lora_rank) ≈ 22.6,
+    # causing extreme attention scores and numerical instability in LSE merging.
+    weight_scale = 1.0 / (kv_lora_rank**0.5)
+    kv_b_proj_weight = kv_b_proj_weight * weight_scale
+
     for i, backend in enumerate(BACKENDS_TO_TEST):
         all_sdpa_outputs.append([])
 


### PR DESCRIPTION
V1 Test attention (B200) CI run fails. Here #32484 was committed workaround. 

This PR make a root cause fix. 

Apply `1/sqrt(kv_lora_rank)` scaling to `kv_b_proj_weight` to produce outputs with unit-variance.

Without scaling, random weight matrices with `kv_lora_rank=512` inputs produce projection outputs with std ≈ √512 ≈ 22.6. These large magnitudes cause extreme attention scores, which destabilize LSE (log-sum-exp) merging across chunks and lead to spurious test failures due to numerical precision loss - not actual backend bugs.

This scaling ensures the test exercises realistic operating conditions where attention backends can be compared fairly.
