### PR TITLE
Fix UnboundLocalError in unquantized MoE backend selection

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -59,6 +59,9 @@ def select_unquantized_moe_backend(
     def _make_log_backend(backend: UnquantizedMoeBackend):
         return f"Using {backend.value} backend for Unquantized MoE"
 
+    # Default to TRITON backend if no specific platform matches
+    backend = UnquantizedMoeBackend.TRITON
+
     rocm_aiter_moe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
 
     # FlashInfer CUTLASS MoE is only supported on Hopper and later GPUS


### PR DESCRIPTION
Summary:
Fixes `buck test fbcode//mode/opt fbcode//vllm/fb/mtia/tests/iris_bringup:test_llama_with_dp2ep2_iris_2_ranks_2_sunics_1_sonics` failing with:

```
UnboundLocalError: cannot access local variable 'backend' where it is not associated with a value
```

**Root Cause:**
In `select_unquantized_moe_backend()`, the `backend` variable was only assigned within platform-specific conditional branches. When running on platforms that didn't match any condition (such as MTIA), the code reached `logger.info_once(_make_log_backend(backend))` with `backend` never having been assigned a value.

**Fix:**
Initialize `backend = UnquantizedMoeBackend.TRITON` as the default before the platform-specific checks. TRITON is the appropriate fallback as it's the most widely compatible backend across platforms.

Test Plan: buck test fbcode//mode/opt fbcode//vllm/fb/mtia/tests/iris_bringup:test_llama_with_dp2ep2_iris_2_ranks_2_sunics_1_sonics

Differential Revision: D90938874


