### PR TITLE
[Bugfix] ModelScope is supported when downloading LORA models.

### DIFF
--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -9,6 +9,7 @@ from huggingface_hub.utils import HfHubHTTPError, HFValidationError
 from torch import nn
 from transformers import PretrainedConfig
 
+from vllm import envs
 from vllm.config.lora import LoRAConfig
 from vllm.logger import init_logger
 
@@ -235,13 +236,27 @@ def get_adapter_absolute_path(lora_path: str) -> str:
     if os.path.exists(lora_path):
         return os.path.abspath(lora_path)
 
-    # If the path does not exist locally, assume it's a Hugging Face repo.
+    # If the path does not exist locally.
+    if envs.VLLM_USE_MODELSCOPE:
+        # If using ModelScope, we assume the path is a ModelScope repo.
+        from modelscope.hub.snapshot_download import InvalidParameter, snapshot_download
+        from requests import HTTPError
+
+        download_fn = lambda: snapshot_download(model_id=lora_path)
+        download_exceptions = (HTTPError, InvalidParameter)
+        error_log = "Error downloading the ModelScope model"
+    else:
+        # Otherwise, we assume the path is a Hugging Face Hub repo.
+        download_fn = lambda: huggingface_hub.snapshot_download(repo_id=lora_path)
+        download_exceptions = (HfHubHTTPError, HFValidationError)
+        error_log = "Error downloading the HuggingFace model"
+
     try:
-        local_snapshot_path = huggingface_hub.snapshot_download(repo_id=lora_path)
-    except (HfHubHTTPError, HFValidationError):
-        # Handle errors that may occur during the download
-        # Return original path instead of throwing error here
-        logger.exception("Error downloading the HuggingFace model")
+        local_snapshot_path = download_fn()
+    except download_exceptions:
+        # Handle errors that may occur during the download.
+        # Return original path instead of throwing error here.
+        logger.exception(error_log)
         return lora_path
 
     return local_snapshot_path


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix the bug that the environment variable `VLLM_USE_MODELSCOPE=1` is ineffective when downloading LoRA models, which is described in #32841 .

## Test Plan
After setting the environment variables `VLLM_USE_MODELSCOPE=1`, this command tests downloading the LoRA model from ModelScope.
```
vllm serve LLM-Research/Llama-3.2-3B-Instruct --enable-lora --lora-modules sql-lora=vllm-ascend/llama32-3b-text2sql-spider
```

## Test Result
After setting the environment variables, you can now download the LoRA models from ModelScope. The current output is:
```
Downloading Model from https://www.modelscope.cn to directory: /home/.../.cache/modelscope/hub/models/vllm-ascend/llama32-3b-text2sql-spider
...
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

