### PR TITLE
[BugFix] Fix AttributeError in MooncakeConnector logging for non-tensor KV caches

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
@@ -681,9 +681,14 @@ class MooncakeConnectorWorker:
         split_k_and_v = self.kv_topo.split_k_and_v
         tensor_size_bytes = None
         for layer_name, cache_or_caches in kv_caches.items():
-            logger.debug(
-                "registering layer %s with shape %s", layer_name, cache_or_caches.shape
-            )
+            if hasattr(cache_or_caches, "shape"):
+                logger.debug(
+                    "registering layer %s with shape %s", layer_name, cache_or_caches.shape
+                )
+            else:
+                logger.debug(
+                    "registering layer %s with type %s", layer_name, type(cache_or_caches)
+                )
             cache_list = cache_or_caches if split_k_and_v else [cache_or_caches]
 
             for cache in cache_list:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
@@ -683,11 +683,26 @@ class MooncakeConnectorWorker:
         for layer_name, cache_or_caches in kv_caches.items():
             if hasattr(cache_or_caches, "shape"):
                 logger.debug(
-                    "registering layer %s with shape %s", layer_name, cache_or_caches.shape
+                    "registering layer %s with shape %s",
+                    layer_name,
+                    cache_or_caches.shape,
+                )
+            elif isinstance(cache_or_caches, (list, tuple)):
+                shapes = [
+                    c.shape if hasattr(c, "shape") else str(type(c))
+                    for c in cache_or_caches
+                ]
+                logger.debug(
+                    "registering layer %s with type %s, shapes: %s",
+                    layer_name,
+                    type(cache_or_caches),
+                    shapes,
                 )
             else:
                 logger.debug(
-                    "registering layer %s with type %s", layer_name, type(cache_or_caches)
+                    "registering layer %s with type %s",
+                    layer_name,
+                    type(cache_or_caches),
                 )
             cache_list = cache_or_caches if split_k_and_v else [cache_or_caches]
 


### PR DESCRIPTION
## Purpose

This PR fixes an `AttributeError: 'tuple' object has no attribute 'shape'` that occurs in `MooncakeConnector.register_kv_caches` when using hardware backends (like Ascend NPU) that represent KV caches as tuples (separate Key/Value tensors) rather than a single tensor.

The existing logging implementation assumed that `kv_caches` values always possessed a `.shape` attribute. When running with the `vllm-ascend` plugin, this assumption failed, causing the engine initialization to crash. This change implements a safer check using `hasattr` (duck typing) to log the shape only if available, and falls back to logging the type otherwise.

## Test Plan

- Verify the fix in an environment where KV caches are returned as tuples (e.g., vLLM with Ascend backend + Mooncake enabled).
- Ensure existing functionality (CUDA backend with single tensor caches) remains unaffected.

## Test Result

**Before:**
Crash during startup with `AttributeError`:
```text
(EngineCore_DP0)   File "/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py", line 694, in register_kv_caches
(EngineCore_DP0)     "registering layer %s with shape %s", layer_name, cache_or_caches.shape
(EngineCore_DP0) AttributeError: 'tuple' object has no attribute 'shape'
```

**After:**
Engine initializes successfully, efficiently handling tuple caches without error. Logs now correctly reflect the type when shape is unavailable:
```text
DEBUG: registering layer layers.0.key_value with type <class 'tuple'>
```