### PR TITLE
[Bugfix] Suppress log on non-ROCm platform

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_ocp_mx.py
@@ -154,10 +154,11 @@ try:
         dispatch_key=current_platform.dispatch_key,
     )
 except (ImportError, AttributeError, RuntimeError):
-    logger.warning(
-        "AITER is not found or QuarkOCP_MX is not supported on the current "
-        "platform. QuarkOCP_MX quantization will not be available."
-    )
+    if current_platform.is_rocm():
+        logger.warning(
+            "AITER is not found or QuarkOCP_MX is not supported on the current "
+            "platform. QuarkOCP_MX quantization will not be available."
+        )
     dynamic_mxfp4_quant = gemm_afp4wfp4 = None
 
 


### PR DESCRIPTION

## Purpose

Suppress the log of `QuarkOCP_MX` on non-ROCm platform introduced in PR https://github.com/vllm-project/vllm/pull/31715 .

The try-catch is still kept the same to make the `QuarkOCP_MX` import as a no-op without raising error on gfx1201.

## Test Plan

There should not be log printed on non-ROCm platform.

## Test Result

Log is suppressed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

