### PR TITLE
[ROCm][CI] Force max_num_seqs=1 on ROCm In test_sharded_state_loader to reduce flakiness

### DIFF
--- a/tests/model_executor/model_loader/test_sharded_state_loader.py
+++ b/tests/model_executor/model_loader/test_sharded_state_loader.py
@@ -97,7 +97,7 @@ def test_sharded_state_loader(
     ctx = mp.get_context("spawn")
 
     platform_args = {}
-    if not current_platform.is_rocm():
+    if current_platform.is_rocm():
         platform_args["max_num_seqs"] = 1
 
     # Run in separate processes for memory & CUDA isolation


### PR DESCRIPTION
<!-- markdownlint-disable -->
Model Executor test has been flaky in AMD CI for a while (e.g. https://buildkite.com/vllm/amd-ci/builds/3717/steps/canvas?sid=019c0077-cd76-4db0-8ccf-4ca7964be56f), and we have identified that it is due to batch variance in test_sharded_state_loader . This PR forces max_num_seqs=1 to reduce batch variance effects on ROCm. This should mitigate the flakiness, the test passed 20/20 times locally with this change.