### PR TITLE
[Bugfix][Hardware][AMD] Fix FP8 dtype for gfx950 (MI325X/MI355X)

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -582,8 +582,10 @@ class RocmPlatform(Platform):
 
     @classmethod
     def is_fp8_fnuz(cls) -> bool:
-        # only device 0 is checked, this assumes MI300 platforms are homogeneous
-        return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
+        # MI300 (gfx942) and MI325/MI355 (gfx950) platforms use float8_e4m3fnuz
+        # only device 0 is checked, this assumes platforms are homogeneous
+        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
+        return any(gfx in gcn_arch for gfx in ["gfx94", "gfx95"])
 
     @classmethod
     def fp8_dtype(cls) -> torch.dtype:


### PR DESCRIPTION
## Summary

- Fix `is_fp8_fnuz()` to include gfx950 (MI325X/MI355X) platforms
- gfx950 uses `float8_e4m3fnuz` dtype, same as gfx942 (MI300X)

## Problem

The `is_fp8_fnuz()` method only checked for `gfx94` substring, which matches MI300X (gfx942) but not MI325X/MI355X (gfx950). This caused gfx950 to incorrectly use `float8_e4m3fn` instead of `float8_e4m3fnuz`, leading to numerical divergence between:
- First request (cache miss - full prefill)
- Subsequent requests (cache hit - partial prefill with cached KV)

## Fix

Updated `is_fp8_fnuz()` to check for both `gfx94` and `gfx95` prefixes, consistent with the existing `supports_fp8()` and `use_custom_allreduce()` methods.

## Test plan

- [ ] Test on MI355X with FP8 KV cache enabled
- [ ] Verify first and subsequent requests produce consistent outputs
- [ ] Run `test_serving_tokens.py::test_same_response_as_chat_completions` on gfx950

Fixes: https://github.com/vllm-project/vllm/issues/33123

🤖 Generated with [Claude Code](https://claude.ai/code)