### PR TITLE
[Bugfix][ROCm] Fix DeepSeek-R1 repetition via hybrid sampler routing

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -178,8 +178,9 @@ class TopKTopPSampler(nn.Module):
         if (k is None and p is None) or generators or (p is not None):
             if generators or (p is not None):
                 logger.warning_once(
-                    "aiter sampler does not support per-request generators; "
-                    "falling back to PyTorch-native."
+                    "aiter sampler does not support per-request generators "
+                    "or Top-P sampling; falling back to PyTorch-native"
+                    "to ensure correctness."
                 )
             return self.forward_native(logits, generators, k, p)
         assert self.logprobs_mode not in (

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -174,11 +174,9 @@ class TopKTopPSampler(nn.Module):
         k: torch.Tensor | None,
         p: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        # FIXME: Fix aiter_sampler's accuracy issue and remove this flag
-        DISABLE_AITER_SAMPLER = True
         """Optimized ROCm/aiter path (same structure as forward_cuda)."""
-        if (k is None and p is None) or generators:
-            if generators:
+        if (k is None and p is None) or generators or (p is not None):
+            if generators or (p is not None):
                 logger.warning_once(
                     "aiter sampler does not support per-request generators; "
                     "falling back to PyTorch-native."
@@ -188,8 +186,6 @@ class TopKTopPSampler(nn.Module):
             "processed_logits",
             "processed_logprobs",
         ), "aiter sampler does not support returning logits/logprobs."
-        if DISABLE_AITER_SAMPLER:
-            return self.forward_native(logits, generators, k, p)
         return self.aiter_sample(logits, k, p, generators), None
 
     def aiter_sample(


### PR DESCRIPTION
## Purpose

This PR addresses the output repetition/infinite loop issue observed in DeepSeek-R1 models on AMD ROCm, effectively resolving the root cause behind the workaround in #32413.

The Problem: The current Aiter topk_topp_sampler kernel on ROCm does not fully support per-request RNG generators (required for stochastic sampling where temperature > 0 and seed is dynamic). This limitation caused:

DeepSeek-R1 to produce repetitive garbage tokens or infinite loops during chat completion.

gpt-oss-120b (and potentially other large models) to crash with HSA_STATUS_ERROR_OUT_OF_RESOURCES under high-throughput benchmarks when using default random sampling on specific environment versions.

The Fix: Instead of globally disabling the Aiter sampler which hurts performance for all models, this PR implements a hybrid routing logic:

Fallback to PyTorch Native: Automatically detects requests requiring stochastic sampling (generators present) or Top-P sampling (p is not None), routing them to the stable PyTorch native implementation. This ensures correctness for DeepSeek-R1 and stability for gpt-oss-120b.

Preserve Aiter Acceleration: For Greedy search and Top-K only queries (common in high-performance inference), the request continues to use the high-performance Aiter kernel.

## Test Plan

1. Fix Verification (DeepSeek-R1 Repetition): Verify that the model generates coherent responses without loops.

English version

```
curl http://127.0.0.1:8733/v1/chat/completions \
-H "Content-Type: application/json" \
-d '{
"model": "deepseek-ai/DeepSeek-R1-0528",
"messages": [{"role": "user", "content": "How to 20 pound lose weight in one week"}],
"max_tokens" : 1000, "stream" : false
}'
```

Chinese version

```
curl http://127.0.0.1:8733/v1/chat/completions \
-H "Content-Type: application/json" \
-d '{
"model": "deepseek-ai/DeepSeek-R1-0528",
"messages": [{"role": "user", "content": "如何在一个月内增肌10公斤"}],
"max_tokens" : 1000, "stream" : false
}'
```

2. Accuracy Verification (GSM8K): Ensure the fallback path maintains model accuracy.


3. Regression & Stability Test (gpt-oss-120b): Verify stability on gpt-oss-120b using the specific docker images (rocm/vllm-dev:preview_1231_rc3_amd_dev_20260103, rocm/vllm-dev:preview_1117_rc4_20251205) where users reported crashes.

`VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1 VLLM_ROCM_USE_AITER=1 vllm bench throughput --model openai/gpt-oss-120b --tensor-parallel-size 8 --num-prompts 1024 --input-len 2048 --output-len 2048 --max-num-seqs 1024 --max-num-batched-tokens 8192 --max-model-len 8192 --gpu-memory-utilization 0.9 --block-size 64 --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'`

4. Performance Logic Check (Qwen/Qwen3-235B-A22B-Instruct-2507-FP8): Verify that Aiter is still enabled for supported configurations.

## Test Result

1. DeepSeek-R1 Generation (Fixed)
The model now produces a coherent Chain-of-Thought followed by a structured response, eliminating the previous infinite loop issue.

English version

```
{"id":"chatcmpl-8789ab5578b4a3b6","object":"chat.completion","created":1768792310,"model":"deepseek-ai/DeepSeek-R1-0528","choices":[{"index":0,"message":{"role":"assistant","content":"<think>\nOkay, the user wants to know how to lose 20 pounds in one week. That's a huge number for such a short time. First, I need to consider why they're asking this. Maybe they have an event coming up, like a wedding or vacation, and want quick results. Or perhaps they're feeling desperate about their weight and think extreme measures are the only way. Either way, I should address both the feasibility and the risks.\n\nI recall that losing 1-2 pounds per week is the safe recommendation. 20 pounds in a week is physically impossible without losing muscle, water, and maybe even risking health. The user might not realize how dangerous this is. They might have seen ads promising rapid weight loss and believe it's achievable. I need to debunk that without sounding dismissive.\n\nBreaking down the math: a pound of fat is about 3500 calories. To lose 20 pounds, that's a 70,000 calorie deficit in a week. That's 10,000 calories per day deficit. Since most people's daily intake is 2000-2500 calories, they'd need to eat nothing and burn way more than possible. Even then, it's not fat loss—it's water and muscle. \n\nHealth risks are serious: dehydration, electrolyte imbalance, gallstones, muscle loss, metabolic slowdown. The rebound weight gain is almost certain. The user might not know about these consequences. They might be focused on the scale number without understanding body composition.\n\nI should offer a constructive alternative. Maybe suggest a one-week jumpstart focused on healthier habits that can lead to 5-10 pounds of mostly water weight loss, which is more realistic. Emphasize long-term strategies instead. The user might need reassurance that slower progress is sustainable and healthier.\n\nAlso, consider their possible frustration. They might feel stuck and impatient. Acknowledging their goal while guiding them towards safer methods is key. Recommend consulting a doctor or dietitian to ensure safety. Highlight the importance of professional guidance, especially for extreme goals.\n\nFinally, structure the response to first explain why it's impossible, then the risks, followed by a better approach. Keep it factual but empathetic, avoiding judgment. Make sure they feel supported, not criticized, to encourage a healthier mindset.\n</think>\nLosing 20 pounds (9 kg) in one week is **physically impossible in a healthy or sustainable way**, and attempting it is **extremely dangerous.** Here's why and what you *can* do instead:\n\n### Why It's Impossible & Dangerous\n\n1.  **The Math Doesn't Work:** To lose 1 pound of body fat, you need a calorie deficit of about 3,500 calories. For 20 pounds, that's a deficit of **70,000 calories in 7 days** – a daily deficit of **10,000 calories**. The average person burns only 1,800-2,500 calories per day at rest. Even with extreme exercise, creating this deficit is impossible without severe starvation.\n2.  **It's Not Fat Loss:** Any rapid weight loss you *might* see (5-10 lbs max for most people) would be almost entirely:\n    *   **Water Weight:** From glycogen depletion and dehydration.\n    *   **Muscle Mass:** Your body breaks down muscle for energy when starved.\n    *   **Gut Contents:** Emptying your digestive system.\n3.  **Serious Health Risks:**\n    *   **Severe Dehydration & Electrolyte Imbalance:** Can cause dizziness, fainting, heart palpitations, kidney damage, and even cardiac arrest.\n    *   **Gallstones:** Rapid weight loss is a major risk factor.\n    *   **Muscle Loss (Catabolism):** Slows metabolism long-term, making future weight loss harder and regaining fat easier.\n    *   **Nutrient Deficiencies:** Lack of essential vitamins and minerals weakens your immune system and organs.\n    *   **Metabolic Damage:** Your body goes into \"starvation mode,\" drastically slowing calorie burning to conserve energy.\n    *   **Fatigue, Weakness, and Irritability:** Making daily function difficult.\n    *   **Rebound Weight Gain:** Your body will desperately try to regain the lost water and fat once you eat normally again (the \"yo-yo\" effect).\n\n### A Realistic & Healthier One-Week Jumpstart (Goal: 3-8 lbs)\n\nWhile 20 lbs isn't possible, you *can* kickstart healthier habits and lose some initial water weight:\n\n1.  **Drastically Cut Processed Carbs & Sugar:**\n    *   **Eliminate:** Bread, pasta, rice, cereals, pastries, soda, juice, candy, desserts.\n    *   **Focus:** This rapidly depletes stored glycogen (which holds water), leading to quick water weight loss.\n2. ","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null,"reasoning_content":null},"logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":13,"total_tokens":1013,"comp

```

Chinese version

```
{"id":"chatcmpl-9d06d53ad7faf537","object":"chat.completion","created":1768909025,"model":"deepseek-ai/DeepSeek-R1-0528","choices":[{"index":0,"message":{"role":"assistant","content":"<think>\n嗯，用户问如何在一个月内增肌10公斤。这个问题需要仔细分析。首先得明确，增肌10公斤在一个月内是否可行。根据运动生理学的知识，自然训练者每月最多能增长0.5到1公斤纯肌肉，10公斤显然不现实。用户可能把肌肉和体重混为一谈了，或者看到某些不实宣传。\n\n接下来要考虑用户的需求。用户可能急于求成，或者对健身知识了解不足。深层需求应该是希望快速改变体型，增强力量或自信。这时候需要指出可行目标，避免用户被误导采用极端方法伤害身体。\n\n然后要拆解问题。增肌涉及训练、饮食、恢复三方面。训练需要强调渐进超负荷和复合动作；饮食则需要热量盈余和足够蛋白质；恢复包括睡眠和休息日。同时要提醒用户，水分和糖原导致的体重增加并非肌肉增长。\n\n还要考虑潜在风险。用户可能尝试极端饮食或药物，导致健康问题。必须强调自然增肌的极限，警告类固醇的危害，并建议咨询专业人士。\n\n最后，如何平衡专业性和鼓励。既要明确目标不可行，又要提供实际建议，让用户有动力调整计划。可能需要分点说明训练、饮食、恢复的具体方法，并给出替代目标，比如每月增肌0.5-1公斤更健康可持续。\n</think>\n我理解你想要快速改变体型的渴望，但作为一个负责任的信息来源，我必须坦诚地告诉你：**在一个月内自然增肌10公斤（纯肌肉）是绝对不可能实现的，而且设定这样的目标既不健康也不现实。**\n\n让我来解释一下原因，并提供一个更可行、更健康的增肌方案：\n\n### 🚫 为什么一个月增肌10公斤不可能？\n\n1.  **生理极限：** 自然训练者（不使用合成代谢药物）每月能增长的纯肌肉量是有限的。对于初学者，前几个月可能增长稍快（每月约0.5-1.5公斤纯肌肉），但很快会放缓。经验丰富的训练者每月能增长0.25-0.5公斤纯肌肉就已经非常优秀了。10公斤是生理极限的10-20倍以上。\n2.  **肌肉合成速率：** 肌肉增长是一个复杂的生理过程，涉及蛋白质合成、激素调节、恢复等，这些过程都有其固有的时间限制，无法被无限加速。\n3.  **热量盈余的限制：** 增肌需要热量盈余（摄入>消耗）。为了追求10公斤的\"增重\"，你可能会摄入远超身体需要的热量。这些多余的热量**绝大部分**会转化为脂肪，而不是肌肉。一个月增重10公斤，可能只有1-2公斤是肌肉（如果训练和恢复完美），其余8-9公斤基本是脂肪和水分。\n4.  **训练适应与恢复：** 肌肉是在休息时，特别是在睡眠中修复和生长的。过度训练（为了追求不可能的目标而疯狂加练）会阻碍恢复，抑制生长激素分泌，甚至导致受伤和过度训练综合症，反而**阻碍**肌肉增长。\n\n### 📍 一个月内能实现的\"增重\"是什么？\n\n*   如果你看到体重秤在一个月内上涨了10公斤，这很可能是：\n    *   **水分滞留：** 大量摄入碳水化合物（肌糖原储备增加会结合大量水分）、盐分增加、某些补剂（如肌酸初期）都会导致身体水分增加（2-4公斤甚至更多）。\n    *   **脂肪增加：** 过度热量盈余的直接结果。\n    *   **肠道内容物：** 吃得多了，消化道里的食物残渣也多了。\n    *   **少量肌肉（如果训练科学）：** 可能0.5-1.5公斤（对初学者而言）。\n*   **这种\"增重\"主要是脂肪和水分，不是理想的肌肉增长，会极大地影响你的体脂率，让你看起来更\"胖\"而不是更\"壮\"。**\n\n### 🎯 更现实、更健康的增肌目标与策略（适用于1个月及长期）\n\n**目标修正：** 设定一个**每月增长0.5-1公斤（对于有经验的训练者可能是0.25-0.5公斤）纯肌肉**的目标。这听起来不多，但坚持6个月到1年，累积的效果（3-6公斤纯肌肉）会非常显著地改变你的体型、力量和代谢。\n\n**核心策略：**\n\n1.  **科学的力量训练（重中之重）：**\n    *   **以复合动作为主：** 深蹲、硬拉、卧推、推举、引体向上/高位下拉、划船。这些动作能同时刺激多块大肌肉群，效率最高，促进全身激素分泌。\n    *   **渐进超负荷：** 这是增肌的核心原则。每周/每两周尝试在动作上增加一点重量、多做一次","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null,"reasoning_content":null},"logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":11,"total_tokens":1011,"completion_tokens":1000,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}

```


2. Accuracy Verification (Pass)
gsm8k result on deepseek-ai/DeepSeek-R1-0528

|Tasks|Version|       Filter       |n-shot|  Metric   |   |Value |   |Stderr|
|-----|-------:|--------------------|-----:|-----------|---|------:|---|-----:|
|gsm8k|       3|flexible-extract    |     5|exact_match|↑  |0.9621|±  |0.0053|
|     |        |strict-match        |     5|exact_match|↑  |0.9636|±  |0.0052|


3.gpt-oss-120b Stability (Pass)

```
(EngineCore_DP0 pid=471) INFO 01-21 02:32:09 [core.py:259] init engine (profile, create kv cache, warmup model) took 100.74 seconds
INFO 01-21 02:32:13 [llm.py:360] Supported tasks: ['generate']
Adding requests: 100%|| 1024/1024 [00:05<00:00, 186.29it/s]
Processed prompts:   0%|| | 0/1024 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]
INFO 01-21 02:32:29 [loggers.py:248] Engine 000: Avg prompt throughput: 70644.3 tokens/s, Avg generation throughput: 2444.2 tokens/s, Running: 539 reqs, Waiting: 485 reqs, GPU KV cache usage: 3.4%
INFO 01-21 02:32:42 [loggers.py:248] Engine 000: Avg prompt throughput: 17830.1 tokens/s, Avg generation throughput: 1401.9 tokens/s, Running: 650 reqs, Waiting: 374 reqs, GPU KV cache usage: 4.1%
INFO 01-21 02:32:52 [loggers.py:248] Engine 000: Avg prompt throughput: 68787.9 tokens/s, Avg generation throughput: 7568.9 tokens/s, Running: 989 reqs, Waiting: 35 reqs, GPU KV cache usage: 6.4%
INFO 01-21 02:33:02 [loggers.py:248] Engine 000: Avg prompt throughput: 7348.8 tokens/s, Avg generation throughput: 21519.6 tokens/s, Running: 1024 reqs, Waiting: 0 reqs, GPU KV cache usage: 7.2%
...
INFO 01-21 02:34:02 [loggers.py:248] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 22684.6 tokens/s, Running: 1024 reqs, Waiting: 0 reqs, GPU KV cache usage: 11.0%
Processed prompts:   4%|| | 45/1024 [01:52<15:14,  1.07it/s, est. speed input: 816.24 toks/s, output: 816.24 toks/s]
INFO 01-21 02:34:12 [loggers.py:248] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 22178.6 tokens/s, Running: 964 reqs, Waiting: 0 reqs, GPU KV cache usage: 10.9%
Processed prompts: 100%|| 1024/1024 [01:59<00:00,  8.55it/s, est. speed input: 17513.57 toks/s, output: 17513.57 toks/s]
(Worker_TP0 pid=620) INFO 01-21 02:34:19 [multiproc_executor.py:709] Parent process exited, terminating worker
...
Throughput: 8.18 requests/s, 33489.16 total tokens/s, 16744.58 output tokens/s
Total num prompt tokens: 2097152
Total num output tokens: 2097152
```


4.Performance Logic Check (Qwen/Qwen3-235B-A22B-Instruct-2507-FP8)

**lmeval test**

<img width="506" height="577" alt="Screenshot 2026-01-21 at 11 41 27" src="https://github.com/user-attachments/assets/46969945-e1d1-4204-a464-bc6be4e87161" />

**benchmark**

Benchmark results demonstrate that Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 maintains massive performance gains even with the hybrid sampler routing.

Observation: Even when the sampler falls back to Native (for top-p cases), the End-to-End Throughput is still ~1.35x higher than the baseline.

<img width="608" height="617" alt="Screenshot 2026-01-21 at 11 41 14" src="https://github.com/user-attachments/assets/4a080d3d-8b02-4bbd-b686-1e3638ec018e" />




