### PR TITLE
[Bugfix] Fix FP8 MoE EP Weight Loading for ModelOpt Llama4

### DIFF
--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -506,6 +506,8 @@ class Llama4Model(LlamaModel):
                         .flatten()
                         .to(new_loaded_weight.device)
                     )
+                    # Workaround for FP8 CPU indexing on older PyTorch:
+                    # https://github.com/vllm-project/vllm/issues/32862
                     is_fp8_dtype = new_loaded_weight.dtype == (
                         current_platform.fp8_dtype()
                     ) or (

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -51,6 +51,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.model_executor.models.interfaces import MixtureOfExperts
 from vllm.model_executor.models.utils import sequence_parallel_chunk
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 from .llama import LlamaForCausalLM, LlamaMLP, LlamaModel
@@ -505,9 +506,15 @@ class Llama4Model(LlamaModel):
                         .flatten()
                         .to(new_loaded_weight.device)
                     )
+                    is_fp8_dtype = new_loaded_weight.dtype == (
+                        current_platform.fp8_dtype()
+                    ) or (
+                        new_loaded_weight.dtype.is_floating_point
+                        and new_loaded_weight.element_size() == 1
+                    )
                     if (
                         new_loaded_weight.device.type == "cpu"
-                        and new_loaded_weight.dtype == torch.float8_e4m3fn
+                        and is_fp8_dtype
                         and not is_torch_equal_or_newer("2.11.0")
                     ):
                         # PyTorch < 2.11 doesn't support CPU float8 indexing.

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -37,7 +37,10 @@ def kernel_warmup(worker: "Worker"):
         deep_gemm_warmup(model, max_tokens)
 
     # FlashInfer autotune for Hopper (SM 9.0) and Blackwell (SM 10.0) GPUs
-    if has_flashinfer() and current_platform.has_device_capability(90):
+    if has_flashinfer() and (
+        current_platform.has_device_capability(90)
+        or current_platform.is_device_capability_family(100)
+    ):
         flashinfer_autotune(worker.model_runner)
 
     # FlashInfer attention warmup

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -37,10 +37,7 @@ def kernel_warmup(worker: "Worker"):
         deep_gemm_warmup(model, max_tokens)
 
     # FlashInfer autotune for Hopper (SM 9.0) and Blackwell (SM 10.0) GPUs
-    if has_flashinfer() and (
-        current_platform.has_device_capability(90)
-        or current_platform.is_device_capability_family(100)
-    ):
+    if has_flashinfer() and current_platform.has_device_capability(90):
         flashinfer_autotune(worker.model_runner)
 
     # FlashInfer attention warmup


### PR DESCRIPTION

## Purpose
#32862
  Add a version-guarded fallback in Llama4 MoE weight loading to avoid CPU FP8 indexing on older PyTorch releases. For torch < 2.11, weights are temporarily cast to FP16 for indexing and then cast back, preventing index_cpu errors while leaving newer versions unchanged.
## Test Plan
```
 VLLM_DISABLED_KERNELS=FlashInferFP8ScaledMMLinearKernel \
VLLM_USE_FLASHINFER_MOE_FP8=0 \
vllm bench throughput --model=nvidia/Llama-4-Scout-17B-16E-Instruct-FP8 -tp=2 --enable-expert-parallel --attention-backend=TRITON_ATTN
```
## Test Result
https://paste.ubuntu.com/p/GGRZxFQcdH/



**NOTE: We observed a crash in FlashInfer’s autotuning path on SM100  when running Llama-4 FP8 with expert parallelism. During vLLM startup, flashinfer_autotune is invoked in kernel_warmup, and the process segfaults immediately after autotuning begins. This is a hard crash in the C++/CUDA kernel selection path (not a Python exception), which causes the worker process to die and the engine to report cancelled. We also saw FlashInfer’s FP8 GEMM path be sensitive to layout/contiguity (e.g., mat2 must be contiguous), suggesting a kernel compatibility issue on this hardware/shape combination rather than a configuration error.**


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

