### PR TITLE
[Bugfix] EPLB - Mistral 3 Large

### DIFF
--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -737,6 +737,28 @@ def is_mixture_of_experts(model: object) -> TypeIs[MixtureOfExperts]:
     )
 
 
+def get_mixture_of_experts_model(model: object) -> MixtureOfExperts | None:
+    """
+    Given an arbitrary model, return the MixtureOfExperts instance contained within
+    the model, if it exists. Return None otherwise.
+
+    :param model: Model being served.
+    :type model: object
+    :return: Return the MixtureOfExperts instance contained within the model.
+    :rtype: MixtureOfExperts | None
+    """
+
+    if is_mixture_of_experts(model):
+        return model
+
+    is_mm_model = isinstance(model, SupportsMultiModal)
+    if is_mm_model:
+        language_model = model.get_language_model()
+        return get_mixture_of_experts_model(language_model)
+
+    return None
+
+
 @runtime_checkable
 class HasNoOps(Protocol):
     has_noops: ClassVar[Literal[True]] = True

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -739,22 +739,24 @@ def is_mixture_of_experts(model: object) -> TypeIs[MixtureOfExperts]:
 
 def get_mixture_of_experts_model(model: object) -> MixtureOfExperts | None:
     """
-    Given an arbitrary model, return the MixtureOfExperts instance contained within
-    the model, if it exists. Return None otherwise.
+    Given an arbitrary model,
+     - if the model itself is a MixtureOfExperts, return the model directly.
+     - if the model is a multi-modal model, and its `language_model` is a
+       MixtureOfExperts, return the `language_model`.
+     - if neither, return None.
 
     :param model: Model being served.
     :type model: object
-    :return: Return the MixtureOfExperts instance contained within the model.
+    :return: Return MixtureOfExperts instance contained within the model.
     :rtype: MixtureOfExperts | None
     """
 
     if is_mixture_of_experts(model):
         return model
 
-    is_mm_model = isinstance(model, SupportsMultiModal)
-    if is_mm_model:
-        language_model = model.get_language_model()
-        return get_mixture_of_experts_model(language_model)
+    if isinstance(model, SupportsMultiModal):
+        mm_language_model = model.get_language_model()
+        return mm_language_model if is_mixture_of_experts(mm_language_model) else None
 
     return None
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3840,6 +3840,7 @@ class GPUModelRunner(
                         and self.parallel_config.enable_eplb
                     ):
                         spec_config = self.vllm_config.speculative_config
+                        assert hasattr(self.drafter, "model")
                         assert spec_config is not None
                         assert spec_config.draft_model_config is not None
                         logger.info_once(

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -34,7 +34,9 @@ from vllm.distributed.parallel_state import (
 )
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
-from vllm.model_executor.models.interfaces import is_mixture_of_experts
+from vllm.model_executor.models.interfaces import (
+    get_mixture_of_experts_model,
+)
 from vllm.model_executor.warmup.kernel_warmup import kernel_warmup
 from vllm.platforms import current_platform
 from vllm.profiler.wrapper import CudaProfilerWrapper, TorchProfilerWrapper
@@ -810,7 +812,10 @@ class Worker(WorkerBase):
             self.model_runner.drafter, "model"
         ):
             drafter_model = self.model_runner.drafter.model
-        if drafter_model is not None and is_mixture_of_experts(drafter_model):
+        if (
+            drafter_model is not None
+            and get_mixture_of_experts_model(drafter_model) is not None
+        ):
             drafter_moe_modules = get_moe_modules(drafter_model)
             # Check if drafter and model have matching configs
             assert (


### PR DESCRIPTION
## Purpose
on `main` running, 
```
vllm serve mistralai/Mistral-Large-3-675B-Instruct-2512 --data-parallel-size 8 --enable-expert-parallel --port 9010 --all2all-backend deepep_high_throughput --enable-eplb --eplb-config '{"window_size":100, "step_interval":10, "num_redundant_experts":0, "log_balancedness":true}' --max-model-len 8192 
```
produces the error 
```
EngineCore_DP5 pid=4109610)     topk_weights, topk_ids = router.select_experts(
(EngineCore_DP5 pid=4109610)                              ^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP5 pid=4109610)   File "/home/varun-sundar-rabindranath/code/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 305, in select_experts
(EngineCore_DP5 pid=4109610)     return self.layer._select_experts(hidden_states, router_logits)
(EngineCore_DP5 pid=4109610)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP5 pid=4109610)   File "/home/varun-sundar-rabindranath/code/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 1564, in _select_experts
(EngineCore_DP5 pid=4109610)     raise ValueError(
(EngineCore_DP5 pid=4109610) ValueError: enable_eplb=True requiere expert_load_view != None
```

### Fix
Mistral 3 Large is a multi-modal model that contains within it, an MoE language model. Even though the model as a whole is not an MoE model, the language model is an MoE. EPLB on main, works only if the entire model is an MoE model. This PR, adds additional logic to detect if the given model contains an MoE language_model and plumbs it correctly to the EPLB interface. 

## Test Plan
`main - mistral 3 large without EPLB`
- server command : ` vllm serve mistralai/Mistral-Large-3-675B-Instruct-2512 --data-parallel-size 8 --enable-expert-parallel --port 9010 --all2all-backend deepep_high_throughput --enable-eplb --eplb-config '{"window_size":100, "step_interval":10, "num_redundant_experts":0, "log_balancedness":true}' --max-model-len 8192 `

`PR - mistral 3 large with EPLB`
```
vllm serve mistralai/Mistral-Large-3-675B-Instruct-2512 --data-parallel-size 8 --enable-expert-parallel --port 9010 --all2all-backend deepep_high_throughput --enable-eplb --eplb-config '{"window_size":100, "step_interval":10, "num_redundant_experts":0, "log_balancedness":true}' --max-model-len 8192 
```

lm_eval command : `lm_eval --model local-completions --model_args model=mistralai/Mistral-Large-3-675B-Instruct-2512,base_url=http://127.0.0.1:9010/v1/completions,tokenized_requests=False,num_concurrent=100,trust_remote_code=True --tasks gsm8k`

## Test Result
`main - mistral 3 large without EPLB`
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8355|±  |0.0102|
|     |       |strict-match    |     5|exact_match|↑  |0.6444|±  |0.0132|

```
`PR - mistral 3 large with EPLB`
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8340|±  |0.0102|
|     |       |strict-match    |     5|exact_match|↑  |0.6626|±  |0.0130|
```

Also verified that Qwen3 MoE model produces correct results with EPLB on `main` and this `PR`
