### PR TITLE
[Misc] Don't color stdout/err prefix for non-tty

### DIFF
--- a/vllm/utils/system_utils.py
+++ b/vllm/utils/system_utils.py
@@ -175,7 +175,7 @@ def set_process_title(
 
 def _add_prefix(file: TextIO, worker_name: str, pid: int) -> None:
     """Add colored prefix to file output for log decoration."""
-    if envs.NO_COLOR:
+    if envs.NO_COLOR or not file.isatty():
         prefix = f"({worker_name} pid={pid}) "
     else:
         prefix = f"{CYAN}({worker_name} pid={pid}){RESET} "


### PR DESCRIPTION
There's logic in the custom logger for omitting the ansi color coding when logging target is not a terminal device. However there isn't such a check for the colored process-specific stdout/err prefix (like `(APIServer pid=20586) `). I have noticed these control chars in logs that folks have posted. We shouldn't include them if vlLM stdout is directed to a file.