### PR TITLE
[CI/Build] Use Common Event Map Fixture in Harmony / MCP Server Tests

### DIFF
--- a/tests/entrypoints/openai/responses/conftest.py
+++ b/tests/entrypoints/openai/responses/conftest.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+
+@pytest.fixture
+def pairs_of_event_types() -> dict[str, str]:
+    """Links the 'done' event type with the corresponding 'start' event type.
+
+    This mapping should link all done <-> start events; if tests mean to
+    restrict the allowed events, they should filter this fixture to avoid
+    copy + paste errors in the mappings or unexpected KeyErrors due to missing
+    events.
+    """
+    # fmt: off
+    event_pairs = {
+        "response.completed": "response.created",
+        "response.output_item.done": "response.output_item.added",
+        "response.content_part.done": "response.content_part.added",
+        "response.output_text.done": "response.output_text.delta",
+        "response.reasoning_text.done": "response.reasoning_text.delta",
+        "response.reasoning_part.done": "response.reasoning_part.added",
+        "response.mcp_call_arguments.done": "response.mcp_call_arguments.delta",
+        "response.mcp_call.completed": "response.mcp_call.in_progress",
+        "response.function_call_arguments.done": "response.function_call_arguments.delta", # noqa: E501
+        "response.code_interpreter_call_code.done": "response.code_interpreter_call_code.delta", # noqa: E501
+        "response.web_search_call.completed": "response.web_search_call.in_progress",
+    }
+    # fmt: on
+    return event_pairs

--- a/tests/entrypoints/openai/responses/test_harmony.py
+++ b/tests/entrypoints/openai/responses/test_harmony.py
@@ -280,23 +280,12 @@ async def test_stateful_multi_turn(client: OpenAI, model_name: str):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
-async def test_streaming_types(client: OpenAI, model_name: str):
+async def test_streaming_types(
+    pairs_of_event_types: dict[str, str], client: OpenAI, model_name: str
+):
     prompts = [
         "tell me a story about a cat in 20 words",
     ]
-
-    # this links the "done" type with the "start" type
-    # so every "done" type should have a corresponding "start" type
-    # and every open block should be closed by the end of the stream
-    pairs_of_event_types = {
-        "response.completed": "response.created",
-        "response.output_item.done": "response.output_item.added",
-        "response.content_part.done": "response.content_part.added",
-        "response.output_text.done": "response.output_text.delta",
-        "response.web_search_call.done": "response.web_search_call.added",
-        "response.reasoning_text.done": "response.reasoning_text.delta",
-        "response.reasoning_part.done": "response.reasoning_part.added",
-    }
 
     for prompt in prompts:
         response = await client.responses.create(
@@ -329,19 +318,9 @@ async def test_streaming_types(client: OpenAI, model_name: str):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
-async def test_function_calling_with_streaming_types(client: OpenAI, model_name: str):
-    # this links the "done" type with the "start" type
-    # so every "done" type should have a corresponding "start" type
-    # and every open block should be closed by the end of the stream
-    pairs_of_event_types = {
-        "response.completed": "response.created",
-        "response.output_item.done": "response.output_item.added",
-        "response.output_text.done": "response.output_text.delta",
-        "response.reasoning_text.done": "response.reasoning_text.delta",
-        "response.reasoning_part.done": "response.reasoning_part.added",
-        "response.function_call_arguments.done": "response.function_call_arguments.delta",  # noqa
-    }
-
+async def test_function_calling_with_streaming_types(
+    pairs_of_event_types: dict[str, str], client: OpenAI, model_name: str
+):
     tools = [GET_WEATHER_SCHEMA]
     input_list = [
         {

--- a/tests/entrypoints/openai/responses/test_mcp_tools.py
+++ b/tests/entrypoints/openai/responses/test_mcp_tools.py
@@ -210,19 +210,11 @@ class TestMCPEnabled:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("model_name", [MODEL_NAME])
     async def test_mcp_tool_calling_streaming_types(
-        self, mcp_enabled_client: OpenAI, model_name: str
+        self,
+        pairs_of_event_types: dict[str, str],
+        mcp_enabled_client: OpenAI,
+        model_name: str,
     ):
-        pairs_of_event_types = {
-            "response.completed": "response.created",
-            "response.output_item.done": "response.output_item.added",
-            "response.content_part.done": "response.content_part.added",
-            "response.output_text.done": "response.output_text.delta",
-            "response.reasoning_text.done": "response.reasoning_text.delta",
-            "response.reasoning_part.done": "response.reasoning_part.added",
-            "response.mcp_call_arguments.done": ("response.mcp_call_arguments.delta"),
-            "response.mcp_call.completed": "response.mcp_call.in_progress",
-        }
-
         tools = [
             {
                 "type": "mcp",


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fixes https://github.com/vllm-project/vllm/issues/32495

There are a few places in the Harmony / MCP server tests that we hardcode response mappings from `done` events to `start` events. This is pretty error prone and can lead to issues like the `KeyError` above, or things like wrong event names in some places, e.g., this one,

```
"response.web_search_call.done": "response.web_search_call.added"
```

which I think are not correct names for the `web_search_call` events.

This PR refactors the tests that hard code their own mappings to use a common fixture to avoid issues due to incomplete mappings and/or copy paste errors. Also, if we explicitly want to disallow certain events in the future, we can add utils to filter the common fixture to get the 'allowed' events to have better error messages than what is currently there, since some of these tests seem a bit flaky


## Test Plan
Current and future tests should pass (more) reliably, since `response.mcp_call_arguments.done` is added, the web search event name is fixed, and other missing event types that could trigger similar issues from being omitted, e.g., `response.code_interpreter_call_code.done`, are added.

## Test Result
Tests pass

CC @robertgshaw2-redhat 