### PR TITLE
Support compress-tensors with nvfp4 or fp8 weights and modelopt with nvfp4 weights on Turing

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
@@ -29,7 +29,7 @@ class CompressedTensorsW4A16Fp4(CompressedTensorsScheme):
     @classmethod
     def get_min_capability(cls) -> int:
         # don't restrict as emulations
-        return 80
+        return 75
 
     def create_weights(
         self,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -34,8 +34,8 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        # ampere and up
-        return 80
+        # turing and up
+        return 75
 
     # W8A8-Fp8 kernels support only per-tensor and per-channel cases.
     # So if we have a fused module (QKV, MLP) with per tensor scales,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -96,6 +96,7 @@ from vllm.model_executor.parameter import (
     PerTensorScaleParameter,
 )
 from vllm.model_executor.utils import replace_parameter
+from vllm.platforms import current_platform
 from vllm.utils.flashinfer import (
     flashinfer_scaled_fp4_mm,
     has_flashinfer,
@@ -1110,7 +1111,7 @@ class ModelOptNvFp4LinearMethod(LinearMethodBase):
 
         self.backend = "none"
         if envs.VLLM_NVFP4_GEMM_BACKEND is None:
-            if has_flashinfer():
+            if current_platform.has_device_capability(100) and has_flashinfer():
                 self.backend = "flashinfer-cutlass"
             elif cutlass_fp4_supported():
                 self.backend = "cutlass"


### PR DESCRIPTION
<!-- markdownlint-disable -->
Since v0.14.0, Turing GPU support to run nvfp4 and fp8 weights models through merlin kernel. But without enable compress-tensors with nvfp4 or fp8 weights and modelopt with nvfp4 weights on Turing.
In my test, compress-tensors with nvfp4 or fp8 weights and modelopt with nvfp4 weights are work.

https://github.com/vllm-project/vllm/issues/32838

## Purpose

## Test Plan

## Test Result

Tested models on Turing (RTX 2080Ti):
- nv-community/Qwen3-30B-A3B-NVFP4 # modelopt nvfp4: pass
- RedHatAI/Qwen3-30B-A3B-NVFP4 # compressed-tensors nvfp4: pass
- RedHatAI/Qwen3-32B-NVFP4A16 # compressed-tensors nvfp4: pass
- RedHatAI/Qwen3-32B-NVFP4 # compressed-tensors nvfp4: pass
- RedHatAI/Qwen3-4B-FP8-dynamic # compressed-tensors fp8: pass
- nm-testing/Phi-3-mini-128k-instruct-FP8 # compressed-tensors fp8: pass
- RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8 # compressed-tensors fp8: pass

Previously, these models were unable to start. And the vLLM print "Quantization scheme is not supported for the current GPU."
The `nv-community/Qwen3-30B-A3B-NVFP4` is an exception; and the vLLM print "mm_fp4 does not support backend 'cutlass' with capability 75".

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

