### PR TITLE
[UX] Enable nested configs in config yaml files

### DIFF
--- a/tests/utils_/test_argparse_utils.py
+++ b/tests/utils_/test_argparse_utils.py
@@ -381,93 +381,46 @@ def test_load_config_file(tmp_path):
 
 def test_load_config_file_nested(tmp_path):
     """Test that nested dicts in YAML config are converted to JSON strings."""
-    # Define the configuration data with nested dicts
     config_data = {
         "port": 8000,
         "compilation-config": {
-            "pass_config": {
-                "fuse_allreduce_rms": True,
-                "eliminate_noops": True,
-            }
-        },
-        "speculative-config": {
-            "model": "nvidia/gpt-oss-120b-Eagle3-v2",
-            "num_speculative_tokens": 3,
-            "method": "eagle3",
+            "pass_config": {"fuse_allreduce_rms": True},
         },
     }
-
-    # Write the configuration data to a temporary YAML file
     config_file_path = tmp_path / "nested_config.yaml"
-    with open(config_file_path, "w") as config_file:
-        yaml.dump(config_data, config_file)
+    with open(config_file_path, "w") as f:
+        yaml.dump(config_data, f)
 
-    # Initialize the parser
     parser = FlexibleArgumentParser()
-
-    # Call the function with the temporary file path
     processed_args = parser.load_config_file(str(config_file_path))
 
-    # Find the indices of each argument
-    port_idx = processed_args.index("--port")
-    cc_idx = processed_args.index("--compilation-config")
-    sc_idx = processed_args.index("--speculative-config")
-
-    # Verify port is a plain string
-    assert processed_args[port_idx + 1] == "8000"
-
-    # Verify nested dicts are converted to JSON strings
-    cc_value = json.loads(processed_args[cc_idx + 1])
-    assert cc_value == {
-        "pass_config": {
-            "fuse_allreduce_rms": True,
-            "eliminate_noops": True,
-        }
-    }
-
-    sc_value = json.loads(processed_args[sc_idx + 1])
-    assert sc_value == {
-        "model": "nvidia/gpt-oss-120b-Eagle3-v2",
-        "num_speculative_tokens": 3,
-        "method": "eagle3",
-    }
-
-    os.remove(str(config_file_path))
+    assert processed_args[processed_args.index("--port") + 1] == "8000"
+    cc_value = json.loads(
+        processed_args[processed_args.index("--compilation-config") + 1]
+    )
+    assert cc_value == {"pass_config": {"fuse_allreduce_rms": True}}
 
 
 def test_nested_config_end_to_end(tmp_path):
     """Test end-to-end parsing of nested configs in YAML files."""
-    # Define the configuration data with nested dict
     config_data = {
         "compilation-config": {
             "mode": 3,
-            "pass_config": {
-                "fuse_allreduce_rms": True,
-            },
+            "pass_config": {"fuse_allreduce_rms": True},
         },
     }
+    config_file_path = tmp_path / "nested_config.yaml"
+    with open(config_file_path, "w") as f:
+        yaml.dump(config_data, f)
 
-    # Write the configuration data to a temporary YAML file
-    config_file_path = tmp_path / "nested_e2e.yaml"
-    with open(config_file_path, "w") as config_file:
-        yaml.dump(config_data, config_file)
-
-    # Create a parser with compilation-config argument
     parser = FlexibleArgumentParser()
     parser.add_argument("-cc", "--compilation-config", type=json.loads)
-
-    # Parse with config file
     args = parser.parse_args(["--config", str(config_file_path)])
 
-    # Verify the nested config was parsed correctly
     assert args.compilation_config == {
         "mode": 3,
-        "pass_config": {
-            "fuse_allreduce_rms": True,
-        },
+        "pass_config": {"fuse_allreduce_rms": True},
     }
-
-    os.remove(str(config_file_path))
 
 
 def test_compilation_mode_string_values(parser):

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -444,16 +444,30 @@ class FlexibleArgumentParser(ArgumentParser):
 
     def load_config_file(self, file_path: str) -> list[str]:
         """Loads a yaml file and returns the key value pairs as a
-        flattened list with argparse like pattern
+        flattened list with argparse like pattern.
+
+        Supports both flat configs and nested YAML structures.
+
+        Flat config example:
         ```yaml
             port: 12323
             tensor-parallel-size: 4
         ```
         returns:
-            processed_args: list[str] = [
-                '--port': '12323',
-                '--tensor-parallel-size': '4'
-            ]
+            ['--port', '12323', '--tensor-parallel-size', '4']
+
+        Nested config example:
+        ```yaml
+            compilation-config:
+              pass_config:
+                fuse_allreduce_rms: true
+            speculative-config:
+              model: "nvidia/gpt-oss-120b-Eagle3-v2"
+              num_speculative_tokens: 3
+        ```
+        returns:
+            ['--compilation-config', '{"pass_config": {"fuse_allreduce_rms": true}}',
+             '--speculative-config', '{"model": "nvidia/gpt-oss-120b-Eagle3-v2", ...}']
         """
         extension: str = file_path.split(".")[-1]
         if extension not in ("yaml", "yml"):
@@ -461,10 +475,10 @@ class FlexibleArgumentParser(ArgumentParser):
                 f"Config file must be of a yaml/yml type. {extension} supplied"
             )
 
-        # only expecting a flat dictionary of atomic types
+        # Supports both flat configs and nested dicts (converted to JSON strings)
         processed_args: list[str] = []
 
-        config: dict[str, int | str] = {}
+        config: dict[str, Any] = {}
         try:
             with open(file_path) as config_file:
                 config = yaml.safe_load(config_file)
@@ -484,6 +498,17 @@ class FlexibleArgumentParser(ArgumentParser):
                     processed_args.append("--" + key)
                     for item in value:
                         processed_args.append(str(item))
+            elif isinstance(value, dict):
+                # Convert nested dicts to JSON strings so they can be parsed
+                # by the existing JSON argument parsing machinery.
+                # This allows YAML configs like:
+                #   compilation-config:
+                #     pass_config:
+                #       fuse_allreduce_rms: true
+                # Instead of requiring:
+                #   compilation-config: '{"pass_config":{"fuse_allreduce_rms":true}}'
+                processed_args.append("--" + key)
+                processed_args.append(json.dumps(value))
             else:
                 processed_args.append("--" + key)
                 processed_args.append(str(value))

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -475,7 +475,7 @@ class FlexibleArgumentParser(ArgumentParser):
                 f"Config file must be of a yaml/yml type. {extension} supplied"
             )
 
-        # Supports both flat configs and nested dicts (converted to JSON strings)
+        # Supports both flat configs and nested dicts
         processed_args: list[str] = []
 
         config: dict[str, Any] = {}
@@ -501,12 +501,6 @@ class FlexibleArgumentParser(ArgumentParser):
             elif isinstance(value, dict):
                 # Convert nested dicts to JSON strings so they can be parsed
                 # by the existing JSON argument parsing machinery.
-                # This allows YAML configs like:
-                #   compilation-config:
-                #     pass_config:
-                #       fuse_allreduce_rms: true
-                # Instead of requiring:
-                #   compilation-config: '{"pass_config":{"fuse_allreduce_rms":true}}'
                 processed_args.append("--" + key)
                 processed_args.append(json.dumps(value))
             else:


### PR DESCRIPTION
Signed-off-by: mgoin <mgoin64@gmail.com>

<!-- markdownlint-disable -->

## Purpose

Now users can write this cleaner nested yaml:
```yaml
kv-cache-dtype: fp8
async-scheduling: true
no-enable-prefix-caching: true
max-cudagraph-capture-size: 2048
max-num-batched-tokens: 8192
stream-interval: 20
compilation-config:
  pass_config:
    fuse_allreduce_rms: true
    eliminate_noops: true
speculative-config:
  model: "nvidia/gpt-oss-120b-Eagle3-v2"
  num_speculative_tokens: 3
  method: "eagle3"
  draft_tensor_parallel_size: 1
```

Instead of the previous awkward json-in-yaml:
```yaml
compilation-config: '{"pass_config":{"fuse_allreduce_rms":true,"eliminate_noops":true}}'
speculative-config: '{"model":"nvidia/gpt-oss-120b-Eagle3-v2","num_speculative_tokens":3,"method":"eagle3","draft_tensor_parallel_size":1}'
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

