### PR TITLE
[Bugfix] Upgrade Numba to fix segfault on CUDA drivers version 580

### DIFF
--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -3,7 +3,7 @@
 
 setuptools==77.0.3 # this version can reuse CMake build dir
 
-numba == 0.61.2; platform_machine != "s390x" # Required for N-gram speculative decoding
+numba == 0.63.1; platform_machine != "s390x" # Required for N-gram speculative decoding
 
 # Dependencies for CPUs
 torch==2.10.0+cpu; platform_machine == "x86_64" or platform_machine == "s390x"

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,7 +1,7 @@
 # Common dependencies
 -r common.txt
 
-numba == 0.61.2 # Required for N-gram speculative decoding
+numba == 0.62.1 # Required for N-gram speculative decoding
 
 # Dependencies for NVIDIA GPUs
 ray[cgraph]>=2.48.0 # Ray Compiled Graph, required for pipeline parallelism in V1.

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,7 +1,7 @@
 # Common dependencies
 -r common.txt
 
-numba == 0.62.1 # Required for N-gram speculative decoding
+numba == 0.63.1 # Required for N-gram speculative decoding
 
 # Dependencies for NVIDIA GPUs
 ray[cgraph]>=2.48.0 # Ray Compiled Graph, required for pipeline parallelism in V1.

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -40,7 +40,7 @@ buildkite-test-collector==0.1.9
 genai_perf>=0.0.8
 tritonclient>=2.51.0
 
-numba == 0.61.2 # Required for N-gram speculative decoding
+numba == 0.63.1 # Required for N-gram speculative decoding
 numpy
 runai-model-streamer[s3,gcs]==0.15.3
 fastsafetensors>=0.1.10

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -1,7 +1,7 @@
 # Common dependencies
 -r common.txt
 
-numba == 0.61.2 # Required for N-gram speculative decoding
+numba == 0.63.1 # Required for N-gram speculative decoding
 
 # Dependencies for AMD GPUs
 datasets

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -49,7 +49,7 @@ genai_perf>=0.0.8
 tritonclient>=2.51.0
 
 arctic-inference == 0.1.1 # Required for suffix decoding test
-numba == 0.61.2 # Required for N-gram speculative decoding
+numba == 0.63.1 # Required for N-gram speculative decoding
 numpy
 runai-model-streamer[s3,gcs]==0.15.3
 fastsafetensors>=0.1.10

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -456,7 +456,7 @@ lightning-utilities==0.14.3
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-llvmlite==0.44.0
+llvmlite==0.46.0
     # via numba
 lm-eval==0.4.9.2
     # via -r requirements/test.in
@@ -527,7 +527,7 @@ nltk==3.9.1
     # via rouge-score
 num2words==0.5.14
     # via -r requirements/test.in
-numba==0.61.2
+numba==0.63.1
     # via
     #   -r requirements/test.in
     #   librosa

--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -9,7 +9,7 @@ setuptools>=77.0.3,<81.0.0
 wheel
 jinja2>=3.1.6
 datasets # for benchmark scripts
-numba == 0.61.2 # Required for N-gram speculative decoding
+numba == 0.63.1 # Required for N-gram speculative decoding
 --extra-index-url=https://download.pytorch.org/whl/xpu
 torch==2.9.0+xpu
 torchaudio


### PR DESCRIPTION
This PR fixes a segmentation fault that's happening in some cases when querying and selecting a CUDA device (CUDA 13, NVIDIA driver version 580, numba 0.61.2). This should only affect CUDA systems but I went ahead and upgraded Numba everywhere for consistency.

* Documentation on the seg fault from Red Hat with repro steps: https://issues.redhat.com/browse/AIPCC-9384 
* This is the numba PR that fixes the issue: https://github.com/numba/numba/pull/10237
* Numba release notes:
https://numba.readthedocs.io/en/stable/release/0.63.0-notes.html#fix-cuda-target-crash-bug-with-nvidia-driver-version-580

From the release notes:
>This was already fixed in the numba-cuda package, but has been backported here for users who haven’t migrated yet. (We still encourage all CUDA users to switch to the numba-cuda package for the most up to date CUDA support in Numba.)

Should we consider switching to numba-cuda?