### PR TITLE
[StepVL] support close img patch

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -810,11 +810,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
         ["blake3", "sha256", "sha512"],
         case_sensitive=False,
     ),
-
     # Enable patch for step vl model to support image inputs
     "VLLM_ENABLE_STEP_VL_IMG_PATCH": lambda: bool(
         int(os.getenv("VLLM_ENABLE_STEP_VL_IMG_PATCH", "1"))
-    ),  
+    ), 
     # Path to the XLA persistent cache directory.
     # Only used for XLA devices such as TPUs.
     "VLLM_XLA_CACHE_PATH": lambda: os.path.expanduser(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -136,6 +136,7 @@ if TYPE_CHECKING:
     K_SCALE_CONSTANT: int = 200
     V_SCALE_CONSTANT: int = 100
     VLLM_SERVER_DEV_MODE: bool = False
+    VLLM_ENABLE_STEP_VL_IMG_PATCH: bool = True
     VLLM_V1_OUTPUT_PROC_CHUNK_SIZE: int = 128
     VLLM_MLA_DISABLE: bool = False
     VLLM_RAY_PER_WORKER_GPUS: float = 1.0
@@ -809,6 +810,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
         ["blake3", "sha256", "sha512"],
         case_sensitive=False,
     ),
+
+    # Enable patch for step vl model to support image inputs
+    "VLLM_ENABLE_STEP_VL_IMG_PATCH": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_STEP_VL_IMG_PATCH", "1"))
+    ),  
     # Path to the XLA persistent cache directory.
     # Only used for XLA devices such as TPUs.
     "VLLM_XLA_CACHE_PATH": lambda: os.path.expanduser(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -136,7 +136,6 @@ if TYPE_CHECKING:
     K_SCALE_CONSTANT: int = 200
     V_SCALE_CONSTANT: int = 100
     VLLM_SERVER_DEV_MODE: bool = False
-    VLLM_ENABLE_STEP_VL_IMG_PATCH: bool = True
     VLLM_V1_OUTPUT_PROC_CHUNK_SIZE: int = 128
     VLLM_MLA_DISABLE: bool = False
     VLLM_RAY_PER_WORKER_GPUS: float = 1.0
@@ -810,10 +809,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
         ["blake3", "sha256", "sha512"],
         case_sensitive=False,
     ),
-    # Enable patch for step vl model to support image inputs
-    "VLLM_ENABLE_STEP_VL_IMG_PATCH": lambda: bool(
-        int(os.getenv("VLLM_ENABLE_STEP_VL_IMG_PATCH", "1"))
-    ), 
     # Path to the XLA persistent cache directory.
     # Only used for XLA devices such as TPUs.
     "VLLM_XLA_CACHE_PATH": lambda: os.path.expanduser(

--- a/vllm/model_executor/models/step3_vl.py
+++ b/vllm/model_executor/models/step3_vl.py
@@ -341,7 +341,7 @@ class Step3VLProcessor:
         self.image_token = "<im_patch>"
         self.image_feature_placeholder = self.image_token * self.num_image_feature_size
         self.patch_feature_placeholder = self.image_token * self.num_patch_feature_size
-        
+
         # Respect vision config switch to enable/disable patch extraction.
         # For video understanding, it's preferable to disable patch.
         enable_patch = getattr(self.config.vision_config, "enable_patch", True)

--- a/vllm/model_executor/models/step3_vl.py
+++ b/vllm/model_executor/models/step3_vl.py
@@ -15,7 +15,6 @@ from torchvision import transforms
 from torchvision.transforms.functional import InterpolationMode
 from transformers import BatchFeature, PretrainedConfig, TensorType
 
-from vllm import envs
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.distributed import get_tensor_model_parallel_world_size
@@ -143,8 +142,11 @@ class Step3VisionProcessor:
 
 
 class ImagePatcher:
+    def __init__(self, enable_patch: bool = True) -> None:
+        self.enable_patch = enable_patch
+
     def determine_window_size(self, long: int, short: int) -> int:
-        if long <= 728:
+        if long < 728:
             return short if long / short > 1.5 else 0
         return min(short, 504) if long / short > 4 else 504
 
@@ -242,7 +244,7 @@ class ImagePatcher:
         window_size = self.determine_window_size(
             max(img_height, img_width), min(img_height, img_width)
         )
-        if window_size == 0 or not envs.VLLM_ENABLE_STEP_VL_IMG_PATCH:
+        if window_size == 0 or not self.enable_patch:
             return 0, 0
         else:
             img_width, img_height = self.get_image_size_for_crop(
@@ -278,7 +280,7 @@ class ImagePatcher:
             max(new_img_height, new_img_width), min(new_img_height, new_img_width)
         )
 
-        if window_size == 0 or not envs.VLLM_ENABLE_STEP_VL_IMG_PATCH:
+        if window_size == 0 or not self.enable_patch:
             return img, [], None
         else:
             new_img_width, new_img_height = self.get_image_size_for_crop(
@@ -328,9 +330,9 @@ class Step3VLProcessor:
 
         self.config = config
         self.tokenizer = tokenizer
-
         self.image_size = 728
         self.patch_size = 504
+        enable_patch = getattr(self.config.vision_config, "enable_patch", True)
         self.image_preprocessor = Step3VisionProcessor(
             self.image_size, "bilinear", self.patch_size
         )
@@ -341,7 +343,7 @@ class Step3VLProcessor:
         self.image_feature_placeholder = self.image_token * self.num_image_feature_size
         self.patch_feature_placeholder = self.image_token * self.num_patch_feature_size
 
-        self.patcher = ImagePatcher()
+        self.patcher = ImagePatcher(enable_patch=enable_patch)
 
     @property
     def image_token_id(self) -> int:

--- a/vllm/model_executor/models/step3_vl.py
+++ b/vllm/model_executor/models/step3_vl.py
@@ -14,6 +14,7 @@ from PIL import Image
 from torchvision import transforms
 from torchvision.transforms.functional import InterpolationMode
 from transformers import BatchFeature, PretrainedConfig, TensorType
+
 from vllm import envs
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions

--- a/vllm/model_executor/models/step3_vl.py
+++ b/vllm/model_executor/models/step3_vl.py
@@ -332,7 +332,6 @@ class Step3VLProcessor:
         self.tokenizer = tokenizer
         self.image_size = 728
         self.patch_size = 504
-        enable_patch = getattr(self.config.vision_config, "enable_patch", True)
         self.image_preprocessor = Step3VisionProcessor(
             self.image_size, "bilinear", self.patch_size
         )
@@ -342,7 +341,10 @@ class Step3VLProcessor:
         self.image_token = "<im_patch>"
         self.image_feature_placeholder = self.image_token * self.num_image_feature_size
         self.patch_feature_placeholder = self.image_token * self.num_patch_feature_size
-
+        
+        # Respect vision config switch to enable/disable patch extraction.
+        # For video understanding, it's preferable to disable patch.
+        enable_patch = getattr(self.config.vision_config, "enable_patch", True)
         self.patcher = ImagePatcher(enable_patch=enable_patch)
 
     @property

--- a/vllm/model_executor/models/step3_vl.py
+++ b/vllm/model_executor/models/step3_vl.py
@@ -241,7 +241,7 @@ class ImagePatcher:
         window_size = self.determine_window_size(
             max(img_height, img_width), min(img_height, img_width)
         )
-        if window_size == 0:
+        if window_size == 0 or not envs.VLLM_ENABLE_STEP_VL_IMG_PATCH:
             return 0, 0
         else:
             img_width, img_height = self.get_image_size_for_crop(

--- a/vllm/model_executor/models/step3_vl.py
+++ b/vllm/model_executor/models/step3_vl.py
@@ -14,7 +14,7 @@ from PIL import Image
 from torchvision import transforms
 from torchvision.transforms.functional import InterpolationMode
 from transformers import BatchFeature, PretrainedConfig, TensorType
-
+from vllm import envs
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.distributed import get_tensor_model_parallel_world_size
@@ -277,7 +277,7 @@ class ImagePatcher:
             max(new_img_height, new_img_width), min(new_img_height, new_img_width)
         )
 
-        if window_size == 0:
+        if window_size == 0 or not envs.VLLM_ENABLE_STEP_VL_IMG_PATCH:
             return img, [], None
         else:
             new_img_width, new_img_height = self.get_image_size_for_crop(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
The default behavior of the StepVL model involves patch operations for image computation. For video understanding, in this case it’s preferable to disable img_patch and instead extract frames and feed in only the key frames.
Use hf-overrides to pass parameters and disable the patching behavior.

```bash
vllm serve stepfun-ai/Step3-VL-10B --trust-remote-code \
 --hf-overrides '{"vision_config":{"enable_patch":false}}'
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

