### PR TITLE
[Feature][Tool Parser] Add dedicated parser for Qwen2.5-Coder models

### DIFF
--- a/tests/tool_parsers/test_qwen25_coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen25_coder_tool_parser.py
@@ -5,6 +5,7 @@ Tests for Qwen2.5-Coder tool parser.
 
 This tests the <tools>JSON</tools> format used by Qwen2.5-Coder models.
 """
+
 import json
 from collections.abc import Generator
 
@@ -16,7 +17,6 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 )
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
-    FunctionCall,
     ToolCall,
 )
 from vllm.tokenizers import TokenizerLike, get_tokenizer
@@ -71,7 +71,10 @@ def sample_tools():
                     "type": "object",
                     "properties": {
                         "query": {"type": "string", "description": "Search query"},
-                        "num_results": {"type": "integer", "description": "Number of results"},
+                        "num_results": {
+                            "type": "integer",
+                            "description": "Number of results",
+                        },
                     },
                     "required": ["query"],
                 },
@@ -375,7 +378,9 @@ class TestExtractToolCallsStreaming:
                         if tool_call.function.name:
                             tool_states[idx]["name"] = tool_call.function.name
                         if tool_call.function.arguments is not None:
-                            tool_states[idx]["arguments"] += tool_call.function.arguments
+                            tool_states[idx]["arguments"] += (
+                                tool_call.function.arguments
+                            )
 
         # Verify we got the tool call
         assert len(tool_states) == 1
@@ -425,7 +430,9 @@ class TestExtractToolCallsStreaming:
                         if tool_call.function.name:
                             tool_states[idx]["name"] = tool_call.function.name
                         if tool_call.function.arguments is not None:
-                            tool_states[idx]["arguments"] += tool_call.function.arguments
+                            tool_states[idx]["arguments"] += (
+                                tool_call.function.arguments
+                            )
 
         # Content before tool call should be collected
         assert "Let me check" in collected_content

--- a/tests/tool_parsers/test_qwen25_coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen25_coder_tool_parser.py
@@ -1,0 +1,542 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tests for Qwen2.5-Coder tool parser.
+
+This tests the <tools>JSON</tools> format used by Qwen2.5-Coder models.
+"""
+import json
+from collections.abc import Generator
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+)
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaMessage,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.tokenizers import TokenizerLike, get_tokenizer
+from vllm.tokenizers.detokenizer_utils import detokenize_incrementally
+from vllm.tool_parsers.qwen25_coder_tool_parser import Qwen25CoderToolParser
+
+# Use a model that has the <tools> token in vocabulary
+# Fallback to a common model if specific Qwen2.5-Coder model not available
+MODEL = "gpt2"
+
+
+@pytest.fixture(scope="module")
+def qwen25_tokenizer():
+    return get_tokenizer(tokenizer_name=MODEL)
+
+
+@pytest.fixture
+def qwen25_tool_parser(qwen25_tokenizer):
+    return Qwen25CoderToolParser(qwen25_tokenizer)
+
+
+@pytest.fixture
+def sample_tools():
+    return [
+        ChatCompletionToolsParam(
+            type="function",
+            function={
+                "name": "get_current_weather",
+                "description": "Get the current weather in a given location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The city and state, e.g. San Francisco, CA",
+                        },
+                        "unit": {
+                            "type": "string",
+                            "enum": ["celsius", "fahrenheit"],
+                        },
+                    },
+                    "required": ["location"],
+                },
+            },
+        ),
+        ChatCompletionToolsParam(
+            type="function",
+            function={
+                "name": "search_web",
+                "description": "Search the web for information",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search query"},
+                        "num_results": {"type": "integer", "description": "Number of results"},
+                    },
+                    "required": ["query"],
+                },
+            },
+        ),
+    ]
+
+
+def assert_tool_calls(
+    actual_tool_calls: list[ToolCall], expected_tool_calls: list[ToolCall]
+):
+    """Assert that actual tool calls match expected tool calls."""
+    assert len(actual_tool_calls) == len(expected_tool_calls)
+
+    for actual, expected in zip(actual_tool_calls, expected_tool_calls):
+        assert actual.type == "function"
+        assert actual.function.name == expected.function.name
+        assert json.loads(actual.function.arguments) == json.loads(
+            expected.function.arguments
+        )
+
+
+def stream_delta_message_generator(
+    tool_parser: Qwen25CoderToolParser,
+    tokenizer: TokenizerLike,
+    model_output: str,
+    request: ChatCompletionRequest | None = None,
+) -> Generator[DeltaMessage, None, None]:
+    """Generate delta messages by streaming tokens one at a time."""
+    all_token_ids = tokenizer.encode(model_output, add_special_tokens=False)
+
+    previous_text = ""
+    previous_tokens = None
+    prefix_offset = 0
+    read_offset = 0
+
+    for i, delta_token in enumerate(all_token_ids):
+        delta_token_ids = [delta_token]
+        previous_token_ids = all_token_ids[:i]
+        current_token_ids = all_token_ids[: i + 1]
+
+        (new_tokens, delta_text, new_prefix_offset, new_read_offset) = (
+            detokenize_incrementally(
+                tokenizer=tokenizer,
+                all_input_ids=current_token_ids,
+                prev_tokens=previous_tokens,
+                prefix_offset=prefix_offset,
+                read_offset=read_offset,
+                skip_special_tokens=False,
+                spaces_between_special_tokens=True,
+            )
+        )
+
+        current_text = previous_text + delta_text
+
+        delta_message = tool_parser.extract_tool_calls_streaming(
+            previous_text,
+            current_text,
+            delta_text,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+            request=request,
+        )
+        if delta_message:
+            yield delta_message
+
+        previous_text = current_text
+        previous_tokens = (
+            previous_tokens + new_tokens if previous_tokens else new_tokens
+        )
+        prefix_offset = new_prefix_offset
+        read_offset = new_read_offset
+
+
+class TestExtractToolCallsNonStreaming:
+    """Test non-streaming tool call extraction."""
+
+    def test_no_tool_calls(self, qwen25_tool_parser):
+        """Test response without any tool calls."""
+        model_output = "This is a regular response without tool calls."
+        result = qwen25_tool_parser.extract_tool_calls(model_output, request=None)
+
+        assert not result.tools_called
+        assert result.tool_calls == []
+        assert result.content == model_output
+
+    def test_single_tool_call(self, qwen25_tool_parser, sample_tools):
+        """Test extracting a single tool call."""
+        model_output = """<tools>
+{"name": "get_current_weather", "arguments": {"location": "San Francisco, CA", "unit": "celsius"}}
+</tools>"""
+
+        request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
+        result = qwen25_tool_parser.extract_tool_calls(model_output, request=request)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "get_current_weather"
+
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args["location"] == "San Francisco, CA"
+        assert args["unit"] == "celsius"
+
+    def test_single_tool_call_with_content(self, qwen25_tool_parser, sample_tools):
+        """Test tool call with preceding content."""
+        model_output = """Let me check the weather for you.
+<tools>
+{"name": "get_current_weather", "arguments": {"location": "Tokyo, Japan"}}
+</tools>"""
+
+        request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
+        result = qwen25_tool_parser.extract_tool_calls(model_output, request=request)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.content == "Let me check the weather for you."
+
+    def test_parallel_tool_calls_array(self, qwen25_tool_parser, sample_tools):
+        """Test extracting multiple tool calls as JSON array."""
+        model_output = """<tools>
+[
+    {"name": "get_current_weather", "arguments": {"location": "Paris, France"}},
+    {"name": "search_web", "arguments": {"query": "Paris attractions", "num_results": 5}}
+]
+</tools>"""
+
+        request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
+        result = qwen25_tool_parser.extract_tool_calls(model_output, request=request)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 2
+
+        assert result.tool_calls[0].function.name == "get_current_weather"
+        assert result.tool_calls[1].function.name == "search_web"
+
+        args1 = json.loads(result.tool_calls[0].function.arguments)
+        assert args1["location"] == "Paris, France"
+
+        args2 = json.loads(result.tool_calls[1].function.arguments)
+        assert args2["query"] == "Paris attractions"
+        assert args2["num_results"] == 5
+
+    def test_multiple_tools_blocks(self, qwen25_tool_parser, sample_tools):
+        """Test extracting from multiple <tools> blocks."""
+        model_output = """<tools>
+{"name": "get_current_weather", "arguments": {"location": "London, UK"}}
+</tools>
+<tools>
+{"name": "search_web", "arguments": {"query": "London events"}}
+</tools>"""
+
+        request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
+        result = qwen25_tool_parser.extract_tool_calls(model_output, request=request)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 2
+
+    def test_parameters_key_support(self, qwen25_tool_parser, sample_tools):
+        """Test that 'parameters' key is also supported (alias for 'arguments')."""
+        model_output = """<tools>
+{"name": "get_current_weather", "parameters": {"location": "Berlin, Germany"}}
+</tools>"""
+
+        request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
+        result = qwen25_tool_parser.extract_tool_calls(model_output, request=request)
+
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args["location"] == "Berlin, Germany"
+
+    def test_nested_json_arguments(self, qwen25_tool_parser):
+        """Test tool call with nested JSON in arguments."""
+        tools = [
+            ChatCompletionToolsParam(
+                type="function",
+                function={
+                    "name": "complex_function",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "config": {"type": "object"},
+                            "items": {"type": "array"},
+                        },
+                    },
+                },
+            )
+        ]
+
+        model_output = """<tools>
+{"name": "complex_function", "arguments": {"config": {"nested": {"deep": true}}, "items": [1, 2, {"key": "value"}]}}
+</tools>"""
+
+        request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
+        result = qwen25_tool_parser.extract_tool_calls(model_output, request=request)
+
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args["config"]["nested"]["deep"] is True
+        assert args["items"] == [1, 2, {"key": "value"}]
+
+    def test_empty_arguments(self, qwen25_tool_parser):
+        """Test tool call with empty arguments."""
+        tools = [
+            ChatCompletionToolsParam(
+                type="function",
+                function={
+                    "name": "no_args_function",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            )
+        ]
+
+        model_output = """<tools>
+{"name": "no_args_function", "arguments": {}}
+</tools>"""
+
+        request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
+        result = qwen25_tool_parser.extract_tool_calls(model_output, request=request)
+
+        assert result.tools_called
+        assert result.tool_calls[0].function.name == "no_args_function"
+        assert json.loads(result.tool_calls[0].function.arguments) == {}
+
+    def test_malformed_json_returns_content(self, qwen25_tool_parser):
+        """Test that malformed JSON is returned as content."""
+        model_output = """<tools>
+{"name": "broken", "arguments": {invalid json
+</tools>"""
+
+        result = qwen25_tool_parser.extract_tool_calls(model_output, request=None)
+
+        # Should not crash, returns original as content
+        assert not result.tools_called
+
+    def test_unicode_in_arguments(self, qwen25_tool_parser, sample_tools):
+        """Test tool call with unicode characters in arguments."""
+        model_output = """<tools>
+{"name": "get_current_weather", "arguments": {"location": "Tokyo, Japan"}}
+</tools>"""
+
+        request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
+        result = qwen25_tool_parser.extract_tool_calls(model_output, request=request)
+
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert "Tokyo" in args["location"]
+
+
+class TestExtractToolCallsStreaming:
+    """Test streaming tool call extraction."""
+
+    def test_no_tool_calls_streaming(
+        self, qwen25_tool_parser, qwen25_tokenizer, sample_tools
+    ):
+        """Test streaming response without tool calls."""
+        model_output = "This is a regular response without any tool calls."
+        request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
+
+        collected_content = ""
+        for delta in stream_delta_message_generator(
+            qwen25_tool_parser, qwen25_tokenizer, model_output, request
+        ):
+            if delta.content:
+                collected_content += delta.content
+
+        assert collected_content == model_output
+
+    def test_single_tool_streaming(
+        self, qwen25_tool_parser, qwen25_tokenizer, sample_tools
+    ):
+        """Test streaming a single tool call."""
+        model_output = """<tools>
+{"name": "get_current_weather", "arguments": {"location": "NYC"}}
+</tools>"""
+
+        request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
+
+        tool_states = {}
+        for delta in stream_delta_message_generator(
+            qwen25_tool_parser, qwen25_tokenizer, model_output, request
+        ):
+            if delta.tool_calls:
+                for tool_call in delta.tool_calls:
+                    idx = tool_call.index
+
+                    if idx not in tool_states:
+                        tool_states[idx] = {
+                            "id": None,
+                            "name": None,
+                            "arguments": "",
+                            "type": None,
+                        }
+
+                    if tool_call.id:
+                        tool_states[idx]["id"] = tool_call.id
+                    if tool_call.type:
+                        tool_states[idx]["type"] = tool_call.type
+                    if tool_call.function:
+                        if tool_call.function.name:
+                            tool_states[idx]["name"] = tool_call.function.name
+                        if tool_call.function.arguments is not None:
+                            tool_states[idx]["arguments"] += tool_call.function.arguments
+
+        # Verify we got the tool call
+        assert len(tool_states) == 1
+        state = tool_states[0]
+        assert state["name"] == "get_current_weather"
+        assert state["type"] == "function"
+        assert state["id"] is not None
+
+        # Verify arguments
+        args = json.loads(state["arguments"])
+        assert args["location"] == "NYC"
+
+    def test_tool_with_content_streaming(
+        self, qwen25_tool_parser, qwen25_tokenizer, sample_tools
+    ):
+        """Test streaming tool call with preceding content."""
+        model_output = """Let me check that for you.
+<tools>
+{"name": "get_current_weather", "arguments": {"location": "LA"}}
+</tools>"""
+
+        request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
+
+        collected_content = ""
+        tool_states = {}
+
+        for delta in stream_delta_message_generator(
+            qwen25_tool_parser, qwen25_tokenizer, model_output, request
+        ):
+            if delta.content:
+                collected_content += delta.content
+            if delta.tool_calls:
+                for tool_call in delta.tool_calls:
+                    idx = tool_call.index
+                    if idx not in tool_states:
+                        tool_states[idx] = {
+                            "id": None,
+                            "name": None,
+                            "arguments": "",
+                            "type": None,
+                        }
+                    if tool_call.id:
+                        tool_states[idx]["id"] = tool_call.id
+                    if tool_call.type:
+                        tool_states[idx]["type"] = tool_call.type
+                    if tool_call.function:
+                        if tool_call.function.name:
+                            tool_states[idx]["name"] = tool_call.function.name
+                        if tool_call.function.arguments is not None:
+                            tool_states[idx]["arguments"] += tool_call.function.arguments
+
+        # Content before tool call should be collected
+        assert "Let me check" in collected_content
+
+        # Tool call should be parsed
+        assert len(tool_states) == 1
+
+
+class TestAdjustRequest:
+    """Test request adjustment for tool parsing."""
+
+    def test_adjust_request_disables_skip_special_tokens(
+        self, qwen25_tool_parser, sample_tools
+    ):
+        """Test that request is adjusted to not skip special tokens."""
+        request = ChatCompletionRequest(
+            model=MODEL,
+            messages=[],
+            tools=sample_tools,
+            skip_special_tokens=True,
+        )
+
+        adjusted = qwen25_tool_parser.adjust_request(request)
+        assert adjusted.skip_special_tokens is False
+
+    def test_adjust_request_no_tools(self, qwen25_tool_parser):
+        """Test that request without tools is not modified."""
+        request = ChatCompletionRequest(
+            model=MODEL,
+            messages=[],
+            tools=None,
+            skip_special_tokens=True,
+        )
+
+        adjusted = qwen25_tool_parser.adjust_request(request)
+        # Should still be True when no tools
+        assert adjusted.skip_special_tokens is True
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_incomplete_tools_tag(self, qwen25_tool_parser):
+        """Test handling of incomplete <tools> tag."""
+        model_output = """<tools>
+{"name": "test", "arguments": {}}"""  # Missing </tools>
+
+        result = qwen25_tool_parser.extract_tool_calls(model_output, request=None)
+
+        # Should still parse the tool call
+        assert result.tools_called
+        assert result.tool_calls[0].function.name == "test"
+
+    def test_whitespace_handling(self, qwen25_tool_parser, sample_tools):
+        """Test handling of various whitespace in tool calls."""
+        model_output = """<tools>
+
+  {  "name"  :  "get_current_weather"  ,  "arguments"  :  {  "location"  :  "Chicago"  }  }
+
+</tools>"""
+
+        request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
+        result = qwen25_tool_parser.extract_tool_calls(model_output, request=request)
+
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args["location"] == "Chicago"
+
+    def test_special_characters_in_arguments(self, qwen25_tool_parser, sample_tools):
+        """Test handling of special characters in argument values."""
+        model_output = """<tools>
+{"name": "search_web", "arguments": {"query": "What's the weather? <tag> & stuff"}}
+</tools>"""
+
+        request = ChatCompletionRequest(model=MODEL, messages=[], tools=sample_tools)
+        result = qwen25_tool_parser.extract_tool_calls(model_output, request=request)
+
+        assert result.tools_called
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert "What's the weather?" in args["query"]
+        assert "<tag>" in args["query"]
+        assert "&" in args["query"]
+
+
+@pytest.mark.parametrize(
+    "model_output,expected_tool_name,expected_args",
+    [
+        (
+            '<tools>{"name": "func1", "arguments": {"a": 1}}</tools>',
+            "func1",
+            {"a": 1},
+        ),
+        (
+            '<tools>{"name": "func2", "parameters": {"b": "test"}}</tools>',
+            "func2",
+            {"b": "test"},
+        ),
+        (
+            '<tools>\n{"name": "func3", "arguments": {}}\n</tools>',
+            "func3",
+            {},
+        ),
+    ],
+    ids=["simple", "parameters_key", "with_newlines"],
+)
+def test_various_formats(
+    qwen25_tool_parser, model_output, expected_tool_name, expected_args
+):
+    """Test various valid tool call formats."""
+    result = qwen25_tool_parser.extract_tool_calls(model_output, request=None)
+
+    assert result.tools_called
+    assert result.tool_calls[0].function.name == expected_tool_name
+    assert json.loads(result.tool_calls[0].function.arguments) == expected_args

--- a/vllm/tool_parsers/__init__.py
+++ b/vllm/tool_parsers/__init__.py
@@ -118,6 +118,10 @@ _TOOL_PARSERS_TO_REGISTER = {
         "pythonic_tool_parser",
         "PythonicToolParser",
     ),
+    "qwen2_5_coder": (
+        "qwen25_coder_tool_parser",
+        "Qwen25CoderToolParser",
+    ),
     "qwen3_coder": (
         "qwen3coder_tool_parser",
         "Qwen3CoderToolParser",

--- a/vllm/tool_parsers/qwen25_coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen25_coder_tool_parser.py
@@ -1,0 +1,484 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tool parser for Qwen2.5-Coder models.
+
+Qwen2.5-Coder models output tool calls in <tools> tags with JSON content,
+unlike Hermes format (<tool_call>) or Qwen3-Coder format (XML parameters).
+
+Expected format (single tool):
+<tools>
+{"name": "function_name", "arguments": {"param1": "value1"}}
+</tools>
+
+Expected format (multiple tools):
+<tools>
+[{"name": "func1", "arguments": {...}}, {"name": "func2", "arguments": {...}}]
+</tools>
+
+The model follows this format with high compliance when given appropriate
+few-shot examples in the chat template.
+"""
+import json
+from collections.abc import Sequence
+
+import partial_json_parser
+import regex as re
+from partial_json_parser.core.options import Allow
+
+from vllm.entrypoints.chat_utils import make_tool_call_id
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
+    DeltaMessage,
+    DeltaToolCall,
+    ExtractedToolCallInformation,
+    FunctionCall,
+    ToolCall,
+)
+from vllm.logger import init_logger
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.abstract_tool_parser import (
+    ToolParser,
+)
+from vllm.tool_parsers.utils import (
+    find_common_prefix,
+    is_complete_json,
+    partial_json_loads,
+)
+
+logger = init_logger(__name__)
+
+
+class Qwen25CoderToolParser(ToolParser):
+    """
+    Tool call parser for Qwen2.5-Coder models.
+
+    Qwen2.5-Coder outputs tool calls within <tools></tools> tags containing
+    JSON objects or arrays. This differs from:
+    - Hermes format: uses <tool_call></tool_call> tags
+    - Qwen3-Coder format: uses XML-style <function=name><parameter=...>
+
+    This parser extracts JSON tool calls from <tools> tags and supports
+    both single tool calls and parallel (array) tool calls.
+    """
+
+    def __init__(self, tokenizer: TokenizerLike):
+        super().__init__(tokenizer)
+
+        self.current_tool_name_sent: bool = False
+        self.prev_tool_call_arr: list[dict] = []
+        self.current_tool_id: int = -1
+        self.streamed_args_for_tool: list[str] = []
+
+        # Define the tag markers for Qwen2.5-Coder format
+        self.tool_call_start_token: str = "<tools>"
+        self.tool_call_end_token: str = "</tools>"
+
+        # Regex to extract content between <tools> tags
+        # Handles both complete and incomplete (streaming) cases
+        self.tool_call_regex = re.compile(
+            r"<tools>(.*?)</tools>|<tools>(.*)", re.DOTALL
+        )
+
+        if not self.model_tokenizer:
+            raise ValueError(
+                "The model tokenizer must be passed to the ToolParser "
+                "constructor during construction."
+            )
+
+        # Get token IDs for start/end markers
+        self.tool_call_start_token_ids = self.model_tokenizer.encode(
+            self.tool_call_start_token, add_special_tokens=False
+        )
+        self.tool_call_end_token_ids = self.model_tokenizer.encode(
+            self.tool_call_end_token, add_special_tokens=False
+        )
+
+        # Create arrays for buffering partial tokens
+        self.tool_call_start_token_array = [
+            self.model_tokenizer.decode([token_id])
+            for token_id in self.tool_call_start_token_ids
+        ]
+
+        self.tool_call_end_token_array = [
+            self.model_tokenizer.decode([token_id])
+            for token_id in self.tool_call_end_token_ids
+        ]
+
+        self.buffered_delta_text = ""
+
+        logger.info(
+            "vLLM Successfully initialized tool parser %s!", self.__class__.__name__
+        )
+
+    def _buffer_delta_text(self, delta_text: str) -> str:
+        """
+        Buffer tokens that might be part of <tools> or </tools> tags.
+
+        When encountering tokens like <, tools, >, store them in a buffer.
+        When the last token is encountered, return the buffer.
+        If tokens don't form a valid sequence, return buffered + current.
+        """
+        if (
+            delta_text in self.tool_call_start_token_array
+            or delta_text in self.tool_call_end_token_array
+        ):
+            # Check if this completes a start or end token
+            if (
+                delta_text == self.tool_call_start_token_array[-1]
+                or delta_text == self.tool_call_end_token_array[-1]
+            ):
+                buffered_text = self.buffered_delta_text
+                self.buffered_delta_text = ""
+                return buffered_text + delta_text
+            else:
+                self.buffered_delta_text = self.buffered_delta_text + delta_text
+                return ""
+        else:
+            if self.buffered_delta_text:
+                buffered_text = self.buffered_delta_text
+                self.buffered_delta_text = ""
+                return buffered_text + delta_text
+            else:
+                return delta_text
+
+    def _parse_tool_calls_from_json(
+        self, json_content: str
+    ) -> list[ToolCall]:
+        """
+        Parse tool calls from JSON content.
+
+        Supports both single object and array formats:
+        - {"name": "func", "arguments": {...}}
+        - [{"name": "func1", ...}, {"name": "func2", ...}]
+        """
+        tool_calls = []
+
+        try:
+            parsed = json.loads(json_content)
+
+            # Handle array of tool calls
+            if isinstance(parsed, list):
+                raw_function_calls = parsed
+            # Handle single tool call object
+            elif isinstance(parsed, dict):
+                raw_function_calls = [parsed]
+            else:
+                logger.warning(
+                    "Unexpected JSON type in tool call: %s", type(parsed)
+                )
+                return []
+
+            for function_call in raw_function_calls:
+                if not isinstance(function_call, dict):
+                    continue
+
+                name = function_call.get("name")
+                if not name:
+                    continue
+
+                # Support both "arguments" and "parameters" keys
+                arguments = function_call.get(
+                    "arguments", function_call.get("parameters", {})
+                )
+
+                tool_calls.append(
+                    ToolCall(
+                        type="function",
+                        function=FunctionCall(
+                            name=name,
+                            arguments=json.dumps(arguments, ensure_ascii=False),
+                        ),
+                    )
+                )
+
+        except json.JSONDecodeError:
+            logger.exception("Failed to parse JSON from tool call content")
+
+        return tool_calls
+
+    def adjust_request(self, request: ChatCompletionRequest) -> ChatCompletionRequest:
+        """Adjust request to not skip special tokens for tool parsing."""
+        request = super().adjust_request(request)
+        if request.tools and request.tool_choice != "none":
+            # Don't skip special tokens as <tools> tags need to be parsed
+            request.skip_special_tokens = False
+        return request
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        """
+        Extract tool calls from a complete model response.
+
+        Looks for <tools>...</tools> tags and parses the JSON content within.
+        """
+        # Quick check to avoid unnecessary processing
+        if self.tool_call_start_token not in model_output:
+            return ExtractedToolCallInformation(
+                tools_called=False, tool_calls=[], content=model_output
+            )
+
+        try:
+            # Find all tool call blocks
+            matches = self.tool_call_regex.findall(model_output)
+
+            all_tool_calls = []
+            for match in matches:
+                # match is a tuple - get the non-empty group
+                json_content = match[0] if match[0] else match[1]
+                json_content = json_content.strip()
+
+                if json_content:
+                    tool_calls = self._parse_tool_calls_from_json(json_content)
+                    all_tool_calls.extend(tool_calls)
+
+            if all_tool_calls:
+                # Extract content before the first tool call
+                content_end = model_output.find(self.tool_call_start_token)
+                content = model_output[:content_end].strip() if content_end > 0 else None
+
+                return ExtractedToolCallInformation(
+                    tools_called=True,
+                    tool_calls=all_tool_calls,
+                    content=content if content else None,
+                )
+
+        except Exception:
+            logger.exception("Error in extracting tool call from response.")
+
+        return ExtractedToolCallInformation(
+            tools_called=False, tool_calls=[], content=model_output
+        )
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> DeltaMessage | None:
+        """
+        Extract tool calls from streaming model output.
+
+        Handles incremental parsing of <tools>JSON</tools> content.
+        """
+        # Apply buffering for partial tag tokens
+        delta_text = self._buffer_delta_text(delta_text)
+
+        # Adjust text to account for buffered content
+        if (
+            len(previous_text) >= len(self.buffered_delta_text)
+            and previous_text[-len(self.buffered_delta_text):]
+            == self.buffered_delta_text
+        ):
+            previous_text = previous_text[: -len(self.buffered_delta_text)]
+            current_text = previous_text + delta_text
+
+        # If no tool call started yet, check if we should stream content
+        if self.tool_call_start_token not in current_text:
+            return DeltaMessage(content=delta_text)
+
+        try:
+            # Count start and end tags
+            prev_tool_start_count = previous_text.count(self.tool_call_start_token)
+            prev_tool_end_count = previous_text.count(self.tool_call_end_token)
+            cur_tool_start_count = current_text.count(self.tool_call_start_token)
+            cur_tool_end_count = current_text.count(self.tool_call_end_token)
+
+            # If we're outside tool calls (equal start/end), stream as content
+            if (
+                cur_tool_start_count == cur_tool_end_count
+                and prev_tool_end_count == cur_tool_end_count
+                and self.tool_call_end_token not in delta_text
+            ):
+                return DeltaMessage(content=delta_text)
+
+            # Get the current tool call JSON content
+            tool_call_content = None
+
+            if cur_tool_start_count > cur_tool_end_count:
+                # We're inside a tool call - extract content after last <tools>
+                last_start = current_text.rfind(self.tool_call_start_token)
+                tool_call_content = current_text[
+                    last_start + len(self.tool_call_start_token):
+                ]
+            elif self.tool_call_end_token in delta_text:
+                # Tool call is being closed
+                last_start = current_text.rfind(self.tool_call_start_token)
+                last_end = current_text.rfind(self.tool_call_end_token)
+                if last_start < last_end:
+                    tool_call_content = current_text[
+                        last_start + len(self.tool_call_start_token): last_end
+                    ]
+
+            if not tool_call_content:
+                return None
+
+            tool_call_content = tool_call_content.strip()
+
+            # Use partial JSON parser for streaming
+            flags = Allow.ALL if self.current_tool_name_sent else Allow.ALL & ~Allow.STR
+
+            try:
+                tool_call_arr = []
+                is_complete = []
+                start_idx = 0
+
+                while start_idx < len(tool_call_content):
+                    try:
+                        (obj, end_idx) = partial_json_loads(
+                            tool_call_content[start_idx:], flags
+                        )
+                        is_complete.append(
+                            is_complete_json(
+                                tool_call_content[start_idx: start_idx + end_idx]
+                            )
+                        )
+                        # Support both "arguments" and "parameters"
+                        if "parameters" in obj and "arguments" not in obj:
+                            obj["arguments"] = obj["parameters"]
+                        tool_call_arr.append(obj)
+                        # Move past this JSON object (handle comma/whitespace)
+                        remaining = tool_call_content[start_idx + end_idx:].lstrip()
+                        if remaining.startswith(","):
+                            remaining = remaining[1:].lstrip()
+                        start_idx = len(tool_call_content) - len(remaining)
+                        if start_idx == len(tool_call_content) - len(
+                            tool_call_content[start_idx + end_idx:]
+                        ):
+                            break
+                    except partial_json_parser.core.exceptions.MalformedJSON:
+                        break
+
+            except partial_json_parser.core.exceptions.MalformedJSON:
+                logger.debug("Not enough tokens to parse into JSON yet")
+                return None
+
+            if len(tool_call_arr) == 0:
+                return None
+
+            current_tool_call: dict = (
+                tool_call_arr[self.current_tool_id] if len(tool_call_arr) > 0 else {}
+            )
+
+            # Starting a new tool call
+            if len(tool_call_arr) > self.current_tool_id + 1:
+                # Handle completion of previous tool if any
+                if self.current_tool_id >= 0:
+                    cur_arguments = current_tool_call.get("arguments")
+                    if cur_arguments:
+                        cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
+                        sent = len(self.streamed_args_for_tool[self.current_tool_id])
+                        argument_diff = cur_args_json[sent:]
+
+                        if argument_diff:
+                            delta = DeltaMessage(
+                                tool_calls=[
+                                    DeltaToolCall(
+                                        index=self.current_tool_id,
+                                        function=DeltaFunctionCall(
+                                            arguments=argument_diff
+                                        ).model_dump(exclude_none=True),
+                                    )
+                                ]
+                            )
+                            self.streamed_args_for_tool[self.current_tool_id] += (
+                                argument_diff
+                            )
+                            self.prev_tool_call_arr = tool_call_arr
+                            return delta
+                    delta = None
+                else:
+                    delta = None
+
+                # Start new tool
+                self.current_tool_id = len(tool_call_arr) - 1
+                self.current_tool_name_sent = False
+                self.streamed_args_for_tool.append("")
+                logger.debug("Starting on new tool %d", self.current_tool_id)
+                self.prev_tool_call_arr = tool_call_arr
+                return delta
+
+            # Send tool name if not sent yet
+            elif not self.current_tool_name_sent:
+                function_name = current_tool_call.get("name")
+                if function_name:
+                    delta = DeltaMessage(
+                        tool_calls=[
+                            DeltaToolCall(
+                                index=self.current_tool_id,
+                                type="function",
+                                id=make_tool_call_id(),
+                                function=DeltaFunctionCall(
+                                    name=function_name
+                                ).model_dump(exclude_none=True),
+                            )
+                        ]
+                    )
+                    self.current_tool_name_sent = True
+                    self.prev_tool_call_arr = tool_call_arr
+                    return delta
+                return None
+
+            # Stream arguments
+            else:
+                cur_arguments = current_tool_call.get("arguments")
+                delta = None
+
+                if cur_arguments:
+                    sent = len(self.streamed_args_for_tool[self.current_tool_id])
+                    cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
+
+                    prev_arguments = None
+                    if (
+                        self.prev_tool_call_arr
+                        and self.current_tool_id < len(self.prev_tool_call_arr)
+                    ):
+                        prev_arguments = self.prev_tool_call_arr[
+                            self.current_tool_id
+                        ].get("arguments")
+
+                    argument_diff = None
+                    if is_complete and self.current_tool_id < len(is_complete):
+                        if is_complete[self.current_tool_id]:
+                            argument_diff = cur_args_json[sent:]
+                        elif prev_arguments:
+                            prev_args_json = json.dumps(
+                                prev_arguments, ensure_ascii=False
+                            )
+                            if cur_args_json != prev_args_json:
+                                prefix = find_common_prefix(
+                                    prev_args_json, cur_args_json
+                                )
+                                argument_diff = prefix[sent:]
+
+                    if argument_diff:
+                        delta = DeltaMessage(
+                            tool_calls=[
+                                DeltaToolCall(
+                                    index=self.current_tool_id,
+                                    function=DeltaFunctionCall(
+                                        arguments=argument_diff
+                                    ).model_dump(exclude_none=True),
+                                )
+                            ]
+                        )
+                        self.streamed_args_for_tool[self.current_tool_id] += (
+                            argument_diff
+                        )
+
+                self.prev_tool_call_arr = tool_call_arr
+                return delta
+
+        except Exception:
+            logger.exception("Error trying to handle streaming tool call.")
+            return None

--- a/vllm/tool_parsers/qwen25_coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen25_coder_tool_parser.py
@@ -19,6 +19,7 @@ Expected format (multiple tools):
 The model follows this format with high compliance when given appropriate
 few-shot examples in the chat template.
 """
+
 import json
 from collections.abc import Sequence
 
@@ -145,9 +146,7 @@ class Qwen25CoderToolParser(ToolParser):
             else:
                 return delta_text
 
-    def _parse_tool_calls_from_json(
-        self, json_content: str
-    ) -> list[ToolCall]:
+    def _parse_tool_calls_from_json(self, json_content: str) -> list[ToolCall]:
         """
         Parse tool calls from JSON content.
 
@@ -167,9 +166,7 @@ class Qwen25CoderToolParser(ToolParser):
             elif isinstance(parsed, dict):
                 raw_function_calls = [parsed]
             else:
-                logger.warning(
-                    "Unexpected JSON type in tool call: %s", type(parsed)
-                )
+                logger.warning("Unexpected JSON type in tool call: %s", type(parsed))
                 return []
 
             for function_call in raw_function_calls:
@@ -241,7 +238,9 @@ class Qwen25CoderToolParser(ToolParser):
             if all_tool_calls:
                 # Extract content before the first tool call
                 content_end = model_output.find(self.tool_call_start_token)
-                content = model_output[:content_end].strip() if content_end > 0 else None
+                content = (
+                    model_output[:content_end].strip() if content_end > 0 else None
+                )
 
                 return ExtractedToolCallInformation(
                     tools_called=True,
@@ -277,7 +276,7 @@ class Qwen25CoderToolParser(ToolParser):
         # Adjust text to account for buffered content
         if (
             len(previous_text) >= len(self.buffered_delta_text)
-            and previous_text[-len(self.buffered_delta_text):]
+            and previous_text[-len(self.buffered_delta_text) :]
             == self.buffered_delta_text
         ):
             previous_text = previous_text[: -len(self.buffered_delta_text)]
@@ -309,7 +308,7 @@ class Qwen25CoderToolParser(ToolParser):
                 # We're inside a tool call - extract content after last <tools>
                 last_start = current_text.rfind(self.tool_call_start_token)
                 tool_call_content = current_text[
-                    last_start + len(self.tool_call_start_token):
+                    last_start + len(self.tool_call_start_token) :
                 ]
             elif self.tool_call_end_token in delta_text:
                 # Tool call is being closed
@@ -317,7 +316,7 @@ class Qwen25CoderToolParser(ToolParser):
                 last_end = current_text.rfind(self.tool_call_end_token)
                 if last_start < last_end:
                     tool_call_content = current_text[
-                        last_start + len(self.tool_call_start_token): last_end
+                        last_start + len(self.tool_call_start_token) : last_end
                     ]
 
             if not tool_call_content:
@@ -340,7 +339,7 @@ class Qwen25CoderToolParser(ToolParser):
                         )
                         is_complete.append(
                             is_complete_json(
-                                tool_call_content[start_idx: start_idx + end_idx]
+                                tool_call_content[start_idx : start_idx + end_idx]
                             )
                         )
                         # Support both "arguments" and "parameters"
@@ -348,12 +347,12 @@ class Qwen25CoderToolParser(ToolParser):
                             obj["arguments"] = obj["parameters"]
                         tool_call_arr.append(obj)
                         # Move past this JSON object (handle comma/whitespace)
-                        remaining = tool_call_content[start_idx + end_idx:].lstrip()
+                        remaining = tool_call_content[start_idx + end_idx :].lstrip()
                         if remaining.startswith(","):
                             remaining = remaining[1:].lstrip()
                         start_idx = len(tool_call_content) - len(remaining)
                         if start_idx == len(tool_call_content) - len(
-                            tool_call_content[start_idx + end_idx:]
+                            tool_call_content[start_idx + end_idx :]
                         ):
                             break
                     except partial_json_parser.core.exceptions.MalformedJSON:
@@ -439,9 +438,8 @@ class Qwen25CoderToolParser(ToolParser):
                     cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
 
                     prev_arguments = None
-                    if (
+                    if self.prev_tool_call_arr and self.current_tool_id < len(
                         self.prev_tool_call_arr
-                        and self.current_tool_id < len(self.prev_tool_call_arr)
                     ):
                         prev_arguments = self.prev_tool_call_arr[
                             self.current_tool_id


### PR DESCRIPTION
## Summary

- Add a dedicated `qwen2_5_coder` tool parser for Qwen2.5-Coder models
- Qwen2.5-Coder outputs tool calls in `<tools>JSON</tools>` format, which differs from:
  - Hermes format: uses `<tool_call></tool_call>` tags
  - Qwen3-Coder format: uses XML-style `<function=name><parameter=...>` tags
- The new parser handles both single and parallel (array) tool calls
- Supports streaming with incremental JSON parsing

## Motivation

Qwen2.5-Coder models have no working tool call parser in vLLM. The vLLM documentation recommends `--tool-call-parser hermes` for Qwen2.5, but Qwen2.5-Coder does not follow hermes format - it outputs JSON in `<tools>` tags when prompted with few-shot examples.

See issue #32926 for detailed format analysis showing 100% compliance with `<tools>` tag format when given appropriate few-shot examples.

## Format

The parser handles this format:

**Single tool call:**
```
<tools>
{"name": "function_name", "arguments": {"param1": "value1"}}
</tools>
```

**Multiple tool calls:**
```
<tools>
[{"name": "func1", "arguments": {...}}, {"name": "func2", "arguments": {...}}]
</tools>
```

## Usage

```bash
vllm serve Qwen/Qwen2.5-Coder-7B-Instruct \
  --enable-auto-tool-choice \
  --tool-call-parser qwen2_5_coder
```

## Test Plan

- [x] Unit tests for non-streaming extraction
- [x] Unit tests for streaming extraction  
- [x] Tests for edge cases (empty args, nested JSON, unicode, malformed input)
- [x] Tests for request adjustment (skip_special_tokens handling)

Closes #32926