### PR TITLE
[Refactor] Make Int8ScaledMMLinearLayerConfig to use QuantKey

### DIFF
--- a/tests/kernels/quantization/test_scaled_mm_kernel_selection.py
+++ b/tests/kernels/quantization/test_scaled_mm_kernel_selection.py
@@ -79,6 +79,7 @@ def test_aiter_kernel_implements_is_supported():
 
 def test_cpu_kernel_accepts_all_configs():
     """Test that CPUInt8ScaledMMLinearKernel accepts all config combinations."""
+
     # Helper to build Int8 config
     def make_int8_config(is_channelwise: bool, is_static: bool, symmetric: bool):
         weight_group = GroupShape.PER_TOKEN if is_channelwise else GroupShape.PER_TENSOR

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/ScaledMMLinearKernel.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/ScaledMMLinearKernel.py
@@ -10,6 +10,7 @@ import torch
 
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
     QuantKey,
 )
 from vllm.platforms import current_platform
@@ -22,10 +23,21 @@ class ScaledMMLinearLayerConfig:
 
 @dataclass
 class Int8ScaledMMLinearLayerConfig(ScaledMMLinearLayerConfig):
-    # TODO: Change to QuantKey like FP8ScaledMMLinearLayerConfig
-    is_static_input_scheme: bool
-    is_channelwise: bool
-    input_symmetric: bool
+    weight_quant_key: QuantKey
+    activation_quant_key: QuantKey
+    out_dtype: torch.dtype | None = None
+
+    @property
+    def is_static_input_scheme(self) -> bool:
+        return self.activation_quant_key.scale.static
+
+    @property
+    def is_channelwise(self) -> bool:
+        return self.weight_quant_key.scale.group_shape != GroupShape.PER_TENSOR
+
+    @property
+    def input_symmetric(self) -> bool:
+        return self.activation_quant_key.symmetric
 
 
 @dataclass
@@ -176,6 +188,21 @@ class FP8ScaledMMLinearKernel(
 class Int8ScaledMMLinearKernel(
     ScaledMMLinearKernel[Int8ScaledMMLinearLayerConfig, _Int8ParamsT], ABC
 ):
+    @property
+    def is_static(self) -> bool:
+        return self.config.is_static_input_scheme
+
+    @property
+    def is_symmetric(self) -> bool:
+        return self.config.input_symmetric
+
+    @property
+    def is_channelwise(self) -> bool:
+        return self.config.is_channelwise
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        pass
+
     def _get_layer_params(self, layer) -> _Int8ParamsT:
         w_q, w_s, i_s, i_zp, azp_adj = self.layer_param_names
         return (

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/ScaledMMLinearKernel.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/ScaledMMLinearKernel.py
@@ -9,10 +9,7 @@ from typing import Generic, TypeVar
 import torch
 
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
-from vllm.model_executor.layers.quantization.utils.quant_utils import (
-    GroupShape,
-    QuantKey,
-)
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 from vllm.platforms import current_platform
 
 
@@ -26,18 +23,6 @@ class Int8ScaledMMLinearLayerConfig(ScaledMMLinearLayerConfig):
     weight_quant_key: QuantKey
     activation_quant_key: QuantKey
     out_dtype: torch.dtype | None = None
-
-    @property
-    def is_static_input_scheme(self) -> bool:
-        return self.activation_quant_key.scale.static
-
-    @property
-    def is_channelwise(self) -> bool:
-        return self.weight_quant_key.scale.group_shape != GroupShape.PER_TENSOR
-
-    @property
-    def input_symmetric(self) -> bool:
-        return self.activation_quant_key.symmetric
 
 
 @dataclass

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/ScaledMMLinearKernel.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/ScaledMMLinearKernel.py
@@ -188,18 +188,6 @@ class FP8ScaledMMLinearKernel(
 class Int8ScaledMMLinearKernel(
     ScaledMMLinearKernel[Int8ScaledMMLinearLayerConfig, _Int8ParamsT], ABC
 ):
-    @property
-    def is_static(self) -> bool:
-        return self.config.is_static_input_scheme
-
-    @property
-    def is_symmetric(self) -> bool:
-        return self.config.input_symmetric
-
-    @property
-    def is_channelwise(self) -> bool:
-        return self.config.is_channelwise
-
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         pass
 

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/__init__.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/__init__.py
@@ -42,7 +42,11 @@ from vllm.model_executor.layers.quantization.kernels.scaled_mm.triton import (
 from vllm.model_executor.layers.quantization.kernels.scaled_mm.xpu import (
     XPUFP8ScaledMMLinearKernel,
 )
-from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
+    QuantKey,
+    ScaleDesc,
+)
 from vllm.platforms import PlatformEnum, current_platform
 
 logger = init_logger(__name__)
@@ -206,10 +210,30 @@ def init_int8_linear_kernel(
     input_symmetric: bool,
     module_name: str,
 ) -> Int8ScaledMMLinearKernel:
+    weight_group_shape = (
+        GroupShape.PER_TOKEN if is_channelwise else GroupShape.PER_TENSOR
+    )
+    weight_scale_desc = ScaleDesc(
+        dtype=torch.float32, static=True, group_shape=weight_group_shape
+    )
+    weight_quant_key = QuantKey(
+        dtype=torch.int8, scale=weight_scale_desc, symmetric=True
+    )
+
+    # Build activation QuantKey
+    activation_group_shape = (
+        GroupShape.PER_TENSOR if is_static_input_scheme else GroupShape.PER_TOKEN
+    )
+    activation_scale_desc = ScaleDesc(
+        dtype=torch.float32, static=is_static_input_scheme, group_shape=activation_group_shape
+    )
+    activation_quant_key = QuantKey(
+        dtype=torch.int8, scale=activation_scale_desc, symmetric=input_symmetric
+    )
+
     config = Int8ScaledMMLinearLayerConfig(
-        is_channelwise=is_channelwise,
-        is_static_input_scheme=is_static_input_scheme,
-        input_symmetric=input_symmetric,
+        weight_quant_key=weight_quant_key,
+        activation_quant_key=activation_quant_key,
     )
 
     kernel_type = choose_scaled_mm_linear_kernel(

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/__init__.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/__init__.py
@@ -225,7 +225,9 @@ def init_int8_linear_kernel(
         GroupShape.PER_TENSOR if is_static_input_scheme else GroupShape.PER_TOKEN
     )
     activation_scale_desc = ScaleDesc(
-        dtype=torch.float32, static=is_static_input_scheme, group_shape=activation_group_shape
+        dtype=torch.float32,
+        static=is_static_input_scheme,
+        group_shape=activation_group_shape,
     )
     activation_quant_key = QuantKey(
         dtype=torch.int8, scale=activation_scale_desc, symmetric=input_symmetric

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/__init__.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/__init__.py
@@ -42,11 +42,7 @@ from vllm.model_executor.layers.quantization.kernels.scaled_mm.triton import (
 from vllm.model_executor.layers.quantization.kernels.scaled_mm.xpu import (
     XPUFP8ScaledMMLinearKernel,
 )
-from vllm.model_executor.layers.quantization.utils.quant_utils import (
-    GroupShape,
-    QuantKey,
-    ScaleDesc,
-)
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 from vllm.platforms import PlatformEnum, current_platform
 
 logger = init_logger(__name__)
@@ -205,34 +201,10 @@ def init_fp8_linear_kernel(
 
 
 def init_int8_linear_kernel(
-    is_channelwise: bool,
-    is_static_input_scheme: bool,
-    input_symmetric: bool,
+    activation_quant_key: QuantKey,
+    weight_quant_key: QuantKey,
     module_name: str,
 ) -> Int8ScaledMMLinearKernel:
-    weight_group_shape = (
-        GroupShape.PER_TOKEN if is_channelwise else GroupShape.PER_TENSOR
-    )
-    weight_scale_desc = ScaleDesc(
-        dtype=torch.float32, static=True, group_shape=weight_group_shape
-    )
-    weight_quant_key = QuantKey(
-        dtype=torch.int8, scale=weight_scale_desc, symmetric=True
-    )
-
-    # Build activation QuantKey
-    activation_group_shape = (
-        GroupShape.PER_TENSOR if is_static_input_scheme else GroupShape.PER_TOKEN
-    )
-    activation_scale_desc = ScaleDesc(
-        dtype=torch.float32,
-        static=is_static_input_scheme,
-        group_shape=activation_group_shape,
-    )
-    activation_quant_key = QuantKey(
-        dtype=torch.int8, scale=activation_scale_desc, symmetric=input_symmetric
-    )
-
     config = Int8ScaledMMLinearLayerConfig(
         weight_quant_key=weight_quant_key,
         activation_quant_key=activation_quant_key,

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/aiter.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/aiter.py
@@ -39,7 +39,7 @@ class AiterInt8ScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
 
     @classmethod
     def can_implement(cls, c: Int8ScaledMMLinearLayerConfig) -> tuple[bool, str | None]:
-        if not c.input_symmetric:
+        if not c.activation_quant_key.symmetric:
             return False, "supports symmetric quantization only."
         return True, None
 

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/cpu.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/cpu.py
@@ -65,10 +65,11 @@ class CPUInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         # oneDNN kernels support only per-tensor and per-channel.
         # If we have a fused module (QKV, MLP) with per tensor scales (thus N
         # scales being passed to the kernel), convert to the per-channel case.
-        is_fused_module = len(layer.logical_widths) > 1
+        logical_widths = getattr(layer, "logical_widths")
+        is_fused_module = len(logical_widths) > 1
         weight_scale = getattr(layer, w_s_name)
         if is_fused_module and not self.config.is_channelwise:
-            weight_scale = convert_to_channelwise(weight_scale, layer.logical_widths)
+            weight_scale = convert_to_channelwise(weight_scale, logical_widths)
         replace_parameter(
             layer,
             w_s_name,
@@ -147,7 +148,7 @@ class CPUInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         )
 
         if layer.bias is not None:
-            bias = layer.bias
+            bias = getattr(layer, "bias")
             layer.register_parameter(
                 "bias_fp32", torch.nn.Parameter(bias.float().data, requires_grad=False)
             )

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/cpu.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/cpu.py
@@ -65,11 +65,10 @@ class CPUInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         # oneDNN kernels support only per-tensor and per-channel.
         # If we have a fused module (QKV, MLP) with per tensor scales (thus N
         # scales being passed to the kernel), convert to the per-channel case.
-        logical_widths = getattr(layer, "logical_widths")
-        is_fused_module = len(logical_widths) > 1
+        is_fused_module = len(layer.logical_widths) > 1
         weight_scale = getattr(layer, w_s_name)
         if is_fused_module and not self.config.is_channelwise:
-            weight_scale = convert_to_channelwise(weight_scale, logical_widths)
+            weight_scale = convert_to_channelwise(weight_scale, layer.logical_widths)
         replace_parameter(
             layer,
             w_s_name,
@@ -148,7 +147,7 @@ class CPUInt8ScaledMMLinearKernel(Int8ScaledMMLinearKernel):
         )
 
         if layer.bias is not None:
-            bias = getattr(layer, "bias")
+            bias = layer.bias
             layer.register_parameter(
                 "bias_fp32", torch.nn.Parameter(bias.float().data, requires_grad=False)
             )

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/triton.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/triton.py
@@ -49,10 +49,11 @@ class TritonInt8ScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
         # Triton kernel supports only per-tensor and per-channel.
         # If we have a fused module (QKV, MLP) with per tensor scales (thus N
         # scales being passed to the kernel), convert to the per-channel case.
-        is_fused_module = len(layer.logical_widths) > 1
+        logical_widths = getattr(layer, "logical_widths")
+        is_fused_module = len(logical_widths) > 1
         weight_scale = getattr(layer, w_s_name)
         if is_fused_module and not self.config.is_channelwise:
-            weight_scale = convert_to_channelwise(weight_scale, layer.logical_widths)
+            weight_scale = convert_to_channelwise(weight_scale, logical_widths)
         replace_parameter(
             layer,
             w_s_name,

--- a/vllm/model_executor/layers/quantization/kernels/scaled_mm/triton.py
+++ b/vllm/model_executor/layers/quantization/kernels/scaled_mm/triton.py
@@ -49,11 +49,10 @@ class TritonInt8ScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
         # Triton kernel supports only per-tensor and per-channel.
         # If we have a fused module (QKV, MLP) with per tensor scales (thus N
         # scales being passed to the kernel), convert to the per-channel case.
-        logical_widths = getattr(layer, "logical_widths")
-        is_fused_module = len(logical_widths) > 1
+        is_fused_module = len(layer.logical_widths) > 1
         weight_scale = getattr(layer, w_s_name)
         if is_fused_module and not self.config.is_channelwise:
-            weight_scale = convert_to_channelwise(weight_scale, logical_widths)
+            weight_scale = convert_to_channelwise(weight_scale, layer.logical_widths)
         replace_parameter(
             layer,
             w_s_name,


### PR DESCRIPTION

## Purpose
This PR refactors the Int8 linear kernel integration in vLLM to improve code clarity, maintainability, and path consistency.

It replaces boolean configuration fields in [ScaledMMLinearLayerConfig](https://github.com/vllm-project/vllm/blob/510265472cb216daf7d8e83db6fa03ce48b0f5fc/vllm/model_executor/layers/quantization/kernels/scaled_mm/ScaledMMLinearKernel.py#L10C1-L10C2) with QuantKey objects to provide a more structured, type-safe quantization configuration API.

Fix issue #32268

## Test Plan
End-to-end model evaluations using lm_eval.

## Test Result
**CUDA
RedHatAI/Meta-Llama-3.1-8B-quantized.w8a8**
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.4890|±  |0.0138|
|     |       |strict-match    |     5|exact_match|↑  |0.4875|±  |0.0138|

**CUDA
RedHatAI/gemma-3-12b-it-quantized.w**8a8
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8749|±  |0.0091|
|     |       |strict-match    |     5|exact_match|↑  |0.8696|±  |0.0093|

**CUDA
RedHatAI/phi-4-quantized.w8a8**
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9037|±  |0.0081|
|     |       |strict-match    |     5|exact_match|↑  |0.9030|±  |0.0082|

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>