### PR TITLE
[Bugfix] Fix JSONDecodeError when multiple tool_calls in single message

### DIFF
--- a/tests/tool_parsers/test_utils.py
+++ b/tests/tool_parsers/test_utils.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for tool_parsers/utils.py"""
+
+import pytest
+from json import JSONDecodeError
+
+from vllm.tool_parsers.utils import safe_json_loads
+
+
+class TestSafeJsonLoads:
+    """Tests for the safe_json_loads function."""
+
+    def test_single_json_object(self):
+        """Test parsing a single valid JSON object."""
+        input_str = '{"name": "get_weather", "arguments": {"city": "NYC"}}'
+        result = safe_json_loads(input_str)
+        assert result == {"name": "get_weather", "arguments": {"city": "NYC"}}
+
+    def test_single_json_array(self):
+        """Test parsing a single valid JSON array."""
+        input_str = '[1, 2, 3]'
+        result = safe_json_loads(input_str)
+        assert result == [1, 2, 3]
+
+    def test_multiple_concatenated_json_objects(self):
+        """Test parsing multiple concatenated JSON objects (extracts first)."""
+        input_str = '{"a": 1}{"b": 2}'
+        result = safe_json_loads(input_str)
+        assert result == {"a": 1}
+
+    def test_multiple_concatenated_json_objects_with_whitespace(self):
+        """Test parsing multiple JSON objects separated by whitespace."""
+        input_str = '{"a": 1} {"b": 2}'
+        result = safe_json_loads(input_str)
+        assert result == {"a": 1}
+
+    def test_multiple_tool_calls_scenario(self):
+        """Test the actual scenario from issue #32638."""
+        # This mimics what happens when multiple tool calls are parsed
+        input_str = '{"city": "NYC"}{"unit": "celsius"}'
+        result = safe_json_loads(input_str)
+        assert result == {"city": "NYC"}
+
+    def test_nested_json_object(self):
+        """Test parsing nested JSON structures."""
+        input_str = '{"outer": {"inner": {"deep": "value"}}}'
+        result = safe_json_loads(input_str)
+        assert result == {"outer": {"inner": {"deep": "value"}}}
+
+    def test_json_with_special_characters(self):
+        """Test parsing JSON with special characters in strings."""
+        input_str = '{"text": "Hello\\nWorld\\t!"}'
+        result = safe_json_loads(input_str)
+        assert result == {"text": "Hello\nWorld\t!"}
+
+    def test_empty_json_object(self):
+        """Test parsing an empty JSON object."""
+        input_str = '{}'
+        result = safe_json_loads(input_str)
+        assert result == {}
+
+    def test_empty_json_array(self):
+        """Test parsing an empty JSON array."""
+        input_str = '[]'
+        result = safe_json_loads(input_str)
+        assert result == []
+
+    def test_json_primitive_string(self):
+        """Test parsing a JSON primitive string."""
+        input_str = '"hello"'
+        result = safe_json_loads(input_str)
+        assert result == "hello"
+
+    def test_json_primitive_number(self):
+        """Test parsing a JSON primitive number."""
+        input_str = '42'
+        result = safe_json_loads(input_str)
+        assert result == 42
+
+    def test_json_primitive_boolean(self):
+        """Test parsing JSON boolean values."""
+        assert safe_json_loads('true') is True
+        assert safe_json_loads('false') is False
+
+    def test_json_null(self):
+        """Test parsing JSON null."""
+        input_str = 'null'
+        result = safe_json_loads(input_str)
+        assert result is None
+
+    def test_invalid_json_raises_error(self):
+        """Test that invalid JSON raises JSONDecodeError."""
+        with pytest.raises(JSONDecodeError):
+            safe_json_loads('not valid json')
+
+    def test_incomplete_json_raises_error(self):
+        """Test that incomplete JSON raises JSONDecodeError."""
+        with pytest.raises(JSONDecodeError):
+            safe_json_loads('{"incomplete":')
+
+    def test_empty_string_raises_error(self):
+        """Test that empty string raises JSONDecodeError."""
+        with pytest.raises(JSONDecodeError):
+            safe_json_loads('')
+
+    def test_complex_tool_arguments(self):
+        """Test parsing complex tool call arguments."""
+        input_str = '{"location": "San Francisco, CA", "units": "fahrenheit", "forecast_days": 5}'
+        result = safe_json_loads(input_str)
+        assert result == {
+            "location": "San Francisco, CA",
+            "units": "fahrenheit",
+            "forecast_days": 5
+        }

--- a/tests/tool_parsers/test_utils.py
+++ b/tests/tool_parsers/test_utils.py
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for tool_parsers/utils.py"""
 
-import pytest
 from json import JSONDecodeError
+
+import pytest
 
 from vllm.tool_parsers.utils import safe_json_loads
 
@@ -19,7 +20,7 @@ class TestSafeJsonLoads:
 
     def test_single_json_array(self):
         """Test parsing a single valid JSON array."""
-        input_str = '[1, 2, 3]'
+        input_str = "[1, 2, 3]"
         result = safe_json_loads(input_str)
         assert result == [1, 2, 3]
 
@@ -56,13 +57,13 @@ class TestSafeJsonLoads:
 
     def test_empty_json_object(self):
         """Test parsing an empty JSON object."""
-        input_str = '{}'
+        input_str = "{}"
         result = safe_json_loads(input_str)
         assert result == {}
 
     def test_empty_json_array(self):
         """Test parsing an empty JSON array."""
-        input_str = '[]'
+        input_str = "[]"
         result = safe_json_loads(input_str)
         assert result == []
 
@@ -74,25 +75,25 @@ class TestSafeJsonLoads:
 
     def test_json_primitive_number(self):
         """Test parsing a JSON primitive number."""
-        input_str = '42'
+        input_str = "42"
         result = safe_json_loads(input_str)
         assert result == 42
 
     def test_json_primitive_boolean(self):
         """Test parsing JSON boolean values."""
-        assert safe_json_loads('true') is True
-        assert safe_json_loads('false') is False
+        assert safe_json_loads("true") is True
+        assert safe_json_loads("false") is False
 
     def test_json_null(self):
         """Test parsing JSON null."""
-        input_str = 'null'
+        input_str = "null"
         result = safe_json_loads(input_str)
         assert result is None
 
     def test_invalid_json_raises_error(self):
         """Test that invalid JSON raises JSONDecodeError."""
         with pytest.raises(JSONDecodeError):
-            safe_json_loads('not valid json')
+            safe_json_loads("not valid json")
 
     def test_incomplete_json_raises_error(self):
         """Test that incomplete JSON raises JSONDecodeError."""
@@ -102,7 +103,7 @@ class TestSafeJsonLoads:
     def test_empty_string_raises_error(self):
         """Test that empty string raises JSONDecodeError."""
         with pytest.raises(JSONDecodeError):
-            safe_json_loads('')
+            safe_json_loads("")
 
     def test_complex_tool_arguments(self):
         """Test parsing complex tool call arguments."""
@@ -111,5 +112,5 @@ class TestSafeJsonLoads:
         assert result == {
             "location": "San Francisco, CA",
             "units": "fahrenheit",
-            "forecast_days": 5
+            "forecast_days": 5,
         }

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -38,6 +38,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     StreamOptions,
 )
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.tool_parsers.utils import safe_json_loads
 
 logger = logging.getLogger(__name__)
 
@@ -284,7 +285,7 @@ class AnthropicServingMessages(OpenAIServingChat):
                 type="tool_use",
                 id=tool_call.id,
                 name=tool_call.function.name,
-                input=json.loads(tool_call.function.arguments),
+                input=safe_json_loads(tool_call.function.arguments),
             )
             content += [anthropic_tool_call]
 

--- a/vllm/tool_parsers/ernie45_tool_parser.py
+++ b/vllm/tool_parsers/ernie45_tool_parser.py
@@ -22,6 +22,7 @@ from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import (
     ToolParser,
 )
+from vllm.tool_parsers.utils import safe_json_loads
 
 logger = init_logger(__name__)
 
@@ -184,7 +185,7 @@ class Ernie45ToolParser(ToolParser):
             tool_call = extracted_tool_calls.tool_calls[0]
             self.prev_tool_call_arr[self.current_tool_id] = {
                 "name": tool_call.function.name,
-                "arguments": json.loads(tool_call.function.arguments),
+                "arguments": safe_json_loads(tool_call.function.arguments),
             }
             self.streamed_args_for_tool[self.current_tool_id] = (
                 tool_call.function.arguments

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -25,6 +25,7 @@ from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import (
     ToolParser,
 )
+from vllm.tool_parsers.utils import safe_json_loads
 
 logger = init_logger(__name__)
 
@@ -196,7 +197,7 @@ class Glm4MoeModelToolParser(ToolParser):
             tool_call = extracted_tool_calls.tool_calls[0]
             self.prev_tool_call_arr[self.current_tool_id] = {
                 "name": tool_call.function.name,
-                "arguments": json.loads(tool_call.function.arguments),
+                "arguments": safe_json_loads(tool_call.function.arguments),
             }
             self.streamed_args_for_tool[self.current_tool_id] = (
                 tool_call.function.arguments


### PR DESCRIPTION
## Summary

This PR fixes issue #32638 where `json.loads()` fails with "Extra data" `JSONDecodeError` when multiple tool calls are parsed in a single assistant message.

**Problem**: When multiple tool calls are parsed from model output (e.g., by `hermes_tool_parser`), the `function.arguments` field may contain multiple JSON objects concatenated together like `{"a": 1}{"b": 2}`. Standard `json.loads()` fails in this case.

**Solution**: Added a `safe_json_loads()` utility function in `vllm/tool_parsers/utils.py` that handles this case by using `JSONDecoder.raw_decode()` to parse only the first valid JSON object when the "Extra data" error occurs.

### Changes
- Added `safe_json_loads()` function to `vllm/tool_parsers/utils.py`
- Updated `vllm/entrypoints/anthropic/serving.py` to use `safe_json_loads()`
- Updated `vllm/tool_parsers/ernie45_tool_parser.py` to use `safe_json_loads()`
- Updated `vllm/tool_parsers/glm4_moe_tool_parser.py` to use `safe_json_loads()`
- Added comprehensive tests in `tests/tool_parsers/test_utils.py`

Fixes #32638

## Test plan

- [x] Added unit tests for `safe_json_loads()` covering:
  - Single valid JSON objects
  - Multiple concatenated JSON objects (the bug scenario)
  - JSON arrays, primitives, and nested structures
  - Error cases (invalid JSON, incomplete JSON, empty string)
- [ ] Manual testing with multiple tool calls in single message