### PR TITLE
[Docs] Update README with uv recommendation and Python version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,15 @@ Find the full list of supported models [here](https://docs.vllm.ai/en/latest/mod
 
 ## Getting Started
 
-Install vLLM with `pip` or [from source](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/index.html#build-wheel-from-source):
+**Requirements:** Python 3.10 - 3.13
+
+Install vLLM with `uv` (recommended) or `pip`. For source builds and other platforms, see the [installation guide](https://docs.vllm.ai/en/latest/getting_started/installation.html).
 
 ```bash
+# Recommended: using uv (https://docs.astral.sh/uv/)
+uv pip install vllm --torch-backend=auto
+
+# Alternative: using pip
 pip install vllm
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Install vLLM with `uv` (recommended) or `pip`. For source builds and other platf
 # Recommended: using uv (https://docs.astral.sh/uv/)
 uv pip install vllm --torch-backend=auto
 
-# Alternative: using pip
+# Alternative: using pip (see installation guide for GPU setup)
 pip install vllm
 ```
 


### PR DESCRIPTION
## Summary
Update the README.md "Getting Started" section to:
- Add Python version requirements (3.10 - 3.13) prominently
- Recommend `uv` as the preferred installation method
- Keep `pip` as an alternative for users who prefer it
- Update installation guide link to the general installation page

## Motivation
- `uv` is significantly faster than `pip` for installing vLLM
- The docs already recommend `uv`, README should be consistent
- Python version requirements are important for new users
- Link to general installation page covers more platforms

## Changes
```markdown
**Requirements:** Python 3.10 - 3.13

Install vLLM with `uv` (recommended) or `pip`. For source builds...

# Recommended: using uv (https://docs.astral.sh/uv/)
uv pip install vllm --torch-backend=auto

# Alternative: using pip
pip install vllm
```

## Test Plan
- Visual inspection of README rendering on GitHub
- Verify both installation commands work

## Risk
- Low risk: documentation-only change
- Both `pip` and `uv` paths are preserved