### PR TITLE
[Bugfix][Quant] fix online fp8 quantization oom

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 from torch.nn import Module
-from torch.utils._python_dispatch import TorchDispatchMode
 
 import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -275,26 +275,6 @@ class Fp8Config(QuantizationConfig):
         return None
 
 
-class CopyNumelCounter(TorchDispatchMode):
-    """
-    Tracks total number of elements modified with `copy_`. Useful for keeping
-    track of weight loading where underlying weights can be arbitrarily
-    transformed (such as with `narrow`) before calling copy.
-    """
-
-    def __init__(self):
-        super().__init__()
-        self.copied_numel = 0
-
-    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
-        if kwargs is None:
-            kwargs = {}
-        out = func(*args, **kwargs)
-        if func == torch.ops.aten.copy_.default:
-            self.copied_numel += args[0].numel()
-        return out
-
-
 class Fp8LinearMethod(LinearMethodBase):
     """Linear method for FP8.
     Supports loading FP8 checkpoints with static weight scale and
@@ -577,31 +557,6 @@ class Fp8OnlineLinearMethod(Fp8LinearMethod):
         layer.weight_block_size = None
 
         # WEIGHT
-        def patched_weight_loader(param, loaded_weight, *args, **kwargs):
-            # track how many elements we have updated
-            if not hasattr(layer, "_loaded_numel"):
-                layer._loaded_numel = 0
-
-            # load the current weight chunk
-            copy_numel_counter = CopyNumelCounter()
-            with copy_numel_counter:
-                res = weight_loader(param, loaded_weight, *args, **kwargs)  # type: ignore[misc]
-            layer._loaded_numel += copy_numel_counter.copied_numel
-
-            # if we have loaded all of the elements, call
-            # process_weights_after_loading
-            target_loaded_numel = layer.weight.numel()
-            if layer._loaded_numel == target_loaded_numel:
-                self.process_weights_after_loading(layer)
-
-                # Delete the bookkeeping
-                del layer._loaded_numel
-                # Prevent the usual `process_weights_after_loading` call from doing
-                # anything
-                layer._already_called_process_weights_after_loading = True
-
-            return res
-
         weight = ModelWeightParameter(
             data=torch.empty(
                 output_size_per_partition,
@@ -610,14 +565,11 @@ class Fp8OnlineLinearMethod(Fp8LinearMethod):
             ),
             input_dim=1,
             output_dim=0,
-            weight_loader=patched_weight_loader,
+            weight_loader=weight_loader,
         )
         layer.register_parameter("weight", weight)
 
     def process_weights_after_loading(self, layer: Module) -> None:
-        if getattr(layer, "_already_called_process_weights_after_loading", False):
-            return
-
         # TODO(future): support block_quant in online quant path
         assert not self.block_quant
 
@@ -853,9 +805,6 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             )
 
     def process_weights_after_loading(self, layer: Module) -> None:
-        if getattr(layer, "_already_called_process_weights_after_loading", False):
-            return
-
         # Allow for accessing weights and scales in standard way.
         w13 = layer.w13_weight
         w2 = layer.w2_weight
@@ -1132,42 +1081,6 @@ class Fp8OnlineMoEMethod(Fp8MoEMethod):
         layer.orig_dtype = params_dtype
         layer.weight_block_size = None
 
-        # We are doing online quantization, patch the weight loaded
-        # to call `process_weights_after_loading` in a streaming fashion
-        # as soon as the last weight chunk is loaded.
-        weight_loader = extra_weight_attrs["weight_loader"]
-        # create a new holder to prevent modifying behavior of any other
-        # objects which might depend on the old one
-        new_extra_weight_attrs = extra_weight_attrs
-
-        def patched_weight_loader(param, loaded_weight, *args, **kwargs):
-            # add a counter to track how many elements we have updated
-            if not hasattr(layer, "_loaded_numel"):
-                layer._loaded_numel = 0
-
-            # load the current weight chunk
-            copy_numel_counter = CopyNumelCounter()
-            with copy_numel_counter:
-                res = weight_loader(param, loaded_weight, *args, **kwargs)  # type: ignore[misc]
-            layer._loaded_numel += copy_numel_counter.copied_numel
-
-            # if we have loaded all of the elements, call
-            # process_weights_after_loading
-            target_loaded_numel = layer.w13_weight.numel() + layer.w2_weight.numel()
-            if layer._loaded_numel == target_loaded_numel:
-                self.process_weights_after_loading(layer)
-
-                # Delete the bookkeeping
-                del layer._loaded_numel
-                # Prevent the usual `process_weights_after_loading` call
-                # from doing anything
-                layer._already_called_process_weights_after_loading = True
-
-            return res
-
-        new_extra_weight_attrs["weight_loader"] = patched_weight_loader
-        extra_weight_attrs = new_extra_weight_attrs
-
         # WEIGHTS
         w13_weight = torch.nn.Parameter(
             torch.empty(
@@ -1211,9 +1124,6 @@ class Fp8OnlineMoEMethod(Fp8MoEMethod):
         layer.w2_input_scale = None
 
     def process_weights_after_loading(self, layer: Module) -> None:
-        if getattr(layer, "_already_called_process_weights_after_loading", False):
-            return
-
         # If checkpoint is fp16, quantize in place.
         fp8_dtype = current_platform.fp8_dtype()
         w13 = torch.empty_like(layer.w13_weight, dtype=fp8_dtype)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

https://github.com/vllm-project/vllm/pull/29196 was intended to reduce GPU memory usage by using streaming online fp8 quantization, but in practice it did not achieve this goal. Instead, it increased peak memory usage (even exceeding the memory required by BF16), causing the model to fail to load weights properly.

- `Qwen3-30B-A3B` and `ERNIE-4.5-VL-28B-A3B-PT`: Both can start on a single 80GB GPU with BF16, but fail to start with online FP8 due to OOM.
- `ERNIE-4.5-300B-A47B-PT`: Previously could start with 8×80GB GPUs + online FP8, but now fails to start.

vllm 0.13.0 and 0.14.0 are affected

By revert https://github.com/vllm-project/vllm/pull/29196, the OOM issue with online FP8 quantization was fixed. With the current PR, `Qwen3-30B-A3B` and `ERNIE-4.5-VL-28B-A3B-PT` can now start normally.


## Test Plan
```bash
# 80G*1 nvidia H GPU
vllm serve Qwen/Qwen3-30B-A3B --port 8506 --quantization fp8
```

## Test Result
main
```text
(EngineCore_DP0 pid=641420) ERROR 01-21 18:57:04 [core.py:935]   File "/root/paddlejob/workspace/env_run/output/wangyafeng/myGithub/vllm/vllm/model_executor/models/qwen3_moe.py", line 590, in load_weights
(EngineCore_DP0 pid=641420) ERROR 01-21 18:57:04 [core.py:935]     success = weight_loader(
(EngineCore_DP0 pid=641420) ERROR 01-21 18:57:04 [core.py:935]               ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=641420) ERROR 01-21 18:57:04 [core.py:935]   File "/root/paddlejob/workspace/env_run/output/wangyafeng/myGithub/vllm/vllm/model_executor/layers/quantization/fp8.py", line 1158, in patched_weight_loader
(EngineCore_DP0 pid=641420) ERROR 01-21 18:57:04 [core.py:935]     self.process_weights_after_loading(layer)
(EngineCore_DP0 pid=641420) ERROR 01-21 18:57:04 [core.py:935]   File "/root/paddlejob/workspace/env_run/output/wangyafeng/myGithub/vllm/vllm/model_executor/layers/quantization/fp8.py", line 1220, in process_weights_after_loading
(EngineCore_DP0 pid=641420) ERROR 01-21 18:57:04 [core.py:935]     w2 = torch.empty_like(layer.w2_weight, dtype=fp8_dtype)
(EngineCore_DP0 pid=641420) ERROR 01-21 18:57:04 [core.py:935]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=641420) ERROR 01-21 18:57:04 [core.py:935] torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 192.00 MiB. GPU 0 has a total capacity of 79.10 GiB of which 111.88 MiB is free. Process 1955871 has 78.98 GiB memory in use. Of the allocated memory 78.24 GiB is allocated by PyTorch, and 79.25 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://pytorch.org/docs/stable/notes/cuda.html#environment-variables)
```
This PR
successfully started

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

