### PR TITLE
[Benchmark][Bugfix] Fix race condtion when starting server for sweep benchmark

### DIFF
--- a/vllm/benchmarks/sweep/serve.py
+++ b/vllm/benchmarks/sweep/serve.py
@@ -4,7 +4,6 @@ import argparse
 import contextlib
 import json
 import shlex
-import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -44,14 +43,7 @@ def run_server(
         return
 
     with ServerProcess(server_cmd, after_bench_cmd, show_stdout=show_stdout) as server:
-        start_time = time.monotonic()
-        while not server.is_server_ready():
-            if time.monotonic() - start_time > server_ready_timeout:
-                raise TimeoutError(
-                    "Server failed to become ready within "
-                    f"{server_ready_timeout} seconds."
-                )
-            time.sleep(1)
+        server.wait_until_ready(timeout=server_ready_timeout)
         yield server
 
     print("[END SERVER]")

--- a/vllm/benchmarks/sweep/serve.py
+++ b/vllm/benchmarks/sweep/serve.py
@@ -4,6 +4,7 @@ import argparse
 import contextlib
 import json
 import shlex
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -43,14 +44,14 @@ def run_server(
         return
 
     with ServerProcess(server_cmd, after_bench_cmd, show_stdout=show_stdout) as server:
-        start_time = datetime.now()
+        start_time = time.monotonic()
         while not server.is_server_ready():
-            duration = (datetime.now() - start_time).total_seconds()
-            if duration > server_ready_timeout:
+            if time.monotonic() - start_time > server_ready_timeout:
                 raise TimeoutError(
                     "Server failed to become ready within "
                     f"{server_ready_timeout} seconds."
                 )
+            time.sleep(1)
         yield server
 
     print("[END SERVER]")

--- a/vllm/benchmarks/sweep/serve.py
+++ b/vllm/benchmarks/sweep/serve.py
@@ -29,6 +29,7 @@ def run_server(
     show_stdout: bool,
     serve_overrides: ParameterSweepItem,
     dry_run: bool,
+    server_ready_timeout: int = 300,
 ):
     server_cmd = serve_overrides.apply_to_cmd(serve_cmd)
 
@@ -42,6 +43,14 @@ def run_server(
         return
 
     with ServerProcess(server_cmd, after_bench_cmd, show_stdout=show_stdout) as server:
+        start_time = datetime.now()
+        while not server.is_server_ready():
+            duration = (datetime.now() - start_time).total_seconds()
+            if duration > server_ready_timeout:
+                raise TimeoutError(
+                    "Server failed to become ready within "
+                    f"{server_ready_timeout} seconds."
+                )
         yield server
 
     print("[END SERVER]")
@@ -212,6 +221,7 @@ def run_combs(
     num_runs: int,
     dry_run: bool,
     links: list[tuple[str, str]],
+    server_ready_timeout: int = 300,
 ):
     all_data = list[dict[str, object]]()
     for serve_comb in serve_params:
@@ -222,6 +232,7 @@ def run_combs(
                 show_stdout=show_stdout,
                 serve_overrides=serve_comb,
                 dry_run=dry_run,
+                server_ready_timeout=server_ready_timeout,
             )
             if _comb_needs_server(serve_comb, bench_params, output_dir)
             else contextlib.nullcontext()
@@ -272,6 +283,7 @@ class SweepServeArgs:
     dry_run: bool
     resume: str | None
     link_vars: list[tuple[str, str]] | None
+    server_ready_timeout: int
 
     parser_name: ClassVar[str] = "serve"
     parser_help: ClassVar[str] = "Run vLLM server benchmark under multiple settings."
@@ -312,6 +324,7 @@ class SweepServeArgs:
             dry_run=args.dry_run,
             resume=args.resume,
             link_vars=link_vars,
+            server_ready_timeout=args.server_ready_timeout,
         )
 
     @classmethod
@@ -340,6 +353,12 @@ class SweepServeArgs:
             action="store_true",
             help="If set, logs the standard output of subcommands. "
             "Useful for debugging but can be quite spammy.",
+        )
+        parser.add_argument(
+            "--server-ready-timeout",
+            type=int,
+            default=300,
+            help="Timeout in seconds to wait for the server to become ready.",
         )
         parser.add_argument(
             "--serve-params",
@@ -431,6 +450,7 @@ def run_main(args: SweepServeArgs):
             num_runs=args.num_runs,
             dry_run=args.dry_run,
             links=args.link_vars,
+            server_ready_timeout=args.server_ready_timeout,
         )
     except BaseException as exc:
         raise RuntimeError(

--- a/vllm/benchmarks/sweep/server.py
+++ b/vllm/benchmarks/sweep/server.py
@@ -100,6 +100,12 @@ class ServerProcess:
     def wait_until_ready(self, timeout: int) -> None:
         start_time = time.monotonic()
         while not self.is_server_ready():
+            # Check if server process has crashed
+            if self._server_process.poll() is not None:
+                returncode = self._server_process.returncode
+                raise RuntimeError(
+                    f"Server process crashed with return code {returncode}"
+                )
             if time.monotonic() - start_time > timeout:
                 raise TimeoutError(
                     f"Server failed to become ready within {timeout} seconds."

--- a/vllm/benchmarks/sweep/server.py
+++ b/vllm/benchmarks/sweep/server.py
@@ -4,6 +4,7 @@ import contextlib
 import os
 import signal
 import subprocess
+import time
 from types import TracebackType
 
 import requests
@@ -95,6 +96,15 @@ class ServerProcess:
             return response.status_code == 200
         except requests.RequestException:
             return False
+
+    def wait_until_ready(self, timeout: int) -> None:
+        start_time = time.monotonic()
+        while not self.is_server_ready():
+            if time.monotonic() - start_time > timeout:
+                raise TimeoutError(
+                    f"Server failed to become ready within {timeout} seconds."
+                )
+            time.sleep(1)
 
     def reset_caches(self) -> None:
         server_cmd = self.server_cmd

--- a/vllm/benchmarks/sweep/server.py
+++ b/vllm/benchmarks/sweep/server.py
@@ -88,6 +88,14 @@ class ServerProcess:
 
         return f"http://{host}:{port}"
 
+    def is_server_ready(self) -> bool:
+        server_address = self._get_vllm_server_address()
+        try:
+            response = requests.get(f"{server_address}/health")
+            return response.status_code == 200
+        except requests.RequestException:
+            return False
+
     def reset_caches(self) -> None:
         server_cmd = self.server_cmd
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Currently, there is a race condition that bench command is executed too early before server become ready for `vllm bench sweep serve`:
```
[BEGIN SERVER]
Server overrides: {'mm_encoder_attn_backend': 'FLASH_ATTN'}
Server command: ['vllm', 'serve', '/home/mozf/LLM/Qwen3-VL-4B-Instruct/', '--enforce-eager', '--max-model-len', '32768', '--mm-processor-cache-gb=0', '--media-io-kwargs.video.num_frames', '-1', '--mm-encoder-attn-backend', 'FLASH_ATTN']
[BEGIN BENCHMARK]
Benchmark overrides: {}
Run Number: 0
Benchmark command: ['vllm', 'bench', 'serve', '--backend', 'openai-chat', '--model', '/home/mozf/LLM/Qwen3-VL-4B-Instruct/', '--endpoint', '/v1/chat/completions', '--dataset-name', 'hf', '--dataset-path', 'yale-nlp/MMVU', '--hf-split', 'train', '--num-prompts', '200', '--percentile-metrics', 'ttft,tpot,itl,e2el', '--save-result', '--result-dir', 'benchmarks/results/20260123_180343/SERVE--mm_encoder_attn_backend=FLASH_ATTN', '--result-filename', 'run=0.json']
Output file: benchmarks/results/20260123_180343/SERVE--mm_encoder_attn_backend=FLASH_ATTN/run=0.json
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:00<00:00, 817.45it/s]
/home/mozf/develop-projects/vllm/vllm/benchmarks/serve.py:886: UserWarning: All requests failed. This is likely due to a misconfiguration on the benchmark arguments.
  metrics, actual_output_lens = calculate_metrics(
Resetting caches at http://localhost:8000
Traceback (most recent call last):
  File "/home/mozf/develop-projects/vllm/.venv/lib/python3.12/site-packages/urllib3/connection.py", line 204, in _new_conn
    sock = connection.create_connection(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mozf/develop-projects/vllm/.venv/lib/python3.12/site-packages/urllib3/util/connection.py", line 85, in create_connection
    raise err
  File "/home/mozf/develop-projects/vllm/.venv/lib/python3.12/site-packages/urllib3/util/connection.py", line 73, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused
``` 
- This PR adds a timeout to wait server become ready before running benchmarks.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

