### PR TITLE
[LoRA] Support add delta inplace for fused_moe_lora_kernel

### DIFF
--- a/tests/lora/test_fused_moe_lora_kernel.py
+++ b/tests/lora/test_fused_moe_lora_kernel.py
@@ -211,6 +211,7 @@ def use_fused_moe_lora_kernel(
         mul_routed_weight,
         fully_sharded=fully_sharded,
         offset=offset,
+        add_inputs=True,
     )
 
 

--- a/vllm/lora/ops/triton_ops/fused_moe_lora_op.py
+++ b/vllm/lora/ops/triton_ops/fused_moe_lora_op.py
@@ -46,7 +46,7 @@ def _get_ptr(lora_weights: list[torch.Tensor], device: torch.device):
         "slice_c_size",
     ]
 )
-def _fused_moe_lora_kernel(
+def _fused_moe_lora_shrink_kernel(
     a_ptr,
     b_ptr,
     c_ptr,
@@ -199,6 +199,171 @@ def _fused_moe_lora_kernel(
         tl.atomic_add(c_ptrs, accumulator, mask=c_mask, sem="relaxed")
 
 
+@triton.jit(
+    do_not_specialize=[
+        "num_valid_tokens",
+        "EM",
+        "stride_tl",
+        "stride_el",
+        "slice_a_size",
+        "slice_c_size",
+    ]
+)
+def _fused_moe_lora_expand_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    topk_weights_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    # Matrix dimensions
+    N,
+    K,
+    EM,
+    num_valid_tokens,
+    num_experts,
+    lora_ids,
+    adapter_enabled,
+    # The stride variables represent how much to increase the ptr by when
+    # moving by 1 element in a particular dimension. E.g. `stride_am` is
+    # how much to increase `a_ptr` by to get the element one row down
+    # (A has M rows).
+    stride_am,
+    stride_ak,
+    stride_bl,
+    stride_be,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_tl,
+    stride_el,
+    slice_a_size,
+    slice_c_size,
+    offset,
+    # Meta-parameters
+    num_slice_a: tl.constexpr,
+    num_slice_c: tl.constexpr,
+    top_k: tl.constexpr,
+    MUL_ROUTED_WEIGHT: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    ADD_INPUTS: tl.constexpr,
+    USE_GDC: tl.constexpr,
+    launch_pdl: tl.constexpr,
+    IS_PRIMARY: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    slice_id = tl.program_id(axis=1)
+    lora_idx = tl.program_id(axis=2)
+    lora_id = tl.load(lora_ids + lora_idx)
+
+    if lora_id == -1:
+        # Early exit for the no-lora case.
+        return
+    moe_enabled = tl.load(adapter_enabled + lora_id)
+    if moe_enabled == 0:
+        # Early exit for the no moe lora case.
+        return
+    max_loras = tl.num_programs(axis=2)
+    grid_k = tl.cdiv(K, BLOCK_SIZE_K)
+
+    # calculate pid_m,pid_n
+    # pid_sk = pid % SPLIT_K
+    # pid_m_n = pid // SPLIT_K
+    num_pid_m = tl.cdiv(EM, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr + lora_id)
+    if pid_m * BLOCK_SIZE_M >= num_tokens_post_padded:
+        return
+    # get the expert_id to process curr shard
+    ind = lora_id * stride_el + pid_m
+    expert_id = tl.load(expert_ids_ptr + ind, ind < max_loras * stride_el, -1)
+    if expert_id == -1:
+        return
+    # get a_ptr,b_ptr
+    cur_a_ptr = a_ptr + (slice_id % num_slice_a) * slice_a_size
+    cur_b_ptr = tl.load(b_ptr + slice_id).to(tl.pointer_type(c_ptr.dtype.element_ty))
+
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+
+    offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    token_ind = stride_tl * lora_id + offs_token_id
+    offs_token = tl.load(
+        sorted_token_ids_ptr + token_ind, token_ind < max_loras * stride_tl, 0
+    )
+    token_mask = offs_token < num_valid_tokens
+
+    # get a_ptrs,b_ptrs
+    a_ptrs = cur_a_ptr + (
+        offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
+    )
+
+    b_ptrs = (
+        cur_b_ptr
+        + lora_id * stride_bl
+        + expert_id * stride_be
+        + offs_k[:, None] * stride_bk
+        + offs_bn[None, :] * stride_bn
+    )
+
+    if USE_GDC and IS_PRIMARY:
+        # GDC launch dependents hints the runtime system to launch dependent kernels.
+        tl.extra.cuda.gdc_launch_dependents()
+
+    # accumulator
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    if USE_GDC and not IS_PRIMARY:
+        tl.extra.cuda.gdc_wait()
+
+    for k in range(0, grid_k):
+        k_remaining = K - k * BLOCK_SIZE_K
+        # GDC wait waits for ALL programs in the prior kernel to complete
+        # before continuing.
+        # pre-fetch lora weight
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < k_remaining, other=0.0)
+        if USE_GDC and not IS_PRIMARY:
+            tl.extra.cuda.gdc_wait()
+        a = tl.load(
+            a_ptrs,
+            mask=token_mask[:, None] & (offs_k[None, :] < k_remaining),
+            other=0.0,
+        )
+        accumulator += tl.dot(a, b)
+        # Advance the ptrs to the next K block.
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    if MUL_ROUTED_WEIGHT:
+        moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
+        accumulator = accumulator * moe_weight[:, None]
+    accumulator = accumulator.to(c_ptr.dtype.element_ty)
+    # Write back the block of the output
+    cur_slice_start = (slice_id % num_slice_c) * slice_c_size + offset
+    offs_cn = pid_n * BLOCK_SIZE_N + cur_slice_start + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = token_mask[:, None] & (offs_cn[None, :] < (cur_slice_start + N))
+
+    if ADD_INPUTS:
+        tiled_out = tl.load(c_ptrs, mask=c_mask)
+        accumulator += tiled_out
+    tl.store(c_ptrs, accumulator, mask=c_mask)
+
+
 @torch.inference_mode()
 def _fused_moe_lora_shrink(
     a_intermediate_cache1: torch.Tensor,
@@ -255,7 +420,7 @@ def _fused_moe_lora_shrink(
         len(lora_a_stacked),
         lora_a_stacked[0].shape[0],
     )
-    _fused_moe_lora_kernel[grid](
+    _fused_moe_lora_shrink_kernel[grid](
         qcurr_hidden_states,
         b_ptr,
         a_intermediate_cache1,
@@ -295,7 +460,6 @@ def _fused_moe_lora_shrink(
 def _fused_moe_lora_expand(
     output: torch.Tensor,  # (num_tokens, top_k_num, N*len(lora_a_stacked),)
     a_intermediate_cache1: torch.Tensor,  # (num_slices, M, top_k_num, max_lora_rank)
-    b_intermediate_cache1: torch.Tensor,  # (num_slices, M, top_k_num, output_dim_size)
     lora_b_stacked: list[
         torch.Tensor
     ],  # [(max_loras, num_experts, max_lora_rank, K,),...]
@@ -326,6 +490,7 @@ def _fused_moe_lora_expand(
     split_k: int,
     mul_routed_weight: bool = False,
     offset: int = 0,
+    add_inputs: bool = False,
     use_gdc: bool = False,
 ) -> None:
     b_ptr = _get_ptr(lora_b_stacked, device)
@@ -355,10 +520,10 @@ def _fused_moe_lora_expand(
         len(lora_b_stacked),
         lora_b_stacked[0].shape[0],
     )
-    _fused_moe_lora_kernel[grid](
+    _fused_moe_lora_expand_kernel[grid](
         a_intermediate_cache1,
         b_ptr,
-        b_intermediate_cache1,
+        output,
         topk_weights,
         sorted_token_ids,
         expert_ids,
@@ -376,21 +541,21 @@ def _fused_moe_lora_expand(
         w1_lora_b_stacked.stride(1),
         w1_lora_b_stacked.stride(3),
         w1_lora_b_stacked.stride(2),
-        b_intermediate_cache1.stride(2),
-        b_intermediate_cache1.stride(3),
+        output.stride(1),
+        output.stride(2),
         sorted_token_ids.stride(0),
         expert_ids.stride(0),
         slice_a_size=a_intermediate_cache1.numel() // num_slices,
-        slice_c_size=b_intermediate_cache1.numel() // num_slices,
+        slice_c_size=w1_output_dim_size,
+        offset=offset,
         num_slice_a=num_slices,
         num_slice_c=num_slices,
         top_k=1,
         MUL_ROUTED_WEIGHT=mul_routed_weight,
+        ADD_INPUTS=add_inputs,
         IS_PRIMARY=False,
         **expand_config,
     )
-    for i in range(num_slices):
-        output[:, :, i * N + offset : (i + 1) * N + offset] += b_intermediate_cache1[i]
 
 
 @torch.inference_mode()
@@ -428,6 +593,7 @@ def _fused_moe_lora(
     mul_routed_weight: bool = False,
     fully_sharded: bool = False,
     offset: int = 0,
+    add_inputs: bool = False,
 ) -> None:
     assert len(lora_a_stacked) == len(lora_b_stacked) > 0
     assert (
@@ -461,11 +627,6 @@ def _fused_moe_lora(
         device=device,
     )
 
-    b_intermediate_cache1 = torch.zeros(
-        (num_slices, M, top_k_num, w1_output_dim_size),
-        dtype=output.dtype,
-        device=device,
-    )
     use_gdc = supports_pdl(device) and not fully_sharded
     _fused_moe_lora_shrink(
         a_intermediate_cache1,
@@ -514,7 +675,6 @@ def _fused_moe_lora(
     _fused_moe_lora_expand(
         output,
         a_intermediate_cache1,
-        b_intermediate_cache1,
         lora_b_stacked,
         topk_weights,
         sorted_token_ids,
@@ -543,6 +703,7 @@ def _fused_moe_lora(
         expand_split_k,
         mul_routed_weight,
         offset,
+        add_inputs,
         use_gdc=use_gdc,
     )
 

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -410,4 +410,5 @@ class PunicaWrapperGPU(PunicaWrapperBase):
             mul_routed_weight,
             fully_sharded,
             offset,
+            add_inputs=True,
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR is to support add LoRA delta inplace into output for fused_moe_lora_kernel. This can improve performance by eliminating adding per-slice results into output in python [here](https://github.com/vllm-project/vllm/blob/v0.14.0/vllm/lora/ops/triton_ops/fused_moe_lora_op.py#L392-L393).

* Separate fused_moe_lora shrink and expand kernel. `_fused_moe_lora_expand_kernel` is mostly copied from _fused_moe_lora_kernel, with slight modification:
  * Do not do split_k because K is small for expand.
  * And if ADD_INPUTS is true, add LoRA delta inplace into output.
* e2e output token throughput improves 1%.

## Test Plan

```
pytest -s -v tests/lora/test_fused_moe_lora_kernel.py
```
```
pytest -s -v tests/lora/test_gptoss_tp.py
```
## Test Result

Unit tests passed.

## Benchmark

* gpt-oss-20b
```
vllm serve openai/gpt-oss-20b \
  --tensor-parallel-size 1 \
  --max-num-seqs 16 \
  --compilation-config '{"compile_sizes": [1, 2, 4, 8, 16]}' \
  --enable-lora \
  --max-loras 1 \
  --lora-modules lora1=/opt/dlami/nvme/models/gpt-oss-20b-gsm8k-rank32-lr1e-5 \
  --max-lora-rank 32 \
  --no-enable-prefix-caching
```
```
vllm bench serve \
  --model openai/gpt-oss-20b \
  --lora-modules lora1 \
  --dataset-name sharegpt \
  --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
  --sharegpt-output-len 800 \
  --max-concurrency 16 \
  --num-prompts 1000 \
  --num-warmups 20 \
  --ignore-eos
```

Main:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  227.06    
Total input tokens:                      226792    
Total generated tokens:                  300000    
Request throughput (req/s):              4.40      
Output token throughput (tok/s):         1321.26   
Peak output token throughput (tok/s):    1472.00   
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          2320.09   
---------------Time to First Token----------------
Mean TTFT (ms):                          103.40    
Median TTFT (ms):                        98.58     
P99 TTFT (ms):                           212.71    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.72     
Median TPOT (ms):                        11.74     
P99 TPOT (ms):                           12.23     
---------------Inter-token Latency----------------
Mean ITL (ms):                           11.72     
Median ITL (ms):                         11.47     
P99 ITL (ms):                            17.76     
==================================================
```

PR:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  223.80    
Total input tokens:                      226792    
Total generated tokens:                  300000    
Request throughput (req/s):              4.47      
Output token throughput (tok/s):         1340.45   
Peak output token throughput (tok/s):    1488.00   
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          2353.80   
---------------Time to First Token----------------
Mean TTFT (ms):                          117.89    
Median TTFT (ms):                        123.70    
P99 TTFT (ms):                           244.09    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          11.49     
Median TPOT (ms):                        11.51     
P99 TPOT (ms):                           12.08     
---------------Inter-token Latency----------------
Mean ITL (ms):                           11.49     
Median ITL (ms):                         11.29     
P99 ITL (ms):                            16.53     
==================================================
```

e2e output token throughput improves 1%.

* Qwen3-Coder-30B-A3B-Instruct
```
vllm serve Qwen/Qwen3-Coder-30B-A3B-Instruct \
  --tensor-parallel-size 1 \
  --max-num-seqs 16 \
  --compilation-config '{"compile_sizes": [1, 2, 4, 8, 16]}' \
  --enable-lora \
  --max-loras 1 \
  --lora-modules lora1=/opt/dlami/nvme/models/qwen-coder-30b-adapter \
  --max-lora-rank 32 \
  --no-enable-prefix-caching
```
```
vllm bench serve \
  --model /opt/dlami/nvme/models/Qwen3-Coder-30B-A3B-Instruct \
  --lora-modules lora1 \
  --dataset-name sharegpt \
  --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
  --sharegpt-output-len 800 \
  --max-concurrency 16 \
  --num-prompts 1000 \
  --num-warmups 20 \
  --ignore-eos
```
Main:
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  986.28    
Total input tokens:                      229334    
Total generated tokens:                  800000    
Request throughput (req/s):              1.01      
Output token throughput (tok/s):         811.13    
Peak output token throughput (tok/s):    928.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          1043.65   
---------------Time to First Token----------------
Mean TTFT (ms):                          403.24    
Median TTFT (ms):                        261.59    
P99 TTFT (ms):                           2481.14   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          19.11     
Median TPOT (ms):                        19.19     
P99 TPOT (ms):                           20.19     
---------------Inter-token Latency----------------
Mean ITL (ms):                           19.11     
Median ITL (ms):                         19.17     
P99 ITL (ms):                            20.80     
==================================================
```

PR:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  970.62    
Total input tokens:                      229334    
Total generated tokens:                  800000    
Request throughput (req/s):              1.03      
Output token throughput (tok/s):         824.21    
Peak output token throughput (tok/s):    960.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          1060.49   
---------------Time to First Token----------------
Mean TTFT (ms):                          464.41    
Median TTFT (ms):                        248.64    
P99 TTFT (ms):                           4663.03   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          18.73     
Median TPOT (ms):                        18.76     
P99 TPOT (ms):                           21.09     
---------------Inter-token Latency----------------
Mean ITL (ms):                           18.73     
Median ITL (ms):                         18.53     
P99 ITL (ms):                            20.17     
==================================================
```
e2e output token throughput improves 1%.

## Accuracy Testing
* gpt-oss-20b

```
OPENAI_API_KEY=EMPTY python3 -m gpt_oss.evals --model lora1 --eval gpqa --n-threads 200 --reasoning-effort low
```

Main:
```
Writing report to /tmp/gpqa_lora1-low_temp1.0_20260117_200501.html
{'chars': np.float64(8.47790404040404), 'chars:std': np.float64(77.74305819574604), 'score': np.float64(0.5675505050505051), 'score:std': np.float64(0.495415915436133)}
Writing results to /tmp/gpqa_lora1-low_temp1.0_20260117_200501.json
Writing all results to /tmp/gpqa_lora1-low_temp1.0_20260117_200501_allresults.json
[{'eval_name': 'gpqa', 'model_name': 'lora1-low_temp1.0_20260117_200501', 'metric': 0.5675505050505051}]
```

PR:

```
Writing report to /tmp/gpqa_lora1-low_temp1.0_20260117_192735.html
{'chars': np.float64(12.079545454545455), 'chars:std': np.float64(92.42200498719986), 'score': np.float64(0.57260101010101), 'score:std': np.float64(0.4947010140805384)}
Writing results to /tmp/gpqa_lora1-low_temp1.0_20260117_192735.json
Writing all results to /tmp/gpqa_lora1-low_temp1.0_20260117_192735_allresults.json
[{'eval_name': 'gpqa', 'model_name': 'lora1-low_temp1.0_20260117_192735', 'metric': 0.57260101010101}]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

