### PR TITLE
[CI/Build][AMD] Fix distributed/test_utils.py

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -257,7 +257,7 @@ steps:
   - TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_internal_lb_dp.py
   - TP_SIZE=1 DP_SIZE=4 pytest -v -s v1/distributed/test_hybrid_lb_dp.py
   - pytest -v -s v1/engine/test_engine_core_client.py::test_kv_cache_events_dp
-  - pytest -v -s distributed/test_utils.py
+  - RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES="" pytest -v -s distributed/test_utils.py
   - pytest -v -s compile/fullgraph/test_basic_correctness.py
   - pytest -v -s distributed/test_pynccl.py
   - pytest -v -s distributed/test_events.py

--- a/tests/distributed/test_utils.py
+++ b/tests/distributed/test_utils.py
@@ -25,12 +25,10 @@ class _DeviceCountStatelessTestActor:
     def get_count(self):
         return torch.cuda.device_count()
 
-    def set_cuda_visible_devices(self, cuda_visible_devices: str):
-        update_environment_variables(
-            {self.visible_devices_env_var: cuda_visible_devices}
-        )
+    def set_visible_devices(self, visible_devices: str):
+        update_environment_variables({self.visible_devices_env_var: visible_devices})
 
-    def get_cuda_visible_devices(self):
+    def get_visible_devices(self):
         return envs.__getattr__(self.visible_devices_env_var)
 
 
@@ -43,11 +41,11 @@ def test_device_count_stateless():
     actor = _DeviceCountStatelessTestActor.options(  # type: ignore
         num_gpus=2
     ).remote(visible_devices_env_var)
-    assert len(sorted(ray.get(actor.get_cuda_visible_devices.remote()).split(","))) == 2
+    assert len(sorted(ray.get(actor.get_visible_devices.remote()).split(","))) == 2
     assert ray.get(actor.get_count.remote()) == 2
-    ray.get(actor.set_cuda_visible_devices.remote("0"))
+    ray.get(actor.set_visible_devices.remote("0"))
     assert ray.get(actor.get_count.remote()) == 1
-    ray.get(actor.set_cuda_visible_devices.remote(""))
+    ray.get(actor.set_visible_devices.remote(""))
     assert ray.get(actor.get_count.remote()) == 0
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     VLLM_FLASH_ATTN_VERSION: int | None = None
     LOCAL_RANK: int = 0
     CUDA_VISIBLE_DEVICES: str | None = None
-    HIP_VISIBLE_DEVICES: str | None = None
     VLLM_ENGINE_ITERATION_TIMEOUT_S: int = 60
     VLLM_ENGINE_READY_TIMEOUT_S: int = 600
     VLLM_API_KEY: str | None = None
@@ -614,8 +613,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "LOCAL_RANK": lambda: int(os.environ.get("LOCAL_RANK", "0")),
     # used to control the visible devices in the distributed setting
     "CUDA_VISIBLE_DEVICES": lambda: os.environ.get("CUDA_VISIBLE_DEVICES", None),
-    # used to control the ROCm visible devices in the distributed setting
-    "HIP_VISIBLE_DEVICES": lambda: os.environ.get("HIP_VISIBLE_DEVICES", None),
     # timeout for each iteration in the engine
     "VLLM_ENGINE_ITERATION_TIMEOUT_S": lambda: int(
         os.environ.get("VLLM_ENGINE_ITERATION_TIMEOUT_S", "60")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     VLLM_FLASH_ATTN_VERSION: int | None = None
     LOCAL_RANK: int = 0
     CUDA_VISIBLE_DEVICES: str | None = None
+    HIP_VISIBLE_DEVICES: str | None = None
     VLLM_ENGINE_ITERATION_TIMEOUT_S: int = 60
     VLLM_ENGINE_READY_TIMEOUT_S: int = 600
     VLLM_API_KEY: str | None = None
@@ -613,6 +614,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "LOCAL_RANK": lambda: int(os.environ.get("LOCAL_RANK", "0")),
     # used to control the visible devices in the distributed setting
     "CUDA_VISIBLE_DEVICES": lambda: os.environ.get("CUDA_VISIBLE_DEVICES", None),
+    # used to control the ROCm visible devices in the distributed setting
+    "HIP_VISIBLE_DEVICES": lambda: os.environ.get("HIP_VISIBLE_DEVICES", None),
     # timeout for each iteration in the engine
     "VLLM_ENGINE_ITERATION_TIMEOUT_S": lambda: int(
         os.environ.get("VLLM_ENGINE_ITERATION_TIMEOUT_S", "60")


### PR DESCRIPTION
## Purpose
To improve the health of AMD's Distributed Tests (4 GPUs) [testgroup](https://github.com/vllm-project/vllm/blob/4a5299c93ff97c26def537b92562df5ada530fea/.buildkite/test-amd.yaml#L260).

Ray uses `HIP_VISIBLE_DEVICES` for GPU allocation when on a ROCm platform.

## Test Plan
`RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES="" pytest -v -s distributed/test_utils.py`

## Test Result
Before:

```text
=================================== FAILURES ===================================
_______________________ test_cuda_device_count_stateless _______________________

    def test_cuda_device_count_stateless():
        """Test that cuda_device_count_stateless changes return value if
        CUDA_VISIBLE_DEVICES is changed."""
        actor = _CUDADeviceCountStatelessTestActor.options(  # type: ignore
            num_gpus=2
        ).remote()
>       assert len(sorted(ray.get(actor.get_cuda_visible_devices.remote()).split(","))) == 2
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       AttributeError: 'NoneType' object has no attribute 'split'

distributed/test_utils.py:38: AttributeError
```

After: Success

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
