### PR TITLE
[Bug] Fix benchmark script `moe_permute_unpermute`

### DIFF
--- a/benchmarks/kernels/benchmark_moe_permute_unpermute.py
+++ b/benchmarks/kernels/benchmark_moe_permute_unpermute.py
@@ -179,7 +179,9 @@ def benchmark_unpermute(
                 sorted_token_ids,
                 expert_ids,
                 inv_perm,
-            ) = _moe_permute(qhidden_states, None, topk_ids, num_experts, None, 16)
+            ) = _moe_permute(
+                qhidden_states, None, topk_ids, num_experts, None, block_m=16
+            )
             # convert to fp16/bf16 as gemm output
             return (
                 permuted_qhidden_states.to(dtype),

--- a/benchmarks/kernels/benchmark_moe_permute_unpermute.py
+++ b/benchmarks/kernels/benchmark_moe_permute_unpermute.py
@@ -8,7 +8,7 @@ import ray
 import torch
 from transformers import AutoConfig
 
-from vllm.model_executor.layers.fused_moe.fused_moe import *
+from vllm.model_executor.layers.fused_moe import fused_topk
 from vllm.model_executor.layers.fused_moe.moe_permute_unpermute import (
     _moe_permute,
     _moe_unpermute_and_reduce,
@@ -86,9 +86,7 @@ def benchmark_permute(
                 sorted_token_ids,
                 expert_ids,
                 inv_perm,
-            ) = _moe_permute(
-                qhidden_states, None, topk_ids, num_experts, None, align_block_size
-            )
+            ) = _moe_permute(qhidden_states, None, topk_ids, num_experts, None, 16)
 
     # JIT compilation & warmup
     run()
@@ -181,9 +179,7 @@ def benchmark_unpermute(
                 sorted_token_ids,
                 expert_ids,
                 inv_perm,
-            ) = _moe_permute(
-                qhidden_states, None, topk_ids, num_experts, None, align_block_size
-            )
+            ) = _moe_permute(qhidden_states, None, topk_ids, num_experts, None, 16)
             # convert to fp16/bf16 as gemm output
             return (
                 permuted_qhidden_states.to(dtype),


### PR DESCRIPTION
## Purpose

`python benchmarks/kernels/benchmark_moe_permute_unpermute.py`

Two bugs fixed

```bash
93, ip=10.243.64.20, actor_id=4b4963ca6aa94bfc7fb40cf101000000, repr=<benchmark_moe_permute_unpermute.BenchmarkWorker object at 0x7f18ef275790>)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yewentao256/vllm-source/benchmarks/kernels/benchmark_moe_permute_unpermute.py", line 285, in benchmark
    permute_time = benchmark_permute(
                   ^^^^^^^^^^^^^^^^^^
  File "/home/yewentao256/vllm-source/benchmarks/kernels/benchmark_moe_permute_unpermute.py", line 59, in benchmark_permute
    topk_weights, topk_ids, token_expert_indices = fused_topk(
                                                   ^^^^^^^^^^
NameError: name 'fused_topk' is not defined
```

and

```bash
                   ^^^^^^^^^^^^^^^^^^
  File "/home/yewentao256/vllm-source/benchmarks/kernels/benchmark_moe_permute_unpermute.py", line 94, in benchmark_permute
    run()
  File "/home/yewentao256/vllm-source/benchmarks/kernels/benchmark_moe_permute_unpermute.py", line 89, in run
    ) = _moe_permute(
        ^^^^^^^^^^^^^
  File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/moe_permute_unpermute.py", line 29, in _moe_permute
    sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
                                                           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/yewentao256/vllm-source/vllm/model_executor/layers/fused_moe/moe_align_block_size.py", line 74, in moe_align_block_size
    max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
                                                              ~~~~~~~~~~~^~~
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```

## Test Plan

Now

```bash
Batch size: 1024
Permute time: 40.99 us
Unpermute time: 16.99 us
Batch size: 1536
Permute time: 49.79 us
Unpermute time: 29.23 us
Batch size: 2048
Permute time: 81.15 us
Unpermute time: 41.65 us
Batch size: 3072
Permute time: 94.42 us
Unpermute time: 64.61 us
Batch size: 4096
Permute time: 104.95 us
Unpermute time: 84.76 us
```