### PR TITLE
Segmented prefill for gapped external KV cache hits

### DIFF
--- a/examples/offline_inference/kv_segmented_prefill/.gitignore
+++ b/examples/offline_inference/kv_segmented_prefill/.gitignore
@@ -1,0 +1,2 @@
+*.txt
+local_storage/

--- a/examples/offline_inference/kv_segmented_prefill/README.md
+++ b/examples/offline_inference/kv_segmented_prefill/README.md
@@ -1,0 +1,29 @@
+# Segmented Prefill test
+
+This example builds upon the `disaggregated-prefill-v1` example in `examples/offline_inference`.
+
+It demonstrates vLLM's ability to perform segmented prefill, in case the KV Connector reports "gaps" in the external cache.
+The goal is to verify that vLLM correctly recalculates the tokens missing in cache (the gaps). Correctness is tested by comparing the generation output using the full cache and the output using a cache with gaps.
+
+## Files
+
+- `segmented_prefill_example_connector.py` – defines `SegmentedPrefillExampleConnector`, a subclass of `ExampleConnector`, that simulates missing external KV blocks by creating gaps in the cache - intentionally failing to load blocks of tokens in the middle of each  prompt.
+- `run.sh` – orchestrates the test: runs a prefill stage which generates the external KV-Cache, then two decode stages:
+    1. Normal decode (baseline).
+    2. Decode with simulated gaps in the KV cache.
+
+    It then compares the two outputs to verify correctness.
+
+<!-- TODO: add info about prefill_example.py / decode_example.py or their replacements -->
+
+## How It Works
+
+- The test dynamically loads `SegmentedPrefillExampleConnector` via `KVTransferConfig.kv_connector_module_path`, enabling controlled simulation of cache gaps without modifying the original connector.
+- The decode stage that simulates gaps is expected to trigger Segmented Prefill in vLLM, resulting in the same output as the baseline decode.
+- In case the outputs differ, the script prints a unified diff of mismatch and exits with error.
+
+## Usage
+
+```bash
+./run.sh
+```

--- a/examples/offline_inference/kv_segmented_prefill/decode_example.py
+++ b/examples/offline_inference/kv_segmented_prefill/decode_example.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import argparse
+
+from vllm import LLM, SamplingParams
+from vllm.config import KVTransferConfig
+
+
+def read_prompts():
+    """Read prompts from prefill_output.txt"""
+    prompts = []
+    try:
+        with open("prefill_output.txt") as f:
+            for line in f:
+                prompts.append(line.strip())
+        print(f"Loaded {len(prompts)} prompts from prefill_output.txt")
+        return prompts
+    except FileNotFoundError:
+        print("Error: prefill_output.txt file not found")
+        exit(-1)
+
+
+def main():
+    prompts = read_prompts()
+    sampling_params = SamplingParams(temperature=0, top_p=0.95, max_tokens=10)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--segmented-prefill", action="store_true", help="Simulate gaps in KV cache"
+    )
+
+    args = parser.parse_args()
+
+    if args.segmented_prefill:
+        ktc = KVTransferConfig(
+            kv_connector="SegmentedPrefillExampleConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "shared_storage_path": "local_storage",
+            },
+            kv_connector_module_path="segmented_prefill_example_connector",
+        )
+        out_file = "segmented_prefill_decode_output.txt"
+    else:
+        ktc = KVTransferConfig(
+            kv_connector="ExampleConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={
+                "shared_storage_path": "local_storage",
+            },
+        )
+        out_file = "decode_output.txt"
+
+    llm = LLM(
+        model="meta-llama/Llama-3.2-1B-Instruct",
+        enforce_eager=True,  # no CUDA graphs, so layer-wise API will be called
+        gpu_memory_utilization=0.8,
+        kv_transfer_config=ktc,
+    )
+
+    outputs = llm.generate(prompts, sampling_params)
+
+    sep_str = "-" * 30 + "\n"
+    with open(out_file, "w", encoding="utf-8") as f:
+        for output in outputs:
+            prompt = output.prompt
+            generated_text = output.outputs[0].text
+            out_str = f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}\n"
+            print(out_str)
+            print(sep_str)
+            f.write(out_str)
+            f.write(sep_str)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/offline_inference/kv_segmented_prefill/prefill_example.py
+++ b/examples/offline_inference/kv_segmented_prefill/prefill_example.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm import LLM, SamplingParams
+from vllm.config import KVTransferConfig
+
+
+def read_prompts():
+    context = "Hi " * 1000
+    context2 = "Hey " * 500
+    return [
+        context + "Hello, my name is",
+        context + context + "The capital of France is",
+        context2 + "Your name is",
+        context2 + context2 + "The capital of China is",
+    ]
+
+
+def main():
+    prompts = read_prompts()
+
+    sampling_params = SamplingParams(temperature=0, top_p=0.95, max_tokens=1)
+
+    llm = LLM(
+        model="meta-llama/Llama-3.2-1B-Instruct",
+        enforce_eager=True,
+        gpu_memory_utilization=0.8,
+        kv_transfer_config=KVTransferConfig(
+            kv_connector="ExampleConnector",
+            kv_role="kv_both",
+            kv_connector_extra_config={"shared_storage_path": "local_storage"},
+        ),
+    )  # , max_model_len=2048, max_num_batched_tokens=2048)
+
+    # 1ST generation (prefill instance)
+    outputs = llm.generate(
+        prompts,
+        sampling_params,
+    )
+
+    new_prompts = []
+    print("-" * 30)
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        new_prompts.append(prompt + generated_text)
+        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
+        print("-" * 30)
+
+    # Write new_prompts to prefill_output.txt
+    with open("prefill_output.txt", "w") as f:
+        for prompt in new_prompts:
+            f.write(prompt + "\n")
+    print(f"Saved {len(new_prompts)} prompts to prefill_output.txt")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/offline_inference/kv_segmented_prefill/run.sh
+++ b/examples/offline_inference/kv_segmented_prefill/run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Constants
+SHARED_STORAGE_DIR="local_storage"
+PREFILL_OUTPUT="prefill_output.txt"
+DECODE_OUTPUT="decode_output.txt"
+SEGMENTED_PREFILL_OUTPUT="segmented_prefill_decode_output.txt"
+
+# Cleanup
+rm -rf "$SHARED_STORAGE_DIR"
+rm -f "$PREFILL_OUTPUT" "$DECODE_OUTPUT" "$SEGMENTED_PREFILL_OUTPUT"
+
+# Run inference examples
+VLLM_ENABLE_V1_MULTIPROCESSING=0 CUDA_VISIBLE_DEVICES=0 python3 prefill_example.py
+VLLM_ENABLE_V1_MULTIPROCESSING=0 CUDA_VISIBLE_DEVICES=0 python3 decode_example.py
+VLLM_ENABLE_V1_MULTIPROCESSING=0 CUDA_VISIBLE_DEVICES=0 python3 decode_example.py --segmented-prefill
+
+# Compare outputs
+if ! cmp -s "$DECODE_OUTPUT" "$SEGMENTED_PREFILL_OUTPUT"; then
+    echo "❌ Outputs differ: segmented prefill output differs from regular prefill."
+    diff -u "$DECODE_OUTPUT" "$SEGMENTED_PREFILL_OUTPUT"
+    exit 1
+fi
+
+
+echo "✅ Outputs match: segmented prefill test successful."

--- a/examples/offline_inference/kv_segmented_prefill/segmented_prefill_example_connector.py
+++ b/examples/offline_inference/kv_segmented_prefill/segmented_prefill_example_connector.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# ruff: noqa: E501
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.example_connector import (
+    ExampleConnector,
+    ExampleConnectorMetadata,
+)
+from vllm.v1.request import Request
+
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+logger = logging.getLogger()
+logging.basicConfig(level=logging.INFO)
+
+
+@dataclass
+class SegmentedPrefillExampleConnectorMetadata(ExampleConnectorMetadata):
+    _req_to_gaps: dict[str, list[tuple[int, int]]] = field(default_factory=dict)
+
+    @classmethod
+    def from_base(cls, base: ExampleConnectorMetadata):
+        return cls(requests=base.requests)
+
+
+class SegmentedPrefillExampleConnector(ExampleConnector):
+    def __init__(self, vllm_config: "VllmConfig", role: KVConnectorRole):
+        super().__init__(vllm_config=vllm_config, role=role)
+        self._req_to_gaps: dict[str, list[tuple[int, int]]] = dict()
+
+    def bind_connector_metadata(self, connector_metadata: KVConnectorMetadata) -> None:
+        assert isinstance(connector_metadata, SegmentedPrefillExampleConnectorMetadata)
+        for req in connector_metadata.requests:
+            if not req.is_store and req.req_id in connector_metadata._req_to_gaps:
+                gaps = connector_metadata._req_to_gaps[req.req_id]
+                self.override_slot_mapping_gaps(req.slot_mapping, gaps)
+                total_gap_tokens = sum(end - start for start, end in gaps)
+                logger.info(
+                    "Simulating gaps in KV token blocks for the "
+                    "first load request. Total tokens: %d",
+                    total_gap_tokens,
+                )
+        super().bind_connector_metadata(connector_metadata)
+
+    def _choose_gaps(
+        self, num_computed_tokens: int, num_external_tokens: int
+    ) -> list[tuple[int, int]]:
+        # Simulate gaps in the external tokens, at block_size granularity.
+        # Create gaps of growing size (1, 2, 3 blocks etc.) in the last num_external tokens,
+        # with non-gap sections of the same growing size between them,
+        # ensuring the last block is not a gap, and all aligned to block_size.
+        block_size = self._block_size
+        external_start = num_computed_tokens
+        external_end = num_computed_tokens + num_external_tokens
+        if external_end - external_start < block_size:
+            return []
+        gaps = []
+        current_pos = external_start
+        size = 1
+        is_gap = True
+        while current_pos < external_end:
+            segment_size_tokens = size * block_size
+            segment_end = min(current_pos + segment_size_tokens, external_end)
+            if is_gap:
+                if segment_end == external_end:
+                    # If this gap would be the last segment, skip it to ensure last is non-gap
+                    break
+                gaps.append((current_pos, segment_end))
+            current_pos = segment_end
+            is_gap = not is_gap
+            if is_gap:
+                size += 1
+        return gaps
+
+    def _print_gaps_representation(
+        self,
+        gaps: list[tuple[int, int]],
+        num_external_tokens: int,
+        num_computed_tokens: int,
+    ) -> None:
+        """Print a human-readable representation of the tokens and gaps for debugging."""
+        total_tokens = num_computed_tokens + num_external_tokens
+        block_size = self._block_size
+        representation = []
+        for block_start in range(0, total_tokens, block_size):
+            block_end = min(block_start + block_size, total_tokens)
+            block_chars = []
+            for i in range(block_start, block_end):
+                if i < num_computed_tokens:
+                    block_chars.append("C")  # Computed token
+                else:
+                    # Check if in gap
+                    in_gap = any(start <= i < end for start, end in gaps)
+                    block_chars.append("-" if in_gap else "E")  # Gap or External token
+            # Determine the character for this block
+            unique_chars = set(block_chars)
+            # print 'X' if mixed token types in block
+            char = unique_chars.pop() if len(unique_chars) == 1 else "X"
+            representation.append(char)
+
+        print("Cache status per block (C=computed, E=external, -=gap, X=mixed):")
+        print("".join(representation))
+        print("Gaps: ", gaps)
+        print(
+            "Total tokens: ",
+            total_tokens,
+            ", computed tokens: ",
+            num_computed_tokens,
+            ", external tokens: ",
+            num_external_tokens,
+        )
+
+    @staticmethod
+    def override_slot_mapping_gaps(
+        slot_mapping: torch.Tensor, gaps: list[tuple[int, int]]
+    ) -> None:
+        """create gaps in slot_mapping by mapping them to an incorrect value"""
+        if not gaps:
+            return
+        gap_value = slot_mapping[-1].item()  # use last value
+        for start, end in gaps:
+            slot_mapping[start:end] = gap_value
+
+    def get_computed_token_gaps(
+        self,
+        request: "Request",
+    ) -> list[tuple[int, int]] | None:
+        return self._req_to_gaps.get(request.request_id)
+
+    def get_num_new_matched_tokens(
+        self,
+        request: Request,
+        num_computed_tokens: int,
+    ) -> tuple[int | None, bool]:
+        num_external_tokens, _ = super().get_num_new_matched_tokens(
+            request, num_computed_tokens
+        )
+        num_external_tokens = (
+            0 if num_external_tokens is None else num_external_tokens
+        )  # don't simulated async lookup for now
+
+        # pick requests with at least 2*block_size external tokens to simulate gaps
+        if num_external_tokens >= self._block_size * 2:
+            gaps = self._choose_gaps(num_computed_tokens, num_external_tokens)
+            self._req_to_gaps[request.request_id] = gaps
+            self._print_gaps_representation(
+                gaps, num_external_tokens, num_computed_tokens
+            )
+
+        return num_external_tokens, False
+
+    def build_connector_meta(
+        self,
+        scheduler_output: "SchedulerOutput",
+    ) -> KVConnectorMetadata:
+        base = super().build_connector_meta(scheduler_output)
+        assert isinstance(base, ExampleConnectorMetadata)
+        meta = SegmentedPrefillExampleConnectorMetadata.from_base(base)
+        meta._req_to_gaps = self._req_to_gaps.copy()
+
+        self._req_to_gaps.clear()
+        return meta

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_connector.py
@@ -37,6 +37,7 @@ class ReqMeta:
     # Is store or load
     is_store: bool
     mm_hashes: list[str]
+    req_id: str
 
     @staticmethod
     def make_meta(
@@ -45,6 +46,7 @@ class ReqMeta:
         block_size: int,
         is_store: bool,
         mm_hashes: list[str],
+        req_id: str = "",
     ) -> "ReqMeta":
         valid_num_tokens = align_to_block_size(len(token_ids), block_size)
         token_ids_tensor = torch.tensor(token_ids)[:valid_num_tokens]
@@ -61,6 +63,7 @@ class ReqMeta:
             slot_mapping=slot_mapping,
             is_store=is_store,
             mm_hashes=mm_hashes,
+            req_id=req_id,
         )
 
 
@@ -75,9 +78,12 @@ class ExampleConnectorMetadata(KVConnectorMetadata):
         block_size: int,
         is_store: bool,
         mm_hashes: list[str],
+        req_id: str = "",
     ) -> None:
         self.requests.append(
-            ReqMeta.make_meta(token_ids, block_ids, block_size, is_store, mm_hashes)
+            ReqMeta.make_meta(
+                token_ids, block_ids, block_size, is_store, mm_hashes, req_id
+            )
         )
 
 
@@ -328,6 +334,7 @@ class ExampleConnector(KVConnectorBase_V1):
                     block_size=self._block_size,
                     is_store=False,
                     mm_hashes=mm_hashes,
+                    req_id=new_req.req_id,
                 )
                 total_need_load += 1
             else:
@@ -342,6 +349,7 @@ class ExampleConnector(KVConnectorBase_V1):
                         block_size=self._block_size,
                         is_store=True,
                         mm_hashes=mm_hashes,
+                        req_id=new_req.req_id,
                     )
 
         cached_reqs = scheduler_output.scheduled_cached_reqs
@@ -372,6 +380,7 @@ class ExampleConnector(KVConnectorBase_V1):
                 block_size=self._block_size,
                 is_store=False,
                 mm_hashes=[f.identifier for f in request.mm_features],
+                req_id=req_id,
             )
             total_need_load += 1
 

--- a/vllm/v1/core/sched/async_scheduler.py
+++ b/vllm/v1/core/sched/async_scheduler.py
@@ -16,7 +16,9 @@ class AsyncScheduler(Scheduler):
         pending_structured_output_tokens = False
         spec_decode_tokens = scheduler_output.scheduled_spec_decode_tokens
         for req_id in scheduler_output.num_scheduled_tokens:
-            request = self.requests[req_id]
+            request = self.requests.get(req_id)
+            if request is None:
+                continue
             has_structured_output_requests |= request.use_structured_output
             pending_structured_output_tokens |= (
                 request.use_structured_output and request.num_output_placeholders > 0

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -4,6 +4,7 @@ import itertools
 import time
 from collections import defaultdict
 from collections.abc import Iterable
+from dataclasses import replace
 from typing import Any
 
 import numpy as np
@@ -754,6 +755,11 @@ class Scheduler(SchedulerInterface):
                 for req in scheduled_new_reqs
             ]
 
+        if self.connector is not None and len(new_reqs_data) > 0:
+            total_num_scheduled_tokens += self._handle_segmented_prefill(
+                new_reqs_data, num_scheduled_tokens
+            )
+
         with record_function_or_nullcontext("schedule: make_cached_request_data"):
             cached_reqs_data = self._make_cached_request_data(
                 scheduled_running_reqs,
@@ -838,7 +844,9 @@ class Scheduler(SchedulerInterface):
         #    computed tokens will be adjusted in update_from_output.
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
         for req_id, num_scheduled_token in num_scheduled_tokens.items():
-            request = self.requests[req_id]
+            request = self.requests.get(req_id)
+            if request is None:
+                continue
             request.num_computed_tokens += num_scheduled_token
 
             # NOTE: _free_encoder_inputs relies on num_computed_tokens, which
@@ -1942,3 +1950,45 @@ class Scheduler(SchedulerInterface):
         self.failed_recving_kv_req_ids |= async_failed_req_ids
         # Return sync affected IDs to skip in update_from_output
         return sync_failed_req_ids
+
+    def _handle_segmented_prefill(
+        self,
+        new_reqs_data: list[NewRequestData],
+        num_scheduled_tokens: dict[str, int],
+    ) -> int:
+        """
+        A Segmented prefill enables the reuse of a gapped external KV cache by creating
+        multiple virtual requests (one per gap) that execute together in the same batch
+        while sharing tokens and KV-cache blocks.
+
+        Returns the total number of scheduled tokens across all new requests created.
+        """
+        if self.connector is None:
+            return 0
+
+        total_added_scheduled_tokens = 0
+
+        for nrd in new_reqs_data:
+            request = self.requests.get(nrd.req_id)
+            if request is None:
+                continue
+
+            computed_token_gaps = self.connector.get_computed_token_gaps(request)
+            if not computed_token_gaps:
+                continue
+
+            for start, end in computed_token_gaps:
+                nrd_copy = replace(nrd)
+                nrd_copy.req_id = nrd_copy.req_id + "." + str(start)
+                nrd_copy.num_computed_tokens = start
+                req_copy_num_sched_tokens = end - start
+                num_scheduled_tokens[nrd_copy.req_id] = req_copy_num_sched_tokens
+                total_added_scheduled_tokens += req_copy_num_sched_tokens
+                nrd_copy.prompt_token_ids = (
+                    nrd.prompt_token_ids[:end]
+                    if nrd.prompt_token_ids is not None
+                    else None
+                )
+                new_reqs_data.append(nrd_copy)
+
+        return total_added_scheduled_tokens


### PR DESCRIPTION
## Purpose
Implements **segmented prefill** to enable the generalized KV-cache reuse feature described in RFC #25950.

Concretely, this PR:

- Adds a new KV Connector API, `get_computed_token_gaps()`, which allows a connector to report **gaps** (missing/invalid token intervals) within the externally-reported computed-token range where KV must be recomputed.

- Introduces a scheduler-side reduction for gapped hits: prefill over a perforated prompt is reduced to prefill over a **series of gradually increasing prefixes of the perforated prompt**, where each prefix’s **non-computed suffix** corresponds to a gap. This maintains the invariant that `num_computed_tokens` represents a **contiguous computed prefix**.

- Implements the reduction by having the scheduler create multiple **virtual requests** (one per gap) that execute together in the same batch while **sharing tokens and KV-cache blocks**. The main overhead is additional attention metadata (future optimization).

Highlights:
- Attention-backend agnostic
- CUDA Graphs compatible
- Scheduler-only changes (no worker-side changes required for correctness)

## Design Overview

#### Gapped external KV-cache hit
<img width="4109" height="804" alt="gapped cache hit" src="https://github.com/user-attachments/assets/4de06ba1-1fde-4709-b9aa-74a5c3a7c260" />

#### Segmented prefill reduction
Segmented prefill performs a single batched prefill over multiple segments of the same prompt.

<img width="5035" height="1355" alt="segmented prefill" src="https://github.com/user-attachments/assets/843e16ee-29bc-4ab2-ac7a-b9daab7b6f0e" />


## Test Plan

- Run the segmented prefill offline example:
  - `cd vllm/examples/offline_inference/kv_segmented_prefill`
  - `./run.sh`

- What the script does:
  - Runs a baseline prefill with KV offloaded to the filesystem.
  - Runs a decode that **loads KV with injected gaps** (simulated missing/invalid spans).
  - Uses segmented prefill to recompute only the missing spans and then decodes.
  - Compares output against a decode run with **complete KV** (no gaps).

## Test Result
Successful run of the example test:
```
vllm/examples/offline_inference/kv_segmented_prefill$ ./run.sh
...
INFO 01-22 11:15:19 [example_connector.py:291] External Cache Hit!
Cache status per block (C=computed, E=external, -=gap, X=mixed):
-E--EE---EEE----EEEE-----EEEEE------EEEEEE-------EEEEEEEEEEEEE
Gaps:  [(0, 16), (32, 64), (96, 144), (192, 256), (320, 400), (480, 576), (672, 784)]
Total tokens:  992 , computed tokens:  0 , external tokens:  992
INFO 01-22 11:15:19 [example_connector.py:291] External Cache Hit!
Cache status per block (C=computed, E=external, -=gap, X=mixed):
CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC-E--EE---EEE----EEEE-----EEEEE------EEEEEE-------EEEEEEEEEEEEEE
Gaps:  [(992, 1008), (1024, 1056), (1088, 1136), (1184, 1248), (1312, 1392), (1472, 1568), (1664, 1776)]
Total tokens:  2000 , computed tokens:  992 , external tokens:  1008
INFO 01-22 11:15:19 [example_connector.py:291] External Cache Hit!
Cache status per block (C=computed, E=external, -=gap, X=mixed):
-E--EE---EEE----EEEE-----EEEEEE
Gaps:  [(0, 16), (32, 64), (96, 144), (192, 256), (320, 400)]
Total tokens:  496 , computed tokens:  0 , external tokens:  496
INFO 01-22 11:15:19 [example_connector.py:291] External Cache Hit!
Cache status per block (C=computed, E=external, -=gap, X=mixed):
CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC-E--EE---EEE----EEEE-----EEEEEE
Gaps:  [(496, 512), (528, 560), (592, 640), (688, 752), (816, 896)]
Total tokens:  992 , computed tokens:  496 , external tokens:  496
[2026-01-22 11:15:19] INFO segmented_prefill_example_connector.py:49: Simulating gaps in KV token blocks for the first load request. Total tokens: 448
[2026-01-22 11:15:19] INFO segmented_prefill_example_connector.py:49: Simulating gaps in KV token blocks for the first load request. Total tokens: 448
[2026-01-22 11:15:19] INFO segmented_prefill_example_connector.py:49: Simulating gaps in KV token blocks for the first load request. Total tokens: 240
[2026-01-22 11:15:19] INFO segmented_prefill_example_connector.py:49: Simulating gaps in KV token blocks for the first load request. Total tokens: 240
...
✅ Outputs match: segmented prefill test successful.
```