### PR TITLE
[Tests] Clarify pytest skip reasons with actionable context

### DIFF
--- a/tests/samplers/test_beam_search.py
+++ b/tests/samplers/test_beam_search.py
@@ -20,7 +20,7 @@ MM_BEAM_WIDTHS = [2]
 MODELS = ["TinyLlama/TinyLlama-1.1B-Chat-v1.0"]
 
 
-@pytest.mark.skip_v1  # FIXME: This fails on V1 right now.
+@pytest.mark.skip_v1  # V1 engine does not yet support beam search
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("dtype", ["half"])
 @pytest.mark.parametrize("max_tokens", MAX_TOKENS)
@@ -62,7 +62,7 @@ def test_beam_search_single_input(
             )
 
 
-@pytest.mark.skip_v1  # FIXME: This fails on V1 right now.
+@pytest.mark.skip_v1  # V1 engine does not yet support beam search
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("dtype", ["half"])
 @pytest.mark.parametrize("max_tokens", MAX_TOKENS)

--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -48,7 +48,9 @@ def test_topk_impl_equivalence():
     assert torch.allclose(result1, result2)
 
 
-@pytest.mark.skip(reason="FIXME: This test is failing right now.")
+@pytest.mark.skip(reason="FlashInfer top-k/top-p renorm comparison fails; "
+                         "needs investigation of tolerance threshold or "
+                         "interface differences between Python and FlashInfer implementations")
 def test_flashinfer_sampler():
     """
     This test verifies that the FlashInfer top-k and top-p sampling

--- a/tests/v1/sample/test_topk_topp_sampler.py
+++ b/tests/v1/sample/test_topk_topp_sampler.py
@@ -48,9 +48,11 @@ def test_topk_impl_equivalence():
     assert torch.allclose(result1, result2)
 
 
-@pytest.mark.skip(reason="FlashInfer top-k/top-p renorm comparison fails; "
-                         "needs investigation of tolerance threshold or "
-                         "interface differences between Python and FlashInfer implementations")
+@pytest.mark.skip(
+    reason="FlashInfer top-k/top-p renorm comparison fails; "
+    "needs investigation of tolerance threshold or "
+    "interface differences between Python and FlashInfer implementations"
+)
 def test_flashinfer_sampler():
     """
     This test verifies that the FlashInfer top-k and top-p sampling


### PR DESCRIPTION
## Summary
Replace vague FIXME comments in test skip markers with more descriptive reasons:

- `tests/v1/sample/test_topk_topp_sampler.py`: Changed from "FIXME: This test is failing right now" to explain the FlashInfer top-k/top-p renorm comparison issue
- `tests/samplers/test_beam_search.py`: Changed from "FIXME: This fails on V1 right now" to clarify that V1 engine does not yet support beam search

## Test Plan
- Run `pytest --collect-only` on the affected test files to verify no syntax errors
- No functional changes to test behavior

## Risk
- No risk: only changes to skip reason strings, no test logic changes