### PR TITLE
[ROCm][CI] Remove DS async eplb accuracy test from AMD CI

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1673,17 +1673,6 @@ steps:
   commands:
   - bash .buildkite/scripts/scheduled_integration_test/qwen30b_a3b_fp8_block_ep_eplb.sh 0.8 200 8020 2 1
 
-- label: DeepSeek V2-Lite Async EPLB Accuracy
-  timeout_in_minutes: 60
-  mirror_hardwares: [amdexperimental]
-  agent_pool: mi325_4
-  # grade: Blocking
-  gpu: h100
-  optional: true
-  num_gpus: 4
-  working_dir: "/vllm-workspace"
-  commands:
-  - bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_async_eplb.sh 0.25 1319 8030
 
 - label: Qwen3-Next-80B-A3B-Instruct MTP Async EPLB Accuracy
   timeout_in_minutes: 60


### PR DESCRIPTION
The `DeepSeek V2-Lite Async EPLB Accuracy` test was removed in https://github.com/vllm-project/vllm/pull/30431, but we have not yet removed it from AMD CI pipeline. Right now it's essentially a no-op on our full CI runs (e.g. [build 3319](https://buildkite.com/vllm/amd-ci/builds/3319/summary?sid=019bdba5-1945-4688-a1ee-0d5fb5a1ac42)):
```
bash: .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_async_eplb.sh: No such file or directory
```

This PR removes the test from our pipeline to clean it up.