### PR TITLE
[Feature]  Add `qwen2_5_coder` tool parser for Qwen2.5-Coder models

### DIFF
--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -315,6 +315,16 @@ For Qwen2.5, the chat template in tokenizer_config.json has already included sup
 
 Flags: `--tool-call-parser hermes`
 
+### Qwen2.5-Coder Models (`qwen2_5_coder`)
+
+Qwen2.5-Coder models do not follow the Hermes format. This parser uses `<tools>` tags instead.
+
+Supported models:
+
+* `Qwen/Qwen2.5-Coder-*-Instruct` (use with [examples/tool_chat_template_qwen2_5_coder.jinja](../../examples/tool_chat_template_qwen2_5_coder.jinja))
+
+Flags: `--tool-call-parser qwen2_5_coder --chat-template examples/tool_chat_template_qwen2_5_coder.jinja`
+
 ### MiniMax Models (`minimax_m1`)
 
 Supported models:

--- a/examples/tool_chat_template_qwen2_5_coder.jinja
+++ b/examples/tool_chat_template_qwen2_5_coder.jinja
@@ -1,0 +1,68 @@
+{%- if messages[0]["role"] == "system" %}
+    {%- set system_message = messages[0]["content"] %}
+    {%- set loop_messages = messages[1:] %}
+{%- else %}
+    {%- set system_message = "You are Qwen, a helpful assistant." %}
+    {%- set loop_messages = messages %}
+{%- endif %}
+
+{{- "<|im_start|>system\n" + system_message }}
+{%- if tools is iterable and tools | length > 0 %}
+    {{- "\n\nAvailable tools:\n" }}
+    {%- for tool in tools %}
+        {%- if tool.function is defined %}
+            {%- set tool = tool.function %}
+        {%- endif %}
+        {{- tool | tojson }}
+        {{- "\n" }}
+    {%- endfor %}
+    {{- "\nWhen you need to call a tool, use <tools> tags like these examples:\n\n" }}
+    {{- "User: What's the weather in Tokyo?\n" }}
+    {{- 'Assistant: <tools>\n{"name": "get_weather", "arguments": {"city": "Tokyo"}}\n</tools>\n\n' }}
+    {{- "User: How about in Paris and Berlin?\n" }}
+    {{- 'Assistant: <tools>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tools>\n<tools>\n{"name": "get_weather", "arguments": {"city": "Berlin"}}\n</tools>' }}
+{%- endif %}
+{{- "<|im_end|>\n" }}
+{%- for message in loop_messages %}
+    {%- if message.role == "assistant" and message.tool_calls is defined and message.tool_calls | length > 0 %}
+        {{- "<|im_start|>assistant\n" }}
+        {%- if message.content is defined and message.content | trim | length > 0 %}
+            {{- message.content | trim }}
+        {%- endif %}
+        {%- for tool_call in message.tool_calls %}
+            {%- if tool_call.function is defined %}
+                {%- set tool_call = tool_call.function %}
+            {%- endif %}
+            {{- "<tools>\n" }}
+            {{- '{"name": ' ~ (tool_call.name | tojson) }}
+            {%- if tool_call.arguments is defined %}
+                {{- ', "arguments": ' }}
+                {%- if tool_call.arguments is string %}
+                    {{- tool_call.arguments }}
+                {%- else %}
+                    {{- tool_call.arguments | tojson }}
+                {%- endif %}
+            {%- endif %}
+            {{- "}\n" }}
+            {{- "</tools>\n" }}
+        {%- endfor %}
+        {{- "<|im_end|>\n" }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- "<|im_start|>tool\n" }}
+        {%- endif %}
+        {{- "<tool_response>\n" }}
+        {{- message.content }}
+        {{- "\n</tool_response>\n" }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- "<|im_end|>\n" }}
+        {%- elif loop.last %}
+            {{- "<|im_end|>\n" }}
+        {%- endif %}
+    {%- else %}
+        {{- "<|im_start|>" + message.role + "\n" + message.content + "<|im_end|>\n" }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- "<|im_start|>assistant\n" }}
+{%- endif %}

--- a/tests/tool_parsers/test_qwen2_5_coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen2_5_coder_tool_parser.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from tests.tool_parsers.common_tests import ToolParserTestConfig, ToolParserTests
+from tests.tool_parsers.utils import run_tool_extraction_streaming
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers import ToolParserManager
+from vllm.tool_parsers.qwen2_5_coder_tool_parser import Qwen25CoderToolParser
+
+
+class TestQwen25CoderToolParser(ToolParserTests):
+    @pytest.fixture
+    def test_config(self) -> ToolParserTestConfig:
+        return ToolParserTestConfig(
+            parser_name="qwen2_5_coder",
+            no_tool_calls_output=("This is a regular response without any tool calls."),
+            single_tool_call_output=(
+                '<tools>{"name": "get_weather", "arguments": {"city": "Tokyo"}}</tools>'
+            ),
+            parallel_tool_calls_output=(
+                '<tools>{"name": "get_weather", "arguments": {"city": "Tokyo"}}'
+                '</tools><tools>{"name": "get_time", "arguments": '
+                '{"timezone": "Asia/Tokyo"}}</tools>'
+            ),
+            various_data_types_output=(
+                '<tools>{"name": "test_function", "arguments": {'
+                '"string_field": "hello", '
+                '"int_field": 42, '
+                '"float_field": 3.14, '
+                '"bool_field": true, '
+                '"null_field": null, '
+                '"array_field": ["a", "b", "c"], '
+                '"object_field": {"nested": "value"}'
+                "}}</tools>"
+            ),
+            empty_arguments_output=(
+                '<tools>{"name": "refresh", "arguments": {}}</tools>'
+            ),
+            surrounding_text_output=(
+                "Let me check the weather for you.\n\n"
+                '<tools>{"name": "get_weather", "arguments": {"city": "Tokyo"}}'
+                "</tools>\n\n"
+                "I will get that information."
+            ),
+            escaped_strings_output=(
+                '<tools>{"name": "test_function", "arguments": {'
+                '"quoted": "He said \\"hello\\"", '
+                '"path": "C:\\\\Users\\\\file.txt", '
+                '"newline": "line1\\nline2"'
+                "}}</tools>"
+            ),
+            malformed_input_outputs=[
+                "<tools>not valid json</tools>",
+                '<tools>{"name": "no_close",',
+                "<tools></tools>",
+            ],
+        )
+
+
+# =============================================================================
+# Streaming regression tests for partial-tag handling fixes
+# =============================================================================
+
+
+@pytest.fixture
+def parser(default_tokenizer: TokenizerLike) -> Qwen25CoderToolParser:
+    return ToolParserManager.get_tool_parser("qwen2_5_coder")(default_tokenizer)
+
+
+def _emit_one_char_at_a_time(parser: Qwen25CoderToolParser, text: str) -> str:
+    """Drive the streaming API with one-character deltas and join emitted content."""
+    reconstructor = run_tool_extraction_streaming(parser, list(text))
+    return reconstructor.other_content
+
+
+def test_streaming_partial_start_tag_does_not_leak(
+    parser: Qwen25CoderToolParser,
+) -> None:
+    """When '<tools>' arrives one character at a time, the parser must hold
+    back the partial prefix and only emit it (or not) once the full tag
+    state is known. Plain text before the tag must still be emitted.
+    """
+    text = 'Hello <tools>{"name": "f", "arguments": {}}</tools>'
+    emitted = _emit_one_char_at_a_time(parser, text)
+
+    assert "Hello " in emitted
+    for k in range(1, len("<tools>")):
+        assert "<tools>"[:k] not in emitted, (
+            f"partial prefix {'<tools>'[:k]!r} leaked as content"
+        )
+
+
+def test_streaming_trailing_text_in_same_delta_as_close_tag(
+    parser: Qwen25CoderToolParser,
+) -> None:
+    """When '</tools>' and following text arrive in the same delta
+    (e.g. '}</tools> Done!'), the parser must emit both the completed tool
+    call and the trailing text — neither may be dropped.
+    """
+    deltas = [
+        '<tools>{"name": "foo", "arguments": {"a": 1}',
+        "}</tools> Done!",
+    ]
+    reconstructor = run_tool_extraction_streaming(parser, deltas)
+
+    assert len(reconstructor.tool_calls) == 1
+    assert reconstructor.tool_calls[0].function.name == "foo"
+    assert reconstructor.other_content == " Done!"

--- a/vllm/tool_parsers/__init__.py
+++ b/vllm/tool_parsers/__init__.py
@@ -146,6 +146,10 @@ _TOOL_PARSERS_TO_REGISTER = {
         "pythonic_tool_parser",
         "PythonicToolParser",
     ),
+    "qwen2_5_coder": (
+        "qwen2_5_coder_tool_parser",
+        "Qwen25CoderToolParser",
+    ),
     "qwen3_coder": (
         "qwen3coder_tool_parser",
         "Qwen3CoderToolParser",

--- a/vllm/tool_parsers/qwen2_5_coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen2_5_coder_tool_parser.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+from collections.abc import Sequence
+from typing import Any
+
+import regex as re
+
+from vllm.entrypoints.chat_utils import make_tool_call_id
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.logger import init_logger
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
+
+logger = init_logger(__name__)
+
+
+def _partial_tag_overlap(text: str, tag: str) -> int:
+    """Length of the longest prefix of `tag` that matches a suffix of `text`.
+
+    E.g. text ending in "<too" returns 4 when tag is "<tools>".
+    Returns 0 if there is no overlap.
+    """
+    max_check = min(len(tag) - 1, len(text))
+    for k in range(max_check, 0, -1):
+        if text.endswith(tag[:k]):
+            return k
+    return 0
+
+
+class Qwen25CoderToolParser(ToolParser):
+    """Parser for Qwen2.5-Coder <tools> tag format.
+
+    Requires system prompt with few-shot <tools> examples.
+    Not applicable to Qwen2.5 (non-Coder) which uses hermes natively.
+    """
+
+    def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
+        super().__init__(tokenizer, tools)
+
+        self.tool_call_start_token: str = "<tools>"
+        self.tool_call_end_token: str = "</tools>"
+
+        self.tool_call_regex = re.compile(
+            r"<tools>\s*(.*?)\s*</tools>|<tools>\s*(.*)", re.DOTALL
+        )
+        self.tool_call_closed_regex = re.compile(
+            r"<tools>\s*(.*?)\s*</tools>", re.DOTALL
+        )
+
+        self._sent_content_idx: int = 0
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        """Extract tool calls from a complete model response."""
+        if self.tool_call_start_token not in model_output:
+            return ExtractedToolCallInformation(
+                tools_called=False,
+                tool_calls=[],
+                content=model_output,
+            )
+
+        try:
+            tool_calls: list[ToolCall] = []
+            text_parts: list[str] = []
+            last_end = 0
+
+            for match in self.tool_call_regex.finditer(model_output):
+                if match.start() > last_end:
+                    text_parts.append(model_output[last_end : match.start()])
+
+                # group(1) = closed tag body, group(2) = unclosed tag body
+                json_str = (match.group(1) or match.group(2) or "").strip()
+                parsed = self._parse_tool_json(json_str)
+
+                if parsed:
+                    for tool_data in parsed:
+                        tool_calls.append(
+                            ToolCall(
+                                id=make_tool_call_id(),
+                                type="function",
+                                function=FunctionCall(
+                                    name=tool_data["name"],
+                                    arguments=json.dumps(
+                                        tool_data.get("arguments", {}),
+                                        ensure_ascii=False,
+                                    ),
+                                ),
+                            )
+                        )
+
+                last_end = match.end()
+
+            if last_end < len(model_output):
+                text_parts.append(model_output[last_end:])
+
+            content = "".join(text_parts).strip() or None
+
+            return ExtractedToolCallInformation(
+                tools_called=len(tool_calls) > 0,
+                tool_calls=tool_calls if tool_calls else [],
+                content=content,
+            )
+
+        except Exception:
+            logger.exception("Error in extracting tool call from response.")
+            return ExtractedToolCallInformation(
+                tools_called=False,
+                tool_calls=[],
+                content=model_output,
+            )
+
+    def _extract_content(self, current_text: str) -> str | None:
+        """Return unsent non-tool-call text, or None.
+
+        Holds back any suffix that could be a partial <tools> tag, so that
+        token-level streaming does not leak partial prefixes (e.g. "<", "<t",
+        "<to") to the client before the tag is fully formed.
+        """
+        start = self.tool_call_start_token
+        end = self.tool_call_end_token
+
+        if start not in current_text:
+            overlap = _partial_tag_overlap(current_text, start)
+            sendable_idx = len(current_text) - overlap
+        elif current_text.count(start) > current_text.count(end):
+            # Inside an unclosed tag — sendable up to the open tag.
+            sendable_idx = current_text.index(start)
+        else:
+            # All tags closed — skip past last </tools>, then hold back any
+            # partial <tools> prefix at the tail (could be a new call starting).
+            after_pos = current_text.rfind(end) + len(end)
+            if self._sent_content_idx < after_pos:
+                self._sent_content_idx = after_pos
+            overlap = _partial_tag_overlap(current_text[after_pos:], start)
+            sendable_idx = len(current_text) - overlap
+
+        if sendable_idx > self._sent_content_idx:
+            content = current_text[self._sent_content_idx : sendable_idx]
+            self._sent_content_idx = sendable_idx
+            return content
+        return None
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> DeltaMessage | None:
+        """Extract tool calls in streaming mode, holding back partial tags."""
+        content = self._extract_content(current_text)
+
+        if self.tool_call_start_token not in current_text:
+            if content:
+                return DeltaMessage(content=content)
+            return None
+
+        try:
+            current_matches = list(self.tool_call_closed_regex.finditer(current_text))
+            prev_matches = list(self.tool_call_closed_regex.finditer(previous_text))
+
+            delta_tool_calls: list[DeltaToolCall] | None = None
+            if len(current_matches) > len(prev_matches):
+                delta_tool_calls = []
+                for new_match in current_matches[len(prev_matches) :]:
+                    json_str = new_match.group(1).strip()
+                    parsed = self._parse_tool_json(json_str)
+
+                    if parsed:
+                        for tool_data in parsed:
+                            self.current_tool_id += 1
+                            delta_tool_calls.append(
+                                DeltaToolCall(
+                                    index=self.current_tool_id,
+                                    id=make_tool_call_id(),
+                                    type="function",
+                                    function=DeltaFunctionCall(
+                                        name=tool_data["name"],
+                                        arguments=json.dumps(
+                                            tool_data.get("arguments", {}),
+                                            ensure_ascii=False,
+                                        ),
+                                    ),
+                                )
+                            )
+                if delta_tool_calls:
+                    end_of_last_tag = current_matches[-1].end()
+                    if end_of_last_tag > self._sent_content_idx:
+                        self._sent_content_idx = end_of_last_tag
+                else:
+                    delta_tool_calls = None
+
+            # Inside an unclosed <tools> tag — buffer until closed.
+            if current_text.count(self.tool_call_start_token) > current_text.count(
+                self.tool_call_end_token
+            ):
+                if content or delta_tool_calls:
+                    return DeltaMessage(content=content, tool_calls=delta_tool_calls)
+                return None
+
+            # All tags closed — pick up trailing text after </tools>, which may
+            # have arrived in the same delta as the closing tag.
+            trailing = self._extract_content(current_text)
+            parts = [p for p in (content, trailing) if p]
+            combined = "".join(parts) or None
+
+            if combined or delta_tool_calls:
+                return DeltaMessage(content=combined, tool_calls=delta_tool_calls)
+
+            return None
+
+        except Exception:
+            logger.exception("Error in streaming tool call extraction.")
+            return DeltaMessage(content=delta_text)
+
+    def _parse_tool_json(self, json_str: str) -> list[dict[str, Any]]:
+        """Parse <tools> body as a single object, array, or JSONL.
+
+        Falls back to a double-escape-normalized retry for models that
+        emit ``\\"`` instead of ``\"`` inside JSON strings.
+        """
+        result = self._try_parse_json(json_str)
+        if result:
+            return result
+
+        # Retry after normalizing double-escaped quotes (\\" -> \")
+        # Some models (e.g. 14B) double-escape quotes in JSON output
+        if "\\\\" in json_str or '\\"' in json_str:
+            normalized = json_str.replace('\\\\"', '\\"')
+            result = self._try_parse_json(normalized)
+            if result:
+                return result
+
+        logger.warning("Failed to parse tool JSON: %s...", json_str[:100])
+        return []
+
+    def _try_parse_json(self, json_str: str) -> list[dict[str, Any]]:
+        """Try parsing JSON in multiple formats."""
+        # 1. Try as single JSON (object or array)
+        try:
+            parsed = json.loads(json_str)
+
+            if isinstance(parsed, list):
+                result = []
+                for item in parsed:
+                    if self._is_valid_tool_call(item):
+                        result.append(item)
+                return result
+
+            if self._is_valid_tool_call(parsed):
+                return [parsed]
+
+            return []
+
+        except json.JSONDecodeError:
+            pass
+
+        # 2. Try as JSONL (newline-separated JSON objects)
+        result = []
+        for line in json_str.strip().split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            line = line.rstrip(",")
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+                if self._is_valid_tool_call(parsed):
+                    result.append(parsed)
+            except json.JSONDecodeError:
+                continue
+
+        if result:
+            return result
+
+        # 3. Try as comma-separated objects (wrap in array)
+        # e.g., "{...}, {...}" -> "[{...}, {...}]"
+        wrapped = f"[{json_str.strip()}]"
+        try:
+            parsed = json.loads(wrapped)
+            if isinstance(parsed, list):
+                for item in parsed:
+                    if self._is_valid_tool_call(item):
+                        result.append(item)
+                if result:
+                    return result
+        except json.JSONDecodeError:
+            pass
+
+        return []
+
+    def _is_valid_tool_call(self, obj: Any) -> bool:
+        """Check if obj is a valid tool call dict (has 'name' string)."""
+        if not isinstance(obj, dict):
+            return False
+        if "name" not in obj:
+            return False
+        return isinstance(obj["name"], str)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Add a dedicated `qwen2_5_coder` tool call parser for Qwen2.5-Coder models. These models do not follow hermes `<tool_call>` format ([outputs code blocks instead](https://github.com/hanXen/vllm-qwen2.5-coder-tool-parser#background-why-not-hermes)), but we found they follow `<tools>` tag format with 100% compliance when given few-shot examples in the system prompt.


Fixes #32926

**Usage:**
```bash
vllm serve Qwen/Qwen2.5-Coder-7B-Instruct \
    --enable-auto-tool-choice \
    --tool-call-parser qwen2_5_coder \
    --chat-template examples/tool_chat_template_qwen2_5_coder.jinja
```

## Implementation

**Changes:**

| File | Role |
|------|------|
| `vllm/tool_parsers/qwen2_5_coder_tool_parser.py` (new) | Parses `<tools>` tags from model output → OpenAI `tool_calls` |
| `examples/tool_chat_template_qwen2_5_coder.jinja` (new) | Formats prompt + induces `<tools>` format via few-shot examples |
| `vllm/tool_parsers/__init__.py` | Registered `qwen2_5_coder` parser |
| `docs/features/tool_calling.md` | Usage documentation added |
| `tests/tool_parsers/test_qwen2_5_coder_tool_parser.py` (new) | Standard suite + streaming regression tests |

- Implementation references [`Hermes2ProToolParser`](https://github.com/vllm-project/vllm/blob/main/vllm/tool_parsers/hermes_tool_parser.py)

**Parsing logic:**
1. Regex extracts content from `<tools>...</tools>` tags (including unclosed tags for streaming edge cases)
2. JSON parsing with fallback chain: single object → array → JSONL → comma-separated
3. Text outside `<tools>` tags is returned as regular `content`

**Supported output formats:**
```
Single:    <tools>{"name": "func", "arguments": {...}}</tools>
Parallel:  <tools>{...}</tools><tools>{...}</tools>
Array:     <tools>[{...}, {...}]</tools>
JSONL:     <tools>{"name": "f1", ...}\n{"name": "f2", ...}</tools>
Unclosed:  <tools>{"name": "func", "arguments": {...}}
```

## Test Plan

**In-repo tests** ([`tests/tool_parsers/test_qwen2_5_coder_tool_parser.py`](https://github.com/vllm-project/vllm/blob/main/tests/tool_parsers/test_qwen2_5_coder_tool_parser.py)):

- Standard `ToolParserTests` suite.
- Streaming regression tests for partial `<tools>` prefix buffering and trailing text after `</tools>` in the same delta.

```bash
pytest tests/tool_parsers/test_qwen2_5_coder_tool_parser.py -v
```

Validated via external test suite ([hanXen/vllm-qwen2.5-coder-tool-parser](https://github.com/hanXen/vllm-qwen2.5-coder-tool-parser)):

1. **Unit tests**: comprehensive cases validating parser logic in isolation (no server required)
2. **Integration tests**:  50 cases end-to-end with vLLM server + parser + chat template
   - Categories: single calls (10), parallel calls (10), complex arguments (10), edge cases (10), no-tool rejection (10)

All tests are reproducible with the provided scripts and fixtures.

## Test Result

| Model | Result |
|-------|--------|
| Qwen2.5-Coder-7B-Instruct | 100% (50/50) |
| Qwen2.5-Coder-14B-Instruct | 98% (48/49)* |
| Qwen2.5-Coder-32B-Instruct-AWQ | 100% (50/50) |

\* 1 case excluded (model answered directly, not a parser issue). 1 failure: JSON-in-JSON escaping (known model limitation).

Test environment: vLLM 0.14.0, `temperature=0`, `max_tokens=1024`, `--chat-template`

Raw results: [hanXen/vllm-qwen2.5-coder-tool-parser/results](https://github.com/hanXen/vllm-qwen2.5-coder-tool-parser/tree/main/results)

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

