### PR TITLE
[Bugfix] Fix the  fp8_mqa_logits dim mismatch

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -686,7 +686,7 @@ def sparse_attn_indexer(
                 fp8_mqa_logits_func = rocm_fp8_mqa_logits
             logits = fp8_mqa_logits_func(
                 q_fp8[chunk.token_start : chunk.token_end],
-                (k_fp8, k_scale.view(torch.float32)),
+                (k_fp8, k_scale.view(torch.float32).flatten()),
                 weights[chunk.token_start : chunk.token_end],
                 chunk.cu_seqlen_ks,
                 chunk.cu_seqlen_ke,

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -249,8 +249,8 @@ def fp8_mqa_logits(
         q: Query tensor of shape [M, H, D]. Casted to
             `torch.float8_e4m3fn` by caller.
         kv: Tuple `(k_fp8, k_scales)` where `k_fp8` has shape [N, D] with
-            dtype `torch.float8_e4m3fn` and `k_scales` has shape [N] (or
-            [N, 1]) with dtype `torch.float32`.
+            dtype `torch.float8_e4m3fn` and `k_scales` has shape [N])
+            with dtype `torch.float32`.
         weights: weights of shape [M, H], dtype `torch.float32`.
         cu_seqlen_ks: Start indices (inclusive) for valid K per query position,
             shape [M], dtype int32.


### PR DESCRIPTION

## Purpose

FIX https://github.com/vllm-project/vllm/issues/32647
Fix the  fp8_mqa_logits dim mismatch

Refer 
https://github.com/deepseek-ai/DeepGEMM/blob/main/csrc/apis/attention.hpp#L86

```
static torch::Tensor fp8_mqa_logits(const torch::Tensor& q,
                                    const std::pair<torch::Tensor, torch::Tensor>& kv,
                                    const torch::Tensor& weights,
                                    const torch::Tensor& cu_seq_len_k_start,
                                    const torch::Tensor& cu_seq_len_k_end,
                                    const bool& clean_logits,
                                    const int& max_seqlen_k) {
    const auto& [seq_len, num_heads, head_dim] = get_shape<3>(q);
    const auto& [seq_len_kv, head_dim_] = get_shape<2>(kv.first);
    const auto& [seq_len_, num_heads_] = get_shape<2>(weights);
    const auto& [seq_len_kv_] = get_shape<1>(kv.second);            //       <----- here

```

## Test Plan
```
bash tools/install_deepgemm.sh
```
```
 vllm serve /mnt/nfs/models/deepseek-ai/DeepSeek-V3.2 -tp=4  --tokenizer-mode deepseek_v32
...
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /v1/audio/transcriptions, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /v1/audio/translations, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /classify, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /v1/embeddings, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /score, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /v1/score, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /rerank, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /v1/rerank, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /v2/rerank, Methods: POST
(APIServer pid=4001692) INFO 01-20 08:20:15 [launcher.py:46] Route: /pooling, Methods: POST
(APIServer pid=4001692) INFO:     Started server process [4001692]
(APIServer pid=4001692) INFO:     Waiting for application startup.
(APIServer pid=4001692) INFO:     Application startup complete.
```
## Test Result
```
python examples/online_serving/openai_chat_completion_client.py
--------------------------------------------------
Chat completion results:
ChatCompletion(id='chatcmpl-b56a594c6bde62dd', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The 2020 World Series was held entirely at **Globe Life Field in Arlington, Texas**.\n\nDue to the COVID-19 pandemic, the entire postseason was played in neutral-site "bubbles" with no fans in attendance for the early rounds and limited capacity for the World Series. This was the first time in modern history the World Series was played at a single, predetermined neutral site.', refusal=None, role='assistant', annotations=None, audio=None, function_call=None, tool_calls=[], reasoning=None, reasoning_content=None), stop_reason=None, token_ids=None)], created=1768897221, model='/mnt/nfs/models/deepseek-ai/DeepSeek-V3.2', object='chat.completion', service_tier=None, system_fingerprint=None, usage=CompletionUsage(completion_tokens=80, prompt_tokens=42, total_tokens=122, completion_tokens_details=None, prompt_tokens_details=None), prompt_logprobs=None, prompt_token_ids=None, kv_transfer_params=None)
--------------------------------------------------
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

