### PR TITLE
[Core][Bugfix] allow graceful worker termination

### DIFF
--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -391,14 +391,17 @@ class MultiprocExecutor(Executor):
                 time.sleep(0.1)
             return False
 
+        active_procs = lambda: [proc for proc in worker_procs if proc.is_alive()]
+        # Give processes time to clean themselves up properly first
+        if wait_for_termination(active_procs(), 4):
+            return
+
         # Send SIGTERM if still running
-        active_procs = [proc for proc in worker_procs if proc.is_alive()]
-        for p in active_procs:
+        for p in active_procs():
             p.terminate()
         if not wait_for_termination(active_procs, 4):
             # Send SIGKILL if still running
-            active_procs = [p for p in active_procs if p.is_alive()]
-            for p in active_procs:
+            for p in active_procs():
                 p.kill()
 
     def shutdown(self):
@@ -701,6 +704,9 @@ class WorkerProc:
             nonlocal shutdown_requested
             if not shutdown_requested:
                 shutdown_requested = True
+                logger.debug(
+                    "WorkerProc handling signal %d, raising SystemExit", signum
+                )
                 raise SystemExit()
 
         # Either SIGTERM or SIGINT will terminate the worker
@@ -773,6 +779,13 @@ class WorkerProc:
             # any worker dies. Set this value so we don't re-throw
             # SystemExit() to avoid zmq exceptions in __del__.
             shutdown_requested = True
+
+        except SystemExit as e:
+            # SystemExit is raised on SIGTERM or SIGKILL, which usually indicates that
+            # the graceful shutdown process did not succeed
+            logger.warning("WorkerProc was terminated")
+            # SystemExit must never be ignored
+            raise e
 
         finally:
             if ready_writer is not None:

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -399,7 +399,7 @@ class MultiprocExecutor(Executor):
         # Send SIGTERM if still running
         for p in active_procs():
             p.terminate()
-        if not wait_for_termination(active_procs, 4):
+        if not wait_for_termination(active_procs(), 4):
             # Send SIGKILL if still running
             for p in active_procs():
                 p.kill()


### PR DESCRIPTION
## Purpose

This PR fixes a small bug where workers are immediately sent a SIGTERM on shutdown. 

(This was extracted from #28053)

When using the MultiprocExecutor, the parent process signals the local worker processes to shut down by closing a pipe (`self.death_pipe`). The worker processes each have a thread waiting for this pipe to close, and will gracefully shut themselves down when it does. However, the parent process immediately sends all workers a `SIGTERM` right after closing its death pipe, giving them no time to clean up and terminate before they're interrupted with the `SIGTERM`. This PR adds a small waiting period before sending the `SIGTERM`s, giving the workers time to clean up after themselves.

I've added a warning log here anywhere that the worker processes raise a `SystemExit` exception, which will happen if they ever handle a `SIGTERM` or `SIGKILL`. I've verified that this does not log normally when shutting down a 2-way tensor parallel deployment on H100s.

## Test Plan

Boot up a tensor parallel deployment:

```
vllm serve ibm-granite/granite-3.3-8b-instruct --tensor-parallel-size 2
```

And in a separate terminal, kill it:
```
pkill -e vllm
```

## Test Result

The logs show the workers properly handling their graceful shutdowns, with no warning log:
```
...
(APIServer pid=10439) INFO 01-23 20:14:10 [launcher.py:46] Route: /pooling, Methods: POST
(APIServer pid=10439) INFO 01-23 20:14:20 [launcher.py:110] Shutting down FastAPI HTTP server.
(Worker_TP0 pid=10583) INFO 01-23 20:14:20 [multiproc_executor.py:730] Parent process exited, terminating worker
(Worker_TP1 pid=10584) INFO 01-23 20:14:20 [multiproc_executor.py:730] Parent process exited, terminating worker
(Worker_TP0 pid=10583) INFO 01-23 20:14:20 [multiproc_executor.py:774] WorkerProc shutting down.
(Worker_TP1 pid=10584) INFO 01-23 20:14:20 [multiproc_executor.py:774] WorkerProc shutting down.
```
