### PR TITLE
[Perf] Cache exc.errors() result in validation exception handler

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -558,7 +558,8 @@ def build_app(args: Namespace) -> FastAPI:
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(_: Request, exc: RequestValidationError):
         param = None
-        for error in exc.errors():
+        errors = exc.errors()
+        for error in errors:
             if "ctx" in error and "error" in error["ctx"]:
                 ctx_error = error["ctx"]["error"]
                 if isinstance(ctx_error, VLLMValidationError):
@@ -566,9 +567,9 @@ def build_app(args: Namespace) -> FastAPI:
                     break
 
         exc_str = str(exc)
-        errors_str = str(exc.errors())
+        errors_str = str(errors)
 
-        if exc.errors() and errors_str and errors_str != exc_str:
+        if errors and errors_str and errors_str != exc_str:
             message = f"{exc_str} {errors_str}"
         else:
             message = exc_str


### PR DESCRIPTION
## Summary
Cache the result of `exc.errors()` to avoid calling it multiple times in the `validation_exception_handler`.

**Before:** `exc.errors()` called 3 times
**After:** Result cached in `errors` variable, used 3 times

## Motivation
- Avoids redundant method calls
- Improves code readability
- Error handling paths should be efficient

## Test Plan
- Existing OpenAI API server tests should pass
- Send an invalid request to verify error response format is unchanged

## Risk
- Very low risk: simple variable caching
- No change to error response format or behavior