### PR TITLE
[Config] Add explicit bind flag for KV events

### DIFF
--- a/vllm/config/kv_events.py
+++ b/vllm/config/kv_events.py
@@ -28,6 +28,10 @@ class KVEventsConfig:
     """The zmq endpoint to use for publishing kv events.
     """
 
+    bind: bool = True
+    """If True, bind the publisher socket to the endpoint. If False, connect.
+    """
+
     replay_endpoint: str | None = None
     """The zmq endpoint to use for replaying kv events.
     """


### PR DESCRIPTION
Replace the PUB socket bind/connect heuristic with an explicit config option so users can choose behavior deterministically.

## Purpose
- Replace heuristic bind/connect logic with explicit `bind` config option.
- Default `bind=True` preserves existing behavior while clarifying intent.

## Test Plan
- Not run (not requested).

## Test Result
- Not run (not requested).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

