### PR TITLE
[Core] Optimize SWA KV cache management for prefix caching

### DIFF
--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -357,7 +357,8 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
             dcp_world_size=self.dcp_world_size,
             pcp_world_size=self.pcp_world_size,
         )
-        return hit_blocks, len(hit_blocks[0]) * self.block_size
+        hit_length = len(hit_blocks[0]) * self.block_size
+        return hit_blocks, hit_length
 
 
 class HybridKVCacheCoordinator(KVCacheCoordinator):

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -918,7 +918,19 @@ class Scheduler(SchedulerInterface):
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
         for req_id, num_scheduled_token in num_scheduled_tokens.items():
             request = self.requests[req_id]
+            old_computed = request.num_computed_tokens
             request.num_computed_tokens += num_scheduled_token
+
+            # Immediately free SWA out-of-window blocks after prefill completes.
+            # This ensures block pool capacity is reclaimed for concurrent
+            # requests, rather than waiting until the next scheduling cycle.
+            if (
+                old_computed < request.num_prompt_tokens
+                and request.num_computed_tokens >= request.num_prompt_tokens
+            ):
+                self.kv_cache_manager.remove_skipped_blocks(
+                    request.request_id, request.num_computed_tokens
+                )
 
             # NOTE: _free_encoder_inputs relies on num_computed_tokens, which
             # may be updated again in _update_from_output for speculative

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -382,6 +382,11 @@ class SingleTypeKVCacheManager(ABC):
             removed_blocks.append(blocks[i])
             blocks[i] = self._null_block
         self.block_pool.free_blocks(removed_blocks)
+        # Evict hashes of freed SWA blocks from the prefix cache.
+        # These blocks are outside the sliding window and will never be
+        # looked up again, so keeping their hashes wastes cache capacity
+        # and causes LRU eviction of actually-reusable hashes.
+        self.block_pool.evict_blocks({b.block_id for b in removed_blocks})
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
         """
@@ -573,13 +578,65 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         attention computation since they are outside the sliding window.
         Thus, get_num_skipped_tokens(7) == 4.
 
+        Note: When prefix caching is enabled, we keep one extra block to ensure
+        cache hit compatibility. The lookup uses max_length = num_tokens - 1
+        (from full attention), causing an off-by-one with the eviction boundary.
+        By keeping one extra block, the lookup can find enough contiguous blocks.
+
         Args:
             num_computed_tokens: The number of tokens that have been computed.
 
         Returns:
             The number of tokens that will be skipped for attention computation.
         """
-        return max(0, num_computed_tokens - self.sliding_window + 1)
+        skipped = max(0, num_computed_tokens - self.sliding_window + 1)
+        # Keep one extra block for prefix cache hit compatibility.
+        # Lookup starts at max_num_blocks-1 due to full attention's
+        # max_cache_hit_length = num_tokens-1, creating an off-by-one
+        # with the eviction boundary.
+        if skipped > 0 and self.enable_caching:
+            skipped = max(0, skipped - self.block_size)
+        return skipped
+
+    def cache_blocks(self, request: Request, num_tokens: int) -> None:
+        """
+        Cache only the blocks within the sliding window for prefix caching.
+
+        For SWA, only the last `sliding_window_blocks` blocks are useful for
+        prefix cache lookup (since find_longest_cache_hit searches from right
+        to left and only needs contiguous blocks within the window).
+        Caching earlier blocks wastes hash table capacity and causes LRU
+        eviction of actually-reusable hashes (e.g., full attention blocks).
+        """
+        num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
+        num_full_blocks = num_tokens // self.block_size
+
+        if num_cached_blocks >= num_full_blocks:
+            return
+
+        # Only cache blocks within the sliding window.
+        # Earlier blocks will be freed by remove_skipped_blocks anyway.
+        # Cache one extra block at the beginning to account for the off-by-one
+        # in cache hit lookup: lookup starts at max_num_blocks-1 (excluding the
+        # incomplete last block), so we need sliding_window_blocks + 1 cached
+        # blocks to achieve sliding_window_blocks contiguous hits.
+        sliding_window_blocks = cdiv(self.sliding_window, self.block_size)
+        start_cache_block = max(
+            num_cached_blocks, num_full_blocks - sliding_window_blocks - 1
+        )
+
+        if start_cache_block < num_full_blocks:
+            self.block_pool.cache_full_blocks(
+                request=request,
+                blocks=self.req_to_blocks[request.request_id],
+                num_cached_blocks=start_cache_block,
+                num_full_blocks=num_full_blocks,
+                block_size=self.block_size,
+                kv_cache_group_id=self.kv_cache_group_id,
+            )
+
+        # Mark all blocks up to num_full_blocks as processed (even if skipped).
+        self.num_cached_block[request.request_id] = num_full_blocks
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         """


### PR DESCRIPTION
## Summary         

Optimize sliding window attention KV cache management to improve prefix cache hit rates and memory efficiency.                                                                                                                                                            
                                                                                                                                                                                                                                                                            
  Key changes:                                                                                                                                                                                                                                                              
  - Add prepend_n() to free block queue for LIFO allocation of fresh blocks                                                                                                                                                                                                 
  - Separate fresh and cached blocks during deallocation                                                                                                                                                                                                                    
  - Evict SWA block hashes when blocks exit sliding window                                                                                                                                                                                                                  
  - Free SWA blocks immediately after prefill completes                                                                                                                                                                                                                     
  - Simplified hybrid KV cache coordinator algorithm                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                            
  ## Test Plan                                                                                                                                                                                                                                                              

Tested with GPT-OSS model benchmarks showing improved cache hit rates. 
This allowed much bigger batch size vs. what's originally suggested by "concurrency" during server boot up, correctly accounting for SWA. 