### PR TITLE
[CI] Update job dependency syntax for Intel and AMD jobs

### DIFF
--- a/.buildkite/hardware_tests/amd.yaml
+++ b/.buildkite/hardware_tests/amd.yaml
@@ -1,7 +1,7 @@
 group: Hardware
 steps:
   - label: "AMD: :docker: build image"
-    depends_on: ~
+    depends_on: []
     device: amd_cpu
     no_plugin: true
     commands:

--- a/.buildkite/hardware_tests/intel.yaml
+++ b/.buildkite/hardware_tests/intel.yaml
@@ -16,7 +16,7 @@ steps:
     - bash .buildkite/scripts/hardware_ci/run-hpu-test.sh
 
   - label: "Intel GPU Test"
-    depends_on: ~
+    depends_on: []
     soft_fail: true
     device: intel_gpu
     no_plugin: true

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -27,7 +27,8 @@ steps:
     - pytest -v -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
 
 - label: V1 Others (CPU)
-  depends_on: image-build-cpu
+  depends_on: 
+    - image-build-cpu
   source_file_dependencies:
     - vllm/
     - tests/v1
@@ -114,7 +115,8 @@ steps:
   - pytest -v -s utils_
 
 - label: Async Engine, Inputs, Utils, Worker, Config (CPU)
-  depends_on: image-build-cpu
+  depends_on: 
+  image-build-cpu
   timeout_in_minutes: 30
   source_file_dependencies:
   - vllm/

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -27,7 +27,7 @@ steps:
     - pytest -v -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
 
 - label: V1 Others (CPU)
-  depends_on: 
+  depends_on:
     - image-build-cpu
   source_file_dependencies:
     - vllm/
@@ -116,7 +116,7 @@ steps:
 
 - label: Async Engine, Inputs, Utils, Worker, Config (CPU)
   depends_on: 
-  image-build-cpu
+  - image-build-cpu
   timeout_in_minutes: 30
   source_file_dependencies:
   - vllm/

--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -39,7 +39,8 @@ steps:
     - pytest -v -s models/test_transformers.py models/test_registry.py
 
 - label: Basic Models Test (Other CPU) # 5min
-  depends_on: image-build-cpu
+  depends_on: 
+  - image-build-cpu
   timeout_in_minutes: 10
   source_file_dependencies:
   - vllm/

--- a/.buildkite/test_areas/models_multimodal.yaml
+++ b/.buildkite/test_areas/models_multimodal.yaml
@@ -14,7 +14,8 @@ steps:
     - cd .. && VLLM_WORKER_MULTIPROC_METHOD=spawn pytest -v -s tests/models/multimodal/generation/test_whisper.py -m core_model  # Otherwise, mp_method="spawn" doesn't work
 
 - label: Multi-Modal Processor Test (CPU)
-  depends_on: image-build-cpu
+  depends_on: 
+  - image-build-cpu
   timeout_in_minutes: 60
   source_file_dependencies:
   - vllm/


### PR DESCRIPTION
Use `[]` instead of `~`, and list instead of string for other jobs