### PR TITLE
[ROCm][CI] Lower Acceptance Len Threshold For test_draft_model_quantization

### DIFF
--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -808,7 +808,7 @@ def some_high_acceptance_metrics() -> dict:
     return {
         "sampling_config": greedy_sampling(),
         "num_speculative_tokens": 3,
-        "expected_acceptance_len": 2.6 + 1,
+        "expected_acceptance_len": 2.8 + 1,
         "expected_acceptance_rate": 0.90,
     }
 

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -808,7 +808,7 @@ def some_high_acceptance_metrics() -> dict:
     return {
         "sampling_config": greedy_sampling(),
         "num_speculative_tokens": 3,
-        "expected_acceptance_len": 2.90 + 1,
+        "expected_acceptance_len": 2.6 + 1,
         "expected_acceptance_rate": 0.90,
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
https://github.com/vllm-project/vllm/pull/24322 introduced tests for spec decoding with draft models in the `V1 Test e2e + engine` test group. One test case fails on AMD ci:
```
pytest -v -s tests/v1/e2e/test_spec_decode.py::test_draft_model_quantization[True-target_quantized]
```

The test fails in an assertion:
```
>       assert acceptance_len >= args.expected_acceptance_len
--
E       AssertionError: assert 3.8933333333333335 >= 3.9
E        +  where 3.9 = ArgsTest(target_model='Qwen/Qwen3-1.7B-FP8', draft_model='Qwen/Qwen3-0.6B', sampling_config=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0, top_p=1.0, top_k=0, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=10, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, structured_outputs=None, extra_args=None), num_speculative_tokens=3, expected_acceptance_rate=0.9, expected_acceptance_len=3.9, target_tensor_parallel_size=1, draft_tensor_parallel_size=1, max_model_len=1024, gpu_memory_utilization=0.5, dataset='test_prompts', num_prompts=100).expected_acceptance_len
```
(e.g. [build 3319](https://buildkite.com/vllm/amd-ci/builds/3319/steps/canvas?sid=019bdba5-192c-4f1a-bda7-5d4b47c65d8d)).

As you can see, the threshold is just a little bit too tight so we are loosening it. I chose a threshold of 3.8, on MI325 I am consistently getting an `acceptance_len` of 3.89.

FIX #29510