### PR TITLE
[Docs] Sync quantization list between README files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ vLLM is fast with:
 - Efficient management of attention key and value memory with [**PagedAttention**](https://blog.vllm.ai/2023/06/20/vllm.html)
 - Continuous batching of incoming requests
 - Fast model execution with CUDA/HIP graph
-- Quantization: [GPTQ](https://arxiv.org/abs/2210.17323), [AWQ](https://arxiv.org/abs/2306.00978), INT4, INT8, and FP8
+- Quantization: [GPTQ](https://arxiv.org/abs/2210.17323), [AWQ](https://arxiv.org/abs/2306.00978), [AutoRound](https://arxiv.org/abs/2309.05516), INT4, INT8, and FP8
 - Optimized CUDA kernels, including integration with FlashAttention and FlashInfer.
 - Speculative decoding
 - Chunked prefill


### PR DESCRIPTION
## Summary
- Add AutoRound to the quantization list in `docs/README.md`
- Ensures consistency with the root `README.md` which already lists AutoRound

## Test Plan
- Build documentation with `mkdocs build` to verify no rendering issues
- Visual inspection of the docs landing page

## Risk
- Very low risk: documentation-only change, adding one line