### PR TITLE
feat: add parallel token drafting for EAGLE

### DIFF
--- a/examples/offline_inference/spec_decode.py
+++ b/examples/offline_inference/spec_decode.py
@@ -54,8 +54,13 @@ def parse_args():
         "--method",
         type=str,
         default="eagle",
-        choices=["ngram", "eagle", "eagle3", "eagle-ptd", "eagle3-ptd",
-                 "mtp", "draft_model"],
+        choices=["ngram", "eagle", "eagle3", "mtp", "draft_model"],
+    )
+    parser.add_argument(
+        "--parallel-draft",
+        action="store_true",
+        help="Generate all draft tokens in a single forward pass. "
+        "Requires a draft model trained for parallel drafting.",
     )
     parser.add_argument("--num-spec-tokens", type=int, default=2)
     parser.add_argument("--prompt-lookup-max", type=int, default=5)
@@ -105,21 +110,28 @@ def main(args):
     else:
         prompts = get_custom_mm_prompts(args.num_prompts)
 
-    if args.method in ("eagle", "eagle3", "eagle-ptd", "eagle3-ptd"):
+    if args.method in ("eagle", "eagle3"):
         eagle_dir = args.eagle_dir
         if args.method == "eagle" and eagle_dir is None:
+            if args.parallel_draft:
+                raise ValueError(
+                    "--eagle-dir is required when using --parallel-draft. "
+                    "No public parallel draft model is available yet."
+                )
             eagle_dir = "yuhuili/EAGLE-LLaMA3.1-Instruct-8B"
         elif args.method == "eagle3" and eagle_dir is None:
+            if args.parallel_draft:
+                raise ValueError(
+                    "--eagle-dir is required when using --parallel-draft. "
+                    "No public parallel draft model is available yet."
+                )
             eagle_dir = "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B"
-        elif args.method in ("eagle-ptd", "eagle3-ptd") and eagle_dir is None:
-            raise ValueError(
-                f"--eagle-dir is required for method {args.method}"
-            )
         speculative_config = {
             "method": args.method,
             "model": eagle_dir,
             "num_speculative_tokens": args.num_spec_tokens,
             "disable_padded_drafter_batch": args.disable_padded_drafter_batch,
+            "parallel_draft": args.parallel_draft,
         }
     elif args.method == "ngram":
         speculative_config = {
@@ -227,7 +239,7 @@ if __name__ == "__main__":
 
     if args.test:
         # takes ~30s to run on 1xH100
-        assert args.method in ["eagle", "eagle3", "eagle-ptd", "eagle3-ptd"]
+        assert args.method in ["eagle", "eagle3"]
         assert args.tp == 1
         assert args.num_spec_tokens == 3
         assert args.dataset_name == "hf"

--- a/examples/offline_inference/spec_decode.py
+++ b/examples/offline_inference/spec_decode.py
@@ -54,7 +54,8 @@ def parse_args():
         "--method",
         type=str,
         default="eagle",
-        choices=["ngram", "eagle", "eagle3", "mtp", "draft_model"],
+        choices=["ngram", "eagle", "eagle3", "eagle-ptd", "eagle3-ptd",
+                 "mtp", "draft_model"],
     )
     parser.add_argument("--num-spec-tokens", type=int, default=2)
     parser.add_argument("--prompt-lookup-max", type=int, default=5)
@@ -104,13 +105,16 @@ def main(args):
     else:
         prompts = get_custom_mm_prompts(args.num_prompts)
 
-    if args.method == "eagle" or args.method == "eagle3":
+    if args.method in ("eagle", "eagle3", "eagle-ptd", "eagle3-ptd"):
         eagle_dir = args.eagle_dir
         if args.method == "eagle" and eagle_dir is None:
             eagle_dir = "yuhuili/EAGLE-LLaMA3.1-Instruct-8B"
-
         elif args.method == "eagle3" and eagle_dir is None:
             eagle_dir = "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B"
+        elif args.method in ("eagle-ptd", "eagle3-ptd") and eagle_dir is None:
+            raise ValueError(
+                f"--eagle-dir is required for method {args.method}"
+            )
         speculative_config = {
             "method": args.method,
             "model": eagle_dir,
@@ -223,7 +227,7 @@ if __name__ == "__main__":
 
     if args.test:
         # takes ~30s to run on 1xH100
-        assert args.method in ["eagle", "eagle3"]
+        assert args.method in ["eagle", "eagle3", "eagle-ptd", "eagle3-ptd"]
         assert args.tp == 1
         assert args.num_spec_tokens == 3
         assert args.dataset_name == "hf"

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -553,14 +553,14 @@ def test_eagle_correctness(
     [
         pytest.param(
             (
-                "eagle3-ptd",
+                "eagle3",
                 "openai/gpt-oss-120b",
-                "PATH_TO_PTD_MODEL",  # Replace with actual PTD model path
+                "PATH_TO_PARALLEL_DRAFT_MODEL",
                 1,
             ),
             False,
             marks=pytest.mark.skip(
-                reason="PTD model not publicly available yet"
+                reason="Parallel draft model not publicly available yet"
             ),
         ),
     ],
@@ -576,12 +576,12 @@ def test_ptd_correctness(
 ):
     """
     Compare the outputs of an original LLM and a speculative LLM
-    using PTD (Parallel Token Decoding) speculative decoding.
-    PTD generates K draft tokens in a single forward pass using mask tokens.
-    model_setup: (method, model_name, ptd_model_name, tp_size)
+    using parallel drafting.
+    Generates K draft tokens in a single forward pass using mask tokens.
+    model_setup: (method, model_name, draft_model_name, tp_size)
     """
     if attn_backend == "TREE_ATTN":
-        pytest.skip("TREE_ATTN not yet supported with PTD")
+        pytest.skip("TREE_ATTN not yet supported with parallel drafting")
 
     test_prompts = get_test_prompts(mm_enabled)
     attention_config = {"backend": attn_backend}
@@ -617,6 +617,7 @@ def test_ptd_correctness(
                 "model": spec_model_name,
                 "num_speculative_tokens": 6,
                 "max_model_len": max_model_len,
+                "parallel_draft": True,
             },
             max_model_len=max_model_len,
             attention_config=attention_config,

--- a/tests/v1/spec_decode/test_ptd_eagle.py
+++ b/tests/v1/spec_decode/test_ptd_eagle.py
@@ -1,0 +1,822 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest import mock
+
+import pytest
+import torch
+
+from tests.v1.attention.utils import (
+    BatchSpec,
+    create_common_attn_metadata,
+    create_standard_kv_cache_spec,
+    try_get_attention_backend,
+)
+from vllm.config import (
+    AttentionConfig,
+    CacheConfig,
+    CUDAGraphMode,
+    DeviceConfig,
+    ModelConfig,
+    ParallelConfig,
+    SchedulerConfig,
+    SpeculativeConfig,
+    VllmConfig,
+)
+from vllm.config.load import LoadConfig
+from vllm.model_executor.models.llama import LlamaForCausalLM
+from vllm.platforms import current_platform
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+from vllm.v1.spec_decode.ptd_eagle import PtdEagleProposer
+
+model_dir = "openai/gpt-oss-120b"
+draft_model_dir = "nvidia/gpt-oss-120b-Eagle3-throughput"
+
+KERNEL_CONFIG = {
+    "hidden_size": 256,
+    "block_size": 16,
+    "max_blocks": 2048,
+    "mask_token_id": 128256,
+    "max_model_len": 32768,
+    "HIDDEN_TILE_SIZE": 256,
+}
+
+
+def build_kernel_test_data(
+    K: int,
+    num_verified: list[int],
+    start_pos: list[int] | None = None,
+) -> dict:
+    """Build kernel test inputs and expected outputs from minimal parameters."""
+    batch_size = len(num_verified)
+    draft_len = K - 1
+    mask_token_id = KERNEL_CONFIG["mask_token_id"]
+
+    if start_pos is None:
+        start_pos = [0] * batch_size
+
+    target_token_ids = []
+    target_positions = []
+    input_query_start_loc = [0]
+    output_query_start_loc = [0]
+    last_token_indices = []
+
+    token_counter = 0
+    for i, num_verified_tokens in enumerate(num_verified):
+        target_token_ids.extend(
+            range(token_counter, token_counter + num_verified_tokens)
+        )
+        pos_range = range(start_pos[i], start_pos[i] + num_verified_tokens)
+        target_positions.extend(pos_range)
+        input_query_start_loc.append(input_query_start_loc[-1] + num_verified_tokens)
+        output_query_start_loc.append(
+            output_query_start_loc[-1] + num_verified_tokens + draft_len
+        )
+        last_token_indices.append(input_query_start_loc[-2] + num_verified_tokens - 1)
+        token_counter += num_verified_tokens
+
+    next_token_ids = [100 + i for i in range(batch_size)]
+
+    expected_token_ids = []
+    expected_positions = []
+    for i, num_verified_tokens in enumerate(num_verified):
+        request_start_idx = input_query_start_loc[i]
+        # Shift left: drop first, keep [1:n], append next_token
+        for j in range(1, num_verified_tokens):
+            expected_token_ids.append(target_token_ids[request_start_idx + j])
+            expected_positions.append(target_positions[request_start_idx + j - 1])
+        expected_token_ids.append(next_token_ids[i])
+        expected_positions.append(
+            target_positions[request_start_idx + num_verified_tokens - 1]
+        )
+        # Append K-1 mask tokens
+        last_position = target_positions[request_start_idx + num_verified_tokens - 1]
+        for d in range(1, K):
+            expected_token_ids.append(mask_token_id)
+            expected_positions.append(last_position + d)
+
+    return {
+        "batch_size": batch_size,
+        "num_spec_tokens": K,
+        "target_token_ids": target_token_ids,
+        "target_positions": target_positions,
+        "next_token_ids": next_token_ids,
+        "last_token_indices": last_token_indices,
+        "input_query_start_loc": input_query_start_loc,
+        "output_query_start_loc": output_query_start_loc,
+        "expected_token_ids": expected_token_ids,
+        "expected_positions": expected_positions,
+    }
+
+
+def _create_proposer(
+    method: str,
+    num_speculative_tokens: int,
+    attention_backend: str | None = None,
+) -> PtdEagleProposer:
+    model_config = ModelConfig(model=model_dir, runner="generate", max_model_len=100)
+
+    speculative_config = SpeculativeConfig(
+        target_model_config=model_config,
+        target_parallel_config=ParallelConfig(),
+        model=draft_model_dir,
+        method=method,
+        num_speculative_tokens=num_speculative_tokens,
+        parallel_draft=True,
+    )
+
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        cache_config=CacheConfig(),
+        speculative_config=speculative_config,
+        device_config=DeviceConfig(device=current_platform.device_type),
+        parallel_config=ParallelConfig(),
+        load_config=LoadConfig(),
+        scheduler_config=SchedulerConfig(
+            max_model_len=model_config.max_model_len,
+            is_encoder_decoder=model_config.is_encoder_decoder,
+        ),
+        attention_config=AttentionConfig(backend=attention_backend),
+    )
+
+    return PtdEagleProposer(
+        vllm_config=vllm_config, device=current_platform.device_type
+    )
+
+
+def run_ptd_kernel(
+    device: torch.device,
+    config: dict,
+    *,
+    batch_size: int,
+    target_token_ids: list[int],
+    target_positions: list[int],
+    target_hidden: torch.Tensor | None = None,
+    mask_hidden_val: float = 99.0,
+    next_token_ids: list[int],
+    last_token_indices: list[int],
+    original_slot_mapping: list[int] | None = None,
+    in_query_start_loc: list[int],
+    out_query_start_loc: list[int],
+    block_table: torch.Tensor | None = None,
+    max_model_len: int | None = None,
+) -> dict:
+    """Run parallel drafting kernel and return outputs."""
+    from vllm.v1.spec_decode.ptd_eagle import ptd_prepare_inputs_kernel
+
+    hidden_size = config["hidden_size"]
+    block_size = config["block_size"]
+    max_blocks = config["max_blocks"]
+    mask_token_id = config["mask_token_id"]
+    HIDDEN_TILE_SIZE = config["HIDDEN_TILE_SIZE"]
+    if max_model_len is None:
+        max_model_len = config["max_model_len"]
+
+    num_tokens = len(target_token_ids)
+    total_output_tokens = out_query_start_loc[-1]
+
+    target_token_ids_gpu = torch.tensor(
+        target_token_ids, dtype=torch.int32, device=device
+    )
+    target_positions_gpu = torch.tensor(
+        target_positions, dtype=torch.int32, device=device
+    )
+    if target_hidden is None:
+        target_hidden = torch.randn(num_tokens, hidden_size, device=device)
+    mask_hidden = torch.full((hidden_size,), mask_hidden_val, device=device)
+    next_token_ids_gpu = torch.tensor(next_token_ids, dtype=torch.int32, device=device)
+    last_token_indices_gpu = torch.tensor(
+        last_token_indices, dtype=torch.int32, device=device
+    )
+
+    if original_slot_mapping is None:
+        original_slot_mapping = target_positions
+    original_slot_mapping_gpu = torch.tensor(
+        original_slot_mapping, dtype=torch.int64, device=device
+    )
+
+    if block_table is None:
+        block_table = torch.arange(max_blocks, dtype=torch.int32, device=device)
+        block_table = block_table.unsqueeze(0).expand(batch_size, -1).contiguous()
+
+    in_query_start_loc_gpu = torch.tensor(
+        in_query_start_loc, dtype=torch.int32, device=device
+    )
+    out_query_start_loc_gpu = torch.tensor(
+        out_query_start_loc, dtype=torch.int32, device=device
+    )
+
+    out_input_ids = torch.zeros(total_output_tokens, dtype=torch.int32, device=device)
+    out_positions = torch.zeros(total_output_tokens, dtype=torch.int32, device=device)
+    out_hidden = torch.zeros(total_output_tokens, hidden_size, device=device)
+    out_slot_mapping = torch.zeros(
+        total_output_tokens, dtype=torch.int64, device=device
+    )
+
+    num_hidden_tiles = (hidden_size + HIDDEN_TILE_SIZE - 1) // HIDDEN_TILE_SIZE
+
+    ptd_prepare_inputs_kernel[(total_output_tokens, num_hidden_tiles)](
+        target_token_ids_gpu,
+        target_positions_gpu,
+        target_hidden,
+        mask_hidden,
+        next_token_ids_gpu,
+        last_token_indices_gpu,
+        original_slot_mapping_gpu,
+        block_table,
+        in_query_start_loc_gpu,
+        out_query_start_loc_gpu,
+        out_input_ids,
+        out_positions,
+        out_hidden,
+        out_slot_mapping,
+        batch_size=batch_size,
+        hidden_size=hidden_size,
+        block_size=block_size,
+        max_blocks=block_table.shape[1],
+        mask_token_id=mask_token_id,
+        max_model_len=max_model_len,
+        HIDDEN_TILE_SIZE=HIDDEN_TILE_SIZE,
+    )
+
+    return {
+        "input_ids": out_input_ids.cpu(),
+        "positions": out_positions.cpu(),
+        "hidden": out_hidden,
+        "slot_mapping": out_slot_mapping.cpu(),
+        "target_hidden": target_hidden,
+        "mask_hidden": mask_hidden,
+        "mask_token_id": mask_token_id,
+    }
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Triton kernel requires CUDA"
+)
+@pytest.mark.parametrize(
+    "K, num_verified, start_pos",
+    [
+        # Single request scenarios
+        pytest.param(1, [3], [5], id="K=1_single"),
+        pytest.param(4, [1], [10], id="K=4_all_rejected"),
+        pytest.param(4, [4], [0], id="K=4_all_accepted"),
+        pytest.param(4, [3], [0], id="K=4_partial"),
+        pytest.param(2, [3], [0], id="K=2_single"),
+        pytest.param(6, [2], [0], id="K=6_single"),
+        # Batched scenarios (batch_size=2)
+        pytest.param(1, [3, 2], [0, 0], id="K=1_batch2"),
+        pytest.param(4, [1, 1], [10, 20], id="K=4_batch2_all_rejected"),
+        pytest.param(4, [4, 3], [0, 0], id="K=4_batch2_all_accepted"),
+        pytest.param(4, [3, 1], [5, 10], id="K=4_batch2_mixed"),
+        pytest.param(2, [3, 2], [0, 0], id="K=2_batch2"),
+        # Batch size 3
+        pytest.param(4, [4, 2, 1], [0, 0, 0], id="K=4_batch3_varying"),
+        # Larger K value
+        pytest.param(8, [3], [0], id="K=8_single"),
+        # Long sequence positions (deep in context)
+        pytest.param(4, [3], [8000], id="K=4_pos_8k"),
+        pytest.param(4, [2, 3], [16000, 8000], id="K=4_batch2_long_pos"),
+        # Larger batch
+        pytest.param(4, [2, 3, 1, 4], [0, 0, 0, 0], id="K=4_batch4"),
+    ],
+)
+def test_ptd_kernel_scenarios(K, num_verified, start_pos):
+    """Parametrized test covering core kernel scenarios."""
+    device = torch.device("cuda")
+    scenario = build_kernel_test_data(K, num_verified, start_pos)
+
+    result = run_ptd_kernel(
+        device,
+        KERNEL_CONFIG,
+        batch_size=scenario["batch_size"],
+        target_token_ids=scenario["target_token_ids"],
+        target_positions=scenario["target_positions"],
+        next_token_ids=scenario["next_token_ids"],
+        last_token_indices=scenario["last_token_indices"],
+        in_query_start_loc=scenario["input_query_start_loc"],
+        out_query_start_loc=scenario["output_query_start_loc"],
+    )
+
+    expected_token_ids = torch.tensor(scenario["expected_token_ids"], dtype=torch.int32)
+    assert torch.equal(result["input_ids"], expected_token_ids), (
+        f"input_ids mismatch: got {result['input_ids']}, expected {expected_token_ids}"
+    )
+
+    expected_positions = torch.tensor(scenario["expected_positions"], dtype=torch.int32)
+    assert torch.equal(result["positions"], expected_positions), (
+        f"positions mismatch: got {result['positions']}, expected {expected_positions}"
+    )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Triton kernel requires CUDA"
+)
+def test_ptd_kernel_slot_mapping():
+    """Test that slot mapping is computed correctly."""
+    device = torch.device("cuda")
+    scenario = build_kernel_test_data(K=4, num_verified=[3], start_pos=[5])
+
+    result = run_ptd_kernel(
+        device,
+        KERNEL_CONFIG,
+        batch_size=scenario["batch_size"],
+        target_token_ids=scenario["target_token_ids"],
+        target_positions=scenario["target_positions"],
+        next_token_ids=scenario["next_token_ids"],
+        last_token_indices=scenario["last_token_indices"],
+        in_query_start_loc=scenario["input_query_start_loc"],
+        out_query_start_loc=scenario["output_query_start_loc"],
+    )
+
+    # Slots should match positions for simple block table (identity mapping)
+    expected_slots = torch.tensor([5, 6, 7, 8, 9, 10], dtype=torch.int64)
+    assert torch.equal(result["slot_mapping"], expected_slots), (
+        f"slot_mapping mismatch: got {result['slot_mapping']}, "
+        f"expected {expected_slots}"
+    )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Triton kernel requires CUDA"
+)
+def test_ptd_overflow_uses_padding_slot():
+    """Verify PADDING_SLOT_ID (-1) is used when positions exceed max_model_len."""
+    device = torch.device("cuda")
+    PADDING_SLOT_ID = -1
+
+    result = run_ptd_kernel(
+        device,
+        KERNEL_CONFIG,
+        batch_size=1,
+        target_token_ids=[10, 20, 30],
+        target_positions=[97, 98, 99],
+        next_token_ids=[99],
+        last_token_indices=[2],
+        original_slot_mapping=[97, 98, 99],
+        in_query_start_loc=[0, 3],
+        out_query_start_loc=[0, 6],
+        max_model_len=100,
+    )
+
+    # Draft positions (100, 101, 102) exceed max_model_len=100
+    draft_slots = result["slot_mapping"][3:]
+    assert torch.all(draft_slots == PADDING_SLOT_ID), (
+        f"Expected PADDING_SLOT_ID for overflow, got {draft_slots}"
+    )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Triton kernel requires CUDA"
+)
+def test_ptd_slot_crosses_block_boundary():
+    """Test slot computation when draft positions span KV cache block boundaries."""
+    device = torch.device("cuda")
+    max_blocks = KERNEL_CONFIG["max_blocks"]
+
+    # Create block table where block 0 -> physical 5, block 1 -> physical 7
+    block_table = torch.zeros(max_blocks, dtype=torch.int32, device=device)
+    block_table[0] = 5
+    block_table[1] = 7
+    block_table = block_table.unsqueeze(0)
+
+    result = run_ptd_kernel(
+        device,
+        KERNEL_CONFIG,
+        batch_size=1,
+        target_token_ids=[10, 20],
+        target_positions=[14, 15],  # End of block 0
+        next_token_ids=[42],
+        last_token_indices=[1],
+        original_slot_mapping=[14, 15],
+        in_query_start_loc=[0, 2],
+        out_query_start_loc=[0, 5],
+        block_table=block_table,
+    )
+
+    # Verified: from slot_mapping. Draft: computed via block_table (block 1 = phys 7)
+    expected_slots = torch.tensor([14, 15, 112, 113, 114], dtype=torch.int64)
+    assert torch.equal(result["slot_mapping"], expected_slots)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Triton kernel requires CUDA"
+)
+def test_ptd_hidden_states_copied_correctly():
+    """Verify hidden states are copied from target or mask_hidden correctly."""
+    device = torch.device("cuda")
+    hidden_size = KERNEL_CONFIG["hidden_size"]
+
+    target_hidden = torch.zeros(3, hidden_size, device=device)
+    target_hidden[0, :] = 1.0
+    target_hidden[1, :] = 2.0
+    target_hidden[2, :] = 3.0
+
+    result = run_ptd_kernel(
+        device,
+        KERNEL_CONFIG,
+        batch_size=1,
+        target_token_ids=[10, 20, 30],
+        target_positions=[5, 6, 7],
+        target_hidden=target_hidden,
+        mask_hidden_val=99.0,
+        next_token_ids=[42],
+        last_token_indices=[2],
+        in_query_start_loc=[0, 3],
+        out_query_start_loc=[0, 6],
+    )
+
+    assert torch.allclose(result["hidden"][0], target_hidden[0])
+    assert torch.allclose(result["hidden"][1], target_hidden[1])
+    assert torch.allclose(result["hidden"][2], target_hidden[2])
+    for i in range(3, 6):
+        assert torch.allclose(result["hidden"][i], result["mask_hidden"])
+
+
+@mock.patch("vllm.v1.spec_decode.eagle.get_pp_group")
+@mock.patch("vllm.v1.spec_decode.eagle.get_layers_from_vllm_config")
+@mock.patch("vllm.v1.spec_decode.eagle.get_model")
+def test_ptd_load_model(
+    mock_get_model,
+    mock_get_layers,
+    mock_get_pp_group,
+):
+    """Test load_model sets up mask_token_id and mask_hidden."""
+    proposer = _create_proposer(
+        "eagle3", num_speculative_tokens=8, attention_backend="FLASH_ATTN"
+    )
+    proposer.draft_model_config.hf_config.ptd_token_id = "128256"
+
+    draft_model = mock.MagicMock()
+    draft_model.model = mock.MagicMock()
+    draft_model.has_own_embed_tokens = False
+    draft_model.model.embed_tokens = mock.MagicMock()
+    draft_model.has_own_lm_head = False
+    draft_model.lm_head = mock.MagicMock()
+    draft_model.mask_hidden = torch.ones(
+        proposer.hidden_size, dtype=torch.float32, device=proposer.device
+    )
+    mock_get_model.return_value = draft_model
+
+    target_attn_layers = {"target_attn_1": mock.MagicMock()}
+    all_attn_layers = {**target_attn_layers, "draft_extra_attn": mock.MagicMock()}
+    mock_get_layers.side_effect = [target_attn_layers, {}, all_attn_layers, {}]
+
+    mock_pp_group = mock.MagicMock()
+    mock_pp_group.world_size = 1
+    mock_get_pp_group.return_value = mock_pp_group
+
+    class _TargetModelStub(LlamaForCausalLM):
+        model: mock.MagicMock
+        lm_head: mock.MagicMock
+
+    target_model = mock.create_autospec(_TargetModelStub, instance=True)
+    target_model.model = mock.MagicMock()
+    target_model.lm_head = mock.MagicMock()
+    target_model.model.embed_tokens = mock.MagicMock()
+
+    proposer.load_model(target_model)
+
+    assert proposer.mask_token_id == 128256
+    assert proposer.mask_hidden is draft_model.mask_hidden
+
+
+@mock.patch("vllm.v1.spec_decode.eagle.get_pp_group")
+@mock.patch("vllm.v1.spec_decode.eagle.get_layers_from_vllm_config")
+@mock.patch("vllm.v1.spec_decode.eagle.get_model")
+def test_ptd_load_model_requires_ptd_token_id(
+    mock_get_model,
+    mock_get_layers,
+    mock_get_pp_group,
+):
+    """Test that missing ptd_token_id raises ValueError."""
+    from types import SimpleNamespace
+
+    proposer = _create_proposer("eagle3", num_speculative_tokens=4)
+    proposer.draft_model_config.hf_config = SimpleNamespace()
+
+    draft_model = mock.MagicMock()
+    draft_model.model = mock.MagicMock()
+    draft_model.has_own_embed_tokens = False
+    draft_model.model.embed_tokens = mock.MagicMock()
+    draft_model.has_own_lm_head = False
+    draft_model.lm_head = mock.MagicMock()
+    draft_model.mask_hidden = torch.zeros(proposer.hidden_size, dtype=torch.float32)
+    mock_get_model.return_value = draft_model
+
+    target_attn_layers = {"target_attn": mock.MagicMock()}
+    all_attn_layers = {**target_attn_layers, "draft_extra_attn": mock.MagicMock()}
+    mock_get_layers.side_effect = [target_attn_layers, {}, all_attn_layers, {}]
+
+    mock_pp_group = mock.MagicMock()
+    mock_pp_group.world_size = 1
+    mock_get_pp_group.return_value = mock_pp_group
+
+    class _TargetModelStub(LlamaForCausalLM):
+        model: mock.MagicMock
+        lm_head: mock.MagicMock
+
+    target_model = mock.create_autospec(_TargetModelStub, instance=True)
+    target_model.model = mock.MagicMock()
+    target_model.lm_head = mock.MagicMock()
+    target_model.model.embed_tokens = mock.MagicMock()
+
+    with pytest.raises(ValueError, match="ptd_token_id"):
+        proposer.load_model(target_model)
+
+
+@pytest.mark.parametrize("num_speculative_tokens", [2, 4])
+def test_ptd_propose(num_speculative_tokens):
+    """Test propose returns correct draft tokens."""
+    device = torch.device(current_platform.device_type)
+
+    batch_size = 2
+    seq_lens = [5, 3]
+    total_tokens = sum(seq_lens)
+    vocab_size = 128
+
+    proposer = _create_proposer(
+        "eagle3", num_speculative_tokens, attention_backend="FLASH_ATTN"
+    )
+    hidden_size = proposer.hidden_size
+
+    model_mock = mock.MagicMock()
+    proposer.model = model_mock
+    proposer.attn_layer_names = ["layer.0"]
+
+    backend_enum = AttentionBackendEnum.FLASH_ATTN
+
+    attn_metadata_builder_cls, _ = try_get_attention_backend(backend_enum)
+    attn_metadata_builder = attn_metadata_builder_cls(
+        kv_cache_spec=create_standard_kv_cache_spec(proposer.vllm_config),
+        layer_names=proposer.attn_layer_names,
+        vllm_config=proposer.vllm_config,
+        device=device,
+    )
+
+    proposer.runner = mock.MagicMock()
+    proposer.runner.attn_groups.append([mock.MagicMock()])
+    proposer.runner.attn_groups[0][
+        0
+    ].get_metadata_builder.return_value = attn_metadata_builder
+    proposer._get_attention_metadata_builder = mock.MagicMock(
+        return_value=attn_metadata_builder
+    )
+
+    batch_spec = BatchSpec(seq_lens=seq_lens, query_lens=seq_lens)
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec, block_size=16, device=device
+    )
+
+    target_token_ids = torch.randint(
+        0, vocab_size, (total_tokens,), dtype=torch.int32, device=device
+    )
+    target_positions = torch.cat(
+        [torch.arange(s, device=device, dtype=torch.int32) for s in seq_lens]
+    )
+    target_hidden_states = torch.randn(total_tokens, hidden_size, device=device)
+    next_token_ids = torch.randint(
+        0, vocab_size, (batch_size,), dtype=torch.int32, device=device
+    )
+    sampling_metadata = mock.MagicMock()
+
+    draft_len = num_speculative_tokens - 1
+    total_output_tokens = (
+        common_attn_metadata.num_actual_tokens + batch_size * draft_len
+    )
+    slot_mapping = torch.arange(total_output_tokens, device=device, dtype=torch.int64)
+
+    proposer._prepare_ptd_inputs = mock.MagicMock(return_value=slot_mapping)
+    proposer._get_ptd_cudagraph_config = mock.MagicMock(
+        return_value=(total_output_tokens, CUDAGraphMode.NONE)
+    )
+
+    hidden_states = torch.zeros(total_output_tokens, hidden_size, device=device)
+    proposer._run_ptd_forward = mock.MagicMock(return_value=hidden_states)
+
+    base_token_ids = [42, 60]
+    logits = torch.full(
+        (batch_size * num_speculative_tokens, vocab_size), -100.0, device=device
+    )
+    for i in range(batch_size):
+        for j in range(num_speculative_tokens):
+            logits[i * num_speculative_tokens + j, base_token_ids[i] + j] = 100.0
+    model_mock.compute_logits.return_value = logits
+
+    result = proposer.propose(
+        target_token_ids=target_token_ids,
+        target_positions=target_positions,
+        target_hidden_states=target_hidden_states,
+        next_token_ids=next_token_ids,
+        last_token_indices=None,
+        common_attn_metadata=common_attn_metadata,
+        sampling_metadata=sampling_metadata,
+    )
+
+    expected_tokens = torch.tensor(
+        [
+            [base_token_ids[0] + i for i in range(num_speculative_tokens)],
+            [base_token_ids[1] + i for i in range(num_speculative_tokens)],
+        ],
+        device=device,
+    )
+    assert torch.equal(result, expected_tokens)
+
+
+def test_ptd_propose_rejects_multimodal():
+    """Test that multimodal inputs raise NotImplementedError."""
+    device = torch.device(current_platform.device_type)
+    proposer = _create_proposer("eagle3", num_speculative_tokens=4)
+    dummy_tensor = torch.zeros(1, device=device)
+
+    with pytest.raises(NotImplementedError):
+        proposer.propose(
+            target_token_ids=dummy_tensor,
+            target_positions=dummy_tensor,
+            target_hidden_states=dummy_tensor,
+            next_token_ids=dummy_tensor,
+            last_token_indices=None,
+            common_attn_metadata=mock.MagicMock(),
+            sampling_metadata=mock.MagicMock(),
+            mm_embed_inputs=([dummy_tensor], dummy_tensor),
+        )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Triton kernel requires CUDA"
+)
+def test_ptd_propose_updates_metadata():
+    """Verify propose() correctly updates common_attn_metadata fields."""
+    device = torch.device("cuda")
+
+    num_speculative_tokens = 4
+    proposer = _create_proposer(
+        "eagle3", num_speculative_tokens, attention_backend="FLASH_ATTN"
+    )
+    hidden_size = proposer.hidden_size
+
+    proposer.mask_token_id = 128256
+    proposer.mask_hidden = torch.randn(hidden_size, device=device)
+
+    batch_size = 2
+    seq_lens = [5, 3]
+    total_tokens = sum(seq_lens)
+    vocab_size = 128
+
+    batch_spec = BatchSpec(seq_lens=seq_lens, query_lens=seq_lens)
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec, block_size=16, device=device
+    )
+
+    original_num_tokens = common_attn_metadata.num_actual_tokens
+    original_max_query_len = common_attn_metadata.max_query_len
+
+    target_token_ids = torch.randint(
+        0, vocab_size, (total_tokens,), dtype=torch.int32, device=device
+    )
+    target_positions = torch.cat(
+        [torch.arange(s, device=device, dtype=torch.int32) for s in seq_lens]
+    )
+    target_hidden_states = torch.randn(total_tokens, hidden_size, device=device)
+    next_token_ids = torch.randint(
+        0, vocab_size, (batch_size,), dtype=torch.int32, device=device
+    )
+    sampling_metadata = mock.MagicMock()
+
+    model_mock = mock.MagicMock()
+    # combine_hidden_states is called for eagle3 - return input unchanged
+    model_mock.combine_hidden_states.side_effect = lambda x: x
+    proposer.model = model_mock
+    proposer.attn_layer_names = ["layer.0"]
+
+    attn_metadata_builder_cls, _ = try_get_attention_backend(
+        AttentionBackendEnum.FLASH_ATTN
+    )
+    attn_metadata_builder = attn_metadata_builder_cls(
+        kv_cache_spec=create_standard_kv_cache_spec(proposer.vllm_config),
+        layer_names=proposer.attn_layer_names,
+        vllm_config=proposer.vllm_config,
+        device=device,
+    )
+
+    proposer.runner = mock.MagicMock()
+    proposer.runner.attn_groups.append([mock.MagicMock()])
+    proposer.runner.attn_groups[0][
+        0
+    ].get_metadata_builder.return_value = attn_metadata_builder
+    proposer._get_attention_metadata_builder = mock.MagicMock(
+        return_value=attn_metadata_builder
+    )
+
+    draft_len = num_speculative_tokens - 1
+    total_output_tokens = original_num_tokens + batch_size * draft_len
+
+    proposer._get_ptd_cudagraph_config = mock.MagicMock(
+        return_value=(total_output_tokens, CUDAGraphMode.NONE)
+    )
+    hidden_states = torch.zeros(total_output_tokens, hidden_size, device=device)
+    proposer._run_ptd_forward = mock.MagicMock(return_value=hidden_states)
+
+    logits = torch.full(
+        (batch_size * num_speculative_tokens, vocab_size), -100.0, device=device
+    )
+    for i in range(batch_size):
+        logits[i * num_speculative_tokens, 42 + i] = 100.0
+    model_mock.compute_logits.return_value = logits
+
+    proposer.propose(
+        target_token_ids=target_token_ids,
+        target_positions=target_positions,
+        target_hidden_states=target_hidden_states,
+        next_token_ids=next_token_ids,
+        last_token_indices=None,
+        common_attn_metadata=common_attn_metadata,
+        sampling_metadata=sampling_metadata,
+    )
+
+    assert common_attn_metadata.num_actual_tokens == total_output_tokens
+    assert common_attn_metadata.max_query_len == original_max_query_len + draft_len
+    assert common_attn_metadata.slot_mapping is not None
+    assert common_attn_metadata.slot_mapping.shape[0] == total_output_tokens
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Triton kernel requires CUDA"
+)
+def test_ptd_prepare_inputs_method():
+    """Test _prepare_ptd_inputs method with real kernel execution."""
+    device = torch.device("cuda")
+
+    num_speculative_tokens = 4
+    proposer = _create_proposer("eagle3", num_speculative_tokens)
+
+    proposer.mask_token_id = 128256
+    proposer.mask_hidden = torch.randn(
+        proposer.hidden_size, device=device, dtype=torch.float32
+    )
+
+    batch_size = 2
+    seq_lens = [5, 3]
+    total_tokens = sum(seq_lens)
+
+    target_token_ids = torch.arange(total_tokens, dtype=torch.int32, device=device)
+    target_positions = torch.cat(
+        [torch.arange(s, device=device, dtype=torch.int32) for s in seq_lens]
+    )
+    target_hidden_states = torch.randn(
+        total_tokens, proposer.hidden_size, device=device
+    )
+    next_token_ids = torch.tensor([100, 101], dtype=torch.int32, device=device)
+
+    last_token_indices = torch.tensor([4, 7], dtype=torch.int32, device=device)
+
+    slot_mapping = torch.arange(total_tokens, dtype=torch.int64, device=device)
+    block_table = torch.arange(
+        KERNEL_CONFIG["max_blocks"], dtype=torch.int32, device=device
+    )
+    block_table = block_table.unsqueeze(0).expand(batch_size, -1).contiguous()
+
+    input_query_start_loc = torch.tensor(
+        [0, seq_lens[0], total_tokens], dtype=torch.int32, device=device
+    )
+
+    draft_len = num_speculative_tokens - 1
+    accepted_lengths = last_token_indices - input_query_start_loc[:batch_size] + 1
+    out_lens = accepted_lengths + draft_len
+    output_query_start_loc = torch.zeros(
+        batch_size + 1, dtype=torch.int32, device=device
+    )
+    output_query_start_loc[1:] = torch.cumsum(out_lens, dim=0)
+
+    total_output_tokens = total_tokens + batch_size * draft_len
+
+    result_slot_mapping = proposer._prepare_ptd_inputs(
+        target_token_ids,
+        target_positions,
+        target_hidden_states,
+        next_token_ids,
+        last_token_indices,
+        slot_mapping,
+        block_table,
+        input_query_start_loc,
+        output_query_start_loc,
+        total_output_tokens,
+        batch_size,
+    )
+
+    assert result_slot_mapping.shape[0] == total_output_tokens
+    assert proposer.input_ids[:total_output_tokens].shape[0] == total_output_tokens
+    assert proposer.positions[:total_output_tokens].shape[0] == total_output_tokens
+    assert proposer.hidden_states[:total_output_tokens].shape == (
+        total_output_tokens,
+        proposer.hidden_size,
+    )
+
+    out_input_ids = proposer.input_ids[:total_output_tokens].cpu()
+    output_query_start_locs = output_query_start_loc.cpu().tolist()
+    for i in range(batch_size):
+        start = output_query_start_locs[i]
+        end = output_query_start_locs[i + 1]
+        non_draft_tokens = out_input_ids[start : end - draft_len]
+        assert torch.all(non_draft_tokens != proposer.mask_token_id)
+        draft_tokens = out_input_ids[end - draft_len : end]
+        assert torch.all(draft_tokens == proposer.mask_token_id)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -41,13 +41,15 @@ MTPModelTypes = Literal[
     "mtp",
     "pangu_ultra_moe_mtp",
 ]
-EagleModelTypes = Literal["eagle", "eagle3", MTPModelTypes]
+EagleModelTypes = Literal["eagle", "eagle3", "eagle-ptd", "eagle3-ptd", MTPModelTypes]
 SpeculativeMethod = Literal[
     "ngram",
     "medusa",
     "mlp_speculator",
     "draft_model",
     "suffix",
+    "eagle-ptd",
+    "eagle3-ptd",
     EagleModelTypes,
 ]
 
@@ -365,8 +367,8 @@ class SpeculativeConfig:
                     config_format=self.target_model_config.config_format,
                 )
 
-                # Automatically detect the method
-                if self.method in ("eagle", "eagle3"):
+                # Automatically detect the method (skip if already set to eagle variant)
+                if self.method in ("eagle", "eagle3", "eagle-ptd", "eagle3-ptd"):
                     pass
                 # examples:
                 # yuhuili/EAGLE-LLaMA3-Instruct-8B
@@ -408,7 +410,7 @@ class SpeculativeConfig:
                     )
 
                 # Replace hf_config for EAGLE draft_model
-                if self.method in ("eagle", "eagle3"):
+                if self.method in ("eagle", "eagle3", "eagle-ptd", "eagle3-ptd"):
                     from vllm.transformers_utils.configs import SpeculatorsConfig
                     from vllm.transformers_utils.configs.eagle import EAGLEConfig
 
@@ -697,7 +699,9 @@ class SpeculativeConfig:
                 )
 
     def use_eagle(self) -> bool:
-        return self.method in ("eagle", "eagle3", "mtp")
+        return self.method in (
+            "eagle", "eagle3", "eagle-ptd", "eagle3-ptd", "mtp"
+        )
 
     def uses_draft_model(self) -> bool:
         return self.method == "draft_model"

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -41,15 +41,13 @@ MTPModelTypes = Literal[
     "mtp",
     "pangu_ultra_moe_mtp",
 ]
-EagleModelTypes = Literal["eagle", "eagle3", "eagle-ptd", "eagle3-ptd", MTPModelTypes]
+EagleModelTypes = Literal["eagle", "eagle3", MTPModelTypes]
 SpeculativeMethod = Literal[
     "ngram",
     "medusa",
     "mlp_speculator",
     "draft_model",
     "suffix",
-    "eagle-ptd",
-    "eagle3-ptd",
     EagleModelTypes,
 ]
 
@@ -109,6 +107,10 @@ class SpeculativeConfig:
     speculative input batches can contain sequences of different lengths,
     which may only be supported by certain attention backends. This currently
     only affects the EAGLE method of speculation."""
+    parallel_draft: bool = False
+    """When True, generate all draft tokens in a single forward pass instead
+    of sequential passes. Requires a draft model trained for parallel
+    drafting."""
 
     # Ngram proposer configuration
     prompt_lookup_max: int | None = Field(default=None, ge=1)
@@ -368,7 +370,7 @@ class SpeculativeConfig:
                 )
 
                 # Automatically detect the method (skip if already set to eagle variant)
-                if self.method in ("eagle", "eagle3", "eagle-ptd", "eagle3-ptd"):
+                if self.method in ("eagle", "eagle3"):
                     pass
                 # examples:
                 # yuhuili/EAGLE-LLaMA3-Instruct-8B
@@ -410,7 +412,7 @@ class SpeculativeConfig:
                     )
 
                 # Replace hf_config for EAGLE draft_model
-                if self.method in ("eagle", "eagle3", "eagle-ptd", "eagle3-ptd"):
+                if self.method in ("eagle", "eagle3"):
                     from vllm.transformers_utils.configs import SpeculatorsConfig
                     from vllm.transformers_utils.configs.eagle import EAGLEConfig
 
@@ -699,9 +701,7 @@ class SpeculativeConfig:
                 )
 
     def use_eagle(self) -> bool:
-        return self.method in (
-            "eagle", "eagle3", "eagle-ptd", "eagle3-ptd", "mtp"
-        )
+        return self.method in ("eagle", "eagle3", "mtp")
 
     def uses_draft_model(self) -> bool:
         return self.method == "draft_model"

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1218,16 +1218,21 @@ class VllmConfig:
         computed_compile_ranges_split_points = []
 
         # The upper bound of the compile ranges is the max_num_batched_tokens.
-        # For speculative decoding with draft model, the compile range must be extended
-        # by 1 for each sequence.
+        # For speculative decoding, the compile range must be extended
+        # - Sequential: + 1 * max_num_seqs (one draft token per iteration)
+        # - Parallel draft: + num_speculative_tokens * max_num_seqs
         compile_range_end = self.scheduler_config.max_num_batched_tokens
         if compile_range_end is not None:
-            do_extend: bool = (
-                self.speculative_config is not None
-                and self.speculative_config.uses_draft_model()
-            )
-            if do_extend:
-                compile_range_end += self.scheduler_config.max_num_seqs
+            if self.speculative_config is not None and (
+                self.speculative_config.uses_draft_model()
+                or self.speculative_config.use_eagle()
+            ):
+                multiplier = (
+                    self.speculative_config.num_speculative_tokens
+                    if self.speculative_config.parallel_draft
+                    else 1
+                )
+                compile_range_end += multiplier * self.scheduler_config.max_num_seqs
 
             computed_compile_ranges_split_points.append(compile_range_end)
 

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -296,18 +296,9 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
             requires_grad=False,
         )
 
-        # Buffer for parallel drafting mask hidden state (loaded from checkpoint)
-        # Size depends on whether model uses aux hidden states (3x hidden_size)
-        eagle_config = getattr(self.config, "eagle_config", None)
-        use_aux = True  # Default for EAGLE3
-        if eagle_config is not None and "use_aux_hidden_state" in eagle_config:
-            use_aux = eagle_config["use_aux_hidden_state"]
-        mask_hidden_size = (
-            self.config.hidden_size * 3 if use_aux else self.config.hidden_size
-        )
         self.register_buffer(
             "mask_hidden",
-            torch.zeros(1, mask_hidden_size),
+            torch.zeros(1, self.config.hidden_size),
             persistent=False,
         )
 

--- a/vllm/transformers_utils/configs/eagle.py
+++ b/vllm/transformers_utils/configs/eagle.py
@@ -41,7 +41,7 @@ class EAGLEConfig(PretrainedConfig):
         # LlamaForCausalLM -> EagleLlamaForCausalLM
         # LlamaForCausalLM -> Eagle3LlamaForCausalLM
         # LlamaForCausalLMEagle3 -> LlamaForCausalLMEagle3
-        if method == "eagle":
+        if method in ("eagle", "eagle-ptd"):
             assert self.model is not None, (
                 "model should not be None when method is eagle"
             )
@@ -50,7 +50,7 @@ class EAGLEConfig(PretrainedConfig):
                 for arch in self.model.architectures
             ]
 
-        elif method == "eagle3":
+        elif method in ("eagle3", "eagle3-ptd"):
             assert self.model is not None, (
                 "model should not be None when method is eagle3"
             )
@@ -62,7 +62,8 @@ class EAGLEConfig(PretrainedConfig):
             ]
         else:
             raise ValueError(
-                f"Invalid method {method}. Supported methods are eagle and eagle3."
+                f"Invalid method {method}. Supported methods are "
+                "eagle, eagle3, eagle-ptd, and eagle3-ptd."
             )
 
         super().__init__(**kwargs)

--- a/vllm/transformers_utils/configs/eagle.py
+++ b/vllm/transformers_utils/configs/eagle.py
@@ -41,7 +41,7 @@ class EAGLEConfig(PretrainedConfig):
         # LlamaForCausalLM -> EagleLlamaForCausalLM
         # LlamaForCausalLM -> Eagle3LlamaForCausalLM
         # LlamaForCausalLMEagle3 -> LlamaForCausalLMEagle3
-        if method in ("eagle", "eagle-ptd"):
+        if method == "eagle":
             assert self.model is not None, (
                 "model should not be None when method is eagle"
             )
@@ -50,7 +50,7 @@ class EAGLEConfig(PretrainedConfig):
                 for arch in self.model.architectures
             ]
 
-        elif method in ("eagle3", "eagle3-ptd"):
+        elif method == "eagle3":
             assert self.model is not None, (
                 "model should not be None when method is eagle3"
             )
@@ -62,8 +62,7 @@ class EAGLEConfig(PretrainedConfig):
             ]
         else:
             raise ValueError(
-                f"Invalid method {method}. Supported methods are "
-                "eagle, eagle3, eagle-ptd, and eagle3-ptd."
+                f"Invalid method {method}. Supported methods are eagle and eagle3."
             )
 
         super().__init__(**kwargs)

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -76,8 +76,12 @@ class SpecDecodeBaseProposer:
         self.num_speculative_tokens = self.speculative_config.num_speculative_tokens
         # The drafter can get longer sequences than the target model.
         max_batch_size = vllm_config.scheduler_config.max_num_seqs
+        multiplier = (
+            self.num_speculative_tokens if self.speculative_config.parallel_draft else 1
+        )
         self.max_num_tokens = (
-            vllm_config.scheduler_config.max_num_batched_tokens + max_batch_size
+            vllm_config.scheduler_config.max_num_batched_tokens
+            + max_batch_size * multiplier
         )
         self.token_arange_np = np.arange(self.max_num_tokens)
         # We need to get the hidden size from the draft model config because

--- a/vllm/v1/spec_decode/ptd_eagle.py
+++ b/vllm/v1/spec_decode/ptd_eagle.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from vllm.forward_context import set_forward_context
+from vllm.logger import init_logger
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.model_executor.model_loader import get_model
+from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.spec_decode.eagle import EagleProposer
+
+logger = init_logger(__name__)
+
+PTD_METHODS = ("eagle-ptd", "eagle3-ptd")
+
+
+@triton.jit
+def ptd_prepare_inputs_kernel(
+    target_token_ids_ptr,
+    target_positions_ptr,
+    target_hidden_ptr,
+    mask_hidden_ptr,
+    next_token_ids_ptr,
+    last_token_indices_ptr,
+    original_slot_mapping_ptr,
+    block_table_ptr,
+    in_query_start_loc_ptr,
+    out_query_start_loc_ptr,
+    out_input_ids_ptr,
+    out_positions_ptr,
+    out_hidden_ptr,
+    out_slot_mapping_ptr,
+    batch_size: tl.constexpr,
+    K: tl.constexpr,
+    hidden_size: tl.constexpr,
+    block_size: tl.constexpr,
+    max_blocks: tl.constexpr,
+    mask_token_id: tl.constexpr,
+    max_model_len: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    """
+    Prepares inputs for PTD (Parallel Token Decoding) by constructing:
+    - Input token IDs: [shifted verified tokens, next_token, mask, mask, ...]
+    - Positions: [verified positions, incremented positions for draft tokens]
+    - Hidden states: [verified hidden states, mask_hidden for draft positions]
+    - Slot mapping: [verified slots, computed slots for draft positions]
+    """
+    out_idx = tl.program_id(0)
+    h_block = tl.program_id(1)
+
+    req_idx = 0
+    for r in range(batch_size):
+        out_start = tl.load(out_query_start_loc_ptr + r)
+        out_end = tl.load(out_query_start_loc_ptr + r + 1)
+        req_idx = tl.where((out_idx >= out_start) & (out_idx < out_end), r, req_idx)
+
+    in_start = tl.load(in_query_start_loc_ptr + req_idx)
+    out_start = tl.load(out_query_start_loc_ptr + req_idx)
+    global_last_idx = tl.load(last_token_indices_ptr + req_idx)
+    last_idx = global_last_idx - in_start
+
+    local_idx = out_idx - out_start
+    is_verified = local_idx <= last_idx
+
+    if h_block == 0:
+        if is_verified:
+            if local_idx < last_idx:
+                out_tok = tl.load(target_token_ids_ptr + in_start + local_idx + 1)
+            else:
+                out_tok = tl.load(next_token_ids_ptr + req_idx)
+        else:
+            out_tok = mask_token_id
+        tl.store(out_input_ids_ptr + out_idx, out_tok)
+
+        if is_verified:
+            out_pos = tl.load(target_positions_ptr + in_start + local_idx)
+        else:
+            last_pos = tl.load(target_positions_ptr + in_start + last_idx)
+            out_pos = last_pos + (local_idx - last_idx)
+            out_pos = tl.where(out_pos >= max_model_len, 0, out_pos)
+        tl.store(out_positions_ptr + out_idx, out_pos)
+
+        if is_verified:
+            slot = tl.load(original_slot_mapping_ptr + in_start + local_idx)
+        else:
+            last_pos = tl.load(target_positions_ptr + in_start + last_idx)
+            draft_pos = last_pos + (local_idx - last_idx)
+            draft_pos = tl.where(draft_pos >= max_model_len, 0, draft_pos)
+            block_num = draft_pos // block_size
+            block_offset = draft_pos % block_size
+            block_id = tl.load(block_table_ptr + req_idx * max_blocks + block_num)
+            slot = block_id * block_size + block_offset
+        tl.store(out_slot_mapping_ptr + out_idx, slot)
+
+    h_start = h_block * BLOCK_H
+    h_offs = h_start + tl.arange(0, BLOCK_H)
+    h_mask = h_offs < hidden_size
+
+    if is_verified:
+        out_vals = tl.load(
+            target_hidden_ptr + (in_start + local_idx) * hidden_size + h_offs,
+            mask=h_mask, other=0.0
+        )
+    else:
+        out_vals = tl.load(mask_hidden_ptr + h_offs, mask=h_mask, other=0.0)
+
+    tl.store(out_hidden_ptr + out_idx * hidden_size + h_offs, out_vals, mask=h_mask)
+
+
+class PtdEagleProposer(EagleProposer):
+    """Generates K draft tokens in a single forward pass using mask tokens."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        runner=None,
+    ):
+        super().__init__(vllm_config, device, runner)
+        self._raise_if_unsupported_method()
+        self._raise_if_multimodal()
+
+        self.K = self.num_speculative_tokens
+        self.slot_buffer = torch.zeros(
+            self.max_num_tokens, dtype=torch.int64, device=device
+        )
+        self.arange_K = torch.arange(self.K, device=device, dtype=torch.int64)
+
+        self.mask_hidden: torch.Tensor | None = None
+        self.mask_token_id: int | None = None
+        self.block_size = vllm_config.cache_config.block_size
+
+    def _raise_if_unsupported_method(self):
+        if self.method not in PTD_METHODS:
+            raise ValueError(
+                f"PtdEagleProposer only supports methods {PTD_METHODS}, "
+                f"got {self.method}"
+            )
+
+    def _raise_if_multimodal(self):
+        if self.supports_mm_inputs:
+            raise NotImplementedError(
+                "PTD speculative decoding does not support multimodal models"
+            )
+
+    def _get_eagle3_use_aux_hidden_state_from_config(self) -> bool:
+        if self.method != "eagle3-ptd":
+            return False
+        use_aux = True
+        eagle_config = getattr(
+            self.draft_model_config.hf_config, "eagle_config", None
+        )
+        if eagle_config is not None:
+            use_aux = eagle_config.get("use_aux_hidden_state", True)
+        return use_aux
+
+    def load_model(self, target_model: nn.Module) -> None:
+        draft_model_config = self.vllm_config.speculative_config.draft_model_config
+        target_attn_layer_names = set(
+            get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase).keys()
+        )
+
+        from vllm.compilation.backends import set_model_tag
+        with set_model_tag("ptd_eagle_head"):
+            self.model = get_model(
+                vllm_config=self.vllm_config, model_config=draft_model_config
+            )
+
+        draft_attn_layer_names = (
+            get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase).keys()
+            - target_attn_layer_names
+        )
+        self.attn_layer_names = list(draft_attn_layer_names)
+
+        config = self.draft_model_config.hf_config
+        self.mask_token_id = getattr(config, 'ptd_token_id', None)
+        if self.mask_token_id is None:
+            raise ValueError(
+                "PTD requires 'ptd_token_id' in draft model config.json"
+            )
+        self.mask_token_id = int(self.mask_token_id)
+
+        self.mask_hidden = self._load_mask_hidden()
+
+        if self.method == "eagle3-ptd" and self.eagle3_use_aux_hidden_state:
+            expected_aux_size = self.hidden_size * 3
+            if self.mask_hidden.shape[-1] == expected_aux_size:
+                self.mask_hidden = self.model.combine_hidden_states(self.mask_hidden)
+                logger.info(
+                    "Transformed mask_hidden from aux format to hidden_size"
+                )
+
+    def _load_mask_hidden(self) -> torch.Tensor:
+        checkpoint_path = Path(self.draft_model_config.model)
+
+        def normalize_shape(t: torch.Tensor) -> torch.Tensor:
+            t = t.to(device=self.device, dtype=self.dtype)
+            while t.dim() > 2 and t.size(0) == 1:
+                t = t.squeeze(0)
+            if t.dim() == 1:
+                t = t.unsqueeze(0)
+            return t
+
+        from safetensors.torch import load_file
+
+        # Look for mask_hidden in main model safetensors files
+        safetensor_files = list(checkpoint_path.glob("*.safetensors"))
+        for path in sorted(safetensor_files):
+            try:
+                weights = load_file(str(path))
+                if "mask_hidden" in weights:
+                    logger.info(f"Loaded mask_hidden from {path}")
+                    return normalize_shape(weights["mask_hidden"])
+            except Exception as e:
+                logger.warning(f"Failed to load {path}: {e}")
+
+        # Fallback: use embedding of mask token
+        logger.warning(
+            "mask_hidden not found in checkpoint, "
+            "using embedding of ptd_token_id as fallback"
+        )
+        embed = self.model.model.embed_tokens.weight[self.mask_token_id]
+        return normalize_shape(embed)
+
+    def propose(
+        self,
+        target_token_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        last_token_indices: torch.Tensor | None,
+        common_attn_metadata: CommonAttentionMetadata,
+        sampling_metadata: SamplingMetadata,
+        mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+        num_rejected_tokens_gpu: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if mm_embed_inputs is not None:
+            raise NotImplementedError(
+                "PTD speculative decoding does not support multimodal inputs"
+            )
+
+        batch_size = next_token_ids.shape[0]
+
+        if last_token_indices is None:
+            last_token_indices = common_attn_metadata.query_start_loc[1:] - 1
+
+        if self.method == "eagle3-ptd":
+            assert isinstance(self.model, Eagle3LlamaForCausalLM)
+            target_hidden_states = self.model.combine_hidden_states(
+                target_hidden_states
+            )
+
+        if self.attn_metadata_builder is None:
+            self.attn_metadata_builder = self._get_attention_metadata_builder()
+
+        K = self.K
+        draft_len = K - 1
+        in_qsl = common_attn_metadata.query_start_loc
+
+        accepted_lengths = last_token_indices - in_qsl[:batch_size] + 1
+        out_lens = accepted_lengths + draft_len
+
+        out_qsl = torch.zeros(
+            batch_size + 1, dtype=torch.int32, device=self.device
+        )
+        out_qsl[1:] = torch.cumsum(out_lens, dim=0)
+
+        total_out = (
+            common_attn_metadata.num_actual_tokens + batch_size * draft_len
+        )
+
+        in_qsl_cpu = common_attn_metadata.query_start_loc_cpu
+        accepted_lengths_cpu = (
+            in_qsl_cpu[1:batch_size+1] - in_qsl_cpu[:batch_size]
+        )
+        out_qsl_cpu = torch.zeros(batch_size + 1, dtype=torch.int32)
+        out_qsl_cpu[1:] = torch.cumsum(accepted_lengths_cpu + draft_len, dim=0)
+
+        slot_mapping = self._prepare_ptd_inputs(
+            target_token_ids, target_positions, target_hidden_states,
+            next_token_ids, last_token_indices,
+            common_attn_metadata.slot_mapping,
+            common_attn_metadata.block_table_tensor,
+            in_qsl, out_qsl, total_out, batch_size
+        )
+
+        seq_lens = common_attn_metadata.seq_lens.clone()
+        if num_rejected_tokens_gpu is not None:
+            seq_lens = seq_lens - num_rejected_tokens_gpu
+        seq_lens = (seq_lens + K).to(common_attn_metadata.seq_lens.dtype)
+
+        common_attn_metadata.query_start_loc = out_qsl
+        common_attn_metadata.query_start_loc_cpu = out_qsl_cpu
+        common_attn_metadata.seq_lens = seq_lens
+        common_attn_metadata.num_actual_tokens = total_out
+        common_attn_metadata.max_query_len = (
+            common_attn_metadata.max_query_len + draft_len
+        )
+        common_attn_metadata.max_seq_len = (
+            common_attn_metadata.max_seq_len + draft_len
+        )
+        common_attn_metadata.slot_mapping = slot_mapping
+        common_attn_metadata._seq_lens_cpu = None
+        common_attn_metadata._num_computed_tokens_cpu = None
+
+        attn_metadata = self.attn_metadata_builder.build_for_drafting(
+            common_attn_metadata=common_attn_metadata, draft_index=0
+        )
+        per_layer_metadata = {
+            name: attn_metadata for name in self.attn_layer_names
+        }
+
+        num_input, cudagraph_mode = self._get_ptd_cudagraph_config(total_out)
+
+        hidden = self._run_ptd_forward(
+            num_input, total_out, per_layer_metadata, cudagraph_mode
+        )
+
+        ends = out_qsl[1:batch_size+1]
+        starts = ends - K
+        indices = starts.unsqueeze(1) + self.arange_K
+        hidden_selected = hidden[indices.flatten()]
+
+        logits = self.model.compute_logits(hidden_selected)
+        return logits.argmax(dim=-1).view(batch_size, K)
+
+    def _prepare_ptd_inputs(
+        self,
+        target_token_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        last_token_indices: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        block_table: torch.Tensor,
+        in_qsl: torch.Tensor,
+        out_qsl: torch.Tensor,
+        total_out: int,
+        batch_size: int,
+    ) -> torch.Tensor:
+        BLOCK_H = 256
+        num_h_blocks = (self.hidden_size + BLOCK_H - 1) // BLOCK_H
+
+        ptd_prepare_inputs_kernel[(total_out, num_h_blocks)](
+            target_token_ids, target_positions, target_hidden_states,
+            self.mask_hidden, next_token_ids, last_token_indices,
+            slot_mapping, block_table, in_qsl, out_qsl,
+            self.input_ids, self.positions, self.hidden_states, self.slot_buffer,
+            batch_size=batch_size, K=self.K, hidden_size=self.hidden_size,
+            block_size=self.block_size, max_blocks=block_table.shape[1],
+            mask_token_id=self.mask_token_id, max_model_len=self.max_model_len,
+            BLOCK_H=BLOCK_H
+        )
+        return self.slot_buffer[:total_out]
+
+    def _get_ptd_cudagraph_config(
+        self, num_tokens: int
+    ) -> tuple[int, CUDAGraphMode]:
+        num_padded, _ = self._pad_batch_across_dp(num_tokens, num_tokens)
+
+        if (
+            self.use_cuda_graph
+            and num_padded <= self.compilation_config.max_cudagraph_capture_size
+        ):
+            num_input = self.vllm_config.pad_for_cudagraph(num_padded)
+            return num_input, CUDAGraphMode.PIECEWISE
+
+        return num_padded, CUDAGraphMode.NONE
+
+    def _run_ptd_forward(
+        self,
+        num_input: int,
+        num_out: int,
+        per_layer_metadata: dict,
+        cudagraph_mode: CUDAGraphMode,
+    ) -> torch.Tensor:
+        with set_forward_context(
+            per_layer_metadata, self.vllm_config,
+            num_tokens=num_input, cudagraph_runtime_mode=cudagraph_mode
+        ):
+            result = self.model(
+                input_ids=self.input_ids[:num_input],
+                positions=self._get_positions(num_input),
+                hidden_states=self.hidden_states[:num_input],
+                inputs_embeds=None,
+            )
+            hidden = result[0] if isinstance(result, tuple) else result
+        return hidden[:num_out]

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -147,9 +147,9 @@ from vllm.v1.sample.sampler import Sampler
 from vllm.v1.spec_decode.draft_model import DraftModelProposer
 from vllm.v1.spec_decode.eagle import EagleProposer
 from vllm.v1.spec_decode.medusa import MedusaProposer
-from vllm.v1.spec_decode.ptd_eagle import PTD_METHODS, PtdEagleProposer
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.spec_decode.ngram_proposer import NgramProposer
+from vllm.v1.spec_decode.ptd_eagle import PtdEagleProposer
 from vllm.v1.spec_decode.suffix_decoding import SuffixDecodingProposer
 from vllm.v1.structured_output.utils import apply_grammar_bitmask
 from vllm.v1.utils import CpuGpuBuffer, record_function_or_nullcontext
@@ -450,19 +450,13 @@ class GPUModelRunner(
                 )
             elif self.speculative_config.method == "suffix":
                 self.drafter = SuffixDecodingProposer(self.vllm_config)
-            elif self.speculative_config.method in PTD_METHODS:
-                # PTD: Parallel Token Decoding - uses separate proposer class
-                # NOTE: Must check BEFORE use_eagle() since PTD methods are
-                # included there
-                self.drafter = PtdEagleProposer(
-                    self.vllm_config, self.device, self
-                )
-                if self.speculative_config.method == "eagle3-ptd":
-                    self.use_aux_hidden_state_outputs = (
-                        self.drafter.eagle3_use_aux_hidden_state
-                    )
             elif self.speculative_config.use_eagle():
-                self.drafter = EagleProposer(self.vllm_config, self.device, self)
+                if self.speculative_config.parallel_draft:
+                    # Parallel drafting: generates all draft tokens in a
+                    # single forward pass
+                    self.drafter = PtdEagleProposer(self.vllm_config, self.device, self)
+                else:
+                    self.drafter = EagleProposer(self.vllm_config, self.device, self)
                 if self.speculative_config.method == "eagle3":
                     self.use_aux_hidden_state_outputs = (
                         self.drafter.eagle3_use_aux_hidden_state


### PR DESCRIPTION
## Purpose

PTD (Parallel Token Decoding) generates K draft tokens in a single forward pass instead of K sequential passes, reducing draft overhead for EAGLE speculative decoding.

```bash
vllm serve openai/gpt-oss-120b \
  --speculative-config '{"model": "<ptd-draft>", "method": "eagle3-ptd", "num_speculative_tokens": 4}' \
  --tensor-parallel-size 1 \
  --max-model-len 4096 \
  --no-enable-prefix-caching \
  --async-scheduling
```

## Performance

### TPOT: Constant vs Linear Growth

![TPOT Comparison](https://github.com/user-attachments/assets/74a36d21-543a-4459-a836-ec3057b3edbb)

### Throughput Comparison (C=1)

![Throughput Comparison](https://github.com/user-attachments/assets/cfd8dfb0-7497-4faf-8778-3ac1af70a707)

### Speedup vs Vanilla EAGLE3

![Speedup Comparison](https://github.com/user-attachments/assets/b23cef0d-33de-441d-9b78-0682ecc5a423)

## Status

**Output throughput** improvement at comparable acceptance rates (within ±2%):
- **C=1**: +12% (MT-Bench) to +16% (HumanEval) comparing optimal K for each method
- **C=8**: +6.5% (MT-Bench) to +10% (HumanEval) comparing optimal K for each method

**TPOT** remains constant at ~2.7-2.9ms regardless of K, while vanilla increases linearly from 3.15ms (K=3) to 4.33ms (K=8).

**TTFT** is comparable: PTD 33-38ms vs Vanilla 34-44ms.

## Best Throughput Comparison

| Scenario | PTD | Vanilla | Improvement |
|----------|------|---------|-------------|
| MT-Bench C=1 | 345 tok/s (K=4) | 308 tok/s (K=3) | **+12%** |
| MT-Bench C=8 | 1165 tok/s (K=3) | 1094 tok/s (K=3) | **+6.5%** |
| HumanEval C=1 | 391 tok/s (K=4) | 336 tok/s (K=3) | **+16%** |
| HumanEval C=8 | 1301 tok/s (K=6) | 1180 tok/s (K=3) | **+10%** |

Vanilla peaks at K=3; higher K incurs sequential overhead. PTD EAGLE3 benefits from K=4-6 due to parallel drafting.

## Speedup by K Value

| K | MT-Bench C=1 | HumanEval C=1 |
|---|--------------|---------------|
| 3 | +11% | +13% |
| 4 | +19% | +21% |
| 5 | +24% | +28% |
| 6 | +33% | +36% |
| 7 | +39% | +43% |
| 8 | +47% | +50% |

## TPOT Analysis

| K | PTD | Vanilla | Delta |
|---|------|---------|-------|
| 3 | 2.79ms | 3.15ms | -11% |
| 4 | 2.74ms | 3.33ms | -18% |
| 5 | 2.77ms | 3.52ms | -21% |
| 6 | 2.79ms | 3.80ms | -27% |
| 7 | 2.83ms | 4.05ms | -30% |
| 8 | 2.88ms | 4.33ms | -33% |

PTD EAGLE3 TPOT is constant; vanilla grows linearly with K.

## Implications for K Selection

Selecting K involves balancing two factors: higher K can yield more accepted tokens per verification, but also increases draft cost when acceptance is low. With vanilla EAGLE, generating K tokens requires K sequential forward passes, so the optimal K depends on expected acceptance rates.

PTD generates all K tokens in a single forward pass. For the K values tested (3-8), the additional tokens processed per forward have minimal impact on draft latency, as shown in the TPOT data above. This sublinear scaling reduces the cost of higher K settings relative to vanilla EAGLE.

This has a practical benefit: K selection becomes less sensitive to workload characteristics. Acceptance rates vary by prompt type. The benchmark data shows HumanEval averaging ~50% acceptance while MT-Bench averages ~35%. With PTD, choosing a higher K captures more tokens on high-acceptance prompts without proportionally increasing cost on lower-acceptance ones.

The benchmark results reflect this: vanilla EAGLE performs best at K=3, while PTD peaks at K=4-6 depending on workload.

<details>
<summary>PTD EAGLE3 Results (MT-Bench)</summary>

| K | C=1 | C=2 | C=4 | C=8 | TTFT | TPOT | Accept |
|---|-----|-----|-----|-----|------|------|--------|
| 3 | 342 | 538 | 794 | 1165 | 33ms | 2.79ms | 44.7% |
| 4 | 345 | 532 | 792 | 1148 | 33ms | 2.74ms | 37.3% |
| 5 | 341 | 526 | 779 | 1133 | 33ms | 2.77ms | 31.7% |
| 6 | 335 | 510 | 774 | 1133 | 33ms | 2.79ms | 26.9% |
| 7 | 331 | 503 | 728 | 1103 | 33ms | 2.83ms | 23.7% |
| 8 | 324 | 493 | 731 | 1083 | 35ms | 2.88ms | 21.0% |

**Per-Position Acceptance**

| K | P0 | P1 | P2 | P3 | P4 | P5 | P6 | P7 |
|---|-----|-----|-----|-----|-----|-----|-----|-----|
| 3 | 65% | 42% | 27% | - | - | - | - | - |
| 4 | 65% | 41% | 26% | 17% | - | - | - | - |
| 5 | 64% | 40% | 25% | 17% | 12% | - | - | - |
| 6 | 64% | 39% | 24% | 16% | 11% | 7% | - | - |
| 7 | 64% | 39% | 24% | 16% | 11% | 7% | 5% | - |
| 8 | 63% | 39% | 24% | 15% | 11% | 7% | 5% | 4% |

</details>

<details>
<summary>PTD EAGLE3 Results (HumanEval)</summary>

| K | C=1 | C=2 | C=4 | C=8 | TTFT | TPOT | Accept |
|---|-----|-----|-----|-----|------|------|--------|
| 3 | 379 | 596 | 867 | 1254 | 37ms | 2.57ms | 56.8% |
| 4 | 391 | 599 | 902 | 1284 | 38ms | 2.49ms | 48.7% |
| 5 | 391 | 597 | 875 | 1283 | 38ms | 2.48ms | 42.2% |
| 6 | 389 | 590 | 870 | 1301 | 38ms | 2.50ms | 36.7% |
| 7 | 385 | 576 | 832 | 1269 | 38ms | 2.52ms | 32.5% |
| 8 | 381 | 564 | 827 | 1241 | 38ms | 2.55ms | 29.3% |

**Per-Position Acceptance**

| K | P0 | P1 | P2 | P3 | P4 | P5 | P6 | P7 |
|---|-----|-----|-----|-----|-----|-----|-----|-----|
| 3 | 77% | 54% | 40% | - | - | - | - | - |
| 4 | 76% | 52% | 38% | 28% | - | - | - | - |
| 5 | 75% | 51% | 36% | 27% | 21% | - | - | - |
| 6 | 74% | 50% | 35% | 26% | 20% | 15% | - | - |
| 7 | 74% | 50% | 35% | 25% | 19% | 14% | 11% | - |
| 8 | 74% | 49% | 34% | 25% | 19% | 14% | 11% | 9% |

</details>

<details>
<summary>Vanilla EAGLE3 Results (MT-Bench)</summary>

| K | C=1 | C=2 | C=4 | C=8 | TTFT | TPOT | Accept |
|---|-----|-----|-----|-----|------|------|--------|
| 3 | 308 | 490 | 743 | 1094 | 34ms | 3.15ms | 43.0% |
| 4 | 289 | 466 | 715 | 1057 | 35ms | 3.33ms | 35.2% |
| 5 | 276 | 440 | 671 | 1005 | 37ms | 3.52ms | 30.9% |
| 6 | 252 | 401 | 626 | 951 | 38ms | 3.80ms | 25.5% |
| 7 | 238 | 380 | 588 | 916 | 39ms | 4.05ms | 22.4% |
| 8 | 221 | 352 | 560 | 859 | 40ms | 4.33ms | 19.4% |

**Per-Position Acceptance**

| K | P0 | P1 | P2 | P3 | P4 | P5 | P6 | P7 |
|---|-----|-----|-----|-----|-----|-----|-----|-----|
| 3 | 64% | 40% | 25% | - | - | - | - | - |
| 4 | 64% | 39% | 24% | 15% | - | - | - | - |
| 5 | 64% | 40% | 25% | 15% | 10% | - | - | - |
| 6 | 63% | 38% | 23% | 14% | 9% | 5% | - | - |
| 7 | 63% | 38% | 23% | 15% | 9% | 5% | 3% | - |
| 8 | 63% | 38% | 23% | 14% | 9% | 5% | 3% | 2% |

</details>

<details>
<summary>Vanilla EAGLE3 Results (HumanEval)</summary>

| K | C=1 | C=2 | C=4 | C=8 | TTFT | TPOT | Accept |
|---|-----|-----|-----|-----|------|------|--------|
| 3 | 336 | 536 | 803 | 1180 | 38ms | 2.91ms | 53.5% |
| 4 | 324 | 516 | 795 | 1167 | 39ms | 3.02ms | 45.2% |
| 5 | 305 | 488 | 756 | 1140 | 41ms | 3.20ms | 38.5% |
| 6 | 286 | 459 | 712 | 1090 | 42ms | 3.41ms | 33.3% |
| 7 | 269 | 431 | 673 | 1053 | 43ms | 3.63ms | 29.1% |
| 8 | 254 | 411 | 639 | 1018 | 44ms | 3.86ms | 25.7% |

**Per-Position Acceptance**

| K | P0 | P1 | P2 | P3 | P4 | P5 | P6 | P7 |
|---|-----|-----|-----|-----|-----|-----|-----|-----|
| 3 | 73% | 52% | 36% | - | - | - | - | - |
| 4 | 72% | 51% | 35% | 23% | - | - | - | - |
| 5 | 72% | 50% | 34% | 22% | 15% | - | - | - |
| 6 | 72% | 50% | 33% | 22% | 14% | 9% | - | - |
| 7 | 72% | 50% | 33% | 21% | 14% | 9% | 6% | - |
| 8 | 71% | 49% | 32% | 21% | 14% | 9% | 5% | 3% |

</details>

<details>
<summary>Benchmark Configuration</summary>

**Hardware**: P5e (H200), TP=1

**Draft Models**:
- PTD EAGLE3: Internally trained PTD draft model
- Vanilla EAGLE3: `nvidia/gpt-oss-120b-Eagle3-short-context`

**Server**:
```bash
vllm serve openai/gpt-oss-120b \
  --tensor-parallel-size 1 \
  --max-model-len 4096 \
  --speculative-config '{"model": "<draft>", "method": "<method>", "num_speculative_tokens": <K>}' \
  --no-enable-prefix-caching \
  --async-scheduling
```

**Benchmark (MT-Bench)**:
```bash
vllm bench serve \
  --backend openai-chat \
  --dataset-name hf \
  --dataset-path philschmid/mt-bench \
  --hf-split train \
  --hf-output-len 2048 \
  --num-prompts 80 \
  --max-concurrency <C> \
  --num-warmups 5 \
  --request-rate inf
```

**Benchmark (HumanEval)**:
```bash
vllm bench serve \
  --backend openai-chat \
  --dataset-name custom \
  --dataset-path /tmp/humaneval_custom.jsonl \
  --custom-output-len 512 \
  --num-prompts 164 \
  --max-concurrency <C> \
  --num-warmups 5 \
  --request-rate inf
```

</details>

## Changes

| File | Description |
|------|-------------|
| `vllm/v1/spec_decode/ptd_eagle.py` | New file: PtdEagleProposer with Triton kernel |
| `vllm/config/speculative.py` | Add `eagle-ptd`, `eagle3-ptd` to EagleModelTypes |
| `vllm/v1/worker/gpu_model_runner.py` | PTD proposer initialization and selection |
| `vllm/model_executor/models/llama_eagle3.py` | Skip `mask_hidden` during weight loading |
| `vllm/transformers_utils/configs/eagle.py` | Config validation for PTD fields |
| `examples/offline_inference/spec_decode.py` | Add PTD method to examples |
| `tests/v1/e2e/test_spec_decode.py` | Add `test_ptd_correctness` |

## Test Plan

- [x] MT-Bench benchmark (K=3-8, C=1,2,4,8)
- [x] HumanEval benchmark (K=3-8, C=1,2,4,8)
- [x] Vanilla EAGLE3 comparison
- [x] End-to-end inference test