### PR TITLE
[Platform] Replace hardcoded cuda by current_platform in ModelRunner

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3606,10 +3606,10 @@ class GPUModelRunner(
         if self.valid_sampled_token_count_event is None:
             return
 
-        default_stream = torch.current_stream()
+        default_stream = current_platform.current_stream()  # type: ignore[attr-defined]
         # Initialize a new stream to overlap the copy operation with
         # prepare_input of draft model.
-        with torch.stream(self.valid_sampled_token_count_copy_stream):
+        with current_platform.stream(self.valid_sampled_token_count_copy_stream):  # type: ignore[attr-defined]
             self.valid_sampled_token_count_copy_stream.wait_stream(default_stream)  # type: ignore
             counts = valid_sampled_tokens_count
             counts_cpu = self.valid_sampled_token_count_cpu

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -196,7 +196,7 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         sampled_token_ids: torch.Tensor,
         logprobs_tensors: LogprobsTensors | None,
         invalid_req_indices: list[int],
-        async_output_copy_stream: current_platform.Stream,  # type: ignore[attr-defined]
+        async_output_copy_stream: current_platform.Stream,  # type: ignore
         vocab_size: int,
     ):
         self._model_runner_output = model_runner_output
@@ -212,8 +212,8 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         self._logprobs_tensors = logprobs_tensors
 
         # Initiate the copy on a separate stream, but do not synchronize it.
-        default_stream = current_platform.current_stream()  # type: ignore[attr-defined]
-        with current_platform.stream(async_output_copy_stream):  # type: ignore[attr-defined]
+        default_stream = current_platform.current_stream()  # type: ignore
+        with current_platform.stream(async_output_copy_stream):  # type: ignore
             async_output_copy_stream.wait_stream(default_stream)
             self.sampled_token_ids_cpu = self._sampled_token_ids.to(
                 "cpu", non_blocking=True
@@ -263,7 +263,7 @@ class AsyncGPUPoolingModelRunnerOutput(AsyncModelRunnerOutput):
         model_runner_output: ModelRunnerOutput,
         raw_pooler_output: PoolerOutput,
         finished_mask: list[bool],
-        async_output_copy_stream: current_platform.Stream,  # type: ignore[attr-defined]
+        async_output_copy_stream: current_platform.Stream,  # type: ignore
     ):
         self._model_runner_output = model_runner_output
 
@@ -275,8 +275,8 @@ class AsyncGPUPoolingModelRunnerOutput(AsyncModelRunnerOutput):
         self._raw_pooler_output = raw_pooler_output
 
         # Initiate the copy on a separate stream, but do not synchronize it.
-        default_stream = current_platform.current_stream()  # type: ignore[attr-defined]
-        with current_platform.stream(async_output_copy_stream):  # type: ignore[attr-defined]
+        default_stream = current_platform.current_stream()  # type: ignore
+        with current_platform.stream(async_output_copy_stream):  # type: ignore
             async_output_copy_stream.wait_stream(default_stream)
             raw_pooler_output_cpu = json_map_leaves(
                 lambda x: None if x is None else x.to("cpu", non_blocking=True),
@@ -470,7 +470,7 @@ class GPUModelRunner(
         # NOTE(rob): num_prompt_logprobs only includes reqs
         # that are currently in the prefill phase.
         self.num_prompt_logprobs: dict[str, int] = {}
-        self.comm_stream = current_platform.Stream()  # type: ignore[attr-defined]
+        self.comm_stream = current_platform.Stream()  # type: ignore
 
         # Input Batch
         # NOTE(Chen): Ideally, we should initialize the input batch inside
@@ -513,12 +513,12 @@ class GPUModelRunner(
 
         # Separate cuda stream for overlapping transfer of sampled token ids from
         # GPU to CPU when async scheduling is enabled.
-        self.async_output_copy_stream: current_platform.Stream | None = None  # type: ignore[attr-defined]
+        self.async_output_copy_stream: current_platform.Stream | None = None  # type: ignore
         # cuda event to synchronize use of reused CPU tensors between steps
         # when async scheduling is enabled.
         self.prepare_inputs_event: torch.Event | None = None
         if self.use_async_scheduling:
-            self.async_output_copy_stream = current_platform.Stream()  # type: ignore[attr-defined]
+            self.async_output_copy_stream = current_platform.Stream()  # type: ignore
             self.prepare_inputs_event = torch.Event()
 
         # self.cudagraph_batch_sizes sorts in ascending order.
@@ -650,18 +650,18 @@ class GPUModelRunner(
         # Pre-allocated tensor for copying valid sampled token counts to CPU,
         # with dedicated stream for overlapping and event for coordination.
         self.valid_sampled_token_count_event: torch.Event | None = None
-        self.valid_sampled_token_count_copy_stream: current_platform.Stream | None = (  # type: ignore[attr-defined]
+        self.valid_sampled_token_count_copy_stream: current_platform.Stream | None = (  # type: ignore
             None
         )
         # We also copy the drafted tokens to the CPU asynchronously,
         # in case we need them for structured outputs.
         self.draft_token_ids_event: torch.Event | None = None
-        self.draft_token_ids_copy_stream: current_platform.Stream | None = None  # type: ignore[attr-defined]
+        self.draft_token_ids_copy_stream: current_platform.Stream | None = None  # type: ignore
         self.valid_sampled_token_count_cpu: torch.Tensor | None = None
         self.draft_token_ids_cpu: torch.Tensor | None = None
         if self.num_spec_tokens:
             self.draft_token_ids_event = torch.Event()
-            self.draft_token_ids_copy_stream = current_platform.Stream()  # type: ignore[attr-defined]
+            self.draft_token_ids_copy_stream = current_platform.Stream()  # type: ignore
             self.draft_token_ids_cpu = torch.empty(
                 (self.max_num_reqs, self.num_spec_tokens),
                 dtype=torch.int64,
@@ -670,7 +670,7 @@ class GPUModelRunner(
             )
             if self.use_async_scheduling:
                 self.valid_sampled_token_count_event = torch.Event()
-                self.valid_sampled_token_count_copy_stream = current_platform.Stream()  # type: ignore[attr-defined]
+                self.valid_sampled_token_count_copy_stream = current_platform.Stream()  # type: ignore
                 self.valid_sampled_token_count_cpu = torch.empty(
                     self.max_num_reqs,
                     dtype=torch.int64,
@@ -825,12 +825,12 @@ class GPUModelRunner(
     # Note: used for model runner override.
     def _init_device_properties(self) -> None:
         """Initialize attributes from current_platform.get_device_properties"""
-        self.device_properties = current_platform.get_device_properties(self.device)  # type: ignore[attr-defined]
+        self.device_properties = current_platform.get_device_properties(self.device)  # type: ignore
         self.num_sms = self.device_properties.multi_processor_count
 
     # Note: used for model runner override.
     def _sync_device(self) -> None:
-        current_platform.synchronize()  # type: ignore[attr-defined]
+        current_platform.synchronize()  # type: ignore
 
     def _update_states(self, scheduler_output: "SchedulerOutput") -> None:
         """Update the cached states and the persistent batch with the scheduler
@@ -2244,7 +2244,7 @@ class GPUModelRunner(
 
             if hasattr(self.model, "get_num_mm_connector_tokens"):
                 post_op_counts = [
-                    self.model.get_num_mm_connector_tokens(num_tokens)  # type: ignore[attr-defined]
+                    self.model.get_num_mm_connector_tokens(num_tokens)  # type: ignore
                     for num_tokens in encoder_token_counts
                 ]
 
@@ -3575,9 +3575,9 @@ class GPUModelRunner(
         assert self.draft_token_ids_event is not None
         assert self.draft_token_ids_copy_stream is not None
         assert self.draft_token_ids_cpu is not None
-        default_stream = current_platform.current_stream()  # type: ignore[attr-defined]
+        default_stream = current_platform.current_stream()  # type: ignore
         num_reqs = draft_token_ids.shape[0]
-        with current_platform.stream(self.draft_token_ids_copy_stream):  # type: ignore[attr-defined]
+        with current_platform.stream(self.draft_token_ids_copy_stream):  # type: ignore
             if not zeros_only:
                 # Trigger async copy of draft token ids to cpu.
                 self.draft_token_ids_copy_stream.wait_stream(default_stream)
@@ -3606,10 +3606,10 @@ class GPUModelRunner(
         if self.valid_sampled_token_count_event is None:
             return
 
-        default_stream = current_platform.current_stream()  # type: ignore[attr-defined]
+        default_stream = current_platform.current_stream()  # type: ignore
         # Initialize a new stream to overlap the copy operation with
         # prepare_input of draft model.
-        with current_platform.stream(self.valid_sampled_token_count_copy_stream):  # type: ignore[attr-defined]
+        with current_platform.stream(self.valid_sampled_token_count_copy_stream):  # type: ignore
             self.valid_sampled_token_count_copy_stream.wait_stream(default_stream)  # type: ignore
             counts = valid_sampled_tokens_count
             counts_cpu = self.valid_sampled_token_count_cpu
@@ -3897,7 +3897,7 @@ class GPUModelRunner(
                     self.model.set_aux_hidden_state_layers(aux_layers)
                 time_after_load = time.perf_counter()
             self.model_memory_usage = m.consumed_memory
-        except current_platform.OutOfMemoryError as e:  # type: ignore[attr-defined]
+        except current_platform.OutOfMemoryError as e:  # type: ignore
             msg = (
                 "Failed to load model - not enough GPU memory. "
                 "Try lowering --gpu-memory-utilization to free memory for weights, "
@@ -4795,7 +4795,7 @@ class GPUModelRunner(
         # can reuse the memory pool allocated for the large shapes.
         set_cudagraph_capturing_enabled(True)
         with freeze_gc(), graph_capture(device=self.device):
-            start_free_gpu_memory = current_platform.mem_get_info()[0]  # type: ignore[attr-defined]
+            start_free_gpu_memory = current_platform.mem_get_info()[0]  # type: ignore
             cudagraph_mode = self.compilation_config.cudagraph_mode
             assert cudagraph_mode is not None
 
@@ -4842,8 +4842,8 @@ class GPUModelRunner(
                     uniform_decode=True,
                 )
 
-            current_platform.synchronize()  # type: ignore[attr-defined]
-            end_free_gpu_memory = current_platform.mem_get_info()[0]  # type: ignore[attr-defined]
+            current_platform.synchronize()  # type: ignore
+            end_free_gpu_memory = current_platform.mem_get_info()[0]  # type: ignore
 
         # Disable cudagraph capturing globally, so any unexpected cudagraph
         # capturing will be detected and raise an error after here.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -83,6 +83,7 @@ from vllm.multimodal.inputs import (
     PlaceholderRange,
 )
 from vllm.multimodal.utils import group_mm_kwargs_by_modality
+from vllm.platforms import current_platform
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingType
 from vllm.sequence import IntermediateTensors
@@ -195,7 +196,7 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         sampled_token_ids: torch.Tensor,
         logprobs_tensors: LogprobsTensors | None,
         invalid_req_indices: list[int],
-        async_output_copy_stream: torch.cuda.Stream,
+        async_output_copy_stream: current_platform.Stream,
         vocab_size: int,
     ):
         self._model_runner_output = model_runner_output
@@ -211,8 +212,8 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         self._logprobs_tensors = logprobs_tensors
 
         # Initiate the copy on a separate stream, but do not synchronize it.
-        default_stream = torch.cuda.current_stream()
-        with torch.cuda.stream(async_output_copy_stream):
+        default_stream = current_platform.current_stream()
+        with current_platform.stream(async_output_copy_stream):
             async_output_copy_stream.wait_stream(default_stream)
             self.sampled_token_ids_cpu = self._sampled_token_ids.to(
                 "cpu", non_blocking=True
@@ -262,7 +263,7 @@ class AsyncGPUPoolingModelRunnerOutput(AsyncModelRunnerOutput):
         model_runner_output: ModelRunnerOutput,
         raw_pooler_output: PoolerOutput,
         finished_mask: list[bool],
-        async_output_copy_stream: torch.cuda.Stream,
+        async_output_copy_stream: current_platform.Stream,
     ):
         self._model_runner_output = model_runner_output
 
@@ -274,8 +275,8 @@ class AsyncGPUPoolingModelRunnerOutput(AsyncModelRunnerOutput):
         self._raw_pooler_output = raw_pooler_output
 
         # Initiate the copy on a separate stream, but do not synchronize it.
-        default_stream = torch.cuda.current_stream()
-        with torch.cuda.stream(async_output_copy_stream):
+        default_stream = current_platform.current_stream()
+        with current_platform.stream(async_output_copy_stream):
             async_output_copy_stream.wait_stream(default_stream)
             raw_pooler_output_cpu = json_map_leaves(
                 lambda x: None if x is None else x.to("cpu", non_blocking=True),
@@ -469,7 +470,7 @@ class GPUModelRunner(
         # NOTE(rob): num_prompt_logprobs only includes reqs
         # that are currently in the prefill phase.
         self.num_prompt_logprobs: dict[str, int] = {}
-        self.comm_stream = torch.cuda.Stream()
+        self.comm_stream = current_platform.Stream()
 
         # Input Batch
         # NOTE(Chen): Ideally, we should initialize the input batch inside
@@ -512,12 +513,12 @@ class GPUModelRunner(
 
         # Separate cuda stream for overlapping transfer of sampled token ids from
         # GPU to CPU when async scheduling is enabled.
-        self.async_output_copy_stream: torch.cuda.Stream | None = None
+        self.async_output_copy_stream: current_platform.Stream | None = None
         # cuda event to synchronize use of reused CPU tensors between steps
         # when async scheduling is enabled.
         self.prepare_inputs_event: torch.Event | None = None
         if self.use_async_scheduling:
-            self.async_output_copy_stream = torch.cuda.Stream()
+            self.async_output_copy_stream = current_platform.Stream()
             self.prepare_inputs_event = torch.Event()
 
         # self.cudagraph_batch_sizes sorts in ascending order.
@@ -649,16 +650,18 @@ class GPUModelRunner(
         # Pre-allocated tensor for copying valid sampled token counts to CPU,
         # with dedicated stream for overlapping and event for coordination.
         self.valid_sampled_token_count_event: torch.Event | None = None
-        self.valid_sampled_token_count_copy_stream: torch.cuda.Stream | None = None
+        self.valid_sampled_token_count_copy_stream: current_platform.Stream | None = (
+            None
+        )
         # We also copy the drafted tokens to the CPU asynchronously,
         # in case we need them for structured outputs.
         self.draft_token_ids_event: torch.Event | None = None
-        self.draft_token_ids_copy_stream: torch.cuda.Stream | None = None
+        self.draft_token_ids_copy_stream: current_platform.Stream | None = None
         self.valid_sampled_token_count_cpu: torch.Tensor | None = None
         self.draft_token_ids_cpu: torch.Tensor | None = None
         if self.num_spec_tokens:
             self.draft_token_ids_event = torch.Event()
-            self.draft_token_ids_copy_stream = torch.cuda.Stream()
+            self.draft_token_ids_copy_stream = current_platform.Stream()
             self.draft_token_ids_cpu = torch.empty(
                 (self.max_num_reqs, self.num_spec_tokens),
                 dtype=torch.int64,
@@ -667,7 +670,7 @@ class GPUModelRunner(
             )
             if self.use_async_scheduling:
                 self.valid_sampled_token_count_event = torch.Event()
-                self.valid_sampled_token_count_copy_stream = torch.cuda.Stream()
+                self.valid_sampled_token_count_copy_stream = current_platform.Stream()
                 self.valid_sampled_token_count_cpu = torch.empty(
                     self.max_num_reqs,
                     dtype=torch.int64,
@@ -821,13 +824,13 @@ class GPUModelRunner(
 
     # Note: used for model runner override.
     def _init_device_properties(self) -> None:
-        """Initialize attributes from torch.cuda.get_device_properties"""
-        self.device_properties = torch.cuda.get_device_properties(self.device)
+        """Initialize attributes from current_platform.get_device_properties"""
+        self.device_properties = current_platform.get_device_properties(self.device)
         self.num_sms = self.device_properties.multi_processor_count
 
     # Note: used for model runner override.
     def _sync_device(self) -> None:
-        torch.cuda.synchronize()
+        current_platform.synchronize()
 
     def _update_states(self, scheduler_output: "SchedulerOutput") -> None:
         """Update the cached states and the persistent batch with the scheduler
@@ -3572,9 +3575,9 @@ class GPUModelRunner(
         assert self.draft_token_ids_event is not None
         assert self.draft_token_ids_copy_stream is not None
         assert self.draft_token_ids_cpu is not None
-        default_stream = torch.cuda.current_stream()
+        default_stream = torch.current_stream()
         num_reqs = draft_token_ids.shape[0]
-        with torch.cuda.stream(self.draft_token_ids_copy_stream):
+        with torch.stream(self.draft_token_ids_copy_stream):
             if not zeros_only:
                 # Trigger async copy of draft token ids to cpu.
                 self.draft_token_ids_copy_stream.wait_stream(default_stream)
@@ -3603,10 +3606,10 @@ class GPUModelRunner(
         if self.valid_sampled_token_count_event is None:
             return
 
-        default_stream = torch.cuda.current_stream()
+        default_stream = torch.current_stream()
         # Initialize a new stream to overlap the copy operation with
         # prepare_input of draft model.
-        with torch.cuda.stream(self.valid_sampled_token_count_copy_stream):
+        with torch.stream(self.valid_sampled_token_count_copy_stream):
             self.valid_sampled_token_count_copy_stream.wait_stream(default_stream)  # type: ignore
             counts = valid_sampled_tokens_count
             counts_cpu = self.valid_sampled_token_count_cpu
@@ -3894,7 +3897,7 @@ class GPUModelRunner(
                     self.model.set_aux_hidden_state_layers(aux_layers)
                 time_after_load = time.perf_counter()
             self.model_memory_usage = m.consumed_memory
-        except torch.cuda.OutOfMemoryError as e:
+        except current_platform.OutOfMemoryError as e:
             msg = (
                 "Failed to load model - not enough GPU memory. "
                 "Try lowering --gpu-memory-utilization to free memory for weights, "
@@ -4792,7 +4795,7 @@ class GPUModelRunner(
         # can reuse the memory pool allocated for the large shapes.
         set_cudagraph_capturing_enabled(True)
         with freeze_gc(), graph_capture(device=self.device):
-            start_free_gpu_memory = torch.cuda.mem_get_info()[0]
+            start_free_gpu_memory = current_platform.mem_get_info()[0]
             cudagraph_mode = self.compilation_config.cudagraph_mode
             assert cudagraph_mode is not None
 
@@ -4839,8 +4842,8 @@ class GPUModelRunner(
                     uniform_decode=True,
                 )
 
-            torch.cuda.synchronize()
-            end_free_gpu_memory = torch.cuda.mem_get_info()[0]
+            current_platform.synchronize()
+            end_free_gpu_memory = current_platform.mem_get_info()[0]
 
         # Disable cudagraph capturing globally, so any unexpected cudagraph
         # capturing will be detected and raise an error after here.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

In https://github.com/vllm-project/vllm-ascend/issues/5449, we're trying to align the downstream ModelRunner with `GPUModelRunner` to reduce the cost of maintaining the custom code, which will require greater reuse of the `GPUModelRunner` code. I think it's also one step to make GPUModelRunner more hardware-agnostic. Removing hardware-specific hardcoding will be the simple but first step. Our goal is to gradually reduce the amount of `NPUModelRunner` code.

## Test Plan

CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

