### PR TITLE
[CI] fix(tests): avoid Open-Meteo API timeout in test_function_calling_with_stream

### DIFF
--- a/tests/entrypoints/openai/responses/test_harmony.py
+++ b/tests/entrypoints/openai/responses/test_harmony.py
@@ -3,11 +3,9 @@
 import importlib.util
 import json
 import time
-from unittest.mock import Mock, patch
 
 import pytest
 import pytest_asyncio
-import requests
 from openai import BadRequestError, NotFoundError, OpenAI
 from openai_harmony import (
     Message,
@@ -514,12 +512,9 @@ async def test_code_interpreter(client: OpenAI, model_name: str):
 
 
 def get_weather(latitude, longitude):
-    response = requests.get(
-        f"https://api.open-meteo.com/v1/forecast?latitude={latitude}&longitude={longitude}&current=temperature_2m,wind_speed_10m&hourly=temperature_2m,relative_humidity_2m,wind_speed_10m", # noqa
-        timeout=30,
-    )
-    data = response.json()
-    return data["current"]["temperature_2m"]
+    # NOTE: Keep this function fully deterministic for CI stability.
+    # The tests validate tool-calling wiring, not the external weather API.
+    return 7.3
 
 
 def get_place_to_travel():
@@ -807,10 +802,7 @@ async def test_function_calling_with_stream(client: OpenAI, model_name: str):
     for tc in final_tool_calls.values():
         if tc and tc.type == "function_call" and tc.name == "get_weather":
             args = json.loads(tc.arguments)
-            mock_resp = Mock()
-            mock_resp.json.return_value = {"current": {"temperature_2m": 7.3}}
-            with patch(f"{__name__}.requests.get", return_value=mock_resp):
-                result = call_function(tc.name, args)
+            result = call_function(tc.name, args)
             tool_call = tc
             input_list += [tc]
             break


### PR DESCRIPTION
## Purpose

The CI sometimes failed for  `api.open-meteo.com` ReadTimeout.
```
[2026-01-26T20:58:50Z] E               requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='api.open-meteo.com', port=443): Read timed out. (read timeout=None)
```

For instance, 

- https://buildkite.com/vllm/ci/builds/48514/steps/canvas?sid=019bfb32-27b2-4448-ac7a-b29e6ccf5b05 
- https://buildkite.com/vllm/ci/builds/48503/steps/canvas?sid=019bfb06-90fc-403f-b7c9-b4730e2bac34

The network call here is completely unnecessary. This set of tests is meant to validate the tool-calling protocol and orchestration, not the availability of Open-Meteo.

So this PR propose to remove the network call.

The test history: added in https://github.com/vllm-project/vllm/pull/22554.

## Test Plan



## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

