### PR TITLE
[Bugfix] Fix E2E latency calculation and add warmup support in mm_processor benchmark

### DIFF
--- a/vllm/benchmarks/mm_processor.py
+++ b/vllm/benchmarks/mm_processor.py
@@ -59,15 +59,16 @@ def collect_mm_processor_stats(
 
     for stats_dict in stats_list:
         stats_by_stage["hf_processor_time"].append(
-            stats_dict.get("hf_processor_time", 0.0))
-        stats_by_stage["hashing_time"].append(
-            stats_dict.get("hashing_time", 0.0))
+            stats_dict.get("hf_processor_time", 0.0)
+        )
+        stats_by_stage["hashing_time"].append(stats_dict.get("hashing_time", 0.0))
         stats_by_stage["cache_lookup_time"].append(
-            stats_dict.get("cache_lookup_time", 0.0))
+            stats_dict.get("cache_lookup_time", 0.0)
+        )
         stats_by_stage["prompt_update_time"].append(
-            stats_dict.get("prompt_update_time", 0.0))
-        stats_by_stage["total_time"].append(
-            stats_dict.get("total_time", 0.0))
+            stats_dict.get("prompt_update_time", 0.0)
+        )
+        stats_by_stage["total_time"].append(stats_dict.get("total_time", 0.0))
 
     return stats_by_stage
 
@@ -200,9 +201,7 @@ def benchmark_multimodal_processor(
     end_time = time.perf_counter()
     total_time = end_time - start_time
 
-    mm_stats_by_stage = collect_mm_processor_stats(
-        llm.llm_engine, num_warmups
-    )
+    mm_stats_by_stage = collect_mm_processor_stats(llm.llm_engine, num_warmups)
 
     if not any(mm_stats_by_stage.values()):
         print(
@@ -224,7 +223,7 @@ def benchmark_multimodal_processor(
         if not output.finished or output.metrics is None:
             continue
         metrics = output.metrics
-        # Use first_token_latency + (last_token_ts - first_token_ts) to calculate E2E latency
+        # Calculate E2E latency as: TTFT + (last_token_ts - first_token_ts)
         if (
             getattr(metrics, "first_token_latency", None) is not None
             and getattr(metrics, "last_token_ts", None) is not None
@@ -238,7 +237,8 @@ def benchmark_multimodal_processor(
     if not e2el_times and completed > 0:
         print(
             "\n⚠️  Warning: Detailed end-to-end latency metrics not available.\n"
-            "   Falling back to average request latency (total_time / num_completed_requests).\n"
+            "   Falling back to average request latency "
+            "(total_time / num_completed_requests).\n"
         )
         avg_time_per_request = total_time / completed
         e2el_times = [avg_time_per_request * 1000] * completed

--- a/vllm/benchmarks/mm_processor.py
+++ b/vllm/benchmarks/mm_processor.py
@@ -38,7 +38,7 @@ except ImportError:
 
 def collect_mm_processor_stats(
     llm_engine: Any,
-    warmup_requests: int = 0,
+    num_warmup_reqs: int = 0,
 ) -> dict[str, list[float]]:
     """
     Collect multimodal processor timing stats.
@@ -55,7 +55,7 @@ def collect_mm_processor_stats(
     }
 
     # Skip warmup requests
-    stats_list = list(all_stats.values())[warmup_requests:]
+    stats_list = list(all_stats.values())[num_warmup_reqs:]
 
     for stats_dict in stats_list:
         stats_by_stage["hf_processor_time"].append(
@@ -177,13 +177,7 @@ def benchmark_multimodal_processor(
         warmup_prompts = [req.prompt for req in warmup_requests]
         warmup_output_lens = [req.expected_output_len for req in warmup_requests]
         warmup_sampling_params = [
-            SamplingParams(
-                n=1,
-                temperature=0.0,
-                max_tokens=output_len,
-                detokenize=True,
-            )
-            for output_len in warmup_output_lens
+            SamplingParams(max_tokens=output_len) for output_len in warmup_output_lens
         ]
         llm.chat(
             warmup_prompts,

--- a/vllm/benchmarks/mm_processor.py
+++ b/vllm/benchmarks/mm_processor.py
@@ -171,6 +171,7 @@ def benchmark_multimodal_processor(
         # Create a temporary args object for warmup requests
         warmup_args = argparse.Namespace(**vars(args))
         warmup_args.num_prompts = num_warmups
+        warmup_args.seed += 1
         warmup_requests = get_requests(warmup_args, tokenizer)
         warmup_prompts = [req.prompt for req in warmup_requests]
         warmup_output_lens = [req.expected_output_len for req in warmup_requests]


### PR DESCRIPTION
## Purpose
This PR fixes a bug in the end-to-end (E2E) latency calculation logic within `vllm/benchmarks/mm_processor.py` and introduces a warm-up mechanism for more stable benchmarking.

**The Problem:**
**Missing Fields**: The code attempted to access `finished_time` or `last_token_time` in `output.metrics` (which is `RequestStateStats`). These fields do not exist in the v1 metrics implementation. As a result, the benchmark always fell back to calculating a simple average (Total Time / Requests) for all requests, losing distribution details (like P99/P50).

**The Solution:**
1. **Fix Latency Calculation**: Re-implemented the calculation using valid, clock-aligned fields from `RequestStateStats`:
   `e2e_latency = metrics.first_token_latency + (metrics.last_token_ts - metrics.first_token_ts)`
2. **Add Warm-up Support**: Added a `--num-warmups` argument (default: 1) to allow running warm-up requests before the actual benchmark. The statistics from these warm-up requests are excluded from the final results to ensure accuracy.

## Test Plan

```bash
vllm bench mm-processor     --model /workspace/models/Qwen3-VL-32B-Instruct/     --dataset-name random-mm     --random-input-len 1024     --random-output-len 16     --random-mm-base-items-per-request 10     --random-mm-bucket-config '{(256, 512, 1): 0.4, (224, 480, 1): 0.3, (288, 544, 1): 0.3}'     --num-prompts 32     --metric-percentiles 75     --tensor-parallel-size 4   --no-enable-prefix-caching     --mm-processor-cache-gb 0
```

## Test Result
Main Branch
```
================================================================================
Multimodal Processor Benchmark Results
================================================================================

MM Processor Timing (ms):
             Stage  Mean Median   Std P75.0
 hf_processor_time 62.75  59.25 21.79 69.68
      hashing_time  0.01   0.01  0.01  0.01
 cache_lookup_time  0.00   0.00  0.00  0.00
prompt_update_time  2.26   2.17  0.24  2.25
        total_time 65.02  61.53 21.87 72.27

End-to-End Latency (ms):
Metric Value (ms)
  Mean     660.36
Median     660.36
   Std       0.00
 P75.0     660.36
```
(Note: Mean, Median, and P75.0 are identical due to fallback logic. Also, without warmup, the MM Processor Timing stats show high variance/Std.)

This PR
```
================================================================================
Multimodal Processor Benchmark Results
================================================================================

MM Processor Timing (ms):
             Stage  Mean Median  Std P75.0
 hf_processor_time 50.81  48.28 7.03 52.51
      hashing_time  0.01   0.01 0.00  0.01
 cache_lookup_time  0.00   0.00 0.00  0.00
prompt_update_time  2.21   2.21 0.08  2.27
        total_time 53.03  50.47 7.03 54.74

End-to-End Latency (ms):
Metric Value (ms)
  Mean    4043.66
Median    3925.96
   Std     758.46
 P75.0    4321.55
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

