### PR TITLE
[CI] Split responses API MCP tests into separate CI step

### DIFF
--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -81,6 +81,7 @@ steps:
   source_file_dependencies:
   - vllm/
   - tests/entrypoints/openai/responses/test_mcp_tools.py
+  - tests/entrypoints/openai/responses/conftest.py
   commands:
   # Run MCP-enabled/disabled responses tests in isolation so each pytest
   # process only ever holds a single openai/gpt-oss-20b server instance.

--- a/.buildkite/test_areas/entrypoints.yaml
+++ b/.buildkite/test_areas/entrypoints.yaml
@@ -70,7 +70,21 @@ steps:
   - vllm/
   - tests/entrypoints/openai/responses
   commands:
-  - pytest -v -s entrypoints/openai/responses
+  # Run all Responses API tests except the heavy MCP tests in a single session.
+  # MCP tests are split into their own step below to avoid running two large
+  # gpt-oss servers concurrently on the same GPU, which can exhaust memory.
+  - pytest -v -s entrypoints/openai/responses --ignore=entrypoints/openai/responses/test_mcp_tools.py
+
+- label: Entrypoints Integration (Responses API – MCP)
+  timeout_in_minutes: 50
+  working_dir: "/vllm-workspace/tests"
+  source_file_dependencies:
+  - vllm/
+  - tests/entrypoints/openai/responses/test_mcp_tools.py
+  commands:
+  # Run MCP-enabled/disabled responses tests in isolation so each pytest
+  # process only ever holds a single openai/gpt-oss-20b server instance.
+  - pytest -v -s entrypoints/openai/responses/test_mcp_tools.py
 
 - label: Entrypoints V1
   timeout_in_minutes: 50


### PR DESCRIPTION
Isolate test_mcp_tools.py into its own Buildkite entrypoints step so it runs in a fresh pytest process and GPU context, avoiding concurrent gpt-oss-20b servers on the same L4 GPU that previously caused OOM failures in the Responses API integration job.

## Purpose

https://buildkite.com/vllm/ci/builds/48519/steps/canvas?sid=019bfb44-bd6b-46a6-bca8-8e75e43994f9

```
[2026-01-26T17:25:37Z] ^[[0;36m(EngineCore_DP0 pid=738)^[[0;0m ^[[31mERROR^[[0m ^[[90m01-26 09:25:37^[[0m ^[[90m[core.py:935]^[[0m     raise ValueError(

[2026-01-26T17:25:37Z] ^[[0;36m(EngineCore_DP0 pid=738)^[[0;0m ^[[31mERROR^[[0m ^[[90m01-26 09:25:37^[[0m ^[[90m[core.py:935]^[[0m ValueError: Free memory on device cuda:0 (1.54/22.05 GiB) on startup is less than desired GPU memory utilization (0.9, 19.84 GiB). Decrease GPU memory utilization or reduce GPU memory used by other processes.
```
> ValueError: Free memory on device cuda:0 (1.54/22.05 GiB) on startup is less than desired GPU memory utilization (0.9, 19.84 GiB). Decrease GPU memory utilization or reduce GPU memory used by other processes.

The purpose of this PR is similar to https://github.com/vllm-project/vllm/pull/32110.

Fixes https://github.com/vllm-project/vllm/issues/33297

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

