### PR TITLE
Relax protobuf library version constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
     "torch == 2.9.1",
     "wheel",
     "jinja2",
-    "grpcio-tools>=1.76.0",
+    "grpcio-tools",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -9,5 +9,5 @@ wheel
 jinja2>=3.1.6
 regex
 build
-protobuf>=6.33.2
-grpcio-tools>=1.76.0
+protobuf
+grpcio-tools

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -9,7 +9,7 @@ blake3
 py-cpuinfo
 transformers >= 4.56.0, < 5
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
-protobuf >= 6.30.0 # Required by LlamaTokenizer, gRPC.
+protobuf # Required by LlamaTokenizer, gRPC.
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.
 aiohttp
 openai >= 1.99.1  # For Responses API with reasoning content
@@ -51,5 +51,5 @@ openai-harmony >= 0.0.3  # Required for gpt-oss
 anthropic >= 0.71.0
 model-hosting-container-standards >= 0.1.13, < 1.0.0
 mcp
-grpcio>=1.76.0
-grpcio-reflection>=1.76.0
+grpcio
+grpcio-reflection


### PR DESCRIPTION
## Purpose
Relaxes the strict version pins for protobuf, grpcio, and grpcio-reflection introduced in #30190 (gRPC server entrypoint). This allows vLLM to work with a wider range of protobuf versions while maintaining compatibility.

Ray is upgrading vLLM to 0.14.0, but there are other dependencies in Ray conflicting with the protobuf version that vLLM requires (>=6.30.0) starting from the introduction of #30190. It's because that some [other libraries](https://github.com/ray-project/ray/blob/master/python/requirements_compiled.txt#L1532-L1555) that ray depends on require an older version of protobuf. For example with tensorflow, we run into such errors:
```
tensorflow 2.15.1 depends on protobuf!=4.21.0, !=4.21.1, !=4.21.2, !=4.21.3, !=4.21.4, !=4.21.5, <5.0.0dev and >=3.20.3
```

## Test Plan & Result
Verified that installing common.txt with `uv pip install -r requirements/common.txt` in a clean conda environment resolves to the same versions with and without the constraints.

- With
```
protobuf==6.33.4
grpcio==1.76.0
```

- Without
```
protobuf==6.33.4
grpcio==1.76.0
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

