### PR TITLE
[WIP] Add Mistral guidance

### DIFF
--- a/tests/tool_parsers/test_mistral_tool_parser.py
+++ b/tests/tool_parsers/test_mistral_tool_parser.py
@@ -973,14 +973,14 @@ class TestToolsLarkConverter:
                 7,
                 "auto",
                 True,
-                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "minLength": 1}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}}\n',
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "minLength": 1}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}}\n',  # noqa: E501
             ),
             (
                 [_create_tool("non_strict_func", {"param": "value"}, strict=False)],
                 7,
                 "auto",
                 False,
-                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "minLength": 1}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}, "maxItems": 1}\n',
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "minLength": 1}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}, "maxItems": 1}\n',  # noqa: E501
             ),
             # Single strict tool
             (
@@ -988,14 +988,14 @@ class TestToolsLarkConverter:
                 7,
                 "auto",
                 True,
-                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "strict_func"}, "arguments": {"param": "value"}}}]}}\n',
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "strict_func"}, "arguments": {"param": "value"}}}]}}\n',  # noqa: E501
             ),
             (
                 [_create_tool("strict_func", {"param": "value"}, strict=True)],
                 7,
                 "auto",
                 False,
-                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "strict_func"}, "arguments": {"param": "value"}}}]}, "maxItems": 1}\n',
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "strict_func"}, "arguments": {"param": "value"}}}]}, "maxItems": 1}\n',  # noqa: E501
             ),
             # Single strict tool with empty parameters
             (
@@ -1003,7 +1003,7 @@ class TestToolsLarkConverter:
                 7,
                 "auto",
                 True,
-                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "empty_strict_func"}, "arguments": {"type": "object", "properties": {}, "additionalProperties": false}}}]}}\n',
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "empty_strict_func"}, "arguments": {"type": "object", "properties": {}, "additionalProperties": false}}}]}}\n',  # noqa: E501
             ),
             # Multiple non-strict tools
             (
@@ -1014,7 +1014,7 @@ class TestToolsLarkConverter:
                 7,
                 "auto",
                 True,
-                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "minLength": 1}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}}\n',
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "minLength": 1}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}}\n',  # noqa: E501
             ),
             # Multiple mixed tools (some strict, some not)
             (
@@ -1025,7 +1025,7 @@ class TestToolsLarkConverter:
                 7,
                 "auto",
                 True,
-                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "strict_func"}, "arguments": {"param": "value"}}}, {"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "non_strict_func"}, "arguments": {"type": "object"}}}]}}\n',
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "strict_func"}, "arguments": {"param": "value"}}}, {"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "non_strict_func"}, "arguments": {"type": "object"}}}]}}\n',  # noqa: E501
             ),
             # Test cases for mode="auto" with tokenizer version 11 (post-v11)
             # Single non-strict tool
@@ -1034,14 +1034,14 @@ class TestToolsLarkConverter:
                 11,
                 "auto",
                 True,
-                '(<TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)+',
+                '(<TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)+',  # noqa: E501
             ),
             (
                 [_create_tool("non_strict_func", {"param": "value"}, strict=False)],
                 11,
                 "auto",
                 False,
-                '<TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?',
+                '<TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?',  # noqa: E501
             ),
             # Single strict tool
             (
@@ -1049,14 +1049,14 @@ class TestToolsLarkConverter:
                 11,
                 "auto",
                 True,
-                '((<TOOL_CALLS> SAFE_WS? "strict_func" <ARGS> SAFE_WS? %json {"param": "value"} SAFE_WS?))+',
+                '((<TOOL_CALLS> SAFE_WS? "strict_func" <ARGS> SAFE_WS? %json {"param": "value"} SAFE_WS?))+',  # noqa: E501
             ),
             (
                 [_create_tool("strict_func", {"param": "value"}, strict=True)],
                 11,
                 "auto",
                 False,
-                '(<TOOL_CALLS> SAFE_WS? "strict_func" <ARGS> SAFE_WS? %json {"param": "value"} SAFE_WS?)',
+                '(<TOOL_CALLS> SAFE_WS? "strict_func" <ARGS> SAFE_WS? %json {"param": "value"} SAFE_WS?)',  # noqa: E501
             ),
             # Single strict tool with empty parameters
             (
@@ -1064,7 +1064,7 @@ class TestToolsLarkConverter:
                 11,
                 "auto",
                 True,
-                '((<TOOL_CALLS> SAFE_WS? "empty_strict_func" <ARGS> SAFE_WS? %json {"type": "object", "properties": {}, "additionalProperties": false} SAFE_WS?))+',
+                '((<TOOL_CALLS> SAFE_WS? "empty_strict_func" <ARGS> SAFE_WS? %json {"type": "object", "properties": {}, "additionalProperties": false} SAFE_WS?))+',  # noqa: E501
             ),
             # Multiple non-strict tools
             (
@@ -1075,7 +1075,7 @@ class TestToolsLarkConverter:
                 11,
                 "auto",
                 True,
-                '(<TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)+',
+                '(<TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)+',  # noqa: E501
             ),
             # Multiple mixed tools (some strict, some not)
             (
@@ -1086,23 +1086,22 @@ class TestToolsLarkConverter:
                 11,
                 "auto",
                 True,
-                '((<TOOL_CALLS> SAFE_WS? "strict_func" <ARGS> SAFE_WS? %json {"param": "value"} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "non_strict_func" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+',
+                '((<TOOL_CALLS> SAFE_WS? "strict_func" <ARGS> SAFE_WS? %json {"param": "value"} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "non_strict_func" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+',  # noqa: E501
             ),
-            # Test cases for mode="required" - should be same as "auto" for grammar generation
-            # Just test a few representative cases to ensure mode is handled correctly
+            # Test cases for mode="required" - should be same as "auto" for grammar
             (
                 [_create_tool("test_func", {"param": "value"}, strict=True)],
                 7,
                 "required",
                 True,
-                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "test_func"}, "arguments": {"param": "value"}}}]}}\n',
+                '<TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "test_func"}, "arguments": {"param": "value"}}}]}}\n',  # noqa: E501
             ),
             (
                 [_create_tool("test_func", {"param": "value"}, strict=False)],
                 11,
                 "required",
                 False,
-                '<TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?',
+                '<TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?',  # noqa: E501
             ),
         ],
         ids=[
@@ -1189,7 +1188,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1202,7 +1201,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: content | (content? fcalls)\nfcalls: ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content | (content? fcalls)\nfcalls: ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "auto",
@@ -1217,7 +1216,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1230,7 +1229,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: think? (content | fcalls)\nfcalls: content? ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\nthink: <THINK> content </THINK>\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: think? (content | fcalls)\nfcalls: content? ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\nthink: <THINK> content </THINK>\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "auto",
@@ -1245,7 +1244,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1258,7 +1257,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: content | (content? fcalls)\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool1"}, "arguments": {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}}, {"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool2"}, "arguments": {"type": "object"}}}]}}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content | (content? fcalls)\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool1"}, "arguments": {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}}, {"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool2"}, "arguments": {"type": "object"}}}]}}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "auto",
@@ -1273,7 +1272,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1286,7 +1285,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: content | (content? fcalls)\nfcalls: ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content | (content? fcalls)\nfcalls: ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "auto",
@@ -1301,7 +1300,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1314,7 +1313,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: content | (content? fcalls)\nfcalls: ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content | (content? fcalls)\nfcalls: ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "auto",
@@ -1322,7 +1321,7 @@ class TestMistralGrammarFactory:
                 False,
                 7,
                 [_create_tool("tool1", {}, strict=False)],
-                'start: body\nbody: content | (content? fcalls)\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "minLength": 1}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}, "maxItems": 1}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content | (content? fcalls)\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "minLength": 1}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}, "maxItems": 1}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "auto",
@@ -1337,7 +1336,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1349,7 +1348,7 @@ class TestMistralGrammarFactory:
                         strict=True,
                     )
                 ],
-                'start: body\nbody: content | (content? fcalls)\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool1"}, "arguments": {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}}]}, "maxItems": 1}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content | (content? fcalls)\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool1"}, "arguments": {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}}]}, "maxItems": 1}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "auto",
@@ -1364,7 +1363,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1377,7 +1376,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: content | (content? fcalls)\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool1"}, "arguments": {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}}, {"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool2"}, "arguments": {"type": "object"}}}]}, "maxItems": 1}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content | (content? fcalls)\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool1"}, "arguments": {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}}, {"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool2"}, "arguments": {"type": "object"}}}]}, "maxItems": 1}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "auto",
@@ -1385,7 +1384,7 @@ class TestMistralGrammarFactory:
                 False,
                 11,
                 [_create_tool("tool1", {}, strict=False)],
-                'start: body\nbody: content | (content? fcalls)\nfcalls: <TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content | (content? fcalls)\nfcalls: <TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "auto",
@@ -1400,7 +1399,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1412,7 +1411,7 @@ class TestMistralGrammarFactory:
                         strict=True,
                     )
                 ],
-                'start: body\nbody: content | (content? fcalls)\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content | (content? fcalls)\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "auto",
@@ -1427,7 +1426,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1440,7 +1439,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: content | (content? fcalls)\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content | (content? fcalls)\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "auto",
@@ -1448,7 +1447,7 @@ class TestMistralGrammarFactory:
                 False,
                 13,
                 [_create_tool("tool1", {}, strict=False)],
-                'start: body\nbody: content | (content? fcalls)\nfcalls: <TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content | (content? fcalls)\nfcalls: <TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "auto",
@@ -1463,7 +1462,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1475,7 +1474,7 @@ class TestMistralGrammarFactory:
                         strict=True,
                     )
                 ],
-                'start: body\nbody: content | (content? fcalls)\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content | (content? fcalls)\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "auto",
@@ -1490,7 +1489,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1503,7 +1502,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: content | (content? fcalls)\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content | (content? fcalls)\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "required",
@@ -1518,7 +1517,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1531,7 +1530,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: content? fcalls\nfcalls: ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content? fcalls\nfcalls: ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "required",
@@ -1546,7 +1545,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1559,7 +1558,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: think? fcalls\nfcalls: content? ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\nthink: <THINK> content </THINK>\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: think? fcalls\nfcalls: content? ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\nthink: <THINK> content </THINK>\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "required",
@@ -1574,7 +1573,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1587,7 +1586,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: content? fcalls\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool1"}, "arguments": {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}}, {"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool2"}, "arguments": {"type": "object"}}}]}}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content? fcalls\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool1"}, "arguments": {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}}, {"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool2"}, "arguments": {"type": "object"}}}]}}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "required",
@@ -1602,7 +1601,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1615,7 +1614,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: content? fcalls\nfcalls: ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content? fcalls\nfcalls: ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "required",
@@ -1630,7 +1629,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1643,7 +1642,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: content? fcalls\nfcalls: ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content? fcalls\nfcalls: ((<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?))+\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "required",
@@ -1651,34 +1650,7 @@ class TestMistralGrammarFactory:
                 False,
                 7,
                 [_create_tool("tool1", {}, strict=False)],
-                'start: body\nbody: content? fcalls\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "minLength": 1}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}, "maxItems": 1}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
-            ),
-            (
-                "required",
-                False,
-                False,
-                7,
-                [
-                    _create_tool(
-                        "tool1",
-                        {
-                            "type": "object",
-                            "properties": {
-                                "location": {
-                                    "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
-                                },
-                                "unit": {
-                                    "type": "string",
-                                    "enum": ["celsius", "fahrenheit"],
-                                },
-                            },
-                            "required": ["location", "unit"],
-                        },
-                        strict=True,
-                    )
-                ],
-                'start: body\nbody: content? fcalls\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool1"}, "arguments": {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}}]}, "maxItems": 1}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content? fcalls\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {"name": {"type": "string", "minLength": 1}, "arguments": {"type": "object"}}, "required": ["name", "arguments"]}, "maxItems": 1}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "required",
@@ -1693,43 +1665,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
-                                },
-                                "unit": {
-                                    "type": "string",
-                                    "enum": ["celsius", "fahrenheit"],
-                                },
-                            },
-                            "required": ["location", "unit"],
-                        },
-                        strict=True,
-                    ),
-                    _create_tool("tool2", {}, strict=False),
-                ],
-                'start: body\nbody: content? fcalls\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool1"}, "arguments": {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}}, {"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool2"}, "arguments": {"type": "object"}}}]}, "maxItems": 1}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
-            ),
-            (
-                "required",
-                False,
-                False,
-                11,
-                [_create_tool("tool1", {}, strict=False)],
-                'start: body\nbody: content? fcalls\nfcalls: <TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
-            ),
-            (
-                "required",
-                False,
-                False,
-                11,
-                [
-                    _create_tool(
-                        "tool1",
-                        {
-                            "type": "object",
-                            "properties": {
-                                "location": {
-                                    "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1741,7 +1677,43 @@ class TestMistralGrammarFactory:
                         strict=True,
                     )
                 ],
-                'start: body\nbody: content? fcalls\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content? fcalls\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool1"}, "arguments": {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}}]}, "maxItems": 1}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
+            ),
+            (
+                "required",
+                False,
+                False,
+                7,
+                [
+                    _create_tool(
+                        "tool1",
+                        {
+                            "type": "object",
+                            "properties": {
+                                "location": {
+                                    "type": "string",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
+                                },
+                                "unit": {
+                                    "type": "string",
+                                    "enum": ["celsius", "fahrenheit"],
+                                },
+                            },
+                            "required": ["location", "unit"],
+                        },
+                        strict=True,
+                    ),
+                    _create_tool("tool2", {}, strict=False),
+                ],
+                'start: body\nbody: content? fcalls\nfcalls: <TOOL_CALLS> SAFE_WS? fcall_array SAFE_WS?\nfcall_array: %json {"minItems": 1, "type": "array", "items": {"anyOf": [{"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool1"}, "arguments": {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]}}}, {"type": "object", "required": ["name", "arguments"], "additionalProperties": false, "properties": {"name": {"const": "tool2"}, "arguments": {"type": "object"}}}]}, "maxItems": 1}\n\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
+            ),
+            (
+                "required",
+                False,
+                False,
+                11,
+                [_create_tool("tool1", {}, strict=False)],
+                'start: body\nbody: content? fcalls\nfcalls: <TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "required",
@@ -1756,43 +1728,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
-                                },
-                                "unit": {
-                                    "type": "string",
-                                    "enum": ["celsius", "fahrenheit"],
-                                },
-                            },
-                            "required": ["location", "unit"],
-                        },
-                        strict=True,
-                    ),
-                    _create_tool("tool2", {}, strict=False),
-                ],
-                'start: body\nbody: content? fcalls\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
-            ),
-            (
-                "required",
-                False,
-                False,
-                13,
-                [_create_tool("tool1", {}, strict=False)],
-                'start: body\nbody: content? fcalls\nfcalls: <TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
-            ),
-            (
-                "required",
-                False,
-                False,
-                13,
-                [
-                    _create_tool(
-                        "tool1",
-                        {
-                            "type": "object",
-                            "properties": {
-                                "location": {
-                                    "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1804,7 +1740,43 @@ class TestMistralGrammarFactory:
                         strict=True,
                     )
                 ],
-                'start: body\nbody: content? fcalls\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content? fcalls\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
+            ),
+            (
+                "required",
+                False,
+                False,
+                11,
+                [
+                    _create_tool(
+                        "tool1",
+                        {
+                            "type": "object",
+                            "properties": {
+                                "location": {
+                                    "type": "string",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
+                                },
+                                "unit": {
+                                    "type": "string",
+                                    "enum": ["celsius", "fahrenheit"],
+                                },
+                            },
+                            "required": ["location", "unit"],
+                        },
+                        strict=True,
+                    ),
+                    _create_tool("tool2", {}, strict=False),
+                ],
+                'start: body\nbody: content? fcalls\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
+            ),
+            (
+                "required",
+                False,
+                False,
+                13,
+                [_create_tool("tool1", {}, strict=False)],
+                'start: body\nbody: content? fcalls\nfcalls: <TOOL_CALLS> SAFE_WS? /.+/ <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "required",
@@ -1819,7 +1791,34 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
+                                },
+                                "unit": {
+                                    "type": "string",
+                                    "enum": ["celsius", "fahrenheit"],
+                                },
+                            },
+                            "required": ["location", "unit"],
+                        },
+                        strict=True,
+                    )
+                ],
+                'start: body\nbody: content? fcalls\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
+            ),
+            (
+                "required",
+                False,
+                False,
+                13,
+                [
+                    _create_tool(
+                        "tool1",
+                        {
+                            "type": "object",
+                            "properties": {
+                                "location": {
+                                    "type": "string",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1832,7 +1831,7 @@ class TestMistralGrammarFactory:
                     ),
                     _create_tool("tool2", {}, strict=False),
                 ],
-                'start: body\nbody: content? fcalls\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',
+                'start: body\nbody: content? fcalls\nfcalls: (<TOOL_CALLS> SAFE_WS? "tool1" <ARGS> SAFE_WS? %json {"type": "object", "properties": {"location": {"type": "string", "description": "City and state, e.g., \'San Francisco, CA\'"}, "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}}, "required": ["location", "unit"]} SAFE_WS?) | (<TOOL_CALLS> SAFE_WS? "tool2" <ARGS> SAFE_WS? %json {"type": "object"} SAFE_WS?)\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/',  # noqa: E501
             ),
             (
                 "none",
@@ -1840,7 +1839,7 @@ class TestMistralGrammarFactory:
                 False,
                 7,
                 [_create_tool("tool1", {}, strict=False)],
-                "start: body\nbody: content\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/",
+                "start: body\nbody: content\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/",  # noqa: E501
             ),
             (
                 "none",
@@ -1855,7 +1854,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1867,7 +1866,7 @@ class TestMistralGrammarFactory:
                         strict=True,
                     )
                 ],
-                "start: body\nbody: content\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/",
+                "start: body\nbody: content\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/",  # noqa: E501
             ),
             (
                 "none",
@@ -1875,7 +1874,7 @@ class TestMistralGrammarFactory:
                 False,
                 11,
                 [_create_tool("tool1", {}, strict=False)],
-                "start: body\nbody: content\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/",
+                "start: body\nbody: content\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/",  # noqa: E501
             ),
             (
                 "none",
@@ -1890,7 +1889,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1902,7 +1901,7 @@ class TestMistralGrammarFactory:
                         strict=True,
                     )
                 ],
-                "start: body\nbody: content\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/",
+                "start: body\nbody: content\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/",  # noqa: E501
             ),
             (
                 "none",
@@ -1910,7 +1909,7 @@ class TestMistralGrammarFactory:
                 False,
                 13,
                 [_create_tool("tool1", {}, strict=False)],
-                "start: body\nbody: content\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/",
+                "start: body\nbody: content\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/",  # noqa: E501
             ),
             (
                 "none",
@@ -1925,7 +1924,7 @@ class TestMistralGrammarFactory:
                             "properties": {
                                 "location": {
                                     "type": "string",
-                                    "description": "City and state, e.g., 'San Francisco, CA'",
+                                    "description": "City and state, e.g., 'San Francisco, CA'",  # noqa: E501
                                 },
                                 "unit": {
                                     "type": "string",
@@ -1937,7 +1936,7 @@ class TestMistralGrammarFactory:
                         strict=True,
                     )
                 ],
-                "start: body\nbody: content\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/",
+                "start: body\nbody: content\ncontent: (/(.|\\n)+/)+\nSAFE_WS: /[ \\t\\r\\n]+/",  # noqa: E501
             ),
         ],
     )

--- a/tests/v1/entrypoints/llm/test_struct_output_generate.py
+++ b/tests/v1/entrypoints/llm/test_struct_output_generate.py
@@ -78,6 +78,7 @@ PARAMS_MODELS_BACKENDS_TOKENIZER_MODE = [
     # ("Qwen/Qwen2.5-1.5B-Instruct", "guidance", "auto"),
     ("mistralai/Ministral-8B-Instruct-2410", "outlines", "auto", NGRAM_SPEC_CONFIG),
     ("mistralai/Ministral-8B-Instruct-2410", "guidance", "hf", NGRAM_SPEC_CONFIG),
+    ("mistralai/Ministral-8B-Instruct-2410", "guidance", "mistral", NGRAM_SPEC_CONFIG),
     ("Qwen/Qwen2.5-1.5B-Instruct", "xgrammar", "auto", NGRAM_SPEC_CONFIG),
     ("meta-llama/Meta-Llama-3.1-8B-Instruct", "xgrammar", "auto", EAGLE_SPEC_CONFIG),
 ]

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -140,7 +140,10 @@ class OpenAIServingChat(OpenAIServing):
             enable_auto_tools=enable_auto_tools,
             model_name=self.model_config.model,
         )
-        if self.tool_parser == MistralToolParser and self.reasoning_parser is not None:
+        if (
+            self.tool_parser == MistralToolParser
+            and self.reasoning_parser_cls is not None
+        ):
             self.tool_parser.reasoning = True
 
         self.exclude_tools_when_tool_choice_none = exclude_tools_when_tool_choice_none

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -83,7 +83,7 @@ from vllm.tokenizers.mistral import (
     validate_request_params,
 )
 from vllm.tool_parsers import ToolParser
-from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
+from vllm.tool_parsers.mistral_tool_parser import MistralToolCall, MistralToolParser
 from vllm.tool_parsers.utils import partial_json_loads
 from vllm.utils.collection_utils import as_list
 
@@ -140,6 +140,9 @@ class OpenAIServingChat(OpenAIServing):
             enable_auto_tools=enable_auto_tools,
             model_name=self.model_config.model,
         )
+        if self.tool_parser == MistralToolParser and self.reasoning_parser is not None:
+            self.tool_parser.reasoning = True
+
         self.exclude_tools_when_tool_choice_none = exclude_tools_when_tool_choice_none
 
         self.enable_prompt_tokens_details = enable_prompt_tokens_details

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -749,12 +749,6 @@ class SamplingParams(
             # allows <|special_token|> and similar, see
             # https://github.com/guidance-ai/llguidance/blob/main/docs/syntax.md#special-tokens
             # Without tokenizer these are disallowed in grammars.
-            if isinstance(tokenizer, MistralTokenizer):
-                raise ValueError(
-                    "Mistral tokenizer is not supported for the 'guidance' "
-                    "structured output backend. Please use ['xgrammar', 'outlines'] "
-                    "backends or tokenizer_mode='hf' instead."
-                )
             validate_guidance_grammar(self, tokenizer=None)
         elif backend == "outlines":
             # outlines backend
@@ -793,7 +787,7 @@ class SamplingParams(
                         schema = so_params.json
                     skip_guidance = has_guidance_unsupported_json_features(schema)
 
-                if isinstance(tokenizer, MistralTokenizer) or skip_guidance:
+                if skip_guidance:
                     # Fall back to outlines if the tokenizer is Mistral
                     # or if schema contains features unsupported by guidance
                     validate_structured_output_request_outlines(self)

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -38,6 +38,7 @@ class StructuredOutputsParams:
     regex: str | None = None
     choice: list[str] | None = None
     grammar: str | None = None
+    lark: str | None = None
     json_object: bool | None = None
     # These are other options that can be set.
     disable_fallback: bool = False
@@ -59,6 +60,7 @@ class StructuredOutputsParams:
                 self.regex is not None,
                 self.choice is not None,
                 self.grammar is not None,
+                self.lark is not None,
                 self.json_object is not None,
                 self.structural_tag is not None,
             ]
@@ -85,6 +87,7 @@ class StructuredOutputsParams:
                 "regex",
                 "choice",
                 "grammar",
+                "lark",
                 "json_object",
                 "structural_tag",
             )
@@ -101,6 +104,7 @@ class StructuredOutputsParams:
                 "regex",
                 "choice",
                 "grammar",
+                "lark",
                 "json_object",
             )
         )

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast, overload
 
+import llguidance as llg
+import regex as re
 from mistral_common.protocol.instruct.request import (
     ChatCompletionRequest as MistralChatCompletionRequest,
 )
@@ -11,8 +13,15 @@ from mistral_common.protocol.instruct.validator import ValidationMode
 from mistral_common.tokens.tokenizers.base import (
     SpecialTokenPolicy,
     SpecialTokens,
+    Tokenizer,
 )
-from mistral_common.tokens.tokenizers.instruct import InstructTokenizerV13
+from mistral_common.tokens.tokenizers.instruct import (
+    InstructTokenizerBase,
+    InstructTokenizerV13,
+)
+from mistral_common.tokens.tokenizers.mistral import (
+    MistralTokenizer as MistralCommonTokenizer,
+)
 from mistral_common.tokens.tokenizers.sentencepiece import (
     SentencePieceTokenizer,
 )
@@ -21,20 +30,21 @@ from mistral_common.tokens.tokenizers.tekken import Tekkenizer
 from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.logger import init_logger
+from vllm.tokenizers.protocol import TokenizerLike
 
-from .protocol import TokenizerLike
+try:
+    # Transformers v5
+    from transformers.tokenization_mistral_common import MistralCommonBackend
+except ImportError:
+    # Transformers v4
+    from transformers.tokenization_mistral_common import (
+        MistralCommonTokenizer as MistralCommonBackend,
+    )
+
 
 if TYPE_CHECKING:
     from transformers import BatchEncoding
 
-    try:
-        # Transformers v5
-        from transformers.tokenization_mistral_common import MistralCommonBackend
-    except ImportError:
-        # Transformers v4
-        from transformers.tokenization_mistral_common import (
-            MistralCommonTokenizer as MistralCommonBackend,
-        )
 
 logger = init_logger(__name__)
 
@@ -217,15 +227,6 @@ class MistralTokenizer(TokenizerLike):
         download_dir: str | None = None,
         **kwargs,
     ) -> "MistralTokenizer":
-        try:
-            # Transformers v5
-            from transformers.tokenization_mistral_common import MistralCommonBackend
-        except ImportError:
-            # Transformers v4
-            from transformers.tokenization_mistral_common import (
-                MistralCommonTokenizer as MistralCommonBackend,
-            )
-
         tokenizer = MistralCommonBackend.from_pretrained(
             path_or_repo_id,
             *args,
@@ -240,10 +241,10 @@ class MistralTokenizer(TokenizerLike):
     def __init__(self, tokenizer: "MistralCommonBackend") -> None:
         super().__init__()
 
-        self.transformers_tokenizer = tokenizer
-        self.mistral = tokenizer.tokenizer
-        self.instruct = self.mistral.instruct_tokenizer
-        self.tokenizer = self.instruct.tokenizer
+        self.transformers_tokenizer: MistralCommonBackend = tokenizer
+        self.mistral: MistralCommonTokenizer = tokenizer.tokenizer
+        self.instruct: InstructTokenizerBase = self.mistral.instruct_tokenizer
+        self.tokenizer: Tokenizer = self.instruct.tokenizer
 
         mode = self.mistral._chat_completion_request_validator._mode
         if mode != ValidationMode.test:
@@ -514,7 +515,7 @@ class MistralTokenizer(TokenizerLike):
             return [self.tokenizer.id_to_piece(token_id) for token_id in ids]
 
         non_skip_special_tokens_ids = {
-            self.tokenizer.get_control_token(SpecialTokens.tool_calls),
+            self.tokenizer.get_special_token(SpecialTokens.tool_calls),
         }
         if isinstance(self.instruct, InstructTokenizerV13):
             if self.instruct.BEGIN_THINK:
@@ -546,3 +547,66 @@ class MistralTokenizer(TokenizerLike):
             ]
 
         return tokens
+
+
+class MistralLLGTokenizer:
+    """Wraps a mistral tokenizer for use with llguidance."""
+
+    eos_token_id: int
+    bos_token_id: int
+    tokens: list[bytes]
+    special_token_ids: list[int]
+
+    def __init__(self, tokenizer: MistralTokenizer) -> None:
+        self._tokenizer = tokenizer.tokenizer
+        self.eos_token_id = self._tokenizer.eos_id
+        self.bos_token_id = self._tokenizer.bos_id
+
+        self.tokens: list[bytes] = []
+        self.special_token_ids: list[int] = []
+
+        seen_special_tokens: set[str] = set()
+        for i in range(self._tokenizer.n_words):
+            # Convert square brackets to angle brackets for special tokens,
+            # since llg only recognizes the latter.
+            if self._tokenizer.is_special(i):
+                token_rep = self._tokenizer.id_to_piece(i)
+                if match := re.fullmatch(r"\[(.*)\]", token_rep):
+                    token_rep_llg = f"<{match.group(1)}>"
+                else:
+                    token_rep_llg = token_rep
+
+                if not re.fullmatch(r"<.*>", token_rep_llg):
+                    raise ValueError(
+                        f"Invalid special token: {token_rep_llg} ({token_rep})"
+                    )
+                assert token_rep_llg not in seen_special_tokens, (
+                    token_rep_llg,
+                    seen_special_tokens,
+                )
+                seen_special_tokens.add(token_rep_llg)
+                self.special_token_ids.append(i)
+                self.tokens.append(token_rep_llg.encode("utf-8"))
+            else:
+                token = self._tokenizer.id_to_byte_piece(i, SpecialTokenPolicy.RAISE)
+                self.tokens.append(token)
+
+        assert len(self.special_token_ids) == self._tokenizer.num_special_tokens, (
+            len(self.special_token_ids),
+            self._tokenizer.num_special_tokens,
+        )
+
+    def __call__(self, s: str, *args, **kwds) -> list[int]:
+        # HACK: add a null byte to the start of the string to avoid the tokenizer
+        # absorbing the first character of tokens that start with "▁".
+        # we then ignore the first two tokens the "▁" and the null byte.
+        # This gives us the pure tokenized text without SP shit.
+        if isinstance(self._tokenizer, SentencePieceTokenizer):
+            return self._tokenizer.encode("\00" + s, bos=False, eos=False)[2:]
+        else:
+            return self._tokenizer.encode(s, bos=False, eos=False)
+
+
+def guidance_tokenizer_from_mistral_tokenizer(tokenizer: Tokenizer) -> llg.LLTokenizer:
+    tokenizer_data = MistralLLGTokenizer(tokenizer)
+    return llg.LLTokenizer(llg.TokenizerWrapper(tokenizer_data))

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -214,7 +214,7 @@ class MistralGrammarFactory:
 
     def __init__(self, tokenizer: MistralTokenizer) -> None:
         if not isinstance(tokenizer, MistralTokenizer):
-            raise ValueError("`MistralGrammarFactory` expectes a `MistralTokenizer`.")
+            raise ValueError("`MistralGrammarFactory` expects a `MistralTokenizer`.")
         self._tokenizer = tokenizer
         self._tokenizer_version = tokenizer.tokenizer._version
 

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -21,6 +21,7 @@ class StructuredOutputOptions(enum.Enum):
     JSON_OBJECT = enum.auto()
     REGEX = enum.auto()
     GRAMMAR = enum.auto()
+    LARK = enum.auto()
     CHOICE = enum.auto()
     STRUCTURAL_TAG = enum.auto()
 

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -354,3 +354,8 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
                 xgr.Grammar.from_structural_tag(so_params.structural_tag)
         except Exception as e:
             raise ValueError("Invalid structural tag specification.") from e
+
+    if so_params.lark:
+        raise ValueError(
+            "xgrazmmar does not support grammar from Lark. Use guidance instead."
+        )

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -86,6 +86,8 @@ def get_structured_output_key(params: StructuredOutputsParams) -> StructuredOutp
         return StructuredOutputOptions.CHOICE, json_str
     if params.grammar is not None:
         return StructuredOutputOptions.GRAMMAR, params.grammar
+    if params.lark is not None:
+        return StructuredOutputOptions.LARK, params.lark
     if params.structural_tag is not None:
         return StructuredOutputOptions.STRUCTURAL_TAG, params.structural_tag
     raise ValueError("No valid structured output parameter found")


### PR DESCRIPTION
## Purpose

This is a work in progress branch to add better guidance for Mistral Tool Parser with the Mistral Tokenizer.

To do so a lark grammar is generated when the `--tool-call-parser mistral` is used:
- the lark grammar handles auto, required and none tool choices.
- naming is also handled by filtering the tools before passing it to the grammar factory.

This PR also brings support for the MistralTokenizer guidance backend.

## Test Plan

Right now there are no unit tests attached to the draft PR and has only been checked by manual requests.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

