### PR TITLE
[Bugfix] Fix potential EAGLE spec decode segfault during graph capture

### DIFF
--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1222,10 +1222,14 @@ class SpecDecodeBaseProposer:
                 num_tokens_dp_padded, num_tokens_across_dp = self._pad_batch_across_dp(
                     num_tokens_unpadded=num_tokens, num_tokens_padded=num_tokens
                 )
-                cudagraph_runtime_mode, batch_desc = self.cudagraph_dispatcher.dispatch(
-                    num_tokens_dp_padded
-                )
-                num_input_tokens = batch_desc.num_tokens
+                if use_cudagraphs:
+                    cudagraph_runtime_mode, batch_desc = (
+                        self.cudagraph_dispatcher.dispatch(num_tokens_dp_padded)
+                    )
+                    num_input_tokens = batch_desc.num_tokens
+                else:
+                    cudagraph_runtime_mode = CUDAGraphMode.NONE
+                    num_input_tokens = num_tokens_dp_padded
                 if num_tokens_across_dp is not None:
                     num_tokens_across_dp[self.dp_rank] = num_input_tokens
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
This PR restores the original logic in `SpecDecodeBaseProposer`'s `dummy_run` function, which was changed after the refactor in https://github.com/vllm-project/vllm/pull/30143. Credits also to @micah-wil for the investigation and fix.

After the refactor, the `use_cudagraphs` parameter is left unused which incorrectly leads to CUDA graph dispatch where they previously would not have occurred. We are seeing this manifest on MI300X as a segfault during CUDA graph capture with EAGLE spec decode on TP > 1, e.g.  by running
`vllm serve meta-llama/Llama-3.1-8B-Instruct --max-model-len 2048 -tp 2 --max-num-batched-tokens 2048 --speculative-config='{"method": "eagle", "model": "yuhuili/EAGLE-LLaMA3.1-Instruct-8B", "num_speculative_tokens": 3, "max_model_len": 2048}'`
or
`vllm serve meta-llama/Llama-4-Scout-17B-16E-Instruct --max-model-len 2048 -tp 2 --max-num-batched-tokens 2048 --speculative-config='{"method": "eagle", "model": "morgendave/EAGLE-Llama-4-Scout-17B-16E-Instruct", "num_speculative_tokens": 3, "max_model_len": 2048}' --load-format dummy --max-num-seqs 1 --compilation-config='{"cudagraph_capture_sizes": [1]}'`

This is also leading to failures inside tests like `tests/v1/e2e/test_spec_decode.py::test_eagle_correctness`.

## Test Plan
`pytest -sv tests/v1/e2e/test_spec_decode.py -k test_eagle_correctness`

## Test Result
The test above should pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

