### PR TITLE
[Bugfix] Use 'sum' reduction instead of 'avg' in Async TP reduce-scatter

### DIFF
--- a/vllm/compilation/passes/fusion/collective_fusion.py
+++ b/vllm/compilation/passes/fusion/collective_fusion.py
@@ -53,7 +53,7 @@ class GEMMReduceScatterPattern(BasePattern):
             gemm_rs = torch.ops.symm_mem.fused_matmul_reduce_scatter(
                 mul,
                 mm_weight,
-                "avg",
+                "sum",
                 scatter_dim=0,
                 group_name=self.tp.device_group.group_name,
             )
@@ -150,7 +150,7 @@ class ScaledMMReduceScatterPattern(BasePattern):
                 mat2,
                 scale_a,
                 scale_b,
-                "avg",
+                "sum",
                 scatter_dim,  # orig_scatter_dim
                 scatter_dim,  # scatter_dim_after_maybe_reshape
                 self.tp.device_group.group_name,
@@ -285,7 +285,7 @@ class CutlassScaledMMReduceScatterPattern(BasePattern):
                 mat2,
                 scale_a,
                 scale_b,
-                "avg",
+                "sum",
                 scatter_dim,  # orig_scatter_dim
                 scatter_dim,  # scatter_dim_after_maybe_reshape
                 self.tp.device_group.group_name,


### PR DESCRIPTION
## Purpose

For Row Parallel Linear layers, the partial results from different TP ranks should be summed, not averaged. This PR changes the reduce_op to "sum" to ensure the output magnitude is mathematically correct.

## Test Plan && Test Result

**Test Environment:** H800, TP=4

We tested the accuracy on MMLU and GSM8K. Strangely, on GSM8K, using "avg" outperformed "sum" and the default config (Async TP off). However, we should change "avg" to "sum" to maintain mathematical equivalence.

We also noticed a ~3% accuracy loss on the MMMU-Val benchmark with Qwen3-VL-32B. Note that there are issues with SP + Async TP enabled on multi-modal models in the current vLLM main branch, will address these in a separate PR.

### Qwen/Qwen3-32B

#### SP + Async TP, reduce_op="avg" (Main)

vLLM Serve Command:

```bash
vllm serve Qwen/Qwen3-32B \
        --tensor-parallel-size 4 \
        --port 9000 \
        --no-enable-prefix-caching \
        --compilation-config '{"pass_config": { "enable_sp": true,"fuse_gemm_comms": true}, "splitting_ops":[], "cudagraph_mode": "FULL"}'
```

GSM8K Reuslts:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6566|±  |0.0131|
|     |       |strict-match    |     5|exact_match|↑  |0.7733|±  |0.0115|

MMLU Results:

|      Groups      |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|------------------|------:|------|------|------|---|-----:|---|-----:|
|mmlu              |      2|none  |      |acc   |↑  |0.8052|±  |0.0032|
| - humanities     |      2|none  |      |acc   |↑  |0.7177|±  |0.0063|
| - other          |      2|none  |      |acc   |↑  |0.8326|±  |0.0065|
| - social sciences|      2|none  |      |acc   |↑  |0.8856|±  |0.0056|
| - stem           |      2|none  |      |acc   |↑  |0.8303|±  |0.0065|

#### SP + Async TP, reduce_op="sum" (This PR)

vLLM Serve Command: Same as the "Main" section

GSM8K Reuslts:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6255|±  |0.0133|
|     |       |strict-match    |     5|exact_match|↑  |0.7445|±  |0.0120|

MMLU Results:

|      Groups      |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|------------------|------:|------|------|------|---|-----:|---|-----:|
|mmlu              |      2|none  |      |acc   |↑  |0.8074|±  |0.0032|
| - humanities     |      2|none  |      |acc   |↑  |0.7209|±  |0.0063|
| - other          |      2|none  |      |acc   |↑  |0.8368|±  |0.0064|
| - social sciences|      2|none  |      |acc   |↑  |0.8915|±  |0.0055|
| - stem           |      2|none  |      |acc   |↑  |0.8256|±  |0.0065|

#### TP4

vLLM Serve Command:

```bash
vllm serve Qwen/Qwen3-32B \
        --tensor-parallel-size 4 \
        --port 9000 \
        --no-enable-prefix-caching
```

GSM8K Reuslts:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6240|±  |0.0133|
|     |       |strict-match    |     5|exact_match|↑  |0.7392|±  |0.0121|

MMLU Results:

|      Groups      |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|------------------|------:|------|------|------|---|-----:|---|-----:|
|mmlu              |      2|none  |      |acc   |↑  |0.8069|±  |0.0032|
| - humanities     |      2|none  |      |acc   |↑  |0.7197|±  |0.0063|
| - other          |      2|none  |      |acc   |↑  |0.8365|±  |0.0064|
| - social sciences|      2|none  |      |acc   |↑  |0.8937|±  |0.0055|
| - stem           |      2|none  |      |acc   |↑  |0.8233|±  |0.0066|

### AngelSlim/Qwen3-32B_fp8_static

#### SP + Async TP, reduce_op="avg" (Main)

GSM8K Reuslts:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6247|±  |0.0133|
|     |       |strict-match    |     5|exact_match|↑  |0.7255|±  |0.0123|

#### SP + Async TP, reduce_op="sum" (This PR)

GSM8K Reuslts:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.5580|±  |0.0137|
|     |       |strict-match    |     5|exact_match|↑  |0.7005|±  |0.0126|

#### TP4

GSM8K Reuslts:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.5701|±  |0.0136|
|     |       |strict-match    |     5|exact_match|↑  |0.7005|±  |0.0126|

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

