### PR TITLE
replace `with torch.cuda.stream()`

### DIFF
--- a/benchmarks/kernels/benchmark_device_communicators.py
+++ b/benchmarks/kernels/benchmark_device_communicators.py
@@ -344,7 +344,7 @@ class CommunicatorBenchmark:
 
             torch.accelerator.synchronize()
             stream = torch.cuda.Stream()
-            with torch.cuda.stream(stream):
+            with stream:
                 graph_input = tensor.clone()
 
                 # Warmup before capture

--- a/benchmarks/kernels/utils.py
+++ b/benchmarks/kernels/utils.py
@@ -133,7 +133,7 @@ class Bench:
         self.args_iterator.reset()
         args_it = self.args_iterator.__next__()
         stream = torch.cuda.Stream()
-        with torch.cuda.stream(stream):
+        with stream:
             g = torch.cuda.CUDAGraph()
             with torch.cuda.graph(g):
                 for _ in range(num_graph_ops):

--- a/docs/usage/troubleshooting.md
+++ b/docs/usage/troubleshooting.md
@@ -125,7 +125,7 @@ If GPU/CPU communication cannot be established, you can use the following Python
     pynccl.disabled = False
 
     s = torch.cuda.Stream()
-    with torch.cuda.stream(s):
+    with s:
         data.fill_(1)
         out = pynccl.all_reduce(data, stream=s)
         value = out.mean().item()

--- a/tests/kernels/quantization/test_cutlass_scaled_mm.py
+++ b/tests/kernels/quantization/test_cutlass_scaled_mm.py
@@ -539,7 +539,7 @@ def test_cutlass_cuda_graph(per_act_token: bool, per_out_ch: bool):
 
     # Run the model with a cuda graph
     stream = torch.cuda.Stream()
-    with torch.cuda.stream(stream):
+    with stream:
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):
             out = model(a)

--- a/tests/kernels/quantization/test_cutlass_w4a8.py
+++ b/tests/kernels/quantization/test_cutlass_w4a8.py
@@ -284,7 +284,7 @@ def test_w4a8_cuda_graph():
 
     # Run the model with a cuda graph
     stream = torch.cuda.Stream()
-    with torch.cuda.stream(stream):
+    with stream:
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):
             output = model(a)

--- a/tests/kernels/quantization/test_cutlass_w4a8_moe.py
+++ b/tests/kernels/quantization/test_cutlass_w4a8_moe.py
@@ -332,7 +332,7 @@ def test_cutlass_w4a8_moe_mm_cuda_graph():
     a_static = setup.a.clone()  # static input tensor for graph replay
 
     stream = torch.cuda.Stream()
-    with torch.cuda.stream(stream):
+    with stream:
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):
             out_static = model(a_static)

--- a/tests/kernels/quantization/test_machete_mm.py
+++ b/tests/kernels/quantization/test_machete_mm.py
@@ -435,7 +435,7 @@ def test_machete_cuda_graph():
 
     # Run the model with a cuda graph
     stream = torch.cuda.Stream()
-    with torch.cuda.stream(stream):
+    with stream:
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):
             output = model(a)

--- a/tests/utils_/test_torch_utils.py
+++ b/tests/utils_/test_torch_utils.py
@@ -68,7 +68,7 @@ def _test_stream_thread(main_expected_stream: torch.cuda.Stream):
     thread_can_exit = threading.Event()
 
     def child_thread_func():
-        with torch.cuda.stream(child_stream):
+        with child_stream:
             thread_stream_ready.set()
             thread_can_exit.wait(timeout=10)
 

--- a/tools/pre_commit/check_torch_cuda.py
+++ b/tools/pre_commit/check_torch_cuda.py
@@ -8,7 +8,7 @@ import regex as re
 # Regex: match `torch.cuda.xxx` but allow `torch.accelerator.xxx`
 # --------------------------------------------------------------------------- #
 _TORCH_CUDA_PATTERNS = [
-    r"\btorch\.cuda\.(empty_cache|synchronize|device_count|current_device|memory_reserved|memory_allocated|max_memory_allocated|max_memory_reserved|reset_peak_memory_stats|memory_stats|set_device|device\()\b",
+    r"\btorch\.cuda\.(stream|empty_cache|synchronize|device_count|current_device|memory_reserved|memory_allocated|max_memory_allocated|max_memory_reserved|reset_peak_memory_stats|memory_stats|set_device|device\()\b",
     r"\btorch\.cuda\.(manual_seed|manual_seed_all)\b",
     r"\bwith\storch\.cuda\.device\b",
     # Calls torch.cuda.{_is_compiled/_device_count_amdsmi/_device_count_nvml} internally

--- a/vllm/distributed/eplb/eplb_communicator.py
+++ b/vllm/distributed/eplb/eplb_communicator.py
@@ -6,6 +6,7 @@ EPLB communicator implementations and factory.
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from contextlib import nullcontext
 
 import torch
 from torch.distributed import (
@@ -85,7 +86,10 @@ class TorchDistNcclEplbCommunicator(EplbCommunicator):
         if not self._p2p_ops:
             return
         try:
-            with torch.cuda.stream(self._cuda_stream):
+            astream = (
+                self._cuda_stream if self._cuda_stream is not None else nullcontext()
+            )
+            with astream:
                 reqs = batch_isend_irecv(self._p2p_ops)
                 for req in reqs:
                     req.wait()
@@ -144,7 +148,10 @@ class TorchDistGlooStagedEplbCommunicator(EplbCommunicator):
                 recv_staging.append((tensor, cpu_tensor))
 
         try:
-            with torch.cuda.stream(self._cuda_stream):
+            astream = (
+                self._cuda_stream if self._cuda_stream is not None else nullcontext()
+            )
+            with astream:
                 build_ops()
         finally:
             self._ops.clear()
@@ -162,7 +169,8 @@ class TorchDistGlooStagedEplbCommunicator(EplbCommunicator):
 
         if not recv_staging:
             return
-        with torch.cuda.stream(self._cuda_stream):
+        astream = self._cuda_stream if self._cuda_stream is not None else nullcontext()
+        with astream:
             for dst_tensor, cpu_tensor in recv_staging:
                 dst_tensor.copy_(cpu_tensor, non_blocking=True)
 

--- a/vllm/distributed/eplb/rebalance_execute.py
+++ b/vllm/distributed/eplb/rebalance_execute.py
@@ -7,6 +7,7 @@ This involves the exchange of expert weights between GPUs.
 """
 
 from collections.abc import Sequence
+from contextlib import nullcontext
 from dataclasses import dataclass
 
 import numpy as np
@@ -237,7 +238,8 @@ def move_to_buffer(
             expert = new_local_expert_ids[dst]
             src_local = expert_to_src_map.get(expert, -1)
             if src_local != -1:
-                with torch.cuda.stream(cuda_stream):
+                astream = cuda_stream if cuda_stream is not None else nullcontext()
+                with astream:
                     for w, b in zip(expert_weights, expert_weights_buffers):
                         b[dst].copy_(w[src_local], non_blocking=True)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_client.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_client.py
@@ -211,7 +211,7 @@ class Hf3fsClient:
         resv = self.ior_r.submit().wait(min_results=ionum)
 
         # results
-        with torch.cuda.stream(self.stream):
+        with self.stream:
             hf3fs_utils.read_shm(
                 self.shm_r_tensor, self.r_pinned, tensors, self.stream_ptr_int
             )
@@ -238,7 +238,7 @@ class Hf3fsClient:
         assert self.iov_w is not None
 
         # prepare
-        with torch.cuda.stream(self.stream):
+        with self.stream:
             self.stream.wait_event(event)
             hf3fs_utils.write_shm(
                 tensors, self.shm_w_tensor, self.w_pinned, self.stream_ptr_int

--- a/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/hf3fs/hf3fs_connector.py
@@ -298,7 +298,7 @@ class AsyncOperationManager:
                 )
 
             # Synchronize streams and gather data
-            with torch.cuda.stream(self._save_stream):
+            with self._save_stream:
                 self._save_stream.wait_event(main_stream_event)  # Wait for main stream
                 self._connector._gather_or_scatter_kv_caches(
                     block_ids, buffers, "gather"
@@ -401,7 +401,7 @@ class AsyncOperationManager:
                 )
 
             # Step3: Scatter data back to KV cache
-            with torch.cuda.stream(self._load_stream):
+            with self._load_stream:
                 self._connector._gather_or_scatter_kv_caches(
                     block_ids, buffers, "scatter"
                 )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -568,7 +568,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         if len(request_ids) == 0:
             return
 
-        with torch.cuda.stream(torch.cuda.current_stream()):
+        with torch.cuda.current_stream():
             event = torch.cuda.Event(interprocess=True)
             event.record()
 
@@ -638,7 +638,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         if len(request_ids) == 0:
             return
 
-        with torch.cuda.stream(torch.cuda.current_stream()):
+        with torch.cuda.current_stream():
             event = torch.cuda.Event(interprocess=True)
             event.record()
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_engine.py
@@ -358,7 +358,7 @@ class P2pNcclEngine:
             )
             return None
 
-        with torch.cuda.stream(self.recv_stream):
+        with self.recv_stream:
             tensor = torch.empty(
                 data["shape"], dtype=getattr(torch, data["dtype"]), device=self.device
             )
@@ -393,7 +393,7 @@ class P2pNcclEngine:
             elif data["cmd"] == "PUT":
                 tensor_id = data["tensor_id"]
                 try:
-                    with torch.cuda.stream(self.recv_stream):
+                    with self.recv_stream:
                         tensor = torch.empty(
                             data["shape"],
                             dtype=getattr(torch, data["dtype"]),
@@ -594,7 +594,7 @@ class P2pNcclEngine:
         if stream is None:
             stream = current_stream()
 
-        with torch.cuda.stream(stream):
+        with stream:
             self.nccl.ncclSend(
                 buffer_type(tensor.data_ptr()),
                 tensor.numel(),
@@ -613,7 +613,7 @@ class P2pNcclEngine:
         if stream is None:
             stream = current_stream()
 
-        with torch.cuda.stream(stream):
+        with stream:
             self.nccl.ncclRecv(
                 buffer_type(tensor.data_ptr()),
                 tensor.numel(),

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -486,7 +486,7 @@ class GroupCoordinator:
         if curr_stream != stream:
             stream.wait_stream(curr_stream)
 
-        with torch.cuda.stream(stream), maybe_ca_context:
+        with stream, maybe_ca_context:
             yield graph_capture_context
 
     def all_reduce(self, input_: torch.Tensor) -> torch.Tensor:

--- a/vllm/distributed/weight_transfer/packed_tensor.py
+++ b/vllm/distributed/weight_transfer/packed_tensor.py
@@ -51,7 +51,7 @@ def packed_broadcast_producer(
         # Synchronize the current stream
         streams[buffer_idx].synchronize()
         # Start tasks for the new buffer in a new stream
-        with torch.cuda.stream(streams[buffer_idx]):
+        with streams[buffer_idx]:
             try:
                 # Initialize the packing tensor list and sizes
                 packing_tensor_list[buffer_idx] = []
@@ -155,7 +155,7 @@ def packed_broadcast_consumer(
     while True:
         # Synchronize the current stream
         streams[buffer_idx].synchronize()
-        with torch.cuda.stream(streams[buffer_idx]):
+        with streams[buffer_idx]:
             # Initialize the packing tensor meta data
             packing_tensor_meta_data[buffer_idx] = []
             packing_tensor_sizes[buffer_idx] = 0

--- a/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
+++ b/vllm/model_executor/layers/fused_moe/runner/shared_experts.py
@@ -149,7 +149,8 @@ class SharedExperts:
         # TODO: assert that maybe_sync_shared_experts_stream has been called.
 
         # Run shared experts in parallel on a separate stream.
-        with torch.cuda.stream(self._stream):
+        assert self._stream is not None
+        with self._stream:
             output = self._layer(shared_experts_input)
         current_stream().wait_stream(self._stream)
 

--- a/vllm/model_executor/offloader/prefetch.py
+++ b/vllm/model_executor/offloader/prefetch.py
@@ -522,7 +522,7 @@ class _ModuleOffloader:
         torch.cuda.current_stream().record_event(fork_event)
         self.copy_stream.wait_event(fork_event)
 
-        with torch.cuda.stream(self.copy_stream):
+        with self.copy_stream:
             for name, offloader in self._param_offloaders.items():
                 cpu_storage = offloader._cpu_storage
                 gpu_buffer = offloader._gpu_buffer

--- a/vllm/utils/multi_stream_utils.py
+++ b/vllm/utils/multi_stream_utils.py
@@ -37,7 +37,7 @@ def maybe_execute_in_parallel(
     if aux_stream is not None:
         event0.record()
         result0 = fn0()
-        with torch.cuda.stream(aux_stream):
+        with aux_stream:
             event0.wait()
             result1 = fn1()
             event1.record()

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -549,7 +549,11 @@ def current_stream() -> torch.cuda.Stream:
     the underlying hypothesis is that we do not call `torch._C._cuda_setStream`
     from C/C++ code.
     """
+
     from vllm.platforms import current_platform
+
+    if current_platform.is_cuda():
+        return torch.cuda.current_stream()
 
     if not hasattr(_current_stream_tls, "value") or _current_stream_tls.value is None:
         # when this function is called before any stream is set,

--- a/vllm/v1/kv_offload/worker/cpu_gpu.py
+++ b/vllm/v1/kv_offload/worker/cpu_gpu.py
@@ -226,7 +226,7 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
             last_event = last_transfer.end_event
             # assure job will start only after the previous one completes
             stream.wait_event(last_event)
-        with torch.cuda.stream(stream):
+        with stream:
             start_event.record(stream)
             if total > 0:
                 ops.swap_blocks_batch(batch_src, batch_dst, batch_sizes)

--- a/vllm/v1/spec_decode/ngram_proposer_gpu.py
+++ b/vllm/v1/spec_decode/ngram_proposer_gpu.py
@@ -654,7 +654,7 @@ def copy_num_valid_draft_tokens(
         return
 
     default_stream = torch.cuda.current_stream()
-    with torch.cuda.stream(num_valid_draft_tokens_copy_stream):
+    with num_valid_draft_tokens_copy_stream:
         num_valid_draft_tokens_copy_stream.wait_stream(default_stream)
         num_valid_draft_tokens_cpu[:num_reqs_to_copy].copy_(
             num_valid_draft_tokens[:num_reqs_to_copy], non_blocking=True

--- a/vllm/v1/worker/gpu/async_utils.py
+++ b/vllm/v1/worker/gpu/async_utils.py
@@ -110,7 +110,7 @@ def async_copy_to_np(x: torch.Tensor) -> np.ndarray:
 
 @contextlib.contextmanager
 def stream(to_stream: torch.cuda.Stream, from_stream: torch.cuda.Stream):
-    """Lightweight version of torch.cuda.stream() context manager which
+    """Lightweight version of torch.Stream context manager which
     avoids current_stream and device lookups.
     """
     try:

--- a/vllm/v1/worker/gpu/spec_decode/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/utils.py
@@ -33,7 +33,7 @@ class DraftTokensHandler:
         # draft tokens back to the scheduler for grammar validation.
         current_stream = torch.cuda.current_stream(self.device)
         self.copy_stream.wait_stream(current_stream)
-        with torch.cuda.stream(self.copy_stream):
+        with self.copy_stream:
             self.draft_tokens_np = async_copy_to_np(draft_tokens)
             self.copy_event.record()
 

--- a/vllm/v1/worker/gpu/structured_outputs.py
+++ b/vllm/v1/worker/gpu/structured_outputs.py
@@ -31,7 +31,7 @@ class StructuredOutputsWorker:
             return
 
         # Asynchronously copy the bitmask to GPU.
-        with torch.cuda.stream(self.copy_stream):
+        with self.copy_stream:
             bitmask = async_copy_to_gpu(
                 grammar_bitmask, out=self.grammar_bitmask[: grammar_bitmask.shape[0]]
             )
@@ -48,7 +48,7 @@ class StructuredOutputsWorker:
             mapping.extend(range(logits_start_idx, logits_end_idx))
 
         # Asynchronously copy the mapping to GPU.
-        with torch.cuda.stream(self.copy_stream):
+        with self.copy_stream:
             logits_indices = torch.tensor(
                 mapping, dtype=torch.int32, device="cpu", pin_memory=True
             )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -245,7 +245,7 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
 
         # Initiate the copy on a separate stream, but do not synchronize it.
         default_stream = torch.cuda.current_stream()
-        with torch.cuda.stream(async_output_copy_stream):
+        with async_output_copy_stream:
             async_output_copy_stream.wait_stream(default_stream)
             self.sampled_token_ids_cpu = self._sampled_token_ids.to(
                 "cpu", non_blocking=True
@@ -353,7 +353,7 @@ class AsyncGPUPoolingModelRunnerOutput(AsyncModelRunnerOutput):
 
         # Initiate the copy on a separate stream, but do not synchronize it.
         default_stream = torch.cuda.current_stream()
-        with torch.cuda.stream(async_output_copy_stream):
+        with async_output_copy_stream:
             async_output_copy_stream.wait_stream(default_stream)
             self._model_runner_output.pooler_output = _copy_pooler_output_to_cpu(
                 raw_pooler_output=self._raw_pooler_output,
@@ -814,18 +814,18 @@ class GPUModelRunner(
         # Pre-allocated tensor for copying valid sampled token counts to CPU,
         # with dedicated stream for overlapping and event for coordination.
         self.valid_sampled_token_count_event: torch.Event | None = None
-        self.valid_sampled_token_count_copy_stream: torch.cuda.Stream | None = None
+        self.valid_sampled_token_count_copy_stream: torch.Stream | None = None
         # We also copy the drafted tokens to the CPU asynchronously,
         # in case we need them for structured outputs.
         self.draft_token_ids_event: torch.Event | None = None
-        self.draft_token_ids_copy_stream: torch.cuda.Stream | None = None
+        self.draft_token_ids_copy_stream: torch.Stream | None = None
         self.valid_sampled_token_count_cpu: torch.Tensor | None = None
         self.draft_token_ids_cpu: torch.Tensor | None = None
         self.num_accepted_tokens_event: torch.Event | None = None
         if self.num_spec_tokens:
             self.draft_token_ids_event = torch.Event()
             self.num_accepted_tokens_event = torch.Event()
-            self.draft_token_ids_copy_stream = torch.cuda.Stream()
+            self.draft_token_ids_copy_stream = torch.Stream()
             self.draft_token_ids_cpu = torch.empty(
                 (self.max_num_reqs, self.num_spec_tokens),
                 dtype=torch.int64,
@@ -834,7 +834,7 @@ class GPUModelRunner(
             )
             if self.use_async_scheduling:
                 self.valid_sampled_token_count_event = torch.Event()
-                self.valid_sampled_token_count_copy_stream = torch.cuda.Stream()
+                self.valid_sampled_token_count_copy_stream = torch.Stream()
                 self.valid_sampled_token_count_cpu = torch.empty(
                     self.max_num_reqs,
                     dtype=torch.int32,
@@ -4429,7 +4429,7 @@ class GPUModelRunner(
         assert self.draft_token_ids_cpu is not None
         default_stream = torch.cuda.current_stream()
         num_reqs = draft_token_ids.shape[0]
-        with torch.cuda.stream(self.draft_token_ids_copy_stream):
+        with self.draft_token_ids_copy_stream:
             if not zeros_only:
                 # Trigger async copy of draft token ids to cpu.
                 self.draft_token_ids_copy_stream.wait_stream(default_stream)
@@ -4461,7 +4461,8 @@ class GPUModelRunner(
         default_stream = torch.cuda.current_stream()
         # Initialize a new stream to overlap the copy operation with
         # prepare_input of draft model.
-        with torch.cuda.stream(self.valid_sampled_token_count_copy_stream):
+        assert self.valid_sampled_token_count_copy_stream is not None
+        with self.valid_sampled_token_count_copy_stream:
             self.valid_sampled_token_count_copy_stream.wait_stream(default_stream)  # type: ignore
             counts = valid_sampled_tokens_count
             counts_cpu = self.valid_sampled_token_count_cpu

--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -209,9 +209,9 @@ class UBatchWrapper:
         def _capture_ubatch_thread(results, ubatch_metadata):
             torch.accelerator.set_device_index(self.device)
             ubatch_context = ubatch_metadata.context
-            with torch.cuda.stream(ubatch_context.compute_stream):
+            with ubatch_context.compute_stream:
                 _ = torch.cuda.current_blas_handle()
-            with torch.cuda.stream(ubatch_context.comm_stream):
+            with ubatch_context.comm_stream:
                 _ = torch.cuda.current_blas_handle()
             with ubatch_context:
                 model_output = model(

--- a/vllm/v1/worker/ubatching.py
+++ b/vllm/v1/worker/ubatching.py
@@ -195,7 +195,7 @@ def dbo_get_previous_event(func, *args, **kwargs):
         ctx_idx = _THREAD_ID_TO_CONTEXT[threading.get_ident()]
         ctx = _CURRENT_CONTEXTS[ctx_idx]
         # execute callable on the ubatch compute stream to record/wait events there
-        with torch.cuda.stream(ctx.compute_stream):
+        with ctx.compute_stream:
             return func(*args, **kwargs)
 
 

--- a/vllm/v1/worker/xpu_model_runner.py
+++ b/vllm/v1/worker/xpu_model_runner.py
@@ -44,7 +44,6 @@ def _torch_cuda_wrapper():
     torch.cuda.Stream = torch.xpu.Stream
     torch.cuda.default_stream = torch.xpu.current_stream
     torch.cuda.current_stream = torch.xpu.current_stream
-    torch.cuda.stream = torch.xpu.stream
     torch.cuda.mem_get_info = torch.xpu.mem_get_info
     torch.cuda.Event = torch.Event
     torch.cuda.set_stream = torch.xpu.set_stream


### PR DESCRIPTION
## Purpose

Part of #30679

In PyTorch, torch.Stream objects implement __enter__ / __exit__ and it should work well with context manager. So, replace `with torch.cuda.stream(astream):` with `with astream:`. For cases which astream can be None, use torch. accelerator.current_stream() instead. 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

