### PR TITLE
[Bugfix]: Prevent reasoning_content leak 

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -916,6 +916,8 @@ class OpenAIServingChat(OpenAIServing):
                         # must not contain content.
                         if tools_streamed_flag and delta_message:
                             delta_message.content = None
+                            delta_message.reasoning = None
+                            delta_message.reasoning_content = None
                     # handle streaming deltas for tools with named tool_choice
                     elif tool_choice_function_name:
                         if (


### PR DESCRIPTION
## Purpose
Fix a bug where reasoning_content was incorrectly flushed into content in the final streamed chunk when finish_reason='tool_calls'.

## Root Cause & Solution
Stream finalization did not clear content/reasoning buffers when finish_reason='tool_calls', allowing leftover reasoning_content (especially from speculative decoding) to leak. 
Added guards to clear content/reasoning fields before final chunk creation and after tool call extraction.

## Test Plan
- Added regression test `test_no_content_leak_when_finish_reason_tool_calls` in `tests/entrypoints/openai/test_chat_with_tool_reasoning.py`.
- The test simulates streaming with reasoning + tool_choice="auto" and asserts that the final chunk has no content/reasoning leaks while earlier reasoning is preserved.

## Test Result
- Regression test passes ✅
- Final chunk with finish_reason="tool_calls" has content=null and no reasoning/reasoning_content

Fixes: #32921 

