### PR TITLE
Add triton support for compressed_tensors GPTQ W4A16 on Tesla V100 (Volta CUDA 70)

### DIFF
--- a/benchmarks/kernels/tune_moe_wna16_triton.py
+++ b/benchmarks/kernels/tune_moe_wna16_triton.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tune Triton WNA16 MoE configs for int4 W4A16 kernels.
+
+Example (GLM-4.5 MoE on V100, TP=2):
+  python benchmarks/kernels/tune_moe_wna16_triton.py \
+    --model MOE_MODEL_NAME/ \
+    --tp-size 2 \
+    --group-size 32 \
+    --batch-sizes 1 2 4 8 16 32 64 \
+    --save-dir vllm/model_executor/layers/fused_moe/configs
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from itertools import product
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.fused_moe import (
+    get_config_file_name,
+    invoke_fused_moe_wna16_triton_kernel,
+)
+from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+    moe_align_block_size,
+)
+from vllm.transformers_utils.config import get_config
+from vllm.triton_utils import tl
+
+
+def _read_model_config(
+    model: str | None, trust_remote_code: bool
+) -> tuple[int, int, int, int] | None:
+    if model is None:
+        return None
+    cfg = get_config(model, trust_remote_code=trust_remote_code)
+    archs = getattr(cfg, "architectures", None) or []
+
+    if any(name.startswith("Glm4Moe") for name in archs):
+        return (
+            int(cfg.n_routed_experts),
+            int(cfg.num_experts_per_tok),
+            int(cfg.moe_intermediate_size),
+            int(cfg.hidden_size),
+        )
+    if hasattr(cfg, "num_local_experts") and hasattr(cfg, "num_experts_per_tok"):
+        return (
+            int(cfg.num_local_experts),
+            int(cfg.num_experts_per_tok),
+            int(cfg.intermediate_size),
+            int(cfg.hidden_size),
+        )
+    if hasattr(cfg, "num_experts") and hasattr(cfg, "num_experts_per_tok"):
+        return (
+            int(cfg.num_experts),
+            int(cfg.num_experts_per_tok),
+            int(cfg.moe_intermediate_size),
+            int(cfg.hidden_size),
+        )
+    return None
+
+
+def _make_weights(
+    device: torch.device,
+    num_experts: int,
+    hidden_size: int,
+    intermediate_size_per_partition: int,
+    group_size: int,
+    gate_up_multiplier: int,
+    dtype: torch.dtype,
+):
+    w1_n = gate_up_multiplier * intermediate_size_per_partition
+    w2_k = intermediate_size_per_partition
+
+    # Packed int4 weights are uint8 with 2 values per byte.
+    w1 = torch.randint(
+        0,
+        256,
+        (num_experts, w1_n, hidden_size // 2),
+        device=device,
+        dtype=torch.uint8,
+    )
+    w2 = torch.randint(
+        0,
+        256,
+        (num_experts, hidden_size, w2_k // 2),
+        device=device,
+        dtype=torch.uint8,
+    )
+
+    w1_scale = torch.rand(
+        (num_experts, w1_n, hidden_size // group_size),
+        device=device,
+        dtype=dtype,
+    )
+    w2_scale = torch.rand(
+        (num_experts, hidden_size, w2_k // group_size),
+        device=device,
+        dtype=dtype,
+    )
+
+    return w1, w2, w1_scale, w2_scale
+
+
+def _get_align_cache(
+    topk_ids: torch.Tensor,
+    num_experts: int,
+    block_size_m: int,
+    cache: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if block_size_m in cache:
+        return cache[block_size_m]
+    sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+        topk_ids,
+        block_size_m,
+        num_experts,
+        expert_map=None,
+        ignore_invalid_experts=True,
+    )
+    cache[block_size_m] = (sorted_token_ids, expert_ids, num_tokens_post_padded)
+    return cache[block_size_m]
+
+
+def _run_once(
+    config: dict[str, Any],
+    hidden_states: torch.Tensor,
+    inter_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk: int,
+    group_size: int,
+    compute_type: tl.dtype,
+    align_cache: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
+):
+    block_size_m = config["BLOCK_SIZE_M"]
+    sorted_token_ids, expert_ids, num_tokens_post_padded = _get_align_cache(
+        topk_ids, w1.size(0), block_size_m, align_cache
+    )
+
+    # W1: [M, H] x [E, 2I, H/2] -> [M, topk, 2I]
+    out_w1 = torch.empty(
+        (hidden_states.size(0), topk, w1.size(1)),
+        device=hidden_states.device,
+        dtype=hidden_states.dtype,
+    )
+    invoke_fused_moe_wna16_triton_kernel(
+        hidden_states,
+        w1,
+        out_w1,
+        w1_scale,
+        None,
+        topk_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        False,
+        topk,
+        config,
+        compute_type=compute_type,
+        use_int8_w8a16=False,
+        use_int4_w4a16=True,
+        block_shape=[0, group_size],
+    )
+
+    # W2: [M*topk, I] x [E, H, I/2] -> [M*topk, 1, H]
+    out_w2 = torch.empty(
+        (hidden_states.size(0), topk, w2.size(1)),
+        device=hidden_states.device,
+        dtype=hidden_states.dtype,
+    )
+    invoke_fused_moe_wna16_triton_kernel(
+        inter_states,
+        w2,
+        out_w2,
+        w2_scale,
+        None,
+        topk_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        False,
+        1,
+        config,
+        compute_type=compute_type,
+        use_int8_w8a16=False,
+        use_int4_w4a16=True,
+        block_shape=[0, group_size],
+    )
+
+
+def _benchmark_config(
+    config: dict[str, Any],
+    hidden_states: torch.Tensor,
+    inter_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk: int,
+    group_size: int,
+    compute_type: tl.dtype,
+    warmup: int,
+    iters: int,
+    align_cache: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
+) -> float:
+    for _ in range(warmup):
+        _run_once(
+            config,
+            hidden_states,
+            inter_states,
+            w1,
+            w2,
+            w1_scale,
+            w2_scale,
+            topk_weights,
+            topk_ids,
+            topk,
+            group_size,
+            compute_type,
+            align_cache,
+        )
+    torch.cuda.synchronize()
+
+    start = time.perf_counter()
+    for _ in range(iters):
+        _run_once(
+            config,
+            hidden_states,
+            inter_states,
+            w1,
+            w2,
+            w1_scale,
+            w2_scale,
+            topk_weights,
+            topk_ids,
+            topk,
+            group_size,
+            compute_type,
+            align_cache,
+        )
+    torch.cuda.synchronize()
+    return (time.perf_counter() - start) / iters
+
+
+def main(args: argparse.Namespace) -> None:
+    torch.manual_seed(args.seed)
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for this benchmark.")
+
+    model_config = _read_model_config(args.model, args.trust_remote_code)
+    if model_config is None:
+        if None in (
+            args.num_experts,
+            args.topk,
+            args.intermediate_size,
+            args.hidden_size,
+        ):
+            raise ValueError(
+                "Provide --model or all of --num-experts, --topk, "
+                "--intermediate-size, --hidden-size."
+            )
+        num_experts = args.num_experts
+        topk = args.topk
+        intermediate_size = args.intermediate_size
+        hidden_size = args.hidden_size
+    else:
+        num_experts, topk, intermediate_size, hidden_size = model_config
+
+    if intermediate_size % args.tp_size != 0:
+        raise ValueError("intermediate_size must be divisible by tp_size.")
+
+    group_size = args.group_size
+    inter_size_per_tp = intermediate_size // args.tp_size
+    w1_n = args.gate_up_multiplier * inter_size_per_tp
+    if hidden_size % 2 != 0 or inter_size_per_tp % 2 != 0:
+        raise ValueError("hidden_size and intermediate_size must be even for int4.")
+    if hidden_size % group_size != 0 or inter_size_per_tp % group_size != 0:
+        raise ValueError(
+            "hidden_size and intermediate_size must be divisible by group_size."
+        )
+
+    device = torch.device("cuda")
+    dtype = torch.float16 if args.dtype == "float16" else torch.bfloat16
+    compute_type = tl.float16 if dtype == torch.float16 else tl.bfloat16
+
+    # Candidate search space
+    block_ms = args.block_m
+    block_ns = args.block_n
+    block_ks = args.block_k
+    num_warps_list = args.num_warps
+    num_stages_list = args.num_stages
+
+    candidates: list[dict[str, Any]] = []
+    for bm, bn, bk, nw, ns in product(
+        block_ms, block_ns, block_ks, num_warps_list, num_stages_list
+    ):
+        if bk % group_size != 0:
+            continue
+        if hidden_size % bk != 0 or inter_size_per_tp % bk != 0:
+            continue
+        if bn > w1_n or bn > hidden_size:
+            continue
+        candidates.append(
+            {
+                "BLOCK_SIZE_M": bm,
+                "BLOCK_SIZE_N": bn,
+                "BLOCK_SIZE_K": bk,
+                "GROUP_SIZE_M": 1,
+                "SPLIT_K": 1,
+                "num_warps": nw,
+                "num_stages": ns,
+            }
+        )
+
+    if not candidates:
+        raise RuntimeError("No valid candidates. Adjust block sizes.")
+
+    w1, w2, w1_scale, w2_scale = _make_weights(
+        device,
+        num_experts,
+        hidden_size,
+        inter_size_per_tp,
+        group_size,
+        args.gate_up_multiplier,
+        dtype,
+    )
+
+    results: dict[int, dict[str, Any]] = {}
+    for m in args.batch_sizes:
+        print(f"Tuning batch size M={m} with {len(candidates)} candidates...")
+        hidden_states = torch.randn((m, hidden_size), device=device, dtype=dtype)
+        inter_states = torch.randn(
+            (m * topk, inter_size_per_tp), device=device, dtype=dtype
+        )
+        topk_ids = torch.randint(
+            0, num_experts, (m, topk), device=device, dtype=torch.int32
+        )
+        topk_weights = torch.rand((m, topk), device=device, dtype=dtype)
+
+        align_cache: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
+        best_time = float("inf")
+        best_cfg: dict[str, Any] | None = None
+        for cfg in candidates:
+            try:
+                t = _benchmark_config(
+                    cfg,
+                    hidden_states,
+                    inter_states,
+                    w1,
+                    w2,
+                    w1_scale,
+                    w2_scale,
+                    topk_weights,
+                    topk_ids,
+                    topk,
+                    group_size,
+                    compute_type,
+                    args.warmup,
+                    args.iters,
+                    align_cache,
+                )
+            except Exception as exc:
+                print(f"  skip {cfg} -> {exc}")
+                continue
+            if t < best_time:
+                best_time = t
+                best_cfg = cfg
+        if best_cfg is None:
+            raise RuntimeError(f"No valid config for M={m}.")
+        results[m] = best_cfg
+        print(f"  best for M={m}: {best_cfg} ({best_time * 1e3:.3f} ms)")
+
+    dtype_str = "int4_w4a16"
+    file_name = get_config_file_name(num_experts, inter_size_per_tp, dtype_str)
+    output_path = Path(args.save_dir) / file_name
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with output_path.open("w") as f:
+        json.dump({str(k): v for k, v in results.items()}, f, indent=2)
+
+    print(f"Saved tuned config to {output_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, default=None)
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--num-experts", type=int, default=None)
+    parser.add_argument("--topk", type=int, default=None)
+    parser.add_argument("--intermediate-size", type=int, default=None)
+    parser.add_argument("--hidden-size", type=int, default=None)
+    parser.add_argument("--tp-size", type=int, default=2)
+    parser.add_argument("--group-size", type=int, default=32)
+    parser.add_argument("--gate-up-multiplier", type=int, default=2)
+    parser.add_argument(
+        "--dtype", type=str, choices=["float16", "bfloat16"], default="float16"
+    )
+    parser.add_argument(
+        "--batch-sizes", nargs="+", type=int, default=[1, 2, 4, 8, 16, 32, 64]
+    )
+    parser.add_argument("--block-m", nargs="+", type=int, default=[16, 32, 64])
+    parser.add_argument("--block-n", nargs="+", type=int, default=[32, 64, 128])
+    parser.add_argument("--block-k", nargs="+", type=int, default=[32, 64])
+    parser.add_argument("--num-warps", nargs="+", type=int, default=[2, 4])
+    parser.add_argument("--num-stages", nargs="+", type=int, default=[1, 2])
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--save-dir",
+        type=str,
+        default="vllm/model_executor/layers/fused_moe/configs",
+    )
+    main(parser.parse_args())

--- a/vllm/model_executor/layers/fused_moe/configs/E=96,N=704,device_name=Tesla_V100-SXM2-32GB,dtype=int4_w4a16.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=96,N=704,device_name=Tesla_V100-SXM2-32GB,dtype=int4_w4a16.json
@@ -1,0 +1,110 @@
+{
+  "1": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 1,
+    "SPLIT_K": 1,
+    "num_warps": 4,
+    "num_stages": 1
+  },
+  "2": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 1,
+    "SPLIT_K": 1,
+    "num_warps": 2,
+    "num_stages": 1
+  },
+  "4": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 1,
+    "SPLIT_K": 1,
+    "num_warps": 2,
+    "num_stages": 2
+  },
+  "8": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 1,
+    "SPLIT_K": 1,
+    "num_warps": 2,
+    "num_stages": 2
+  },
+  "16": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 1,
+    "SPLIT_K": 1,
+    "num_warps": 2,
+    "num_stages": 2
+  },
+  "24": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "SPLIT_K": 1,
+    "num_warps": 4,
+    "num_stages": 2
+  },
+  "32": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 1,
+    "SPLIT_K": 1,
+    "num_warps": 2,
+    "num_stages": 2
+  },
+  "48": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "SPLIT_K": 1,
+    "num_warps": 4,
+    "num_stages": 2
+  },
+  "64": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 32,
+    "BLOCK_SIZE_K": 32,
+    "GROUP_SIZE_M": 1,
+    "SPLIT_K": 1,
+    "num_warps": 2,
+    "num_stages": 2
+  },
+  "96": {
+    "BLOCK_SIZE_M": 32,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "SPLIT_K": 1,
+    "num_warps": 4,
+    "num_stages": 2
+  },
+  "128": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "SPLIT_K": 1,
+    "num_warps": 4,
+    "num_stages": 2
+  },
+  "256": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 1,
+    "SPLIT_K": 1,
+    "num_warps": 4,
+    "num_stages": 2
+  }
+}

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1148,6 +1148,35 @@ def get_moe_wna16_block_config(
         return {}
     if not use_moe_wna16_cuda:
         # triton moe wna16 kernel
+        capability = current_platform.get_device_capability()
+        is_volta = (
+            current_platform.is_cuda()
+            and capability is not None
+            and capability == (7, 0)
+        )
+        if is_volta:
+            # Volta tuning derived from local benchmarks (int4).
+            m = max(1, num_valid_tokens // max(1, real_top_k))
+            if m <= 1:
+                return {
+                    "BLOCK_SIZE_N": 64,
+                    "BLOCK_SIZE_K": 32,
+                    "num_warps": 4,
+                    "num_stages": 1,
+                }
+            if m <= 2:
+                return {
+                    "BLOCK_SIZE_N": 32,
+                    "BLOCK_SIZE_K": 32,
+                    "num_warps": 2,
+                    "num_stages": 1,
+                }
+            return {
+                "BLOCK_SIZE_N": 32,
+                "BLOCK_SIZE_K": 32,
+                "num_warps": 2,
+                "num_stages": 2,
+            }
         if num_valid_tokens // real_top_k == 1:
             # if bs=1, use a smaller BLOCK_SIZE_N
             return {"BLOCK_SIZE_N": 32, "BLOCK_SIZE_K": 64}
@@ -1206,8 +1235,13 @@ def get_moe_wna16_block_config(
 def should_moe_wna16_use_cuda(
     num_valid_tokens: int, group_size: int, num_experts: int, bit: int
 ):
+    # CUDA WNA16 MoE kernel requires SM75+ (Turing and later).
+    # Volta (SM70) falls back to the Triton kernel.
+    capability = current_platform.get_device_capability()
     return (
         current_platform.is_cuda()
+        and capability is not None
+        and capability >= (7, 5)
         and bit == 4
         and group_size in [32, 64, 128]
         and num_valid_tokens / num_experts <= 6

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -79,8 +79,8 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        # Turing and up
-        return 75
+        # Volta and up (Volta uses Triton fallback, >=75 uses existing kernels)
+        return 70
 
     def create_weights(
         self,

--- a/vllm/model_executor/layers/quantization/gptq_triton.py
+++ b/vllm/model_executor/layers/quantization/gptq_triton.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+GPTQ_TRITON_SUPPORTED_GROUP_SIZES = [-1, 32, 64, 128]
+
+
+@triton.jit
+def gptq_gemm_kernel(
+    a_ptr,  # input activations [M, K] (already reordered if g_idx present)
+    b_qweight_ptr,  # quantized weights [K // 8, N], int32
+    # (already shuffled if g_idx present)
+    b_scales_ptr,  # scales [K // group_size, N], float16
+    c_ptr,  # output [M, N]
+    M,  # batch size
+    N,  # output features
+    K,  # input features
+    group_size,  # quantization group size
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+):
+    """
+    GPTQ Triton GEMM kernel for 4-bit symmetric quantization.
+
+    Supports:
+    - 4-bit weights only
+    - Symmetric quantization (no zero points)
+    - Group sizes: -1 (channelwise), 32, 64, 128
+
+    Note: Input activations and weights should be pre-processed (reordered/shuffled)
+    if g_idx is present. This kernel assumes inputs are already in the correct order.
+    """
+    pid = tl.program_id(axis=0)
+    pid_z = tl.program_id(1)
+
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+
+    accumulator_dtype = c_ptr.type.element_ty
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=accumulator_dtype)
+
+    # Offsets and masks for input A [M, K]
+    offsets_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    masks_am = offsets_am < M
+
+    # Offsets for output N dimension
+    offsets_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    masks_bn = offsets_bn < N
+
+    # Offsets for scales [K // group_size, N]
+    offsets_sn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    masks_sn = offsets_sn < N
+
+    offsets_k = pid_z * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+    offsets_a = K * offsets_am[:, None] + offsets_k[None, :]
+    a_ptrs = a_ptr + offsets_a
+    b_ptrs = b_qweight_ptr + offsets_k[:, None] // 8 * N + offsets_bn[None, :]
+
+    # Main loop over K dimension
+    for _ in range(0, tl.cdiv(K, BLOCK_SIZE_K * SPLIT_K)):
+        masks_k = offsets_k < K
+        masks_a = masks_am[:, None] & masks_k[None, :]
+        a = tl.load(a_ptrs, mask=masks_a, other=0.0)
+
+        masks_b = masks_k[:, None] & masks_bn[None, :]
+        b_qweight = tl.load(b_ptrs, mask=masks_b, other=0)
+
+        # Unpack 4-bit weights from int32 packed along K dimension.
+        # Each int32 corresponds to 8 K elements for a given N.
+        k_shifts = (offsets_k % 8) * 4
+        shifts = tl.broadcast_to(k_shifts[:, None], (BLOCK_SIZE_K, BLOCK_SIZE_N))
+        b_qweight = (b_qweight >> shifts) & 0xF
+
+        # Convert from uint4 [0, 15] to int4 [-8, 7] for GPTQ symmetric quantization
+        # GPTQ uses bias of 8, so subtract 8 to get signed range
+        b_qweight = b_qweight.to(tl.int8) - 8
+        b_qweight = b_qweight.to(accumulator_dtype)
+
+        # Load and apply scales
+        # Scales are per group, compute which group each K element belongs to
+        group_idx = offsets_k // group_size
+        offsets_s = N * group_idx[:, None] + offsets_sn[None, :]
+        masks_sk = group_idx < K // group_size
+        masks_s = masks_sk[:, None] & masks_sn[None, :]
+        scales_ptrs = b_scales_ptr + offsets_s
+        scales = tl.load(scales_ptrs, mask=masks_s, other=1.0)
+        scales = tl.broadcast_to(scales, (BLOCK_SIZE_K, BLOCK_SIZE_N))
+
+        # Dequantize: weight = (quantized - 8) * scale
+        # We already subtracted 8 above, so just multiply by scale
+        b_qweight = b_qweight * scales
+
+        # Accumulate results
+        accumulator = tl.dot(a, b_qweight, accumulator, out_dtype=accumulator_dtype)
+
+        offsets_k += BLOCK_SIZE_K * SPLIT_K
+        a_ptrs += BLOCK_SIZE_K * SPLIT_K
+        b_ptrs = b_qweight_ptr + offsets_k[:, None] // 8 * N + offsets_bn[None, :]
+
+    # Store results
+    c = accumulator.to(c_ptr.type.element_ty)
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + pid_z * N * M + N * offs_cm[:, None] + offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+def gptq_gemm_triton(
+    input: torch.Tensor,  # [M, K] (should be reordered if g_idx present)
+    qweight: torch.Tensor,  # [K // 8, N], int32 (should be shuffled if g_idx present)
+    scales: torch.Tensor,  # [K // group_size, N], float16
+    group_size: int,
+    split_k_iters: int = 1,
+    block_size_m: int = 32,
+    block_size_n: int = 32,
+    block_size_k: int = 32,
+) -> torch.Tensor:
+    """
+    GPTQ Triton GEMM for 4-bit symmetric quantization.
+
+    Args:
+        input: Input activations [M, K], float16. Should be reordered using g_idx
+               if activation reordering is enabled.
+        qweight: Quantized weights [K // 8, N], int32. Should be shuffled using
+                 gptq_shuffle if activation reordering is enabled.
+        scales: Scales [K // group_size, N], float16
+        group_size: Quantization group size. Use -1 for channelwise.
+        split_k_iters: Parallelism along K-dimension (power of 2, <= 32)
+        block_size_m: Block size for M dimension
+        block_size_n: Block size for N dimension
+        block_size_k: Block size for K dimension
+
+    Returns:
+        Output tensor [M, N], float16
+    """
+    M, K = input.shape
+    N = qweight.shape[1]
+
+    # Validate inputs
+    assert N > 0 and K > 0 and M > 0
+    assert qweight.shape[0] == K // 8 and qweight.shape[1] == N
+    assert scales.shape[1] == N
+    assert split_k_iters & (split_k_iters - 1) == 0 and split_k_iters != 0
+    assert split_k_iters <= 32
+
+    # Handle group_size
+    effective_group_size = group_size if group_size != -1 else K
+    assert scales.shape[0] == K // effective_group_size
+    assert effective_group_size <= K
+    assert (
+        effective_group_size in GPTQ_TRITON_SUPPORTED_GROUP_SIZES
+        or effective_group_size == K
+    )
+
+    # Ensure inputs are contiguous
+    input = input.contiguous()
+    qweight = qweight.contiguous()
+    scales = scales.contiguous()
+
+    # Launch kernel
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        split_k_iters,
+    )
+
+    result = torch.zeros((split_k_iters, M, N), dtype=scales.dtype, device=input.device)
+
+    gptq_gemm_kernel[grid](
+        input,
+        qweight,
+        scales,
+        result,
+        M,
+        N,
+        K,
+        effective_group_size,
+        BLOCK_SIZE_M=block_size_m,
+        BLOCK_SIZE_N=block_size_n,
+        BLOCK_SIZE_K=block_size_k,
+        SPLIT_K=split_k_iters,
+    )
+
+    # Sum across split_k dimension
+    result = result.sum(0)
+
+    return result

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/__init__.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/__init__.py
@@ -33,6 +33,9 @@ from vllm.model_executor.layers.quantization.kernels.mixed_precision.MPLinearKer
     MPLinearKernel,
     MPLinearLayerConfig,
 )
+from vllm.model_executor.layers.quantization.kernels.mixed_precision.triton import (  # noqa: E501
+    TritonLinearKernel,
+)
 from vllm.model_executor.layers.quantization.kernels.mixed_precision.xpu import (  # noqa: E501
     XPUwNa16LinearKernel,
 )
@@ -47,6 +50,7 @@ _POSSIBLE_KERNELS: list[type[MPLinearKernel]] = [
     Dynamic4bitLinearKernel,
     BitBLASLinearKernel,
     ConchLinearKernel,
+    TritonLinearKernel,
     ExllamaLinearKernel,
     XPUwNa16LinearKernel,
     CPUWNA16LinearKernel,

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/triton.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/triton.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.quantization.gptq_triton import (
+    GPTQ_TRITON_SUPPORTED_GROUP_SIZES,
+    gptq_gemm_triton,
+)
+from vllm.model_executor.layers.quantization.kernels.mixed_precision.MPLinearKernel import (  # noqa: E501
+    MPLinearKernel,
+    MPLinearLayerConfig,
+)
+from vllm.model_executor.parameter import BasevLLMParameter, permute_param_layout_
+from vllm.platforms import current_platform
+from vllm.scalar_type import scalar_types
+from vllm.triton_utils import HAS_TRITON
+
+
+class TritonLinearKernel(MPLinearKernel):
+    """Triton kernel for GPTQ W4A16 on compute capability >= 7.0 (Volta and above)."""
+
+    SUPPORTED_QUANT_TYPES = [scalar_types.uint4b8]
+
+    # Type annotations for inherited attributes (helps mypy with --follow-imports skip)
+    config: MPLinearLayerConfig
+    w_q_name: str
+    w_s_name: str
+    w_zp_name: str | None
+    w_gidx_name: str | None
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 70
+
+    @classmethod
+    def can_implement(cls, c: MPLinearLayerConfig) -> tuple[bool, str | None]:
+        if not current_platform.is_cuda_alike():
+            return (
+                False,
+                "GPTQ Triton is only supported on CUDA and ROCm",
+            )
+        capability_tuple = current_platform.get_device_capability()
+        if capability_tuple is None or capability_tuple.to_int() < 70:
+            return False, "GPTQ Triton requires compute capability >= 7.0"
+        if not HAS_TRITON:
+            return False, "Triton is not available"
+        if c.weight_type not in cls.SUPPORTED_QUANT_TYPES:
+            return (
+                False,
+                "GPTQ Triton only supports GPTQ W4A16 "
+                f"(weights {cls.SUPPORTED_QUANT_TYPES})",
+            )
+        if c.zero_points:
+            return False, "GPTQ Triton only supports symmetric GPTQ W4A16"
+        if c.act_type != torch.float16:
+            return False, "GPTQ Triton only supports float16 activations (W4A16)"
+        if c.out_type is not None and c.out_type != torch.float16:
+            return False, "GPTQ Triton only supports float16 outputs (W4A16)"
+        if c.has_g_idx and c.partition_weight_shape[0] != c.full_weight_shape[0]:
+            return (
+                False,
+                "Act reordering not supported when input features "
+                "are partitioned across devices",
+            )
+        if c.partition_weight_shape[0] % 8 != 0:
+            return (
+                False,
+                "Input features must be divisible by 8 for GPTQ 4-bit packing",
+            )
+        if c.group_size != -1 and c.full_weight_shape[0] % c.group_size != 0:
+            return (
+                False,
+                f"Group size ({c.group_size}) does not evenly divide "
+                f"the number of input features ({c.full_weight_shape[0]})",
+            )
+        if c.group_size not in GPTQ_TRITON_SUPPORTED_GROUP_SIZES:
+            return (
+                False,
+                f"Unsupported group_size {c.group_size} for GPTQ Triton",
+            )
+        return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        c = self.config
+
+        if c.has_g_idx:
+
+            def transform_w_g_idx(x):
+                # Convert group indices to permutation array
+                return torch.argsort(x).to(torch.int)
+
+            self._transform_param(layer, self.w_gidx_name, transform_w_g_idx)
+        else:
+            self.w_gidx_name = "weight_g_idx"
+            device = getattr(layer, self.w_q_name).device
+            empty_g_idx = torch.nn.Parameter(
+                torch.empty((0,), dtype=torch.int, device=device), requires_grad=False
+            )
+            setattr(layer, self.w_gidx_name, empty_g_idx)
+
+        def transform_w_q(x):
+            assert isinstance(x, BasevLLMParameter)
+            assert self.w_gidx_name is not None
+            g_idx = getattr(layer, self.w_gidx_name)
+
+            permute_param_layout_(x, input_dim=0, output_dim=1, packed_dim=0)
+            x_cont = x.data.contiguous()
+            if g_idx.numel() > 0:
+                ops.gptq_shuffle(x_cont, g_idx, c.weight_type.size_bits)
+            return x_cont
+
+        def transform_w_s(x):
+            assert isinstance(x, BasevLLMParameter)
+            permute_param_layout_(x, input_dim=0, output_dim=1)
+            x.data = x.data.contiguous()
+            return x.to(dtype=c.act_type)
+
+        self._transform_param(layer, self.w_q_name, transform_w_q)
+        self._transform_param(layer, self.w_s_name, transform_w_s)
+
+    def apply_weights(
+        self, layer: torch.nn.Module, x: torch.Tensor, bias: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        c = self.config
+        x_2d = x.reshape(-1, x.shape[-1])
+        out_shape = x.shape[:-1] + (c.partition_weight_shape[1],)
+
+        w_q, w_s, _, w_g_idx = self._get_weight_params(layer)
+
+        if w_g_idx is not None and w_g_idx.numel() > 0:
+            x_2d = x_2d[:, w_g_idx.to(torch.long)]
+
+        output = gptq_gemm_triton(x_2d, w_q, w_s, c.group_size, split_k_iters=1)
+
+        if bias is not None:
+            output.add_(bias)
+        return output.reshape(out_shape)

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -229,6 +229,10 @@ def check_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
 def check_moe_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:
     if current_platform.is_rocm():
         return False
+    # Marlin requires compute capability >= 7.5 (Turing)
+    capability_tuple = current_platform.get_device_capability()
+    if capability_tuple is None or capability_tuple.to_int() < 75:
+        return False
     hidden_size = layer.hidden_size
     intermediate_size_per_partition = layer.intermediate_size_per_partition
     # apply_router_weight_on_input is not supported for moe marlin


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
Add triton support for compressed_tensors GPTQ W4A16 on Tesla V100 (Volta CUDA 70)

## Test Plan

## Test Result
I ran successfully the following models using this patch and Teslas V100 32GB SXM

plezan/MiniMax-M2.1-REAP-50-W4A16
MidnightPhreaker/GLM-4.5-Air-REAP-82B-A12B-GPTQ-INT4-gs32
0xSero/GLM-4.7-REAP-218B-A32B-W4A16

Performance is not great:
TG ~ 10 tk/s for MiniMax and GLM4.5Air
TG ~ 6 tk/s for GLM4.7

But it's a start.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

