### PR TITLE
[Feature] (grpc): add standard gRPC health checking protocol for Kubernetes native probes

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -51,8 +51,9 @@ openai-harmony >= 0.0.3  # Required for gpt-oss
 anthropic >= 0.71.0
 model-hosting-container-standards >= 0.1.13, < 1.0.0
 mcp
-grpcio
-grpcio-reflection
+grpcio>=1.76.0
+grpcio-health-checking>=1.76.0
+grpcio-reflection>=1.76.0
 opentelemetry-sdk >= 1.27.0
 opentelemetry-api >= 1.27.0
 opentelemetry-exporter-otlp >= 1.27.0

--- a/tests/entrypoints/test_grpc_server.py
+++ b/tests/entrypoints/test_grpc_server.py
@@ -460,9 +460,7 @@ async def test_grpc_health_service_overall(health_stub):
 @pytest.mark.asyncio
 async def test_grpc_health_service_vllm_engine(health_stub):
     """Test standard gRPC health check for the VllmEngine service."""
-    request = health_pb2.HealthCheckRequest(
-        service="vllm.grpc.engine.VllmEngine"
-    )
+    request = health_pb2.HealthCheckRequest(service="vllm.grpc.engine.VllmEngine")
     response = await health_stub.Check(request)
 
     assert response.status == health_pb2.HealthCheckResponse.SERVING
@@ -509,8 +507,9 @@ async def test_health_monitor_sets_serving_when_healthy():
         stop_event.set()
 
     await asyncio.gather(
-        _health_monitor(mock_health_servicer, mock_async_llm, stop_event,
-                        interval=0.01),
+        _health_monitor(
+            mock_health_servicer, mock_async_llm, stop_event, interval=0.01
+        ),
         stop_after_one_cycle(),
     )
 
@@ -539,8 +538,9 @@ async def test_health_monitor_sets_not_serving_when_errored():
         stop_event.set()
 
     await asyncio.gather(
-        _health_monitor(mock_health_servicer, mock_async_llm, stop_event,
-                        interval=0.01),
+        _health_monitor(
+            mock_health_servicer, mock_async_llm, stop_event, interval=0.01
+        ),
         stop_after_one_cycle(),
     )
 
@@ -570,8 +570,9 @@ async def test_health_monitor_stops_on_event():
 
     # Should return promptly since stop_event is already set
     await asyncio.wait_for(
-        _health_monitor(mock_health_servicer, mock_async_llm, stop_event,
-                        interval=0.01),
+        _health_monitor(
+            mock_health_servicer, mock_async_llm, stop_event, interval=0.01
+        ),
         timeout=2.0,
     )
 
@@ -601,8 +602,9 @@ async def test_health_monitor_handles_exception():
         stop_event.set()
 
     await asyncio.gather(
-        _health_monitor(mock_health_servicer, mock_async_llm, stop_event,
-                        interval=0.01),
+        _health_monitor(
+            mock_health_servicer, mock_async_llm, stop_event, interval=0.01
+        ),
         stop_after_recovery(),
     )
 

--- a/tests/entrypoints/test_grpc_server.py
+++ b/tests/entrypoints/test_grpc_server.py
@@ -482,14 +482,14 @@ async def test_grpc_health_service_unknown_service(health_stub):
 @pytest.mark.asyncio
 async def test_grpc_health_service_reflection(grpc_server):
     """Test that grpc.health.v1.Health appears in the reflection service list."""
-    channel = grpc.aio.insecure_channel(f"localhost:{grpc_server.port}")
+    channel = grpc.insecure_channel(f"localhost:{grpc_server.port}")
     try:
         reflection_db = ProtoReflectionDescriptorDatabase(channel)
         services = reflection_db.get_services()
 
         assert "grpc.health.v1.Health" in services
     finally:
-        await channel.close()
+        channel.close()
 
 
 # ---- _health_monitor Unit Tests ----

--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -33,7 +33,7 @@ from grpc_reflection.v1alpha import reflection
 
 from vllm import SamplingParams, TextPrompt, TokensPrompt
 from vllm.engine.arg_utils import AsyncEngineArgs
-from vllm.entrypoints.utils import log_version_and_model
+from vllm.entrypoints.utils import cli_env_setup, log_version_and_model
 from vllm.grpc import vllm_engine_pb2, vllm_engine_pb2_grpc
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
@@ -569,6 +569,8 @@ async def serve_grpc(args: argparse.Namespace):
 
 def main():
     """Main entry point."""
+    cli_env_setup()
+
     parser = FlexibleArgumentParser(
         description="vLLM gRPC Server",
     )

--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -23,6 +23,7 @@ import signal
 import sys
 import time
 from collections.abc import AsyncGenerator
+from contextlib import suppress
 
 import grpc
 import uvloop
@@ -446,10 +447,8 @@ async def _health_monitor(
         except Exception as e:
             logger.error("Health monitor error: %s", e)
 
-        try:
+        with suppress(asyncio.TimeoutError):
             await asyncio.wait_for(stop_event.wait(), timeout=interval)
-        except asyncio.TimeoutError:
-            pass
 
 
 async def serve_grpc(args: argparse.Namespace):
@@ -551,10 +550,8 @@ async def serve_grpc(args: argparse.Namespace):
         # Stop health monitoring
         stop_event.set()
         health_monitor_task.cancel()
-        try:
+        with suppress(asyncio.CancelledError):
             await health_monitor_task
-        except asyncio.CancelledError:
-            pass
 
         # Mark all services as NOT_SERVING during graceful shutdown
         health_servicer.enter_graceful_shutdown()

--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -26,6 +26,8 @@ from collections.abc import AsyncGenerator
 
 import grpc
 import uvloop
+from grpc_health.v1 import health_pb2, health_pb2_grpc
+from grpc_health.v1.health import HealthServicer
 from grpc_reflection.v1alpha import reflection
 
 from vllm import SamplingParams, TextPrompt, TokensPrompt
@@ -411,6 +413,45 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
         )
 
 
+async def _health_monitor(
+    health_servicer: HealthServicer,
+    async_llm: "AsyncLLM",
+    stop_event: asyncio.Event,
+    interval: float = 1.0,
+):
+    """
+    Monitor engine health and update gRPC health service status.
+
+    This background task periodically checks the engine state and updates
+    the standard gRPC health service accordingly. This enables Kubernetes
+    native gRPC health probes.
+
+    Args:
+        health_servicer: The gRPC health servicer to update
+        async_llm: The AsyncLLM instance to monitor
+        stop_event: Event to signal shutdown
+        interval: Polling interval in seconds
+    """
+    service_names = ["", "vllm.grpc.engine.VllmEngine"]
+
+    while not stop_event.is_set():
+        try:
+            status = (
+                health_pb2.HealthCheckResponse.NOT_SERVING
+                if async_llm.errored
+                else health_pb2.HealthCheckResponse.SERVING
+            )
+            for name in service_names:
+                health_servicer.set(name, status)
+        except Exception as e:
+            logger.error("Health monitor error: %s", e)
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval)
+        except asyncio.TimeoutError:
+            pass
+
+
 async def serve_grpc(args: argparse.Namespace):
     """
     Main serving function.
@@ -453,9 +494,23 @@ async def serve_grpc(args: argparse.Namespace):
     # Add servicer to server
     vllm_engine_pb2_grpc.add_VllmEngineServicer_to_server(servicer, server)
 
+    # Add standard gRPC health checking service (grpc.health.v1.Health)
+    # This enables Kubernetes native gRPC health probes
+    health_servicer = HealthServicer()
+    health_pb2_grpc.add_HealthServicer_to_server(health_servicer, server)
+
+    # Set initial health status to SERVING
+    # "" represents overall server health (default for K8s probes)
+    health_servicer.set("", health_pb2.HealthCheckResponse.SERVING)
+    health_servicer.set(
+        "vllm.grpc.engine.VllmEngine",
+        health_pb2.HealthCheckResponse.SERVING,
+    )
+
     # Enable reflection for grpcurl and other tools
     service_names = (
         vllm_engine_pb2.DESCRIPTOR.services_by_name["VllmEngine"].full_name,
+        "grpc.health.v1.Health",
         reflection.SERVICE_NAME,
     )
     reflection.enable_server_reflection(service_names, server)
@@ -480,6 +535,11 @@ async def serve_grpc(args: argparse.Namespace):
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, signal_handler)
 
+    # Start health monitoring background task
+    health_monitor_task = asyncio.create_task(
+        _health_monitor(health_servicer, async_llm, stop_event, interval=1.0)
+    )
+
     # Serve until shutdown signal
     try:
         await stop_event.wait()
@@ -487,6 +547,17 @@ async def serve_grpc(args: argparse.Namespace):
         logger.info("Interrupted by user")
     finally:
         logger.info("Shutting down vLLM gRPC server...")
+
+        # Stop health monitoring
+        stop_event.set()
+        health_monitor_task.cancel()
+        try:
+            await health_monitor_task
+        except asyncio.CancelledError:
+            pass
+
+        # Mark all services as NOT_SERVING during graceful shutdown
+        health_servicer.enter_graceful_shutdown()
 
         # Stop gRPC server
         await server.stop(grace=5.0)


### PR DESCRIPTION
## Purpose

Add support for the standard `grpc.health.v1.Health` service to enable **Kubernetes native gRPC health probes** (GA since K8s 1.27).

**Motivation**: Online inference serving platforms need standard gRPC health checking to properly determine service readiness. The existing custom `VllmEngine/HealthCheck` RPC is not compatible with:
- Kubernetes native gRPC probes (`livenessProbe.grpc` / `readinessProbe.grpc`)
- Standard tools like `grpc_health_probe`
- Service meshes and load balancers expecting `grpc.health.v1.Health`

Without this, platforms must fall back to TCP socket checks, which only verify port availability — they cannot detect whether the model is loaded or the engine is truly ready to serve requests.

**Implementation follows the [gRPC Health Checking Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md)**:

| Requirement | Implementation |
|-------------|----------------|
| Register `grpc.health.v1.Health` service | ✅ Using `grpcio-health-checking` |
| Implement `Check` RPC (required by K8s) | ✅ Built-in |
| Implement `Watch` RPC (optional) | ✅ Built-in |
| Support `service == ""` for overall health | ✅ Registered with empty string key |
| Return `SERVING` / `NOT_SERVING` correctly | ✅ Based on `async_llm.errored` |
| Return `NOT_FOUND` for unknown services | ✅ Built-in behavior |
| No TLS/mTLS requirement | ✅ Uses `add_insecure_port` |

**Changes**:
- Add `grpcio-health-checking` dependency
- Register `grpc.health.v1.Health` service alongside `VllmEngine`
- Add background health monitor task (1s interval) to update status based on `async_llm.errored`
- Handle graceful shutdown with `enter_graceful_shutdown()`
- Add automated tests (E2E + unit) for the health check functionality

**Backward Compatibility**: Existing custom `VllmEngine/HealthCheck` RPC is preserved.

## Test Plan

### Automated Tests

```bash
python -m pytest tests/entrypoints/test_grpc_server.py -v
```

**E2E integration tests** (against a real gRPC server subprocess):
- `test_grpc_health_service_overall` — Verify `Check("")` returns `SERVING`
- `test_grpc_health_service_vllm_engine` — Verify `Check("vllm.grpc.engine.VllmEngine")` returns `SERVING`
- `test_grpc_health_service_unknown_service` — Verify `Check("nonexistent.Service")` returns `NOT_FOUND`
- `test_grpc_health_service_reflection` — Verify `grpc.health.v1.Health` appears in server reflection

**Unit tests** (mock-based, no server required):
- `test_health_monitor_sets_serving_when_healthy` — Monitor sets `SERVING` when `async_llm.errored == False`
- `test_health_monitor_sets_not_serving_when_errored` — Monitor sets `NOT_SERVING` when `async_llm.errored == True`
- `test_health_monitor_stops_on_event` — Monitor exits promptly when `stop_event` is set
- `test_health_monitor_handles_exception` — Monitor survives and continues after `set()` raises

## Test Result

### Automated Tests — All 19 passed (11 existing + 8 new)

```
$ python -m pytest tests/entrypoints/test_grpc_server.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0

tests/entrypoints/test_grpc_server.py::test_health_check PASSED          [  5%]
tests/entrypoints/test_grpc_server.py::test_get_model_info PASSED        [ 10%]
tests/entrypoints/test_grpc_server.py::test_get_server_info PASSED       [ 15%]
tests/entrypoints/test_grpc_server.py::test_generate_non_streaming PASSED [ 21%]
tests/entrypoints/test_grpc_server.py::test_generate_streaming PASSED    [ 26%]
tests/entrypoints/test_grpc_server.py::test_generate_with_different_sampling_params PASSED [ 31%]
tests/entrypoints/test_grpc_server.py::test_generate_with_stop_strings PASSED [ 36%]
tests/entrypoints/test_grpc_server.py::test_generate_multiple_requests PASSED [ 42%]
tests/entrypoints/test_grpc_server.py::test_generate_with_seed PASSED    [ 47%]
tests/entrypoints/test_grpc_server.py::test_generate_error_handling PASSED [ 52%]
tests/entrypoints/test_grpc_server.py::test_abort_request PASSED         [ 57%]
tests/entrypoints/test_grpc_server.py::test_grpc_health_service_overall PASSED [ 63%]
tests/entrypoints/test_grpc_server.py::test_grpc_health_service_vllm_engine PASSED [ 68%]
tests/entrypoints/test_grpc_server.py::test_grpc_health_service_unknown_service PASSED [ 73%]
tests/entrypoints/test_grpc_server.py::test_grpc_health_service_reflection PASSED [ 78%]
tests/entrypoints/test_grpc_server.py::test_health_monitor_sets_serving_when_healthy PASSED [ 84%]
tests/entrypoints/test_grpc_server.py::test_health_monitor_sets_not_serving_when_errored PASSED [ 89%]
tests/entrypoints/test_grpc_server.py::test_health_monitor_stops_on_event PASSED [ 94%]
tests/entrypoints/test_grpc_server.py::test_health_monitor_handles_exception PASSED [100%]

======================= 19 passed, 2 warnings in 46.99s ========================
```

### Kubernetes Native gRPC Health Probe — Verified

```yaml
Readiness Probe:
          Grpc:
            Port:             50051
          Success Threshold:  1
...
  Ready Replicas:          1
  Replicas:                1
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

---