### PR TITLE
[Bugfix] Register fp8 cutlass_group_gemm as supported for only SM90+SM100

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -789,6 +789,8 @@ def cutlass_sparse_scaled_mm_supported(cuda_device_capability: int) -> bool:
 
 
 def cutlass_group_gemm_supported(cuda_device_capability: int) -> bool:
+    if cuda_device_capability < 90 or cuda_device_capability >= 110:
+        return False
     try:
         return torch.ops._C.cutlass_group_gemm_supported(cuda_device_capability)
     except AttributeError:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

FIX https://github.com/vllm-project/vllm/issues/32109

We only have implementation for SM90 and SM100, so we should properly restrict for the FP8 oracle to work. Without this change users on SM120 would default to this kernel backend and see an unsupported error when it should be using the Triton kernel.
```
csrc/quantization/w8a8/cutlass/moe/grouped_mm_c3x_sm90.cu
csrc/quantization/w8a8/cutlass/moe/grouped_mm_c3x_sm100.cu
```


## Test Plan

## Test Result


Tested manually by locally changing the condition to disqualify `cuda_device_capability == 100`, where my resulting kernel selection changed from
```
(Worker_TP0 pid=1113294) INFO 01-28 17:18:33 [fp8.py:329] Using VLLM_CUTLASS Fp8 MoE backend out of potential backends: ['AITER', 'FLASHINFER_TRTLLM', 'FLASHINFER_CUTLASS', 'DEEPGEMM', 'BATCHED_DEEPGEMM', 'VLLM_CUTLASS', 'BATCHED_VLLM_CUTLASS', 'TRITON', 'BATCHED_TRITON', 'MARLIN'].
```
to
```
(Worker_TP0 pid=1118221) INFO 01-28 17:19:55 [fp8.py:329] Using TRITON Fp8 MoE backend out of potential backends: ['AITER', 'FLASHINFER_TRTLLM', 'FLASHINFER_CUTLASS', 'DEEPGEMM', 'BATCHED_DEEPGEMM', 'VLLM_CUTLASS', 'BATCHED_VLLM_CUTLASS', 'TRITON', 'BATCHED_TRITON', 'MARLIN'].
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

