### PR TITLE
[Misc] fix: GPU Worker uses allowlist for distributed_executor_backend

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -177,8 +177,7 @@ class Worker(WorkerBase):
             os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
             parallel_config = self.parallel_config
             if (
-                parallel_config.distributed_executor_backend
-                not in ("ray", "external_launcher")
+                parallel_config.distributed_executor_backend in ("mp", "uni")
                 and parallel_config.data_parallel_backend != "ray"
                 and parallel_config.nnodes_within_dp == 1
             ):


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Related to the changes in https://github.com/vllm-project/vllm/pull/27564

Fixes Verl related issue: https://github.com/volcengine/verl/issues/4926#issuecomment-3753234063

It's better to use allowlist when checking `distributed_executor_backend`, as `distributed_executor_backend` also accepts custom executor class, some of the customization is built on top of ray as well, which can go wrong. While user's executor class might not be built on top of ray, they can easily apply similar logic on their side.

## Test Plan

Tested together with Verl

## Test Result

Verl now works fine with TP>2 / EP, error is gone

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

