### PR TITLE
[BugFix] KeyError when loading Mistral/vision-enabled checkpoints

### DIFF
--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -511,7 +511,9 @@ class PixtralForConditionalGeneration(
             )
 
         def is_patch_merger(weight: tuple[str, torch.Tensor]):
-            return weight[0].startswith("patch_merger")
+            return weight[0].startswith(
+                ("patch_merger", "multi_modal_projector.patch_merger")
+            )
 
         def is_pre_mm_projector_norm(weight: tuple[str, torch.Tensor]):
             return weight[0].startswith("pre_mm_projector_norm")
@@ -554,18 +556,23 @@ class PixtralForConditionalGeneration(
                     if self.patch_merger is None:
                         continue
                     # Load vision patch merger weights directly
-                    trimmed_name = ".".join(name.split(".")[1:])
-                    param = patch_merger_dict[trimmed_name]
-                    with torch.no_grad():
-                        default_weight_loader(param, w)
+                    if name.startswith("multi_modal_projector.patch_merger"):
+                        trimmed_name = ".".join(name.split(".")[2:])
+                    else:
+                        trimmed_name = ".".join(name.split(".")[1:])
+                    param = patch_merger_dict.get(trimmed_name)
+                    if param is not None:
+                        with torch.no_grad():
+                            default_weight_loader(param, w)
                 elif is_pre_mm_projector_norm((name, w)):
                     if self.pre_mm_projector_norm is None:
                         continue
                     # Load vision pre_mm_projector_norm weights directly
                     trimmed_name = ".".join(name.split(".")[1:])
-                    param = pre_mm_projector_norm_dict[trimmed_name]
-                    with torch.no_grad():
-                        default_weight_loader(param, w)
+                    param = pre_mm_projector_norm_dict.get(trimmed_name)
+                    if param is not None:
+                        with torch.no_grad():
+                            default_weight_loader(param, w)
                 elif is_vision_lang_adapter_weights((name, w)):
                     if self.vision_language_adapter is None:
                         continue


### PR DESCRIPTION
## Purpose

This PR fixes a bug introduced by PR #32780 where loading Mistral/vision-enabled checkpoints (e.g., `mistralai/Devstral-Small-2-24B-Instruct-2512`) fails with a `KeyError: 'merging_layer.weight'`.

The refactor in PR #32780 moved Mistral-specific code from `llama.py` to a new `mistral.py` file, which is correct. However, the `pixtral.py` file had unsafe dictionary accesses that caused KeyErrors when loading checkpoints containing `multi_modal_projector.patch_merger` weights.

### Root Cause

In `pixtral.py`'s `load_weights` method, the code used direct dictionary access without null checks:

```python
param = patch_merger_dict[trimmed_name]  # Could raise KeyError
```

This caused failures when:
1. The checkpoint contained `multi_modal_projector.patch_merger.merging_layer.weight` keys
2. The model's `patch_merger` module didn't have the expected parameter (or was None)
3. The `is_patch_merger` function didn't recognize `multi_modal_projector.patch_merger` prefix

### Changes

#### 1. Fixed unsafe dictionary access for patch_merger
Changed from direct access to safe access with null check:
```python
param = patch_merger_dict.get(trimmed_name)
if param is not None:
    with torch.no_grad():
        default_weight_loader(param, w)
```

#### 2. Fixed unsafe dictionary access for pre_mm_projector_norm
Applied the same fix to `pre_mm_projector_norm_dict` access.

#### 3. Improved patch_merger weight detection
Updated `is_patch_merger` function to recognize both prefixes:
```python
def is_patch_merger(weight: tuple[str, torch.Tensor]):
    return weight[0].startswith(
        ("patch_merger", "multi_modal_projector.patch_merger")
    )
```

## Test Plan

1. **Reproduce the original issue**:
   ```bash
   vllm serve mistralai/Devstral-Small-2-24B-Instruct-2512 \
     --tokenizer-mode mistral \
     --config-format mistral \
     --load-format mistral \
     --dtype half
   ```
   This should fail with `KeyError: 'merging_layer.weight'` before the fix.

2. **Verify the fix**:
   - The same command should now work without errors
   - Loading should complete successfully and the model should be ready for inference
   - Multimodality should work during inference time (eg. with `mistralai/Devstral-Small-2-24B-Instruct-2512` model)

3. **Test with other Mistral models**:
   - Test with regular Mistral models (without vision) to ensure no regression
   - Test with other multimodal Mistral models if available

## Test Result

✅ **Before fix**: Command fails with `KeyError: 'merging_layer.weight'`
✅ **After fix**: Command completes successfully, model loads and is ready for inference
✅ **Regression test**: Regular Mistral models still load correctly
✅ **Multimodality**: Works, we can use images in input to the model (tested with `mistralai/Devstral-Small-2-24B-Instruct-2512`)

## Related Issues

- Fixes #32959
- Related to PR #32780

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>