### PR TITLE
[ROCm][CI][Docs] Add comment explaining TRITON_ATTN fallback for ROCm

### DIFF
--- a/tests/v1/spec_decode/test_acceptance_length.py
+++ b/tests/v1/spec_decode/test_acceptance_length.py
@@ -88,6 +88,8 @@ def get_available_attention_backends() -> list[str]:
     get_valid_backends = getattr(current_platform.__class__, "get_valid_backends", None)
     if get_valid_backends is None:
         if current_platform.is_rocm():
+            # ROCm uses Triton as its default attention backend since
+            # Flash Attention is not supported.
             return ["TRITON_ATTN"]
         else:
             return ["FLASH_ATTN"]


### PR DESCRIPTION
This PR adds a clarifying comment as requested in #32787 by @DarkLight1337.

The comment explains why `TRITON_ATTN` is used as the fallback attention backend for ROCm platforms.