### PR TITLE
[MISC] Fix Tensor Parallelism for Quantized Mamba Models with n_groups=1

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -40,6 +40,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     composed_weight_loader,
     sharded_weight_loader,
 )
+from vllm.model_executor.parameter import BasevLLMParameter
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
@@ -414,7 +415,7 @@ class MambaMixer2(MambaBase, CustomOp):
             # Apply the custom weight loader to in_proj.weight
             # Works for both non-quantized (Parameter) and quantized
             # (ModelWeightParameter which extends BasevLLMParameter)
-            if hasattr(self.in_proj.weight, "_weight_loader"):
+            if isinstance(self.in_proj.weight, BasevLLMParameter):
                 # For BasevLLMParameter subclasses (quantized layers like FP8)
                 # These have a weight_loader property that can be directly set
                 self.in_proj.weight.weight_loader = mamba_loader

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -17,7 +17,6 @@ from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
-    MergedColumnParallelLinear,
     RowParallelLinear,
 )
 from vllm.model_executor.layers.mamba.abstract import MambaBase
@@ -302,127 +301,94 @@ class MambaMixer2(MambaBase, CustomOp):
         self.groups_ssm_state_size = self.n_groups * self.ssm_state_size
         self.conv_dim = intermediate_size + 2 * self.groups_ssm_state_size
 
-        if n_groups % self.tp_size == 0:
-            self.conv1d = MergedColumnParallelLinear(
-                input_size=conv_kernel_size,
-                output_sizes=[
-                    intermediate_size,
-                    self.groups_ssm_state_size,
-                    self.groups_ssm_state_size,
-                ],
-                bias=use_conv_bias,
-                quant_config=None,
-                prefix=f"{prefix}.conv1d",
-            )
+        # Use ColumnParallelLinear with custom weight loaders for both cases:
+        # - When n_groups % tp_size == 0: standard sharding without duplication
+        # - When n_groups == 1: groups are duplicated across TP ranks
+        # The custom weight loader handles both cases correctly.
 
-            self.in_proj = MergedColumnParallelLinear(
-                input_size=hidden_size,
-                output_sizes=[
-                    intermediate_size,
-                    intermediate_size,
-                    self.groups_ssm_state_size,
-                    self.groups_ssm_state_size,
-                    self.num_heads,
-                ],
-                bias=use_bias,
-                quant_config=quant_config,
-                prefix=f"{prefix}.in_proj",
-            )
+        self.conv1d = ColumnParallelLinear(
+            input_size=conv_kernel_size,
+            output_size=self.conv_dim,
+            bias=use_conv_bias,
+            quant_config=None,
+            prefix=f"{prefix}.conv1d",
+        )
+
+        self.in_proj = ColumnParallelLinear(
+            input_size=hidden_size,
+            output_size=intermediate_size + self.conv_dim + self.num_heads,
+            bias=use_bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.in_proj",
+        )
+
+        # Configure shard settings for the custom weight loader:
+        # - group_shard_settings handles group duplication when n_groups == 1
+        # - When n_groups % tp_size == 0, extra=0 and duplicate_groups=False
+        group_shard_settings = (
+            self.groups_ssm_state_size,  # expected model size
+            (self.n_groups - n_groups) * self.ssm_state_size,  # extra dims assigned
+            n_groups == 1,  # duplicate groups when n_groups == 1
+        )
+        intermediate_settings = (intermediate_size, 0, False)
+        head_settings = (self.num_heads, 0, False)
+
+        # Apply custom weight loaders for conv1d (bias and weight)
+        delattr(self.conv1d.bias, "weight_loader")
+        set_weight_attrs(
+            self.conv1d.bias,
+            {
+                "weight_loader": mamba_v2_sharded_weight_loader(
+                    [
+                        intermediate_settings,
+                        group_shard_settings,
+                        group_shard_settings,
+                    ],
+                    self.tp_size,
+                    tp_rank,
+                )
+            },
+        )
+
+        delattr(self.conv1d.weight, "weight_loader")
+        set_weight_attrs(
+            self.conv1d.weight,
+            {
+                "weight_loader": mamba_v2_sharded_weight_loader(
+                    [
+                        intermediate_settings,
+                        group_shard_settings,
+                        group_shard_settings,
+                    ],
+                    self.tp_size,
+                    tp_rank,
+                )
+            },
+        )
+
+        # Create the custom weight loader for in_proj
+        mamba_loader = mamba_v2_sharded_weight_loader(
+            [
+                intermediate_settings,  # for gate
+                intermediate_settings,
+                group_shard_settings,
+                group_shard_settings,
+                head_settings,  # for dt
+            ],
+            self.tp_size,
+            tp_rank,
+        )
+
+        # Apply the custom weight loader to in_proj.weight
+        # Works for both non-quantized (Parameter) and quantized
+        # (ModelWeightParameter which extends BasevLLMParameter)
+        if isinstance(self.in_proj.weight, BasevLLMParameter):
+            # For BasevLLMParameter subclasses (quantized layers like FP8)
+            self.in_proj.weight.weight_loader = mamba_loader
         else:
-            # This is the n_groups == 1 case,
-            # where we need to duplicate groups if TP>1.
-
-            self.conv1d = ColumnParallelLinear(
-                input_size=conv_kernel_size,
-                output_size=self.conv_dim,
-                bias=use_conv_bias,
-                quant_config=None,
-                prefix=f"{prefix}.conv1d",
-            )
-
-            self.in_proj = ColumnParallelLinear(
-                input_size=hidden_size,
-                output_size=intermediate_size + self.conv_dim + self.num_heads,
-                bias=use_bias,
-                quant_config=quant_config,
-                prefix=f"{prefix}.in_proj",
-            )
-
-            # - because in_proj is a concatenation of 3 weights, we
-            #   need to interleave them before sharding
-            # - use the custom weight loader mamba_v2_sharded_weight_loader
-            #   for conv1d.bias, covn1d.weight and in_proj.weight
-            # - need to set these settings, to assign the groups
-            #   to the head shards
-            group_shard_settings = (
-                self.groups_ssm_state_size,  # expected model size
-                (self.n_groups - n_groups) * self.ssm_state_size,  # extra dims assigned
-                n_groups == 1,  # if there was only one group
-            )
-            intermediate_settings = (intermediate_size, 0, False)
-            head_settings = (self.num_heads, 0, False)
-
-            # - the weight already has a "weight_loader" attribute
-            #   which set_weight_attrs will raise if we do not
-            #   delete before trying to override it
-            # - ditto for the other two weights below
-            delattr(self.conv1d.bias, "weight_loader")
-            set_weight_attrs(
-                self.conv1d.bias,
-                {
-                    "weight_loader": mamba_v2_sharded_weight_loader(
-                        [
-                            intermediate_settings,
-                            group_shard_settings,
-                            group_shard_settings,
-                        ],
-                        self.tp_size,
-                        tp_rank,
-                    )
-                },
-            )
-
-            delattr(self.conv1d.weight, "weight_loader")
-            set_weight_attrs(
-                self.conv1d.weight,
-                {
-                    "weight_loader": mamba_v2_sharded_weight_loader(
-                        [
-                            intermediate_settings,
-                            group_shard_settings,
-                            group_shard_settings,
-                        ],
-                        self.tp_size,
-                        tp_rank,
-                    )
-                },
-            )
-
-            # Create the custom weight loader for Mamba sharding with group
-            # replication. This handles the interleaved projections correctly.
-            mamba_loader = mamba_v2_sharded_weight_loader(
-                [
-                    intermediate_settings,  # for gate
-                    intermediate_settings,
-                    group_shard_settings,
-                    group_shard_settings,
-                    head_settings,  # for dt
-                ],
-                self.tp_size,
-                tp_rank,
-            )
-
-            # Apply the custom weight loader to in_proj.weight
-            # Works for both non-quantized (Parameter) and quantized
-            # (ModelWeightParameter which extends BasevLLMParameter)
-            if isinstance(self.in_proj.weight, BasevLLMParameter):
-                # For BasevLLMParameter subclasses (quantized layers like FP8)
-                # These have a weight_loader property that can be directly set
-                self.in_proj.weight.weight_loader = mamba_loader
-            else:
-                # For standard Parameter (non-quantized layers)
-                delattr(self.in_proj.weight, "weight_loader")
-                set_weight_attrs(self.in_proj.weight, {"weight_loader": mamba_loader})
+            # For standard Parameter (non-quantized layers)
+            delattr(self.in_proj.weight, "weight_loader")
+            set_weight_attrs(self.in_proj.weight, {"weight_loader": mamba_loader})
 
         # unsqueeze to fit conv1d weights shape into the linear weights shape.
         # Can't do this in `weight_loader` since it already exists in


### PR DESCRIPTION
### Summary

Enable tensor parallelism (TP > 1) for quantized hybrid Mamba models (e.g., Falcon-H1R-7B with FP8) when `n_groups=1`.


### Root Cause

Custom weight loaders for group replication were only implemented for non-quantized layers. This PR extends support to quantized layers by leveraging the `weight_loader` property on `ModelWeightParameter` (extends `BasevLLMParameter`).

### Test
```bash
vllm serve tiiuae/Falcon-H1R-7B -tp 2 --quantization fp8
```
Previously failed, now works

### Validation (lm_eval)

```bash
lm_eval --model local-chat-completions \
  --model_args model=tiiuae/Falcon-H1R-7B,base_url=http://localhost:8000/v1/chat/completions,num_concurrent=250 \
  --tasks gsm8k --apply_chat_template --num_fewshot 5
```

**Results with TP=2 (this PR):**
| Tasks | Version | Filter           | n-shot | Metric      |   | Value  |   | Stderr |
|-------|--------:|------------------|-------:|-------------|---|-------:|---|-------:|
| gsm8k |       3 | flexible-extract |      5 | exact_match | ↑ | 0.3283 | ± | 0.0129 |
|       |         | strict-match     |      5 | exact_match | ↑ | 0.0963 | ± | 0.0081 |

**Results with TP=1 (baseline):**
| Tasks | Version | Filter           | n-shot | Metric      |   | Value  |   | Stderr |
|-------|--------:|------------------|-------:|-------------|---|-------:|---|-------:|
| gsm8k |       3 | flexible-extract |      5 | exact_match | ↑ | 0.3154 | ± | 0.0128 |
|       |         | strict-match     |      5 | exact_match | ↑ | 0.1031 | ± | 0.0084 |

Results are consistent within statistical error margins, confirming correctness.

### Related Issues

- Fixes: #14618
- Related PRs: #14617, #24593
