### PR TITLE
[ROCm][CI] fix get_valid_backends

### DIFF
--- a/tests/v1/spec_decode/test_acceptance_length.py
+++ b/tests/v1/spec_decode/test_acceptance_length.py
@@ -83,8 +83,14 @@ EXCLUDED_BACKENDS = {AttentionBackendEnum.FLEX_ATTENTION}
 
 
 def get_available_attention_backends() -> list[str]:
-    if not hasattr(current_platform, "get_valid_backends"):
-        return ["FLASH_ATTN"]
+    # Check if get_valid_backends is actually defined in the platform class
+    # (not just returning None from __getattr__)
+    get_valid_backends = getattr(current_platform.__class__, "get_valid_backends", None)
+    if get_valid_backends is None:
+        if current_platform.is_rocm():
+            return ["TRITON_ATTN"]
+        else:
+            return ["FLASH_ATTN"]
 
     device_capability = current_platform.get_device_capability()
     if device_capability is None:


### PR DESCRIPTION
This PR fixes the "get_valid_backends" check

Details - the [__getattr__ is overridden in interface.py](https://github.com/vllm-project/vllm/blob/808d6fd7b97f71f64a14ad4eecb9afd7b4d9dcf8/vllm/platforms/interface.py#L589-L603) which returns `None` if the attribute is not found instead of raising an AttributeError

`pytest -s -v tests/v1/spec_decode/test_acceptance_length.py`

Note: There is more debugging ongoing, might need another PR to fully fix this test. Preliminary analysis hints towards the refactored cudagraph PR causing issue for this test.