### PR TITLE
[Bugfix] Fix Nemotron-Nano-v2-vlm static resolution

### DIFF
--- a/vllm/model_executor/models/nano_nemotron_vl.py
+++ b/vllm/model_executor/models/nano_nemotron_vl.py
@@ -1678,7 +1678,9 @@ class NemotronH_Nano_VL_V2(
                 pixel_values_flat=pixel_values_flat, **kwargs
             )
         else:
-            return NanoNemotronVLImagePixelInputs(**kwargs)
+            return NanoNemotronVLImagePixelInputs(
+                num_patches=kwargs.pop("image_num_patches"), **kwargs
+            )
 
     def _process_image_input_dynamic(
         self, image_input: NanoNemotronVLImagePixelInputsDynamic


### PR DESCRIPTION
`NanoNemotronVLImagePixelInputs.__init__()` expects `num_patches`, not `image_num_patches`.
Regression introduced in: https://github.com/vllm-project/vllm/pull/32121