### PR TITLE
[CI] Fix MHA attention test failure (AttributeError when model_config is None in ViT attention backend)

### DIFF
--- a/vllm/model_executor/models/vision.py
+++ b/vllm/model_executor/models/vision.py
@@ -104,8 +104,9 @@ def get_vit_attn_backend(
     """
     try:
         vllm_config: VllmConfig = get_current_vllm_config()
+        model_config = vllm_config.model_config
         multimodal_config: MultiModalConfig | None = (
-            vllm_config.model_config.multimodal_config
+            model_config.multimodal_config if model_config is not None else None
         )
     except AssertionError:
         multimodal_config = None
@@ -129,8 +130,9 @@ def is_vit_use_data_parallel():
     """
     try:
         vllm_config: VllmConfig = get_current_vllm_config()
+        model_config = vllm_config.model_config
         multimodal_config: MultiModalConfig | None = (
-            vllm_config.model_config.multimodal_config
+            model_config.multimodal_config if model_config is not None else None
         )
     except AssertionError:
         multimodal_config = None


### PR DESCRIPTION
Fixes `AttributeError: 'NoneType' object has no attribute 'multimodal_config'` in `get_vit_attn_backend()` and `is_vit_use_data_parallel()` functions.

Breaking Commit: `9ad7f89f5` - [Models]: Make Multimodal config implicit in ViT implementation (#31972)

FIX https://github.com/vllm-project/vllm/issues/33028

## Root Cause

The breaking commit introduced new functions `get_vit_attn_backend()` and `is_vit_use_data_parallel()` in `vllm/model_executor/models/vision.py` that access `vllm_config.model_config.multimodal_config`. However, the code only catches `AssertionError` from `get_current_vllm_config()`, but doesn't handle the case where `model_config` itself is `None`.

When tests use the `default_vllm_config` fixture, `get_current_vllm_config()` returns a `VllmConfig` where `model_config` is `None`. Accessing `.multimodal_config` on `None` raises `AttributeError`, which isn't caught.

## Fix

Added a null check for `model_config` before accessing `multimodal_config`:

## Test

```bash
python -m pytest tests/kernels/attention/test_mha_attn.py::test_mha_attn_varlen_forward[cuda-dtype2-64-1-16-var_seq_len0] -v
```