### PR TITLE
[BugFix] p2p_nccl_connector: Skip non-chunked requests

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
@@ -430,7 +430,8 @@ class P2pNcclConnector(KVConnectorBase_V1):
             if self.is_producer:
                 num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
                 num_tokens = num_scheduled_tokens + num_computed_tokens
-                assert req_id in self.chunked_prefill
+                if req_id not in self.chunked_prefill:
+                    continue
                 assert new_block_ids is not None
                 block_ids = new_block_ids[0]
                 if not resumed_from_preemption:


### PR DESCRIPTION
Resolves: https://github.com/vllm-project/vllm/issues/33092

Since the scheduled_cached_reqs does not contain short requests that were not chunked and already processed, skip them