### PR TITLE
[BugFix] Fix CPU Weight Offloading with UVA

### DIFF
--- a/csrc/cuda_view.cu
+++ b/csrc/cuda_view.cu
@@ -22,10 +22,10 @@ torch::Tensor get_cuda_view_from_cpu_tensor(torch::Tensor& cpu_tensor) {
   auto strides = cpu_tensor.strides();
   auto options = cpu_tensor.options().device(torch::kCUDA);
 
-  // use default no-op deleter, since the memory is owned by the original CPU
-  // tensor
-  torch::Tensor cuda_tensor =
-      torch::from_blob(device_ptr, sizes, strides, options);
+  torch::Tensor cuda_tensor = torch::from_blob(
+      device_ptr, sizes, strides,
+      [base = cpu_tensor](void*) {},  // keep the cpu data alive
+      options);
 
   TORCH_CHECK(cuda_tensor.device().is_cuda(),
               "Resulting tensor is not on CUDA device");

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -661,8 +661,7 @@ def maybe_offload_to_cpu(module: torch.nn.Module) -> torch.nn.Module:
         if not uva_offloading:
             p.data = cpu_data
         else:
-            # keep the cpu data alive
-            p._vllm_offloaded_cpu_data = cpu_data
+            p._vllm_is_uva_offloaded = True
             p.data = get_cuda_view_from_cpu_tensor(cpu_data)
         _CPU_OFFLOAD_BYTES += p.data.numel() * p.data.element_size()
         offloaded_parameters = True


### PR DESCRIPTION

## Purpose

This PR fixes a bug in the CPU offloading logic where weights re-initialized during quantization processing are not being correctly re-offloaded to the CPU when using Unified Virtual Addressing (UVA).

**Bug:**

During `process_weights_after_loading`, certain quantization methods replace original model weights with newly initialized tensors (e.g., [here](https://github.com/vllm-project/vllm/blob/97ef11dd3406ab7a9080921c62f001d60399d928/vllm/model_executor/layers/quantization/modelopt.py#L884)). These new tensors are initialized as device tensors. The current logic fails to re-offload these "replaced" tensors to CPU memory. As a result, weights that were supposed to be offloaded end up on the GPU, undoing the effects of offloading.

In contrast, the [non-UVA code path](https://github.com/vllm-project/vllm/blob/97ef11dd3406ab7a9080921c62f001d60399d928/vllm/model_executor/model_loader/utils.py#L146) (currently disabled) correctly handles this by re-offloading weights by name. This PR brings that consistency to the UVA path.

## Test Plan

As an example of the bug, running deepseek r1 nvfp4 (~350 GB) on GB300 (288 GB) with 200 GB CPU offloading results in OOM:

Current main:
```shell
python3 -m vllm.entrypoints.openai.api_server  \
    --model nvidia/DeepSeek-R1-NVFP4     \
    --trust-remote-code    \
    --cpu-offload-gb 200 \
    --load-format dummy
```

```
File "vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py", line 539, in prepare_nvfp4_moe_layer_for_fi_or_cutlass
     w13, w13_scale, w2, w2_scale = prepare_static_weights_for_trtllm_fp4_moe(
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py", line 278, in prepare_static_weights_for_trtllm_fp4_moe
     gemm1_weights_fp4_shuffled = torch.stack(gemm1_weights_fp4_shuffled)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 3.50 GiB. GPU 0 has a total capacity of 276.62 GiB of which 1.18 GiB is free.
```

## Test Result

Using this PR allows the above configuration to run.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

