### PR TITLE
[CI] Add pip and pre-commit caching to pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,6 +20,13 @@ jobs:
     - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
       with:
         python-version: "3.12"
+        cache: 'pip'
+    - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+        restore-keys: |
+          pre-commit-${{ runner.os }}-
     - run: echo "::add-matcher::.github/workflows/matchers/actionlint.json"
     - run: echo "::add-matcher::.github/workflows/matchers/markdownlint.json"
     - run: echo "::add-matcher::.github/workflows/matchers/mypy.json"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,9 +24,9 @@ jobs:
     - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.cache/pre-commit
-        key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+        key: pre-commit-${{ runner.os }}-py3.12-${{ hashFiles('.pre-commit-config.yaml') }}
         restore-keys: |
-          pre-commit-${{ runner.os }}-
+          pre-commit-${{ runner.os }}-py3.12-
     - run: echo "::add-matcher::.github/workflows/matchers/actionlint.json"
     - run: echo "::add-matcher::.github/workflows/matchers/markdownlint.json"
     - run: echo "::add-matcher::.github/workflows/matchers/mypy.json"


### PR DESCRIPTION
## Summary
- Add `cache: 'pip'` to speed up pip dependency installation
- Add `actions/cache` for `~/.cache/pre-commit` to cache pre-commit hook environments
- Cache key is based on `.pre-commit-config.yaml` hash for proper invalidation

## Test Plan
- Run the pre-commit workflow on a test PR
- Verify cache is created on first run (check logs for "Cache saved")
- Verify cache is restored on subsequent runs (check logs for "Cache restored")
- Confirm workflow time decreases by ~30-60 seconds on cache hits

## Risk
- Low risk: caching is a standard CI practice
- Rollback: remove the cache steps if issues occur
- No functional changes to the workflow