### PR TITLE
[Perf] Overlap workspace_buffer.fill_(0) with compute in MLA attention

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -214,6 +214,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_nvidia_artifactory
 from vllm.utils.math_utils import cdiv, round_down
+from vllm.utils.torch_utils import aux_stream
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionLayer,
@@ -1342,6 +1343,12 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
+        # Flag indicating whether the prefill backend requires workspace buffer
+        # zeroing (only TRT-LLM ragged attention needs this)
+        self._uses_trtllm_workspace_fill = False
+        # Event to synchronize workspace buffer fill operation across streams
+        self._workspace_fill_event: torch.cuda.Event | None = None
+
         if use_trtllm_ragged_deepseek_prefill():
             logger.info_once(
                 "Using TRT-LLM ragged DeepSeek prefill for MLA", scope="local"
@@ -1351,6 +1358,7 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             )
             self._run_prefill_new_tokens = self._run_prefill_new_tokens_trtllm_ragged
             self._pad_v = False
+            self._uses_trtllm_workspace_fill = True
         elif use_flashinfer_prefill():
             logger.info_once("Using FlashInfer prefill for MLA", scope="local")
             self._run_prefill_context_chunk = self._run_prefill_context_chunk_fi
@@ -1585,6 +1593,40 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             return ret[0], ret[1].transpose(0, 1).contiguous()
         return ret
 
+    def _start_workspace_fill_async(self, prefill: MLACommonPrefillMetadata) -> None:
+        """Start workspace buffer fill in auxiliary stream for overlap.
+
+        This launches workspace_buffer.fill_(0) in a separate CUDA stream
+        so it can overlap with compute operations (e.g., kv_b_proj, gather).
+        The main stream must call _wait_workspace_fill() before using the buffer.
+        """
+        if not self._uses_trtllm_workspace_fill:
+            return
+
+        assert prefill.workspace_buffer is not None
+        stream = aux_stream()
+        if stream is not None:
+            # Create event lazily
+            if self._workspace_fill_event is None:
+                self._workspace_fill_event = torch.cuda.Event()
+            # Launch fill in auxiliary stream
+            with torch.cuda.stream(stream):
+                prefill.workspace_buffer.fill_(0)
+            # Record event so main stream can wait
+            self._workspace_fill_event.record(stream)
+        else:
+            # Fallback: fill synchronously on current stream
+            prefill.workspace_buffer.fill_(0)
+
+    def _wait_workspace_fill(self) -> None:
+        """Wait for async workspace buffer fill to complete.
+
+        Must be called before using the workspace buffer after
+        _start_workspace_fill_async().
+        """
+        if self._workspace_fill_event is not None:
+            torch.cuda.current_stream().wait_event(self._workspace_fill_event)
+
     def _run_prefill_context_chunk_trtllm_ragged(
         self, prefill: MLACommonPrefillMetadata, chunk_idx: int, q, k, v
     ):
@@ -1602,7 +1644,8 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
             device=q.device,
             dtype=q.dtype,
         )
-        prefill.workspace_buffer.fill_(0)
+        # Wait for async fill started by _start_workspace_fill_async()
+        self._wait_workspace_fill()
 
         attn_out, lse = trtllm_ragged_attention_deepseek(
             query=q,
@@ -1670,6 +1713,10 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         iters = len(prefill_metadata.chunked_context.seq_tot)
         workspace = prefill_metadata.chunked_context.workspace
         for i in range(iters):
+            # Start workspace buffer fill in aux stream to overlap with
+            # gather_and_maybe_dequant_cache, kv_b_proj, and _concat_k_nope_k_pe
+            self._start_workspace_fill_async(prefill_metadata)
+
             toks = prefill_metadata.chunked_context.seq_tot[i]
             ops.gather_and_maybe_dequant_cache(
                 src_cache=kv_c_and_k_pe_cache,
@@ -1743,6 +1790,10 @@ class MLACommonImpl(MLACommonBaseImpl[M], Generic[M]):
         workspace = prefill_metadata.chunked_context.workspace
 
         for i in range(iters):
+            # Start workspace buffer fill in aux stream to overlap with
+            # cp_gather_cache, all_gather, reorg_kvcache, and kv_b_proj
+            self._start_workspace_fill_async(prefill_metadata)
+
             toks = prefill_metadata.chunked_context.seq_tot[i]
             ops.cp_gather_cache(
                 src_cache=kv_c_and_k_pe_cache,

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -565,6 +565,121 @@ def aux_stream() -> torch.cuda.Stream | None:
     return _aux_stream
 
 
+@contextlib.contextmanager
+def run_on_aux_stream(
+    stream: torch.cuda.Stream | None = None,
+    skip_if_main_stream: bool = False,
+):
+    """
+    Context manager for running operations on the auxiliary CUDA stream.
+
+    This context manager handles the synchronization needed to safely run
+    operations on a separate CUDA stream and wait for them to complete.
+
+    On entry:
+        - The aux stream waits for the current (main) stream to complete
+          any pending work (ensures input tensors are ready)
+    On exit:
+        - The main stream waits for the aux stream to complete
+          (ensures output tensors are ready for use on the main stream)
+
+    Args:
+        stream: Optional CUDA stream to use. If None, uses aux_stream().
+        skip_if_main_stream: If True and stream is the current stream,
+            yields without any stream switching (avoids unnecessary overhead).
+
+    Yields:
+        The stream being used, or None if no stream switching occurred.
+
+    Example:
+        # Clone tensor before switching to avoid race conditions
+        hidden_states_clone = hidden_states.clone()
+        hidden_states_clone.record_stream(aux_stream())
+
+        with run_on_aux_stream() as stream:
+            if stream is not None:
+                output = some_operation(hidden_states_clone)
+
+    Note:
+        - If stream is None (e.g., on non-CUDA platforms), yields None
+          and no operations are performed.
+        - For tensors created in the aux stream that will be used on the
+          main stream, the exit synchronization ensures they are ready.
+        - For input tensors passed to the aux stream, use record_stream()
+          to prevent premature deallocation.
+    """
+    if stream is None:
+        stream = aux_stream()
+
+    if stream is None:
+        # Non-CUDA platform, nothing to do
+        yield None
+        return
+
+    if skip_if_main_stream and stream == current_stream():
+        yield None
+        return
+
+    # Wait for main stream work to complete before starting on aux stream
+    stream.wait_stream(current_stream())
+
+    try:
+        with torch.cuda.stream(stream):
+            yield stream
+    finally:
+        # Wait for aux stream work to complete before continuing on main stream
+        current_stream().wait_stream(stream)
+
+
+@contextlib.contextmanager
+def separate_stream(defer_sync: bool = False):
+    """Context manager for running code on a separate CUDA stream.
+
+    Args:
+        defer_sync: If True, returns a sync callable instead of
+            auto-synchronizing. If False, synchronizes automatically
+            on context exit.
+
+    Yields:
+        A sync callable that can be used to synchronize with the
+        separate stream. Safe to call multiple times (only syncs once).
+
+    Example:
+        # Auto-sync on exit
+        with separate_stream():
+            overlap_op()
+
+        # Deferred sync
+        with separate_stream(defer_sync=True) as sync:
+            overlap_op()
+
+        # ... do other work on default stream ...
+        sync()  # Synchronize when ready
+    """
+    stream = aux_stream()
+
+    if stream is None:
+        # Non-CUDA platform, yield a no-op sync function
+        yield lambda: None
+        return
+
+    event = torch.cuda.Event()
+    synced = False
+
+    def sync():
+        nonlocal synced
+        if not synced:
+            event.synchronize()
+            synced = True
+
+    with torch.cuda.stream(stream):
+        yield sync
+        event.record(stream)
+
+    if not defer_sync:
+        sync()
+
+
 @lru_cache(maxsize=8)
 def _cuda_device_count_stateless(cuda_visible_devices: str | None = None) -> int:
     # Note: cuda_visible_devices is not used, but we keep it as an argument for


### PR DESCRIPTION
Move workspace_buffer.fill_(0) for TRT-LLM ragged attention to run in a separate CUDA stream (aux_stream) so it can overlap with the compute operations that precede the attention kernel:

- gather_and_maybe_dequant_cache (or cp_gather_cache for context parallel)
- kv_b_proj
- _concat_k_nope_k_pe

The fill operation is launched at the start of each loop iteration in _compute_prefill_context and _context_parallel_compute_prefill_context, allowing it to execute concurrently with these compute operations on the main stream. The main stream then waits for completion right before the attention kernel uses the workspace buffer.

This optimization only affects the TRT-LLM ragged DeepSeek prefill path. Other attention backends are unaffected.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

