### PR TITLE
[Doc] Add Qwen2.5 models to batch invariance tested models

### DIFF
--- a/docs/features/batch_invariance.md
+++ b/docs/features/batch_invariance.md
@@ -106,6 +106,7 @@ Batch invariance has been tested and verified on the following models:
 - **DeepSeek series**: `deepseek-ai/DeepSeek-V3`, `deepseek-ai/DeepSeek-V3-0324`, `deepseek-ai/DeepSeek-R1`, `deepseek-ai/DeepSeek-V3.1`
 - **Qwen3 (Dense)**: `Qwen/Qwen3-1.7B`, `Qwen/Qwen3-8B`
 - **Qwen3 (MoE)**: `Qwen/Qwen3-30B-A3B`, `Qwen/Qwen3-Next-80B-A3B-Instruct`
+- **Qwen2.5**: `Qwen/Qwen2.5-0.5B-Instruct`, `Qwen/Qwen2.5-1.5B-Instruct`, `Qwen/Qwen2.5-3B-Instruct`, `Qwen/Qwen2.5-7B-Instruct`, `Qwen/Qwen2.5-14B-Instruct`, `Qwen/Qwen2.5-32B-Instruct`
 - **Llama 3**: `meta-llama/Llama-3.1-8B-Instruct`, `meta-llama/Llama-3.2-1B-Instruct`
 
 Other models may also work, but these have been explicitly validated. If you encounter issues with a specific model, please report them on the [GitHub issue tracker](https://github.com/vllm-project/vllm/issues/new/choose).


### PR DESCRIPTION
## Description
Add Qwen2.5 model family to the validated batch invariance models list:
- Qwen2.5-0.5B-Instruct
- Qwen2.5-1.5B-Instruct
- Qwen2.5-3B-Instruct
- Qwen2.5-7B-Instruct
- Qwen2.5-14B-Instruct
- Qwen2.5-32B-Instruct

Tested on H200 with both FLASH_ATTN and FLASHINFER backends.

Related to #27433


## Purpose

Add Qwen2.5 model family to the batch invariance documentation as validated models.

This addresses the "Help needed for validations of more models" request in #27433.

## Test Plan

Ran the batch invariance test suite on H200 GPUs with both `FLASH_ATTN` and `FLASHINFER` backends across different TP sizes.

Example command for one model/TP configuration:

```bash
VLLM_TEST_MODEL="Qwen/Qwen2.5-7B-Instruct" \
VLLM_TEST_TP_SIZE=1 \
VLLM_TP_SIZE=1 \
pytest tests/v1/determinism/test_batch_invariance.py -v -s
```

## Test Result

| Model | TP | FLASH_ATTN | FLASHINFER |
|-------|:--:|:----------:|:----------:|
| Qwen2.5-0.5B-Instruct | 1 | PASS | PASS |
| Qwen2.5-1.5B-Instruct | 1 | PASS | PASS |
| Qwen2.5-3B-Instruct | 1 | PASS | PASS |
| Qwen2.5-7B-Instruct | 1 | PASS | PASS |
| Qwen2.5-14B-Instruct | 1 | PASS | PASS |
| Qwen2.5-14B-Instruct | 2 | PASS | PASS |
| Qwen2.5-32B-Instruct | 2 | PASS | PASS |
| Qwen2.5-32B-Instruct | 4 | PASS | PASS |

All tests passed:
- `test_logprobs_bitwise_batch_invariance_bs1_vs_bsN`
- `test_v1_generation_is_deterministic_across_batch_sizes_with_needle`
- `test_simple_generation`
- `test_decode_logprobs_match_prefill_logprobs`

Related to #27433

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

