### PR TITLE
Don't use `min_pixels`/`max_pixels` from Qwen2VL's processor

### DIFF
--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -841,8 +841,8 @@ class Qwen2VLProcessingInfo(BaseProcessingInfo):
                 height=image_height,
                 width=image_width,
                 factor=patch_size * merge_size,
-                min_pixels=image_processor.min_pixels,
-                max_pixels=image_processor.max_pixels,
+                min_pixels=image_processor.size["shortest_edge"],
+                max_pixels=image_processor.size["longest_edge"],
             )
             preprocessed_size = ImageSize(width=resized_width, height=resized_height)
         else:
@@ -914,9 +914,7 @@ class Qwen2VLProcessingInfo(BaseProcessingInfo):
         merge_size = vision_config.spatial_merge_size
         if max_pixels is None:
             image_processor = self.get_image_processor()
-            max_pixels = (
-                image_processor.max_pixels or image_processor.size["longest_edge"]
-            )
+            max_pixels = image_processor.size["longest_edge"]
         unit = patch_size * merge_size
         max_seq_len = max_pixels // (unit * unit)
 


### PR DESCRIPTION
These attributes are outdated and have been removed in Transformers v5.

This PR updates the Qwen2VL modelling code to use the new equivalent.