### PR TITLE
[DOC]: Add warning about max_num_batched_tokens and max_model_len when chunked prefill is disabled

### DIFF
--- a/docs/configuration/optimization.md
+++ b/docs/configuration/optimization.md
@@ -47,6 +47,10 @@ You can tune the performance by adjusting `max_num_batched_tokens`:
 - For optimal throughput, we recommend setting `max_num_batched_tokens > 8192` especially for smaller models on large GPUs.
 - If `max_num_batched_tokens` is the same as `max_model_len`, that's almost the equivalent to the V0 default scheduling policy (except that it still prioritizes decodes).
 
+!!! warning
+    **When chunked prefill is disabled** – `max_num_batched_tokens` must be **greater than** `max_model_len`.  
+    In that case, if `max_num_batched_tokens < max_model_len`, vLLM may crash at server start‑up.
+
 ```python
 from vllm import LLM
 

--- a/docs/configuration/optimization.md
+++ b/docs/configuration/optimization.md
@@ -48,7 +48,7 @@ You can tune the performance by adjusting `max_num_batched_tokens`:
 - If `max_num_batched_tokens` is the same as `max_model_len`, that's almost the equivalent to the V0 default scheduling policy (except that it still prioritizes decodes).
 
 !!! warning
-    **When chunked prefill is disabled** – `max_num_batched_tokens` must be **greater than** `max_model_len`.  
+    When chunked prefill is disabled, `max_num_batched_tokens` must be greater than `max_model_len`.  
     In that case, if `max_num_batched_tokens < max_model_len`, vLLM may crash at server start‑up.
 
 ```python


### PR DESCRIPTION
This PR adds a documentation warning clarifying a required configuration constraint:

When chunked prefill is disabled, max_num_batched_tokens must be greater than max_model_len.
Otherwise, vLLM fails at server startup due to argument validation.

This behavior is enforced in the codebase but was previously undocumented, which can lead to confusing startup failures when tuning memory or throughput parameters.

You can check the statement here: 
https://github.com/vllm-project/vllm/blob/main/vllm/config/scheduler.py#L246-L258

No functional changes — documentation only.