### PR TITLE
[Hardware][AMD][CI][Bugfix] Fix regressions from deprecated env vars

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1473,7 +1473,7 @@ steps:
     - tests/v1/kv_connector/nixl_integration/
   commands:
     - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
-    - bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh --attention-backend ROCM_ATTN
+    - ROCM_ATTN=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 - label: DP EP NixlConnector PD accuracy tests (Distributed) # 15min
   mirror_hardwares: [amdexperimental, amdproduction]
@@ -1487,7 +1487,7 @@ steps:
     - tests/v1/kv_connector/nixl_integration/
   commands:
     - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
-    - DP_EP=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh --attention-backend ROCM_ATTN
+    - DP_EP=1 ROCM_ATTN=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
 ##### multi gpus test #####
 ##### A100 test #####

--- a/tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
@@ -43,7 +43,12 @@ run_tests() {
 }
 
 # Run tests
-run_tests "default backend" ""
+if [[ -n "${ROCM_ATTN:-}" ]]; then
+  echo "ROCM_ATTN is set, running with --attention-backend ROCM_ATTN"
+  run_tests "ROCM_ATTN backend" "--attention-backend ROCM_ATTN"
+else
+  run_tests "default backend" ""
+fi
 
 # Check if FLASHINFER is set (non-empty)
 if [[ -n "${FLASHINFER:-}" ]]; then

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -287,10 +287,13 @@ class RocmPlatform(Platform):
                 return AttentionBackendEnum.ROCM_AITER_FA.get_path()
 
             # Priority 3: Check for ROCM_ATTN (prefill-decode split)
-            from vllm.config import get_current_vllm_config
+            from vllm.config import get_current_vllm_config_or_none
 
-            vllm_config = get_current_vllm_config()
-            if vllm_config.attention_config.use_prefill_decode_attention:
+            vllm_config = get_current_vllm_config_or_none()
+            if (
+                vllm_config is not None
+                and vllm_config.attention_config.use_prefill_decode_attention
+            ):
                 logger.info("Using Rocm Attention backend.")
                 return AttentionBackendEnum.ROCM_ATTN.get_path()
 


### PR DESCRIPTION
## Purpose
This PR fixes various issues on AMD ROCm caused by the deprecation of environment variables in https://github.com/vllm-project/vllm/pull/32812.

Firstly, the deprecation of `VLLM_V1_USE_PREFILL_DECODE_ATTENTION` means that `get_current_vllm_config` is now called as a replacement in `RocmPlatform.get_attn_backend_cls` to determine if the `ROCM_ATTN` backend should be used. However, there are instances where the current vLLM config is not yet set, which causes the above function to error.
For instance, this causes a test regression in
`v1/attention/test_rocm_attention_backends_selection.py::test_standard_attention_backend_selection`

Secondly, the deprecation of `VLLM_ATTENTION_BACKEND` meant that the required `ROCM_ATTN` backend was no longer correctly passed to the NIXL accuracy tests, resulting in failing tests.

The aforementioned test regressions can be seen on this [AMD CI nightly build](https://buildkite.com/vllm/amd-ci/builds/3452) under the failing
1. V1 Test attention (H100)
2. NixlConnector PD accuracy tests (Distributed)
3. DP EP NixlConnector PD accuracy tests (Distributed)

test groups.

## Test Plan
Run the following

1. `pytest -sv tests/v1/attention/test_rocm_attention_backends_selection.py -k test_standard_attention_backend_selection`
2. `ROCM_ATTN=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh`
3. `DP_EP=1 ROCM_ATTN=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh`

as part of the

1. V1 Test attention (H100)
2. NixlConnector PD accuracy tests (Distributed)
3. DP EP NixlConnector PD accuracy tests (Distributed)

test groups in AMD CI.

## Test Result
The tests now pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

