### PR TITLE
[Bugfix] Remap FP8 scale names for Mistral3/Pixtral models

### DIFF
--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -582,9 +582,9 @@ class PixtralForConditionalGeneration(
 
                     # Remap FP8 scale names for HuggingFace checkpoints.
                     if name.endswith(".activation_scale"):
-                        name = name.replace(".activation_scale", ".input_scale")
+                        name = name.removesuffix(".activation_scale") + ".input_scale"
                     elif name.endswith(".weight_scale_inv"):
-                        name = name.replace(".weight_scale_inv", ".weight_scale")
+                        name = name.removesuffix(".weight_scale_inv") + ".weight_scale"
                     yield (name, w)
 
         # Now we call the language model load with the generator

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -579,6 +579,12 @@ class PixtralForConditionalGeneration(
                     # by language_model.load_weights
                     # Strip "language_model." prefix if present (HF sharded format)
                     name = name.removeprefix("language_model.")
+
+                    # Remap FP8 scale names for HuggingFace checkpoints.
+                    if name.endswith(".activation_scale"):
+                        name = name.replace(".activation_scale", ".input_scale")
+                    elif name.endswith(".weight_scale_inv"):
+                        name = name.replace(".weight_scale_inv", ".weight_scale")
                     yield (name, w)
 
         # Now we call the language model load with the generator


### PR DESCRIPTION
## Summary
Fix loading FP8 quantized Mistral3/Pixtral models by remapping HuggingFace scale parameter names to vLLM format.

**Changes:**
- `activation_scale` → `input_scale`
- `weight_scale_inv` → `weight_scale`

## Testing
Tested with FP8 quantized Mistral3 model (e.g., `mistralai/Ministral-3-8B-Instruct-2512 `).

Related https://github.com/vllm-project/vllm/pull/32673