### PR TITLE
Add the missing router_logits_dtype for nemotron_h

### DIFF
--- a/vllm/model_executor/models/nemotron_h.py
+++ b/vllm/model_executor/models/nemotron_h.py
@@ -207,6 +207,7 @@ class NemotronHMoE(nn.Module):
             enable_eplb=self.enable_eplb,
             num_redundant_experts=self.n_redundant_experts,
             is_sequence_parallel=self.is_sequence_parallel,
+            router_logits_dtype=self.gate.params_dtype,
         )
 
         if self.use_latent_moe:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Nemotron H uses FP32 linear for gate and the router logits are FP32 instead of the default BF16.

This fixes the error triggered

```
(EngineCore_DP2 pid=147)     return self.forward_impl_chunked(
(EngineCore_DP2 pid=147)            ^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP2 pid=147)   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/layer.py", line 1780, in forward_impl_chunked
(EngineCore_DP2 pid=147)     assert self.batched_router_logits.dtype == full_router_logits.dtype
(EngineCore_DP2 pid=147)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Test Plan

Deploy nemotron nano v3 NVFP4 checkpoint and observe the error is gone

## Test Result

The error is gone.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

