### PR TITLE
[Misc][Build] Lazy load cv2 in nemotron_parse.py

### DIFF
--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -416,6 +416,7 @@ class NemotronParseImageProcessor:
             self.target_height = self.target_width = int(self.final_size)
 
         import cv2
+
         self.transform = A.Compose(
             [
                 A.PadIfNeeded(
@@ -458,6 +459,7 @@ class NemotronParseImageProcessor:
 
         # Use cv2.INTER_LINEAR like the original
         import cv2
+
         return cv2.resize(
             image, (new_width, new_height), interpolation=cv2.INTER_LINEAR
         )

--- a/vllm/model_executor/models/nemotron_parse.py
+++ b/vllm/model_executor/models/nemotron_parse.py
@@ -11,7 +11,6 @@ import math
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Annotated, Literal
 
-import cv2
 import numpy as np
 import torch
 import torch.nn as nn
@@ -416,6 +415,7 @@ class NemotronParseImageProcessor:
         else:
             self.target_height = self.target_width = int(self.final_size)
 
+        import cv2
         self.transform = A.Compose(
             [
                 A.PadIfNeeded(
@@ -457,6 +457,7 @@ class NemotronParseImageProcessor:
             new_height = int(new_width / aspect_ratio)
 
         # Use cv2.INTER_LINEAR like the original
+        import cv2
         return cv2.resize(
             image, (new_width, new_height), interpolation=cv2.INTER_LINEAR
         )


### PR DESCRIPTION
## Purpose
Lazy loads the cv2 module to avoid import errors in certain envs when not needed

<details>
<summary>Error trace</summary>

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.12/multiprocessing/spawn.py", line 122, in spawn_main
    exitcode = _main(fd, parent_sentinel)
  File "/usr/lib/python3.12/multiprocessing/spawn.py", line 131, in _main
    prepare(preparation_data)
  File "/usr/lib/python3.12/multiprocessing/spawn.py", line 246, in prepare
    _fixup_main_from_path(data['init_main_from_path'])
  File "/usr/lib/python3.12/multiprocessing/spawn.py", line 297, in _fixup_main_from_path
    main_content = runpy.run_path(main_path,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen runpy>", line 280, in run_path
  File "<frozen runpy>", line 92, in _run_module_code
  File "<frozen runpy>", line 86, in _run_code
  File "/opt/venv/bin/vllm", line 5, in <module>
    from vllm.scripts import main
  File "/opt/venv/lib/python3.12/site-packages/vllm/__init__.py", line 3, in <module>
    from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
  File "/opt/venv/lib/python3.12/site-packages/vllm/engine/__init__.py", line 1, in <module>
    from vllm.engine.async_llm_engine import AsyncLLMEngine
  File "/opt/venv/lib/python3.12/site-packages/vllm/engine/async_llm_engine.py", line 11, in <module>
    from vllm.executor.executor_base import ExecutorBase
  File "/opt/venv/lib/python3.12/site-packages/vllm/executor/__init__.py", line 1, in <module>
    from vllm.executor.executor_base import ExecutorBase, ExecutorAsyncBase
  File "/opt/venv/lib/python3.12/site-packages/vllm/executor/executor_base.py", line 7, in <module>
    from vllm.lora.request import LoRARequest
  File "/opt/venv/lib/python3.12/site-packages/vllm/lora/__init__.py", line 1, in <module>
    from vllm.lora.layers import (
  File "/opt/venv/lib/python3.12/site-packages/vllm/lora/layers.py", line 14, in <module>
    from vllm.model_executor.layers.linear import (
  File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/__init__.py", line 1, in <module>
    from vllm.model_executor.models import ModelRegistry
  File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/__init__.py", line 9, in <module>
    _MODELS = {
              ^
  File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/__init__.py", line 127, in <dictcomp>
    model: _get_model_architecture(model) for model in _MODELS
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/__init__.py", line 127, in <dictcomp>
    model: _get_model_architecture(model) for model in _MODELS
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/__init__.py", line 35, in _get_model_architecture
    mod = importlib.import_module(
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/nemotron_parse.py", line 14, in <module>
    import cv2
  File "/opt/venv/lib/python3.12/site-packages/cv2/__init__.py", line 181, in <module>
    bootstrap()
  File "/opt/venv/lib/python3.12/site-packages/cv2/__init__.py", line 153, in bootstrap
    native_module = importlib.import_module("cv2")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/cv2/typing/__init__.py", line 62, in <module>
    import cv2.mat_wrapper
ImportError: libxcb.so.1: cannot open shared object file: No such file or directory
```
</details>

## Test Plan
Build locally in problem env and test for above error

## Test Result
Local build succeeded as expected without above error 
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

