### PR TITLE
[Bugfix] Add glm4_moe_lite to MLA model list to fix excessive KV cache memory usage

### DIFF
--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -194,6 +194,7 @@ class ModelArchConfigConvertorBase:
             "longcat_flash",
             "pangu_ultra_moe",
             "pangu_ultra_moe_mtp",
+            "glm4_moe_lite",
         ):
             return self.hf_text_config.kv_lora_rank is not None
         elif self.hf_text_config.model_type == "eagle":


### PR DESCRIPTION
## Purpose

Add `glm4_moe_lite` architecture to the MLA supported model list to enable MLA attention for GLM-4.7-Flash.

GLM-4.7-Flash uses the `glm4_moe_lite` architecture with MLA attention parameters (`kv_lora_rank=512`, `q_lora_rank=768`), but was not recognized by `is_deepseek_mla()`, preventing MLA attention from being enabled and causing excessive KV cache memory usage.