### PR TITLE
Fix mkdocs_autorefs error

### DIFF
--- a/vllm/model_executor/models/interfaces_base.py
+++ b/vllm/model_executor/models/interfaces_base.py
@@ -166,7 +166,7 @@ class VllmModelForPooling(VllmModel[T_co], Protocol[T_co]):
     default_pooling_type: ClassVar[str] = "LAST"
     """
     Indicates the
-    [vllm.model_executor.layers.pooler.PoolerConfig.pooling_type][]
+    [vllm.config.PoolerConfig.pooling_type][]
     to use by default.
 
     You can use the


### PR DESCRIPTION
Fixes this docs build error:

```
WARNING -  mkdocs_autorefs: api/vllm/model_executor/models/index.md: from /home/docs/checkouts/readthedocs.org/user_builds/vllm/checkouts/32849/vllm/model_executor/models/interfaces_base.py:167: (vllm.model_executor.models.VllmModelForPooling.default_pooling_type) Could not find cross-reference target 'vllm.model_executor.layers.pooler.PoolerConfig.pooling_type'
WARNING -  mkdocs_autorefs: api/vllm/model_executor/models/interfaces_base.md: from /home/docs/checkouts/readthedocs.org/user_builds/vllm/checkouts/32849/vllm/model_executor/models/interfaces_base.py:167: (vllm.model_executor.models.interfaces_base.VllmModelForPooling.default_pooling_type) Could not find cross-reference target 'vllm.model_executor.layers.pooler.PoolerConfig.pooling_type'
```