### PR TITLE
[Frontend] Cleanup serving engine

### DIFF
--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -36,6 +36,7 @@ from vllm.entrypoints.renderer import RenderConfig
 from vllm.entrypoints.utils import get_max_tokens, should_include_usage
 from vllm.exceptions import VLLMValidationError
 from vllm.inputs.data import EmbedsPrompt, TokensPrompt, is_embeds_prompt
+from vllm.inputs.parse import get_prompt_components
 from vllm.logger import init_logger
 from vllm.logprobs import Logprob
 from vllm.outputs import RequestOutput
@@ -162,25 +163,12 @@ class OpenAIServingCompletion(OpenAIServing):
         generators: list[AsyncGenerator[RequestOutput, None]] = []
         try:
             for i, engine_prompt in enumerate(engine_prompts):
-                prompt_text, prompt_token_ids, prompt_embeds = (
-                    self._get_prompt_components(engine_prompt)
-                )
-
-                input_length = None
-                if prompt_token_ids is not None:
-                    input_length = len(prompt_token_ids)
-                elif prompt_embeds is not None:
-                    input_length = len(prompt_embeds)
-                else:
-                    raise NotImplementedError
-
-                if self.default_sampling_params is None:
-                    self.default_sampling_params = {}
+                prompt_text, _, _ = get_prompt_components(engine_prompt)
 
                 max_tokens = get_max_tokens(
                     max_model_len=self.max_model_len,
                     request=request,
-                    input_length=input_length,
+                    prompt=engine_prompt,
                     default_sampling_params=self.default_sampling_params,
                 )
 

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -115,6 +115,7 @@ from vllm.entrypoints.openai.responses.utils import (
     extract_tool_types,
     should_continue_final_message,
 )
+from vllm.entrypoints.utils import get_max_tokens
 from vllm.exceptions import VLLMValidationError
 from vllm.inputs.data import TokensPrompt
 from vllm.logger import init_logger
@@ -423,8 +424,11 @@ class OpenAIServingResponses(OpenAIServing):
                 if maybe_error is not None:
                     return maybe_error
 
-                default_max_tokens = self.max_model_len - len(
-                    engine_prompt["prompt_token_ids"]
+                default_max_tokens = get_max_tokens(
+                    self.max_model_len,
+                    request,
+                    engine_prompt,
+                    self.default_sampling_params,
                 )
 
                 sampling_params = request.to_sampling_params(

--- a/vllm/entrypoints/utils.py
+++ b/vllm/entrypoints/utils.py
@@ -221,19 +221,21 @@ def get_max_tokens(
     prompt: TokensPrompt | EmbedsPrompt,
     default_sampling_params: dict,
 ) -> int:
-    from vllm.config.utils import getattr_iter
-
     # NOTE: Avoid isinstance() for better efficiency
-    max_tokens = getattr_iter(
-        request,
-        [
-            # ChatCompletionRequest
-            "max_completion_tokens",
-            # ResponsesRequest
-            "max_output_tokens",
-            # CompletionRequest (also a fallback for ChatCompletionRequest)
-            "max_tokens",
-        ],
+    max_tokens: int | None = next(
+        (
+            val
+            for attr in [
+                # ChatCompletionRequest
+                "max_completion_tokens",
+                # ResponsesRequest
+                "max_output_tokens",
+                # CompletionRequest (also a fallback for ChatCompletionRequest)
+                "max_tokens",
+            ]
+            if (val := getattr(request, attr, None)) is not None
+        ),
+        None,
     )
 
     input_length = length_from_prompt_token_ids_or_embeds(

--- a/vllm/entrypoints/utils.py
+++ b/vllm/entrypoints/utils.py
@@ -222,21 +222,16 @@ def get_max_tokens(
     default_sampling_params: dict,
 ) -> int:
     # NOTE: Avoid isinstance() for better efficiency
-    max_tokens: int | None = next(
-        (
-            val
-            for attr in [
-                # ChatCompletionRequest
-                "max_completion_tokens",
-                # ResponsesRequest
-                "max_output_tokens",
-                # CompletionRequest (also a fallback for ChatCompletionRequest)
-                "max_tokens",
-            ]
-            if (val := getattr(request, attr, None)) is not None
-        ),
-        None,
-    )
+    max_tokens: int | None = None
+    if max_tokens is None:
+        # ChatCompletionRequest
+        max_tokens = getattr(request, "max_completion_tokens", None)
+    if max_tokens is None:
+        # ResponsesRequest
+        max_tokens = getattr(request, "max_output_tokens", None)
+    if max_tokens is None:
+        # CompletionRequest (also a fallback for ChatCompletionRequest)
+        max_tokens = getattr(request, "max_tokens", None)
 
     input_length = length_from_prompt_token_ids_or_embeds(
         prompt.get("prompt_token_ids"),  # type: ignore[arg-type]


### PR DESCRIPTION
## Purpose

- Use `get_prompt_components` directly via import instead of having a method in `OpenAIServing`.
- Pass the prompt instead of length to `get_max_tokens` to avoid duplicating logic to get prompt length.
- Extend `get_max_tokens` to Responses API.
- Removed unnecessary `self.default_sampling_params` init checks.

Split out from https://github.com/vllm-project/vllm/pull/32863

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

