### PR TITLE
[UX] Deduplicate sampling parameter startup logs

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1339,10 +1339,9 @@ class ModelConfig:
         Returns:
             A dictionary containing the non-default sampling parameters.
         """
-        if self.generation_config == "vllm":
-            config = {}
-        else:
-            config = self.try_get_generation_config()
+        src = self.generation_config
+
+        config = {} if src == "vllm" else self.try_get_generation_config()
 
         # Overriding with given generation config
         config.update(self.override_generation_config)
@@ -1368,19 +1367,14 @@ class ModelConfig:
         else:
             diff_sampling_param = {}
 
-        if diff_sampling_param:
-            source = self.generation_config
-            logger.info_once(
-                "Using default sampling params from %s: %s",
-                "model" if source == "auto" else source,
-                str(diff_sampling_param),
-            )
-
+        if diff_sampling_param and src != "vllm":
             logger.warning_once(
-                "Default sampling parameters have been overridden by the "
-                "model's Hugging Face generation config recommended from the "
-                "model creator. If this is not intended, please relaunch "
-                "vLLM instance with `--generation-config vllm`."
+                "Default vLLM sampling parameters have been overridden by %s: `%s`. "
+                "If this is not intended, please relaunch vLLM instance "
+                "with `--generation-config vllm`.",
+                "the model's `generation_config.json`" if src == "auto" else src,
+                str(diff_sampling_param),
+                scope="local",
             )
 
         return diff_sampling_param

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1369,12 +1369,20 @@ class ModelConfig:
             diff_sampling_param = {}
 
         if diff_sampling_param:
+            source = self.generation_config
+            logger.info_once(
+                "Using default sampling params from %s: %s",
+                "model" if source == "auto" else source,
+                str(diff_sampling_param),
+            )
+
             logger.warning_once(
                 "Default sampling parameters have been overridden by the "
                 "model's Hugging Face generation config recommended from the "
                 "model creator. If this is not intended, please relaunch "
                 "vLLM instance with `--generation-config vllm`."
             )
+
         return diff_sampling_param
 
     @property

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -143,14 +143,6 @@ class OpenAIServingChat(OpenAIServing):
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
         self.enable_force_include_usage = enable_force_include_usage
         self.default_sampling_params = self.model_config.get_diff_sampling_param()
-        if self.default_sampling_params:
-            source = self.model_config.generation_config
-            source = "model" if source == "auto" else source
-            logger.info(
-                "Using default chat sampling params from %s: %s",
-                source,
-                self.default_sampling_params,
-            )
         if self.model_config.hf_config.model_type == "kimi_k2":
             self.tool_call_id_type = "kimi_k2"
         else:

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -72,16 +72,9 @@ class OpenAIServingCompletion(OpenAIServing):
         self.logits_processors = self.model_config.logits_processors
 
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
-        self.default_sampling_params = self.model_config.get_diff_sampling_param()
         self.enable_force_include_usage = enable_force_include_usage
-        if self.default_sampling_params:
-            source = self.model_config.generation_config
-            source = "model" if source == "auto" else source
-            logger.info(
-                "Using default completion sampling params from %s: %s",
-                source,
-                self.default_sampling_params,
-            )
+
+        self.default_sampling_params = self.model_config.get_diff_sampling_param()
 
     async def render_completion_request(
         self,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -221,15 +221,8 @@ class OpenAIServingResponses(OpenAIServing):
         )
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
         self.enable_force_include_usage = enable_force_include_usage
+
         self.default_sampling_params = self.model_config.get_diff_sampling_param()
-        if self.default_sampling_params:
-            source = self.model_config.generation_config
-            source = "model" if source == "auto" else source
-            logger.info(
-                "Using default chat sampling params from %s: %s",
-                source,
-                self.default_sampling_params,
-            )
 
         # If False (default), the "store" option is (silently) ignored and the
         # response is not stored. If True, the response is stored in memory.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Since multiple `OpenAIServing*` classes are instantiated by `vllm serve` (even for a single process), the startup log gets spammed like so:

```
(EngineCore_DP0 pid=2378269) INFO 01-23 15:32:21 [core.py:272] init engine (profile, create kv cache, warmup model) took 83.04 seconds
(EngineCore_DP0 pid=2378269) INFO 01-23 15:32:21 [vllm.py:618] Asynchronous scheduling is enabled.
(APIServer pid=2377843) INFO 01-23 15:32:22 [api_server.py:664] Supported tasks: ['generate']
(APIServer pid=2377843) WARNING 01-23 15:32:23 [model.py:1372] Default sampling parameters have been overridden by the model's Hugging Face generation config recommended from the model creator. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(APIServer pid=2377843) INFO 01-23 15:32:23 [serving.py:226] Using default chat sampling params from model: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
(APIServer pid=2377843) INFO 01-23 15:32:26 [serving.py:149] Using default chat sampling params from model: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
(APIServer pid=2377843) INFO 01-23 15:32:26 [serving.py:185] Warming up chat template processing...
(APIServer pid=2377843) INFO 01-23 15:32:38 [hf.py:309] Detected the chat template content format to be 'openai'. You can set `--chat-template-content-format` to override this.
(APIServer pid=2377843) INFO 01-23 15:32:38 [serving.py:210] Chat template warmup completed in 12094.5ms
(APIServer pid=2377843) INFO 01-23 15:32:39 [serving.py:78] Using default completion sampling params from model: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
(APIServer pid=2377843) INFO 01-23 15:32:40 [serving.py:149] Using default chat sampling params from model: {'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}
(APIServer pid=2377843) INFO 01-23 15:32:40 [api_server.py:945] Starting vLLM API server 0 on http://0.0.0.0:8000
```

This PR moves the logging into `get_diff_sampling_params` to avoid repeated logs. Here's what it looks like afterwards:

```
(EngineCore_DP0 pid=2758787) INFO 01-24 02:43:42 [core.py:272] init engine (profile, create kv cache, warmup model) took 42.27 seconds
(EngineCore_DP0 pid=2758787) INFO 01-24 02:43:42 [vllm.py:618] Asynchronous scheduling is enabled.
(APIServer pid=2758320) INFO 01-24 02:43:43 [api_server.py:664] Supported tasks: ['generate']
(APIServer pid=2758320) WARNING 01-24 02:43:43 [model.py:1374] Default sampling parameters have been overridden by the model's `generation_config.json`: `{'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(APIServer pid=2758320) INFO 01-24 02:43:43 [serving.py:177] Warming up chat template processing...
(APIServer pid=2758320) INFO 01-24 02:43:49 [hf.py:308] Detected the chat template content format to be 'openai'. You can set `--chat-template-content-format` to override this.
(APIServer pid=2758320) INFO 01-24 02:43:49 [serving.py:212] Chat template warmup completed in 5866.3ms
(APIServer pid=2758320) INFO 01-24 02:43:49 [api_server.py:945] Starting vLLM API server 0 on http://0.0.0.0:8000
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

