### PR TITLE
[EncoderCacheManager] Remove unnecessary copy

### DIFF
--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -237,7 +237,7 @@ class EncoderCacheManager:
 
         Typically called when a request is finished, cancelled, or aborted.
         """
-        input_ids = self.get_cached_input_ids(request).copy()
+        input_ids = self.get_cached_input_ids(request)
         for input_id in input_ids:
             self.free_encoder_input(request, input_id)
 


### PR DESCRIPTION
## Purpose

#13173 introduced this copy. Since then `self.get_cached_input_ids` changed to always return a new set so no need to copy it again.

https://github.com/vllm-project/vllm/blob/180fba653ead2274bfcd3951a275f4d6cf9ade04/vllm/v1/core/encoder_cache_manager.py#L196-L208

https://github.com/vllm-project/vllm/blob/180fba653ead2274bfcd3951a275f4d6cf9ade04/vllm/v1/core/encoder_cache_manager.py#L392-L393

## Test Plan

CI