### PR TITLE
Fix dtype detection for local model paths

### DIFF
--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -16,6 +16,8 @@ from vllm.logger import init_logger
 from vllm.transformers_utils.config import (
     try_get_safetensors_metadata,
 )
+from vllm.transformers_utils.utils import parse_safetensors_file_metadata
+from pathlib import Path
 from vllm.utils.torch_utils import common_broadcastable_dtype
 
 logger = init_logger(__name__)
@@ -117,18 +119,37 @@ class ModelArchConfigConvertorBase:
 
         # Try to read the dtype of the weights if they are in safetensors format
         if config_dtype is None:
-            repo_mt = try_get_safetensors_metadata(model_id, revision=revision)
-
-            if repo_mt and (files_mt := repo_mt.files_metadata):
-                param_dtypes: set[torch.dtype] = {
-                    _SAFETENSORS_TO_TORCH_DTYPE[dtype_str]
-                    for file_mt in files_mt.values()
-                    for dtype_str in file_mt.parameter_count
-                    if dtype_str in _SAFETENSORS_TO_TORCH_DTYPE
-                }
-
+            model_path = Path(model_id)
+            if model_path.exists():
+                # Local path: read dtype from local safetensors files
+                param_dtypes: set[torch.dtype] = set()
+                for file_path in model_path.glob("*.safetensors"):
+                    if file_path.is_file():
+                        metadata = parse_safetensors_file_metadata(file_path)
+                        for key, value in metadata.items():
+                            if key != "__metadata__" and "dtype" in value:
+                                dtype_str = value["dtype"]
+                                if dtype_str in _SAFETENSORS_TO_TORCH_DTYPE:
+                                    param_dtypes.add(
+                                        _SAFETENSORS_TO_TORCH_DTYPE[dtype_str])
                 if param_dtypes:
-                    return common_broadcastable_dtype(param_dtypes)
+                    result = common_broadcastable_dtype(param_dtypes)
+                    logger.info("Detected dtype %s from local safetensors", result)
+                    return result
+            else:
+                # Remote repo: use HF metadata API
+                repo_mt = try_get_safetensors_metadata(model_id, revision=revision)
+
+                if repo_mt and (files_mt := repo_mt.files_metadata):
+                    param_dtypes = {
+                        _SAFETENSORS_TO_TORCH_DTYPE[dtype_str]
+                        for file_mt in files_mt.values()
+                        for dtype_str in file_mt.parameter_count
+                        if dtype_str in _SAFETENSORS_TO_TORCH_DTYPE
+                    }
+
+                    if param_dtypes:
+                        return common_broadcastable_dtype(param_dtypes)
 
         if config_dtype is None:
             config_dtype = torch.float32

--- a/vllm/transformers_utils/repo_utils.py
+++ b/vllm/transformers_utils/repo_utils.py
@@ -62,7 +62,7 @@ def with_retry(
             if attempt == max_retries - 1:
                 logger.error("%s: %s", log_msg, e)
                 raise
-            logger.error(
+            logger.warning(
                 "%s: %s, retrying %d of %d", log_msg, e, attempt + 1, max_retries
             )
             time.sleep(retry_delay)


### PR DESCRIPTION
When loading models from local paths, vLLM was calling the HuggingFace metadata API which only accepts repo IDs (e.g. "meta-llama/Llama-2-7b"), not filesystem paths. This caused misleading ERROR logs during startup:

  ERROR: Repo id must be in the form 'repo_name' or 'namespace/repo_name'

These errors appeared during production debugging and suggested something was broken, when in reality the code gracefully fell back to float32. However, this fallback was also incorrect - local models with bfloat16 weights would be detected as float32, triggering unnecessary "Downcasting torch.float32 to torch.bfloat16" messages.

Changes:
- Read dtype directly from local safetensors file headers when model path exists on disk, matching the pattern in get_safetensors_params_metadata()
- Change intermediate retry log level from ERROR to WARNING since retries are not failures
- Add INFO log confirming dtype detection from local safetensors

<!-- markdownlint-disable -->

## Purpose

## Test Plan

Tested by updating the vllm docker image, the following log line is now being printed:

```
(APIServer pid=10) INFO 01-20 15:16:41 [model.py:530] Resolved architecture: GptOssForCausalLM
(APIServer pid=10) INFO 01-20 15:16:41 [model_arch_config_convertor.py:137] Detected dtype torch.bfloat16 from local safetensors
(APIServer pid=10) INFO 01-20 15:16:41 [model.py:1545] Using max model len 131072
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

