### PR TITLE
[ROCm][Bugfix] Resolve request_id mismatch and prevent crashes in Disaggregated Serving for moriio kv-connector

### DIFF
--- a/examples/online_serving/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/online_serving/disaggregated_serving/moriio_toy_proxy_server.py
@@ -100,11 +100,13 @@ async def send_request_to_prefill(
     endpoint, req_data, request_id, d_endpoint, dip, dport, selected_prefill_dp_rank
 ):
     req_data_copy = req_data
+    external_req_id = f"cmpl-{request_id}-0"
 
     req_data_copy["kv_transfer_params"].update(
         {
             "do_remote_decode": True,
             "do_remote_prefill": False,
+            "external_req_id": external_req_id,
             "remote_handshake_port": d_endpoint["handshake_port"],
             "remote_notify_port": d_endpoint["notify_port"],
             "remote_engine_id": None,
@@ -162,6 +164,8 @@ async def stream_decode_response(session, response, request_id):
             raise RuntimeError(
                 f"decode response.status != 200, status = {response.status}"
             )
+    except Exception as e:
+        raise
     finally:
         await session.close()
 
@@ -256,6 +260,14 @@ async def handle_request():
                 selected_prefill_dp_rank,
             )
         )
+        def prefill_done_callback(task):
+            try:
+                task.result()
+            except Exception as e:
+                print(f"DEBUG: Prefill task failed with exception: {e}")
+
+        send_prefill_task.add_done_callback(prefill_done_callback)
+
         ip, port = extract_ip_port_fast(prefill_instance_endpoint["request_address"])
 
         req_data["max_tokens"] -= 1
@@ -263,6 +275,7 @@ async def handle_request():
         req_data["kv_transfer_params"] = {
             "do_remote_decode": False,
             "do_remote_prefill": True,
+            "external_req_id": f"cmpl-{request_id}-0",
             "remote_handshake_port": prefill_instance_endpoint["handshake_port"],
             "remote_notify_port": prefill_instance_endpoint["notify_port"],
             "remote_engine_id": None,

--- a/examples/online_serving/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/online_serving/disaggregated_serving/moriio_toy_proxy_server.py
@@ -164,7 +164,7 @@ async def stream_decode_response(session, response, request_id):
             raise RuntimeError(
                 f"decode response.status != 200, status = {response.status}"
             )
-    except Exception as e:
+    except Exception:
         raise
     finally:
         await session.close()

--- a/examples/online_serving/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/online_serving/disaggregated_serving/moriio_toy_proxy_server.py
@@ -260,13 +260,6 @@ async def handle_request():
                 selected_prefill_dp_rank,
             )
         )
-        def prefill_done_callback(task):
-            try:
-                task.result()
-            except Exception as e:
-                print(f"DEBUG: Prefill task failed with exception: {e}")
-
-        send_prefill_task.add_done_callback(prefill_done_callback)
 
         ip, port = extract_ip_port_fast(prefill_instance_endpoint["request_address"])
 

--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -103,15 +103,16 @@ def gptoss_server(default_server_args: list[str]):
 
 @pytest.fixture(scope="class")
 def gptoss_speculative_server(default_server_args: list[str]):
+    attention_backend = (
+        "TRITON_ATTN"
+        if not is_aiter_found_and_supported()
+        else "ROCM_AITER_UNIFIED_ATTN"
+    )
     server_args = default_server_args + [
         "--speculative-config",
         f'{{"model": "{GPT_OSS_SPECULATOR_NAME}", '
         f'"method": "eagle3", "num_speculative_tokens": 3}}',
-        f"--attention-backend={
-            'TRITON_ATTN'
-            if not is_aiter_found_and_supported()
-            else 'ROCM_AITER_UNIFIED_ATTN'
-        }",
+        f"--attention-backend={attention_backend}",
     ]
     # gpt-oss requires AITER unified attention on ROCm
     # TODO: Remove after fixing TRITON_ATTN issue on ROCm

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1833,9 +1833,7 @@ class Scheduler(SchedulerInterface):
                     req_id,
                 )
                 continue
-            logger.debug(
-                "Finished recving KV transfer for request %s", internal_id
-            )
+            logger.debug("Finished recving KV transfer for request %s", internal_id)
             self.finished_recving_kv_req_ids.add(internal_id)
         for req_id in kv_connector_output.finished_sending or ():
             internal_id = self._resolve_internal_req_id(req_id)
@@ -1845,9 +1843,7 @@ class Scheduler(SchedulerInterface):
                     req_id,
                 )
                 continue
-            logger.debug(
-                "Finished sending KV transfer for request %s", internal_id
-            )
+            logger.debug("Finished sending KV transfer for request %s", internal_id)
             self._free_blocks(self.requests[internal_id])
 
     def _update_requests_with_invalid_blocks(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -149,6 +149,9 @@ class Scheduler(SchedulerInterface):
 
         # req_id -> Request
         self.requests: dict[str, Request] = {}
+        # External <-> internal request ID mapping for fast KV transfer lookups.
+        self.external_to_internal_req_id: dict[str, set[str]] = {}
+        self.internal_to_external_req_id: dict[str, str] = {}
         # Scheduling policy
         try:
             self.policy = SchedulingPolicy(self.scheduler_config.policy)
@@ -1454,6 +1457,7 @@ class Scheduler(SchedulerInterface):
     def add_request(self, request: Request) -> None:
         self.waiting.add_request(request)
         self.requests[request.request_id] = request
+        self._track_external_req_id(request)
         if self.log_stats:
             request.record_event(EngineCoreEventType.QUEUED)
 
@@ -1517,6 +1521,7 @@ class Scheduler(SchedulerInterface):
     def _free_blocks(self, request: Request):
         assert request.is_finished()
         self.kv_cache_manager.free(request)
+        self._untrack_external_req_id(request.request_id)
         del self.requests[request.request_id]
 
     def get_num_unfinished_requests(self) -> int:
@@ -1745,6 +1750,66 @@ class Scheduler(SchedulerInterface):
         self.finished_recving_kv_req_ids.remove(request.request_id)
         return True
 
+    def _get_external_req_id(self, request: Request) -> str | None:
+        kv_transfer_params = request.kv_transfer_params or {}
+        external_req_id = kv_transfer_params.get("external_req_id")
+        if isinstance(external_req_id, str):
+            return external_req_id
+        return getattr(request, "external_req_id", None)
+
+    def _track_external_req_id(self, request: Request) -> None:
+        external_req_id = self._get_external_req_id(request)
+        if not external_req_id:
+            return
+        internal_id = request.request_id
+        existing_external = self.internal_to_external_req_id.get(internal_id)
+        if existing_external and existing_external != external_req_id:
+            internal_ids = self.external_to_internal_req_id.get(existing_external)
+            if internal_ids:
+                internal_ids.discard(internal_id)
+                if not internal_ids:
+                    del self.external_to_internal_req_id[existing_external]
+        self.internal_to_external_req_id[internal_id] = external_req_id
+        self.external_to_internal_req_id.setdefault(external_req_id, set()).add(
+            internal_id
+        )
+
+    def _untrack_external_req_id(self, request_id: str) -> None:
+        external_req_id = self.internal_to_external_req_id.pop(request_id, None)
+        if external_req_id is None:
+            return
+        internal_ids = self.external_to_internal_req_id.get(external_req_id)
+        if not internal_ids:
+            return
+        internal_ids.discard(request_id)
+        if not internal_ids:
+            del self.external_to_internal_req_id[external_req_id]
+
+    def _resolve_internal_req_id(self, req_id: str) -> str | None:
+        if req_id in self.requests:
+            return req_id
+        internal_ids = self.external_to_internal_req_id.get(req_id)
+        if internal_ids:
+            if len(internal_ids) == 1:
+                return next(iter(internal_ids))
+            for internal_id in self.requests:
+                if internal_id in internal_ids:
+                    return internal_id
+        for internal_id, request in self.requests.items():
+            if getattr(request, "external_req_id", None) == req_id:
+                self.external_to_internal_req_id.setdefault(req_id, set()).add(
+                    internal_id
+                )
+                self.internal_to_external_req_id[internal_id] = req_id
+                return internal_id
+            if internal_id.startswith(f"{req_id}-"):
+                self.external_to_internal_req_id.setdefault(req_id, set()).add(
+                    internal_id
+                )
+                self.internal_to_external_req_id[internal_id] = req_id
+                return internal_id
+        return None
+
     def _update_from_kv_xfer_finished(self, kv_connector_output: KVConnectorOutput):
         """
         KV Connector: update the scheduler state based on the output.
@@ -1759,19 +1824,9 @@ class Scheduler(SchedulerInterface):
         if self.connector is not None:
             self.connector.update_connector_output(kv_connector_output)
 
-        def _resolve_internal_req_id(req_id: str) -> str | None:
-            if req_id in self.requests:
-                return req_id
-            for internal_id, request in self.requests.items():
-                if getattr(request, "external_req_id", None) == req_id:
-                    return internal_id
-                if internal_id.startswith(f"{req_id}-"):
-                    return internal_id
-            return None
-
         # KV Connector:: update recv and send status from last step.
         for req_id in kv_connector_output.finished_recving or ():
-            internal_id = _resolve_internal_req_id(req_id)
+            internal_id = self._resolve_internal_req_id(req_id)
             if internal_id is None:
                 logger.warning(
                     "Finished recving KV transfer for unknown request %s",
@@ -1783,7 +1838,7 @@ class Scheduler(SchedulerInterface):
             )
             self.finished_recving_kv_req_ids.add(internal_id)
         for req_id in kv_connector_output.finished_sending or ():
-            internal_id = _resolve_internal_req_id(req_id)
+            internal_id = self._resolve_internal_req_id(req_id)
             if internal_id is None:
                 logger.warning(
                     "Finished sending KV transfer for unknown request %s",


### PR DESCRIPTION
**Problem** :The Decode scheduler crashes in Disaggregated Serving (WRITE mode) due to request_id mismatch during KV cache transfer.

**Root Cause**: Prefill nodes send IDs in a base format (e.g., cmpl-<uuid>), while the Decode node expects internal IDs with specific suffixes (e.g., cmpl-<uuid>-0-<random>). This discrepancy causes the scheduler to fail its internal lookup and hit a fatal assertion.

**Solution**: Implemented a fuzzy ID resolution logic that matches external IDs to internal ones (via prefix and attribute checking).

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

