### PR TITLE
[Hybrid] Simplify mamba block size logic for `all` mode

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -45,6 +45,7 @@ from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.mamba2_attn import Mamba2AttentionMetadata
+from vllm.utils.math_utils import cdiv
 
 # Added by the IBM Team, 2024
 
@@ -744,7 +745,10 @@ class MambaMixer2(MambaBase, CustomOp):
                 # The chunk_stride is the number of chunks per mamba block
                 # e.g., if mamba_block_size = 512 and chunk_size = 256,
                 # then chunk_stride = 2
-                chunk_stride = mamba_block_size // chunk_size
+
+                # NOTE(tdouble) this is no longer divisible
+                # do we need cdiv?
+                chunk_stride = cdiv(mamba_block_size, chunk_size)
 
                 # Save state for sequences with more than just final state
                 for seq_idx in range(num_prefills):

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -743,11 +743,8 @@ class MambaMixer2(MambaBase, CustomOp):
 
             if is_mamba_cache_all:
                 # The chunk_stride is the number of chunks per mamba block
-                # e.g., if mamba_block_size = 512 and chunk_size = 256,
+                # e.g., if mamba_block_size = 400 and chunk_size = 256,
                 # then chunk_stride = 2
-
-                # NOTE(tdouble) this is no longer divisible
-                # do we need cdiv?
                 chunk_stride = cdiv(mamba_block_size, chunk_size)
 
                 # Save state for sequences with more than just final state
@@ -783,19 +780,14 @@ class MambaMixer2(MambaBase, CustomOp):
                     else:
                         first_chunk = 1 + last_chunk_indices_p[seq_idx - 1]
 
-                    #print("chunk_stride: ", chunk_stride)
-                    #print("n_blocks_to_fill: ", n_blocks_to_fill)
-
                     # First chunk that is aligned on the mamba block boundary
                     first_aligned_chunk = first_chunk + chunk_stride - 1
-                    #print("first_aligned_chunk: ", first_aligned_chunk)
 
                     # Calculate the number of computed tokens that were not
                     # already cached
                     num_unaligned_computed_tokens = (
                         num_computed_tokens_p[seq_idx] % mamba_block_size
                     )
-                    #print("num_unaligned_computed_tokens: ", num_unaligned_computed_tokens)
 
                     if num_unaligned_computed_tokens > 0:
                         # If the number of computed tokens is not block aligned,
@@ -803,15 +795,12 @@ class MambaMixer2(MambaBase, CustomOp):
                         first_aligned_chunk -= (
                             num_unaligned_computed_tokens // chunk_size
                         )
-                        # print("first_aligned_chunk: ", first_aligned_chunk)
 
                     # Get states to write
                     from_where = varlen_states[
                         first_aligned_chunk : first_aligned_chunk
                         + n_blocks_to_fill * chunk_stride : chunk_stride
                     ]
-
-                    
 
                     # Write the states
                     ssm_state[cache_blocks_to_fill] = from_where

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -783,14 +783,19 @@ class MambaMixer2(MambaBase, CustomOp):
                     else:
                         first_chunk = 1 + last_chunk_indices_p[seq_idx - 1]
 
+                    #print("chunk_stride: ", chunk_stride)
+                    #print("n_blocks_to_fill: ", n_blocks_to_fill)
+
                     # First chunk that is aligned on the mamba block boundary
                     first_aligned_chunk = first_chunk + chunk_stride - 1
+                    #print("first_aligned_chunk: ", first_aligned_chunk)
 
                     # Calculate the number of computed tokens that were not
                     # already cached
                     num_unaligned_computed_tokens = (
                         num_computed_tokens_p[seq_idx] % mamba_block_size
                     )
+                    #print("num_unaligned_computed_tokens: ", num_unaligned_computed_tokens)
 
                     if num_unaligned_computed_tokens > 0:
                         # If the number of computed tokens is not block aligned,
@@ -798,12 +803,15 @@ class MambaMixer2(MambaBase, CustomOp):
                         first_aligned_chunk -= (
                             num_unaligned_computed_tokens // chunk_size
                         )
+                        # print("first_aligned_chunk: ", first_aligned_chunk)
 
                     # Get states to write
                     from_where = varlen_states[
                         first_aligned_chunk : first_aligned_chunk
                         + n_blocks_to_fill * chunk_stride : chunk_stride
                     ]
+
+                    
 
                     # Write the states
                     ssm_state[cache_blocks_to_fill] = from_where

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -480,11 +480,20 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
             # easily by changing the way we layout chunks in the
             # mamba2 kernels.
 
+            '''
             base_chunk_size = mamba_block_size or model_config.get_mamba_chunk_size()
             attn_tokens_per_mamba_state = cdiv(mamba_page_size, attn_page_size_1_token)
             chunk_size = lcm(base_chunk_size, kernel_block_alignment_size)
             attn_block_size = chunk_size * cdiv(attn_tokens_per_mamba_state, chunk_size)
             cache_config.mamba_block_size = attn_block_size
+            '''
+            
+            attn_block_size = kernel_block_alignment_size * cdiv(
+                mamba_page_size, kernel_block_alignment_size * attn_page_size_1_token
+            )
+            cache_config.mamba_block_size = attn_block_size
+
+
         else:
             # Without prefix caching, select minimum valid attention block size
             # to minimize mamba state padding

--- a/vllm/v1/attention/backends/mamba2_attn.py
+++ b/vllm/v1/attention/backends/mamba2_attn.py
@@ -168,17 +168,18 @@ class Mamba2AttentionMetadataBuilder(
                 - query_start_loc_p_cpu[req_idx].item()
             )
          
+            is_first = True
+
             while this_new_tokens > 0:
 
                 # are we starting a new sequence?
-                is_first = len(last_chunk_indices) == req_idx
-
                 if is_first and this_num_computed % block_size != 0:
                     # how many tokens to finish the block?
                     chunks_len = (
                         cdiv(this_num_computed, block_size) * block_size
                         - this_num_computed
                     )
+                    is_first = False
                 else:
                     # partition the next block into chunks
                     chunks_len = block_size

--- a/vllm/v1/attention/backends/mamba2_attn.py
+++ b/vllm/v1/attention/backends/mamba2_attn.py
@@ -162,14 +162,12 @@ class Mamba2AttentionMetadataBuilder(
 
         for req_idx in range(num_prefills):
             this_num_computed = num_computed_tokens_p_cpu[req_idx].item()
-
             this_new_tokens = (
                 query_start_loc_p_cpu[req_idx + 1].item()
                 - query_start_loc_p_cpu[req_idx].item()
             )
-         
-            is_first = True
 
+            is_first = True
             while this_new_tokens > 0:
 
                 # are we starting a new sequence?


### PR DESCRIPTION
## Purpose

The logic for choosing the mamba block size (and thus attention block size) for mamba2-based models using the `all` mode is currently quite complicated. We have to choose to align the mamba block size with the chunk size of the underlying kernel, which introduces another constraint, and also results in quite some padding being used:

This PR changes the chunk-packing logic for mamba2 such that we can use the same logic for choosing the mamba and attention block size as the `align` mode. This makes the code easier to understand and doesn't seem to make the performance noticeably worse. 

To-do:
- [ ] Check mamba1 behaviour
- [ ] Check that user can still override mamba block size

## Test Plan

Server:
```
vllm serve --enable-prefix-caching ibm-granite/granite-4.0-tiny-preview -
```
Client:
```
vllm bench serve         --model ibm-granite/granite-4.0-tiny-preview         --dataset-name sharegpt         --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json         --ignore_eos
```
This benchmark shouldn't really trigger cache hits, but is a good measure of whether we make the worst-case performance any worse by changing the chunking strategy. 

## Test Result

Main:
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  33.65     
Total input tokens:                      239511    
Total generated tokens:                  225864    
Request throughput (req/s):              29.72     
Output token throughput (tok/s):         6711.96   
Peak output token throughput (tok/s):    17023.00  
Peak concurrent requests:                1000.00   
Total token throughput (tok/s):          13829.46  
---------------Time to First Token----------------
Mean TTFT (ms):                          9748.82   
Median TTFT (ms):                        9483.12   
P99 TTFT (ms):                           12711.42  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          91.05     
Median TPOT (ms):                        71.35     
P99 TPOT (ms):                           197.98    
---------------Inter-token Latency----------------
Mean ITL (ms):                           48.64     
Median ITL (ms):                         28.04     
P99 ITL (ms):                            205.70    
==================================================
```


PR:
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  33.81     
Total input tokens:                      239511    
Total generated tokens:                  225864    
Request throughput (req/s):              29.57     
Output token throughput (tok/s):         6679.73   
Peak output token throughput (tok/s):    16725.00  
Peak concurrent requests:                1000.00   
Total token throughput (tok/s):          13763.05  
---------------Time to First Token----------------
Mean TTFT (ms):                          9868.66   
Median TTFT (ms):                        9796.17   
P99 TTFT (ms):                           12798.39  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          91.10     
Median TPOT (ms):                        70.94     
P99 TPOT (ms):                           197.90    
---------------Inter-token Latency----------------
Mean ITL (ms):                           48.59     
Median ITL (ms):                         27.92     
P99 ITL (ms):                            204.64    
==================================================
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

