### PR TITLE
[Feat] Add RMSNorm NvFp4 Quant Operator (#32612)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -657,7 +657,8 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
       "csrc/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu"
       "csrc/quantization/fp4/nvfp4_experts_quant.cu"
       "csrc/quantization/fp4/nvfp4_scaled_mm_sm120_kernels.cu"
-      "csrc/quantization/fp4/nvfp4_blockwise_moe_kernel.cu")
+      "csrc/quantization/fp4/nvfp4_blockwise_moe_kernel.cu"
+      "csrc/quantization/fp4/rmsnorm_nvfp4_quant_kernels.cu")
     set_gencode_flags_for_srcs(
       SRCS "${SRCS}"
       CUDA_ARCHS "${FP4_ARCHS}")
@@ -683,7 +684,8 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
       "csrc/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu"
       "csrc/quantization/fp4/nvfp4_experts_quant.cu"
       "csrc/quantization/fp4/nvfp4_scaled_mm_kernels.cu"
-      "csrc/quantization/fp4/nvfp4_blockwise_moe_kernel.cu")
+      "csrc/quantization/fp4/nvfp4_blockwise_moe_kernel.cu"
+      "csrc/quantization/fp4/rmsnorm_nvfp4_quant_kernels.cu")
     set_gencode_flags_for_srcs(
       SRCS "${SRCS}"
       CUDA_ARCHS "${FP4_ARCHS}")

--- a/benchmarks/fused_kernels/layernorm_rms_benchmarks.py
+++ b/benchmarks/fused_kernels/layernorm_rms_benchmarks.py
@@ -13,9 +13,24 @@ from torch.utils.benchmark import Measurement as TMeasurement
 from tqdm import tqdm
 
 import vllm._custom_ops as ops
+from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
+)
+from vllm.platforms import current_platform
+from vllm.scalar_type import scalar_types
+
+# FP4 constants
+FLOAT4_E2M1_MAX = scalar_types.float4_e2m1f.max()
+FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
+
+# Check if NVFP4 fused ops are available
+rms_norm_nvfp4_quant_supported = current_platform.is_cuda() and hasattr(
+    torch.ops._C, "rms_norm_nvfp4_quant"
+)
+fused_add_rms_norm_nvfp4_quant_supported = current_platform.is_cuda() and hasattr(
+    torch.ops._C, "fused_add_rms_norm_nvfp4_quant"
 )
 
 
@@ -59,6 +74,7 @@ def unfused_int8_impl(
     residual: torch.Tensor | None,
     quant_dtype: torch.dtype,
     group_size: list[int],
+    **kwargs,
 ):
     # Norm
     torch_out = None
@@ -77,6 +93,7 @@ def unfused_fp8_impl(
     residual: torch.Tensor | None,
     quant_dtype: torch.dtype,
     group_size: list[int],
+    **kwargs,
 ):
     # Norm
     torch_out = None
@@ -95,6 +112,7 @@ def unfused_groupwise_fp8_impl(
     residual: torch.Tensor | None,
     quant_dtype: torch.dtype,
     group_size: list[int],
+    **kwargs,
 ):
     # Norm
     torch_out = None
@@ -115,6 +133,7 @@ def fused_impl(
     residual: torch.Tensor | None,
     quant_dtype: torch.dtype,
     group_size: list[int],
+    **kwargs,
 ):
     out, _ = ops.rms_norm_dynamic_per_token_quant(
         x, rms_norm_layer.weight, 1e-6, quant_dtype, residual=residual
@@ -127,6 +146,7 @@ def fused_groupwise_impl(
     residual: torch.Tensor | None,
     quant_dtype: torch.dtype,
     group_size: list[int],
+    **kwargs,
 ):
     out, _ = ops.rms_norm_per_block_quant(
         x,
@@ -137,6 +157,93 @@ def fused_groupwise_impl(
         residual=residual,
         is_scale_transposed=True,
     )
+
+
+def get_fp4_output_tensors(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Allocate output tensors for FP4 quantization."""
+    m, n = x.shape
+    block_size = 16
+    # Two fp4 values will be packed into an uint8.
+    output = torch.empty((m, n // 2), device=x.device, dtype=torch.uint8)
+    # Swizzled scale layout for 128x4 tiles
+    round_up = lambda x, y: (x + y - 1) // y * y
+    rounded_m = round_up(m, 128)
+    scale_n = n // block_size
+    rounded_n = round_up(scale_n, 4)
+    output_scale = torch.empty(
+        (rounded_m, rounded_n // 4), device=x.device, dtype=torch.int32
+    )
+    return output, output_scale
+
+
+def unfused_nvfp4_impl(
+    rms_norm_layer: RMSNorm,
+    x: torch.Tensor,
+    residual: torch.Tensor | None,
+    quant_dtype: torch.dtype,
+    group_size: list[int],
+    global_scale: torch.Tensor | None = None,
+    **kwargs,
+):
+    """Unfused RMSNorm + NVFP4 quantization implementation."""
+    # Norm
+    torch_out = None
+    if residual is None:
+        torch_out = rms_norm_layer.forward_cuda(x, residual)
+    else:
+        torch_out, _ = rms_norm_layer.forward_cuda(x, residual)
+
+    # Use pre-computed global_scale if provided (simulates real inference)
+    if global_scale is None:
+        global_scale = (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.abs(
+            torch_out
+        ).max().to(torch.float32)
+    output_quant, output_scale = ops.scaled_fp4_quant(torch_out, global_scale)
+
+
+def fused_nvfp4_impl(
+    rms_norm_layer: RMSNorm,
+    x: torch.Tensor,
+    residual: torch.Tensor | None,
+    quant_dtype: torch.dtype,
+    group_size: list[int],
+    global_scale: torch.Tensor | None = None,
+    **kwargs,
+):
+    """Fused RMSNorm + NVFP4 quantization implementation."""
+    # Use pre-computed global_scale if provided (simulates real inference)
+    # In practice, global_scale is computed once during calibration
+    if global_scale is None:
+        torch_out_ref = rms_norm_layer.forward_cuda(x, None)
+        global_scale = (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.abs(
+            torch_out_ref
+        ).max().to(torch.float32)
+
+    # Allocate output tensors each time (matching unfused_nvfp4_impl behavior)
+    output_quant, output_scale = get_fp4_output_tensors(x)
+
+    if residual is None:
+        # rms_norm_nvfp4_quant
+        torch.ops._C.rms_norm_nvfp4_quant(
+            output_quant,
+            output_scale,
+            x,
+            rms_norm_layer.weight,
+            global_scale,
+            1e-6,
+        )
+    else:
+        # fused_add_rms_norm_nvfp4_quant
+        # Note: residual is modified in-place, but for benchmark we accept this
+        torch.ops._C.fused_add_rms_norm_nvfp4_quant(
+            output_quant,
+            output_scale,
+            x,
+            residual,
+            rms_norm_layer.weight,
+            global_scale,
+            1e-6,
+        )
 
 
 # Bench functions
@@ -150,6 +257,7 @@ def bench_fn(
     sub_label: str,
     fn: Callable,
     description: str,
+    global_scale: torch.Tensor | None = None,
 ) -> TMeasurement:
     min_run_time = 1
 
@@ -159,10 +267,12 @@ def bench_fn(
         "residual": residual,
         "quant_dtype": quant_dtype,
         "group_size": group_size,
+        "global_scale": global_scale,
         "fn": fn,
     }
     return TBenchmark.Timer(
-        stmt="fn(rms_norm_layer, x, residual, quant_dtype, group_size)",
+        stmt="fn(rms_norm_layer, x, residual, quant_dtype,"
+        " group_size, global_scale=global_scale)",
         globals=globals,
         label=label,
         sub_label=sub_label,
@@ -279,6 +389,53 @@ def bench(params: bench_params_t, label: str, sub_label: str) -> Iterable[TMeasu
         )
     )
 
+    # NVFP4 benchmarks (only if supported, hidden_size is multiple of 16,
+    # and dtype is fp16/bf16 - NVFP4 does not support float32)
+    if params.hidden_size % 16 == 0 and params.dtype in (torch.float16, torch.bfloat16):
+        # Pre-compute global_scale ONCE before benchmark loop
+        # This simulates real inference where global_scale is calibrated offline
+        with torch.no_grad():
+            torch_out_ref = layer.forward_cuda(x, None)
+            nvfp4_global_scale = (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.abs(
+                torch_out_ref
+            ).max().to(torch.float32)
+
+        if rms_norm_nvfp4_quant_supported or fused_add_rms_norm_nvfp4_quant_supported:
+            # unfused nvfp4 impl.
+            timers.append(
+                bench_fn(
+                    layer,
+                    x,
+                    residual,
+                    torch.uint8,  # FP4 is packed as uint8
+                    params.group_size,
+                    label,
+                    sub_label,
+                    unfused_nvfp4_impl,
+                    "unfused_nvfp4_impl",
+                    global_scale=nvfp4_global_scale,
+                )
+            )
+
+        if (not params.add_residual and rms_norm_nvfp4_quant_supported) or (
+            params.add_residual and fused_add_rms_norm_nvfp4_quant_supported
+        ):
+            # fused nvfp4 impl
+            timers.append(
+                bench_fn(
+                    layer,
+                    x,
+                    residual,
+                    torch.uint8,  # FP4 is packed as uint8
+                    params.group_size,
+                    label,
+                    sub_label,
+                    fused_nvfp4_impl,
+                    "fused_nvfp4_impl",
+                    global_scale=nvfp4_global_scale,
+                )
+            )
+
     print_timers(timers)
 
     return timers
@@ -296,8 +453,11 @@ def main():
     bench_params = get_bench_params()
 
     timers = []
-    for bp in tqdm(bench_params):
-        timers.extend(bench(bp, "rms-norm-dynamic-per-token-quant", bp.description()))
+    with set_current_vllm_config(VllmConfig()):
+        for bp in tqdm(bench_params):
+            timers.extend(
+                bench(bp, "rms-norm-dynamic-per-token-quant", bp.description())
+            )
     print_timers(timers)
 
     # pickle all the results

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -139,6 +139,19 @@ void rms_norm_per_block_quant(torch::Tensor& out, torch::Tensor const& input,
                               std::optional<torch::Tensor> residual,
                               int64_t group_size, bool is_scale_transposed);
 
+#ifndef USE_ROCM
+void rms_norm_nvfp4_quant(torch::Tensor& out, torch::Tensor& output_scale,
+                          torch::Tensor& input, torch::Tensor& weight,
+                          torch::Tensor& input_scale, double epsilon);
+
+void fused_add_rms_norm_nvfp4_quant(torch::Tensor& out,
+                                    torch::Tensor& output_scale,
+                                    torch::Tensor& input,
+                                    torch::Tensor& residual,
+                                    torch::Tensor& weight,
+                                    torch::Tensor& input_scale, double epsilon);
+#endif
+
 void rotary_embedding(torch::Tensor& positions, torch::Tensor& query,
                       std::optional<torch::Tensor> key, int64_t head_size,
                       torch::Tensor& cos_sin_cache, bool is_neox);
@@ -153,10 +166,6 @@ void silu_and_mul_nvfp4_quant(torch::Tensor& out,
                               torch::Tensor& output_block_scale,
                               torch::Tensor& input,
                               torch::Tensor& input_global_scale);
-
-void rms_norm_nvfp4_quant(torch::Tensor& out, torch::Tensor& output_scale,
-                          torch::Tensor& input, torch::Tensor& weight,
-                          torch::Tensor& input_scale, double epsilon);
 #endif
 void persistent_masked_m_silu_mul_quant(
     const at::Tensor& input,   // (E, T, 2*H)

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -153,6 +153,10 @@ void silu_and_mul_nvfp4_quant(torch::Tensor& out,
                               torch::Tensor& output_block_scale,
                               torch::Tensor& input,
                               torch::Tensor& input_global_scale);
+
+void rms_norm_nvfp4_quant(torch::Tensor& out, torch::Tensor& output_scale,
+                          torch::Tensor& input, torch::Tensor& weight,
+                          torch::Tensor& input_scale, double epsilon);
 #endif
 void persistent_masked_m_silu_mul_quant(
     const at::Tensor& input,   // (E, T, 2*H)

--- a/csrc/quantization/cuda_type_utils.cuh
+++ b/csrc/quantization/cuda_type_utils.cuh
@@ -8,9 +8,11 @@
 // Conditional compilation for FP4 element packing size
 #if (defined(NVFP4_ENABLE_ELTS16) && (CUDART_VERSION >= 12090) && \
      defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100)
+  #define ELTS_PER_THREAD 16
 constexpr int CVT_FP4_ELTS_PER_THREAD = 16;
 constexpr bool CVT_FP4_PACK16 = true;
 #else
+  #define ELTS_PER_THREAD 8
 constexpr int CVT_FP4_ELTS_PER_THREAD = 8;
 constexpr bool CVT_FP4_PACK16 = false;
 #endif

--- a/csrc/quantization/cuda_type_utils.cuh
+++ b/csrc/quantization/cuda_type_utils.cuh
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <ATen/cuda/CUDAContext.h>
+
+// Conditional compilation for FP4 element packing size
+#if (defined(NVFP4_ENABLE_ELTS16) && (CUDART_VERSION >= 12090) && \
+     defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100)
+constexpr int CVT_FP4_ELTS_PER_THREAD = 16;
+constexpr bool CVT_FP4_PACK16 = true;
+#else
+constexpr int CVT_FP4_ELTS_PER_THREAD = 8;
+constexpr bool CVT_FP4_PACK16 = false;
+#endif
+
+constexpr int CVT_FP4_SF_VEC_SIZE = 16;
+
+namespace vllm {
+
+// Convert PyTorch cpp type to CUDA type
+template <typename T>
+struct CUDATypeConverter {
+  using Type = T;
+};
+
+template <>
+struct CUDATypeConverter<at::Half> {
+  using Type = half;
+};
+
+template <>
+struct CUDATypeConverter<at::BFloat16> {
+  using Type = __nv_bfloat16;
+};
+
+// Get type2 from type or vice versa (half <-> half2, bfloat16 <-> bfloat162)
+template <typename T>
+struct TypeConverter {
+  using Type = half2;
+};
+
+template <>
+struct TypeConverter<half2> {
+  using Type = half;
+};
+
+template <>
+struct TypeConverter<half> {
+  using Type = half2;
+};
+
+template <>
+struct TypeConverter<__nv_bfloat162> {
+  using Type = __nv_bfloat16;
+};
+
+template <>
+struct TypeConverter<__nv_bfloat16> {
+  using Type = __nv_bfloat162;
+};
+
+#if (defined(NVFP4_ENABLE_ELTS16) && (CUDART_VERSION >= 12090) && \
+     defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100)
+// Define a 32 bytes packed data type.
+template <class Type>
+struct alignas(32) PackedVec {
+  typename TypeConverter<Type>::Type elts[8];
+};
+#else
+// Define a 16 bytes packed data type.
+template <class Type>
+struct alignas(16) PackedVec {
+  typename TypeConverter<Type>::Type elts[4];
+};
+#endif
+
+template <>
+struct PackedVec<__nv_fp8_e4m3> {
+  __nv_fp8x2_e4m3 elts[8];
+};
+
+}  // namespace vllm

--- a/csrc/quantization/fp4/nvfp4_quant_entry.cu
+++ b/csrc/quantization/fp4/nvfp4_quant_entry.cu
@@ -51,6 +51,14 @@ void silu_and_mul_scaled_fp4_experts_quant_sm1xxa(
     torch::Tensor const& output_scale_offset_by_experts);
 #endif
 
+#if (defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100) || \
+    (defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120)
+void rms_norm_nvfp4_quant_sm1xxa(torch::Tensor& output,
+                                 torch::Tensor& output_scale,
+                                 torch::Tensor& input, torch::Tensor& weight,
+                                 torch::Tensor& input_scale, double epsilon);
+#endif
+
 void scaled_fp4_quant(torch::Tensor& output, torch::Tensor const& input,
                       torch::Tensor& output_sf, torch::Tensor const& input_sf,
                       bool is_sf_swizzled_layout) {
@@ -100,4 +108,16 @@ void silu_and_mul_scaled_fp4_experts_quant(
 #endif
   TORCH_CHECK_NOT_IMPLEMENTED(
       false, "No compiled silu_and_mul nvfp4 experts quantization kernel");
+}
+
+void rms_norm_nvfp4_quant(torch::Tensor& output, torch::Tensor& output_scale,
+                          torch::Tensor& input, torch::Tensor& weight,
+                          torch::Tensor& input_scale, double epsilon) {
+#if (defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100) || \
+    (defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120)
+  return rms_norm_nvfp4_quant_sm1xxa(output, output_scale, input, weight,
+                                     input_scale, epsilon);
+#endif
+  TORCH_CHECK_NOT_IMPLEMENTED(false,
+                              "No compiled rms_norm nvfp4 quantization kernel");
 }

--- a/csrc/quantization/fp4/nvfp4_quant_entry.cu
+++ b/csrc/quantization/fp4/nvfp4_quant_entry.cu
@@ -59,6 +59,14 @@ void rms_norm_nvfp4_quant_sm1xxa(torch::Tensor& output,
                                  torch::Tensor& input_scale, double epsilon);
 #endif
 
+#if (defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100) || \
+    (defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120)
+void fused_add_rms_norm_nvfp4_quant_sm1xxa(
+    torch::Tensor& output, torch::Tensor& output_scale, torch::Tensor& input,
+    torch::Tensor& residual, torch::Tensor& weight, torch::Tensor& input_scale,
+    double epsilon);
+#endif
+
 void scaled_fp4_quant(torch::Tensor& output, torch::Tensor const& input,
                       torch::Tensor& output_sf, torch::Tensor const& input_sf,
                       bool is_sf_swizzled_layout) {
@@ -120,4 +128,17 @@ void rms_norm_nvfp4_quant(torch::Tensor& output, torch::Tensor& output_scale,
 #endif
   TORCH_CHECK_NOT_IMPLEMENTED(false,
                               "No compiled rms_norm nvfp4 quantization kernel");
+}
+
+void fused_add_rms_norm_nvfp4_quant(
+    torch::Tensor& output, torch::Tensor& output_scale, torch::Tensor& input,
+    torch::Tensor& residual, torch::Tensor& weight, torch::Tensor& input_scale,
+    double epsilon) {
+#if (defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100) || \
+    (defined(ENABLE_NVFP4_SM120) && ENABLE_NVFP4_SM120)
+  return fused_add_rms_norm_nvfp4_quant_sm1xxa(
+      output, output_scale, input, residual, weight, input_scale, epsilon);
+#endif
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      false, "No compiled fused_add_rms_norm nvfp4 quantization kernel");
 }

--- a/csrc/quantization/fp4/nvfp4_utils.cuh
+++ b/csrc/quantization/fp4/nvfp4_utils.cuh
@@ -415,4 +415,54 @@ __inline__ __device__ PackedVec<Type> compute_silu_mul(
   return result;
 }
 
+// Compute sum of squares for a PackedVec (8 elements).
+// Used in RMSNorm variance calculation.
+template <class Type>
+__device__ __forceinline__ float compute_packed_sum_squares(
+    const PackedVec<Type>& vec) {
+  float sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; i++) {
+    float2 fp2;
+    if constexpr (std::is_same_v<Type, half>) {
+      fp2 = __half22float2(vec.elts[i]);
+    } else {
+      fp2 = __bfloat1622float2(vec.elts[i]);
+    }
+    sum += fp2.x * fp2.x + fp2.y * fp2.y;
+  }
+  return sum;
+}
+
+// output = input * rms_inv * weight
+// rms_inv = rsqrt(mean(x^2) + epsilon)
+template <class Type>
+__device__ __forceinline__ PackedVec<Type> compute_rms_norm(
+    const PackedVec<Type>& in_vec, const PackedVec<Type>& w_vec,
+    float rms_inv) {
+  PackedVec<Type> result{};
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; i++) {
+    float2 in_fp2, w_fp2;
+    if constexpr (std::is_same_v<Type, half>) {
+      in_fp2 = __half22float2(in_vec.elts[i]);
+      w_fp2 = __half22float2(w_vec.elts[i]);
+    } else {
+      in_fp2 = __bfloat1622float2(in_vec.elts[i]);
+      w_fp2 = __bfloat1622float2(w_vec.elts[i]);
+    }
+
+    float2 out_fp2;
+    out_fp2.x = in_fp2.x * rms_inv * w_fp2.x;
+    out_fp2.y = in_fp2.y * rms_inv * w_fp2.y;
+
+    if constexpr (std::is_same_v<Type, half>) {
+      result.elts[i] = __float22half2_rn(out_fp2);
+    } else {
+      result.elts[i] = __float22bfloat162_rn(out_fp2);
+    }
+  }
+  return result;
+}
+
 }  // namespace vllm

--- a/csrc/quantization/fp4/nvfp4_utils.cuh
+++ b/csrc/quantization/fp4/nvfp4_utils.cuh
@@ -20,13 +20,6 @@
 #include <cuda_fp8.h>
 #include "../cuda_type_utils.cuh"
 
-#if (defined(NVFP4_ENABLE_ELTS16) && (CUDART_VERSION >= 12090) && \
-     defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100)
-  #define ELTS_PER_THREAD 16
-#else
-  #define ELTS_PER_THREAD 8
-#endif
-
 namespace vllm {
 
 template <typename Int>

--- a/csrc/quantization/fp4/nvfp4_utils.cuh
+++ b/csrc/quantization/fp4/nvfp4_utils.cuh
@@ -18,83 +18,16 @@
 
 #include <cuda_runtime.h>
 #include <cuda_fp8.h>
+#include "../cuda_type_utils.cuh"
 
 #if (defined(NVFP4_ENABLE_ELTS16) && (CUDART_VERSION >= 12090) && \
      defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100)
   #define ELTS_PER_THREAD 16
-constexpr int CVT_FP4_ELTS_PER_THREAD = 16;
-constexpr bool CVT_FP4_PACK16 = true;
 #else
   #define ELTS_PER_THREAD 8
-constexpr int CVT_FP4_ELTS_PER_THREAD = 8;
-constexpr bool CVT_FP4_PACK16 = false;
 #endif
-
-constexpr int CVT_FP4_SF_VEC_SIZE = 16;
 
 namespace vllm {
-
-// Convert PyTorch cpp type to CUDA type
-template <typename T>
-struct CUDATypeConverter {
-  using Type = T;
-};
-
-template <>
-struct CUDATypeConverter<at::Half> {
-  using Type = half;
-};
-
-template <>
-struct CUDATypeConverter<at::BFloat16> {
-  using Type = __nv_bfloat16;
-};
-
-// Get type2 from type or vice versa (applied to half and bfloat16)
-template <typename T>
-struct TypeConverter {
-  using Type = half2;
-};  // keep for generality
-
-template <>
-struct TypeConverter<half2> {
-  using Type = half;
-};
-
-template <>
-struct TypeConverter<half> {
-  using Type = half2;
-};
-
-template <>
-struct TypeConverter<__nv_bfloat162> {
-  using Type = __nv_bfloat16;
-};
-
-template <>
-struct TypeConverter<__nv_bfloat16> {
-  using Type = __nv_bfloat162;
-};
-
-#if (defined(NVFP4_ENABLE_ELTS16) && (CUDART_VERSION >= 12090) && \
-     defined(ENABLE_NVFP4_SM100) && ENABLE_NVFP4_SM100)
-// Define a 32 bytes packed data type.
-template <class Type>
-struct alignas(32) PackedVec {
-  typename TypeConverter<Type>::Type elts[8];
-};
-#else
-// Define a 16 bytes packed data type.
-template <class Type>
-struct alignas(16) PackedVec {
-  typename TypeConverter<Type>::Type elts[4];
-};
-#endif
-
-template <>
-struct PackedVec<__nv_fp8_e4m3> {
-  __nv_fp8x2_e4m3 elts[8];
-};
 
 template <typename Int>
 __host__ __device__ inline Int round_up(Int x, Int y) {
@@ -410,56 +343,6 @@ __inline__ __device__ PackedVec<Type> compute_silu_mul(
       float2 silu_vec = silu2(__bfloat1622float2(x_vec.elts[i]));
       result.elts[i] = __float22bfloat162_rn(
           __fmul2_rn(silu_vec, __bfloat1622float2(y_vec.elts[i])));
-    }
-  }
-  return result;
-}
-
-// Compute sum of squares for a PackedVec (8 elements).
-// Used in RMSNorm variance calculation.
-template <class Type>
-__device__ __forceinline__ float compute_packed_sum_squares(
-    const PackedVec<Type>& vec) {
-  float sum = 0.0f;
-#pragma unroll
-  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; i++) {
-    float2 fp2;
-    if constexpr (std::is_same_v<Type, half>) {
-      fp2 = __half22float2(vec.elts[i]);
-    } else {
-      fp2 = __bfloat1622float2(vec.elts[i]);
-    }
-    sum += fp2.x * fp2.x + fp2.y * fp2.y;
-  }
-  return sum;
-}
-
-// output = input * rms_inv * weight
-// rms_inv = rsqrt(mean(x^2) + epsilon)
-template <class Type>
-__device__ __forceinline__ PackedVec<Type> compute_rms_norm(
-    const PackedVec<Type>& in_vec, const PackedVec<Type>& w_vec,
-    float rms_inv) {
-  PackedVec<Type> result{};
-#pragma unroll
-  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; i++) {
-    float2 in_fp2, w_fp2;
-    if constexpr (std::is_same_v<Type, half>) {
-      in_fp2 = __half22float2(in_vec.elts[i]);
-      w_fp2 = __half22float2(w_vec.elts[i]);
-    } else {
-      in_fp2 = __bfloat1622float2(in_vec.elts[i]);
-      w_fp2 = __bfloat1622float2(w_vec.elts[i]);
-    }
-
-    float2 out_fp2;
-    out_fp2.x = in_fp2.x * rms_inv * w_fp2.x;
-    out_fp2.y = in_fp2.y * rms_inv * w_fp2.y;
-
-    if constexpr (std::is_same_v<Type, half>) {
-      result.elts[i] = __float22half2_rn(out_fp2);
-    } else {
-      result.elts[i] = __float22bfloat162_rn(out_fp2);
     }
   }
   return result;

--- a/csrc/quantization/fp4/rmsnorm_nvfp4_quant_kernels.cu
+++ b/csrc/quantization/fp4/rmsnorm_nvfp4_quant_kernels.cu
@@ -137,6 +137,157 @@ __global__ void __launch_bounds__(1024, VLLM_BLOCKS_PER_SM(1024))
   }
 }
 
+// Fused Add + RMSNorm + FP4 quantization kernel
+// Performs: residual = input + residual, then RMSNorm(residual) -> FP4 quant
+// Addition is done in high precision (BF16/FP16) before normalization.
+template <typename scalar_t, bool UE8M0_SF = false>
+__global__ void __launch_bounds__(1024, VLLM_BLOCKS_PER_SM(1024))
+    fused_add_rms_norm_cvt_fp16_to_fp4(
+        const int num_tokens, const int hidden_size,
+        scalar_t const* __restrict__ input, scalar_t* __restrict__ residual,
+        scalar_t const* __restrict__ weight, float const* __restrict__ scale,
+        const float epsilon, uint32_t* __restrict__ output,
+        uint32_t* __restrict__ output_scale) {
+  using PackedVecT = vllm::PackedVec<scalar_t>;
+
+  static constexpr int CVT_FP4_NUM_THREADS_PER_SF =
+      CVT_FP4_SF_VEC_SIZE / CVT_FP4_ELTS_PER_THREAD;
+
+  __shared__ float s_rms_inv;
+
+  const int32_t num_k_tiles = (hidden_size + 63) / 64;
+  const float global_scale = (scale == nullptr) ? 1.0f : scale[0];
+  const int vecs_per_row = hidden_size / CVT_FP4_ELTS_PER_THREAD;
+
+  // SF layout requires rows padded to 128 and cols padded to 64
+  const int sf_rows = (num_tokens + 127) / 128 * 128;
+  const int sf_cols = (hidden_size + 63) / 64 * 64;
+  const int vecs_per_row_padded = sf_cols / CVT_FP4_ELTS_PER_THREAD;
+
+  for (int row_idx = blockIdx.x; row_idx < sf_rows; row_idx += gridDim.x) {
+    const bool valid_row = row_idx < num_tokens;
+    const scalar_t* row_input = input + row_idx * hidden_size;
+    scalar_t* row_residual = residual + row_idx * hidden_size;
+
+    // First pass: compute x = input + residual, update residual, compute
+    // variance
+    float variance = 0.0f;
+    for (int col_idx = threadIdx.x; col_idx < vecs_per_row_padded;
+         col_idx += blockDim.x) {
+      const int elem_idx = col_idx * CVT_FP4_ELTS_PER_THREAD;
+      PackedVecT in_vec{}, res_vec{}, added_vec{};
+
+      bool valid = valid_row && (elem_idx < hidden_size);
+      if constexpr (CVT_FP4_PACK16) {
+        ld256_or_zero_cg_u32<scalar_t>(
+            in_vec, &reinterpret_cast<const uint32_t*>(row_input)[col_idx * 8],
+            valid);
+        ld256_or_zero_cg_u32<scalar_t>(
+            res_vec,
+            &reinterpret_cast<const uint32_t*>(row_residual)[col_idx * 8],
+            valid);
+      } else {
+        ld128_or_zero_cg_u32<scalar_t>(
+            in_vec, &reinterpret_cast<const uint32_t*>(row_input)[col_idx * 4],
+            valid);
+        ld128_or_zero_cg_u32<scalar_t>(
+            res_vec,
+            &reinterpret_cast<const uint32_t*>(row_residual)[col_idx * 4],
+            valid);
+      }
+
+      if (valid) {
+        // Compute fused add and sum squares in one pass
+        variance +=
+            compute_packed_fused_add_sum_squares(in_vec, res_vec, added_vec);
+
+        // Write back updated residual
+        if constexpr (CVT_FP4_PACK16) {
+          reinterpret_cast<uint64_t*>(row_residual)[col_idx * 4] =
+              reinterpret_cast<uint64_t*>(&added_vec)[0];
+          reinterpret_cast<uint64_t*>(row_residual)[col_idx * 4 + 1] =
+              reinterpret_cast<uint64_t*>(&added_vec)[1];
+          reinterpret_cast<uint64_t*>(row_residual)[col_idx * 4 + 2] =
+              reinterpret_cast<uint64_t*>(&added_vec)[2];
+          reinterpret_cast<uint64_t*>(row_residual)[col_idx * 4 + 3] =
+              reinterpret_cast<uint64_t*>(&added_vec)[3];
+        } else {
+          reinterpret_cast<uint64_t*>(row_residual)[col_idx * 2] =
+              reinterpret_cast<uint64_t*>(&added_vec)[0];
+          reinterpret_cast<uint64_t*>(row_residual)[col_idx * 2 + 1] =
+              reinterpret_cast<uint64_t*>(&added_vec)[1];
+        }
+      }
+    }
+
+    using BlockReduce = cub::BlockReduce<float, 1024>;
+    __shared__ typename BlockReduce::TempStorage reduce_storage;
+    variance =
+        BlockReduce(reduce_storage).Reduce(variance, CubAddOp{}, blockDim.x);
+
+    if (threadIdx.x == 0) {
+      s_rms_inv = rsqrtf(variance / static_cast<float>(hidden_size) + epsilon);
+    }
+    __syncthreads();
+
+    const float rms_inv = s_rms_inv;
+    uint32_t* row_out = output + row_idx * vecs_per_row;
+
+    // Second pass: read updated residual, apply RMSNorm and quantize
+    for (int col_idx = threadIdx.x; col_idx < vecs_per_row_padded;
+         col_idx += blockDim.x) {
+      const int elem_idx = col_idx * CVT_FP4_ELTS_PER_THREAD;
+      const bool valid_col = elem_idx < hidden_size;
+      const bool valid = valid_row && valid_col;
+
+      PackedVecT in_vec{}, w_vec{};
+
+      if constexpr (CVT_FP4_PACK16) {
+        // Read from updated residual
+        ld256_or_zero_cg_u32<scalar_t>(
+            in_vec,
+            &reinterpret_cast<const uint32_t*>(row_residual)[col_idx * 8],
+            valid);
+        ld256_or_zero_cg_u32<scalar_t>(
+            w_vec, &reinterpret_cast<const uint32_t*>(weight)[col_idx * 8],
+            valid);
+      } else {
+        ld128_or_zero_cg_u32<scalar_t>(
+            in_vec,
+            &reinterpret_cast<const uint32_t*>(row_residual)[col_idx * 4],
+            valid);
+        ld128_or_zero_cg_u32<scalar_t>(
+            w_vec, &reinterpret_cast<const uint32_t*>(weight)[col_idx * 4],
+            valid);
+      }
+
+      PackedVecT norm_vec = compute_rms_norm(in_vec, w_vec, rms_inv);
+
+      uint8_t* sf_out =
+          cvt_quant_to_fp4_get_sf_out_offset<uint32_t,
+                                             CVT_FP4_NUM_THREADS_PER_SF>(
+              row_idx, col_idx, num_k_tiles, output_scale);
+
+      auto fp4_packed =
+          cvt_warp_fp16_to_fp4<scalar_t, CVT_FP4_NUM_THREADS_PER_SF, UE8M0_SF>(
+              norm_vec, global_scale, sf_out);
+
+      if (valid) {
+        if constexpr (CVT_FP4_PACK16) {
+          int64_t out_offset = row_idx * (hidden_size / 8) + col_idx * 2;
+          uint64_t packed64 =
+              (uint64_t(fp4_packed.hi) << 32) | uint64_t(fp4_packed.lo);
+          reinterpret_cast<uint64_t*>(output)[out_offset >> 1] = packed64;
+        } else {
+          row_out[col_idx] = fp4_packed;
+        }
+      }
+    }
+
+    __syncthreads();
+  }
+}
+
 }  // namespace vllm
 
 void rms_norm_nvfp4_quant_sm1xxa(
@@ -174,5 +325,49 @@ void rms_norm_nvfp4_quant_sm1xxa(
             scale.data_ptr<float>(), static_cast<float>(epsilon),
             reinterpret_cast<uint32_t*>(output.data_ptr()),
             reinterpret_cast<uint32_t*>(output_scale.data_ptr()));
+      });
+}
+
+void fused_add_rms_norm_nvfp4_quant_sm1xxa(
+    torch::Tensor& output,        // [..., hidden_size/2] uint8 (packed FP4)
+    torch::Tensor& output_scale,  // block scale, int32 (swizzled layout)
+    torch::Tensor& input,         // [..., hidden_size] BF16/FP16
+    torch::Tensor& residual,  // [..., hidden_size] BF16/FP16 (in-place updated)
+    torch::Tensor& weight,    // [hidden_size] BF16/FP16
+    torch::Tensor& scale,     // [1] float32 (global scale)
+    double epsilon) {
+  int hidden_size = input.size(-1);
+  int num_tokens = input.numel() / hidden_size;
+
+  TORCH_CHECK(hidden_size % 16 == 0, "The hidden_size must be multiple of 16.");
+  TORCH_CHECK(
+      input.scalar_type() == at::ScalarType::Half ||
+          input.scalar_type() == at::ScalarType::BFloat16,
+      "Unsupported input data type for fused_add_rms_norm_nvfp4_quant.");
+  TORCH_CHECK(input.scalar_type() == residual.scalar_type(),
+              "Input and residual must have the same dtype.");
+
+  int multi_processor_count =
+      get_device_attribute(cudaDevAttrMultiProcessorCount, -1);
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  dim3 block(std::min(hidden_size / ELTS_PER_THREAD, 1024));
+  int const num_blocks_per_sm =
+      vllm_runtime_blocks_per_sm(static_cast<int>(block.x));
+  dim3 grid(std::min(num_tokens, multi_processor_count * num_blocks_per_sm));
+
+  VLLM_DISPATCH_HALF_TYPES(
+      input.scalar_type(), "fused_add_rms_norm_nvfp4_quant_kernel", [&] {
+        using cuda_type = vllm::CUDATypeConverter<scalar_t>::Type;
+        vllm::fused_add_rms_norm_cvt_fp16_to_fp4<cuda_type>
+            <<<grid, block, 0, stream>>>(
+                num_tokens, hidden_size,
+                reinterpret_cast<cuda_type const*>(input.data_ptr()),
+                reinterpret_cast<cuda_type*>(residual.data_ptr()),
+                reinterpret_cast<cuda_type const*>(weight.data_ptr()),
+                scale.data_ptr<float>(), static_cast<float>(epsilon),
+                reinterpret_cast<uint32_t*>(output.data_ptr()),
+                reinterpret_cast<uint32_t*>(output_scale.data_ptr()));
       });
 }

--- a/csrc/quantization/fp4/rmsnorm_nvfp4_quant_kernels.cu
+++ b/csrc/quantization/fp4/rmsnorm_nvfp4_quant_kernels.cu
@@ -60,13 +60,11 @@ __global__ void __launch_bounds__(1024, VLLM_BLOCKS_PER_SM(1024))
       bool valid = valid_row && (elem_idx < hidden_size);
       if constexpr (CVT_FP4_PACK16) {
         ld256_or_zero_cg_u32<scalar_t>(
-            vec,
-            &reinterpret_cast<const uint32_t*>(row_input)[col_idx * 8],
+            vec, &reinterpret_cast<const uint32_t*>(row_input)[col_idx * 8],
             valid);
       } else {
         ld128_or_zero_cg_u32<scalar_t>(
-            vec,
-            &reinterpret_cast<const uint32_t*>(row_input)[col_idx * 4],
+            vec, &reinterpret_cast<const uint32_t*>(row_input)[col_idx * 4],
             valid);
       }
 
@@ -98,21 +96,17 @@ __global__ void __launch_bounds__(1024, VLLM_BLOCKS_PER_SM(1024))
 
       if constexpr (CVT_FP4_PACK16) {
         ld256_or_zero_cg_u32<scalar_t>(
-            in_vec,
-            &reinterpret_cast<const uint32_t*>(row_input)[col_idx * 8],
+            in_vec, &reinterpret_cast<const uint32_t*>(row_input)[col_idx * 8],
             valid);
         ld256_or_zero_cg_u32<scalar_t>(
-            w_vec,
-            &reinterpret_cast<const uint32_t*>(weight)[col_idx * 8],
+            w_vec, &reinterpret_cast<const uint32_t*>(weight)[col_idx * 8],
             valid);
       } else {
         ld128_or_zero_cg_u32<scalar_t>(
-            in_vec,
-            &reinterpret_cast<const uint32_t*>(row_input)[col_idx * 4],
+            in_vec, &reinterpret_cast<const uint32_t*>(row_input)[col_idx * 4],
             valid);
         ld128_or_zero_cg_u32<scalar_t>(
-            w_vec,
-            &reinterpret_cast<const uint32_t*>(weight)[col_idx * 4],
+            w_vec, &reinterpret_cast<const uint32_t*>(weight)[col_idx * 4],
             valid);
       }
 

--- a/csrc/quantization/fp4/rmsnorm_nvfp4_quant_kernels.cu
+++ b/csrc/quantization/fp4/rmsnorm_nvfp4_quant_kernels.cu
@@ -1,0 +1,141 @@
+#include <torch/all.h>
+
+#include <cuda_runtime_api.h>
+#include <cuda_runtime.h>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include <cuda_fp8.h>
+#include <cub/cub.cuh>
+#include "dispatch_utils.h"
+#include "cub_helpers.h"
+
+#include "cuda_utils.h"
+#include "launch_bounds_utils.h"
+#include "nvfp4_utils.cuh"
+
+namespace vllm {
+
+// Use UE4M3 by default.
+template <typename scalar_t, bool UE8M0_SF = false>
+__global__ void __launch_bounds__(1024, VLLM_BLOCKS_PER_SM(1024))
+    rms_norm_cvt_fp16_to_fp4(const int num_tokens, const int hidden_size,
+                             scalar_t const* __restrict__ input,
+                             scalar_t const* __restrict__ weight,
+                             float const* __restrict__ scale,
+                             const float epsilon, uint32_t* __restrict__ output,
+                             uint32_t* __restrict__ output_scale) {
+  using PackedVecT = PackedVec<scalar_t>;
+
+  static constexpr int CVT_FP4_NUM_THREADS_PER_SF =
+      CVT_FP4_SF_VEC_SIZE / CVT_FP4_ELTS_PER_THREAD;
+
+  __shared__ float s_rms_inv;
+
+  const int32_t num_k_tiles = (hidden_size + 63) / 64;
+  const float global_scale = scale == nullptr ? 1.0f : scale[0];
+  const int vecs_per_row = hidden_size / CVT_FP4_ELTS_PER_THREAD;
+
+  // SF layout requires rows padded to 128 and cols padded to 64
+  const int sf_rows = (num_tokens + 127) / 128 * 128;
+  const int sf_cols = (hidden_size + 63) / 64 * 64;
+  const int vecs_per_row_padded = sf_cols / CVT_FP4_ELTS_PER_THREAD;
+
+  for (int row_idx = blockIdx.x; row_idx < sf_rows; row_idx += gridDim.x) {
+    const bool valid_row = row_idx < num_tokens;
+    const scalar_t* row_input = input + row_idx * hidden_size;
+
+    float variance = 0.0f;
+    for (int col_idx = threadIdx.x; col_idx < vecs_per_row_padded;
+         col_idx += blockDim.x) {
+      const int elem_idx = col_idx * CVT_FP4_ELTS_PER_THREAD;
+      if (valid_row && elem_idx < hidden_size) {
+        PackedVecT vec =
+            reinterpret_cast<const PackedVecT*>(row_input)[col_idx];
+        variance += compute_packed_sum_squares(vec);
+      }
+    }
+
+    using BlockReduce = cub::BlockReduce<float, 1024>;
+    __shared__ typename BlockReduce::TempStorage reduce_storage;
+    variance =
+        BlockReduce(reduce_storage).Reduce(variance, CubAddOp{}, blockDim.x);
+
+    if (threadIdx.x == 0) {
+      s_rms_inv = rsqrtf(variance / static_cast<float>(hidden_size) + epsilon);
+    }
+    __syncthreads();
+
+    const float rms_inv = s_rms_inv;
+    uint32_t* row_out = output + row_idx * vecs_per_row;
+
+    for (int col_idx = threadIdx.x; col_idx < vecs_per_row_padded;
+         col_idx += blockDim.x) {
+      const int elem_idx = col_idx * CVT_FP4_ELTS_PER_THREAD;
+      const bool valid_col = elem_idx < hidden_size;
+      PackedVecT in_vec{}, w_vec{};
+
+      if (valid_row && valid_col) {
+        in_vec = reinterpret_cast<const PackedVecT*>(row_input)[col_idx];
+        w_vec = reinterpret_cast<const PackedVecT*>(weight)[col_idx];
+      }
+
+      PackedVecT norm_vec = compute_rms_norm(in_vec, w_vec, rms_inv);
+
+      uint8_t* sf_out =
+          cvt_quant_to_fp4_get_sf_out_offset<uint32_t,
+                                             CVT_FP4_NUM_THREADS_PER_SF>(
+              row_idx, col_idx, num_k_tiles, output_scale);
+
+      uint32_t fp4_packed = cvt_warp_fp16_to_fp4<scalar_t, UE8M0_SF>(
+          norm_vec, global_scale, sf_out);
+
+      if (valid_row && valid_col) {
+        row_out[col_idx] = fp4_packed;
+      }
+    }
+
+    __syncthreads();
+  }
+}
+
+}  // namespace vllm
+
+void rms_norm_nvfp4_quant_sm1xxa(
+    torch::Tensor& output,        // [..., hidden_size/2] uint8 (packed FP4)
+    torch::Tensor& output_scale,  // block scale, int32 (swizzled layout)
+    torch::Tensor& input,         // [..., hidden_size] BF16/FP16
+    torch::Tensor& weight,        // [hidden_size] BF16/FP16
+    torch::Tensor& scale,         // [1] float32 (global scale)
+    double epsilon) {
+  int hidden_size = input.size(-1);
+  int num_tokens = input.numel() / hidden_size;
+
+  TORCH_CHECK(hidden_size % 16 == 0, "The hidden_size must be multiple of 16.");
+  TORCH_CHECK(input.scalar_type() == at::ScalarType::Half ||
+                  input.scalar_type() == at::ScalarType::BFloat16,
+              "Unsupported input data type for rms_norm_nvfp4_quant.");
+
+  int multi_processor_count =
+      get_device_attribute(cudaDevAttrMultiProcessorCount, -1);
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  dim3 block(std::min(hidden_size / ELTS_PER_THREAD, 1024));
+  int const num_blocks_per_sm =
+      vllm_runtime_blocks_per_sm(static_cast<int>(block.x));
+  dim3 grid(std::min(num_tokens, multi_processor_count * num_blocks_per_sm));
+
+  VLLM_DISPATCH_HALF_TYPES(
+      input.scalar_type(), "rms_norm_nvfp4_quant_kernel", [&] {
+        using cuda_type = vllm::CUDATypeConverter<scalar_t>::Type;
+        vllm::rms_norm_cvt_fp16_to_fp4<cuda_type><<<grid, block, 0, stream>>>(
+            num_tokens, hidden_size,
+            reinterpret_cast<cuda_type const*>(input.data_ptr()),
+            reinterpret_cast<cuda_type const*>(weight.data_ptr()),
+            scale.data_ptr<float>(), static_cast<float>(epsilon),
+            reinterpret_cast<uint32_t*>(output.data_ptr()),
+            reinterpret_cast<uint32_t*>(output_scale.data_ptr()));
+      });
+}

--- a/csrc/quantization/fused_kernels/layernorm_utils.cuh
+++ b/csrc/quantization/fused_kernels/layernorm_utils.cuh
@@ -45,9 +45,9 @@ __device__ void compute_rms(float* rms, scalar_t const* __restrict__ input,
   *rms = s_rms;
 }
 
-__device__ float warpReduceMaxSpecialized(volatile float* val, int64_t tid,
-                                          int64_t thread_in_warp,
-                                          int64_t reduced_elems) {
+__device__ __forceinline__ float warpReduceMaxSpecialized(
+    volatile float* val, int64_t tid, int64_t thread_in_warp,
+    int64_t reduced_elems) {
   static_assert(WARP_SIZE == 32 || WARP_SIZE == 64);
   if constexpr (WARP_SIZE == 64) {
     if (thread_in_warp + 64 < reduced_elems)

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -114,6 +114,12 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "silu_and_mul_nvfp4_quant(Tensor! result, Tensor! result_block_scale, "
       "Tensor input, Tensor input_global_scale) -> ()");
   ops.impl("silu_and_mul_nvfp4_quant", torch::kCUDA, &silu_and_mul_nvfp4_quant);
+
+  // Fused RMSNorm + NVFP4 quantization
+  ops.def(
+      "rms_norm_nvfp4_quant(Tensor! result, Tensor! result_scale, "
+      "Tensor input, Tensor weight, Tensor input_scale, float epsilon) -> ()");
+  ops.impl("rms_norm_nvfp4_quant", torch::kCUDA, &rms_norm_nvfp4_quant);
 #endif
 
   ops.def("mul_and_silu(Tensor! out, Tensor input) -> ()");

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -114,12 +114,6 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "silu_and_mul_nvfp4_quant(Tensor! result, Tensor! result_block_scale, "
       "Tensor input, Tensor input_global_scale) -> ()");
   ops.impl("silu_and_mul_nvfp4_quant", torch::kCUDA, &silu_and_mul_nvfp4_quant);
-
-  // Fused RMSNorm + NVFP4 quantization
-  ops.def(
-      "rms_norm_nvfp4_quant(Tensor! result, Tensor! result_scale, "
-      "Tensor input, Tensor weight, Tensor input_scale, float epsilon) -> ()");
-  ops.impl("rms_norm_nvfp4_quant", torch::kCUDA, &rms_norm_nvfp4_quant);
 #endif
 
   ops.def("mul_and_silu(Tensor! out, Tensor input) -> ()");
@@ -228,6 +222,22 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "Tensor? scale_ub, Tensor!? residual, int group_size, "
       "bool is_scale_transposed) -> ()");
   ops.impl("rms_norm_per_block_quant", torch::kCUDA, &rms_norm_per_block_quant);
+
+#ifndef USE_ROCM
+  // Fused RMSNorm + NVFP4 quantization
+  ops.def(
+      "rms_norm_nvfp4_quant(Tensor! result, Tensor! result_scale, "
+      "Tensor input, Tensor weight, Tensor input_scale, float epsilon) -> ()");
+  ops.impl("rms_norm_nvfp4_quant", torch::kCUDA, &rms_norm_nvfp4_quant);
+
+  // Fused Add + RMSNorm + NVFP4 quantization
+  ops.def(
+      "fused_add_rms_norm_nvfp4_quant(Tensor! result, Tensor! result_scale, "
+      "Tensor input, Tensor! residual, Tensor weight, Tensor input_scale, "
+      "float epsilon) -> ()");
+  ops.impl("fused_add_rms_norm_nvfp4_quant", torch::kCUDA,
+           &fused_add_rms_norm_nvfp4_quant);
+#endif
 
   // Rotary embedding
   // Apply GPT-NeoX or GPT-J style rotary embedding to query and key.

--- a/tests/kernels/quantization/test_fused_add_rmsnorm_nvfp4_quant.py
+++ b/tests/kernels/quantization/test_fused_add_rmsnorm_nvfp4_quant.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tests for fused Add + RMSNorm + NVFP4 quantization kernel.
+"""
+
+import pytest
+import torch
+
+from tests.kernels.quantization.nvfp4_utils import (
+    FLOAT4_E2M1_MAX,
+    FLOAT8_E4M3_MAX,
+    dequantize_nvfp4_to_dtype,
+)
+from vllm._custom_ops import scaled_fp4_quant
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+if not current_platform.has_device_capability(100):
+    pytest.skip(
+        reason="Nvfp4 Requires compute capability of 10 or above.",
+        allow_module_level=True,
+    )
+
+FP4_DTYPE = torch.uint8
+FP8_DTYPE = current_platform.fp8_dtype()
+
+DTYPES = [torch.float16, torch.bfloat16]
+SHAPES = [(128, 256), (128, 128), (256, 256), (256, 128)]
+EPSILON = 1e-6
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("shape", SHAPES)
+@torch.inference_mode()
+def test_fused_add_rms_norm_nvfp4_quant(
+    default_vllm_config,
+    dtype: torch.dtype,
+    shape: tuple[int, int],
+) -> None:
+    """Test fused Add + RMSNorm + NVFP4 quantization kernel."""
+    set_random_seed(42)
+    device = "cuda:0"
+    torch.set_default_device(device)
+
+    num_tokens, hidden_size = shape
+    x = torch.randn(shape, dtype=dtype)
+    residual = torch.randn(shape, dtype=dtype)
+    weight = torch.randn(hidden_size, dtype=dtype)
+
+    # Reference: x + residual -> RMSNorm -> scaled_fp4_quant
+    ref_residual = x + residual
+    rms_norm = RMSNorm(hidden_size, EPSILON).to(dtype=dtype, device=device)
+    rms_norm.weight.data.copy_(weight)
+    ref_output = rms_norm.forward_native(ref_residual)
+
+    ref_global_scale = (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.abs(
+        ref_output
+    ).max().to(torch.float32)
+    ref_output_quant, ref_block_scale = scaled_fp4_quant(ref_output, ref_global_scale)
+
+    # Fused op: fused_add_rms_norm_nvfp4_quant
+    fused_output_quant = torch.empty_like(ref_output_quant)
+    fused_block_scale = torch.empty_like(ref_block_scale)
+    fused_residual = residual.clone()  # Will be updated in-place
+    torch.ops._C.fused_add_rms_norm_nvfp4_quant(
+        fused_output_quant,
+        fused_block_scale,
+        x,
+        fused_residual,
+        weight,
+        ref_global_scale,
+        EPSILON,
+    )
+
+    # Check residual is updated in-place
+    torch.testing.assert_close(fused_residual, ref_residual, atol=1e-5, rtol=1e-5)
+
+    # Check dtype
+    assert ref_output_quant.dtype == FP4_DTYPE
+    assert fused_output_quant.dtype == FP4_DTYPE
+    assert ref_output_quant.shape == fused_output_quant.shape
+
+    assert ref_block_scale.dtype == FP8_DTYPE
+    assert fused_block_scale.dtype == FP8_DTYPE
+    assert ref_block_scale.shape == fused_block_scale.shape
+
+    # Check dequantized output
+    ref_output_dequant = dequantize_nvfp4_to_dtype(
+        ref_output_quant, ref_block_scale, ref_global_scale, dtype, device
+    )
+    fused_output_dequant = dequantize_nvfp4_to_dtype(
+        fused_output_quant, fused_block_scale, ref_global_scale, dtype, device
+    )
+
+    atol, rtol = 3e-1, 3e-1
+    torch.testing.assert_close(
+        ref_output_dequant, fused_output_dequant, atol=atol, rtol=rtol
+    )
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@torch.inference_mode()
+def test_fused_add_rms_norm_nvfp4_quant_large(
+    default_vllm_config,
+    dtype: torch.dtype,
+) -> None:
+    """Test fused Add + RMSNorm + NVFP4 quantization kernel with larger shapes."""
+    set_random_seed(42)
+    device = "cuda:0"
+    torch.set_default_device(device)
+
+    # Test with larger hidden sizes (typical model dimensions)
+    shape = (64, 4096)
+    num_tokens, hidden_size = shape
+    x = torch.randn(shape, dtype=dtype)
+    residual = torch.randn(shape, dtype=dtype)
+    weight = torch.randn(hidden_size, dtype=dtype)
+
+    # Reference: x + residual -> RMSNorm -> scaled_fp4_quant
+    ref_residual = x + residual
+    rms_norm = RMSNorm(hidden_size, EPSILON).to(dtype=dtype, device=device)
+    rms_norm.weight.data.copy_(weight)
+    ref_output = rms_norm.forward_native(ref_residual)
+
+    ref_global_scale = (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.abs(
+        ref_output
+    ).max().to(torch.float32)
+    ref_output_quant, ref_block_scale = scaled_fp4_quant(ref_output, ref_global_scale)
+
+    # Fused op: fused_add_rms_norm_nvfp4_quant
+    fused_output_quant = torch.empty_like(ref_output_quant)
+    fused_block_scale = torch.empty_like(ref_block_scale)
+    fused_residual = residual.clone()
+    torch.ops._C.fused_add_rms_norm_nvfp4_quant(
+        fused_output_quant,
+        fused_block_scale,
+        x,
+        fused_residual,
+        weight,
+        ref_global_scale,
+        EPSILON,
+    )
+
+    # Check residual is updated in-place
+    torch.testing.assert_close(fused_residual, ref_residual, atol=1e-5, rtol=1e-5)
+
+    # Check dequantized output
+    ref_output_dequant = dequantize_nvfp4_to_dtype(
+        ref_output_quant, ref_block_scale, ref_global_scale, dtype, device
+    )
+    fused_output_dequant = dequantize_nvfp4_to_dtype(
+        fused_output_quant, fused_block_scale, ref_global_scale, dtype, device
+    )
+
+    atol, rtol = 3e-1, 3e-1
+    torch.testing.assert_close(
+        ref_output_dequant, fused_output_dequant, atol=atol, rtol=rtol
+    )

--- a/tests/kernels/quantization/test_rmsnorm_nvfp4_quant.py
+++ b/tests/kernels/quantization/test_rmsnorm_nvfp4_quant.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tests for fused RMSNorm + NVFP4 quantization kernel.
+"""
+
+import pytest
+import torch
+
+from tests.kernels.quantization.nvfp4_utils import (
+    FLOAT4_E2M1_MAX,
+    FLOAT8_E4M3_MAX,
+    dequantize_nvfp4_to_dtype,
+)
+from vllm._custom_ops import scaled_fp4_quant
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+if not current_platform.has_device_capability(100):
+    pytest.skip(
+        reason="Nvfp4 Requires compute capability of 10 or above.",
+        allow_module_level=True,
+    )
+
+FP4_DTYPE = torch.uint8
+FP8_DTYPE = current_platform.fp8_dtype()
+
+DTYPES = [torch.float16, torch.bfloat16]
+SHAPES = [(128, 256), (128, 128), (256, 256), (256, 128)]
+EPSILON = 1e-6
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("shape", SHAPES)
+@torch.inference_mode()
+def test_rms_norm_nvfp4_quant(
+    default_vllm_config,
+    dtype: torch.dtype,
+    shape: tuple[int, int],
+) -> None:
+    """Test RMSNorm + NVFP4 quantization fusion."""
+    set_random_seed(42)
+    device = "cuda:0"
+    torch.set_default_device(device)
+
+    num_tokens, hidden_size = shape
+    x = torch.randn(shape, dtype=dtype)
+    weight = torch.randn(hidden_size, dtype=dtype)
+
+    # Reference: RMSNorm -> scaled_fp4_quant
+    rms_norm = RMSNorm(hidden_size, EPSILON).to(dtype=dtype, device=device)
+    rms_norm.weight.data.copy_(weight)
+    ref_output = rms_norm.forward_native(x)
+
+    ref_global_scale = (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX) / torch.abs(
+        ref_output
+    ).max().to(torch.float32)
+    ref_output_quant, ref_block_scale = scaled_fp4_quant(ref_output, ref_global_scale)
+
+    # Fused op: rms_norm_nvfp4_quant
+    fused_output_quant = torch.empty_like(ref_output_quant)
+    fused_block_scale = torch.empty_like(ref_block_scale)
+    torch.ops._C.rms_norm_nvfp4_quant(
+        fused_output_quant, fused_block_scale, x, weight, ref_global_scale, EPSILON
+    )
+
+    # Check dtype
+    assert ref_output_quant.dtype == FP4_DTYPE
+    assert fused_output_quant.dtype == FP4_DTYPE
+    assert ref_output_quant.shape == fused_output_quant.shape
+
+    assert ref_block_scale.dtype == FP8_DTYPE
+    assert fused_block_scale.dtype == FP8_DTYPE
+    assert ref_block_scale.shape == fused_block_scale.shape
+
+    # Check dequantized output
+    ref_output_dequant = dequantize_nvfp4_to_dtype(
+        ref_output_quant, ref_block_scale, ref_global_scale, dtype, device
+    )
+    fused_output_dequant = dequantize_nvfp4_to_dtype(
+        fused_output_quant, fused_block_scale, ref_global_scale, dtype, device
+    )
+
+    atol, rtol = 3e-1, 3e-1
+    torch.testing.assert_close(
+        ref_output_dequant, fused_output_dequant, atol=atol, rtol=rtol
+    )

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -118,7 +118,7 @@ rms_norm_nvfp4_quant_supported = current_platform.is_cuda() and hasattr(
     torch.ops._C, "rms_norm_nvfp4_quant"
 )
 if rms_norm_nvfp4_quant_supported:
-    FUSED_OPS[FusedRMSQuantKey(kNvfp4Quant, False)] = (
+    FUSED_OPS[FusedRMSQuantKey(kNvfp4Dynamic, False)] = (
         torch.ops._C.rms_norm_nvfp4_quant.default
     )  # noqa: E501
 
@@ -513,8 +513,8 @@ class RMSNormNvfp4QuantPattern:
         config = get_current_vllm_config()
         self.model_dtype = config.model_config.dtype if config.model_config else None
         self.rmsnorm_matcher = MatcherRMSNorm(epsilon)
-        self.QUANT_OP = QUANT_OPS[kNvfp4Quant]
-        self.FUSED_OP = FUSED_OPS[FusedRMSQuantKey(kNvfp4Quant, False)]
+        self.QUANT_OP = QUANT_OPS[kNvfp4Dynamic]
+        self.FUSED_OP = FUSED_OPS[FusedRMSQuantKey(kNvfp4Dynamic, False)]
 
     def get_inputs(self) -> list[torch.Tensor]:
         # result (uint8), output_scale (int32)

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -541,6 +541,7 @@ class RMSNormNvfp4QuantPattern:
                 input=result_rms,
                 output_scale=output_scale,
                 input_scale=input_scale,
+                is_sf_swizzled_layout=True,
             )
             return at[1], at[2]
 

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -517,12 +517,12 @@ class RMSNormNvfp4QuantPattern:
         self.FUSED_OP = FUSED_OPS[FusedRMSQuantKey(kNvfp4Dynamic, False)]
 
     def get_inputs(self) -> list[torch.Tensor]:
-        # result (uint8), output_scale (int32)
-        # input (bf16), weight (bf16), input_scale (fp32)
+        # Use rmsnorm_matcher.inputs() to respect model dtype (bf16 or fp16)
+        rms_inputs = self.rmsnorm_matcher.inputs()  # [input, weight]
+        input_ = rms_inputs[0]
+        weight = rms_inputs[1]
         result = torch.empty(5, 32, dtype=FP4_DTYPE, device="cuda")
         output_scale = empty_i32(128, 4)
-        input_ = empty_bf16(5, 64)
-        weight = empty_bf16(64)
         input_scale = empty_fp32(1, 1)
         return [result, output_scale, input_, weight, input_scale]
 


### PR DESCRIPTION
## Purpose
This commit implements rmsnorm + fp4 quant fusion, and integrate to rmsnorm + quant fusion pass, fixing #32612 
This PR also includes code refactoring for better modularity and maintainability.

To enable the fusion, add the following compilation flags:
```
--compilation-config '{"custom_ops":["+rms_norm"]}'
```
Performance data provided below reflects testing conducted on a B200 platform.

## E2E results
### Dense model

| Metric | MAIN | PR | Delta | Status |
|--------|------|-----|-------|--------|
| Requests/s (Mean) | 6.0 | 6.0 | 0.0% | ✅ Stable |
| Input Tokens/s (Mean) | 648.5 | 649.8 | +0.2% | ✅ Improved |
| Output Tokens/s (Mean) | 803.7 | 805.3 | +0.2% | ✅ Improved |
| Total Tokens/s (Mean) | 1419.7 | 1422.5 | +0.2% | ✅ Improved |

```shell
vllm serve nvidia/Llama-3.3-70B-Instruct-NVFP4 --compilation-config '{"custom_ops":["+rms_norm"]}'
guidellm benchmark --target "http://localhost:8000/v1" --profile concurrent --rate 10 --data "prompt_tokens=64,output_tokens=128" --max-seconds 30
```
```text
# MAIN

|============|=====|======|=======|======|=======|=======|========|=======|=======|========|
| Benchmark  | Requests               |||| Input Tokens || Output Tokens || Total Tokens  ||
| Strategy   | Per Sec   || Concurrency || Per Sec      || Per Sec       || Per Sec       ||
|            | Mdn | Mean | Mdn   | Mean | Mdn   | Mean  | Mdn    | Mean  | Mdn   | Mean   |
|------------|-----|------|-------|------|-------|-------|--------|-------|-------|--------|
| concurrent | 1.3 | 6.0  | 10.0  | 10.0 | 126.1 | 648.5 | 276.0  | 803.7 | 278.0 | 1419.7 |
|============|=====|======|=======|======|=======|=======|========|=======|=======|========|

# PR

|============|=====|======|=======|======|=======|=======|========|=======|=======|========|
| Benchmark  | Requests               |||| Input Tokens || Output Tokens || Total Tokens  ||
| Strategy   | Per Sec   || Concurrency || Per Sec      || Per Sec       || Per Sec       ||
|            | Mdn | Mean | Mdn   | Mean | Mdn   | Mean  | Mdn    | Mean  | Mdn   | Mean   |
|------------|-----|------|-------|------|-------|-------|--------|-------|-------|--------|
| concurrent | 1.3 | 6.0  | 10.0  | 10.0 | 126.3 | 649.8 | 270.3  | 805.3 | 272.6 | 1422.5 |
|============|=====|======|=======|======|=======|=======|========|=======|=======|========|
```

### MoE Model

| Metric | MAIN | PR | Delta | Status |
|--------|------|-----|-------|--------|
| Requests/s (Mean) | 15.0 | 15.0 | 0.0% | ✅ Stable |
| Input Tokens/s (Mean) | 1117.8 | 1119.1 | +0.1% | ✅ Improved |
| Output Tokens/s (Mdn) | 908.1 | 1414.1 | +55.7% | 🚀 Significant |
| Output Tokens/s (Mean) | 1946.6 | 1948.5 | +0.1% | ✅ Improved |
| Total Tokens/s (Mean) | 3049.0 | 3050.8 | +0.06% | ✅ Improved |

```shell
vllm serve nvidia/Qwen3-30B-A3B-NVFP4 --compilation-config '{"custom_ops":["+rms_norm"]}'
guidellm benchmark --target "http://localhost:8000/v1" --profile concurrent --rate 10 --data "prompt_tokens=64,output_tokens=128" --max-seconds 30
```
```text
# MAIN

|============|=====|======|=======|======|=======|========|=======|========|=======|========|
| Benchmark  | Requests               |||| Input Tokens  || Output Tokens || Total Tokens  ||
| Strategy   | Per Sec   || Concurrency || Per Sec       || Per Sec       || Per Sec       ||
|            | Mdn | Mean | Mdn   | Mean | Mdn   | Mean   | Mdn   | Mean   | Mdn   | Mean   |
|------------|-----|------|-------|------|-------|--------|-------|--------|-------|--------|
| concurrent | 3.1 | 15.0 | 10.0  | 10.0 | 237.4 | 1117.8 | 908.1 | 1946.6 | 926.2 | 3049.0 |
|============|=====|======|=======|======|=======|========|=======|========|=======|========|

# PR

|============|=====|======|=======|======|=======|========|========|========|========|========|
| Benchmark  | Requests               |||| Input Tokens  || Output Tokens  || Total Tokens   ||
| Strategy   | Per Sec   || Concurrency || Per Sec       || Per Sec        || Per Sec        ||
|            | Mdn | Mean | Mdn   | Mean | Mdn   | Mean   | Mdn    | Mean   | Mdn    | Mean   |
|------------|-----|------|-------|------|-------|--------|--------|--------|--------|--------|
| concurrent | 3.1 | 15.0 | 10.0  | 10.0 | 225.6 | 1119.1 | 1414.1 | 1948.5 | 1443.1 | 3050.8 |
|============|=====|======|=======|======|=======|========|========|========|========|========|
```


## Accuracy test
### Dense model

| Metric | MAIN | PR | Delta | Status |
|--------|------|-----|-------|--------|
| Accuracy | 0.930 | 0.926 | -0.4% | ✅ Acceptable |
| Invalid responses | 0.000 | 0.001 | +0.1% | ✅ Acceptable |
| Questions/s | 63.698 | 63.053 | -1.0% | ✅ Acceptable |
| Output Tokens/s | 5959.65 | 5899.81 | -1.0% | ✅ Acceptable |

```text
# MAIN

Results:
Accuracy: 0.930
Invalid responses: 0.000
Total latency: 20.707 s
Questions per second: 63.698
Total output tokens: 123407
Output tokens per second: 5959.653

# PR

Results:
Accuracy: 0.926
Invalid responses: 0.001
Total latency: 20.919 s
Questions per second: 63.053
Total output tokens: 123417
Output tokens per second: 5899.810
```

### MoE Model

| Metric | MAIN | PR | Delta | Status |
|--------|------|-----|-------|--------|
| Accuracy | 0.884 | 0.884 | 0.0% | ✅ Stable |
| Invalid responses | 0.001 | 0.001 | 0.0% | ✅ Stable |
| Questions/s | 116.100 | 114.990 | -1.0% | ✅ Acceptable |
| Output Tokens/s | 13637.47 | 13508.78 | -0.9% | ✅ Acceptable |

```text
# MAIN

Results:
Accuracy: 0.884
Invalid responses: 0.001
Total latency: 11.361 s
Questions per second: 116.100
Total output tokens: 154934
Output tokens per second: 13637.468

# PR

Results:
Accuracy: 0.884
Invalid responses: 0.001
Total latency: 11.471 s
Questions per second: 114.990
Total output tokens: 154953
Output tokens per second: 13508.784
```


## Unit tests
`pytest tests/kernels/quantization/test_rmsnorm_nvfp4_quant.py` -- ALL PASSED
`pytest tests/kernels/quantization/test_nvfp4_quant.py` -- ALL PASSED
`pytest tests/compile/test_fusion.py` -- ALL PASSED


## Tested Platforms

The RMSNorm + FP4 quantization fusion has been validated on the following platforms:

| Platform | Compute Capability | Status |
|----------|-------------------|--------|
| NVIDIA B200 | SM100 | ✅ Verified |
| NVIDIA RTX 5090 | SM120 | ✅ Verified |