### PR TITLE
[Bugfix] Disable CG for Whisper+FA2

### DIFF
--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -257,6 +257,26 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
     )
     supports_update_block_table: bool = True
 
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: "VllmConfig",
+        kv_cache_spec: "AttentionSpec",
+    ) -> AttentionCGSupport:
+        # FA2 does not support CUDA graphs with encoder-decoder models due to
+        # accuracy issues reported in https://github.com/vllm-project/vllm/issues/33091
+        if (
+            vllm_config.model_config.is_encoder_decoder
+            and get_flash_attn_version() == 2
+        ):
+            logger.warning_once(
+                "FlashAttention2 does not support CUDA graphs with "
+                "encoder-decoder models due to accuracy issues reported in #33091. "
+                "Disabling CUDA graph."
+            )
+            return AttentionCGSupport.NEVER
+        return cls._cudagraph_support
+
     def __init__(
         self,
         kv_cache_spec: AttentionSpec,


### PR DESCRIPTION
Temporary fix to address https://github.com/vllm-project/vllm/issues/33091 for a tentative v0.15.0 release. As the issue is purely in accuracy and does not produce a crash, I believe it's better to patch it until fixed as to not mislead users deploying Whisper.

This PR disables CG for encoder-decoder models when FA2 is detected.

## Test with

```
python -m pytest -v -s -x tests/entrypoints/openai/test_transcription_validation_whisper.py

# On FA2, with following patch/diff
--- a/tests/entrypoints/openai/test_transcription_validation_whisper.py
+++ b/tests/entrypoints/openai/test_transcription_validation_whisper.py
@@ -16,7 +16,7 @@ import soundfile as sf
 from ...utils import RemoteOpenAIServer

 MODEL_NAME = "openai/whisper-large-v3-turbo"
-SERVER_ARGS = ["--enforce-eager"]
+SERVER_ARGS = ["--attention-config.flash_attn_version=2"]
``` 

or with manual script from issue (failing on master):
```
from vllm.config import AttentionConfig
from vllm import LLM, SamplingParams
from vllm.config.compilation import CompilationConfig, CompilationMode, CUDAGraphMode
from vllm.assets.audio import AudioAsset

def main():
    model_name = "openai/whisper-large-v3-turbo"

    llm = LLM(
        model=model_name,
        tensor_parallel_size=1,
        enforce_eager=False,
        attention_config=AttentionConfig(
            flash_attn_version=2,
        ),
    )
    params = SamplingParams(temperature=0.0, max_tokens=3)
    outputs = llm.generate(
        [
            {
            "prompt": "<|startoftranscript|><|en|><|transcribe|><|notimestamps|>",
            "multi_modal_data": {
                "audio": AudioAsset("mary_had_lamb").audio_and_sample_rate,
            },
        },
        ],
        sampling_params=params,
    )
    for o in outputs:
        generated_text = o.outputs[0].text
        print("output:", generated_text)
        assert "The first" in generated_text

if __name__ == "__main__":
    main()
```
