### PR TITLE
[WIP][CI][build] Move torch deps into requirements/torch.txt and torchlib.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ requires = [
     "packaging>=24.2",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools-scm>=8.0",
-    "torch == 2.9.1",
     "wheel",
     "jinja2",
     "grpcio-tools>=1.76.0",
@@ -306,6 +305,3 @@ extend-ignore-re = []
 windo = "windo"
 
 [tool.typos.type.vimscript.extend-words]
-
-[tool.uv]
-no-build-isolation-package = ["torch"]

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,10 +1,10 @@
 # Should be mirrored in pyproject.toml
+
 cmake>=3.26.1
 ninja
 packaging>=24.2
 setuptools>=77.0.3,<81.0.0
 setuptools-scm>=8
-torch==2.9.1
 wheel
 jinja2>=3.1.6
 regex

--- a/requirements/cpu-build.txt
+++ b/requirements/cpu-build.txt
@@ -1,10 +1,11 @@
+# Torch core dependency, but not all torch libs
+-r torch.txt
+
 cmake>=3.26.1
 ninja
 packaging>=24.2
 setuptools==77.0.3 # this version can reuse CMake build dir
 setuptools-scm>=8
-torch==2.9.1+cpu; platform_machine == "x86_64" or platform_machine == "s390x"
-torch==2.9.1; platform_system == "Darwin" or platform_machine == "ppc64le" or platform_machine == "aarch64"
 scons; platform_machine == "aarch64"    # needed to build Arm Compute Library (ACL)
 wheel
 jinja2>=3.1.6

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -1,19 +1,10 @@
 # Common dependencies
 -r common.txt
+-r torchlibs.txt
 
 setuptools==77.0.3 # this version can reuse CMake build dir
 
 numba == 0.61.2; platform_machine != "s390x" # Required for N-gram speculative decoding
-
-# Dependencies for CPUs
-torch==2.9.1+cpu; platform_machine == "x86_64" or platform_machine == "s390x"
-torch==2.9.1; platform_system == "Darwin" or platform_machine == "ppc64le" or platform_machine == "aarch64"
-
-# required for the image processor of minicpm-o-2_6, this must be updated alongside torch
-torchaudio; platform_machine != "s390x"
-
-# required for the image processor of phi3v, this must be updated alongside torch
-torchvision; platform_machine != "s390x"
 
 # Intel Extension for PyTorch, only for x86_64 CPUs
 intel-openmp==2024.2.1; platform_machine == "x86_64"

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,13 +1,10 @@
 # Common dependencies
 -r common.txt
+-r torchlibs.txt
 
 numba == 0.61.2 # Required for N-gram speculative decoding
 
 # Dependencies for NVIDIA GPUs
 ray[cgraph]>=2.48.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
-torch==2.9.1
-torchaudio==2.9.1
-# These must be updated alongside torch
-torchvision==0.24.1 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # FlashInfer should be updated together with the Dockerfile
 flashinfer-python==0.5.3

--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -1,10 +1,6 @@
 # Common dependencies
 -r common.txt
-
---extra-index-url https://download.pytorch.org/whl/rocm6.4
-torch==2.9.1
-torchvision==0.24.1
-torchaudio==2.9.1
+-r torchlibs.txt
 
 triton==3.5.1
 cmake>=3.26.1,<4

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -1,5 +1,6 @@
 # Common dependencies
 -r common.txt
+-r torchlibs.txt
 
 numba == 0.61.2 # Required for N-gram speculative decoding
 

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -8,6 +8,10 @@ pytest-shard
 pytest-timeout
 pytest-cov
 
+# common dependencies
+-r common.txt
+-r torchlibs.txt
+
 # testing utils
 albumentations # required for Nemotron Parse in test_common.py
 backoff # required for phi4mm test
@@ -25,9 +29,6 @@ soundfile # required for audio tests
 jiwer # required for audio tests
 tblib # for pickling test exceptions
 timm==1.0.17 # required for internvl and gemma3n-mm test
-torch==2.9.1
-torchaudio==2.9.1
-torchvision==0.24.1
 transformers_stream_generator # required for qwen-vl test
 matplotlib # required for qwen-vl test
 mistral_common[image,audio] >= 1.8.8 # required for voxtral test

--- a/requirements/torch.txt
+++ b/requirements/torch.txt
@@ -1,0 +1,10 @@
+# Some installs depend only on torch and not all torch libraries
+# This should be updated alongside torchlibs.txt
+
+# Standard torch
+torch==2.9.1
+
+# Do we need these? Comment out for now
+# Dependencies for CPU
+# torch==2.9.1+cpu; platform_machine == "x86_64" or platform_machine == "s390x"
+# torch==2.9.1; platform_system == "Darwin" or platform_machine == "ppc64le" or platform_machine == "aarch64"

--- a/requirements/torchlibs.txt
+++ b/requirements/torchlibs.txt
@@ -1,0 +1,8 @@
+# This should be updated alongside torch.txt
+
+# Torch core dependency
+-r torch.txt
+
+# Standard torch libraries
+torchaudio==2.9.1
+torchvision==0.24.1

--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -10,6 +10,9 @@ wheel
 jinja2>=3.1.6
 datasets # for benchmark scripts
 numba == 0.61.2 # Required for N-gram speculative decoding
+
+# XPU is behind on torch versions, but eventually transition this to
+# remove here and `-r torchlibs.txt` at the top of this file
 --extra-index-url=https://download.pytorch.org/whl/xpu
 torch==2.9.0+xpu
 torchaudio


### PR DESCRIPTION
This PR will demonstrate (not working yet) a set of changes to centralize PyTorch dependencies (`torch`, `torchaudio`, `torchvision`) into `requirements/torch.txt` and `requirements/torchlib.txt` across all build types and targets. This is a continuation to https://github.com/vllm-project/vllm/pull/30443

Here is the list of todo items:

- [ ] Confirm `pyproject.toml` still works without `torch` references
- [ ] Confirm non-GPU builds can find correct torch versions without extra hints. Greatly simplifies requirements/dependencies if we can do it.
- [ ] Update `docker/Dockerfile` to eliminate torch nightly conditionals and write to `requirements/torch.txt` plus `requirements/torchlib.txt` instead. Flags for pip can be stored in a separate variable in base dockers.
- [ ] Have `use_existing_torch.py` just empty out `requirements/torch.txt` plus `requirements/torchlib.txt` and skip all other rewrites
- [ ] Move XPU builds to latest PyTorch and match to other builds

## Purpose

Simplify torch requirements so they can be more easily changed for:

1. PyTorch version upgrade
2. Using pre-installed PyTorch versions
3. Using nightly PyTorch builds and wheels

## Test Plan

Run through Buildkite and confirm all tests pass

## Test Result

N/A - still early
