### PR TITLE
[Bugfix] Fix getting vision features in Transformer Multimodal backend

### DIFF
--- a/vllm/model_executor/models/transformers/multimodal.py
+++ b/vllm/model_executor/models/transformers/multimodal.py
@@ -376,6 +376,13 @@ class MultiModalMixin(SupportsMultiModal, SupportsMRoPE):
                     pixel_values, **kwargs
                 )
 
+            # Transformers `v5`, `self.get_image_features` returns a tuple
+            # containing the features and optionally attentions/hidden_states
+            # After v5 is settled, we can enable qwen3-vl with several outputs
+            # from `self.get_image_features`
+            if isinstance(vision_embeddings, tuple):
+                vision_embeddings = vision_embeddings[0]
+
             if isinstance(vision_embeddings, torch.Tensor):
                 if vision_embeddings.ndim == 2:
                     vision_embeddings = vision_embeddings.unsqueeze(0)

--- a/vllm/model_executor/models/transformers/multimodal.py
+++ b/vllm/model_executor/models/transformers/multimodal.py
@@ -382,6 +382,8 @@ class MultiModalMixin(SupportsMultiModal, SupportsMRoPE):
             # from `self.get_image_features`
             if isinstance(vision_embeddings, tuple):
                 vision_embeddings = vision_embeddings[0]
+            elif isinstance(vision_embeddings, dict):
+                vision_embeddings = vision_embeddings.pooler_output
 
             if isinstance(vision_embeddings, torch.Tensor):
                 if vision_embeddings.ndim == 2:


### PR DESCRIPTION
Makes sure that transformers multimodal backend keeps working after v5 release.

PR https://github.com/huggingface/transformers/pull/42564 changed the output of `self.model.get_image_features` to `tuple | dict` format. Prev we expected the output to always be a single tensor or a list of tensors for non-homogeneous image sizes. A simple check if the output is `tuple`

The default output format currently depends on `model.config.return_dict`, so I added both formats

cc @hmellor 