### PR TITLE
[torch.compile] Stop assuming 32 bit indexing

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -280,9 +280,10 @@ class DynamicShapesConfig:
     until this change picked up https://github.com/pytorch/pytorch/pull/169239.
     """
 
-    assume_32_bit_indexing: bool = True
+    assume_32_bit_indexing: bool = False
     """
     whether all tensor sizes can use 32 bit indexing.
+    `True` requires PyTorch 2.10+
     """
 
     def compute_hash(self) -> str:


### PR DESCRIPTION
## Purpose

In PyTorch 2.10 we added a way for vLLM to assume 32 bit indexing and made it True by default. In PyTorch 2.9 the default was "don't assume 32 bit indexing".

We ran into some errors with this flag internally. Previously I thought this meant that we assume that the number of tokens is 32-bit, but this flag actually means if the Tensor.numel() is 32-bit, which is not always True.

We should actually be able to infer this, but until then, stop assuming the Tensor.numel is 32-bit.

## Test Plan & Test Result
wait for CI

