### PR TITLE
[Feature] Enable flashinfer moe fp4 by default

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1255,7 +1255,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Allow use of FlashInfer CUTLASS kernels for fused moe ops.
     "VLLM_USE_FLASHINFER_MOE_FP4": lambda: bool(
-        int(os.getenv("VLLM_USE_FLASHINFER_MOE_FP4", "0"))
+        int(os.getenv("VLLM_USE_FLASHINFER_MOE_FP4", "1"))
     ),
     # If set to 1, use the FlashInfer
     # MXFP8 (activation) x MXFP4 (weight) MoE backend.


### PR DESCRIPTION
## Purpose

`export MODEL="nvidia/DeepSeek-R1-NVFP4"`
`vllm serve $MODEL -tp 4 --port 9256  --enable-expert-parallel --max_num_seqs 128`

Currently cutlass moe doesn't fully support nvfp4 with tep and will raise error

```bash
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/layer.py", line 1967, in moe_forward_shared
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return self.forward_impl(hidden_states, router_logits)
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/compilation/piecewise_backend.py", line 191, in __call__
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return range_entry.runnable(*args)
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/layer.py", line 1822, in forward_impl
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     final_hidden_states = self.quant_method.apply(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/_inductor/standalone_compile.py", line 63, in __call__
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]                           ^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return self._compiled_fn(*args)
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/quantization/modelopt.py", line 1651, in apply
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return self.kernel(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py", line 1044, in _fn
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return fn(*args, **kwargs)
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return self._call_impl(*args, **kwargs)
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/_functorch/aot_autograd.py", line 1130, in forward
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return compiled_fn(full_args)
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return forward_call(*args, **kwargs)
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 353, in runtime_wrapper
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     all_outs = call_func_at_runtime_with_args(
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1230, in forward
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     fused_out = self._fused_experts(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/utils.py", line 129, in call_func_at_runtime_with_args
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]                 ^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     out = normalize_as_list(f(args))
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1084, in _fused_experts
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]                             ^^^^^^^
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     self.fused_experts.apply(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 526, in wrapper
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/cutlass_moe.py", line 691, in apply
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return compiled_fn(runtime_args)
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     run_cutlass_moe_fp4(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/cutlass_moe.py", line 550, in run_cutlass_moe_fp4
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/_inductor/output_code.py", line 613, in __call__
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     ops.cutlass_fp4_moe_mm(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return self.current_callable(inputs)
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/_custom_ops.py", line 1184, in cutlass_fp4_moe_mm
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return torch.ops._C.cutlass_fp4_group_mm(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/_inductor/utils.py", line 3017, in run
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     out = model(new_inputs)
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1255, in __call__
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]           ^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return self._op(*args, **kwargs)
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/tmp/torchinductor_yewentao256/dn/cdntm3pmd2yxyti7l666txmopjgi2qzgzxgazawm65arsvvd3ux6.py", line 1248, in call
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     buf6 = torch.ops.vllm.moe_forward_shared.default(buf4, buf5, 'model.layers.3.mlp.experts')
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839] RuntimeError: Failed to initialize GEMM: status=7 workspace_size=113664 num_experts=64 M=65536 N=4096 K=7168
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=1079290) ERROR 01-19 21:51:00 [multiproc_executor.py:839] 
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/_ops.py", line 841, in __call__
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return self._op(*args, **kwargs)
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/layer.py", line 1967, in moe_forward_shared
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return self.forward_impl(hidden_states, router_logits)
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/layer.py", line 1822, in forward_impl
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     final_hidden_states = self.quant_method.apply(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]                           ^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/quantization/modelopt.py", line 1651, in apply
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return self.kernel(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return self._call_impl(*args, **kwargs)
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return forward_call(*args, **kwargs)
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1230, in forward
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     fused_out = self._fused_experts(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]                 ^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/modular_kernel.py", line 1084, in _fused_experts
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     self.fused_experts.apply(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/cutlass_moe.py", line 691, in apply
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     run_cutlass_moe_fp4(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/cutlass_moe.py", line 550, in run_cutlass_moe_fp4
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     ops.cutlass_fp4_moe_mm(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/vllm-source/vllm/_custom_ops.py", line 1184, in cutlass_fp4_moe_mm
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return torch.ops._C.cutlass_fp4_group_mm(
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1255, in __call__
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]     return self._op(*args, **kwargs)
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839] RuntimeError: Failed to initialize GEMM: status=7 workspace_size=113664 num_experts=64 M=65536 N=4096 K=7168
(Worker_TP1_EP1 pid=1079291) ERROR 01-19 21:51:00 [multiproc_executor.py:839] 
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935] EngineCore failed to start.
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935] Traceback (most recent call last):
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 926, in run_engine_core
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 691, in __init__
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]     super().__init__(
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 112, in __init__
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]     num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 242, in _initialize_kv_caches
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]     available_gpu_memory = self.model_executor.determine_available_memory()
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]   File "/home/yewentao256/vllm-source/vllm/v1/executor/abstract.py", line 126, in determine_available_memory
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]     return self.collective_rpc("determine_available_memory")
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 374, in collective_rpc
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]     return aggregate(get_response())
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]                      ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 357, in get_response
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935]     raise RuntimeError(
(EngineCore_DP0 pid=1079063) ERROR 01-19 21:51:00 [core.py:935] RuntimeError: Worker failed with error 'Failed to initialize GEMM: status=7 workspace_size=113664 num_experts=64 M=65536 N=4096 K=7168', please check the stack trace above for the root cause
```

We can `export VLLM_USE_FLASHINFER_MOE_FP4=1` to use flashinfer instead

## Test

Now it works well

```bash
(APIServer pid=1080318) INFO 01-19 22:02:19 [api_server.py:946] Starting vLLM API server 0 on http://0.0.0.0:9256
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:38] Available routes are:
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /redoc, Methods: GET, HEAD
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /start_profile, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /stop_profile, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /pause, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /resume, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /is_paused, Methods: GET
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/audio/transcriptions, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/audio/translations, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /classify, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/embeddings, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /score, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/score, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /rerank, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v1/rerank, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /v2/rerank, Methods: POST
(APIServer pid=1080318) INFO 01-19 22:02:19 [launcher.py:46] Route: /pooling, Methods: POST
(APIServer pid=1080318) INFO:     Started server process [1080318]
(APIServer pid=1080318) INFO:     Waiting for application startup.
(APIServer pid=1080318) INFO:     Application startup complete.
```