### PR TITLE
[Hardware][AMD][Bugfix] Fix PTPC FP8 quantization

### DIFF
--- a/vllm/model_executor/layers/quantization/ptpc_fp8.py
+++ b/vllm/model_executor/layers/quantization/ptpc_fp8.py
@@ -17,7 +17,7 @@ from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBa
 from vllm.model_executor.layers.quantization.fp8 import (
     Fp8Config,
     Fp8KVCacheMethod,
-    Fp8LinearMethod,
+    Fp8OnlineLinearMethod,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     is_layer_skipped,
@@ -72,7 +72,7 @@ class PTPCFp8Config(Fp8Config):
         return None
 
 
-class PTPCFp8LinearMethod(Fp8LinearMethod):
+class PTPCFp8LinearMethod(Fp8OnlineLinearMethod):
     """Linear method for Per-Token and Per-Channel FP8 Quantization.
     Only supports loading quantized BF16 model checkpoints with dynamic
     activation scaling. To load FP16 model checkpoints, user must specify


### PR DESCRIPTION
## Purpose
Fixes PTPC FP8 quantization and thus AMD Quantization Tests after the refactoring done in https://github.com/vllm-project/vllm/pull/32189. `PTPCFP8LinearMethod` should now inherit from `FP8OnlineLinearMethod` rather than `FP8LinearMethod`.

## Test Plan
`pytest -sv quantization/test_ptpc_fp8.py`
The above is implicitly run as part of AMD CI's Quantization Tests group.

## Test Result
The test and test group both pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

