### PR TITLE
[Bugfix][MoE] Remove tests/v1/e2e/test_spec_decode.py::test_mtp_correctness[deepseek]

### DIFF
--- a/tests/kernels/moe/test_routing.py
+++ b/tests/kernels/moe/test_routing.py
@@ -302,7 +302,6 @@ def test_fused_topk(
 @pytest.mark.parametrize("global_num_experts", NUM_EXPERTS)
 @pytest.mark.parametrize("renormalize", [False, True])
 @pytest.mark.parametrize("enable_eplb", [False, True])
-@pytest.mark.parametrize("needs_correction_bias", [False, True])
 @pytest.mark.parametrize("routed_scaling_factor", [1.0, 1.1])
 def test_fused_topk_bias(
     m: int,
@@ -311,7 +310,6 @@ def test_fused_topk_bias(
     global_num_experts: int,
     renormalize: bool,
     enable_eplb: bool,
-    needs_correction_bias: bool,
     routed_scaling_factor: float,
 ):
     if top_k > global_num_experts:
@@ -320,7 +318,7 @@ def test_fused_topk_bias(
     eplb_state = setup_eplb_state(enable_eplb, global_num_experts)
 
     e_score_correction_bias = make_e_score_correction_bias(
-        needs_correction_bias,
+        True,
         global_num_experts,
     )
 

--- a/tests/kernels/moe/test_routing.py
+++ b/tests/kernels/moe/test_routing.py
@@ -363,9 +363,9 @@ def test_fused_topk_bias(
 @pytest.mark.parametrize("renormalize", [False, True])
 @pytest.mark.parametrize("enable_eplb", [False, True])
 @pytest.mark.parametrize("needs_correction_bias", [False, True])
-@pytest.mark.parametrize("routed_scaling_factor", [1.0, 1.1])
+@pytest.mark.parametrize("routed_scaling_factor", [1.1])
 @pytest.mark.parametrize("scoring_func", ["sigmoid", "softmax"])
-@pytest.mark.parametrize("use_custom_op", [True, False])
+@pytest.mark.parametrize("use_custom_op", [False, True])
 def test_grouped_topk(
     m: int,
     k: int,

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -552,9 +552,8 @@ def test_eagle_correctness(
     ["model_setup", "mm_enabled"],
     [
         (("mtp", "XiaomiMiMo/MiMo-7B-Base", 1), False),
-        (("mtp", "ZixiQi/DeepSeek-V3-4layers-MTP-FP8", 1), False),
     ],
-    ids=["mimo", "deepseek"],
+    ids=["mimo"],
 )
 def test_mtp_correctness(
     monkeypatch: pytest.MonkeyPatch,

--- a/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -151,12 +151,8 @@ def grouped_topk(
         # scores for expert selection but original scores for routing weights
         original_scores = scores
         scores = scores + e_score_correction_bias.unsqueeze(0)
-        experts_per_group = num_experts // num_expert_group
-        topk_per_group = min(2, experts_per_group)
         group_scores = (
-            scores.view(num_token, num_expert_group, -1)
-            .topk(topk_per_group, dim=-1)[0]
-            .sum(dim=-1)
+            scores.view(num_token, num_expert_group, -1).topk(2, dim=-1)[0].sum(dim=-1)
         )
     else:
         group_scores = (

--- a/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -142,8 +142,12 @@ def grouped_topk(
         # scores for expert selection but original scores for routing weights
         original_scores = scores
         scores = scores + e_score_correction_bias.unsqueeze(0)
+        experts_per_group = num_experts // num_expert_group
+        topk_per_group = min(2, experts_per_group)
         group_scores = (
-            scores.view(num_token, num_expert_group, -1).topk(2, dim=-1)[0].sum(dim=-1)
+            scores.view(num_token, num_expert_group, -1)
+            .topk(topk_per_group, dim=-1)[0]
+            .sum(dim=-1)
         )
     else:
         group_scores = (
@@ -178,7 +182,6 @@ def grouped_topk(
 
     if routed_scaling_factor != 1.0:
         topk_weights = topk_weights * routed_scaling_factor
-
     return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
 
 

--- a/vllm/model_executor/layers/fused_moe/router/router_factory.py
+++ b/vllm/model_executor/layers/fused_moe/router/router_factory.py
@@ -110,7 +110,7 @@ def create_fused_moe_router(
         # Check if num_experts is greater than or equal to num_expert_group
         # and is divisible by num_expert_group
         assert (
-            global_num_experts >= num_expert_group
+            global_num_experts > num_expert_group
             and global_num_experts % num_expert_group == 0
         )
 

--- a/vllm/model_executor/layers/fused_moe/router/router_factory.py
+++ b/vllm/model_executor/layers/fused_moe/router/router_factory.py
@@ -106,6 +106,14 @@ def create_fused_moe_router(
                 "num_expert_group and topk_group must be provided when "
                 "use_grouped_topk is True"
             )
+
+        # Check if num_experts is greater than or equal to num_expert_group
+        # and is divisible by num_expert_group
+        assert (
+            global_num_experts >= num_expert_group
+            and global_num_experts % num_expert_group == 0
+        )
+
         return GroupedTopKRouter(
             top_k=top_k,
             global_num_experts=global_num_experts,


### PR DESCRIPTION
## Purpose

Remove the `tests/v1/e2e/test_spec_decode.py::test_mtp_correctness[deepseek]` testpoint.  It was exercising an odd edge case in the `grouped_topk` kernel (`num_experts == num_expert_groups`) that would sometimes fall back to `fused_topk` or `fuse_topk_bias` ignoring the activation function.  This test also fails when using the monolithic trtllm MoE kernels with the following assert: `TVM_FFI_ICHECK_LT(args->top_k, (args->topk_group * args->num_experts / args->n_group))` which makes me think that the test model itself is not correct.  This edge case hasn't appeared in any other deepseek models I've tested.

I've also removed the fallback logic from the grouped topk implementation and added more asserts.

## Test Plan
CI tests
Added new routing tests for all grouped routing combinations.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

