### PR TITLE
[Docs] Fix Apple silicon include path in CPU installation docs

### DIFF
--- a/docs/getting_started/installation/cpu.md
+++ b/docs/getting_started/installation/cpu.md
@@ -131,7 +131,7 @@ VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_VARIANT=cpu VLLM_TARGET_DEVICE=cpu
 
 === "Apple silicon"
 
-    --8<-- "docs/getting_started/installation/cpu.arm.inc.md:build-image-from-source"
+    --8<-- "docs/getting_started/installation/cpu.apple.inc.md:build-image-from-source"
 
 === "IBM Z (S390X)"
     --8<-- "docs/getting_started/installation/cpu.s390x.inc.md:build-image-from-source"


### PR DESCRIPTION
## Summary
- Fix incorrect include path in the CPU installation documentation
- The "Build image from source" section for Apple silicon was referencing `cpu.arm.inc.md` instead of `cpu.apple.inc.md`

## Test Plan
- Build the documentation locally with `mkdocs build` or `mkdocs serve`
- Verify the Apple silicon section renders correctly without include errors

## Risk
- Very low risk: documentation-only change
- Rollback: simple revert if needed