### PR TITLE
[Feature] Support LoRA MoE for bitsandbytes quantization

### DIFF
--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.quantization import (
     QuantizationConfig,
     QuantizationMethods,
 )
+from vllm.model_executor.layers.quantization.utils import replace_parameter
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
 
@@ -494,7 +495,53 @@ class BitsAndBytesMoEMethod(FusedMoEMethodBase):
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
     ) -> FusedMoEQuantConfig | None:
-        return None
+        from vllm.model_executor.layers.fused_moe.config import (
+            FUSED_MOE_UNQUANTIZED_CONFIG,
+        )
+
+        return FUSED_MOE_UNQUANTIZED_CONFIG
+
+    def select_gemm_impl(
+        self,
+        prepare_finalize,
+        layer: torch.nn.Module,
+    ):
+        if not self.moe.is_lora_enabled:
+            raise NotImplementedError(
+                "BitsAndBytes uses its own apply() method when LoRA is not enabled. "
+                "Modular kernels are only used for LoRA support."
+            )
+        from vllm.model_executor.layers.fused_moe import modular_kernel as mk
+        from vllm.model_executor.layers.fused_moe.fused_batched_moe import (
+            BatchedTritonExperts,
+        )
+        from vllm.model_executor.layers.fused_moe.fused_moe import TritonExperts
+
+        assert self.moe_quant_config is not None, (
+            "moe_quant_config must be initialized before select_gemm_impl"
+        )
+
+        if self.quant_config.load_in_8bit:
+            w13, w2 = self._apply_8bit_dequant(layer)
+        else:
+            w13, w2 = self._apply_4bit_dequant(layer)
+
+        replace_parameter(layer, "w13_weight", w13)
+        replace_parameter(layer, "w2_weight", w2)
+
+        if (
+            prepare_finalize.activation_format
+            == mk.FusedMoEActivationFormat.BatchedExperts
+        ):
+            max_num_tokens_per_rank = prepare_finalize.max_num_tokens_per_rank()
+            assert max_num_tokens_per_rank is not None
+            return BatchedTritonExperts(
+                max_num_tokens=max_num_tokens_per_rank,
+                num_dispatchers=prepare_finalize.num_dispatchers(),
+                quant_config=self.moe_quant_config,
+            )
+        else:
+            return TritonExperts(self.moe_quant_config)
 
     def apply(
         self,
@@ -513,7 +560,7 @@ class BitsAndBytesMoEMethod(FusedMoEMethodBase):
         if self.quant_config.load_in_8bit:
             w13, w2 = self._apply_8bit_dequant(layer)
         else:
-            w13, w2 = self._apply_4bit_dequnt(layer)
+            w13, w2 = self._apply_4bit_dequant(layer)
         return fused_experts(
             hidden_states=x,
             w1=w13,
@@ -566,6 +613,7 @@ class BitsAndBytesMoEMethod(FusedMoEMethodBase):
                 ),
                 "pack_factor": quant_ratio,
                 "use_bitsandbytes_4bit": True,
+                "dequant_dtype": params_dtype,
             },
         )
         # down_proj (row parallel)
@@ -592,6 +640,7 @@ class BitsAndBytesMoEMethod(FusedMoEMethodBase):
                 ),
                 "pack_factor": quant_ratio,
                 "use_bitsandbytes_4bit": True,
+                "dequant_dtype": params_dtype,
             },
         )
         layer.register_parameter("w2_weight", w2_qweight)
@@ -608,7 +657,7 @@ class BitsAndBytesMoEMethod(FusedMoEMethodBase):
     ):
         raise NotImplementedError
 
-    def _apply_4bit_dequnt(
+    def _apply_4bit_dequant(
         self, layer: torch.nn.Module
     ) -> tuple[torch.Tensor, torch.Tensor]:
         from bitsandbytes.functional import dequantize_4bit
@@ -623,6 +672,14 @@ class BitsAndBytesMoEMethod(FusedMoEMethodBase):
         )
         w13 = w13.reshape(layer.w13_weight.experts_shape)
         w2 = w2.reshape(layer.w2_weight.experts_shape)
+
+        if (
+            hasattr(layer.w13_weight, "dequant_dtype")
+            and layer.w13_weight.dequant_dtype is not None
+        ):
+            w13 = w13.to(layer.w13_weight.dequant_dtype)
+            w2 = w2.to(layer.w13_weight.dequant_dtype)
+
         return w13, w2
 
     def _apply_8bit_dequant(


### PR DESCRIPTION
## Purpose
Solve issue #29424
This PR implements support for LoRA on BitsAndBytes quantized MoE models using Triton backend. Testsed with inflight quantization on `qwen3-30b-a3b` and offline quantization on `qwen3-30b-a3b-bnb-4bit`.
**Key Changes** in `BitsAndBytesMoEMethod`,
1. Implement `get_fused_moe_quant_config`. Returns `FUSED_MOE_UNQUANTIZED_CONFIG` because weights are dequantized before computation. Both the existing non-LoRA path `apply()` and the new LoRA path dequantize weights before passing them to triton fused moe kernels.
2. Implement `select_gemm_impl` to support modular kernels TritonExperts/BatchedTritonExpert required for LoRA integration.
3. Centralized dtype conversion in `_apply_4bit_dequant`. Dequantized weights default to bfloat16, causing dtype mismatches when model use float16. Store target dtype as `dequant_dtype` weight attribute during weight creation, then convert during dequantization. Bitsandbytes fused MoE without LoRA also fails on float16 if dtype is not converted.
## Test Plan
1. Create a dummy LoRA adapter.
2. Load inflight and offline model.
3. Perform single/batched inference with LoRA adapter applied on float16/bfloat16.
Below is the table of tested cases and [test scripts](https://gist.github.com/Allyyi/40eef356901cad2c46de7b17e112d52c).

Scenario | Quantization | LoRA | Dtype | Batch Size
-- | -- | -- | -- | --
Inflight LoRA | Inflight | Yes | float16 / bfloat16 | 1 and 4
Offline LoRA | Offline | Yes | float16 / bfloat16 | 1 and 4
Base Inference | Inflight/Offline | No | float16 / bfloat16 | 1 or 4

## Test Result
All cases passed. Generate readable text without kernel crashes.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

