### PR TITLE
[Bugfix] Fix xgrammar cleanup leakage

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -341,6 +341,9 @@ class InprocClient(EngineCoreClient):
     def dp_engines_running(self) -> bool:
         return False
 
+    def __del__(self):
+        self.shutdown()
+
 
 @dataclass
 class BackgroundResources:

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -136,9 +136,6 @@ class UniProcExecutor(Executor):
         if worker := self.driver_worker:
             worker.shutdown()
 
-        if torch.distributed.is_initialized():
-            torch.distributed.destroy_process_group()
-
 
 class ExecutorWithExternalLauncher(UniProcExecutor):
     """An executor that uses external launchers to launch engines,

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -136,6 +136,9 @@ class UniProcExecutor(Executor):
         if worker := self.driver_worker:
             worker.shutdown()
 
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
 
 class ExecutorWithExternalLauncher(UniProcExecutor):
     """An executor that uses external launchers to launch engines,

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -169,7 +169,7 @@ class XgrammarGrammar(StructuredOutputGrammar):
     _is_terminated: bool = field(default=False, repr=False, hash=False)
 
     def __post_init__(self):
-        atexit.register(self.close)
+        atexit.register(self.clean)
 
     def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
         """Accepts a list of tokens and advances the FSM.
@@ -224,7 +224,7 @@ class XgrammarGrammar(StructuredOutputGrammar):
         self.num_processed_tokens = 0
         self.matcher.reset()
 
-    def close(self):
+    def clean(self):
         if hasattr(self, "matcher"):
             self.matcher = None
         if hasattr(self, "ctx"):

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import atexit
 import json
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -167,6 +168,9 @@ class XgrammarGrammar(StructuredOutputGrammar):
     )
     _is_terminated: bool = field(default=False, repr=False, hash=False)
 
+    def __post_init__(self):
+        atexit.register(self.close)
+
     def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
         """Accepts a list of tokens and advances the FSM.
 
@@ -219,6 +223,12 @@ class XgrammarGrammar(StructuredOutputGrammar):
     def reset(self):
         self.num_processed_tokens = 0
         self.matcher.reset()
+
+    def close(self):
+        if hasattr(self, "matcher"):
+            self.matcher = None
+        if hasattr(self, "ctx"):
+            self.ctx = None
 
 
 # cf https://github.com/mlc-ai/xgrammar/blob/a32ac892676d2eedc0327416105b9b06edfb94b2/cpp/json_schema_converter.cc


### PR DESCRIPTION
## Purpose
To fix xgrammar cleanup leakage issue(https://github.com/vllm-project/vllm/issues/26363).

## Test Plan
1. How to reproduce the bug.

If we set VLLM_WORKER_MULTIPROC_METHOD to spawn,  the ‘matcher’ and 'ctx' of XgrammarGrammar are not freed when the program exits.
```bash
VLLM_WORKER_MULTIPROC_METHOD=spawn python examples/offline_inference/structured_outputs.py 
```
Then you will get the following log.
<img width="1237" height="598" alt="image" src="https://github.com/user-attachments/assets/99912331-2c98-4eb4-bfdc-960dad66273d" />

NOTE: when VLLM_WORKER_MULTIPROC_METHOD equals to `fork`, this leakage won't happen.
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

