### PR TITLE
Add experimental Index-AniSora wrapper (text-to-video)

### DIFF
--- a/tests/unit/model_executor/test_index_anisora.py
+++ b/tests/unit/model_executor/test_index_anisora.py
@@ -1,0 +1,54 @@
+import os
+import pytest
+import torch
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="GPU is required for diffusion inference"
+)
+def test_index_anisora_loads():
+    try:
+        from vllm.model_executor.models.index_anisora import (
+            IndexAniSoraForVideoGeneration,
+        )
+    except Exception as e:
+        pytest.skip(f"Import failed (diffusers likely missing): {e}")
+
+    # Do not trigger a full generation in unit test - just load pipeline
+    model = IndexAniSoraForVideoGeneration(
+        model_id=os.environ.get("ANISORA_MODEL", "IndexTeam/Index-anisora"),
+        torch_dtype=torch.float16,
+        device="cuda",
+    )
+    assert model.pipe is not None
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="GPU is required for diffusion inference"
+)
+def test_index_anisora_forward_smoke():
+    try:
+        from vllm.model_executor.models.index_anisora import (
+            IndexAniSoraForVideoGeneration,
+        )
+    except Exception as e:
+        pytest.skip(f"Import failed (diffusers likely missing): {e}")
+
+    model = IndexAniSoraForVideoGeneration(
+        model_id=os.environ.get("ANISORA_MODEL", "IndexTeam/Index-anisora"),
+        torch_dtype=torch.float16,
+        device="cuda",
+    )
+
+    # Keep params tiny for smoke test; real quality not validated here
+    video = model.forward(
+        prompt="A cat is running",
+        num_frames=2,
+        num_inference_steps=1,
+        height=128,
+        width=128,
+        return_type="tensor",
+    )
+    assert isinstance(video, torch.Tensor)
+    assert video.ndim == 4 and video.shape[-1] == 3

--- a/vllm/model_executor/layers/video_utils.py
+++ b/vllm/model_executor/layers/video_utils.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+import numpy as np
+import torch
+from PIL import Image
+
+
+def pil_frames_to_uint8_tensor(frames: Iterable[Image.Image]) -> torch.Tensor:
+    """Convert a sequence of PIL RGB frames to uint8 torch tensor [F, H, W, 3]."""
+    arrs: List[np.ndarray] = []
+    for img in frames:
+        if img.mode != "RGB":
+            img = img.convert("RGB")
+        arrs.append(np.asarray(img, dtype=np.uint8))
+
+    if not arrs:
+        return torch.empty((0, 0, 0, 3), dtype=torch.uint8)
+
+    stacked = np.stack(arrs, axis=0)  # [F, H, W, 3]
+    return torch.from_numpy(stacked)
+
+
+def uint8_tensor_to_pil_frames(video: torch.Tensor) -> List[Image.Image]:
+    """Convert uint8 torch tensor [F, H, W, 3] to list of PIL RGB images."""
+    if video.dtype != torch.uint8:
+        raise ValueError("Expected uint8 tensor for conversion to PIL frames")
+    if video.ndim != 4 or video.shape[-1] != 3:
+        raise ValueError("Expected shape [F, H, W, 3] for video tensor")
+
+    video_np = video.detach().cpu().numpy()
+    frames = [Image.fromarray(frame, mode="RGB") for frame in video_np]
+    return frames
+
+
+__all__ = ["pil_frames_to_uint8_tensor", "uint8_tensor_to_pil_frames"]

--- a/vllm/model_executor/models/index_anisora.py
+++ b/vllm/model_executor/models/index_anisora.py
@@ -1,0 +1,186 @@
+"""Experimental Index-AniSora (text-to-video) wrapper for vLLM.
+
+This module provides a minimal integration of Index-AniSora via
+Hugging Face diffusers AutoPipelineForText2Video.
+
+Notes
+-----
+- This is an experimental, non-streaming video generation path.
+- It loads the diffusers pipeline and runs a full generation call
+  per request. It does not use token streaming or KV cache.
+- Designed to be called directly for now; registry/runner wiring
+  can be added incrementally.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+
+
+@dataclass
+class IndexAniSoraParams:
+    """Generation parameters with safe defaults for VRAM.
+
+    These defaults aim to reduce OOM risk on common GPUs.
+    """
+
+    height: int = 360
+    width: int = 640
+    num_frames: int = 16
+    num_inference_steps: int = 6
+    guidance_scale: float = 7.5
+    seed: Optional[int] = None
+
+
+class IndexAniSoraForVideoGeneration:
+    """Minimal wrapper around diffusers text-to-video pipeline.
+
+    Usage
+    -----
+    model = IndexAniSoraForVideoGeneration(
+        model_id="IndexTeam/Index-anisora",
+        torch_dtype=torch.float16,
+        device="cuda",
+    )
+    frames = model.forward("A girl running", num_frames=8, height=360, width=640)
+    """
+
+    def __init__(
+        self,
+        model_id: str = "IndexTeam/Index-anisora",
+        *,
+        device: str | torch.device = "cuda",
+        torch_dtype: torch.dtype = torch.float16,
+        trust_remote_code: bool = True,
+        hf_token: Optional[str] = None,
+        pipeline_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.model_id = model_id
+        self.device = torch.device(device) if isinstance(device, str) else device
+        self.torch_dtype = torch_dtype
+        self.trust_remote_code = trust_remote_code
+        self.hf_token = hf_token
+        self.pipeline_kwargs = pipeline_kwargs or {}
+
+        self.pipe = None
+        self._load_model()
+
+    # Keep a simple API aligned with the docs drafts
+    @staticmethod
+    def get_supported_models() -> List[str]:
+        return ["IndexTeam/Index-anisora"]
+
+    def _load_model(self) -> None:
+        try:
+            from diffusers import AutoPipelineForText2Video
+        except Exception as e:  # pragma: no cover - import path
+            raise ImportError(
+                "diffusers is required for Index-AniSora. Install with `pip install diffusers transformers accelerate`"
+            ) from e
+
+        # Lazily enable common memory savers; users can override via pipeline_kwargs
+        self.pipe = AutoPipelineForText2Video.from_pretrained(
+            self.model_id,
+            torch_dtype=self.torch_dtype,
+            use_safetensors=True,
+            trust_remote_code=self.trust_remote_code,
+            token=self.hf_token,
+            **self.pipeline_kwargs,
+        )
+
+        # Move to device and apply typical optimizations
+        self.pipe = self.pipe.to(self.device)
+        # Enable attention slicing if available to reduce VRAM
+        if hasattr(self.pipe, "enable_attention_slicing"):
+            try:
+                self.pipe.enable_attention_slicing()
+            except Exception:
+                pass
+
+        # Optionally compile the UNet for speed (PyTorch 2.x)
+        try:  # pragma: no cover - runtime dependent
+            self.pipe.unet = torch.compile(self.pipe.unet)  # type: ignore[attr-defined]
+        except Exception:
+            # Compilation may fail depending on env; ignore safely
+            pass
+
+    @torch.inference_mode()
+    def forward(
+        self,
+        prompt: str,
+        *,
+        negative_prompt: Optional[str] = None,
+        image: Optional[Any] = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        num_frames: Optional[int] = None,
+        num_inference_steps: Optional[int] = None,
+        guidance_scale: Optional[float] = None,
+        seed: Optional[int] = None,
+        generator: Optional[torch.Generator] = None,
+        return_type: str = "tensor",  # "tensor" | "pil_list"
+        **kwargs: Any,
+    ) -> Any:
+        """Generate a video.
+
+        Parameters mirror diffusers Text2Video pipeline where relevant.
+        Returns either a torch.Tensor [F,H,W,3] uint8 or list of PIL.Image.
+        """
+        if self.pipe is None:
+            raise RuntimeError("Pipeline not loaded. Call __init__ again.")
+
+        params = IndexAniSoraParams()
+        h = height or params.height
+        w = width or params.width
+        f = num_frames or params.num_frames
+        steps = num_inference_steps or params.num_inference_steps
+        gs = guidance_scale if guidance_scale is not None else params.guidance_scale
+
+        if generator is None:
+            if seed is None:
+                seed = params.seed
+            if seed is not None:
+                generator = torch.Generator(device=self.device).manual_seed(seed)
+
+        # Prepare kwargs for pipeline
+        pipe_kwargs: Dict[str, Any] = dict(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            height=h,
+            width=w,
+            num_frames=f,
+            num_inference_steps=steps,
+            guidance_scale=gs,
+            generator=generator,
+        )
+        if image is not None:
+            # Some anisora variants support img-to-video guidance
+            pipe_kwargs["image"] = image
+
+        pipe_kwargs.update(kwargs)
+
+        output = self.pipe(**pipe_kwargs)
+
+        # diffusers returns a list of PIL images as output.frames
+        frames = getattr(output, "frames", None)
+        if frames is None:
+            # Some pipelines use .images naming
+            frames = getattr(output, "images", None)
+        if frames is None:
+            raise RuntimeError("Unexpected output from diffusers pipeline.")
+
+        if return_type == "pil_list":
+            return frames
+
+        # Convert to torch uint8 tensor [F, H, W, 3]
+        from vllm.model_executor.layers.video_utils import (
+            pil_frames_to_uint8_tensor,
+        )
+
+        return pil_frames_to_uint8_tensor(frames)
+
+
+__all__ = ["IndexAniSoraForVideoGeneration", "IndexAniSoraParams"]


### PR DESCRIPTION
## Summary
- add experimental Index-AniSora text-to-video wrapper using diffusers
- add video frame conversion utils
- add GPU-only smoke tests (load + tiny generation)

## Notes
- Experimental, non-streaming video-generation path; loads diffusers pipeline and runs full generation per request.
- Tests require CUDA and diffusers; smoke test uses num_frames=2, num_inference_steps=1, 128x128 to minimize VRAM.
