### PR TITLE
[Bugfix] fix the ima issue of qwen-vit

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -384,6 +384,7 @@ class Qwen2_5_VisionAttention(nn.Module):
             qk_reshaped = einops.rearrange(
                 qk, "b s two head head_dim -> (two b) s head head_dim", two=2
             )
+            qk_reshaped = qk_reshaped.contiguous()
             qk_rotated = self.apply_rotary_emb(
                 qk_reshaped,
                 rotary_pos_emb_cos,

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -128,8 +128,8 @@ from .vision import (
 
 logger = init_logger(__name__)
 
-# Official recommended max pixels is 24576 * 32 * 32
-_MAX_FRAMES_PER_VIDEO = 24576
+# Official recommended max frames is 2048
+_MAX_FRAMES_PER_VIDEO = 2048
 
 
 class Qwen3_VisionPatchEmbed(nn.Module):


### PR DESCRIPTION
After changing the default value of Qwen3VL `_MAX_FRAMES_PER_VIDEO`, I encounted the ima issues at the forward of Qwen-ViT (profiling stage). I found it's a corner case when `bs=1`.

https://github.com/vllm-project/vllm/blob/13f6630a9ea78bee4bd80bb6e842e55e374eec9a/vllm/model_executor/models/qwen2_5_vl.py#L384-L386

When `b=1`, `qk_reshaped` is not contiguous and cause the ima issue. So this pr just add one line. 🫡


<details>

```bash
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]   File "/root/code/vllm-internal/vllm/model_executor/models/qwen2_5_vl.py", line 386, in forward
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     qk_rotated = self.apply_rotary_emb(
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]         qk_reshaped,
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]         rotary_pos_emb_cos,
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]         rotary_pos_emb_sin,
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     )
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]   File "/opt/venv/lib/python3.13/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     return self._call_impl(*args, **kwargs)
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]            ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]   File "/opt/venv/lib/python3.13/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     return forward_call(*args, **kwargs)
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]   File "/root/code/vllm-internal/vllm/model_executor/custom_op.py", line 47, in forward
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     return self._forward_method(*args, **kwargs)
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]   File "/root/code/vllm-internal/vllm/model_executor/layers/rotary_embedding/common.py", line 241, in forward_cuda
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     output = apply_rotary_emb(x, cos, sin, interleaved)
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]   File "/root/code/vllm-internal/vllm/vllm_flash_attn/layers/rotary.py", line 124, in apply_rotary_emb
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     return ApplyRotaryEmb.apply(
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]            ~~~~~~~~~~~~~~~~~~~~^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]         x, cos, sin, interleaved, inplace, seqlen_offsets, cu_seqlens, max_seqlen
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     )
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     ^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]   File "/opt/venv/lib/python3.13/site-packages/torch/autograd/function.py", line 581, in apply
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     return super().apply(*args, **kwargs)  # type: ignore[misc]
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]            ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]   File "/root/code/vllm-internal/vllm/vllm_flash_attn/layers/rotary.py", line 50, in forward
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     out = apply_rotary(
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]         x,
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     ...<6 lines>...
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]         inplace=inplace,
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     )
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]   File "/root/code/vllm-internal/vllm/vllm_flash_attn/ops/triton/rotary.py", line 203, in apply_rotary
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     rotary_kernel[grid](
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     ~~~~~~~~~~~~~~~~~~~^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]         output,  # data ptrs
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]         ^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     ...<22 lines>...
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]         num_warps=2 if rotary_dim <= 64 else 4,
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     )
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     ^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]   File "/root/code/thirdparty/triton/python/triton/runtime/jit.py", line 419, in <lambda>
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]                                    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]   File "/root/code/thirdparty/triton/python/triton/runtime/jit.py", line 757, in run
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]                knobs.runtime.launch_enter_hook, knobs.runtime.launch_exit_hook, *bound_args.values())
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]   File "/root/code/thirdparty/triton/python/triton/backends/nvidia/driver.py", line 712, in __call__
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     self.launch(gridX, gridY, gridZ, stream, function, self.launch_cooperative_grid, self.launch_pdl,
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]     ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]                 global_scratch, profile_scratch, *args)
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=395418) ERROR 01-20 23:18:46 [multiproc_executor.py:822] RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
```
</details>