### PR TITLE
[Bugfix] Add tool chat template for Olmo3 models

### DIFF
--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -412,9 +412,13 @@ Olmo 3 models output tool calls in a format that is very similar to the one expe
 Supported models:
 
 * `allenai/Olmo-3-7B-Instruct`
-* `allenai/Olmo-3-32B-Think`
+* `allenai/Olmo-3.1-32B-Think`
 
-Flags: `--tool-call-parser olmo3`
+vLLM provides a tool chat template for Olmo 3 models:
+
+* [examples/tool_chat_template_olmo3.jinja](../../examples/tool_chat_template_olmo3.jinja) - this template instructs the model to output tool calls in the `<function_calls>` format expected by the parser.
+
+Recommended flags: `--tool-call-parser olmo3 --chat-template examples/tool_chat_template_olmo3.jinja`
 
 ### Gigachat 3 Models (`gigachat3`)
 

--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -412,7 +412,9 @@ Olmo 3 models output tool calls in a format that is very similar to the one expe
 Supported models:
 
 * `allenai/Olmo-3-7B-Instruct`
-* `allenai/Olmo-3.1-32B-Think`
+* `allenai/Olmo-3.1-32B-Instruct`
+
+Note: OLMo 3 **Think** models (e.g., `Olmo-3.1-32B-Think`) do **not** support tool calling. Only the **Instruct** models listed above are supported.
 
 vLLM provides a tool chat template for Olmo 3 models:
 

--- a/examples/tool_chat_template_olmo3.jinja
+++ b/examples/tool_chat_template_olmo3.jinja
@@ -1,0 +1,96 @@
+{{- bos_token }}
+{%- if custom_tools is defined %}
+    {%- set tools = custom_tools %}
+{%- endif %}
+{%- if not tools is defined %}
+    {%- set tools = none %}
+{%- endif %}
+
+{#- Extract the system message if present #}
+{%- if messages[0]['role'] == 'system' %}
+    {%- set system_message = messages[0]['content']|trim %}
+    {%- set messages = messages[1:] %}
+{%- else %}
+    {%- set system_message = "You are a helpful function-calling AI assistant." %}
+{%- endif %}
+
+{#- System message with tools #}
+{{- "<|im_start|>system\n" }}
+{{- system_message }}
+{%- if tools is not none and tools | length > 0 %}
+{{- "\n\nYou have access to the following functions. To call functions, respond with a pythonic function call wrapped in <function_calls></function_calls> XML tags." }}
+{{- "\n\nFor example, to call a function named 'get_weather' with parameters city='New York' and units='celsius', respond with:" }}
+{{- "\n<function_calls>\nget_weather(city='New York', units='celsius')\n</function_calls>" }}
+{{- "\n\nYou can call multiple functions by putting each call on a new line within the tags:" }}
+{{- "\n<function_calls>\nfunction1(param1='value1')\nfunction2(param2='value2')\n</function_calls>" }}
+{{- "\n\nHere are the available functions:\n<functions>\n" }}
+    {%- for tool in tools %}
+        {%- if tool.function is defined %}
+            {%- set tool = tool.function %}
+        {%- endif %}
+        {{- tool | tojson }}
+        {%- if not loop.last %}
+            {{- "\n" }}
+        {%- endif %}
+    {%- endfor %}
+{{- "\n</functions>" }}
+{%- else %}
+{{- "\nYou do not currently have access to any functions." }}
+{%- endif %}
+{{- "<|im_end|>\n" }}
+
+{#- Process conversation messages #}
+{%- for message in messages %}
+    {%- if message.role == "user" %}
+        {{- "<|im_start|>user\n" + message.content|trim + "<|im_end|>\n" }}
+    {%- elif message.role == "assistant" %}
+        {%- if message.tool_calls is defined and message.tool_calls | length > 0 %}
+            {{- "<|im_start|>assistant\n<function_calls>\n" }}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- tool_call.name + "(" }}
+                {%- if tool_call.arguments is string %}
+                    {%- set args = tool_call.arguments | from_json %}
+                {%- else %}
+                    {%- set args = tool_call.arguments %}
+                {%- endif %}
+                {%- for key, value in args.items() %}
+                    {{- key + "=" }}
+                    {%- if value is string %}
+                        {{- "'" + value + "'" }}
+                    {%- elif value is none %}
+                        {{- "null" }}
+                    {%- elif value is sameas true %}
+                        {{- "true" }}
+                    {%- elif value is sameas false %}
+                        {{- "false" }}
+                    {%- else %}
+                        {{- value | tojson }}
+                    {%- endif %}
+                    {%- if not loop.last %}
+                        {{- ", " }}
+                    {%- endif %}
+                {%- endfor %}
+                {{- ")" }}
+                {%- if not loop.last %}
+                    {{- "\n" }}
+                {%- endif %}
+            {%- endfor %}
+            {{- "\n</function_calls><|im_end|>\n" }}
+        {%- else %}
+            {{- "<|im_start|>assistant\n" + message.content|trim + "<|im_end|>\n" }}
+        {%- endif %}
+    {%- elif message.role == "tool" %}
+        {{- "<|im_start|>tool\n" }}
+        {%- if message.name is defined %}
+            {{- "Function " + message.name + " returned:\n" }}
+        {%- endif %}
+        {{- message.content|trim + "<|im_end|>\n" }}
+    {%- endif %}
+{%- endfor %}
+
+{%- if add_generation_prompt %}
+    {{- "<|im_start|>assistant\n" }}
+{%- endif %}


### PR DESCRIPTION
## Summary

This PR fixes GitHub issue #32534 by adding a tool chat template for OLMo 3 **Instruct** models.

**Note:** OLMo 3 **Think** models (e.g., `Olmo-3.1-32B-Think`) do **not** support tool calling per the OLMo team. Only the **Instruct** models are supported:
- `allenai/OLMo-3-7B-Instruct`
- `allenai/OLMo-3.1-32B-Instruct`

**Root Cause:** While the `olmo3` tool parser exists to parse the expected output format (`<function_calls>...</function_calls>`), there was no chat template provided to instruct the model to use this format when generating tool calls. Without proper instructions in the prompt, the model generates natural language descriptions of tool calls instead of structured tool calls.

**Changes:**
- Add `examples/tool_chat_template_olmo3.jinja`: A new chat template that instructs OLMo3 Instruct models to output tool calls in the pythonic format wrapped in `<function_calls>` XML tags as expected by the olmo3 parser
- Update `docs/features/tool_calling.md`: Document the required chat template for OLMo3 and clarify which models are supported

**Usage:** 
```bash
vllm serve allenai/OLMo-3-7B-Instruct \
  --tool-call-parser olmo3 \
  --enable-auto-tool-choice \
  --chat-template examples/tool_chat_template_olmo3.jinja
```

Fixes: #32534

## Test plan
- [ ] Verify the template generates correct prompts with tools
- [ ] Test tool calling with OLMo-3 Instruct models using the new template
- [ ] Verify the olmo3 parser correctly parses the model output