### PR TITLE
[Bugfix][MXFP4] Call `trtllm_fp4_block_scale_moe` with kwargs

### DIFF
--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -1053,32 +1053,32 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 x_scale = x_scale.view(torch.float8_e4m3fn).reshape(*x.shape[:-1], -1)
 
             trtllm_gen_output = trtllm_fp4_block_scale_moe(
-                router_logits.to(torch.bfloat16),
-                None,  # routing_bias
-                x_quant,
-                x_scale,
-                layer.w13_weight,  # uint8 (e2m1 x 2)
-                layer.w13_weight_scale,  # uint8 (e4m3 x 2)
-                layer.w13_bias,  # fp32 per expert per channel
-                layer.gemm1_alpha,  # fp32 per expert
-                layer.gemm1_beta,  # fp32 per expert
-                layer.gemm1_clamp_limit,  # fp32 per expert
-                layer.w2_weight,  # uint8 (e2m1 x 2)
-                layer.w2_weight_scale,  # ue8m0
-                layer.w2_bias,  # fp32 per expert per channel
-                None,  # output1_scale_scalar
-                None,  # output1_scale_gate_scalar
-                None,  # output2_scale_scalar
-                layer.global_num_experts,
-                layer.top_k,
-                None,  # n_group
-                None,  # topk_group
-                self.intermediate_size,  # padded to multiple of 256
-                layer.ep_rank * layer.local_num_experts,  # local_expert_offset
-                self.num_experts,  # local num experts
-                None,  # routed_scaling_factor
-                1 if layer.renormalize else 0,  # routing_method_type, renormalize
-                True,  # do finalize
+                routing_logits=router_logits.to(torch.bfloat16),
+                routing_bias=None,
+                hidden_states=x_quant,
+                hidden_states_scale=x_scale,
+                gemm1_weights=layer.w13_weight,  # uint8 (e2m1 x 2)
+                gemm1_weights_scale=layer.w13_weight_scale,  # uint8 (e4m3 x 2)
+                gemm1_bias=layer.w13_bias,  # fp32 per expert per channel
+                gemm1_alpha=layer.gemm1_alpha,  # fp32 per expert
+                gemm1_beta=layer.gemm1_beta,  # fp32 per expert
+                gemm1_clamp_limit=layer.gemm1_clamp_limit,  # fp32 per expert
+                gemm2_weights=layer.w2_weight,  # uint8 (e2m1 x 2)
+                gemm2_weights_scale=layer.w2_weight_scale,  # ue8m0
+                gemm2_bias=layer.w2_bias,  # fp32 per expert per channel
+                output1_scale_scalar=None,
+                output1_scale_gate_scalar=None,
+                output2_scale_scalar=None,
+                num_experts=layer.global_num_experts,
+                top_k=layer.top_k,
+                n_group=None,
+                topk_group=None,
+                intermediate_size=self.intermediate_size,  # padded to multiple of 256
+                local_expert_offset=layer.ep_rank * layer.local_num_experts,
+                local_num_experts=self.num_experts,
+                routed_scaling_factor=None,
+                routing_method_type=1 if layer.renormalize else 0,
+                do_finalize=True,
                 tune_max_num_tokens=max(self.max_capture_size, 1),
             )[0]
             return trtllm_gen_output


### PR DESCRIPTION
## Purpose
We are maintaining our own version of flashinfer in our own infra, PR #30993 breaks our internal integration because positioned arg tile_tokens_dim is removed from trtllm_fp4_block_scale_moe. 
```
[0;36m(Worker_TP0 pid=1547236)^[[0;0m ERROR 01-25 13:49:16 [multiproc_executor.py:839] RuntimeError: Error in function 'TrtllmGenBatchedGemmRunner' at flashinfer/csrc/trtllm_batched_gemm_runner.cu:126: No kernel found for the given options: mDtypeA: %s, mDtypeB: %s, mDtypeC: %s, mUseDeepSeekFp8: %d, mTransposeMmaOutput: %d, mRouteAct: %d, mFusedAct: %d, mIsStaticBatch: %d, mTileSize: %d MxE2m1 Bfloat16 Bfloat16 0 1 1 1 0 1
```
This diff try convert the kernel call to use name args instead depending on order, this should make it easier to work with different version of flashinfer also make code easier to read.

## Test Plan

build new aarch64 docker image, on gb200 host, use gpt-oss-120b

```
$ podman run --rm --network=host --device nvidia.com/gpu=all --ipc=host --privileged --pids-limit -1 -e TIKTOKEN_RS_CACHE_DIR=/data/local/models/gpt-oss-120b -v /data/local/models/gpt-oss-120b:/data/local/models/gpt-oss-120b localhost/vllm/vllm-openai:cu130-aarch64-41a7aa710-p --host :: --port 8081 --enable-ssl-refresh --model /data/local/models/gpt-oss-120b --served-model-name default --kv-cache-dtype=fp8 '--compilation-config={"pass_config":{"fuse_allreduce_rms":true,"eliminate_noops":true}}' --async-scheduling --no-enable-prefix-caching --max-cudagraph-capture-size=2048 --max-num-batched-tokens=8192 --stream-interval=20

(APIServer pid=1) INFO 01-26 08:03:59 [serving.py:212] Chat template warmup completed in 620.0ms
(APIServer pid=1) INFO 01-26 08:03:59 [api_server.py:946] Starting vLLM API server 0 on https://[::]:8081
(APIServer pid=1) INFO 01-26 08:03:59 [launcher.py:38] Available routes are:
...
(APIServer pid=1) INFO:     Started server process [1]
(APIServer pid=1) INFO:     Waiting for application startup.
(APIServer pid=1) INFO:     Application startup complete.
```
## Test Result
curl chat completion
```
$ curl "https://$(hostname):8081/v1/chat/completions"   -H "Content-Type: application/json"   -d '{
      "model": "default",
      "messages": [
        {
          "role": "user",
          "content": "Hello, how are you?"
        }
      ],
      "max_tokens": 100,
      "temperature": 0.7
    }'
{"id":"chatcmpl-96df5b5bd66c6f12","object":"chat.completion","created":1769447060,"model":"default","choices":[{"index":0,"message":{"role":"assistant","content":"Hello! I'm doing great, thanks for asking. How can I help you today?","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":"We need to respond as ChatGPT, likely friendly. Provide a brief answer.","reasoning_content":"We need to respond as ChatGPT, likely friendly. Provide a brief answer."},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":71,"total_tokens":114,"completion_tokens":43,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
```
also verified it works with older version of flashinfer


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

