### PR TITLE
[CI][Pooling] Stabilize ModernBERT test

### DIFF
--- a/tests/models/language/pooling/test_token_classification.py
+++ b/tests/models/language/pooling/test_token_classification.py
@@ -51,6 +51,7 @@ def test_bert_models(
 
 @pytest.mark.parametrize("model", ["disham993/electrical-ner-ModernBERT-base"])
 @pytest.mark.parametrize("dtype", ["float"])
+@pytest.mark.flaky(reruns=3)
 @torch.inference_mode
 def test_modernbert_models(
     hf_runner,
@@ -59,6 +60,15 @@ def test_modernbert_models(
     model: str,
     dtype: str,
 ) -> None:
+    # NOTE: https://github.com/vllm-project/vllm/pull/32403
+    # `disham993/electrical-ner-ModernBERT-base` is a randomly initialized
+    # model, which can cause numerical precision variance and edge cases.
+    # We use @flaky(reruns=3) to mitigate intermittent failures.
+    print(
+        f"\n[NOTE] Testing {model} (randomly initialized weights) - "
+        "flaky tolerance enabled due to numerical precision variance."
+    )
+
     with vllm_runner(model, max_model_len=None, dtype=dtype) as vllm_model:
         vllm_outputs = vllm_model.token_classify(example_prompts)
 

--- a/tests/models/language/pooling/test_token_classification.py
+++ b/tests/models/language/pooling/test_token_classification.py
@@ -1,11 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import random
+
+import numpy as np
 import pytest
 import torch
 from transformers import AutoModelForTokenClassification
 
 from tests.models.utils import softmax
 from vllm.platforms import current_platform
+
+
+@pytest.fixture(autouse=True)
+def seed_everything():
+    """Seed all random number generators for reproducibility."""
+    seed = 0
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    yield
 
 
 @pytest.mark.parametrize("model", ["boltuix/NeuroBERT-NER"])


### PR DESCRIPTION
This PR attempts to stabilize the `Language Models Test (Extended Pooling)`. It marks it as flaky, enables rerunning the test, and logs an informative message regarding the possible inaccurate results based on the conversation here: https://github.com/vllm-project/vllm/pull/32403#pullrequestreview-3695341925

## Related

- Addresses flaky test: `test_modernbert_models[float-disham993/electrical-ner-ModernBERT-base]`
- Related to #32403 which increased test tolerance from `atol=1.2e-2` to `atol=3.2e-2` to work around this issue. 

<details>

<summary>Flaky test failure log</summary>

```
=================================== FAILURES ===================================
____ test_modernbert_models[float-disham993/electrical-ner-ModernBERT-base] ____

hf_runner = <class 'tests.conftest.HfRunner'>
vllm_runner = <class 'tests.conftest.VllmRunner'>
example_prompts = ['vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs.\n', ...]
model = 'disham993/electrical-ner-ModernBERT-base', dtype = 'float'

>       torch.testing.assert_close(hf_output, vllm_output, atol=1.2e-2, rtol=1e-3)
E       AssertionError: Tensor-likes are not close!
E
E       Mismatched elements: 1 / 323 (0.3%)
E       Greatest absolute difference: 0.017615288496017456 at index (13, 0) (up to 0.012 allowed)
E       Greatest relative difference: 0.045670073479413986 at index (13, 0) (up to 0.001 allowed)

models/language/pooling/test_token_classification.py:89: AssertionError
```

</details>