### PR TITLE
[LoRA] Support LoRA for Embedding and LMHead in Qwen2/3 family

### DIFF
--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -532,6 +532,12 @@ class Qwen2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle3):
         ],
     }
 
+    # LoRA specific attributes
+    embedding_modules = {
+        "embed_tokens": "input_embeddings",
+        "lm_head": "output_embeddings",
+    }
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         config = vllm_config.model_config.hf_config.get_text_config()

--- a/vllm/model_executor/models/qwen2_moe.py
+++ b/vllm/model_executor/models/qwen2_moe.py
@@ -545,6 +545,12 @@ class Qwen2MoeForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
         ]
     }
 
+    # LoRA specific attributes
+    embedding_modules = {
+        "embed_tokens": "input_embeddings",
+        "lm_head": "output_embeddings",
+    }
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         config = vllm_config.model_config.hf_config

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -263,6 +263,12 @@ class Qwen3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle3):
         ],
     }
 
+    # LoRA specific attributes
+    embedding_modules = {
+        "embed_tokens": "input_embeddings",
+        "lm_head": "output_embeddings",
+    }
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         config = vllm_config.model_config.hf_config

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -683,6 +683,12 @@ class Qwen3MoeForCausalLM(
         ]
     }
 
+    # LoRA specific attributes
+    embedding_modules = {
+        "embed_tokens": "input_embeddings",
+        "lm_head": "output_embeddings",
+    }
+
     fall_back_to_pt_during_load = False
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):

--- a/vllm/v1/serial_utils.py
+++ b/vllm/v1/serial_utils.py
@@ -186,7 +186,7 @@ class MsgpackEncoder:
 
         if not envs.VLLM_ALLOW_INSECURE_SERIALIZATION:
             raise TypeError(
-                f"Object of type {type(obj)} is not serializable"
+                f"Object of type {type(obj)} is not serializable. "
                 "Set VLLM_ALLOW_INSECURE_SERIALIZATION=1 to allow "
                 "fallback to pickle-based serialization."
             )


### PR DESCRIPTION
<!-- markdownlint-disable -->
This PR enables LoRA support for embed_tokens and lm_head modules in Qwen2, Qwen2.5, and Qwen3 (including MoE variants).

## Purpose
As is mentioned in #32599, currently, attempting to load LoRA adapters containing embed_tokens and lm_head modules for Qwen models encounter a ValueError because these modules are not registered in the respective ForCausalLM classes.

## Test Plan
Tested with dummy LoRA weights on Qwen3-8B. The dummy LoRA weights are generated and used in the way of following script:
```
import torch
from peft import LoraConfig, get_peft_model
from transformers import AutoModelForCausalLM
from vllm import LLM, SamplingParams
from vllm.lora.request import LoRARequest
from pathlib import Path

model_id = "Qwen/Qwen3-8B"
lora_save_path = "./dummy_qwen_lora"

config = LoraConfig(
    r=8,
    lora_alpha=16,
    target_modules=["lm_head", "embed_tokens", "q_proj", "v_proj"],
    lora_dropout=0.05,
    bias="none",
    task_type="CAUSAL_LM",
)

model = AutoModelForCausalLM.from_pretrained(model_id, dtype=torch.float16)
lora_model = get_peft_model(model, config)
lora_model.save_pretrained(lora_save_path)

llm = LLM(
    model=model_id,
    enable_lora=True,
    max_loras=1,
    tensor_parallel_size=1,
)

sampling_params = SamplingParams(temperature=0)

outputs = llm.generate(
    "hello",
    sampling_params=sampling_params,
    lora_request=LoRARequest("dummy-lora", 1, lora_save_path),
)

print(outputs[0].outputs[0].text)
```

To verify  the LoRA weights are correctly applied, I tested with an abnormal LoRA weights by adding following code before `lora_model.save_pretrained`:
```
for name, param in lora_model.named_parameters():
    if "lora" in name:
        param.data.fill_(100.0)
``` 

## Test Result
Without this change: ValueError: While loading ***/dummy_qwen_lora, expected target modules in {'down_proj', 'k_proj', 'up_proj', 'o_proj', 'v_proj', 'gate_proj', 'q_proj'} but received ['lm_head', 'lm_head', 'model.embed_tokens', 'model.embed_tokens']. Please verify that the loaded LoRA module is correct
With this change: LoRA weights are correctly applied. vLLM correctly ran the model with LoRA weights and generated output. And when using abnormal weights, the output is also abnormal).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

