### PR TITLE
[CI][Models] Add VLM Support for Sequence Classification Conversion

### DIFF
--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -278,21 +278,35 @@ class GemmaRMSNorm(CustomOp):
         self.variance_epsilon = eps
 
     @staticmethod
-    def forward_static(
+    def _forward_static_no_residual(
         weight: torch.Tensor,
         variance_epsilon: float,
         x: torch.Tensor,
-        residual: torch.Tensor | None,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        """PyTorch-native implementation equivalent to forward()."""
+    ) -> torch.Tensor:
+        """PyTorch-native implementation equivalent to forward() without residual."""
         orig_dtype = x.dtype
-        if residual is not None:
-            x = (
-                x.float() + residual.float()
-                if orig_dtype == torch.float16
-                else x + residual
-            )
-            residual = x
+        x = x.float()
+        variance = x.pow(2).mean(dim=-1, keepdim=True)
+        x = x * torch.rsqrt(variance + variance_epsilon)
+        x = x * (1.0 + weight.float())
+        x = x.to(orig_dtype)
+        return x
+
+    @staticmethod
+    def _forward_static_with_residual(
+        weight: torch.Tensor,
+        variance_epsilon: float,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """PyTorch-native implementation equivalent to forward() with residual."""
+        orig_dtype = x.dtype
+        x = (
+            x.float() + residual.float()
+            if orig_dtype == torch.float16
+            else x + residual
+        )
+        residual = x
 
         x = x.float()
         variance = x.pow(2).mean(dim=-1, keepdim=True)
@@ -301,7 +315,7 @@ class GemmaRMSNorm(CustomOp):
         # See https://github.com/huggingface/transformers/pull/29402
         x = x * (1.0 + weight.float())
         x = x.to(orig_dtype)
-        return x if residual is None else (x, residual)
+        return x, residual
 
     def forward_native(
         self,
@@ -309,7 +323,14 @@ class GemmaRMSNorm(CustomOp):
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         """PyTorch-native implementation equivalent to forward()."""
-        return self.forward_static(self.weight.data, self.variance_epsilon, x, residual)
+        if residual is None:
+            return self._forward_static_no_residual(
+                self.weight.data, self.variance_epsilon, x
+            )
+        else:
+            return self._forward_static_with_residual(
+                self.weight.data, self.variance_epsilon, x, residual
+            )
 
     def forward_cuda(
         self,
@@ -320,8 +341,11 @@ class GemmaRMSNorm(CustomOp):
             return self.forward_native(x, residual)
 
         if not getattr(self, "_is_compiled", False):
-            self.forward_static = torch.compile(  # type: ignore
-                self.forward_static
+            self._forward_static_no_residual = torch.compile(  # type: ignore
+                self._forward_static_no_residual
+            )
+            self._forward_static_with_residual = torch.compile(  # type: ignore
+                self._forward_static_with_residual
             )
             self._is_compiled = True
         return self.forward_native(x, residual)

--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -373,6 +373,39 @@ class SequenceClassificationConfig(VerifyAndUpdateConfig):
         text_config.use_sep_token = use_sep_token
 
 
+def _get_language_model_for_seq_cls(model) -> nn.Module:
+    """
+    Get the language model component for sequence classification conversion.
+    For VLMs, returns the inner language model. For standard LLMs, returns model itself.
+    """
+    if supports_multimodal(model):
+        try:
+            lm = model.get_language_model()
+            if lm is not model:
+                return lm
+        except Exception:
+            pass
+
+    for attr_name in ("language_model", "lm", "text_model"):
+        if hasattr(model, attr_name):
+            candidate = getattr(model, attr_name)
+            if (
+                isinstance(candidate, nn.Module)
+                and candidate is not model
+                and hasattr(candidate, "model")
+            ):
+                return candidate
+
+    for name, child in model.named_children():
+        child_name = type(child).__name__
+        if ("ForCausalLM" in child_name or "LMHead" in child_name) and hasattr(
+            child, "model"
+        ):
+            return child
+
+    return model
+
+
 def load_weights_using_from_2_way_softmax(
     model, weights: Iterable[tuple[str, torch.Tensor]]
 ):
@@ -393,9 +426,9 @@ def load_weights_using_from_2_way_softmax(
     tokens = cast(list[int], tokens)
     assert len(tokens) == 2
 
-    language_model = (
-        model.get_language_model() if hasattr(model, "get_language_model") else model
-    )
+    language_model = _get_language_model_for_seq_cls(model)
+    is_vlm = language_model is not model
+
     language_model.lm_head = ParallelLMHead(
         text_config.vocab_size, text_config.hidden_size, quant_config=quant_config
     )
@@ -411,12 +444,40 @@ def load_weights_using_from_2_way_softmax(
         )
         language_model.lm_head = language_model.lm_head.tie_weights(embed_tokens)
 
-    # ModelForPooling is dynamically defined inside the _create_pooling_model_cls
-    # function, so we need use this hacky method to obtain it.
-    pooling_model_cls = next(
-        x for x in type(model).__mro__ if x.__name__ == "ModelForPooling"
-    )
-    loaded_weights = pooling_model_cls.load_weights(model, weights)
+    inner_hf_config = None
+    inner_text_config = None
+    original_method = None
+    original_tokens = None
+    original_hf_tokens = None
+    if is_vlm:
+        inner_hf_config = getattr(language_model, "config", None)
+        if inner_hf_config is not None:
+            inner_text_config = inner_hf_config.get_text_config()
+            original_method = getattr(inner_text_config, "method", None)
+            if original_method is not None:
+                inner_text_config.method = None
+            original_tokens = getattr(inner_text_config, "classifier_from_token", None)
+            if original_tokens is not None:
+                inner_text_config.classifier_from_token = None
+            original_hf_tokens = getattr(inner_hf_config, "classifier_from_token", None)
+            if original_hf_tokens is not None:
+                inner_hf_config.classifier_from_token = None
+
+    try:
+        # ModelForPooling is dynamically defined inside the _create_pooling_model_cls
+        # function, so we need use this hacky method to obtain it.
+        pooling_model_cls = next(
+            x for x in type(model).__mro__ if x.__name__ == "ModelForPooling"
+        )
+        loaded_weights = pooling_model_cls.load_weights(model, weights)
+    finally:
+        if inner_text_config is not None:
+            if original_method is not None:
+                inner_text_config.method = original_method
+            if original_tokens is not None:
+                inner_text_config.classifier_from_token = original_tokens
+        if inner_hf_config is not None and original_hf_tokens is not None:
+            inner_hf_config.classifier_from_token = original_hf_tokens
 
     from vllm.tokenizers import get_tokenizer
 
@@ -434,12 +495,15 @@ def load_weights_using_from_2_way_softmax(
         torch.float32
     ) - lm_head_weight.data[[false_id]].to(torch.float32)
 
-    param = model.score.weight
+    score_layer = language_model.score if is_vlm else model.score
+    param = score_layer.weight
     weight_loader = getattr(param, "weight_loader", default_weight_loader)
     weight_loader(param, score_weight)
 
     del language_model.lm_head
-    loaded_weights.add("score.weight")
+
+    score_weight_name = "language_model.score.weight" if is_vlm else "score.weight"
+    loaded_weights.add(score_weight_name)
 
     lm_head_name = "lm_head.weight"
     if hf_to_vllm_mapper := getattr(model, "hf_to_vllm_mapper", None):
@@ -460,22 +524,57 @@ def load_weights_no_post_processing(model, weights: Iterable[tuple[str, torch.Te
     tokens = cast(list[int], tokens)
     assert len(tokens) > 0
 
-    model.lm_head = ParallelLMHead(
+    language_model = _get_language_model_for_seq_cls(model)
+    is_vlm = language_model is not model
+
+    language_model.lm_head = ParallelLMHead(
         text_config.vocab_size, text_config.hidden_size, quant_config=quant_config
     )
     if text_config.tie_word_embeddings:
         # embed_tokens is the assumed name for input embeddings. If the model does not
         # have this attribute, we fall back to get_input_embeddings(), which is used by
         # the Transformers modeling backend.
+        text_backbone = language_model.model
         embed_tokens = (
-            model.model.embed_tokens
-            if hasattr(model.model, "embed_tokens")
-            else model.model.get_input_embeddings()
+            text_backbone.embed_tokens
+            if hasattr(text_backbone, "embed_tokens")
+            else text_backbone.get_input_embeddings()
         )
-        model.lm_head = model.lm_head.tie_weights(embed_tokens)
+        language_model.lm_head = language_model.lm_head.tie_weights(embed_tokens)
 
-    # Skip ModelForSequenceClassification in MRO to avoid infinite recursion
-    loaded_weights = type(model).__mro__[1].load_weights(model, weights)
+    inner_hf_config = None
+    inner_text_config = None
+    original_method = None
+    original_tokens = None
+    original_hf_tokens = None
+    if is_vlm:
+        inner_hf_config = getattr(language_model, "config", None)
+        if inner_hf_config is not None:
+            inner_text_config = inner_hf_config.get_text_config()
+            original_method = getattr(inner_text_config, "method", None)
+            if original_method is not None:
+                inner_text_config.method = None
+            original_tokens = getattr(inner_text_config, "classifier_from_token", None)
+            if original_tokens is not None:
+                inner_text_config.classifier_from_token = None
+            original_hf_tokens = getattr(inner_hf_config, "classifier_from_token", None)
+            if original_hf_tokens is not None:
+                inner_hf_config.classifier_from_token = None
+
+    try:
+        pooling_model_cls = next(
+            x for x in type(model).__mro__ if x.__name__ == "ModelForPooling"
+        )
+        # Skip ModelForSequenceClassification in MRO to avoid infinite recursion
+        loaded_weights = pooling_model_cls.load_weights(model, weights)
+    finally:
+        if inner_text_config is not None:
+            if original_method is not None:
+                inner_text_config.method = original_method
+            if original_tokens is not None:
+                inner_text_config.classifier_from_token = original_tokens
+        if inner_hf_config is not None and original_hf_tokens is not None:
+            inner_hf_config.classifier_from_token = original_hf_tokens
 
     from vllm.tokenizers import get_tokenizer
 
@@ -487,15 +586,22 @@ def load_weights_no_post_processing(model, weights: Iterable[tuple[str, torch.Te
     )
 
     token_ids = [tokenizer.convert_tokens_to_ids(t) for t in tokens]
-    score_weight = model.lm_head.weight.data[token_ids]
+    score_weight = language_model.lm_head.weight.data[token_ids]
 
-    param = model.score.weight
+    score_layer = language_model.score if is_vlm else model.score
+    param = score_layer.weight
     weight_loader = getattr(param, "weight_loader", default_weight_loader)
     weight_loader(param, score_weight)
 
-    del model.lm_head
-    loaded_weights.add("score.weight")
-    loaded_weights.discard("lm_head.weight")
+    del language_model.lm_head
+
+    score_weight_name = "language_model.score.weight" if is_vlm else "score.weight"
+    loaded_weights.add(score_weight_name)
+
+    lm_head_name = "lm_head.weight"
+    if hf_to_vllm_mapper := getattr(model, "hf_to_vllm_mapper", None):
+        lm_head_name = hf_to_vllm_mapper._map_name(lm_head_name)
+    loaded_weights.discard(lm_head_name)
     return loaded_weights
 
 

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -107,7 +107,9 @@ class TritonAttentionMetadata:
             for r in range_lists
         ]
 
-        return torch.nested.nested_tensor(range_tensors).to_padded_tensor(0)
+        return torch.nested.nested_tensor(
+            range_tensors, layout=torch.jagged
+        ).to_padded_tensor(0)
 
 
 class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMetadata]):


### PR DESCRIPTION
This PR enables Vision-Language Models (VLMs) like Gemma 3 to be converted to sequence classifiers using the `no_post_processing` and `from_2_way_softmax` methods. Additionally, it fixes two PyTorch compiler warnings that were causing noise in the logs.

## Changes

### 1. `vllm/model_executor/models/adapters.py`

- Added `_get_language_model_for_seq_cls()` helper function to correctly retrieve the inner language model component from VLMs
- Updated `load_weights_no_post_processing()` and `load_weights_using_from_2_way_softmax()` to:
  - Detect VLM vs standard LLM architecture
  - Temporarily clear `method` and `classifier_from_token` configs on inner model to prevent recursive `seq_cls_model_loader` calls
  - Access the correct `score` layer location (`language_model.score` for VLMs vs `model.score` for LLMs)
  - Use correct weight names for validation (`language_model.score.weight` vs `score.weight`)

### 2. `vllm/model_executor/layers/layernorm.py`

- Split `GemmaRMSNorm.forward_static()` into two separate functions to fix torch.dynamo recompilation warning:
  - `_forward_static_no_residual()` - handles `residual=None` case
  - `_forward_static_with_residual()` - handles `residual=Tensor` case
- Each function is compiled separately, eliminating type-based recompilation

### 3. `vllm/v1/attention/backends/triton_attn.py`

- Fixed PyTorch nested tensor prototype warning by using `layout=torch.jagged`

## Problem

<details>

<summary><b>Original VLM Classification Error</b></summary>
```
AttributeError: 'Gemma3ForSequenceClassification' object has no attribute 'model'
```

The sequence classification conversion assumed all models have a `.model` attribute, but VLMs like Gemma 3 use `.language_model.model` structure.

</details>

<details>

<summary><b>Torch Dynamo Recompilation Warning</b></summary>
```
[rank0]:W0122 21:05:25.851000 torch/_dynamo/convert_frame.py:1358] [0/8] torch._dynamo hit config.recompile_limit (8)
[rank0]:W0122 21:05:25.851000    function: 'forward_static' (/app/vllm/vllm/model_executor/layers/layernorm.py:280)
[rank0]:W0122 21:05:25.851000    last reason: 0/7: expected type of 'residual' to be a tensor type, but found <class 'NoneType'>
```

The `forward_static` function was being recompiled repeatedly because it handled both `residual=None` and `residual=Tensor` cases, causing torch.dynamo to specialize and recompile on each type change.

</details>

<details>

<summary><b>Nested Tensor Prototype Warning</b></summary>
```
UserWarning: The PyTorch API of nested tensors is in prototype stage and will change in the near future. 
We recommend specifying layout=torch.jagged when constructing a nested tensor...
```

</details>

<details>

<summary><b>VLM Architecture Root Cause</b></summary>

VLMs have a nested architecture:
```
Gemma3ForConditionalGeneration (outer VLM):
* vision_tower: SiglipVisionModel
* multi_modal_projector: Gemma3MultiModalProjector
* language_model: Gemma3ForCausalLM (inner LLM):
    - model: Gemma3Model
    - lm_head: ParallelLMHead
```

When wrapped as `ModelForSequenceClassification`, BOTH the outer VLM and inner LLM get the wrapper applied. This caused:

1. **Attribute access failure**: Code tried `model.model.embed_tokens` but VLMs need `model.language_model.model.embed_tokens`
2. **Recursive weight loading**: Inner `language_model` also triggered `seq_cls_model_loader`, deleting `lm_head` before outer model could use it
3. **Missing score layer**: For VLMs, `_init_pooler` (which creates `score`) is not called on outer model since it reuses inner model's pooler
4. **Wrong weight names**: Validation expected `score.weight` but VLMs have `language_model.score.weight`

</details>

## Testing

<details>
<summary><b>Classification Test Results</b></summary>

Tested with `google/gemma-3-4b-it` as a 5-class furniture classifier:
```python
def update_config(config):
    config.text_config.update({
        "architectures": ["Gemma3ForSequenceClassification"],
        "classifier_from_token": ["A", "B", "C", "D", "E"],
        "method": "no_post_processing",
        "id2label": {"0": "Chair", "1": "Couch", "2": "Table", "3": "Bed", "4": "Cupboard"},
    })
    return config
```

**Results on red chair image:**
```
Probabilities: [1.0, 3.27e-09, 9.24e-09, 2.61e-08, 1.96e-08]
Prediction: Chair (100% confidence)
```

</details>

<details>

<summary><b>Generation Test Results (Regression Check)</b></summary>

Verified VLM generation mode still works correctly:
```
Turn 1 - User: What color is this furniture?
Assistant: Frame: Primarily a rich, dark reddish-brown, likely mahogany.
          Seat: A vibrant red leather.
          Details: Touches of black on decorative elements.

Turn 2 - User: What material do you think it's made of?
Assistant: Frame: Almost certainly mahogany wood...
          Seat: Made of leather...

Turn 3 - User: Would this be suitable for an office or a living room?
Assistant: Living Room – Highly Suitable...
          Office – Less Ideal, but Possible...
```

Multi-turn context maintained correctly

</details>


## Backwards Compatibility

| Model Type | Behavior |
|------------|----------|
| Standard LLMs (Gemma, Qwen, etc.) | `_get_language_model_for_seq_cls()` returns `model` itself → unchanged behavior |
| VLMs (Gemma 3, etc.) | Returns inner `language_model` → now works |
| GemmaRMSNorm | Same numerical results, just split compilation paths |