### PR TITLE
[Bugfix][Tool Parser] Fix crash when parameter description contains parentheses

### DIFF
--- a/tests/transformers_utils/test_tool_chat_template.py
+++ b/tests/transformers_utils/test_tool_chat_template.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tests for custom tool chat templates that handle special characters
+in tool parameter descriptions.
+
+This tests the fix for: https://github.com/vllm-project/vllm/issues/32827
+"""
+
+from pathlib import Path
+
+import pytest
+
+from vllm.transformers_utils.chat_templates import get_tool_chat_template_path
+
+
+class TestToolChatTemplate:
+    """Tests for the tool chat template registry."""
+
+    def test_get_minimax_m2_tool_template(self):
+        """Test that MiniMax M2 model gets the custom tool template."""
+        path = get_tool_chat_template_path(
+            model_type="minimax_m2",
+            tokenizer_name_or_path="MiniMax/MiniMax-M2.1",
+        )
+        assert path is not None
+        assert isinstance(path, Path)
+        assert path.name == "template_minimax_m2.jinja"
+        assert path.exists()
+
+    def test_get_tool_template_nonexistent_model(self):
+        """Test that non-registered models return None."""
+        path = get_tool_chat_template_path(
+            model_type="nonexistent_model",
+            tokenizer_name_or_path="some/model",
+        )
+        assert path is None
+
+    def test_minimax_m2_template_uses_tojson(self):
+        """Test that the MiniMax M2 template uses tojson filter for proper escaping."""
+        path = get_tool_chat_template_path(
+            model_type="minimax_m2",
+            tokenizer_name_or_path="MiniMax/MiniMax-M2.1",
+        )
+        assert path is not None
+        template_content = path.read_text()
+        # The template should use tojson to properly escape special characters
+        assert "tojson" in template_content
+
+    def test_minimax_m2_template_renders_parentheses(self):
+        """Test that template can render tools with parentheses in descriptions."""
+        try:
+            import jinja2
+        except ImportError:
+            pytest.skip("jinja2 not available")
+
+        path = get_tool_chat_template_path(
+            model_type="minimax_m2",
+            tokenizer_name_or_path="MiniMax/MiniMax-M2.1",
+        )
+        assert path is not None
+
+        template_content = path.read_text()
+        env = jinja2.Environment()
+        template = env.from_string(template_content)
+
+        # Test with a tool that has parentheses in the description
+        # This is the exact case from issue #32827
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "test",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "The complete command to execute "
+                                         "(e.g. ls -la, ssh user@host, cat file.txt)"
+                        }
+                    },
+                    "required": ["command"]
+                }
+            }
+        }]
+
+        messages = [{"role": "user", "content": "hello"}]
+
+        # This should not raise an exception
+        result = template.render(
+            tools=tools,
+            messages=messages,
+            add_generation_prompt=True,
+        )
+
+        # The parentheses should be properly escaped in the output
+        assert "ls -la" in result or "command" in result
+        # Verify the template actually rendered something
+        assert len(result) > 0

--- a/tests/transformers_utils/test_tool_chat_template.py
+++ b/tests/transformers_utils/test_tool_chat_template.py
@@ -66,23 +66,25 @@ class TestToolChatTemplate:
 
         # Test with a tool that has parentheses in the description
         # This is the exact case from issue #32827
-        tools = [{
-            "type": "function",
-            "function": {
-                "name": "test",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "command": {
-                            "type": "string",
-                            "description": "The complete command to execute "
-                                         "(e.g. ls -la, ssh user@host, cat file.txt)"
-                        }
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "test",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {
+                                "type": "string",
+                                "description": "The complete command to execute "
+                                "(e.g. ls -la, ssh user@host, cat file.txt)",
+                            }
+                        },
+                        "required": ["command"],
                     },
-                    "required": ["command"]
-                }
+                },
             }
-        }]
+        ]
 
         messages = [{"role": "user", "content": "hello"}]
 

--- a/vllm/transformers_utils/chat_templates/__init__.py
+++ b/vllm/transformers_utils/chat_templates/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from .registry import get_chat_template_fallback_path
+from .registry import get_chat_template_fallback_path, get_tool_chat_template_path
 
-__all__ = ["get_chat_template_fallback_path"]
+__all__ = ["get_chat_template_fallback_path", "get_tool_chat_template_path"]

--- a/vllm/transformers_utils/chat_templates/template_minimax_m2.jinja
+++ b/vllm/transformers_utils/chat_templates/template_minimax_m2.jinja
@@ -1,0 +1,56 @@
+{#- Custom tool chat template for MiniMax M2 models. -#}
+{#- This template uses tojson filter to properly escape special characters -#}
+{#- (like parentheses) in tool parameter descriptions that would otherwise -#}
+{#- cause the default HuggingFace template to crash. -#}
+{#- See: https://github.com/vllm-project/vllm/issues/32827 -#}
+{{ '<begin_of_document>' -}}
+{%- if custom_tools is defined %}
+    {%- set tools = custom_tools %}
+{%- endif %}
+{%- if not tools is defined %}
+    {%- set tools = none %}
+{%- endif %}
+
+{#- Tools configuration - use tojson to properly escape special characters in descriptions #}
+{%- if tools is not none %}
+{{ '<beginning_of_sentence>system tool_setting=tools\nYou are provided with these tools:\n<tools>\n' -}}
+{%- for tool in tools %}
+{{ tool | tojson ~ '\n' -}}
+{%- endfor %}
+{{ '</tools>\n\nIf you need to call tools, please respond with <minimax:tool_call></minimax:tool_call> XML tags containing tool invocations.\nFor each tool call, use:\n<invoke name=\"function_name\">\n<parameter name=\"param_name\">value</parameter>\n</invoke>\n<end_of_sentence>' -}}
+{%- endif %}
+
+{#- Process messages #}
+{%- for message in messages %}
+{%- if message['role'] == 'system' %}
+{{ '<beginning_of_sentence>system\n' + message['content'] + '<end_of_sentence>' -}}
+{%- elif message['role'] == 'user' %}
+{{ '<beginning_of_sentence>user\n' + message['content'] + '<end_of_sentence>' -}}
+{%- elif message['role'] == 'assistant' %}
+{%- if message.get('tool_calls') %}
+{{ '<beginning_of_sentence>assistant\n<minimax:tool_call>' -}}
+{%- for tool_call in message['tool_calls'] %}
+{{ '\n<invoke name=\"' + tool_call['function']['name'] + '\">' -}}
+{%- if tool_call['function']['arguments'] is string %}
+{%- set args = tool_call['function']['arguments'] | tojson | fromjson %}
+{%- else %}
+{%- set args = tool_call['function']['arguments'] %}
+{%- endif %}
+{%- for key, value in args.items() %}
+{{ '\n<parameter name=\"' + key + '\">\n' + (value | tojson if value is not string else value) + '\n</parameter>' -}}
+{%- endfor %}
+{{ '\n</invoke>' -}}
+{%- endfor %}
+{{ '\n</minimax:tool_call><end_of_sentence>' -}}
+{%- else %}
+{{ '<beginning_of_sentence>assistant\n' + message['content'] + '<end_of_sentence>' -}}
+{%- endif %}
+{%- elif message['role'] == 'tool' %}
+{{ '<beginning_of_sentence>tool\n' + message['content'] + '<end_of_sentence>' -}}
+{%- endif %}
+{%- endfor %}
+
+{#- Generation prompt #}
+{%- if add_generation_prompt %}
+{{ '<beginning_of_sentence>assistant\n' -}}
+{%- endif %}


### PR DESCRIPTION
## Summary

Fixes #32827

- Add custom tool chat template for MiniMax M2 that uses `tojson` filter to properly escape special characters (like parentheses) in tool parameter descriptions
- Introduce `_MODEL_TYPE_TO_TOOL_CHAT_TEMPLATE` registry for model-specific tool templates
- Update `resolve_chat_template()` to check for custom tool templates when tools are provided

## Root Cause

When using OpenAI-compatible function calling with MiniMax-M2, if a parameter's description contains parentheses like `(e.g. ls -la)`, the default HuggingFace chat template doesn't properly escape these characters. This causes the Jinja2 template rendering to fail, resulting in a server crash with "Connection error".

## Solution

Create a custom tool chat template for MiniMax M2 (`template_minimax_m2.jinja`) that uses the `tojson` Jinja2 filter to properly serialize the tools object. This ensures all special characters (parentheses, quotes, etc.) are correctly escaped.

The fix adds a new registry (`_MODEL_TYPE_TO_TOOL_CHAT_TEMPLATE`) for models that need custom tool templates, and updates the template resolution logic to use these custom templates when tools are provided.

## Test plan

- [x] Added unit tests in `tests/transformers_utils/test_tool_chat_template.py`
- [x] Tests verify that:
  - MiniMax M2 model gets the custom tool template
  - Non-registered models return None
  - Template uses `tojson` filter for proper escaping
  - Template can render tools with parentheses in descriptions without crashing

To verify the fix manually:
```python
# This should now work without crashing
tools = [{
    "type": "function",
    "function": {
        "name": "test",
        "parameters": {
            "type": "object",
            "properties": {
                "command": {
                    "type": "string",
                    "description": "The complete command to execute (e.g. ls -la, ssh user@host, cat file.txt)"
                }
            },
            "required": ["command"]
        }
    }
}]
```