### PR TITLE
Fix IndexError with encoder-decoder models when using Custom Paged Attention

### DIFF
--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -330,7 +330,14 @@ class RocmAttentionImpl(AttentionImpl):
             kv_cache, self.num_kv_heads, self.head_size
         )
 
-        if self.kv_sharing_target_layer_name is None:
+        # key and value may be None in the case of cross attention. They are
+        # calculated once based on the output from the encoder and then cached
+        # in KV cache.
+        if (
+            self.kv_sharing_target_layer_name is None
+            and key is not None
+            and value is not None
+        ):
             # Reshape the input keys and values and store them in the cache.
             # Skip this if sharing KV cache with an earlier attention layer.
 
@@ -382,8 +389,8 @@ class RocmAttentionImpl(AttentionImpl):
         # Compute attention and update output up to `num_actual_tokens`.
         chunked_prefill_paged_decode(
             query=query[:num_actual_tokens],
-            key=key[:num_actual_tokens],
-            value=value[:num_actual_tokens],
+            key=key[:num_actual_tokens] if key is not None else None,
+            value=value[:num_actual_tokens] if value is not None else None,
             output=output[:num_actual_tokens],
             kv_cache_dtype=self.kv_cache_dtype,
             key_cache=key_cache,

--- a/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/v1/attention/ops/chunked_prefill_paged_decode.py
@@ -302,8 +302,9 @@ def chunked_prefill_paged_decode(
     block_size = value_cache.shape[3]
     num_seqs = len(seq_lens)
     num_query_heads = query.shape[1]
-    num_kv_heads = key.shape[1]
-    num_queries_per_kv = query.shape[1] // key.shape[1]
+    # key may be None in cross-attention decode (already cached from encoder)
+    num_kv_heads = key.shape[1] if key is not None else key_cache.shape[1]
+    num_queries_per_kv = num_query_heads // num_kv_heads
     head_size = query.shape[2]
 
     # Conversion of FP8 Tensor from uint8 storage to


### PR DESCRIPTION
## Purpose
Fix `IndexError: Dimension out of range` error when running encoder-decoder models (e.g., Whisper) when using the ROCm Attention (Custom Paged Attention) backend.
```
IndexError: Dimension out of range (expected to be in range of [-1, 0], but got 1)
```
During encoder-decoder cross-attention, key and value are `None` on decode steps (KV is already cached from the encoder). The ROCm Attention backend was unconditionally passing these to `PagedAttention.write_to_paged_cache()` and `chunked_prefill_paged_decode()`, causing the error.

This PR implements the following changes:

- `rocm_attn.py`: Added `None` guard before writing to paged cache, and handle `None `when slicing key/value for the attention call.
- `chunked_prefill_paged_decode.py`: Derive `num_kv_heads` from `key_cache` when `key` is `None` instead of accessing `key.shape[1]`.

## Test Plan
Minimal reproduction script:
```
import dataclasses
import os

from vllm import LLM, SamplingParams
from vllm.assets.audio import AudioAsset
from vllm.config import AttentionConfig
from vllm.engine.arg_utils import EngineArgs


def main():
    # Configure to use rocm_attn backend (triggers the bug before fix)
    engine_args = EngineArgs(
        model="openai/whisper-large-v3",
        max_model_len=448,
        max_num_seqs=16,
        limit_mm_per_prompt={"audio": 1},
        dtype="half",
        # This enables rocm_attn backend on ROCm
        attention_config=AttentionConfig(use_prefill_decode_attention=True),
    )

    llm = LLM(**dataclasses.asdict(engine_args))

    # Encoder-decoder prompt triggers cross-attention
    prompts = [
        {
            "encoder_prompt": {
                "prompt": "",
                "multi_modal_data": {
                    "audio": AudioAsset("winning_call").audio_and_sample_rate,
                },
            },
            "decoder_prompt": "<|startoftranscript|>",
        }
    ]

    sampling_params = SamplingParams(temperature=0, max_tokens=64)

    outputs = llm.generate(prompts, sampling_params)

    for output in outputs:
        print(f"Generated: {output.outputs[0].text}")


if __name__ == "__main__":
    main()
```
## Test Result
Before:
```
(EngineCore_DP0 pid=18637)   File "/opt/venv/lib/python3.12/site-packages/torch/_ops.py", line 1255, in __call__
(EngineCore_DP0 pid=18637)     return self._op(*args, **kwargs)
(EngineCore_DP0 pid=18637)            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=18637) IndexError: Dimension out of range (expected to be in range of [-1, 0], but got 1)
```
After:
```
Adding requests: 100%|█████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.61it/s]
Processed prompts: 100%|██████████████| 1/1 [00:01<00:00,  1.90s/it, est. speed input: 0.53 toks/s, output: 33.66 toks/s]
Generated:  And the 0-1 pitch on the way to Edgar Martinez. Swung on the line. Now the left field line for a base hit. Here comes Joy. Here is Junior to third base. They're going to wave him in. The throw to the plate will be late. The Mariners are
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

