### PR TITLE
[BugFix] Fix tool parser crash with parentheses in descriptions

### DIFF
--- a/tests/tool_use/test_minimax_m2_tool_parser.py
+++ b/tests/tool_use/test_minimax_m2_tool_parser.py
@@ -117,3 +117,117 @@ def test_streaming_minimax_m2_multiple_invokes(minimax_m2_tool_parser):
         expected_call = json.dumps(expected_call)
         actual_call = parser.streamed_args_for_tool[index]
         assert expected_call == actual_call
+
+
+def test_streaming_with_extra_attributes_in_tags(minimax_m2_tool_parser):
+    """Test that parsing handles extra attributes in tags gracefully.
+
+    This tests the fix for issue #32827 where descriptions containing
+    parentheses (e.g., "(e.g. ls -la)") could cause the model to echo
+    these back as additional attributes in the XML tags.
+    """
+    parser = minimax_m2_tool_parser
+    parser._reset_streaming_state()
+
+    # Simulate model output where it echoes description as extra attribute
+    # This could happen when tool description contains "(e.g. ls -la)"
+    chunks = [
+        "<minimax:tool_call>",
+        '<invoke name="execute_command" description="Run a command">',
+        '<parameter name="command" type="string">',
+        "ls -la</parameter>",
+        "</invoke></minimax:tool_call>",
+    ]
+    previous = ""
+    for chunk in chunks:
+        current = previous + chunk
+        delta = chunk
+        parser.extract_tool_calls_streaming(
+            previous_text=previous,
+            current_text=current,
+            delta_text=delta,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=None,
+        )
+        previous = current
+
+    assert len(parser.prev_tool_call_arr) == 1
+    entry = parser.prev_tool_call_arr[0]
+
+    # Should correctly extract function name, ignoring extra attributes
+    assert entry["name"] == "execute_command"
+    args = entry["arguments"]
+    # Should correctly extract parameter name, ignoring extra attributes
+    assert "command" in args
+    assert args["command"] == "ls -la"
+
+
+def test_streaming_with_parentheses_in_value(minimax_m2_tool_parser):
+    """Test that parentheses in parameter values are handled correctly.
+
+    This is related to issue #32827 - ensure values with parentheses
+    like "(e.g. ls -la)" don't break parsing.
+    """
+    parser = minimax_m2_tool_parser
+    parser._reset_streaming_state()
+
+    chunks = [
+        "<minimax:tool_call>",
+        '<invoke name="help">',
+        '<parameter name="topic">',
+        "commands (e.g. ls -la, cat file.txt)</parameter>",
+        "</invoke></minimax:tool_call>",
+    ]
+    previous = ""
+    for chunk in chunks:
+        current = previous + chunk
+        delta = chunk
+        parser.extract_tool_calls_streaming(
+            previous_text=previous,
+            current_text=current,
+            delta_text=delta,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=None,
+        )
+        previous = current
+
+    assert len(parser.prev_tool_call_arr) == 1
+    entry = parser.prev_tool_call_arr[0]
+
+    assert entry["name"] == "help"
+    args = entry["arguments"]
+    assert args["topic"] == "commands (e.g. ls -la, cat file.txt)"
+
+
+def test_non_streaming_with_extra_attributes(minimax_m2_tool_parser):
+    """Test non-streaming parsing with extra attributes in tags."""
+    parser = minimax_m2_tool_parser
+
+    # Create a mock request
+    class MockRequest:
+        tools = None
+
+    model_output = (
+        '<minimax:tool_call>'
+        '<invoke name="test_func" extra="ignored">'
+        '<parameter name="arg1" type="string">value1</parameter>'
+        '<parameter name="arg2" description="(e.g. example)">value2</parameter>'
+        '</invoke>'
+        '</minimax:tool_call>'
+    )
+
+    result = parser.extract_tool_calls(model_output, MockRequest())
+
+    assert result.tools_called is True
+    assert len(result.tool_calls) == 1
+
+    tool_call = result.tool_calls[0]
+    assert tool_call.function.name == "test_func"
+
+    args = json.loads(tool_call.function.arguments)
+    assert args["arg1"] == "value1"
+    assert args["arg2"] == "value2"

--- a/tests/tool_use/test_minimax_m2_tool_parser.py
+++ b/tests/tool_use/test_minimax_m2_tool_parser.py
@@ -212,12 +212,12 @@ def test_non_streaming_with_extra_attributes(minimax_m2_tool_parser):
         tools = None
 
     model_output = (
-        '<minimax:tool_call>'
+        "<minimax:tool_call>"
         '<invoke name="test_func" extra="ignored">'
         '<parameter name="arg1" type="string">value1</parameter>'
         '<parameter name="arg2" description="(e.g. example)">value2</parameter>'
-        '</invoke>'
-        '</minimax:tool_call>'
+        "</invoke>"
+        "</minimax:tool_call>"
     )
 
     result = parser.extract_tool_calls(model_output, MockRequest())

--- a/vllm/tool_parsers/minimax_m2_tool_parser.py
+++ b/vllm/tool_parsers/minimax_m2_tool_parser.py
@@ -73,11 +73,19 @@ class MinimaxM2ToolParser(ToolParser):
         self.tool_call_complete_regex = re.compile(
             r"<minimax:tool_call>(.*?)</minimax:tool_call>", re.DOTALL
         )
+        # Improved regex: capture only the name attribute value (quoted or unquoted)
+        # and ignore any additional attributes that may follow
         self.invoke_complete_regex = re.compile(
-            r"<invoke name=(.*?)</invoke>", re.DOTALL
+            r"<invoke\s+name=(\"[^\"]+\"|'[^']+'|[^\s>]+)(?:\s+[^>]*)?\s*>"
+            r"(.*?)</invoke>",
+            re.DOTALL,
         )
+        # Improved regex for parameters: capture name attribute and content separately
+        # Handles cases where model may include description text in attributes
         self.parameter_complete_regex = re.compile(
-            r"<parameter name=(.*?)</parameter>", re.DOTALL
+            r"<parameter\s+name=(\"[^\"]+\"|'[^']+'|[^\s>]+)(?:\s+[^>]*)?\s*>"
+            r"(.*?)</parameter>",
+            re.DOTALL,
         )
 
         if not self.model_tokenizer:
@@ -302,13 +310,31 @@ class MinimaxM2ToolParser(ToolParser):
     def _parse_single_invoke(
         self, invoke_str: str, tools: list | None
     ) -> ToolCall | None:
-        """Parse a single <invoke> block."""
-        # Extract function name
-        name_match = re.search(r"^([^>]+)", invoke_str)
-        if not name_match:
-            return None
+        """Parse a single <invoke> block.
 
-        function_name = self._extract_name(name_match.group(1))
+        Args:
+            invoke_str: For legacy regex, this is the full content after
+                       '<invoke name='. For new regex with groups, this is
+                       a tuple of (name, content).
+            tools: List of available tools for type information.
+
+        Returns:
+            Parsed ToolCall or None if parsing fails.
+        """
+        # Handle both old format (string) and new format (tuple from regex groups)
+        if isinstance(invoke_str, tuple):
+            # New regex format: (name_raw, content)
+            function_name = self._extract_name(invoke_str[0])
+            invoke_content = invoke_str[1] if len(invoke_str) > 1 else ""
+        else:
+            # Legacy format: full string after '<invoke name='
+            name_match = re.search(r"^([^>]+)", invoke_str)
+            if not name_match:
+                return None
+            function_name = self._extract_name(name_match.group(1))
+            # Extract content after the closing '>'
+            content_match = re.search(r"^[^>]+>(.*)", invoke_str, re.DOTALL)
+            invoke_content = content_match.group(1) if content_match else ""
 
         # Get parameter configuration
         param_config = {}
@@ -324,25 +350,33 @@ class MinimaxM2ToolParser(ToolParser):
                         param_config = params["properties"]
                     break
 
-        # Extract parameters
+        # Extract parameters using the improved regex
         param_dict = {}
-        for match in self.parameter_complete_regex.findall(invoke_str):
-            param_match = re.search(r"^([^>]+)>(.*)", match, re.DOTALL)
-            if param_match:
+        for match in self.parameter_complete_regex.findall(invoke_content):
+            # match is now a tuple: (param_name_raw, param_value)
+            if isinstance(match, tuple) and len(match) >= 2:
+                param_name = self._extract_name(match[0])
+                param_value = match[1].strip()
+            else:
+                # Fallback for unexpected format
+                param_match = re.search(r"^([^>]+)>(.*)", str(match), re.DOTALL)
+                if not param_match:
+                    continue
                 param_name = self._extract_name(param_match.group(1))
                 param_value = param_match.group(2).strip()
-                if param_value.startswith("\n"):
-                    param_value = param_value[1:]
-                if param_value.endswith("\n"):
-                    param_value = param_value[:-1]
 
-                # Get parameter types (supports anyOf/oneOf/allOf)
-                param_type = self._get_param_types_from_config(param_name, param_config)
+            if param_value.startswith("\n"):
+                param_value = param_value[1:]
+            if param_value.endswith("\n"):
+                param_value = param_value[:-1]
 
-                # Convert value
-                param_dict[param_name] = self._convert_param_value_with_types(
-                    param_value, param_type
-                )
+            # Get parameter types (supports anyOf/oneOf/allOf)
+            param_type = self._get_param_types_from_config(param_name, param_config)
+
+            # Convert value
+            param_dict[param_name] = self._convert_param_value_with_types(
+                param_value, param_type
+            )
 
         return ToolCall(
             type="function",
@@ -528,12 +562,39 @@ class MinimaxM2ToolParser(ToolParser):
                 func_start = tool_text.find(self.invoke_start_prefix) + len(
                     self.invoke_start_prefix
                 )
-                # Find the end quote for the function name
+                # Find the end of the opening tag
                 func_end = tool_text.find(">", func_start)
 
                 if func_end != -1:
                     # Found complete function name
-                    function_name_raw = tool_text[func_start:func_end]
+                    # Handle cases where model may add extra attributes after name
+                    attr_section = tool_text[func_start:func_end]
+
+                    # Extract only the name value, ignoring any additional attributes
+                    if attr_section.startswith('"'):
+                        close_quote = attr_section.find('"', 1)
+                        if close_quote != -1:
+                            function_name_raw = attr_section[: close_quote + 1]
+                        else:
+                            function_name_raw = attr_section
+                    elif attr_section.startswith("'"):
+                        close_quote = attr_section.find("'", 1)
+                        if close_quote != -1:
+                            function_name_raw = attr_section[: close_quote + 1]
+                        else:
+                            function_name_raw = attr_section
+                    else:
+                        # Unquoted name - take until first whitespace
+                        space_idx = -1
+                        for i, c in enumerate(attr_section):
+                            if c.isspace():
+                                space_idx = i
+                                break
+                        if space_idx != -1:
+                            function_name_raw = attr_section[:space_idx]
+                        else:
+                            function_name_raw = attr_section
+
                     self.current_function_name = self._extract_name(function_name_raw)
                     self.current_tool_id = self._generate_tool_call_id()
                     self.header_sent = True
@@ -675,8 +736,39 @@ class MinimaxM2ToolParser(ToolParser):
 
                 if ">" in remaining:
                     # We have the complete parameter name
+                    # Handle cases where model may add extra attributes after name
+                    # e.g., <parameter name="cmd" description="(e.g. ls)">
                     name_end = remaining.find(">")
-                    param_name_raw = remaining[:name_end]
+                    attr_section = remaining[:name_end]
+
+                    # Extract only the name value, ignoring any additional attributes
+                    # Check for quoted name first
+                    if attr_section.startswith('"'):
+                        # Find closing quote
+                        close_quote = attr_section.find('"', 1)
+                        if close_quote != -1:
+                            param_name_raw = attr_section[: close_quote + 1]
+                        else:
+                            param_name_raw = attr_section
+                    elif attr_section.startswith("'"):
+                        # Find closing single quote
+                        close_quote = attr_section.find("'", 1)
+                        if close_quote != -1:
+                            param_name_raw = attr_section[: close_quote + 1]
+                        else:
+                            param_name_raw = attr_section
+                    else:
+                        # Unquoted name - take until first whitespace
+                        space_idx = -1
+                        for i, c in enumerate(attr_section):
+                            if c.isspace():
+                                space_idx = i
+                                break
+                        if space_idx != -1:
+                            param_name_raw = attr_section[:space_idx]
+                        else:
+                            param_name_raw = attr_section
+
                     self.current_param_name = self._extract_name(param_name_raw)
 
                     # Find the parameter value

--- a/vllm/tool_parsers/minimax_m2_tool_parser.py
+++ b/vllm/tool_parsers/minimax_m2_tool_parser.py
@@ -76,16 +76,40 @@ class MinimaxM2ToolParser(ToolParser):
         # Improved regex: capture only the name attribute value (quoted or unquoted)
         # and ignore any additional attributes that may follow
         self.invoke_complete_regex = re.compile(
-            r"<invoke\s+name=(\"[^\"]+\"|'[^']+'|[^\s>]+)(?:\s+[^>]*)?\s*>"
-            r"(.*?)</invoke>",
-            re.DOTALL,
+            r"""
+            <invoke\s+name=          # Match tag start and name attribute key
+            (                        # Start Group 1: Name value
+                "[^"]+"              # Double-quoted string
+                |                    # OR
+                '[^']+'              # Single-quoted string
+                |                    # OR
+                [^\s>]+              # Unquoted value (no whitespace or >)
+            )                        # End Group 1
+            (?:\s+[^>]*)?            # Optional: Extra attributes (ignored)
+            \s*>                     # Closing bracket of opening tag
+            (.*?)                    # Group 2: Content (non-greedy)
+            </invoke>                # Closing tag
+            """,
+            re.VERBOSE | re.DOTALL,
         )
         # Improved regex for parameters: capture name attribute and content separately
         # Handles cases where model may include description text in attributes
         self.parameter_complete_regex = re.compile(
-            r"<parameter\s+name=(\"[^\"]+\"|'[^']+'|[^\s>]+)(?:\s+[^>]*)?\s*>"
-            r"(.*?)</parameter>",
-            re.DOTALL,
+            r"""
+            <parameter\s+name=       # Match tag start and name attribute key
+            (                        # Start Group 1: Name value
+                "[^"]+"              # Double-quoted string
+                |                    # OR
+                '[^']+'              # Single-quoted string
+                |                    # OR
+                [^\s>]+              # Unquoted value (no whitespace or >)
+            )                        # End Group 1
+            (?:\s+[^>]*)?            # Optional: Extra attributes (ignored)
+            \s*>                     # Closing bracket of opening tag
+            (.*?)                    # Group 2: Content (non-greedy)
+            </parameter>             # Closing tag
+            """,
+            re.VERBOSE | re.DOTALL,
         )
 
         if not self.model_tokenizer:


### PR DESCRIPTION
## Purpose

Fixes #32827

When using OpenAI-compatible function calling, if a parameter's `description` contains example commands like `(e.g. ls -la, ssh user@host, cat file.txt)`, vLLM server crashes with "Connection error". This happens because the MiniMax-M2 model sometimes echoes the description back as additional attributes in the XML tags, causing the regex parsing to fail.

## Test Plan

```bash
pytest tests/tool_use/test_minimax_m2_tool_parser.py -v
pytest tests/tool_parsers/test_minimax_tool_parser.py -v
```

## Test Result

All 28 tests pass:
- 5 tests in `test_minimax_m2_tool_parser.py` (including 3 new tests)
- 23 tests in `test_minimax_tool_parser.py`

## Changes

- Improved `invoke_complete_regex` to capture only the name attribute value and ignore additional attributes like `description="..."`
- Improved `parameter_complete_regex` similarly
- Updated `_parse_single_invoke` to handle both tuple (new regex groups) and string (legacy) formats
- Fixed streaming parsing to extract only the name value when extra attributes are present

## New Tests Added

- `test_streaming_with_extra_attributes_in_tags`: Tests parsing when model adds extra attributes
- `test_streaming_with_parentheses_in_value`: Tests that parentheses in values work correctly
- `test_non_streaming_with_extra_attributes`: Tests non-streaming mode with extra attributes

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>