### PR TITLE
refactor: extract KV cache update logic into method in RocmAttention

### DIFF
--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -277,6 +277,58 @@ class RocmAttentionImpl(AttentionImpl):
                 f"num_heads: {num_heads}."
             )
 
+    def do_kv_cache_update(
+        self,
+        layer: torch.nn.Module,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: RocmAttentionMetadata,
+    ) -> None:
+        """Update KV cache with new key and value tensors.
+
+        Args:
+            layer: attention layer containing scale factors.
+            key: shape = [num_tokens, num_kv_heads, head_size]
+            value: shape = [num_tokens, num_kv_heads, head_size]
+            kv_cache: shape = [2, num_blocks, block_size, num_kv_heads, head_size]
+            attn_metadata: metadata for attention containing slot_mapping.
+        """
+        key_cache, value_cache = PagedAttention.split_kv_cache(
+            kv_cache, self.num_kv_heads, self.head_size
+        )
+
+        # Get actual block_size from value_cache
+        # value_cache shape: [num_blocks, num_heads, head_size, block_size]
+        block_size = value_cache.shape[3]
+        # Determine if its power of 2
+        is_pow2 = block_size > 0 and (block_size & (block_size - 1) == 0)
+
+        if is_pow2:
+            # For power-of-2 blocks use vLLM native HIP C++ logic
+            PagedAttention.write_to_paged_cache(
+                key,
+                value,
+                key_cache,
+                value_cache,
+                attn_metadata.slot_mapping,
+                self.kv_cache_dtype,
+                layer._k_scale,
+                layer._v_scale,
+            )
+        else:
+            # For non-standard blocks force use modified Triton logic
+            triton_reshape_and_cache_flash(
+                key,
+                value,
+                key_cache,
+                value_cache,
+                attn_metadata.slot_mapping,
+                self.kv_cache_dtype,
+                layer._k_scale,
+                layer._v_scale,
+            )
+
     def forward(
         self,
         layer: torch.nn.Module,
@@ -331,40 +383,9 @@ class RocmAttentionImpl(AttentionImpl):
         )
 
         if self.kv_sharing_target_layer_name is None:
-            # Reshape the input keys and values and store them in the cache.
-            # Skip this if sharing KV cache with an earlier attention layer.
-
-            # Get the actual block_size from value_cache
-            # value_cache shape: [num_blocks, num_heads, head_size, block_size]
-            block_size = value_cache.shape[3]
-            # Determine if it is a power of 2
-            is_pow2 = block_size > 0 and (block_size & (block_size - 1) == 0)
-
-            if is_pow2:
-                # Normal 16, 32, 64, etc., use vLLM native HIP C++ logic
-                PagedAttention.write_to_paged_cache(
-                    key,
-                    value,
-                    key_cache,
-                    value_cache,
-                    attn_metadata.slot_mapping,
-                    self.kv_cache_dtype,
-                    layer._k_scale,
-                    layer._v_scale,
-                )
-            else:
-                # Case B: Non-standard blocks (e.g., 544 in Qwen3),
-                # force using our modified Triton logic
-                triton_reshape_and_cache_flash(
-                    key,
-                    value,
-                    key_cache,
-                    value_cache,
-                    attn_metadata.slot_mapping,
-                    self.kv_cache_dtype,
-                    layer._k_scale,
-                    layer._v_scale,
-                )
+            # Reshape the input keys and values and store them in the cache
+            # Skip if sharing KV cache with an earlier attention layer
+            self.do_kv_cache_update(layer, key, value, kv_cache, attn_metadata)
 
         if self.kv_cache_dtype.startswith("fp8"):
             key_cache = key_cache.view(self.fp8_dtype)

--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -23,7 +23,6 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
 )
-
 from vllm.v1.attention.ops.chunked_prefill_paged_decode import (
     chunked_prefill_paged_decode,
 )
@@ -383,7 +382,14 @@ class RocmAttentionImpl(AttentionImpl):
         if self.kv_sharing_target_layer_name is None:
             # Reshape the input keys and values and store them in the cache
             # Skip if sharing KV cache with an earlier attention layer
-            self.do_kv_cache_update(layer, key, value, key_cache, value_cache, attn_metadata)
+            self.do_kv_cache_update(
+                layer,
+                key,
+                value,
+                key_cache,
+                value_cache,
+                attn_metadata,
+            )
 
         if self.kv_cache_dtype.startswith("fp8"):
             key_cache = key_cache.view(self.fp8_dtype)


### PR DESCRIPTION
## Purpose

Fixes #32335 

This PR separates the KV-cache update from the attention forward pass for the ROCm attention backend by extracting the cache update code into a dedicated method.

* Added a new method `do_kv_cache_update` to encapsulate the logic for updating the KV cache, handling both power-of 2 and non-standard block sizes.
* Updated the `forward` method to call the new `do_kv_cache_update` method instead of duplicating the cache update logic, reducing code duplication and improving maintainability.
