### PR TITLE
[Bugfix][Hardware][AMD] Add LoRA guard to unquantized MoE backend selection

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -958,15 +958,10 @@ class rocm_aiter_ops:
     @classmethod
     @if_aiter_supported
     def is_fused_moe_enabled(cls) -> bool:
-        # Auto-enable AITER MoE on supported ROCm platforms (gfx9).
-        # The @if_aiter_supported decorator ensures this is only called
-        # when AITER is available. Users can opt-out with:
-        # - VLLM_ROCM_USE_AITER=0 (disables all AITER features)
-        # - VLLM_ROCM_USE_AITER_MOE=0 (disables only MoE)
-        if not cls._FMOE_ENABLED:
-            return False
-        # If AITER is explicitly disabled, respect that setting
-        return not (envs.is_set("VLLM_ROCM_USE_AITER") and not cls._AITER_ENABLED)
+        # AITER MoE requires the master AITER flag to be enabled.
+        # Users must set VLLM_ROCM_USE_AITER=1 to enable AITER features,
+        # then can optionally disable MoE with VLLM_ROCM_USE_AITER_MOE=0.
+        return cls._AITER_ENABLED and cls._FMOE_ENABLED
 
     @classmethod
     @if_aiter_supported

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -958,9 +958,6 @@ class rocm_aiter_ops:
     @classmethod
     @if_aiter_supported
     def is_fused_moe_enabled(cls) -> bool:
-        # AITER MoE requires the master AITER flag to be enabled.
-        # Users must set VLLM_ROCM_USE_AITER=1 to enable AITER features,
-        # then can optionally disable MoE with VLLM_ROCM_USE_AITER_MOE=0.
         return cls._AITER_ENABLED and cls._FMOE_ENABLED
 
     @classmethod

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -958,7 +958,15 @@ class rocm_aiter_ops:
     @classmethod
     @if_aiter_supported
     def is_fused_moe_enabled(cls) -> bool:
-        return cls._AITER_ENABLED and cls._FMOE_ENABLED
+        # Auto-enable AITER MoE on supported ROCm platforms (gfx9).
+        # The @if_aiter_supported decorator ensures this is only called
+        # when AITER is available. Users can opt-out with:
+        # - VLLM_ROCM_USE_AITER=0 (disables all AITER features)
+        # - VLLM_ROCM_USE_AITER_MOE=0 (disables only MoE)
+        if not cls._FMOE_ENABLED:
+            return False
+        # If AITER is explicitly disabled, respect that setting
+        return not (envs.is_set("VLLM_ROCM_USE_AITER") and not cls._AITER_ENABLED)
 
     @classmethod
     @if_aiter_supported

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -56,6 +56,7 @@ def select_unquantized_moe_backend(
     moe_config: FusedMoEConfig,
     use_ep: bool,
     use_dp: bool,
+    is_lora_enabled: bool = False,
 ) -> UnquantizedMoeBackend:
     """
     Select the primary Unquantized MoE backend
@@ -64,6 +65,11 @@ def select_unquantized_moe_backend(
 
     def _make_log_backend(backend: UnquantizedMoeBackend):
         return f"Using {backend.value} backend for Unquantized MoE"
+
+    # LoRA requires TRITON backend for moe_sum support (LoRA weight injection)
+    if is_lora_enabled:
+        logger.info_once(_make_log_backend(UnquantizedMoeBackend.TRITON), scope="local")
+        return UnquantizedMoeBackend.TRITON
 
     rocm_aiter_moe_enabled = rocm_aiter_ops.is_fused_moe_enabled()
 

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -61,6 +61,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             moe_config=self.moe,
             use_ep=self.moe.moe_parallel_config.use_ep,
             use_dp=self.moe.moe_parallel_config.dp_size > 1,
+            is_lora_enabled=self.moe.is_lora_enabled,
         )
 
         # AITER only supports gated activations (silu/gelu), so disable it


### PR DESCRIPTION
## Summary
Adds LoRA guard to `select_unquantized_moe_backend()` to force TRITON backend when LoRA is enabled.

## Problem
The FP8 MoE oracle already has a LoRA guard (see `fp8.py:141`), but the unquantized MoE oracle was missing it. This caused test regressions when AITER was enabled with LoRA models, because AITER doesn't support the `moe_sum` operation needed for LoRA weight injection.

## Solution
- Add `is_lora_enabled` parameter to `select_unquantized_moe_backend()`
- Return TRITON backend immediately if LoRA is enabled
- Pass `is_lora_enabled` from `UnquantizedFusedMoEMethod`

This makes the unquantized oracle consistent with the FP8 oracle.

## Test Plan
CI Build #3537 passed with this fix. The LoRA tests that were failing now pass because they correctly use the TRITON backend.

Fixes test regressions reported by @AndreasKaratzas in Build #3511.

## Changes
- `vllm/model_executor/layers/fused_moe/oracle/unquantized.py`: Add LoRA guard
- `vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py`: Pass `is_lora_enabled` parameter