### PR TITLE
[Bugfix] Fix remove_instance logic error in disagg_proxy_demo.py

### DIFF
--- a/examples/online_serving/disaggregated_serving/disagg_proxy_demo.py
+++ b/examples/online_serving/disaggregated_serving/disagg_proxy_demo.py
@@ -328,9 +328,9 @@ class Proxy:
         if instance_type == "decode" and instance in self.decode_instances:
             self.decode_instances.remove(instance)
             self.decode_cycler = itertools.cycle(self.decode_instances)
-        if instance_type == "prefill" and instance in self.decode_instances:
+        if instance_type == "prefill" and instance in self.prefill_instances:
             self.prefill_instances.remove(instance)
-            self.prefill_cycler = itertools.cycle(self.decode_instances)
+            self.prefill_cycler = itertools.cycle(self.prefill_instances)
 
 
 class RoundRobinSchedulingPolicy(SchedulingPolicy):


### PR DESCRIPTION
## Summary

- Fix logic error in `remove_instance_endpoint` method in `disagg_proxy_demo.py`
- The prefill instance branch incorrectly referenced `decode_instances` instead of `prefill_instances`
- When removing prefill instances, the code now correctly checks against and cycles `self.prefill_instances`

## Bug Description

The original code had two bugs in the prefill branch of `remove_instance_endpoint`:

```python
# Before (buggy):
if instance_type == "prefill" and instance in self.decode_instances:  # Wrong list!
    self.prefill_instances.remove(instance)
    self.prefill_cycler = itertools.cycle(self.decode_instances)  # Wrong list!
```

```python
# After (fixed):
if instance_type == "prefill" and instance in self.prefill_instances:
    self.prefill_instances.remove(instance)
    self.prefill_cycler = itertools.cycle(self.prefill_instances)
```

## Related Issues

Fixes #32920

## Test Plan

- The fix is straightforward and addresses a clear copy-paste error
- Code review should verify the correct list is now being used for both the membership check and cycler recreation