### PR TITLE
[Misc] Add index url for torch==2.9.1+cpu

### DIFF
--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -6,7 +6,7 @@ setuptools==77.0.3 # this version can reuse CMake build dir
 numba == 0.61.2; platform_machine != "s390x" # Required for N-gram speculative decoding
 
 # Dependencies for CPUs
-torch==2.9.1+cpu; platform_machine == "x86_64" or platform_machine == "s390x"
+--extra-index-url https://download.pytorch.org/whl/cpu torch==2.9.1+cpu; platform_machine == "x86_64" or platform_machine == "s390x"
 torch==2.9.1; platform_system == "Darwin" or platform_machine == "ppc64le" or platform_machine == "aarch64"
 
 # required for the image processor of minicpm-o-2_6, this must be updated alongside torch


### PR DESCRIPTION
Added extra index URL for CPU version of PyTorch.

Otherwise I hit "not found" error https://vllm-dev.slack.com/archives/C07QP347J4D/p1768948741022109

<!-- markdownlint-disable -->

## Purpose

## Test Plan

```
VLLM_TARGET_DEVICE=cpu pip install -e .
```

## Test Result

successful install

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

