### PR TITLE
[ROCm] fix import for on_gfx9

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
@@ -32,7 +32,6 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
 )
 from vllm.platforms import current_platform
-from vllm.platforms.rocm import on_gfx9
 from vllm.triton_utils import tl, triton
 
 
@@ -914,7 +913,14 @@ class BatchedTritonExperts(mk.FusedMoEPermuteExpertsUnpermute):
         activation_key: QuantKey | None,
     ) -> bool:
         p = current_platform
-        device_supports_fp8 = (p.is_rocm() and on_gfx9()) or (
+        if p.is_rocm():
+            from vllm.platforms.rocm import on_gfx9
+
+            is_rocm_on_gfx9 = on_gfx9()
+        else:
+            is_rocm_on_gfx9 = False
+
+        device_supports_fp8 = (is_rocm_on_gfx9) or (
             p.is_cuda() and p.has_device_capability((8, 9))
         )
 

--- a/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
@@ -920,7 +920,7 @@ class BatchedTritonExperts(mk.FusedMoEPermuteExpertsUnpermute):
         else:
             is_rocm_on_gfx9 = False
 
-        device_supports_fp8 = (is_rocm_on_gfx9) or (
+        device_supports_fp8 = is_rocm_on_gfx9 or (
             p.is_cuda() and p.has_device_capability((8, 9))
         )
 

--- a/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
@@ -32,6 +32,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
 )
 from vllm.platforms import current_platform
+from vllm.platforms.rocm import on_gfx9
 from vllm.triton_utils import tl, triton
 
 
@@ -913,7 +914,7 @@ class BatchedTritonExperts(mk.FusedMoEPermuteExpertsUnpermute):
         activation_key: QuantKey | None,
     ) -> bool:
         p = current_platform
-        device_supports_fp8 = (p.is_rocm() and p.rocm.on_gfx9()) or (
+        device_supports_fp8 = (p.is_rocm() and on_gfx9()) or (
             p.is_cuda() and p.has_device_capability((8, 9))
         )
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1929,7 +1929,7 @@ class TritonExperts(mk.FusedMoEPermuteExpertsUnpermute):
         else:
             is_rocm_on_gfx9 = False
 
-        device_supports_fp8 = (is_rocm_on_gfx9) or (
+        device_supports_fp8 = is_rocm_on_gfx9 or (
             p.is_cuda() and p.has_device_capability((8, 9))
         )
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -51,7 +51,6 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
 )
 from vllm.platforms import current_platform
-from vllm.platforms.rocm import on_gfx9
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op, is_torch_equal_or_newer
 
@@ -1923,7 +1922,14 @@ class TritonExperts(mk.FusedMoEPermuteExpertsUnpermute):
         activation_key: QuantKey | None,
     ) -> bool:
         p = current_platform
-        device_supports_fp8 = (p.is_rocm() and on_gfx9()) or (
+        if p.is_rocm():
+            from vllm.platforms.rocm import on_gfx9
+
+            is_rocm_on_gfx9 = on_gfx9()
+        else:
+            is_rocm_on_gfx9 = False
+
+        device_supports_fp8 = (is_rocm_on_gfx9) or (
             p.is_cuda() and p.has_device_capability((8, 9))
         )
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -51,6 +51,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8StaticTensorSym,
 )
 from vllm.platforms import current_platform
+from vllm.platforms.rocm import on_gfx9
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import direct_register_custom_op, is_torch_equal_or_newer
 
@@ -1922,7 +1923,7 @@ class TritonExperts(mk.FusedMoEPermuteExpertsUnpermute):
         activation_key: QuantKey | None,
     ) -> bool:
         p = current_platform
-        device_supports_fp8 = (p.is_rocm() and p.rocm.on_gfx9()) or (
+        device_supports_fp8 = (p.is_rocm() and on_gfx9()) or (
             p.is_cuda() and p.has_device_capability((8, 9))
         )
 


### PR DESCRIPTION
This PR fixes the import for gfx_9 on rocm for `fused_moe.py` and `fused_batched_moe.py`


import `on_gfx9` directly from `vllm.platforms.rocm` and use it in device support checks, replacing the previous usage of `p.rocm.on_gfx9()`. 