### PR TITLE
[Misc] Add JSON format logging support

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     VLLM_USAGE_SOURCE: str = ""
     VLLM_CONFIGURE_LOGGING: bool = True
     VLLM_LOGGING_LEVEL: str = "INFO"
+    VLLM_LOGGING_JSON: int = 0
     VLLM_LOGGING_PREFIX: str = ""
     VLLM_LOGGING_STREAM: str = "ext://sys.stdout"
     VLLM_LOGGING_CONFIG_PATH: str | None = None
@@ -664,6 +665,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_LOGGING_CONFIG_PATH": lambda: os.getenv("VLLM_LOGGING_CONFIG_PATH"),
     # this is used for configuring the default logging level
     "VLLM_LOGGING_LEVEL": lambda: os.getenv("VLLM_LOGGING_LEVEL", "INFO").upper(),
+    # this is used to switch to structural json logging
+    "VLLM_LOGGING_JSON": lambda: os.getenv("VLLM_LOGGING_JSON", "0"),
     # this is used for configuring the default logging stream
     "VLLM_LOGGING_STREAM": lambda: os.getenv("VLLM_LOGGING_STREAM", "ext://sys.stdout"),
     # if set, VLLM_LOGGING_PREFIX will be prepended to all log messages

--- a/vllm/lora/layers/fused_moe.py
+++ b/vllm/lora/layers/fused_moe.py
@@ -83,11 +83,7 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
     ):
         if envs.VLLM_TUNED_CONFIG_FOLDER:
             hidden_size = layer.hidden_size
-            intermediate_size = (
-                self.w2_lora_a_stacked[0].shape[-1]
-                if op_prefix == "w2"
-                else self.w13_lora_b_stacked[0].shape[-2]
-            )
+            intermediate_size = layer.intermediate_size_per_partition
             shrink_config = get_lora_op_configs(
                 op_type=f"fused_moe_lora_{op_prefix}_shrink",
                 max_loras=num_loras,

--- a/vllm/lora/layers/fused_moe.py
+++ b/vllm/lora/layers/fused_moe.py
@@ -83,7 +83,11 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
     ):
         if envs.VLLM_TUNED_CONFIG_FOLDER:
             hidden_size = layer.hidden_size
-            intermediate_size = layer.intermediate_size_per_partition
+            intermediate_size = (
+                self.w2_lora_a_stacked[0].shape[-1]
+                if op_prefix == "w2"
+                else self.w13_lora_b_stacked[0].shape[-2]
+            )
             shrink_config = get_lora_op_configs(
                 op_type=f"fused_moe_lora_{op_prefix}_shrink",
                 max_loras=num_loras,


### PR DESCRIPTION
Add support of  structured logging.

Inspired by https://github.com/vllm-project/vllm/pull/2432 and https://github.com/vllm-project/vllm/pull/13920, but takes a slightly different approach.

Example of `standard` output:
```
Traceback (most recent call last):
  File "vllm/.venv/lib/python3.10/site-packages/huggingface_hub/utils/_http.py", line 402, in hf_raise_for_status
    response.raise_for_status()
  File "vllm/.venv/lib/python3.10/site-packages/requests/models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/resolve/main/config.json

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "vllm/.venv/lib/python3.10/site-packages/transformers/utils/hub.py", line 479, in cached_files
    hf_hub_download(
  File "vllm/.venv/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
  File "vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1007, in hf_hub_download
    return _hf_hub_download_to_cache_dir(
  File "vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1114, in _hf_hub_download_to_cache_dir
    _raise_on_head_call_error(head_call_error, force_download, local_files_only)
  File "vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1655, in _raise_on_head_call_error
    raise head_call_error
  File "vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1543, in _get_metadata_or_catch_error
    metadata = get_hf_file_metadata(
  File "vllm/.venv/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
  File "vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1460, in get_hf_file_metadata
    r = _request_wrapper(
  File "vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 283, in _request_wrapper
    response = _request_wrapper(
  File "vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 307, in _request_wrapper
    hf_raise_for_status(response)
  File "vllm/.venv/lib/python3.10/site-packages/huggingface_hub/utils/_http.py", line 419, in hf_raise_for_status
    raise _format(GatedRepoError, message, response) from e
huggingface_hub.errors.GatedRepoError: 401 Client Error. (Request ID: Root=1-697080da-48e4e3e774717bfd6949142b;5fc2238d-e537-49c1-b38c-9903c39af107)

Cannot access gated repo for url https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/resolve/main/config.json.
Access to model meta-llama/Llama-2-7b-chat-hf is restricted. You must have access to it and be authenticated to access it. Please log in.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "vllm/test/test_vllm.py", line 4, in <module>
    llm = LLM(model="meta-llama/Llama-2-7b-chat-hf")
  File "vllm/vllm/entrypoints/llm.py", line 342, in __init__
    self.llm_engine = LLMEngine.from_engine_args(
  File "vllm/vllm/v1/engine/llm_engine.py", line 166, in from_engine_args
    vllm_config = engine_args.create_engine_config(usage_context)
  File "vllm/vllm/engine/arg_utils.py", line 1337, in create_engine_config
    maybe_override_with_speculators(
  File "vllm/vllm/transformers_utils/config.py", line 639, in maybe_override_with_speculators
    config_dict, _ = PretrainedConfig.get_config_dict(
  File "vllm/.venv/lib/python3.10/site-packages/transformers/configuration_utils.py", line 662, in get_config_dict
    config_dict, kwargs = cls._get_config_dict(pretrained_model_name_or_path, **kwargs)
  File "vllm/.venv/lib/python3.10/site-packages/transformers/configuration_utils.py", line 721, in _get_config_dict
    resolved_config_file = cached_file(
  File "vllm/.venv/lib/python3.10/site-packages/transformers/utils/hub.py", line 322, in cached_file
    file = cached_files(path_or_repo_id=path_or_repo_id, filenames=[filename], **kwargs)
  File "vllm/.venv/lib/python3.10/site-packages/transformers/utils/hub.py", line 543, in cached_files
    raise OSError(
OSError: You are trying to access a gated repo.
Make sure to have access to it at https://huggingface.co/meta-llama/Llama-2-7b-chat-hf.
401 Client Error. (Request ID: Root=1-697080da-48e4e3e774717bfd6949142b;5fc2238d-e537-49c1-b38c-9903c39af107)

Cannot access gated repo for url https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/resolve/main/config.json.
Access to model meta-llama/Llama-2-7b-chat-hf is restricted. You must have access to it and be authenticated to access it. Please log in.
```

Example of the same but `structured` output:
```
{
  "asctime": "2026-01-21 08:28:33,853",
  "levelname": "CRITICAL",
  "name": "vllm.logger",
  "fileinfo": "vllm/vllm/logger.py",
  "lineno": 73,
  "message": "Uncaught exception",
  "exc_info": [
    "Traceback (most recent call last):",
    "File \"vllm/.venv/lib/python3.10/site-packages/huggingface_hub/utils/_http.py\", line 402, in hf_raise_for_status\n    response.raise_for_status()",
    "File \"vllm/.venv/lib/python3.10/site-packages/requests/models.py\", line 1026, in raise_for_status\n    raise HTTPError(http_error_msg, response=self)",
    "requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/resolve/main/config.json",
    "The above exception was the direct cause of the following exception:",
    "Traceback (most recent call last):",
    "File \"vllm/.venv/lib/python3.10/site-packages/transformers/utils/hub.py\", line 479, in cached_files\n    hf_hub_download(",
    "File \"vllm/.venv/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py\", line 114, in _inner_fn\n    return fn(*args, **kwargs)",
    "File \"vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py\", line 1007, in hf_hub_download\n    return _hf_hub_download_to_cache_dir(",
    "File \"vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py\", line 1114, in _hf_hub_download_to_cache_dir\n    _raise_on_head_call_error(head_call_error, force_download, local_files_only)",
    "File \"vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py\", line 1655, in _raise_on_head_call_error\n    raise head_call_error",
    "File \"vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py\", line 1543, in _get_metadata_or_catch_error\n    metadata = get_hf_file_metadata(",
    "File \"vllm/.venv/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py\", line 114, in _inner_fn\n    return fn(*args, **kwargs)",
    "File \"vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py\", line 1460, in get_hf_file_metadata\n    r = _request_wrapper(",
    "File \"vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py\", line 283, in _request_wrapper\n    response = _request_wrapper(",
    "File \"vllm/.venv/lib/python3.10/site-packages/huggingface_hub/file_download.py\", line 307, in _request_wrapper\n    hf_raise_for_status(response)",
    "File \"vllm/.venv/lib/python3.10/site-packages/huggingface_hub/utils/_http.py\", line 419, in hf_raise_for_status\n    raise _format(GatedRepoError, message, response) from e",
    "huggingface_hub.errors.GatedRepoError: 401 Client Error. (Request ID: Root=1-69708021-4c9458c154d2af9d19f50ca4;e7f33377-5d7c-4adb-baf7-e05318115f89)\n\nCannot access gated repo for url https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/resolve/main/config.json.\nAccess to model meta-llama/Llama-2-7b-chat-hf is restricted. You must have access to it and be authenticated to access it. Please log in.",
    "The above exception was the direct cause of the following exception:",
    "Traceback (most recent call last):",
    "File \"vllm/test/test_vllm.py\", line 4, in <module>\n    llm = LLM(model=\"meta-llama/Llama-2-7b-chat-hf\")",
    "File \"vllm/vllm/entrypoints/llm.py\", line 342, in __init__\n    self.llm_engine = LLMEngine.from_engine_args(",
    "File \"vllm/vllm/v1/engine/llm_engine.py\", line 166, in from_engine_args\n    vllm_config = engine_args.create_engine_config(usage_context)",
    "File \"vllm/vllm/engine/arg_utils.py\", line 1337, in create_engine_config\n    maybe_override_with_speculators(",
    "File \"vllm/vllm/transformers_utils/config.py\", line 639, in maybe_override_with_speculators\n    config_dict, _ = PretrainedConfig.get_config_dict(",
    "File \"vllm/.venv/lib/python3.10/site-packages/transformers/configuration_utils.py\", line 662, in get_config_dict\n    config_dict, kwargs = cls._get_config_dict(pretrained_model_name_or_path, **kwargs)",
    "File \"vllm/.venv/lib/python3.10/site-packages/transformers/configuration_utils.py\", line 721, in _get_config_dict\n    resolved_config_file = cached_file(",
    "File \"vllm/.venv/lib/python3.10/site-packages/transformers/utils/hub.py\", line 322, in cached_file\n    file = cached_files(path_or_repo_id=path_or_repo_id, filenames=[filename], **kwargs)",
    "File \"vllm/.venv/lib/python3.10/site-packages/transformers/utils/hub.py\", line 543, in cached_files\n    raise OSError(",
    "OSError: You are trying to access a gated repo.\nMake sure to have access to it at https://huggingface.co/meta-llama/Llama-2-7b-chat-hf.\n401 Client Error. (Request ID: Root=1-69708021-4c9458c154d2af9d19f50ca4;e7f33377-5d7c-4adb-baf7-e05318115f89)\n\nCannot access gated repo for url https://huggingface.co/meta-llama/Llama-2-7b-chat-hf/resolve/main/config.json.\nAccess to model meta-llama/Llama-2-7b-chat-hf is restricted. You must have access to it and be authenticated to access it. Please log in."
  ]
}
```

Not fully sure about `exc_info` — should it be an array of lines or just a single string? This is probably something that needs discussion.

Fixes https://github.com/vllm-project/vllm/issues/2397