### PR TITLE
[Perf] Create TMA-aligned input scale tensor for DeepGemm on Hopper

### DIFF
--- a/benchmarks/kernels/deepgemm/benchmark_fp8_block_dense_gemm.py
+++ b/benchmarks/kernels/deepgemm/benchmark_fp8_block_dense_gemm.py
@@ -14,7 +14,6 @@ from vllm.triton_utils import triton
 from vllm.utils.deep_gemm import (
     calc_diff,
     fp8_gemm_nt,
-    get_col_major_tma_aligned_tensor,
     per_block_cast_to_fp8,
 )
 
@@ -48,8 +47,9 @@ def benchmark_shape(
     block_size = [128, 128]
 
     # Pre-quantize A for all implementations
-    A_deepgemm, A_scale_deepgemm = per_token_group_quant_fp8(A, block_size[1])
-    A_scale_deepgemm = get_col_major_tma_aligned_tensor(A_scale_deepgemm)
+    A_deepgemm, A_scale_deepgemm = per_token_group_quant_fp8(
+        A, block_size[1], column_major_scales=True, tma_aligned_scales=True
+    )
     C_deepgemm = torch.empty((m, n), device="cuda", dtype=torch.bfloat16)
     A_vllm, A_scale_vllm = per_token_group_quant_fp8(A, block_size[1])
     A_vllm_cutlass, A_scale_vllm_cutlass = per_token_group_quant_fp8(

--- a/tests/kernels/quantization/test_per_token_group_quant.py
+++ b/tests/kernels/quantization/test_per_token_group_quant.py
@@ -8,13 +8,16 @@ import torch
 from vllm.model_executor.layers.quantization.utils import fp8_utils, int8_utils
 
 
-@pytest.mark.parametrize("shape", [(32, 128), (64, 256), (16, 512)])
+@pytest.mark.parametrize(
+    "shape", [(31, 128), (32, 128), (63, 256), (64, 256), (16, 512)]
+)
 @pytest.mark.parametrize("column_major", [False, True])
+@pytest.mark.parametrize("tma_aligned", [False, True])
 @pytest.mark.parametrize("scale_ue8m0", [False, True])
 @pytest.mark.parametrize("group_size", [64, 128])
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_per_token_group_quant_fp8(
-    shape, column_major: bool, scale_ue8m0: bool, group_size: int
+    shape, column_major: bool, tma_aligned: bool, scale_ue8m0: bool, group_size: int
 ):
     device = "cuda"
 
@@ -28,6 +31,7 @@ def test_per_token_group_quant_fp8(
         x,
         group_size,
         column_major_scales=column_major,
+        tma_aligned_scales=tma_aligned,
         use_ue8m0=scale_ue8m0,
     )
 

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -35,6 +35,7 @@ class QuantFP8(CustomOp):
         group_shape: GroupShape,
         num_token_padding: int | None = None,
         column_major_scales: bool = False,
+        tma_aligned_scales: bool = False,
         use_ue8m0: bool | None = None,  # for Torch compile
     ):
         """
@@ -43,6 +44,8 @@ class QuantFP8(CustomOp):
             or arbitrary block size)
         :param num_token_padding: Pad the token dimension of output to this
             size
+        :param tma_aligned_scales: For group quantization, output scales in
+            TMA-aligned layout
         :param column_major_scales: For group quantization, output scales in
             column major format
         """
@@ -52,6 +55,7 @@ class QuantFP8(CustomOp):
         self.use_per_token_if_dynamic = group_shape == GroupShape.PER_TOKEN
         self.num_token_padding = num_token_padding
         self.column_major_scales = column_major_scales
+        self.tma_aligned_scales = tma_aligned_scales
         self.use_ue8m0 = use_ue8m0
 
         self.use_aiter = rocm_aiter_ops.is_linear_fp8_enabled()
@@ -81,6 +85,7 @@ class QuantFP8(CustomOp):
                 x,
                 group_size=self.group_size,
                 column_major_scales=self.column_major_scales,
+                tma_aligned_scales=self.tma_aligned_scales,
                 dtype=_FP8_DTYPE,
                 use_ue8m0=self.use_ue8m0,
             )

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -35,6 +35,7 @@ from vllm.triton_utils import tl, triton
 from vllm.utils.deep_gemm import (
     DeepGemmQuantScaleFMT,
     fp8_gemm_nt,
+    get_tma_aligned_size,
     is_deep_gemm_e8m0_used,
     is_deep_gemm_supported,
     should_use_deepgemm_for_fp8_linear,
@@ -378,6 +379,7 @@ class W8A8BlockFp8LinearOp:
                 False,
                 self.act_quant_group_shape,
                 column_major_scales=True,
+                tma_aligned_scales=True,
                 use_ue8m0=self.use_deep_gemm_e8m0,
             )
             if self.is_deep_gemm_supported
@@ -868,6 +870,7 @@ def per_token_group_quant_fp8(
     eps: float = 1e-10,
     dtype: torch.dtype | None = None,
     column_major_scales: bool = False,
+    tma_aligned_scales: bool = False,
     out_q: torch.Tensor | None = None,
     use_ue8m0: bool | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -878,9 +881,10 @@ def per_token_group_quant_fp8(
         x: The input tensor with ndim >= 2.
         group_size: The group size used for quantization.
         eps: The minimum to avoid dividing zero.
-        dtype: The dype of output tensor. Note that only `torch.float8_e4m3fn`
+        dtype: The dtype of output tensor. Note that only `torch.float8_e4m3fn`
         is supported for now.
         column_major_scales: Outputs scales in column major.
+        tma_aligned_scales: Outputs scales in TMA-aligned layout.
         out_q: Optional output tensor. If not provided, function will create.
     Returns:
         tuple[torch.Tensor, torch.Tensor]: The quantized tensor and the
@@ -904,8 +908,24 @@ def per_token_group_quant_fp8(
 
     # Allocate the scale tensor in either row- or column-major format.
     if column_major_scales:
-        shape = (x.shape[-1] // group_size,) + x.shape[:-1]
-        x_s = torch.empty(shape, device=x.device, dtype=torch.float32).permute(-1, -2)
+        if tma_aligned_scales:
+            m = x.shape[-2]
+            sf_k = x.shape[-1] // group_size
+            tma_aligned_m = get_tma_aligned_size(m, 4)
+            shape = x.shape[:-2] + (m, sf_k)
+            stride = (
+                (1, tma_aligned_m)
+                if x.dim() == 2
+                else (tma_aligned_m * sf_k, 1, tma_aligned_m)
+            )
+            x_s = torch.empty_strided(
+                shape, stride, device=x.device, dtype=torch.float32
+            )
+        else:
+            shape = (x.shape[-1] // group_size,) + x.shape[:-1]
+            x_s = torch.empty(shape, device=x.device, dtype=torch.float32).permute(
+                -1, -2
+            )
     else:
         shape = x.shape[:-1] + (x.shape[-1] // group_size,)
         x_s = torch.empty(shape, device=x.device, dtype=torch.float32)

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -922,7 +922,7 @@ def per_token_group_quant_fp8(
                 shape, stride, device=x.device, dtype=torch.float32
             )
         else:
-            shape = (x.shape[-1] // group_size,) + x.shape[:-1]
+            shape = x.shape[:-2] + (x.shape[-1] // group_size, x.shape[-2])
             x_s = torch.empty(shape, device=x.device, dtype=torch.float32).permute(
                 -1, -2
             )

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -340,6 +340,11 @@ def _align(x: int, y: int) -> int:
     return cdiv(x, y) * y
 
 
+# Taken from https://github.com/deepseek-ai/DeepGEMM/blob/v2.1.1/csrc/utils/math.hpp#L19
+def get_tma_aligned_size(x: int, element_size: int):
+    return _align(x, 16 // element_size)
+
+
 DEFAULT_BLOCK_SIZE = [128, 128]
 
 


### PR DESCRIPTION
## Purpose

This PR is to create TMA-aligned input scale tensor for DeepGemm on Hopper.

I noticed on H200 `deep_gemm::transpose_fp32` was launched before `deep_gemm::sm90_fp8_gemm_1d2d_impl` every time, because deepgemm requires input scale tensor to be column major TMA-aligned layout on Hopper, see [here](https://github.com/deepseek-ai/DeepGEMM/blob/v2.1.1/csrc/apis/layout.hpp#L21-L23). If not in the required layout, deepgemm will launch transpose_fp32 kernel to transpose tensor [here](https://github.com/deepseek-ai/DeepGEMM/blob/v2.1.1/csrc/jit_kernels/impls/smxx_layout.hpp#L143). Therefore, we can directly create the input scale tensor in the required layout, to avoid `deep_gemm::transpose_fp32` kernel launched every time.

* fp8_utils.py: In `per_token_group_quant_fp8`, added `tma_aligned_scales` param. If `tma_aligned_scales` is true, create `x_s` scale tensor with shape (*batch, m, sf_k) and stride (tma_aligned_m * sf_k, 1, tma_aligned_m), following deepgemm implementation [here](https://github.com/deepseek-ai/DeepGEMM/blob/v2.1.1/csrc/jit_kernels/impls/smxx_layout.hpp#L120-L122).
* Downstream `per_token_group_fp8_quant` kernel will write scale values based on the `scale_num_rows` and `scale_stride` value. So there’s no change needed for this kernel.
* Added test cases in test_block_fp8.py and test_per_token_group_quant.py.
* benchmark_fp8_block_dense_gemm.py: Removed `get_col_major_tma_aligned_tensor` because it's no longer needed.
* e2e output token throughput improves 3%.

## Test Plan

```
pytest -s -v tests/kernels/quantization/test_per_token_group_quant.py
```

```
pytest -s -v tests/kernels/quantization/test_block_fp8.py
```

## Test Result

Unit tests passed.

## Profiling
Main:
<img width="1278" height="451" alt="Screenshot 2026-01-19 at 9 19 56 PM" src="https://github.com/user-attachments/assets/9be27e58-5354-417a-b40c-cbd8624a45b8" />

PR:
<img width="1278" height="452" alt="Screenshot 2026-01-19 at 9 24 19 PM" src="https://github.com/user-attachments/assets/9419e6e0-b6d9-443b-8229-48d7e3cadb05" />

Main: `deep_gemm::transpose_fp32` kernel was launched, takes extra 1.4 µs.

PR: There's no `deep_gemm::transpose_fp32` kernel launched.

## Benchmark
```
vllm serve deepseek-ai/DeepSeek-R1-0528 \
    --tensor-parallel-size 8 \
    --max-num-seqs 8 \
    --trust-remote-code \
    --compilation_config '{"compile_sizes": [1,2,4,8]}' \
    --no-enable-prefix-caching
```

```
vllm bench serve \
  --model deepseek-ai/DeepSeek-R1-0528 \
  --dataset-name sharegpt \
  --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
  --sharegpt-output-len 300 \
  --max-concurrency 8 \
  --num-prompts 1000 \
  --num-warmups 20 \
  --ignore-eos
```
Main:
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  667.56    
Total input tokens:                      229418    
Total generated tokens:                  300000    
Request throughput (req/s):              1.50      
Output token throughput (tok/s):         449.40    
Peak output token throughput (tok/s):    480.00    
Peak concurrent requests:                16.00     
Total token throughput (tok/s):          793.06    
---------------Time to First Token----------------
Mean TTFT (ms):                          237.58    
Median TTFT (ms):                        269.25    
P99 TTFT (ms):                           317.58    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          17.07     
Median TPOT (ms):                        17.03     
P99 TPOT (ms):                           17.52     
---------------Inter-token Latency----------------
Mean ITL (ms):                           17.07     
Median ITL (ms):                         17.02     
P99 ITL (ms):                            17.40     
==================================================
```

PR:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  645.73    
Total input tokens:                      229418    
Total generated tokens:                  300000    
Request throughput (req/s):              1.55      
Output token throughput (tok/s):         464.59    
Peak output token throughput (tok/s):    496.00    
Peak concurrent requests:                16.00     
Total token throughput (tok/s):          819.87    
---------------Time to First Token----------------
Mean TTFT (ms):                          226.28    
Median TTFT (ms):                        254.10    
P99 TTFT (ms):                           322.19    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          16.52     
Median TPOT (ms):                        16.49     
P99 TPOT (ms):                           16.95     
---------------Inter-token Latency----------------
Mean ITL (ms):                           16.52     
Median ITL (ms):                         16.47     
P99 ITL (ms):                            16.87     
==================================================
```
e2e output token throughput improves 3%.

## Accuracy Testing
```
python3 tests/evals/gsm8k/gsm8k_eval.py
```

Main:

```
Results:
Accuracy: 0.954
Invalid responses: 0.000
Total latency: 411.100 s
Questions per second: 3.208
Total output tokens: 128944
Output tokens per second: 313.656
```

PR:

```
Results:
Accuracy: 0.955
Invalid responses: 0.000
Total latency: 407.516 s
Questions per second: 3.237
Total output tokens: 130041
Output tokens per second: 319.106
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

