### PR TITLE
[Misc] Add `get_name` to missing AttentionBackends

### DIFF
--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -773,3 +773,23 @@ def subclass_attention_backend_with_overrides(
 ) -> type[AttentionBackend]:
     name: str = name_prefix + attention_backend_cls.__name__  # type: ignore
     return type(name, (attention_backend_cls,), overrides)
+
+
+def backend_name(name: str):
+    """Class decorator to automatically add a `get_name()` method
+    to an AttentionBackend.
+
+    Usage:
+        @backend_name("MY_ATTN")
+        class MyAttentionBackend(AttentionBackend):
+            ...
+    """
+
+    def decorator(cls: type[AttentionBackend]) -> type[AttentionBackend]:
+        def get_name() -> str:
+            return name
+
+        cls.get_name = staticmethod(get_name)  # type: ignore[assignment]
+        return cls
+
+    return decorator

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -773,23 +773,3 @@ def subclass_attention_backend_with_overrides(
 ) -> type[AttentionBackend]:
     name: str = name_prefix + attention_backend_cls.__name__  # type: ignore
     return type(name, (attention_backend_cls,), overrides)
-
-
-def backend_name(name: str):
-    """Class decorator to automatically add a `get_name()` method
-    to an AttentionBackend.
-
-    Usage:
-        @backend_name("MY_ATTN")
-        class MyAttentionBackend(AttentionBackend):
-            ...
-    """
-
-    def decorator(cls: type[AttentionBackend]) -> type[AttentionBackend]:
-        def get_name() -> str:
-            return name
-
-        cls.get_name = staticmethod(get_name)  # type: ignore[assignment]
-        return cls
-
-    return decorator

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -23,6 +23,10 @@ from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
 
 class GDNAttentionBackend(AttentionBackend):
     @staticmethod
+    def get_name() -> str:
+        return "GDN_ATTN"
+
+    @staticmethod
     def get_builder_cls() -> type["GDNAttentionMetadataBuilder"]:
         return GDNAttentionMetadataBuilder
 

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -12,7 +12,6 @@ from vllm.v1.attention.backend import (
     AttentionCGSupport,
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
-    backend_name,
 )
 from vllm.v1.attention.backends.utils import (
     PAD_SLOT_ID,
@@ -22,8 +21,11 @@ from vllm.v1.attention.backends.utils import (
 from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
 
 
-@backend_name("GDN_ATTN")
 class GDNAttentionBackend(AttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "GDN_ATTN"
+
     @staticmethod
     def get_builder_cls() -> type["GDNAttentionMetadataBuilder"]:
         return GDNAttentionMetadataBuilder

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -12,6 +12,7 @@ from vllm.v1.attention.backend import (
     AttentionCGSupport,
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
+    backend_name,
 )
 from vllm.v1.attention.backends.utils import (
     PAD_SLOT_ID,
@@ -21,11 +22,8 @@ from vllm.v1.attention.backends.utils import (
 from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
 
 
+@backend_name("GDN_ATTN")
 class GDNAttentionBackend(AttentionBackend):
-    @staticmethod
-    def get_name() -> str:
-        return "GDN_ATTN"
-
     @staticmethod
     def get_builder_cls() -> type["GDNAttentionMetadataBuilder"]:
         return GDNAttentionMetadataBuilder

--- a/vllm/v1/attention/backends/linear_attn.py
+++ b/vllm/v1/attention/backends/linear_attn.py
@@ -10,11 +10,13 @@ from vllm.v1.attention.backend import (
     AttentionCGSupport,
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
+    backend_name,
 )
 from vllm.v1.attention.backends.utils import split_decodes_and_prefills
 from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
 
 
+@backend_name("LINEAR_ATTN")
 class LinearAttentionBackend(AttentionBackend):
     @staticmethod
     def get_builder_cls() -> type["LinearAttentionMetadataBuilder"]:

--- a/vllm/v1/attention/backends/linear_attn.py
+++ b/vllm/v1/attention/backends/linear_attn.py
@@ -10,14 +10,16 @@ from vllm.v1.attention.backend import (
     AttentionCGSupport,
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
-    backend_name,
 )
 from vllm.v1.attention.backends.utils import split_decodes_and_prefills
 from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
 
 
-@backend_name("LINEAR_ATTN")
 class LinearAttentionBackend(AttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "LINEAR_ATTN"
+
     @staticmethod
     def get_builder_cls() -> type["LinearAttentionMetadataBuilder"]:
         return LinearAttentionMetadataBuilder

--- a/vllm/v1/attention/backends/mamba1_attn.py
+++ b/vllm/v1/attention/backends/mamba1_attn.py
@@ -3,15 +3,18 @@
 
 from dataclasses import dataclass
 
-from vllm.v1.attention.backend import AttentionBackend, backend_name
+from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.attention.backends.mamba_attn import (
     BaseMambaAttentionMetadata,
     BaseMambaAttentionMetadataBuilder,
 )
 
 
-@backend_name("MAMBA1_ATTN")
 class Mamba1AttentionBackend(AttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "MAMBA1_ATTN"
+
     @staticmethod
     def get_builder_cls() -> type["Mamba1AttentionMetadataBuilder"]:
         return Mamba1AttentionMetadataBuilder

--- a/vllm/v1/attention/backends/mamba1_attn.py
+++ b/vllm/v1/attention/backends/mamba1_attn.py
@@ -3,13 +3,14 @@
 
 from dataclasses import dataclass
 
-from vllm.v1.attention.backend import AttentionBackend
+from vllm.v1.attention.backend import AttentionBackend, backend_name
 from vllm.v1.attention.backends.mamba_attn import (
     BaseMambaAttentionMetadata,
     BaseMambaAttentionMetadataBuilder,
 )
 
 
+@backend_name("MAMBA1_ATTN")
 class Mamba1AttentionBackend(AttentionBackend):
     @staticmethod
     def get_builder_cls() -> type["Mamba1AttentionMetadataBuilder"]:

--- a/vllm/v1/attention/backends/mamba2_attn.py
+++ b/vllm/v1/attention/backends/mamba2_attn.py
@@ -10,7 +10,6 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import (
     AttentionBackend,
     CommonAttentionMetadata,
-    backend_name,
 )
 from vllm.v1.attention.backends.mamba_attn import (
     BaseMambaAttentionMetadata,
@@ -88,8 +87,11 @@ def compute_varlen_chunk_metadata(
     return cu_chunk_seqlens, last_chunk_indices_t, seq_idx_chunks_t
 
 
-@backend_name("MAMBA2_ATTN")
 class Mamba2AttentionBackend(AttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "MAMBA2_ATTN"
+
     @staticmethod
     def get_builder_cls() -> type["Mamba2AttentionMetadataBuilder"]:
         return Mamba2AttentionMetadataBuilder

--- a/vllm/v1/attention/backends/mamba2_attn.py
+++ b/vllm/v1/attention/backends/mamba2_attn.py
@@ -7,7 +7,11 @@ import torch
 
 from vllm.config import VllmConfig
 from vllm.utils.math_utils import cdiv
-from vllm.v1.attention.backend import AttentionBackend, CommonAttentionMetadata
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    CommonAttentionMetadata,
+    backend_name,
+)
 from vllm.v1.attention.backends.mamba_attn import (
     BaseMambaAttentionMetadata,
     BaseMambaAttentionMetadataBuilder,
@@ -84,6 +88,7 @@ def compute_varlen_chunk_metadata(
     return cu_chunk_seqlens, last_chunk_indices_t, seq_idx_chunks_t
 
 
+@backend_name("MAMBA2_ATTN")
 class Mamba2AttentionBackend(AttentionBackend):
     @staticmethod
     def get_builder_cls() -> type["Mamba2AttentionMetadataBuilder"]:

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -15,6 +15,7 @@ from vllm.v1.attention.backend import (
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
     MultipleOf,
+    backend_name,
 )
 from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
@@ -24,6 +25,7 @@ from vllm.v1.attention.backends.utils import (
 logger = init_logger(__name__)
 
 
+@backend_name("DEEPSEEK_V32_INDEXER")
 class DeepseekV32IndexerBackend(AttentionBackend):
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -15,7 +15,6 @@ from vllm.v1.attention.backend import (
     AttentionMetadataBuilder,
     CommonAttentionMetadata,
     MultipleOf,
-    backend_name,
 )
 from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
@@ -25,8 +24,11 @@ from vllm.v1.attention.backends.utils import (
 logger = init_logger(__name__)
 
 
-@backend_name("DEEPSEEK_V32_INDEXER")
 class DeepseekV32IndexerBackend(AttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "DEEPSEEK_V32_INDEXER"
+
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
         return [1 if current_platform.is_rocm() else 64]

--- a/vllm/v1/attention/backends/short_conv_attn.py
+++ b/vllm/v1/attention/backends/short_conv_attn.py
@@ -2,15 +2,18 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass
 
-from vllm.v1.attention.backend import AttentionBackend, backend_name
+from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.attention.backends.mamba_attn import (
     BaseMambaAttentionMetadata,
     BaseMambaAttentionMetadataBuilder,
 )
 
 
-@backend_name("SHORT_CONV_ATTN")
 class ShortConvAttentionBackend(AttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "SHORT_CONV_ATTN"
+
     @staticmethod
     def get_builder_cls() -> type["ShortConvAttentionMetadataBuilder"]:
         return ShortConvAttentionMetadataBuilder

--- a/vllm/v1/attention/backends/short_conv_attn.py
+++ b/vllm/v1/attention/backends/short_conv_attn.py
@@ -2,13 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass
 
-from vllm.v1.attention.backend import AttentionBackend
+from vllm.v1.attention.backend import AttentionBackend, backend_name
 from vllm.v1.attention.backends.mamba_attn import (
     BaseMambaAttentionMetadata,
     BaseMambaAttentionMetadataBuilder,
 )
 
 
+@backend_name("SHORT_CONV_ATTN")
 class ShortConvAttentionBackend(AttentionBackend):
     @staticmethod
     def get_builder_cls() -> type["ShortConvAttentionMetadataBuilder"]:


### PR DESCRIPTION
There's a few attention backends that are missing this meta-method, most notably the Mamba ones.
Albeit the `get_name()` descriptor isn't a functional one, I would expect every backend to define a simple unique tag for identification, adhering to the new structure of AttentionBackends.

I don't have a strong opinion on how this should be carried out (I am also fine with baseclass providing a default), but I tried adding a basic decorator util to make the process less verbose in terms of lines of code.
