### PR TITLE
[CPU Backend][BugFix] Fix failing Darwin pipelines

### DIFF
--- a/.github/workflows/macos-smoke-test.yml
+++ b/.github/workflows/macos-smoke-test.yml
@@ -29,8 +29,9 @@ jobs:
 
       - name: Install dependencies and build vLLM
         run: |
+          uv pip install -r requirements/cpu-build.txt --index-strategy unsafe-best-match
           uv pip install -r requirements/cpu.txt --index-strategy unsafe-best-match
-          uv pip install -e .
+          uv pip install -e . --no-build-isolation
         env:
           CMAKE_BUILD_PARALLEL_LEVEL: 4
 


### PR DESCRIPTION
## Purpose

PR https://github.com/vllm-project/vllm/pull/32869 updated CPU Backend to use torch 2.10 which caused Darwin pipelines to fail.
The root cause of the failure is:
- uv uses build isolation by default
- pyproject.toml is at torch 2.9.1, while cpu.txt is at 2.10.0
- hence, vllm gets build against 2.9.1 but uses 2.10.0 at runtime

We should use `--no-build-isolation` in the failing pipeline as the vLLM CPU docs suggest

## Test Plan

CI - this the pipeline that failed: [macos-m1-smoke-test](https://github.com/vllm-project/vllm/actions/runs/21287373211/job/61271750228#logs)

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [Y] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [Y] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

