### PR TITLE
[Perf] Optimize `moe_permute` kernel, 40%~300% kernel performance improvement

### DIFF
--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.h
@@ -60,7 +60,8 @@ void expandInputRowsKernelLauncher(
     T const* unpermuted_input, T* permuted_output, int* sorted_experts,
     int const* expanded_dest_row_to_expanded_source_row,
     int* expanded_source_row_to_expanded_dest_row, int* permuted_idx,
-    int64_t* expert_first_token_offset, int64_t const num_rows,
+    int64_t const* expert_first_token_offset,
+    int64_t const* aligned_expert_first_token_offset, int64_t const num_rows,
     int64_t const* num_valid_tokens_ptr, int64_t const cols, int const k,
     int num_local_experts, const int& align_block_size, cudaStream_t stream);
 

--- a/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.inl
+++ b/csrc/moe/permute_unpermute_kernels/moe_permute_unpermute_kernel.inl
@@ -5,7 +5,8 @@ __global__ void expandInputRowsKernel(
     T const* unpermuted_input, T* permuted_output, int* sorted_experts,
     int const* expanded_dest_row_to_expanded_source_row,
     int* expanded_source_row_to_expanded_dest_row, int* permuted_idx,
-    int64_t* expert_first_token_offset, int64_t const num_rows,
+    int64_t const* expert_first_token_offset,
+    int64_t const* aligned_expert_first_token_offset, int64_t const num_rows,
     int64_t const* num_dest_rows, int64_t const cols, int64_t k,
     int num_local_experts, int align_block_size) {
   // Reverse permutation map.
@@ -18,35 +19,22 @@ __global__ void expandInputRowsKernel(
       expanded_dest_row_to_expanded_source_row[expanded_dest_row];
   int expert_id = sorted_experts[expanded_dest_row];
 
-  extern __shared__ int64_t smem_expert_first_token_offset[];
   if constexpr (ALIGN_BLOCK_SIZE) {
-    // load g2s
-    for (int idx = threadIdx.x; idx < num_local_experts + 1;
-         idx += blockDim.x) {
-      smem_expert_first_token_offset[idx] =
-          __ldg(expert_first_token_offset + idx);
+    // convert (unaligned) expanded_dest_row -> aligned expanded_dest_row.
+    // aligned_expert_first_token_offset[e] provides the aligned prefix start
+    // for expert e. For non-local experts we map to the end (total aligned M).
+    int64_t aligned_base = 0;
+    int64_t token_offset_in_expert = 0;
+    if (expert_id >= num_local_experts) {
+      aligned_base =
+          __ldg(aligned_expert_first_token_offset + num_local_experts);
+      token_offset_in_expert = 0;
+    } else {
+      aligned_base = __ldg(aligned_expert_first_token_offset + expert_id);
+      token_offset_in_expert =
+          expanded_dest_row - __ldg(expert_first_token_offset + expert_id);
     }
-    __syncthreads();
-    int lane_idx = threadIdx.x & 31;
-
-    if (lane_idx == 0) {
-      // set token_offset_in_expert = 0 if this expert is not local expert
-      int token_offset_in_expert =
-          expert_id >= num_local_experts
-              ? 0
-              : expanded_dest_row - smem_expert_first_token_offset[expert_id];
-      int64_t accumulate_align_offset = 0;
-#pragma unroll 1
-      for (int eidx = 1; eidx <= min(expert_id, num_local_experts); eidx++) {
-        auto n_token_in_expert = smem_expert_first_token_offset[eidx] -
-                                 smem_expert_first_token_offset[eidx - 1];
-        accumulate_align_offset += (n_token_in_expert + align_block_size - 1) /
-                                   align_block_size * align_block_size;
-      }
-      expanded_dest_row = accumulate_align_offset + token_offset_in_expert;
-    }
-    // lane0 shuffle broadcast align_expanded_dest_row
-    expanded_dest_row = __shfl_sync(0xffffffff, expanded_dest_row, 0);
+    expanded_dest_row = aligned_base + token_offset_in_expert;
   }
 
   if (threadIdx.x == 0) {
@@ -88,7 +76,8 @@ void expandInputRowsKernelLauncher(
     T const* unpermuted_input, T* permuted_output, int* sorted_experts,
     int const* expanded_dest_row_to_expanded_source_row,
     int* expanded_source_row_to_expanded_dest_row, int* permuted_idx,
-    int64_t* expert_first_token_offset, int64_t const num_rows,
+    int64_t const* expert_first_token_offset,
+    int64_t const* aligned_expert_first_token_offset, int64_t const num_rows,
     int64_t const* num_valid_tokens_ptr, int64_t const cols, int const k,
     int num_local_experts, const int& align_block_size, cudaStream_t stream) {
   int64_t const blocks = num_rows * k;
@@ -104,14 +93,12 @@ void expandInputRowsKernelLauncher(
   bool is_align_block_size = align_block_size != -1;
   auto func = func_map[is_check_skip][is_align_block_size];
 
-  int64_t smem_size = sizeof(int64_t) * (num_local_experts + 1);
-
-  func<<<blocks, threads, smem_size, stream>>>(
+  func<<<blocks, threads, 0, stream>>>(
       unpermuted_input, permuted_output, sorted_experts,
       expanded_dest_row_to_expanded_source_row,
       expanded_source_row_to_expanded_dest_row, permuted_idx,
-      expert_first_token_offset, num_rows, num_valid_tokens_ptr, cols, k,
-      num_local_experts, align_block_size);
+      expert_first_token_offset, aligned_expert_first_token_offset, num_rows,
+      num_valid_tokens_ptr, cols, k, num_local_experts, align_block_size);
 }
 
 template <class T, class U>


### PR DESCRIPTION
## Purpose

Optimize `moe_permute` kernel using `aligned_expert_first_token_offset`

- Reduce calculation
- Reduce shared memory usage

## Test

### Acc

```bash
tests/kernels/moe/test_moe_permute_unpermute.py ........................... [  6%]
........................................................................... [ 23%]
........................................................................... [ 40%]
........................................................................... [ 58%]
........................................................................... [ 75%]
........................................................................... [ 93%]
..............................                                              [100%]

=================== 432 passed, 2 warnings in 176.30s (0:02:56) ===================
```

### Perf

```bash
python benchmarks/kernels/benchmark_moe_permute_unpermute.py   --model deepseek-ai/DeepSeek-V2-lite   --dtype fp8_w8a8   --use-customized-permute    --trust-remote-code
```

Run twice with/without main and get table:

Batch size | now Permute | main Permute | Improvement(%)
-- | -- | -- | --
1 | 15.80 | 22.46 | 42.15%🚀
2 | 15.95 | 22.81 | 43.01%🚀
4 | 16.02 | 22.81 | 42.38%🚀
8 | 16.28 | 23.05 | 41.58%🚀
16 | 17.85 | 24.81 | 38.99%🚀
24 | 18.26 | 25.87 | 41.68%🚀
32 | 18.27 | 25.74 | 40.89%🚀
48 | 18.56 | 27.14 | 46.23%🚀
64 | 18.70 | 26.84 | 43.53%🚀
96 | 19.43 | 30.25 | 55.70%🚀
128 | 19.61 | 31.30 | 59.60%🚀
256 | 21.11 | 39.36 | 86.44%🚀
512 | 23.71 | 56.14 | 136.79%🚀
1024 | 41.03 | 102.76 | 150.49%🚀
1536 | 44.50 | 135.04 | 203.46%🚀
2048 | 49.52 | 169.52 | 242.33%🚀
3072 | 58.46 | 235.55 | 303.02%🚀
4096 | 68.04 | 300.09 | 341.04%🚀
