### PR TITLE
[Bugfix] Fix missing is_layer_skipped check for FusedMoE in AWQConfig

### DIFF
--- a/vllm/model_executor/layers/quantization/awq.py
+++ b/vllm/model_executor/layers/quantization/awq.py
@@ -106,7 +106,7 @@ class AWQConfig(QuantizationConfig):
             return AWQLinearMethod(self)
         elif isinstance(layer, FusedMoE):
             # Lazy import to avoid circular import.
-            from .awq_marlin import AWQMarlinConfig, AWQMarlinMoEMethod
+            from .awq_marlin import AWQMarlinConfig
             from .moe_wna16 import MoeWNA16Config
             from .utils.marlin_utils import check_moe_marlin_supports_layer
 
@@ -121,6 +121,7 @@ class AWQConfig(QuantizationConfig):
                     "group_size": self.group_size,
                     "zero_point": self.zero_point,
                     "lm_head": False,
+                    "modules_to_not_convert": self.modules_to_not_convert,
                 }
                 return MoeWNA16Config.from_config(config).get_quant_method(
                     layer, prefix
@@ -136,7 +137,7 @@ class AWQConfig(QuantizationConfig):
             awq_marlin_config = AWQMarlinConfig.from_config(
                 marlin_compatible_config_dict
             )
-            return AWQMarlinMoEMethod(awq_marlin_config, layer.moe_config)
+            return awq_marlin_config.get_quant_method(layer, prefix)
         return None
 
     def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):


### PR DESCRIPTION
## Purpose

Fix missing `is_layer_skipped` check for FusedMoE layers in `AWQConfig.get_quant_method`. 

This caused models with `modules_to_not_convert` (e.g., MTP layers stored as bfloat16) to incorrectly receive quantized methods, leading to weight loading failures when the code expected quantized weights but found bfloat16.

**Two bugs fixed:**
1. MoeWNA16 fallback config was missing `modules_to_not_convert`, so `MoeWNA16Config` couldn't properly skip layers
2. `AWQMarlinMoEMethod` was returned directly instead of delegating to `AWQMarlinConfig.get_quant_method`, which has the skip check

The fix delegates to `awq_marlin_config.get_quant_method(layer, prefix)` which properly checks `is_layer_skipped` and returns `UnquantizedFusedMoEMethod` for skipped layers.

## Test Plan

Load an AWQ-quantized model that has unquantized MTP layers (modules listed in `modules_to_not_convert`). The FusedMoE layers in MTP should now correctly use `UnquantizedFusedMoEMethod` instead of failing to load quantized weights.

## Test Result

Pre-commit checks all pass. The fix is minimal (3 lines changed) and follows the same pattern already used in `AWQMarlinConfig.get_quant_method` (awq_marlin.py:200-219).