### PR TITLE
[Model] Extend `collect_children` and `no_init_weights` contexts

### DIFF
--- a/tests/utils_/test_collection_utils.py
+++ b/tests/utils_/test_collection_utils.py
@@ -2,11 +2,27 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import pytest
 
-from vllm.utils.collection_utils import swap_dict_values
+from vllm.utils.collection_utils import common_prefix, swap_dict_values
 
 
 @pytest.mark.parametrize(
-    "obj,key1,key2",
+    ("inputs", "output"),
+    [
+        ([""], ""),
+        (["a"], "a"),
+        (["a", "b"], ""),
+        (["a", "ab"], "a"),
+        (["a", "ab", "b"], ""),
+        (["abc", "a", "ab"], "a"),
+        (["aba", "abc", "ab"], "ab"),
+    ],
+)
+def test_common_prefix(inputs, output):
+    assert common_prefix(inputs) == output
+
+
+@pytest.mark.parametrize(
+    ("obj", "key1", "key2"),
     [
         # Tests for both keys exist
         ({1: "a", 2: "b"}, 1, 2),

--- a/tests/utils_/test_collection_utils.py
+++ b/tests/utils_/test_collection_utils.py
@@ -6,7 +6,7 @@ from vllm.utils.collection_utils import common_prefix, swap_dict_values
 
 
 @pytest.mark.parametrize(
-    ("inputs", "output"),
+    ("inputs", "expected_output"),
     [
         ([""], ""),
         (["a"], "a"),
@@ -17,8 +17,8 @@ from vllm.utils.collection_utils import common_prefix, swap_dict_values
         (["aba", "abc", "ab"], "ab"),
     ],
 )
-def test_common_prefix(inputs, output):
-    assert common_prefix(inputs) == output
+def test_common_prefix(inputs, expected_output):
+    assert common_prefix(inputs) == expected_output
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -18,7 +18,7 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
-from vllm.model_executor.models.interfaces import SupportsQuant, supports_multimodal
+from vllm.model_executor.models.interfaces import SupportsQuant
 from vllm.utils.platform_utils import is_pin_memory_available
 
 logger = init_logger(__name__)
@@ -165,11 +165,7 @@ _MODEL_ARCH_BY_HASH = dict[int, tuple[type[nn.Module], str]]()
 
 
 def _get_model_architecture(model_config: ModelConfig) -> tuple[type[nn.Module], str]:
-    from vllm.model_executor.models.adapters import (
-        as_embedding_model,
-        as_seq_cls_model,
-        try_create_mm_pooling_model_cls,
-    )
+    from vllm.model_executor.models.adapters import as_embedding_model, as_seq_cls_model
 
     architectures = getattr(model_config.hf_config, "architectures", [])
 
@@ -189,15 +185,6 @@ def _get_model_architecture(model_config: ModelConfig) -> tuple[type[nn.Module],
             )
 
     convert_type = model_config.convert_type
-    if convert_type != "none" and supports_multimodal(model_cls):
-        logger.debug_once("Detected conversion of Multi Modal model.")
-        converted = try_create_mm_pooling_model_cls(model_cls)
-        if converted is not None:
-            logger.debug_once("Creating wrapper class to forward pooler.")
-            return converted, arch
-        else:
-            logger.debug_once("Attempting direct conversion.")
-
     if convert_type == "none":
         pass
     elif convert_type == "embed":

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -193,7 +193,7 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
         def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
             params_dict = dict(self.named_parameters())
 
-            # We support loading from both `*Model` and `*ForCausalLM`
+            # We support loading from both `*ForCausalLM` and `*Model`
             candidate_prefixes = ["", "model."]
             target_prefix = ""
 

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -150,15 +150,17 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
             self.vllm_config = vllm_config
 
             # If the model already defines a pooler instance, don't overwrite it
-            if not getattr(self, "pooler", None):
+            pooler = getattr(self, "pooler", None)
+            if not pooler:
                 from .interfaces import supports_multimodal
 
                 if supports_multimodal(self):
                     # Try to get the pooler from the LM backbone
                     language_model = self.get_language_model()
                     if hasattr(language_model, "pooler"):
-                        self.pooler = language_model.pooler
+                        self.pooler = pooler = language_model.pooler
 
+            if not pooler:
                 self._init_pooler(vllm_config, prefix=prefix)
 
         def _init_pooler(self, vllm_config: "VllmConfig", prefix: str = ""):

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -202,11 +202,10 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
             # and there are no other inner modules with other parameters,
             # we support loading from both `*Model` and `*ForCausalLM`
             if hasattr(self, "model") and hasattr(self.model, "load_weights"):
-                # Whether all parameters come from `self.model`
+                # Some weights might be tied to weights under `self.model`
                 model_params_ids = [id(p) for p in self.model.parameters()]
 
                 if all(
-                    # Some weights might be tied to weights under `self.model`
                     all(id(p) in model_params_ids for p in child.parameters())
                     for name, child in self.named_children()
                     if name != "model"

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -192,6 +192,8 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
 
         def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
             params_dict = dict(self.named_parameters())
+
+            # We support loading from both `*Model` and `*ForCausalLM`
             candidate_prefixes = ["", "model."]
             target_prefix = ""
 
@@ -218,8 +220,8 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
                         target_model = getattr(self, attr)
 
                 logger.info(
-                    "Mapping weights to %s as the weights "
-                    "are relative to this model instead of %s.",
+                    "Mapping weights to %s as they are "
+                    "relative to this model instead of %s.",
                     target_model._get_name(),
                     self._get_name(),
                 )

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -226,13 +226,17 @@ def _create_pooling_model_cls(orig_cls: _T) -> _T:
                     self._get_name(),
                 )
 
-            loader = AutoWeightsLoader(self)
-            return loader.load_weights(
-                (
-                    (target_prefix + name, weight)
-                    for name, weight in (*seen_weights, *weights)
-                )
+            mapped_weights = (
+                (target_prefix + name, weight)
+                for name, weight in (*seen_weights, *weights)
             )
+
+            def default_load_weights(weights):
+                loader = AutoWeightsLoader(self)
+                return loader.load_weights(weights)
+
+            load_weights = getattr(super(), "load_weights", default_load_weights)
+            return load_weights(mapped_weights)
 
     return ModelForPooling  # type: ignore
 

--- a/vllm/model_executor/models/bagel.py
+++ b/vllm/model_executor/models/bagel.py
@@ -41,10 +41,10 @@ from vllm.utils.tensor_schema import TensorSchema
 
 from .interfaces import (
     MultiModalEmbeddings,
+    StageMissingLayer,
     SupportsLoRA,
     SupportsMultiModal,
     SupportsPP,
-    TowerMissingLayer,
 )
 from .siglip import SiglipVisionModel
 from .utils import (
@@ -426,9 +426,9 @@ class BagelForConditionalGeneration(
                     hidden_size=llm_hidden_size,
                 )
         else:
-            self.vit_model = TowerMissingLayer("image")
-            self.connector = TowerMissingLayer("image")
-            self.vit_pos_embed = TowerMissingLayer("image")
+            self.vit_model = StageMissingLayer("image_tower")
+            self.connector = StageMissingLayer("image_tower")
+            self.vit_pos_embed = StageMissingLayer("image_tower")
 
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors

--- a/vllm/model_executor/models/bagel.py
+++ b/vllm/model_executor/models/bagel.py
@@ -41,7 +41,6 @@ from vllm.utils.tensor_schema import TensorSchema
 
 from .interfaces import (
     MultiModalEmbeddings,
-    StageMissingLayer,
     SupportsLoRA,
     SupportsMultiModal,
     SupportsPP,
@@ -49,6 +48,7 @@ from .interfaces import (
 from .siglip import SiglipVisionModel
 from .utils import (
     AutoWeightsLoader,
+    StageMissingLayer,
     WeightsMapper,
     init_vllm_registered_model,
     maybe_prefix,

--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -539,10 +539,7 @@ class Gemma3ForConditionalGeneration(
             )
 
             logit_scale = getattr(config, "logit_scale", 1.0)
-            if hasattr(self.language_model, "logits_processor"):
-                # The logits processor can be unset if we're using
-                # automatic conversion to pooling model.
-                self.language_model.logits_processor.scale *= logit_scale
+            self.language_model.logits_processor.scale *= logit_scale
 
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors

--- a/vllm/model_executor/models/glm4v.py
+++ b/vllm/model_executor/models/glm4v.py
@@ -53,7 +53,7 @@ from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs import ChatGLMConfig
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
-from .chatglm import ChatGLMBaseModel, ChatGLMModel
+from .chatglm import ChatGLMBaseModel, ChatGLMModel, GLMTransformer
 from .interfaces import (
     MultiModalEmbeddings,
     SupportsLoRA,
@@ -591,10 +591,18 @@ class GLM4VForCausalLM(
         prefix: str = "",
         transformer_type: type[GLM4VModel] = GLM4VModel,
     ) -> None:
+        def transformer_type_(*args, **kwargs):
+            with self._mark_composite_model(
+                vllm_config,
+                language_targets=GLMTransformer,
+                tower_targets={"image": EVA2CLIPModel},
+            ):
+                return transformer_type(*args, **kwargs)
+
         super().__init__(
             vllm_config=vllm_config,
             prefix=prefix,
-            transformer_type=transformer_type,
+            transformer_type=transformer_type_,
         )
 
         self.transformer: GLM4VModel
@@ -751,9 +759,6 @@ class GLM4VForCausalLM(
         llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
         mrope_position_delta = (llm_positions.max() + 1 - len(input_tokens)).item()
         return llm_positions, mrope_position_delta
-
-    def get_language_model(self) -> torch.nn.Module:
-        return self.transformer
 
     embed_input_ids = SupportsMultiModal.embed_input_ids
 

--- a/vllm/model_executor/models/glm4v.py
+++ b/vllm/model_executor/models/glm4v.py
@@ -591,19 +591,16 @@ class GLM4VForCausalLM(
         prefix: str = "",
         transformer_type: type[GLM4VModel] = GLM4VModel,
     ) -> None:
-        def transformer_type_(*args, **kwargs):
-            with self._mark_composite_model(
-                vllm_config,
-                language_targets=GLMTransformer,
-                tower_targets={"image": EVA2CLIPModel},
-            ):
-                return transformer_type(*args, **kwargs)
-
-        super().__init__(
-            vllm_config=vllm_config,
-            prefix=prefix,
-            transformer_type=transformer_type_,
-        )
+        with self._mark_composite_model(
+            vllm_config,
+            language_targets=GLMTransformer,
+            tower_targets={"image": EVA2CLIPModel},
+        ):
+            super().__init__(
+                vllm_config=vllm_config,
+                prefix=prefix,
+                transformer_type=transformer_type,
+            )
 
         self.transformer: GLM4VModel
 

--- a/vllm/model_executor/models/idefics3.py
+++ b/vllm/model_executor/models/idefics3.py
@@ -57,7 +57,11 @@ from vllm.utils.tensor_schema import TensorSchema, TensorShape
 from .idefics2_vision_model import (
     Idefics2VisionTransformer as Idefics3VisionTransformer,
 )
-from .interfaces import MultiModalEmbeddings, SupportsLoRA, SupportsMultiModal
+from .interfaces import (
+    MultiModalEmbeddings,
+    SupportsLoRA,
+    SupportsMultiModal,
+)
 from .llama import LlamaModel
 from .utils import AutoWeightsLoader, maybe_prefix
 
@@ -604,9 +608,16 @@ class Idefics3ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsLo
         self.config = config
         self.multimodal_config = multimodal_config
 
-        self.model = Idefics3Model(
-            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
-        )
+        with self._mark_composite_model(
+            vllm_config,
+            language_targets=LlamaModel,
+            tower_targets={"image": (Idefics3VisionTransformer, Idefics3Connector)},
+        ):
+            self.model = Idefics3Model(
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "model"),
+            )
+
         self.image_token_id = self.config.image_token_id
 
         self.lm_head = ParallelLMHead(
@@ -668,9 +679,6 @@ class Idefics3ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsLo
 
         num_patches = image_input["num_patches"]
         return [e.flatten(0, 1) for e in image_features.split(num_patches.tolist())]
-
-    def get_language_model(self) -> torch.nn.Module:
-        return self.model
 
     def embed_multimodal(self, **kwargs: object) -> MultiModalEmbeddings:
         image_input = self._parse_and_validate_image_input(**kwargs)

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -72,7 +72,7 @@ def _require_is_multimodal(is_multimodal: Tensor | None) -> Tensor:
     return is_multimodal
 
 
-class StageMissingLayer(nn.Identity):
+class StageMissingLayer(nn.Module):
     def __init__(self, name: str) -> None:
         super().__init__()
 
@@ -238,14 +238,11 @@ class SupportsMultiModal(Protocol):
             torch.nn.Module: The core language model component.
         """
         if self._language_model_names:
-            common_path = common_prefix(
-                [name.split(".") for name in self._language_model_names]
-            )
-            assert common_path, "Language model should not be self"
-
             language_model = self
-            for attr in common_path:
-                language_model = getattr(self, attr)
+            for attr in common_prefix(
+                [name.split(".") for name in self._language_model_names]
+            ):
+                language_model = getattr(language_model, attr)
 
             return language_model
 

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -113,12 +113,12 @@ class SupportsMultiModal(Protocol):
 
     _language_model_names: list[str] = []
     """
-    Set internally by `_mark_language_model` or similar methods.
+    Set internally by `_mark_language_model`.
     """
 
     _tower_model_names: list[str] = []
     """
-    Set internally by `_mark_tower_model` or similar methods.
+    Set internally by `_mark_tower_model`.
     """
 
     @classmethod
@@ -166,8 +166,8 @@ class SupportsMultiModal(Protocol):
                 return mod
 
         # Fallback
-        for name, mod in self.named_modules():
-            if mod is not self and hasattr(mod, "embed_input_ids"):
+        for mod in self.children():
+            if hasattr(mod, "embed_input_ids"):
                 _language_model_by_module[self] = mod
                 return mod
 
@@ -263,6 +263,10 @@ class SupportsMultiModal(Protocol):
         language_targets: type[nn.Module] | tuple[type[nn.Module], ...],
         tower_targets: dict[str, type[nn.Module] | tuple[type[nn.Module], ...]],
     ):
+        """
+        Composite wrapper over `_mark_language_model` and
+        `_mark_tower_model` by modality.
+        """
         with ExitStack() as stack:
             stack.enter_context(
                 self._mark_language_model(

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -121,13 +121,6 @@ class SupportsMultiModal(Protocol):
     Set internally by `_mark_tower_model` or similar methods.
     """
 
-    # NOTE: By default, `initialize_model` assigns
-    # `make_empty_intermediate_tensors`, `forward`, `compute_logits` and `pooler`
-    # from the language model to this model.
-    # Compared to HF Transformers, `forward` method is decomposed to
-    # `embed_multimodal` and `embed_input_ids` and `<language model>.forward`
-    # which are executed separately by the model runner.
-
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:
         """

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -159,7 +159,8 @@ class SupportsMultiModal(Protocol):
             for attr in common_prefix(
                 [name.split(".") for name in self._language_model_names]
             ):
-                mod = getattr(mod, attr)
+                if attr:
+                    mod = getattr(mod, attr)
 
             if mod is not self and hasattr(mod, "embed_input_ids"):
                 _language_model_by_module[self] = mod

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -1035,11 +1035,13 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
             )
 
         with self._mark_tower_model(vllm_config, {"image", "video"}):
-            self.vpm = vpm = self.init_vision_module(
+            self.vpm = self.init_vision_module(
                 config, quant_config, prefix=maybe_prefix(prefix, "vpm")
             )
             self.vision_dim = (
-                vpm.embed_dim if self.version == (2, 0) else vpm.embeddings.embed_dim
+                self.vpm.embed_dim
+                if self.version == (2, 0)
+                else self.vpm.embeddings.embed_dim
             )
             self.embed_dim = self.config.hidden_size
 

--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -72,17 +72,13 @@ from vllm.utils.tensor_schema import TensorSchema, TensorShape
 from .interfaces import (
     MixtureOfExperts,
     MultiModalEmbeddings,
-    StageMissingLayer,
     SupportsEagle3,
     SupportsLoRA,
     SupportsMultiModal,
     SupportsPP,
 )
 from .llama4 import Llama4ForCausalLM
-from .utils import (
-    AutoWeightsLoader,
-    maybe_prefix,
-)
+from .utils import AutoWeightsLoader, StageMissingLayer, maybe_prefix
 from .vision import run_dp_sharded_vision_model
 
 

--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -70,14 +70,13 @@ from vllm.sequence import IntermediateTensors
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
 from .interfaces import (
-    LMMissingLayer,
     MixtureOfExperts,
     MultiModalEmbeddings,
+    StageMissingLayer,
     SupportsEagle3,
     SupportsLoRA,
     SupportsMultiModal,
     SupportsPP,
-    TowerMissingLayer,
 )
 from .llama4 import Llama4ForCausalLM
 from .utils import (
@@ -1024,7 +1023,7 @@ class Llama4ForConditionalGeneration(
             renamed = self._rename_weight_for_modelopt_checkpoint(name)
 
             attr = renamed.split(".", 1)[0]
-            if isinstance(getattr(self, attr), (LMMissingLayer, TowerMissingLayer)):
+            if isinstance(getattr(self, attr), StageMissingLayer):
                 continue
 
             if renamed.startswith("language_model."):

--- a/vllm/model_executor/models/nano_nemotron_vl.py
+++ b/vllm/model_executor/models/nano_nemotron_vl.py
@@ -1513,7 +1513,7 @@ class NemotronH_Nano_VL_V2(
         self.video_pruning_rate = multimodal_config.video_pruning_rate
 
         with self._mark_language_model(vllm_config):
-            self.language_model = language_model = init_vllm_registered_model(
+            self.language_model = init_vllm_registered_model(
                 vllm_config=vllm_config,
                 hf_config=config.text_config,
                 prefix=maybe_prefix(prefix, "language_model"),
@@ -1542,7 +1542,7 @@ class NemotronH_Nano_VL_V2(
                 ReLUSquaredActivation(),
                 nn.Linear(vision_projection_hidden_size, llm_hidden_size, bias=False),
             )
-            self.mlp1 = mlp1.to(language_model.config.dtype)
+            self.mlp1 = mlp1.to(self.language_model.config.dtype)
 
         self.config = config
         self.model_config = vllm_config.model_config

--- a/vllm/model_executor/models/paddleocr_vl.py
+++ b/vllm/model_executor/models/paddleocr_vl.py
@@ -1025,12 +1025,12 @@ class PaddleOCRVLForConditionalGeneration(nn.Module, SupportsMultiModal, Support
             self.mlp_AR = Projector(config, config.vision_config)
 
         with self._mark_language_model(vllm_config):
-            self.language_model = language_model = Ernie4_5ForCausalLM(
+            self.language_model = Ernie4_5ForCausalLM(
                 vllm_config=vllm_config,
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 
-            for layer in language_model.model.layers:
+            for layer in self.language_model.model.layers:
                 if not isinstance(layer, PPMissingLayer):
                     layer.self_attn.rotary_emb.is_neox_style = True
 

--- a/vllm/model_executor/models/paligemma.py
+++ b/vllm/model_executor/models/paligemma.py
@@ -314,13 +314,14 @@ class PaliGemmaForConditionalGeneration(
             config.text_config.architectures = ["Gemma2ForCausalLM"]
 
         with self._mark_language_model(vllm_config):
-            self.language_model = language_model = init_vllm_registered_model(
+            self.language_model = init_vllm_registered_model(
                 vllm_config=vllm_config,
                 hf_config=config.text_config,
                 prefix=maybe_prefix(prefix, "language_model"),
             )
+
             logit_scale = getattr(config, "logit_scale", 1.0)
-            language_model.logits_processor.scale *= logit_scale
+            self.language_model.logits_processor.scale *= logit_scale
 
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -466,11 +466,11 @@ class Qwen3VLMoeForConditionalGeneration(
                 prefix=maybe_prefix(prefix, "language_model"),
             )
 
-            # Whether to include the gate_up_proj mapping is determined by
-            # the language model.
-            self.packed_modules_mapping = (
-                self.packed_modules_mapping | self.language_model.packed_modules_mapping
-            )
+        # Whether to include the gate_up_proj mapping is determined by
+        # the language model.
+        self.packed_modules_mapping = (
+            self.packed_modules_mapping | self.language_model.packed_modules_mapping
+        )
 
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -461,14 +461,15 @@ class Qwen3VLMoeForConditionalGeneration(
                 ]
 
         with self._mark_language_model(vllm_config):
-            self.language_model = language_model = Qwen3MoeLLMForCausalLM(
-                vllm_config=vllm_config, prefix=maybe_prefix(prefix, "language_model")
+            self.language_model = Qwen3MoeLLMForCausalLM(
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "language_model"),
             )
 
             # Whether to include the gate_up_proj mapping is determined by
             # the language model.
             self.packed_modules_mapping = (
-                self.packed_modules_mapping | language_model.packed_modules_mapping
+                self.packed_modules_mapping | self.language_model.packed_modules_mapping
             )
 
         self.make_empty_intermediate_tensors = (

--- a/vllm/model_executor/models/qwen_vl.py
+++ b/vllm/model_executor/models/qwen_vl.py
@@ -757,19 +757,16 @@ class QwenVLForConditionalGeneration(
         prefix: str = "",
         transformer_type: type[QwenVLModel] = QwenVLModel,
     ) -> None:
-        def transformer_type_(*args, **kwargs):
-            with self._mark_composite_model(
-                vllm_config,
-                language_targets=QWenBlock,
-                tower_targets={"image": VisionTransformer},
-            ):
-                return transformer_type(*args, **kwargs)
-
-        super().__init__(
-            vllm_config=vllm_config,
-            prefix=prefix,
-            transformer_type=transformer_type_,
-        )
+        with self._mark_composite_model(
+            vllm_config,
+            language_targets=QWenBlock,
+            tower_targets={"image": VisionTransformer},
+        ):
+            super().__init__(
+                vllm_config=vllm_config,
+                prefix=prefix,
+                transformer_type=transformer_type,
+            )
 
         self.transformer: QwenVLModel
 

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -212,8 +212,8 @@ class AutoWeightsLoader:
                     continue
 
                 raise ValueError(
-                    f"Attempted to load nested weight '{weight_qualname}' "
-                    f"into a single parameter '{base_prefix}'"
+                    f"Attempted to load nested weight {weight_qualname!r} "
+                    f"into a single parameter {base_prefix!r}"
                 )
 
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
@@ -314,9 +314,14 @@ class AutoWeightsLoader:
 
                     continue
 
+                desc_param_keys = {
+                    base_prefix + k for k, _ in module.named_parameters(recurse=True)
+                }
                 msg = (
-                    f"There is no module or parameter named '{prefix}' "
-                    f"in {type(self.module).__name__}"
+                    f"There is no module or parameter named {prefix!r} "
+                    f"in {self.module._get_name()}. "
+                    f"The available parameters belonging to {base_prefix} "
+                    f"({module._get_name()}) are: {desc_param_keys}"
                 )
                 raise ValueError(msg)
 

--- a/vllm/utils/collection_utils.py
+++ b/vllm/utils/collection_utils.py
@@ -7,10 +7,10 @@ This is similar in concept to the `collections` module.
 """
 
 from collections import defaultdict
-from collections.abc import Callable, Generator, Hashable, Iterable, Mapping
+from collections.abc import Callable, Generator, Hashable, Iterable, Mapping, Sequence
 from typing import Generic, Literal, TypeVar
 
-from typing_extensions import TypeIs, assert_never
+from typing_extensions import TypeIs, assert_never, overload
 
 T = TypeVar("T")
 
@@ -72,6 +72,34 @@ def is_list_of(
         return all(isinstance(v, typ) for v in value)
 
     assert_never(check)
+
+
+@overload
+def common_prefix(items: Sequence[str]) -> str: ...
+
+
+@overload
+def common_prefix(items: Sequence[Sequence[T]]) -> Sequence[T]: ...
+
+
+def common_prefix(items: Sequence[Sequence[T] | str]) -> Sequence[T] | str:
+    """Find the longest prefix common to all items."""
+    if len(items) == 0:
+        return []
+    if len(items) == 1:
+        return items[0]
+
+    shortest = min(items, key=len)
+    if not shortest:
+        return shortest[:0]
+
+    for match_len in range(1, len(shortest) + 1):
+        match = shortest[:match_len]
+        for item in items:
+            if item[:match_len] != match:
+                return shortest[: match_len - 1]
+
+    return shortest
 
 
 def chunk_list(lst: list[T], chunk_size: int) -> Generator[list[T]]:


### PR DESCRIPTION
## Purpose

Further generalize `_mark_language_model` and `_mark_tower_model` to handle the case where both MM and LM components are in the same child module, by introducing a `target` argument. For convenience, add a wrapper `_mark_composite_model` which enters the context of both `_mark_language_model` and `_mark_tower_model`.

Also, merged `LMMissingLayer` and `TowerMissingLayer` into `StageMissingLayer`, and use this to replace generation-specific modules in pooling adapters as well. cc @noooop 

This enables MM-only and LM-only model for the rest of the models, except for Terratorch and Transformers impl.

CLOSES https://github.com/vllm-project/vllm/issues/32631

## Test Plan & Result

### Baseline

Command:
```
VLLM_LOG_MODEL_INSPECTION=1 vllm serve zai-org/glm-4v-9b --max-model-len 4096 -tp 2 --trust-remote-code --hf-overrides '{"architectures": ["GLM4VForCausalLM"]}'
```

Output:
```
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71] vLLM model structure:
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71] GLM4VForCausalLM()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]   (transformer): GLM4VModel()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]     (embedding): VocabParallelEmbedding(num_embeddings=75776, embedding_dim=4096, org_vocab_size=151552, num_embeddings_padded=151552, tp_size=2)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]     (encoder): GLMTransformer()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]       (layers): ModuleList()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]         (0-39): 40 x GLMBlock()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]           (input_layernorm): RMSNorm(hidden_size=4096, eps=1.5625e-07)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]           (self_attention): GLMAttention()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             (query_key_value): QKVParallelLinear(in_features=4096, output_features=2304, bias=True, tp_size=2, gather_output=False)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             (dense): RowParallelLinear(in_features=2048, output_features=4096, bias=False, tp_size=2, reduce_results=True)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             (rotary_emb): RotaryEmbedding(head_size=128, rotary_dim=64, max_position_embeddings=8192, base=10000.0, is_neox_style=False)(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]               (apply_rotary_emb): ApplyRotaryEmb(is_neox_style=False, enable_fp32_compute=False)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             (attn): Attention(head_size=128, num_heads=16, num_kv_heads=1, scale=0.08838834764831845, backend=FlashAttentionImpl)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]           )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]           (post_attention_layernorm): RMSNorm(hidden_size=4096, eps=1.5625e-07)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]           (mlp): GLMMLP()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             (dense_h_to_4h): MergedColumnParallelLinear(in_features=4096, output_features=13696, bias=False, tp_size=2, gather_output=False)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             (activation_func): SiluAndMul()
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             (dense_4h_to_h): RowParallelLinear(in_features=6848, output_features=4096, bias=False, tp_size=2, reduce_results=True)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]           )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]         )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]       )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]       (final_layernorm): RMSNorm(hidden_size=4096, eps=1.5625e-07)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]     )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]     (output_layer): ParallelLMHead(num_embeddings=75776, embedding_dim=4096, org_vocab_size=151552, num_embeddings_padded=151552, tp_size=2)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]     (vision): EVA2CLIPModel()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]       (patch_embedding): EVA2CLIPPatchEmbedding()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]         (proj): Conv2dLayer(in_channels=3, out_channels=1792, kernel_size=(14, 14), stride=(14, 14), padding=(0, 0), bias=True)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]         (position_embedding): Embedding(6401, 1792)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]       )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]       (transformer): EVA2CLIPTransformer()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]         (layers): ModuleList()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]           (0-62): 63 x EVA2CLIPTransformerLayer()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             (input_layernorm): LayerNorm((1792,), eps=1e-06, elementwise_affine=True)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             (attention): EVA2CLIPAttention()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]               (query_key_value): QKVParallelLinear(in_features=1792, output_features=2688, bias=True, tp_size=2, gather_output=False)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]               (dense): RowParallelLinear(in_features=896, output_features=1792, bias=True, tp_size=2, reduce_results=True)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]               (attn): MMEncoderAttention()
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]               (output_dropout): Dropout(p=0.0, inplace=False)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             (mlp): EVA2CLIPMLP()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]               (activation_fn): GELU(approximate='none')
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]               (fc1): ColumnParallelLinear(in_features=1792, output_features=7680, bias=True, tp_size=2, gather_output=False)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]               (fc2): RowParallelLinear(in_features=7680, output_features=1792, bias=True, tp_size=2, reduce_results=True)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]             (post_attention_layernorm): LayerNorm((1792,), eps=1e-06, elementwise_affine=True)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]           )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]         )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]       )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]       (linear_proj): EVA2CLIPGLU()(
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]         (linear_proj): ReplicatedLinear(in_features=4096, output_features=4096, bias=False)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]         (norm1): LayerNorm((4096,), eps=1e-05, elementwise_affine=True)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]         (act1): GELU(approximate='none')
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]         (act2): SiluAndMul()
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]         (merged_proj): MergedColumnParallelLinear(in_features=4096, output_features=13696, bias=False, tp_size=2, gather_output=False)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]         (dense_4h_to_h): RowParallelLinear(in_features=6848, output_features=4096, bias=False, tp_size=2, reduce_results=True)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]       )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]       (conv): Conv2dLayer(in_channels=1792, out_channels=4096, kernel_size=(2, 2), stride=(2, 2), padding=(0, 0), bias=True)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]     )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]   )
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]   (lm_head): ParallelLMHead(num_embeddings=75776, embedding_dim=4096, org_vocab_size=151552, num_embeddings_padded=151552, tp_size=2)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71]   (logits_processor): LogitsProcessor(vocab_size=151552, org_vocab_size=151552, scale=1.0, logits_as_input=False)
(Worker_TP0 pid=274999) INFO 01-21 04:34:03 [base_loader.py:71] )
...
(Worker_TP0 pid=274999) INFO 01-21 04:34:15 [default_loader.py:291] Loading weights took 10.09 seconds
(Worker_TP0 pid=274999) INFO 01-21 04:34:16 [gpu_model_runner.py:3917] Model loading took 13.07 GiB memory and 12.820951 seconds
```

### MM-only

Command:
```
VLLM_LOG_MODEL_INSPECTION=1 vllm serve zai-org/glm-4v-9b --max-model-len 4096 -tp 2 --trust-remote-code --hf-overrides '{"architectures": ["GLM4VForCausalLM"]}' --mm-encoder-only
```

Output:
```
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71] vLLM model structure:
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71] GLM4VForCausalLM()(
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]   (transformer): GLM4VModel()(
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]     (embedding): VocabParallelEmbedding(num_embeddings=75776, embedding_dim=4096, org_vocab_size=151552, num_embeddings_padded=151552, tp_size=2)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]     (encoder): StageMissingLayer(name='language_model')
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]     (output_layer): ParallelLMHead(num_embeddings=75776, embedding_dim=4096, org_vocab_size=151552, num_embeddings_padded=151552, tp_size=2)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]     (vision): EVA2CLIPModel()(
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]       (patch_embedding): EVA2CLIPPatchEmbedding()(
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]         (proj): Conv2dLayer(in_channels=3, out_channels=1792, kernel_size=(14, 14), stride=(14, 14), padding=(0, 0), bias=True)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]         (position_embedding): Embedding(6401, 1792)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]       )
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]       (transformer): EVA2CLIPTransformer()(
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]         (layers): ModuleList()(
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]           (0-62): 63 x EVA2CLIPTransformerLayer()(
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]             (input_layernorm): LayerNorm((1792,), eps=1e-06, elementwise_affine=True)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]             (attention): EVA2CLIPAttention()(
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]               (query_key_value): QKVParallelLinear(in_features=1792, output_features=2688, bias=True, tp_size=2, gather_output=False)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]               (dense): RowParallelLinear(in_features=896, output_features=1792, bias=True, tp_size=2, reduce_results=True)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]               (attn): MMEncoderAttention()
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]               (output_dropout): Dropout(p=0.0, inplace=False)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]             )
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]             (mlp): EVA2CLIPMLP()(
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]               (activation_fn): GELU(approximate='none')
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]               (fc1): ColumnParallelLinear(in_features=1792, output_features=7680, bias=True, tp_size=2, gather_output=False)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]               (fc2): RowParallelLinear(in_features=7680, output_features=1792, bias=True, tp_size=2, reduce_results=True)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]             )
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]             (post_attention_layernorm): LayerNorm((1792,), eps=1e-06, elementwise_affine=True)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]           )
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]         )
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]       )
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]       (linear_proj): EVA2CLIPGLU()(
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]         (linear_proj): ReplicatedLinear(in_features=4096, output_features=4096, bias=False)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]         (norm1): LayerNorm((4096,), eps=1e-05, elementwise_affine=True)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]         (act1): GELU(approximate='none')
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]         (act2): SiluAndMul()
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]         (merged_proj): MergedColumnParallelLinear(in_features=4096, output_features=13696, bias=False, tp_size=2, gather_output=False)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]         (dense_4h_to_h): RowParallelLinear(in_features=6848, output_features=4096, bias=False, tp_size=2, reduce_results=True)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]       )
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]       (conv): Conv2dLayer(in_channels=1792, out_channels=4096, kernel_size=(2, 2), stride=(2, 2), padding=(0, 0), bias=True)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]     )
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]   )
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]   (lm_head): ParallelLMHead(num_embeddings=75776, embedding_dim=4096, org_vocab_size=151552, num_embeddings_padded=151552, tp_size=2)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71]   (logits_processor): LogitsProcessor(vocab_size=151552, org_vocab_size=151552, scale=1.0, logits_as_input=False)
(Worker_TP0 pid=250306) INFO 01-21 03:59:28 [base_loader.py:71] )
...
(Worker_TP0 pid=261398) INFO 01-21 04:18:05 [default_loader.py:291] Loading weights took 3.78 seconds
(Worker_TP0 pid=261398) INFO 01-21 04:18:07 [gpu_model_runner.py:3917] Model loading took 5.43 GiB memory and 6.536823 seconds
```

### LM-only

Command:
```
VLLM_LOG_MODEL_INSPECTION=1 vllm serve zai-org/glm-4v-9b --max-model-len 4096 -tp 2 --trust-remote-code --hf-overrides '{"architectures": ["GLM4VForCausalLM"]}' --limit-mm-per-prompt.image 0
```

Output:
```
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71] vLLM model structure:
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71] GLM4VForCausalLM()(
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]   (transformer): GLM4VModel()(
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]     (embedding): VocabParallelEmbedding(num_embeddings=75776, embedding_dim=4096, org_vocab_size=151552, num_embeddings_padded=151552, tp_size=2)
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]     (encoder): GLMTransformer()(
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]       (layers): ModuleList()(
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]         (0-39): 40 x GLMBlock()(
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]           (input_layernorm): RMSNorm(hidden_size=4096, eps=1.5625e-07)
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]           (self_attention): GLMAttention()(
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]             (query_key_value): QKVParallelLinear(in_features=4096, output_features=2304, bias=True, tp_size=2, gather_output=False)
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]             (dense): RowParallelLinear(in_features=2048, output_features=4096, bias=False, tp_size=2, reduce_results=True)
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]             (rotary_emb): RotaryEmbedding(head_size=128, rotary_dim=64, max_position_embeddings=8192, base=10000.0, is_neox_style=False)(
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]               (apply_rotary_emb): ApplyRotaryEmb(is_neox_style=False, enable_fp32_compute=False)
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]             )
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]             (attn): Attention(head_size=128, num_heads=16, num_kv_heads=1, scale=0.08838834764831845, backend=FlashAttentionImpl)
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]           )
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]           (post_attention_layernorm): RMSNorm(hidden_size=4096, eps=1.5625e-07)
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]           (mlp): GLMMLP()(
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]             (dense_h_to_4h): MergedColumnParallelLinear(in_features=4096, output_features=13696, bias=False, tp_size=2, gather_output=False)
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]             (activation_func): SiluAndMul()
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]             (dense_4h_to_h): RowParallelLinear(in_features=6848, output_features=4096, bias=False, tp_size=2, reduce_results=True)
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]           )
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]         )
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]       )
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]       (final_layernorm): RMSNorm(hidden_size=4096, eps=1.5625e-07)
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]     )
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]     (output_layer): ParallelLMHead(num_embeddings=75776, embedding_dim=4096, org_vocab_size=151552, num_embeddings_padded=151552, tp_size=2)
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]     (vision): StageMissingLayer(name='image_tower')
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]   )
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]   (lm_head): ParallelLMHead(num_embeddings=75776, embedding_dim=4096, org_vocab_size=151552, num_embeddings_padded=151552, tp_size=2)
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71]   (logits_processor): LogitsProcessor(vocab_size=151552, org_vocab_size=151552, scale=1.0, logits_as_input=False)
(Worker_TP0 pid=264145) INFO 01-21 04:21:21 [base_loader.py:71] )
...
(Worker_TP0 pid=264145) INFO 01-21 04:21:30 [default_loader.py:291] Loading weights took 6.92 seconds
(Worker_TP0 pid=264145) INFO 01-21 04:21:31 [gpu_model_runner.py:3917] Model loading took 8.81 GiB memory and 9.452554 seconds
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

