### PR TITLE
[Bugfix]: Enable Convolution layer custom ops by default

### DIFF
--- a/vllm/model_executor/layers/conv.py
+++ b/vllm/model_executor/layers/conv.py
@@ -18,6 +18,10 @@ class ConvLayerBase(CustomOp):
 
     num_dim: int
 
+    @classmethod
+    def enabled(cls) -> bool:
+        return True
+
     def __init__(
         self,
         in_channels: int,


### PR DESCRIPTION

## Purpose
- Fix https://github.com/vllm-project/vllm/issues/32545#issuecomment-3768448894
- Actually, the `Conv2dLayer` is always use linear implementation without `enforce_eager=True`, because it's disabled by default.
- This PR enabled it by default like `MMEncoderAttention`.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

