### PR TITLE
[fix] tesdt mcp_tool_calling_streaming with a more complex math question

### DIFF
--- a/tests/entrypoints/openai/responses/test_mcp_tools.py
+++ b/tests/entrypoints/openai/responses/test_mcp_tools.py
@@ -229,7 +229,7 @@ class TestMCPEnabled:
                 "server_label": "code_interpreter",
             }
         ]
-        input_text = "What is 13 * 24? Use python to calculate the result."
+        input_text = "What is 123 * 456? Use python to calculate the result."
 
         stream_response = await mcp_enabled_client.responses.create(
             model=model_name,


### PR DESCRIPTION
## Purpose

python tool is not always triggered if the math question is too simple. When asked to compute larger numbers the python tool triggers consistently

## Test Plan
pytest tests/entrypoints/openai/responses/test_mcp_tools.py:: test_mcp_tool_calling_streaming_types

## Test Result

passes consistently