### PR TITLE
[perf] v1/spec_decode: skip softmax for all-greedy rejection sampling

### DIFF
--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -136,13 +136,6 @@ class RejectionSampler(nn.Module):
             metadata.cu_num_draft_tokens,
             sampling_metadata,
         )
-        # Compute probability distribution from target logits.
-        # NOTE: For all-greedy decoding, the rejection sampler only needs
-        # argmax(target_logits), so computing a full-vocab softmax is wasted.
-        if sampling_metadata.all_greedy:
-            target_probs = target_logits
-        else:
-            target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
 
         output_token_ids = rejection_sample(
             metadata.draft_token_ids,
@@ -150,7 +143,7 @@ class RejectionSampler(nn.Module):
             metadata.max_spec_len,
             metadata.cu_num_draft_tokens,
             draft_probs,
-            target_probs,
+            target_logits,
             bonus_token_ids,
             sampling_metadata,
         )
@@ -358,7 +351,7 @@ def rejection_sample(
     # [num_tokens, vocab_size]
     draft_probs: torch.Tensor | None,
     # [num_tokens, vocab_size]
-    target_probs: torch.Tensor,
+    target_logits: torch.Tensor,
     # [batch_size, 1]
     bonus_token_ids: torch.Tensor,
     sampling_metadata: SamplingMetadata,
@@ -366,17 +359,16 @@ def rejection_sample(
     assert draft_token_ids.ndim == 1
     assert draft_probs is None or draft_probs.ndim == 2
     assert cu_num_draft_tokens.ndim == 1
-    assert target_probs.ndim == 2
+    assert target_logits.ndim == 2
 
     batch_size = len(num_draft_tokens)
     num_tokens = draft_token_ids.shape[0]
-    vocab_size = target_probs.shape[-1]
-    device = target_probs.device
+    vocab_size = target_logits.shape[-1]
+    device = target_logits.device
     assert draft_token_ids.is_contiguous()
     assert draft_probs is None or draft_probs.is_contiguous()
-    assert target_probs.is_contiguous()
     assert bonus_token_ids.is_contiguous()
-    assert target_probs.shape == (num_tokens, vocab_size)
+    assert target_logits.shape == (num_tokens, vocab_size)
 
     # Create output buffer.
     output_token_ids = torch.full(
@@ -392,7 +384,7 @@ def rejection_sample(
         is_greedy = sampling_metadata.temperature == GREEDY_TEMPERATURE
     if not sampling_metadata.all_random:
         # Rejection sampling for greedy sampling requests.
-        target_argmax = target_probs.argmax(dim=-1)
+        target_argmax = target_logits.argmax(dim=-1)
         rejection_greedy_sample_kernel[(batch_size,)](
             output_token_ids,
             cu_num_draft_tokens,
@@ -404,6 +396,10 @@ def rejection_sample(
         )
         if sampling_metadata.all_greedy:
             return output_token_ids
+
+    # Compute probability distribution from target logits.
+    target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
+    assert target_probs.is_contiguous()
 
     # Generate uniform probabilities for rejection sampling.
     # [num_tokens]

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -137,7 +137,12 @@ class RejectionSampler(nn.Module):
             sampling_metadata,
         )
         # Compute probability distribution from target logits.
-        target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
+        # NOTE: For all-greedy decoding, the rejection sampler only needs
+        # argmax(target_logits), so computing a full-vocab softmax is wasted.
+        if sampling_metadata.all_greedy:
+            target_probs = target_logits
+        else:
+            target_probs = target_logits.softmax(dim=-1, dtype=torch.float32)
 
         output_token_ids = rejection_sample(
             metadata.draft_token_ids,


### PR DESCRIPTION
<!-- markdownlint-disable -->


## Purpose
This PR avoids computing a full-vocabulary softmax in the v1 speculative decoding rejection sampler when the entire batch is greedy (sampling_metadata.all_greedy).

For all-greedy decoding, the rejection sampler only needs argmax(target_logits); a dense softmax is unnecessary work. Since argmax(softmax(logits)) == argmax(logits), this change is behavior-preserving for the greedy path while reducing compute/memory overhead.


## Test Result
###  Correctness (pytest)

**Command**
```bash
pytest -q tests/v1/sample/test_rejection_sampler.py
```

**Result**
```text
.....................................                                                                                                                   [100%]
====================================================================== warnings summary =======================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
37 passed, 2 warnings in 30.04s
```

---

### Performance

Compared to `main`, on  **NVIDIA H800**, this PR improves **Output token throughput (tok/s) by ~3.14%**, reduces **Mean TPOT (ms) by ~7.04%**, and reduces **Mean E2EL (ms) by ~3.67%**.

<summary>main</summary>

```text
============ Serving Benchmark Result ============
Successful requests:                     1000
Failed requests:                         0
Benchmark duration (s):                  11.14
Total input tokens:                      128000
Total generated tokens:                  100000
Request throughput (req/s):              89.74
Output token throughput (tok/s):         8974.16
Peak output token throughput (tok/s):    7331.00
Peak concurrent requests:                1000.00
Total token throughput (tok/s):          20461.07
---------------Time to First Token----------------
Mean TTFT (ms):                          4673.80
Median TTFT (ms):                        2721.85
P99 TTFT (ms):                           8599.31
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          39.22
Median TPOT (ms):                        37.92
P99 TPOT (ms):                           67.62
---------------Inter-token Latency----------------
Mean ITL (ms):                           79.31
Median ITL (ms):                         72.16
P99 ITL (ms):                            122.20
----------------End-to-end Latency----------------
Mean E2EL (ms):                          8557.05
Median E2EL (ms):                        8733.72
P99 E2EL (ms):                           10952.13
==================================================
```


<summary>PR</summary>

```text
============ Serving Benchmark Result ============
Successful requests:                     1000
Failed requests:                         0
Benchmark duration (s):                  10.80
Total input tokens:                      128000
Total generated tokens:                  100000
Request throughput (req/s):              92.56
Output token throughput (tok/s):         9255.84
Peak output token throughput (tok/s):    8709.00
Peak concurrent requests:                1000.00
Total token throughput (tok/s):          21103.32
---------------Time to First Token----------------
Mean TTFT (ms):                          4633.34
Median TTFT (ms):                        2941.03
P99 TTFT (ms):                           8419.22
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          36.46
Median TPOT (ms):                        34.74
P99 TPOT (ms):                           65.33
---------------Inter-token Latency----------------
Mean ITL (ms):                           76.20
Median ITL (ms):                         69.39
P99 ITL (ms):                            109.64
----------------End-to-end Latency----------------
Mean E2EL (ms):                          8243.21
Median E2EL (ms):                        8503.44
P99 E2EL (ms):                           10646.14
==================================================
```



