### PR TITLE
[BugFix] KV cache layout for raw-copy KV connectors in disaggregated mode

### DIFF
--- a/tests/v1/kv_connector/unit/test_connector_kv_layout.py
+++ b/tests/v1/kv_connector/unit/test_connector_kv_layout.py
@@ -38,13 +38,17 @@ def _make_config(*, use_mla: bool | None):
     [
         "vllm.distributed.kv_transfer.kv_connector.v1.p2p.p2p_nccl_connector.P2pNcclConnector",
         "vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector.NixlConnector",
+        "vllm.distributed.kv_transfer.kv_connector.v1.mooncake_connector.MooncakeConnector",
     ],
 )
 class TestRawCopyConnectorLayout:
     @staticmethod
     def _import_connector(connector_path: str):
         module_path, class_name = connector_path.rsplit(".", 1)
-        module = __import__(module_path, fromlist=[class_name])
+        try:
+            module = __import__(module_path, fromlist=[class_name])
+        except ImportError as exc:
+            pytest.skip(f"Skipping {connector_path}: {exc}")
         return getattr(module, class_name)
 
     def test_non_mla_requires_hnd(self, connector_path):

--- a/tests/v1/kv_connector/unit/test_connector_kv_layout.py
+++ b/tests/v1/kv_connector/unit/test_connector_kv_layout.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Tests for KV-cache layout selection in KV transfer connectors.
+
+Focus:
+- Raw-copy connectors should require HND for non-MLA models.
+- The global layout decision should respect connector requirements.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_config(*, use_mla: bool | None):
+    """Minimal VllmConfig-like mock."""
+    cfg = MagicMock()
+    if use_mla is None:
+        cfg.model_config = None
+    else:
+        cfg.model_config = MagicMock()
+        cfg.model_config.use_mla = use_mla
+
+    # Required by get_kv_connector_cache_layout
+    cfg.kv_transfer_config = MagicMock()
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Connector-level behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "connector_path",
+    [
+        "vllm.distributed.kv_transfer.kv_connector.v1.p2p.p2p_nccl_connector.P2pNcclConnector",
+        "vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector.NixlConnector",
+    ],
+)
+class TestRawCopyConnectorLayout:
+    @staticmethod
+    def _import_connector(connector_path: str):
+        module_path, class_name = connector_path.rsplit(".", 1)
+        module = __import__(module_path, fromlist=[class_name])
+        return getattr(module, class_name)
+
+    def test_non_mla_requires_hnd(self, connector_path):
+        connector = self._import_connector(connector_path)
+        cfg = _make_config(use_mla=False)
+        assert connector.get_required_kvcache_layout(cfg) == "HND"
+
+    def test_mla_requires_no_specific_layout(self, connector_path):
+        connector = self._import_connector(connector_path)
+        cfg = _make_config(use_mla=True)
+        assert connector.get_required_kvcache_layout(cfg) is None
+
+    def test_no_model_config_requires_no_specific_layout(self, connector_path):
+        connector = self._import_connector(connector_path)
+        cfg = _make_config(use_mla=None)
+        assert connector.get_required_kvcache_layout(cfg) is None
+
+
+# ---------------------------------------------------------------------------
+# System-level decision path
+# ---------------------------------------------------------------------------
+
+
+class TestKvConnectorCacheLayoutDecision:
+    def test_falls_back_to_nhd_when_connector_has_no_requirement(self, monkeypatch):
+        from vllm.distributed.kv_transfer.kv_connector import utils as kv_utils
+        from vllm.distributed.kv_transfer.kv_connector.utils import (
+            get_kv_connector_cache_layout,
+        )
+
+        cfg = _make_config(use_mla=True)
+
+        monkeypatch.setattr(kv_utils, "get_current_vllm_config", lambda: cfg)
+
+        class _NoRequirementConnector:
+            @classmethod
+            def get_required_kvcache_layout(cls, _cfg):
+                return None
+
+        monkeypatch.setattr(
+            kv_utils.KVConnectorFactory,
+            "get_connector_class",
+            lambda _kv_transfer_cfg: _NoRequirementConnector,
+        )
+
+        assert get_kv_connector_cache_layout() == "NHD"
+
+    def test_uses_hnd_when_raw_copy_connector_requires_it(self, monkeypatch):
+        from vllm.distributed.kv_transfer.kv_connector import utils as kv_utils
+        from vllm.distributed.kv_transfer.kv_connector.utils import (
+            get_kv_connector_cache_layout,
+        )
+        from vllm.distributed.kv_transfer.kv_connector.v1.p2p import (
+            p2p_nccl_connector,
+        )
+
+        p2p_nccl_connector_cls = p2p_nccl_connector.P2pNcclConnector
+
+        cfg = _make_config(use_mla=False)
+
+        monkeypatch.setattr(kv_utils, "get_current_vllm_config", lambda: cfg)
+
+        monkeypatch.setattr(
+            kv_utils.KVConnectorFactory,
+            "get_connector_class",
+            lambda _kv_transfer_cfg: p2p_nccl_connector_cls,
+        )
+
+        assert get_kv_connector_cache_layout() == "HND"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -543,6 +543,25 @@ class KVConnectorBase_V1(ABC):
             )
         return None
 
+    @classmethod
+    def _get_raw_copy_required_layout(cls, vllm_config: "VllmConfig") -> str | None:
+        if vllm_config.model_config is None:
+            logger.warning_once(
+                "Unable to detect current VLLM config. "
+                "Fallback to default kv cache layout."
+            )
+            return None
+
+        use_mla = vllm_config.model_config.use_mla
+        if use_mla:
+            return None
+
+        logger.info_once(
+            "%s setting KV cache layout to HND to ensure P/D layout compatibility.",
+            cls.__name__,
+        )
+        return "HND"
+
     def get_finished_count(self) -> int | None:
         """
         Get the count of requests expected to complete send/receive operations

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
@@ -137,20 +137,7 @@ class MooncakeConnector(KVConnectorBase_V1):
     ############################################################
     @classmethod
     def get_required_kvcache_layout(cls, vllm_config: VllmConfig) -> str | None:
-        if vllm_config.model_config is None:
-            logger.warning_once(
-                "Unable to detect current VLLM config. "
-                "Fallback to default kv cache layout."
-            )
-            return None
-        use_mla = vllm_config.model_config.use_mla
-        if use_mla:
-            return None
-        logger.info_once(
-            "MooncakeConnector setting KV cache layout to HND to ensure "
-            "P/D layout compatibility."
-        )
-        return "HND"
+        return cls._get_raw_copy_required_layout(vllm_config)
 
     ############################################################
     # Scheduler Side Methods

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
@@ -133,6 +133,26 @@ class MooncakeConnector(KVConnectorBase_V1):
             self.connector_worker = MooncakeConnectorWorker(vllm_config, self.engine_id)
 
     ############################################################
+    # Class Methods
+    ############################################################
+    @classmethod
+    def get_required_kvcache_layout(cls, vllm_config: VllmConfig) -> str | None:
+        if vllm_config.model_config is None:
+            logger.warning_once(
+                "Unable to detect current VLLM config. "
+                "Fallback to default kv cache layout."
+            )
+            return None
+        use_mla = vllm_config.model_config.use_mla
+        if use_mla:
+            return None
+        logger.info_once(
+            "MooncakeConnector setting KV cache layout to HND to ensure "
+            "P/D layout compatibility."
+        )
+        return "HND"
+
+    ############################################################
     # Scheduler Side Methods
     ############################################################
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -339,23 +339,8 @@ class NixlConnector(KVConnectorBase_V1):
     # Class Methods
     ############################################################
     @classmethod
-    def get_required_kvcache_layout(cls, vllm_config: VllmConfig):
-        if vllm_config.model_config is None:
-            logger.warning_once(
-                "Unable to detect current VLLM config. "
-                "Fallback to default kv cache layout."
-            )
-            return None
-        use_mla = vllm_config.model_config.use_mla
-        if use_mla:
-            # return None when we have mla
-            # as the layout should not matter in that case,
-            # which fallback to the default behavior.
-            return None
-        logger.info_once(
-            "NixlConnector setting KV cache layout to HND for better xfer performance."
-        )
-        return "HND"
+    def get_required_kvcache_layout(cls, vllm_config: VllmConfig) -> str | None:
+        return cls._get_raw_copy_required_layout(vllm_config)
 
     ############################################################
     # Scheduler Side Methods

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
@@ -108,21 +108,8 @@ class P2pNcclConnector(KVConnectorBase_V1):
     # Class Methods
     ############################################################
     @classmethod
-    def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:
-        if vllm_config.model_config is None:
-            logger.warning_once(
-                "Unable to detect current VLLM config. "
-                "Fallback to default kv cache layout."
-            )
-            return None
-        use_mla = vllm_config.model_config.use_mla
-        if use_mla:
-            return None
-        logger.info_once(
-            "P2pNcclConnector setting KV cache layout to HND to ensure "
-            "P/D layout compatibility."
-        )
-        return "HND"
+    def get_required_kvcache_layout(cls, vllm_config: VllmConfig) -> str | None:
+        return cls._get_raw_copy_required_layout(vllm_config)
 
     # ==============================
     # Worker-side methods

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
@@ -104,6 +104,26 @@ class P2pNcclConnector(KVConnectorBase_V1):
             else None
         )
 
+    ############################################################
+    # Class Methods
+    ############################################################
+    @classmethod
+    def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:
+        if vllm_config.model_config is None:
+            logger.warning_once(
+                "Unable to detect current VLLM config. "
+                "Fallback to default kv cache layout."
+            )
+            return None
+        use_mla = vllm_config.model_config.use_mla
+        if use_mla:
+            return None
+        logger.info_once(
+            "P2pNcclConnector setting KV cache layout to HND to ensure "
+            "P/D layout compatibility."
+        )
+        return "HND"
+
     # ==============================
     # Worker-side methods
     # ==============================


### PR DESCRIPTION
## Purpose

Fix incorrect KV cache layout selection when using raw-copy KV transfer
connectors (e.g., P2pNcclConnector, MooncakeConnector) in disaggregated
prefill/decode serving.

NixlConnector already enforces the HND KV cache layout for raw-copy
transfers:

https://github.com/thjung123/vllm/blob/main/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py#L341-L358

However, other raw-copy connectors did not specify a required layout.
This could lead to a layout mismatch (e.g., NHD vs HND) between prefiller
and decoder, which may result in incorrect attention behavior and
unexpected generation output.

This change aligns raw-copy connectors to use a consistent HND layout
for non-MLA models.

Related to #32898.


## Test Plan

Run unit tests for KV connector layout selection:
```bash
pytest tests/v1/kv_connector/unit/test_connector_kv_layout.py
```


## Test Result

All tests pass locally.
Tests requiring the optional mooncake dependency are skipped.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

