### PR TITLE
[MoE][Fix] Fix PPLX CUTLASS FP8 incorrect output with apply_router_weight_on_input

### DIFF
--- a/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
@@ -167,8 +167,11 @@ class PplxPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
 
             orig_a_scale_block_shape = a1q_scale.shape[-1]
 
-            if not quant_config.is_block_quantized:
+            if (not quant_config.is_block_quantized
+                    and not quant_config.is_per_act_token):
                 # TODO (bnell): use group_broadcast instead?
+                # Skip repeat for per_act_token since scale shape [M, 1] is
+                # already correct and repeating would corrupt it to [M, 4]
                 a1q_scale = a1q_scale.repeat(repeat_rows, repeat_cols)
 
         assert a1q_scale is None or a1q_scale.ndim == 2, (

--- a/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
@@ -167,8 +167,10 @@ class PplxPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
 
             orig_a_scale_block_shape = a1q_scale.shape[-1]
 
-            if (not quant_config.is_block_quantized
-                    and not quant_config.is_per_act_token):
+            if (
+                not quant_config.is_block_quantized
+                and not quant_config.is_per_act_token
+            ):
                 # TODO (bnell): use group_broadcast instead?
                 # Skip repeat for per_act_token since scale shape [M, 1] is
                 # already correct and repeating would corrupt it to [M, 4]

--- a/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/pplx_prepare_finalize.py
@@ -167,13 +167,12 @@ class PplxPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
 
             orig_a_scale_block_shape = a1q_scale.shape[-1]
 
-            if (
-                not quant_config.is_block_quantized
-                and not quant_config.is_per_act_token
-            ):
+            if quant_config.is_per_tensor:
+                # Per-tensor (static FP8) quantization has scale shape [1, 1]
+                # which needs to be repeated to [M, 4] for PPLX data format.
+                # Per-token scale [M, 1] should NOT be repeated as it is
+                # already in the correct format.
                 # TODO (bnell): use group_broadcast instead?
-                # Skip repeat for per_act_token since scale shape [M, 1] is
-                # already correct and repeating would corrupt it to [M, 4]
                 a1q_scale = a1q_scale.repeat(repeat_rows, repeat_cols)
 
         assert a1q_scale is None or a1q_scale.ndim == 2, (


### PR DESCRIPTION
## Summary

This PR fixes incorrect model outputs (~30% accuracy instead of ~90% on GSM8K) when using **PPLX all2all backend with CUTLASS FP8 quantization** on Llama4 models.

**Fixes:** #33011

## Root Cause

When `per_act_token_quant=True` (Llama4 configuration), the scale tensor with shape `[M, 1]` was incorrectly repeated to `[M, 4]` in `pplx_prepare_finalize.py:163-165`:

```python
# Before (buggy)
if not quant_config.is_block_quantized:
    a1q_scale = a1q_scale.repeat(repeat_rows, repeat_cols)  # [M,1] -> [M,4]
```

This corrupted the per-token scale values, causing NaN in quantized activations (`a1q`) and extreme output values (reaching ±1.3e9), as reported by @baonudesifeizhai.

## Fix

Skip the scale repeat for `per_act_token` quantization since the scale shape `[M, 1]` is already correct:

```python
# After (fixed)
if (
    not quant_config.is_block_quantized
    and not quant_config.is_per_act_token  # Added condition
):
    a1q_scale = a1q_scale.repeat(repeat_rows, repeat_cols)
```

## Changes

1. **Bug Fix** (`pplx_prepare_finalize.py`):
   - Skip `a1q_scale.repeat()` when `is_per_act_token=True`
   - Preserves correct scale shape `[M, 1]` for per-token quantization

2. **Test Coverage** (`test_pplx_cutlass_moe.py`):
   - Add `test_cutlass_moe_pplx_router_weight_on_input` for Llama4 config (`topk=1`, `apply_router_weight_on_input=True`)
   - Update helper functions to support `apply_router_weight_on_input` parameter

## Test Plan

- [ ] Run `pytest tests/kernels/moe/test_pplx_cutlass_moe.py -v` on multi-GPU with pplx-kernels
- [ ] Verify GSM8K accuracy returns to ~90% for Llama4 model with PPLX + CUTLASS FP8