### PR TITLE
[CPU][Feat] Enable KleidiAI accelerated int4 dynamic quant with BF16 activations on Arm CPUs

### DIFF
--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/dynamic_4bit.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/dynamic_4bit.py
@@ -11,6 +11,18 @@ from vllm.scalar_type import scalar_types
 from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
 
 
+# This implementation is for the KleidiAI-accelerated w4a8int quantization
+# scheme on Arm CPUs:
+# torch.ops.aten._dyn_quant_matmul_4bit performs dynamic quantized matmul
+#   it takes:
+#       - int4 weights packed along with bias/scales by
+#         torch.ops.aten._dyn_quant_pack_4bit_weight
+#       - float32/bfloat16 activations
+#   then it leverages KleidiAI ukernels that:
+#       - dynamically quantize the activations to int8
+#       - unpack the int4 weights to int8
+#       - perform int8 x int8 -> int32 matmul
+#       - dequantize the int32 output to float32/bfloat16 outputs
 class Dynamic4bitLinearKernel(MPLinearKernel):
     SUPPORTED_QUANT_TYPES = [scalar_types.int4]
 
@@ -29,9 +41,14 @@ class Dynamic4bitLinearKernel(MPLinearKernel):
             and c.act_type
             not in [
                 torch.float32,
+                torch.bfloat16,
             ]
         ):
-            return False, "Dynamic4bitLinearKernel on Arm requires Float32 activations"
+            return (
+                False,
+                "Dynamic4bitLinearKernel on Arm requires Float32 or"
+                " BFloat16 activations",
+            )
         if c.full_weight_shape[0] % c.group_size != 0:
             return (
                 False,


### PR DESCRIPTION
## Purpose

[CPU][Feat] Enable KleidiAI accelerated int4 dynamic quant with BF16 activations
BF16 act, int4 wei KleidiAI kernels were enabled in PyTorch by https://github.com/pytorch/pytorch/pull/158250 and are available in torch==2.10.0

Currently, our int4 dynamic quant path enabled by https://github.com/vllm-project/vllm/pull/17112 only supports FP32 activations - i.e. all ops but dense layers run in FP32 and our KV cache will be in FP32. 
This PR allows us to serve int4 quantized models with BF16 activations which reduces memory usage and accelerate perf since paged attention & KV cache, etc are all in BF16.

For context about KleidiAI accelerated int4 dynamic quant see: https://learn.arm.com/learning-paths/servers-and-cloud-computing/vllm-acceleration/2-quantize-model/

## Test Plan

- This has been tested thoroughly in PyTorch https://github.com/pytorch/pytorch/pull/158250
- Quantized llama 3.1-8b model using [this](https://learn.arm.com/learning-paths/servers-and-cloud-computing/vllm-acceleration/2-quantize-model/) recipe, ran it with BF16 activations against [CNN eval summaization](https://huggingface.co/datasets/mgoin/mlperf-inference-llama3.1-8b-data/blob/main/README.md) dataset and got similar rouge scores compared to the original BF16 (non-quantized) model. 

## Test Result

All good!

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [Y] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [Y] The test plan, such as providing test command.
- [Y] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

