### PR TITLE
Fix gpt‑oss Harmony token leaks in tool names and streaming content #32587

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/stream_harmony.py
+++ b/vllm/entrypoints/openai/chat_completion/stream_harmony.py
@@ -17,12 +17,6 @@ from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
     DeltaToolCall,
 )
-from vllm.entrypoints.openai.parser.harmony_utils import (
-    _extract_function_name_from_recipient,
-)
-from vllm.logger import init_logger
-
-logger = init_logger(__name__)
 
 
 class TokenState(NamedTuple):
@@ -115,7 +109,7 @@ def extract_harmony_streaming_delta(
             opened_new_call = False
             if prev_recipient != group.recipient:
                 # New tool call - emit the opening message
-                tool_name = _extract_function_name_from_recipient(group.recipient)
+                tool_name = group.recipient.split("functions.", 1)[1]
                 tool_messages.append(
                     DeltaToolCall(
                         id=make_tool_call_id(),

--- a/vllm/entrypoints/openai/chat_completion/stream_harmony.py
+++ b/vllm/entrypoints/openai/chat_completion/stream_harmony.py
@@ -17,6 +17,9 @@ from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
     DeltaToolCall,
 )
+from vllm.entrypoints.openai.parser.harmony_utils import (
+    _extract_function_name_from_recipient,
+)
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -112,21 +115,7 @@ def extract_harmony_streaming_delta(
             opened_new_call = False
             if prev_recipient != group.recipient:
                 # New tool call - emit the opening message
-                # Diagnostic: detect special tokens in recipient
-                if group.recipient and (
-                    "<|channel|>" in group.recipient
-                    or "<|recipient|>" in group.recipient
-                ):
-                    text_preview = group.text[:50] if group.text else None
-                    logger.warning(
-                        "Harmony parser bug: streaming recipient contains "
-                        "special tokens. recipient=%r, channel=%r, "
-                        "text_preview=%r",
-                        group.recipient,
-                        group.channel,
-                        text_preview,
-                    )
-                tool_name = group.recipient.split("functions.", 1)[1]
+                tool_name = _extract_function_name_from_recipient(group.recipient)
                 tool_messages.append(
                     DeltaToolCall(
                         id=make_tool_call_id(),

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -6,6 +6,7 @@ import json
 from collections.abc import Iterable, Sequence
 from typing import Literal
 
+import regex as re
 from openai.types.responses import (
     ResponseFunctionToolCall,
     ResponseOutputItem,
@@ -67,6 +68,30 @@ MCP_BUILTIN_TOOLS: set[str] = {
     "code_interpreter",
     "container",
 }
+
+_HARMONY_CONTROL_TOKEN_RE = re.compile(r"<\|[^>]*?\|>")
+_INVALID_TOOL_NAME = "__invalid_tool__"
+
+
+def sanitize_harmony_tool_name(name: str | None) -> str:
+    if not name:
+        return ""
+    cleaned = name.strip()
+    if "<|" not in cleaned:
+        return cleaned
+    prefix = cleaned.split("<|", 1)[0].strip()
+    if prefix:
+        return prefix
+    cleaned = _HARMONY_CONTROL_TOKEN_RE.sub("", cleaned).strip()
+    return cleaned or _INVALID_TOOL_NAME
+
+
+def strip_harmony_control_tokens(text: str | None) -> str | None:
+    if text is None:
+        return None
+    if "<|" not in text:
+        return text
+    return _HARMONY_CONTROL_TOKEN_RE.sub("", text)
 
 
 def has_custom_tools(tool_types: set[str]) -> bool:
@@ -220,7 +245,8 @@ def parse_response_input(
     elif response_msg["type"] == "function_call":
         msg = Message.from_role_and_content(Role.ASSISTANT, response_msg["arguments"])
         msg = msg.with_channel("commentary")
-        msg = msg.with_recipient(f"functions.{response_msg['name']}")
+        tool_name = sanitize_harmony_tool_name(response_msg.get("name"))
+        msg = msg.with_recipient(f"functions.{tool_name}")
         msg = msg.with_content_type("json")
     else:
         raise ValueError(f"Unknown input type: {response_msg['type']}")
@@ -238,9 +264,8 @@ def parse_chat_inputs_to_harmony_messages(chat_msgs: list) -> list[Message]:
     # Collect tool id to name mappings for tool response recipient values
     for chat_msg in chat_msgs:
         for tool_call in chat_msg.get("tool_calls", []):
-            tool_id_names[tool_call.get("id")] = tool_call.get("function", {}).get(
-                "name"
-            )
+            raw_name = tool_call.get("function", {}).get("name")
+            tool_id_names[tool_call.get("id")] = sanitize_harmony_tool_name(raw_name)
 
     for chat_msg in chat_msgs:
         msgs.extend(parse_chat_input_to_harmony_message(chat_msg, tool_id_names))
@@ -333,7 +358,7 @@ def parse_chat_input_to_harmony_message(
 
         for call in tool_calls:
             func = call.get("function", {})
-            name = func.get("name", "")
+            name = sanitize_harmony_tool_name(func.get("name"))
             arguments = func.get("arguments", "") or ""
             msg = Message.from_role_and_content(Role.ASSISTANT, arguments)
             msg = msg.with_channel("commentary")
@@ -348,7 +373,7 @@ def parse_chat_input_to_harmony_message(
     # Tool role message (tool output)
     if role == "tool":
         tool_call_id = chat_msg.get("tool_call_id", "")
-        name = tool_id_names.get(tool_call_id, "")
+        name = sanitize_harmony_tool_name(tool_id_names.get(tool_call_id, ""))
         content = chat_msg.get("content", "") or ""
         content = flatten_chat_text_content(content)
 
@@ -410,7 +435,7 @@ def parse_input_to_harmony_message(chat_msg) -> list[Message]:
         msgs: list[Message] = []
         for call in tool_calls:
             func = call.get("function", {})
-            name = func.get("name", "")
+            name = sanitize_harmony_tool_name(func.get("name"))
             arguments = func.get("arguments", "") or ""
             msg = Message.from_role_and_content(Role.ASSISTANT, arguments)
             msg = msg.with_channel("commentary")
@@ -421,7 +446,7 @@ def parse_input_to_harmony_message(chat_msg) -> list[Message]:
 
     # Tool role message (tool output)
     if role == "tool":
-        name = chat_msg.get("name", "")
+        name = sanitize_harmony_tool_name(chat_msg.get("name"))
         content = chat_msg.get("content", "") or ""
         content = flatten_chat_text_content(content)
 
@@ -530,7 +555,7 @@ def _parse_browser_tool_call(message: Message, recipient: str) -> ResponseOutput
 
 def _parse_function_call(message: Message, recipient: str) -> list[ResponseOutputItem]:
     """Parse function calls into function tool call items."""
-    function_name = recipient.split(".")[-1]
+    function_name = sanitize_harmony_tool_name(recipient.split(".")[-1])
     output_items = []
     for content in message.content:
         random_id = random_uuid()
@@ -554,7 +579,10 @@ def _parse_reasoning_content(message: Message) -> list[ResponseOutputItem]:
             summary=[],
             type="reasoning",
             content=[
-                ResponseReasoningTextContent(text=content.text, type="reasoning_text")
+                ResponseReasoningTextContent(
+                    text=strip_harmony_control_tokens(content.text),
+                    type="reasoning_text",
+                )
             ],
             status=None,
         )
@@ -567,7 +595,7 @@ def _parse_final_message(message: Message) -> ResponseOutputItem:
     contents = []
     for content in message.content:
         output_text = ResponseOutputText(
-            text=content.text,
+            text=strip_harmony_control_tokens(content.text),
             annotations=[],  # TODO
             type="output_text",
             logprobs=None,  # TODO
@@ -681,13 +709,14 @@ def parse_remaining_state(parser: StreamableParser) -> list[ResponseOutputItem]:
 
     if current_recipient and parser.current_channel in ("commentary", "analysis"):
         if current_recipient.startswith("functions."):
+            function_name = sanitize_harmony_tool_name(current_recipient.split(".")[-1])
             rid = random_uuid()
             return [
                 ResponseFunctionToolCall(
                     arguments=parser.current_content,
                     call_id=f"call_{rid}",
                     type="function_call",
-                    name=current_recipient.split(".")[-1],
+                    name=function_name,
                     id=f"fc_{rid}",
                     status="in_progress",
                 )
@@ -720,7 +749,8 @@ def parse_remaining_state(parser: StreamableParser) -> list[ResponseOutputItem]:
                 type="reasoning",
                 content=[
                     ResponseReasoningTextContent(
-                        text=parser.current_content, type="reasoning_text"
+                        text=strip_harmony_control_tokens(parser.current_content),
+                        type="reasoning_text",
                     )
                 ],
                 status=None,
@@ -735,7 +765,8 @@ def parse_remaining_state(parser: StreamableParser) -> list[ResponseOutputItem]:
                 type="reasoning",
                 content=[
                     ResponseReasoningTextContent(
-                        text=parser.current_content, type="reasoning_text"
+                        text=strip_harmony_control_tokens(parser.current_content),
+                        type="reasoning_text",
                     )
                 ],
                 status=None,
@@ -744,7 +775,7 @@ def parse_remaining_state(parser: StreamableParser) -> list[ResponseOutputItem]:
 
     if parser.current_channel == "final":
         output_text = ResponseOutputText(
-            text=parser.current_content,
+            text=strip_harmony_control_tokens(parser.current_content),
             annotations=[],  # TODO
             type="output_text",
             logprobs=None,  # TODO
@@ -814,6 +845,8 @@ def parse_chat_output(
     final_content: str | None = "\n".join(final_texts)
 
     # Return None instead of empty string since existing callers check for None
+    reasoning = strip_harmony_control_tokens(reasoning)
+    final_content = strip_harmony_control_tokens(final_content)
     reasoning = reasoning or None
     final_content = final_content or None
 

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -87,6 +87,8 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     parse_remaining_state,
     parse_response_input,
     render_for_completion,
+    sanitize_harmony_tool_name,
+    strip_harmony_control_tokens,
 )
 from vllm.entrypoints.openai.responses.context import (
     ConversationContext,
@@ -1616,7 +1618,9 @@ class OpenAIServingResponses(OpenAIServing):
         state: HarmonyStreamingState,
     ) -> list[StreamingResponsesResponse]:
         """Emit events when a function call completes."""
-        function_name = previous_item.recipient[len("functions.") :]
+        function_name = sanitize_harmony_tool_name(
+            previous_item.recipient[len("functions.") :]
+        )
         events = []
         events.append(
             ResponseFunctionCallArgumentsDoneEvent(
@@ -1699,8 +1703,9 @@ class OpenAIServingResponses(OpenAIServing):
         state: HarmonyStreamingState,
     ) -> list[StreamingResponsesResponse]:
         """Emit events when a reasoning (analysis) item completes."""
+        sanitized_text = strip_harmony_control_tokens(previous_item.content[0].text)
         content = ResponseReasoningTextContent(
-            text=previous_item.content[0].text,
+            text=sanitized_text,
             type="reasoning_text",
         )
         reasoning_item = ResponseReasoningItem(
@@ -1718,7 +1723,7 @@ class OpenAIServingResponses(OpenAIServing):
                 sequence_number=-1,
                 output_index=state.current_output_index,
                 content_index=state.current_content_index,
-                text=previous_item.content[0].text,
+                text=sanitized_text,
             )
         )
         events.append(
@@ -1747,9 +1752,10 @@ class OpenAIServingResponses(OpenAIServing):
         state: HarmonyStreamingState,
     ) -> list[StreamingResponsesResponse]:
         """Emit events when a final text output item completes."""
+        sanitized_text = strip_harmony_control_tokens(previous_item.content[0].text)
         text_content = ResponseOutputText(
             type="output_text",
-            text=previous_item.content[0].text,
+            text=sanitized_text,
             annotations=[],
         )
         events = []
@@ -1759,7 +1765,7 @@ class OpenAIServingResponses(OpenAIServing):
                 sequence_number=-1,
                 output_index=state.current_output_index,
                 content_index=state.current_content_index,
-                text=previous_item.content[0].text,
+                text=sanitized_text,
                 logprobs=[],
                 item_id=state.current_item_id,
             )
@@ -1859,7 +1865,7 @@ class OpenAIServingResponses(OpenAIServing):
                 content_index=state.current_content_index,
                 output_index=state.current_output_index,
                 item_id=state.current_item_id,
-                delta=ctx.last_content_delta,
+                delta=strip_harmony_control_tokens(ctx.last_content_delta),
                 # TODO, use logprobs from ctx.last_request_output
                 logprobs=[],
             )
@@ -1909,7 +1915,7 @@ class OpenAIServingResponses(OpenAIServing):
                 item_id=state.current_item_id,
                 output_index=state.current_output_index,
                 content_index=state.current_content_index,
-                delta=ctx.last_content_delta,
+                delta=strip_harmony_control_tokens(ctx.last_content_delta),
                 sequence_number=-1,
             )
         )
@@ -2390,7 +2396,9 @@ class OpenAIServingResponses(OpenAIServing):
         events = []
         if state.is_first_function_call_delta is False:
             state.is_first_function_call_delta = True
-            fc_name = ctx.parser.current_recipient[len("functions.") :]
+            fc_name = sanitize_harmony_tool_name(
+                ctx.parser.current_recipient[len("functions.") :]
+            )
             state.current_item_id = f"fc_{random_uuid()}"
             tool_call_item = ResponseFunctionToolCall(
                 name=fc_name,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -2015,24 +2015,7 @@ class OpenAIServingResponses(OpenAIServing):
         if not state.sent_output_item_added:
             state.sent_output_item_added = True
             state.current_item_id = f"mcp_{random_uuid()}"
-            recipient = ctx.parser.current_recipient
-
-            # Diagnostic: detect special tokens in current_recipient
-            if recipient and (
-                "<|channel|>" in recipient or "<|recipient|>" in recipient
-            ):
-                logger.warning(
-                    "Harmony parser bug: MCP prefix current_recipient "
-                    "contains special tokens. recipient=%r, channel=%r",
-                    recipient,
-                    ctx.parser.current_channel,
-                )
-
-            mcp_name = (
-                recipient[len("mcp.") :]
-                if recipient and recipient.startswith("mcp.")
-                else recipient
-            )
+            mcp_name = ctx.parser.current_recipient[len("mcp.") :]
 
             events.append(
                 ResponseOutputItemAddedEvent(
@@ -2096,25 +2079,8 @@ class OpenAIServingResponses(OpenAIServing):
             or ctx.parser.current_channel == "analysis"
         ) and ctx.parser.current_recipient is not None:
             recipient = ctx.parser.current_recipient
-
-            # Diagnostic: detect special tokens in current_recipient
-            if recipient and (
-                "<|channel|>" in recipient or "<|recipient|>" in recipient
-            ):
-                last_delta = (
-                    ctx.last_content_delta[:50] if ctx.last_content_delta else None
-                )
-                logger.warning(
-                    "Harmony parser bug: streaming current_recipient "
-                    "contains special tokens. recipient=%r, channel=%r, "
-                    "last_content_delta=%r",
-                    recipient,
-                    ctx.parser.current_channel,
-                    last_delta,
-                )
-
             # Check for function calls first - they have their own event handling
-            if recipient and recipient.startswith("functions."):
+            if recipient.startswith("functions."):
                 return self._emit_function_call_delta_events(ctx, state)
             is_mcp_tool = self._is_mcp_tool_by_namespace(recipient)
             if is_mcp_tool:


### PR DESCRIPTION

## Purpose
 #32587

Defined sanitize_harmony_tool_name and strip_harmony_control_tokens in harmony_utils.py.

Used the sanitizer when reconstructing Harmony messages from chat/response history and when converting Harmony outputs back into API responses in harmony_utils.py.

Applied the sanitizer in tool extraction for chat completions (non‑stream) and stripped control tokens from final/commentary content in openai_tool_parser.py.

Applied the sanitizer in streaming deltas for chat completions and stripped control tokens from streamed content/reasoning deltas in stream_harmony.py.

Applied the sanitizer for function call events and stripped control tokens from response streaming deltas and done events in serving.py.

## Test Plan
```
python -m vllm.entrypoints.openai.api_server \
  --model openai/gpt-oss-20b \
  --served-model-name gpt-oss-20b \
  --host 0.0.0.0 \
  --port 8000 \
  --gpu-memory-utilization 0.93 \
  --tensor-parallel-size 1 \
  --max-num-batched-tokens 8192 \
  --disable-log-requests \
  --tool-call-parser openai \
  --reasoning-parser openai_gptoss \
  --enable-auto-tool-choice
```
## Test Result
main branch : https://paste.ubuntu.com/p/YthB2VTPQ8/ 

this branch 
<img width="1180" height="533" alt="image" src="https://github.com/user-attachments/assets/f8e0c4b0-701c-42dc-be38-e574fbf4772e" />

pytest tests/entrypoints/openai/parser/test_harmony_utils.py -v --  passed
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

