### PR TITLE
[Tests] Replace flaky sleep with polling in test_background_cancel

### DIFF
--- a/tests/v1/entrypoints/openai/serving_responses/test_stateful.py
+++ b/tests/v1/entrypoints/openai/serving_responses/test_stateful.py
@@ -71,16 +71,16 @@ async def test_background_cancel(client: openai.AsyncOpenAI):
 
     # Cancel the response before it is completed.
     # Poll until the response is no longer queued (started processing) or timeout
+    loop = asyncio.get_running_loop()
+    start_time = loop.time()
     max_wait_seconds = 5.0
     poll_interval = 0.1
-    elapsed = 0.0
-    while elapsed < max_wait_seconds:
-        await asyncio.sleep(poll_interval)
-        elapsed += poll_interval
+    while loop.time() - start_time < max_wait_seconds:
         response = await client.responses.retrieve(response.id)
         if response.status != "queued":
             # Started processing or completed - try to cancel
             break
+        await asyncio.sleep(poll_interval)
 
     response = await client.responses.cancel(response.id)
     assert response.status == "cancelled"

--- a/tests/v1/entrypoints/openai/serving_responses/test_stateful.py
+++ b/tests/v1/entrypoints/openai/serving_responses/test_stateful.py
@@ -70,15 +70,28 @@ async def test_background_cancel(client: openai.AsyncOpenAI):
     assert response.status == "queued"
 
     # Cancel the response before it is completed.
-    # FIXME: This test can be flaky.
-    await asyncio.sleep(0.5)
+    # Poll until the response is no longer queued (started processing) or timeout
+    max_wait_seconds = 5.0
+    poll_interval = 0.1
+    elapsed = 0.0
+    while elapsed < max_wait_seconds:
+        await asyncio.sleep(poll_interval)
+        elapsed += poll_interval
+        response = await client.responses.retrieve(response.id)
+        if response.status != "queued":
+            # Started processing or completed - try to cancel
+            break
+
     response = await client.responses.cancel(response.id)
     assert response.status == "cancelled"
 
-    # Make sure the response status remains unchanged.
-    await asyncio.sleep(5)
-    response = await client.responses.retrieve(response.id)
-    assert response.status == "cancelled"
+    # Make sure the response status remains unchanged after some time.
+    max_retries = 10
+    for _ in range(max_retries):
+        await asyncio.sleep(0.5)
+        response = await client.responses.retrieve(response.id)
+        # Verify status is still cancelled
+        assert response.status == "cancelled"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Replace the fixed 0.5s sleep (marked with `# FIXME: This test can be flaky`) with a proper polling loop that waits for the response status to change before attempting to cancel.

## Changes
- Poll with 0.1s intervals until status changes from "queued" (max 5s)
- Use proper assertions in the post-cancel verification loop
- Remove FIXME comment as the flakiness is addressed

## Motivation
- Fixed sleeps are unreliable: too short on slow machines, wasteful on fast ones
- Polling adapts to actual server response times
- Reduces test flakiness in CI

## Test Plan
- Run `pytest tests/v1/entrypoints/openai/serving_responses/test_stateful.py::test_background_cancel` multiple times
- Verify test passes consistently

## Risk
- Low risk: only changes test synchronization logic
- No changes to production code