### PR TITLE
[Docs] Simplify CPU x86 Docker build documentation

### DIFF
--- a/docs/getting_started/installation/cpu.x86.inc.md
+++ b/docs/getting_started/installation/cpu.x86.inc.md
@@ -171,10 +171,6 @@ uv pip install dist/*.whl
 
 ## Building for your target CPU
 
-vLLM supports building Docker images for x86 CPU platforms with automatic instruction set detection.
-
-### Basic build command
-
 ```bash
 docker build -f docker/Dockerfile.cpu \
         --build-arg VLLM_CPU_DISABLE_AVX512=<false (default)|true> \
@@ -187,29 +183,21 @@ docker build -f docker/Dockerfile.cpu \
         --target vllm-openai .
 ```
 
-!!! note "Instruction set auto-detection"
-    By default, vLLM will auto-detect CPU instruction sets (AVX512, AVX2, etc.) from the build system's CPU flags. Build arguments like `VLLM_CPU_AVX2`, `VLLM_CPU_AVX512`, `VLLM_CPU_AVX512BF16`, `VLLM_CPU_AVX512VNNI`, and `VLLM_CPU_AMXBF16` are primarily used for **cross-compilation** or for building container images on systems that don't have the target platforms ISA:
+!!! note "Auto-detection by default"
+    By default, CPU instruction sets (AVX512, AVX2, etc.) are automatically detected from the build system's CPU flags. Build arguments like `VLLM_CPU_AVX2`, `VLLM_CPU_AVX512`, `VLLM_CPU_AVX512BF16`, `VLLM_CPU_AVX512VNNI`, and `VLLM_CPU_AMXBF16` are used for cross-compilation:
 
-    - Set `VLLM_CPU_{ISA}=true` to force-enable an instruction set (for cross-compilation to target platforms with that ISA)
-    - Set `VLLM_CPU_{ISA}=false` to rely on auto-detection
-    - When an ISA build arg is set to `true`, vLLM will build with that instruction set regardless of the build system's CPU capabilities
+    - `VLLM_CPU_{ISA}=true` - Force-enable the instruction set (build with ISA regardless of build system capabilities)
+    - `VLLM_CPU_{ISA}=false` - Rely on auto-detection (default)
 
-### Build examples
+### Examples
 
-**Example 1: Auto-detection (native build)**
-
-Build on a machine with the same CPU as your target deployment:
+**Auto-detection build (default)**
 
 ```bash
-# Auto-detects all CPU features from the build system
-docker build -f docker/Dockerfile.cpu \
-        --tag vllm-cpu-env \
-        --target vllm-openai .
+docker build -f docker/Dockerfile.cpu --tag vllm-cpu-env --target vllm-openai .
 ```
 
-**Example 2: Cross-compilation for AVX512 deployment**
-
-Build an AVX512 image on any x86_64 system (even without AVX512):
+**Cross-compile for AVX512**
 
 ```bash
 docker build -f docker/Dockerfile.cpu \
@@ -220,9 +208,7 @@ docker build -f docker/Dockerfile.cpu \
         --target vllm-openai .
 ```
 
-**Example 3: Cross-compilation for AVX2 deployment**
-
-Build an AVX2 image for older CPUs:
+**Cross-compile for AVX2**
 
 ```bash
 docker build -f docker/Dockerfile.cpu \


### PR DESCRIPTION
## Purpose
This PR simplifies the "Building for your target CPU" section in the x86 CPU installation documentation, addressing reviewer feedback from PR #30953.

## Changes
- Streamline build command presentation by showing all available build arguments upfront
- Simplify auto-detection explanation into a concise note
- Reduce examples to essential scenarios: auto-detection, AVX512 cross-compile, and AVX2 cross-compile
- Remove redundant explanatory text, tables, and verbose descriptions

## Motivation
Documentation changes requested in PR #30953 by @bigPYJ1151 

## Test Plan
- Documentation-only change
- Verified markdown rendering locally
- No functional changes to build process

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR
- [x] The test plan
- [ ] The test results (documentation-only change)
- [ ] Release notes update (documentation-only change)
</details>