### PR TITLE
[BugFix] Fix EPLB fail for MoeFP4 model with Marlin backend

### DIFF
--- a/vllm/model_executor/utils.py
+++ b/vllm/model_executor/utils.py
@@ -44,7 +44,9 @@ def set_weight_attrs(
         setattr(weight, key, value)
 
 
-def replace_parameter(layer: torch.nn.Module, param_name: str, new_data: torch.Tensor):
+def replace_parameter(
+    layer: torch.nn.Module, param_name: str, new_data: torch.Tensor | None
+):
     """
     Replace a parameter of a layer while maintaining the ability to reload the weight.
     Called within implementations of the `process_weights_after_loading` method.
@@ -54,9 +56,15 @@ def replace_parameter(layer: torch.nn.Module, param_name: str, new_data: torch.T
     Args:
         layer: Layer containing parameter to replace
         param_name: Name of parameter to replace
-        new_data: New data of the new parameter
+        new_data: New data of the new parameter, or None to set the parameter to None
     """
     # should not be used on a tied/shared param
+
+    # If new_data is None, set the parameter to None
+    if new_data is None:
+        setattr(layer, param_name, None)
+        return
+
     if isinstance(new_data, torch.nn.Parameter):
         new_data = new_data.data
     new_param = torch.nn.Parameter(new_data, requires_grad=False)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
PR fixes a bug when `nvidia/DeepSeek-R1-0528-FP4-v2` crashes when we enable EPLB with Flashinfer MOE FP4 disabled. 

In marlin Moe_FP4 backend we don't use activations scales so we replace them in `replace_parameter` util with None. But  it doesn't set the parameter to None, it creates an empty parameter on cpu which triggers EPLB error:

```
(EngineCore_DP1 pid=3244402)   File "/home/sagemoore/git/nm-vllm/vllm/distributed/eplb/eplb_state.py", line 551, in step
(EngineCore_DP1 pid=3244402)     self.rearrange(is_profile=True)
(EngineCore_DP1 pid=3244402)   File "/home/sagemoore/git/nm-vllm/vllm/distributed/eplb/eplb_state.py", line 815, in rearrange
(EngineCore_DP1 pid=3244402)     rearrange_expert_weights_inplace(
(EngineCore_DP1 pid=3244402)   File "/home/sagemoore/git/nm-vllm/vllm/distributed/eplb/rebalance_execute.py", line 575, in rearrange_expert_weights_inplace
(EngineCore_DP1 pid=3244402)     all_gather(
(EngineCore_DP1 pid=3244402)   File "/home/sagemoore/git/nm-vllm/.venv/lib/python3.12/site-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
(EngineCore_DP1 pid=3244402)     return func(*args, **kwargs)
(EngineCore_DP1 pid=3244402)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP1 pid=3244402)   File "/home/sagemoore/git/nm-vllm/.venv/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py", line 3942, in all_gather
(EngineCore_DP1 pid=3244402)     work = group.allgather([tensor_list], [tensor], opts)
(EngineCore_DP1 pid=3244402)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP1 pid=3244402) RuntimeError: No backend type associated with device type cpu
```

## Validation

`
VLLM_USE_FLASHINFER_MOE_FP4=0 vllm serve nvidia/DeepSeek-R1-0528-FP4-v2 --enable-expert-parallel --all2all-backend allgather_reducescatter --data-parallel-size 4 --enable_eplb 
`

gsm8k

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9560|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9492|±  |0.0060|
```

Without eplb and Flashinfer backend:

`
vllm serve nvidia/DeepSeek-R1-0528-FP4-v2 --enable-expert-parallel --all2all-backend allgather_reducescatter --data-parallel-size 4
`

gsm8k

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9545|±  |0.0057|
|     |       |strict-match    |     5|exact_match|↑  |0.9507|±  |0.0060|
```




---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ x] The test plan, such as providing test command.
- [ x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
