### PR TITLE
[Core]Consolidate RoPE-related parsing into ModelArchitectureConfig

### DIFF
--- a/tests/config/base_model_arch_groundtruth.json
+++ b/tests/config/base_model_arch_groundtruth.json
@@ -14,7 +14,8 @@
         "num_experts": 0,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.float32"
+        "dtype": "torch.float32",
+        "model_max_len": 2048
     },
     "mistralai/Mamba-Codestral-7B-v0.1": {
         "architectures": [
@@ -31,7 +32,8 @@
         "num_experts": 0,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 128000
     },
     "ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11": {
         "architectures": [
@@ -48,7 +50,8 @@
         "num_experts": 0,
         "is_deepseek_mla": false,
         "is_multimodal_model": true,
-        "dtype": "torch.float32"
+        "dtype": "torch.float32",
+        "model_max_len": 2048
     },
     "tiiuae/falcon-mamba-7b-instruct": {
         "architectures": [
@@ -65,7 +68,8 @@
         "num_experts": 0,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 2048
     },
     "Zyphra/Zamba2-7B-instruct": {
         "architectures": [
@@ -82,7 +86,8 @@
         "num_experts": 0,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 4096
     },
     "mosaicml/mpt-7b": {
         "architectures": [
@@ -133,7 +138,8 @@
         "num_experts": 0,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 2048
     },
     "tiiuae/falcon-40b": {
         "architectures": [
@@ -150,7 +156,8 @@
         "num_experts": 0,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 2048
     },
     "luccafong/deepseek_mtp_main_random": {
         "architectures": [
@@ -167,7 +174,8 @@
         "num_experts": 72,
         "is_deepseek_mla": true,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 163840
     },
     "luccafong/deepseek_mtp_draft_random": {
         "architectures": [
@@ -184,7 +192,8 @@
         "num_experts": 72,
         "is_deepseek_mla": true,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 163840
     },
     "Qwen/Qwen3-Next-80B-A3B-Instruct": {
         "architectures": [
@@ -201,7 +210,8 @@
         "num_experts": 512,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 262144
     },
     "tiny-random/qwen3-next-moe": {
         "architectures": [
@@ -218,7 +228,8 @@
         "num_experts": 32,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 262144
     },
     "zai-org/GLM-4.5": {
         "architectures": [
@@ -235,7 +246,8 @@
         "num_experts": 160,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 131072
     },
     "baidu/ERNIE-4.5-21B-A3B-PT": {
         "architectures": [
@@ -252,7 +264,8 @@
         "num_experts": 64,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 131072
     },
     "lmsys/gpt-oss-20b-bf16": {
         "architectures": [
@@ -269,7 +282,8 @@
         "num_experts": 32,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 131072
     },
     "deepseek-ai/DeepSeek-V3.2-Exp": {
         "architectures": [
@@ -286,7 +300,8 @@
         "num_experts": 256,
         "is_deepseek_mla": true,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 163840
     },
     "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
         "architectures": [
@@ -303,7 +318,8 @@
         "num_experts": 16,
         "is_deepseek_mla": false,
         "is_multimodal_model": true,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 10485760
     },
     "nvidia/Llama-3_3-Nemotron-Super-49B-v1": {
         "architectures": [
@@ -320,7 +336,8 @@
         "num_experts": 0,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 131072
     },
     "XiaomiMiMo/MiMo-7B-RL": {
         "architectures": [
@@ -337,7 +354,8 @@
         "num_experts": 0,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 32768
     },
     "meituan-longcat/LongCat-Flash-Chat": {
         "architectures": [
@@ -354,6 +372,7 @@
         "num_experts": 512,
         "is_deepseek_mla": true,
         "is_multimodal_model": false,
-        "dtype": "torch.float32"
+        "dtype": "torch.float32",
+        "model_max_len": 131072
     }
 }

--- a/tests/config/base_model_arch_groundtruth.json
+++ b/tests/config/base_model_arch_groundtruth.json
@@ -15,7 +15,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.float32",
-        "model_max_len": 2048
+        "max_model_len": 2048
     },
     "mistralai/Mamba-Codestral-7B-v0.1": {
         "architectures": [
@@ -33,7 +33,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 128000
+        "max_model_len": 128000
     },
     "ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11": {
         "architectures": [
@@ -51,7 +51,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": true,
         "dtype": "torch.float32",
-        "model_max_len": 2048
+        "max_model_len": 2048
     },
     "tiiuae/falcon-mamba-7b-instruct": {
         "architectures": [
@@ -69,7 +69,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 2048
+        "max_model_len": 2048
     },
     "Zyphra/Zamba2-7B-instruct": {
         "architectures": [
@@ -87,7 +87,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 4096
+        "max_model_len": 4096
     },
     "mosaicml/mpt-7b": {
         "architectures": [
@@ -139,7 +139,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 2048
+        "max_model_len": 2048
     },
     "tiiuae/falcon-40b": {
         "architectures": [
@@ -157,7 +157,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 2048
+        "max_model_len": 2048
     },
     "luccafong/deepseek_mtp_main_random": {
         "architectures": [
@@ -175,7 +175,7 @@
         "is_deepseek_mla": true,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 163840
+        "max_model_len": 163840
     },
     "luccafong/deepseek_mtp_draft_random": {
         "architectures": [
@@ -193,7 +193,7 @@
         "is_deepseek_mla": true,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 163840
+        "max_model_len": 163840
     },
     "Qwen/Qwen3-Next-80B-A3B-Instruct": {
         "architectures": [
@@ -211,7 +211,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 262144
+        "max_model_len": 262144
     },
     "tiny-random/qwen3-next-moe": {
         "architectures": [
@@ -229,7 +229,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 262144
+        "max_model_len": 262144
     },
     "zai-org/GLM-4.5": {
         "architectures": [
@@ -247,7 +247,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 131072
+        "max_model_len": 131072
     },
     "baidu/ERNIE-4.5-21B-A3B-PT": {
         "architectures": [
@@ -265,7 +265,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 131072
+        "max_model_len": 131072
     },
     "lmsys/gpt-oss-20b-bf16": {
         "architectures": [
@@ -283,7 +283,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 131072
+        "max_model_len": 131072
     },
     "deepseek-ai/DeepSeek-V3.2-Exp": {
         "architectures": [
@@ -301,7 +301,7 @@
         "is_deepseek_mla": true,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 163840
+        "max_model_len": 163840
     },
     "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
         "architectures": [
@@ -319,7 +319,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": true,
         "dtype": "torch.bfloat16",
-        "model_max_len": 10485760
+        "max_model_len": 10485760
     },
     "nvidia/Llama-3_3-Nemotron-Super-49B-v1": {
         "architectures": [
@@ -337,7 +337,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 131072
+        "max_model_len": 131072
     },
     "XiaomiMiMo/MiMo-7B-RL": {
         "architectures": [
@@ -355,7 +355,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 32768
+        "max_model_len": 32768
     },
     "meituan-longcat/LongCat-Flash-Chat": {
         "architectures": [
@@ -373,6 +373,6 @@
         "is_deepseek_mla": true,
         "is_multimodal_model": false,
         "dtype": "torch.float32",
-        "model_max_len": 131072
+        "max_model_len": 131072
     }
 }

--- a/tests/config/draft_model_arch_groundtruth.json
+++ b/tests/config/draft_model_arch_groundtruth.json
@@ -15,7 +15,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "torch.float32",
-        "model_max_len": 2048
+        "max_model_len": 2048
     },
     "luccafong/deepseek_mtp_draft_random": {
         "architectures": [
@@ -33,7 +33,7 @@
         "is_deepseek_mla": true,
         "is_multimodal_model": false,
         "dtype": "torch.bfloat16",
-        "model_max_len": 163840
+        "max_model_len": 163840
     },
     "eagle618/eagle-deepseek-v3-random": {
         "architectures": [
@@ -51,7 +51,7 @@
         "is_deepseek_mla": true,
         "is_multimodal_model": false,
         "dtype": "bfloat16",
-        "model_max_len": 163840
+        "max_model_len": 163840
     },
     "yuhuili/EAGLE-LLaMA3-Instruct-8B": {
         "architectures": [
@@ -69,7 +69,7 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "float16",
-        "model_max_len": 2048
+        "max_model_len": 2048
     },
     "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B": {
         "architectures": [
@@ -87,6 +87,6 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "float16",
-        "model_max_len": 2048
+        "max_model_len": 2048
     }
 }

--- a/tests/config/draft_model_arch_groundtruth.json
+++ b/tests/config/draft_model_arch_groundtruth.json
@@ -14,7 +14,8 @@
         "num_experts": 0,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "torch.float32"
+        "dtype": "torch.float32",
+        "model_max_len": 2048
     },
     "luccafong/deepseek_mtp_draft_random": {
         "architectures": [
@@ -31,7 +32,8 @@
         "num_experts": 72,
         "is_deepseek_mla": true,
         "is_multimodal_model": false,
-        "dtype": "torch.bfloat16"
+        "dtype": "torch.bfloat16",
+        "model_max_len": 163840
     },
     "eagle618/eagle-deepseek-v3-random": {
         "architectures": [
@@ -48,7 +50,8 @@
         "num_experts": 72,
         "is_deepseek_mla": true,
         "is_multimodal_model": false,
-        "dtype": "bfloat16"
+        "dtype": "bfloat16",
+        "model_max_len": 163840
     },
     "yuhuili/EAGLE-LLaMA3-Instruct-8B": {
         "architectures": [
@@ -65,7 +68,8 @@
         "num_experts": 0,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "float16"
+        "dtype": "float16",
+        "model_max_len": 2048
     },
     "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B": {
         "architectures": [
@@ -82,6 +86,7 @@
         "num_experts": 0,
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
-        "dtype": "float16"
+        "dtype": "float16",
+        "model_max_len": 2048
     }
 }

--- a/tests/config/test_model_arch_config.py
+++ b/tests/config/test_model_arch_config.py
@@ -91,11 +91,10 @@ def _assert_model_arch_config(
         assert model_arch_config.head_size == expected["head_size"]
 
 
-def _assert_model_config_methods(
-    model_config, expected: dict, check_head_size: bool = True
-):
-    """Assert model_config methods return expected values."""
+def _assert_model_config(model_config, expected: dict, check_head_size: bool = True):
+    """Assert model_config return expected values."""
     assert model_config.architectures == expected["architectures"]
+    assert model_config.max_model_len == expected["max_model_len"]
     assert model_config.get_vocab_size() == expected["vocab_size"]
     assert model_config.get_hidden_size() == expected["hidden_size"]
     assert model_config.get_total_num_kv_heads() == expected["total_num_kv_heads"]
@@ -120,7 +119,7 @@ def test_base_model_arch_config(model: str):
     )
 
     _assert_model_arch_config(model_config, expected)
-    _assert_model_config_methods(model_config, expected)
+    _assert_model_config(model_config, expected)
 
 
 @pytest.mark.parametrize(
@@ -147,6 +146,4 @@ def test_draft_model_arch_config(
     check_head_size = isinstance(expected["head_size"], int)
 
     _assert_model_arch_config(model_config, expected, check_head_size=check_head_size)
-    _assert_model_config_methods(
-        model_config, expected, check_head_size=check_head_size
-    )
+    _assert_model_config(model_config, expected, check_head_size=check_head_size)

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1919,8 +1919,8 @@ def _get_and_verify_max_len(
     """Get and verify the model's maximum length."""
     # Get pre-computed derived max model len info (includes RoPE scaling)
     max_len_info = model_arch_config.derived_max_model_len_info
-    derived_max_model_len = max_len_info.derived_max_model_len
-    max_len_key = max_len_info.max_len_key
+    derived_max_model_len = max_len_info.derived
+    max_len_key = max_len_info.derived_key
 
     # If sliding window is manually disabled, max_length should be less
     # than the sliding window length in the model config.
@@ -1967,15 +1967,12 @@ def _get_and_verify_max_len(
     # then use that derived from the model config as a default value.
     # When -1 is specified, the engine will later auto-fit to available memory.
     if max_model_len is None or max_model_len == -1:
-        # For LongRoPE, default to original_max_position_embeddings to avoid
-        # performance degradation for shorter sequences
-        if max_len_info.is_longrope:
-            original_max_pos = max_len_info.original_max_position_embeddings
-            if original_max_pos is not None:
-                max_model_len = int(original_max_pos)
-            else:
-                max_model_len = int(derived_max_model_len)
+        if max_len_info.default is not None:
+            # For LongRoPE, default to original_max_position_embeddings to avoid
+            # performance degradation for shorter sequences
+            max_model_len = int(max_len_info.default)
         else:
+            # Non-LongRoPE: use derived_max_model_len with caps applied
             max_model_len = int(derived_max_model_len)
         max_model_len = current_platform.check_max_model_len(max_model_len)
 

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1918,7 +1918,7 @@ def _get_and_verify_max_len(
 ) -> int:
     """Get and verify the model's maximum length."""
     # Get pre-computed derived max model len info (includes RoPE scaling)
-    max_len_info = model_arch_config.derived_max_model_len_info
+    max_len_info = model_arch_config.max_model_len_info
     derived_max_model_len = max_len_info.derived
     max_len_key = max_len_info.derived_key
 
@@ -1982,9 +1982,7 @@ def _get_and_verify_max_len(
         # Some models might have a separate key for specifying model_max_length
         # that will be bigger than derived_max_model_len. We compare user input
         # with model_max_length and allow this override when it's smaller.
-        # NOTE: model_max_length is not consolidated into model_arch_config
-        # as it's primarily used for tokenizer limits, not model architecture.
-        model_max_length = getattr(hf_config, "model_max_length", None)
+        model_max_length = max_len_info.model_max_length
         if model_max_length is None or max_model_len > model_max_length:
             msg = (
                 f"User-specified max_model_len ({max_model_len}) is greater "

--- a/vllm/config/model_arch.py
+++ b/vllm/config/model_arch.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from typing import Any
+from typing import Any, NamedTuple
 
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
@@ -8,6 +8,22 @@ from pydantic.dataclasses import dataclass
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+
+class DerivedMaxModelLenInfo(NamedTuple):
+    """Information about the derived maximum model length."""
+
+    derived_max_model_len: float
+    """The derived maximum model length after applying RoPE scaling."""
+
+    max_len_key: str | None
+    """The key in the config that was used to derive the max length."""
+
+    is_longrope: bool
+    """Whether the model uses LongRoPE (affects default max_model_len selection)."""
+
+    original_max_position_embeddings: int | None
+    """Original max position embeddings before RoPE scaling (for LongRoPE models)."""
 
 
 @dataclass(config=ConfigDict(arbitrary_types_allowed=True))
@@ -53,8 +69,8 @@ class ModelArchitectureConfig:
     is_deepseek_mla: bool
     """Whether the model is a DeepSeek MLA model."""
 
-    derived_max_model_len_and_key: tuple[float, str | None]
-    """Derived maximum model length and key from the hf config."""
+    derived_max_model_len_info: DerivedMaxModelLenInfo
+    """Derived maximum model length information including RoPE scaling."""
 
     # RoPE-related fields
     uses_mrope: bool
@@ -62,11 +78,3 @@ class ModelArchitectureConfig:
 
     uses_xdrope_dim: int
     """Number of dimensions for XD-RoPE. 0 if not used."""
-
-    rope_parameters: dict[str, Any] | None
-    """RoPE parameters dictionary containing RoPE configuration.
-       Can be None if the model doesn't use RoPE."""
-
-    original_max_position_embeddings: int | None
-    """Original maximum position embeddings before any RoPE scaling.
-       Used for models with extended context via RoPE scaling."""

--- a/vllm/config/model_arch.py
+++ b/vllm/config/model_arch.py
@@ -10,8 +10,8 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 
-class DerivedMaxModelLenInfo(NamedTuple):
-    """Information about the derived maximum model length."""
+class MaxModelLenInfo(NamedTuple):
+    """Information about the maximum model length."""
 
     derived: float
     """Maximum supported sequence length after RoPE scaling.
@@ -26,6 +26,10 @@ class DerivedMaxModelLenInfo(NamedTuple):
     """For LongRoPE models only: original_max_position_embeddings.
     Used as the default max_model_len to avoid performance degradation.
     None for non-LongRoPE models (derived is used instead)."""
+
+    model_max_length: int | None
+    """The model_max_length from hf_config. Used as a fallback for validation
+    when user-specified max_model_len exceeds derived."""
 
 
 @dataclass(config=ConfigDict(arbitrary_types_allowed=True))
@@ -71,7 +75,7 @@ class ModelArchitectureConfig:
     is_deepseek_mla: bool
     """Whether the model is a DeepSeek MLA model."""
 
-    derived_max_model_len_info: DerivedMaxModelLenInfo
+    max_model_len_info: MaxModelLenInfo
     """Derived maximum model length information including RoPE scaling."""
 
     # RoPE-related fields

--- a/vllm/config/model_arch.py
+++ b/vllm/config/model_arch.py
@@ -55,3 +55,18 @@ class ModelArchitectureConfig:
 
     derived_max_model_len_and_key: tuple[float, str | None]
     """Derived maximum model length and key from the hf config."""
+
+    # RoPE-related fields
+    uses_mrope: bool
+    """Whether the model uses M-RoPE (multi-dimensional rotary position embedding)."""
+
+    uses_xdrope_dim: int
+    """Number of dimensions for XD-RoPE. 0 if not used."""
+
+    rope_parameters: dict[str, Any] | None
+    """RoPE parameters dictionary containing RoPE configuration.
+       Can be None if the model doesn't use RoPE."""
+
+    original_max_position_embeddings: int | None
+    """Original maximum position embeddings before any RoPE scaling.
+       Used for models with extended context via RoPE scaling."""

--- a/vllm/config/model_arch.py
+++ b/vllm/config/model_arch.py
@@ -13,17 +13,19 @@ logger = init_logger(__name__)
 class DerivedMaxModelLenInfo(NamedTuple):
     """Information about the derived maximum model length."""
 
-    derived_max_model_len: float
-    """The derived maximum model length after applying RoPE scaling."""
+    derived: float
+    """Maximum supported sequence length after RoPE scaling.
+    Used for:
+    1. Validation - user-specified max_model_len cannot exceed this.
+    2. Default for non-LongRoPE models (with sliding_window/tokenizer caps)."""
 
-    max_len_key: str | None
-    """The key in the config that was used to derive the max length."""
+    derived_key: str | None
+    """The config key used to derive the max length (for error messages)."""
 
-    is_longrope: bool
-    """Whether the model uses LongRoPE (affects default max_model_len selection)."""
-
-    original_max_position_embeddings: int | None
-    """Original max position embeddings before RoPE scaling (for LongRoPE models)."""
+    default: float | None
+    """For LongRoPE models only: original_max_position_embeddings.
+    Used as the default max_model_len to avoid performance degradation.
+    None for non-LongRoPE models (derived is used instead)."""
 
 
 @dataclass(config=ConfigDict(arbitrary_types_allowed=True))

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -9,7 +9,7 @@ from transformers import PretrainedConfig
 
 from vllm import envs
 from vllm.config.model_arch import (
-    DerivedMaxModelLenInfo,
+    MaxModelLenInfo,
     ModelArchitectureConfig,
 )
 from vllm.config.utils import getattr_iter
@@ -210,7 +210,7 @@ class ModelArchConfigConvertorBase:
             )
         return False
 
-    def derive_max_model_len_info(self) -> DerivedMaxModelLenInfo:
+    def derive_max_model_len_info(self) -> MaxModelLenInfo:
         """Derive maximum model length including RoPE scaling factors.
 
         This method computes the derived max model length by:
@@ -314,10 +314,14 @@ class ModelArchConfigConvertorBase:
         else:
             default_max_model_len = None
 
-        return DerivedMaxModelLenInfo(
+        # Get model_max_length for validation fallback
+        model_max_length = getattr(self.hf_config, "model_max_length", None)
+
+        return MaxModelLenInfo(
             derived=derived_max_model_len,
             derived_key=max_len_key,
             default=default_max_model_len,
+            model_max_length=model_max_length,
         )
 
     def get_uses_mrope(self) -> bool:
@@ -340,7 +344,7 @@ class ModelArchConfigConvertorBase:
             num_experts=self.get_num_experts(),
             quantization_config=self.get_quantization_config(),
             is_deepseek_mla=self.is_deepseek_mla(),
-            derived_max_model_len_info=self.derive_max_model_len_info(),
+            max_model_len_info=self.derive_max_model_len_info(),
             # RoPE-related fields
             uses_mrope=self.get_uses_mrope(),
             uses_xdrope_dim=self.get_uses_xdrope_dim(),

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -303,11 +303,21 @@ class ModelArchConfigConvertorBase:
                 # should have the same scaling
                 derived_max_model_len *= scaling_factor
 
+        # Compute default_max_model_len:
+        # For LongRoPE, use original_max_position_embeddings to avoid
+        # performance degradation for shorter sequences.
+        # For non-LongRoPE, return None (caller should use derived_max_model_len).
+        if is_longrope and original_max_position_embeddings is not None:
+            default_max_model_len: float | None = float(
+                original_max_position_embeddings
+            )
+        else:
+            default_max_model_len = None
+
         return DerivedMaxModelLenInfo(
-            derived_max_model_len=derived_max_model_len,
-            max_len_key=max_len_key,
-            is_longrope=is_longrope,
-            original_max_position_embeddings=original_max_position_embeddings,
+            derived=derived_max_model_len,
+            derived_key=max_len_key,
+            default=default_max_model_len,
         )
 
     def get_uses_mrope(self) -> bool:


### PR DESCRIPTION

## Purpose

We are introducing model_arch_config https://github.com/vllm-project/vllm/pull/28454, which defines explicitly what kind of information vLLM engine need from hugggingface config/ user-defined config, so we could avoid hf_config/getattr(hf_config, xxx) got passing around in engine.

Before this PR, `_get_and_verify_max_len` in model.py directly accessed multiple HuggingFace config fields:

- rope_parameters
- original_max_position_embeddings
- model_max_length

By moving this logic into the convertor, we:

- Centralize all RoPE-related decisions in one place
- Reduce hf_config access in model.py

## Behavior Differences/ Potential Bug Fix
**Order of RoPE Scaling vs Caps**
Before: RoPE scaling was applied AFTER sliding_window and tokenizer caps

1. Get base max_len from config
2. Apply sliding_window cap
3. Apply tokenizer cap
4. Apply RoPE scaling (yarn override + scaling_factor)

After: RoPE scaling is applied BEFORE caps

1. Get base max_len from config
2. Apply RoPE scaling (yarn override + scaling_factor)  <- Moved here
3. Apply sliding_window cap
4. Apply tokenizer cap

Rationale: The new order is more correct. Sliding_window is a hard architectural limit that shouldn't be scaled up. The old behavior could result in incorrect values like sliding_window(2048) * factor(8) = 16384.

## Test Plan
Select several models, run and get `max_model_len` groundtruth before this PR, compare if the values after this PR is the same.

```
pytest  tests/config/test_model_arch_config.py
```


## Test Result

passed


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

