### PR TITLE
[Hardware][AMD][CI][Bugfix] Fix Kernels Attention Cache test

### DIFF
--- a/tests/kernels/attention/test_cache.py
+++ b/tests/kernels/attention/test_cache.py
@@ -242,7 +242,7 @@ def test_reshape_and_cache_flash(
     value_cache_compact = permute_and_compact(value_cache)
 
     def convert_fp8_local(output, input, scale, kv_dtype):
-        fp8_input = input.view(torch.float8_e4m3fn)
+        fp8_input = input.view(current_platform.fp8_dtype())
         if scale.numel() == 1:  # per-tensor
             result = scaled_dequantize(
                 fp8_input.flatten(0, 2), scale, group_shape=None, out_dtype=output.dtype


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
This PR fixes a failing test (`kernels/attention/test_cache.py::test_reshape_and_cache_flash`) caused by https://github.com/vllm-project/vllm/pull/30141. The reference dequantization implementation used in the test assumes the FP8 data format is `e4m3fn`, but on AMD `gfx942`-series cards, the FP8 data type used is `e4m3fnuz` instead.

## Test Plan
Run
`pytest -sv tests/kernels/attention/test_cache.py -k test_reshape_and_cache_flash`
on a MI325X as part of the Kernels Attention tests in AMD CI.

## Test Result
The above test now passes.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

