### PR TITLE
[Metrics] Add labeled prompt token metrics for P/D disaggregation

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1378,6 +1378,7 @@ class Scheduler(SchedulerInterface):
                         kv_transfer_params=kv_transfer_params,
                         trace_headers=request.trace_headers,
                         num_cached_tokens=request.num_cached_tokens,
+                        num_external_computed_tokens=request.num_external_computed_tokens,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,
                     )

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -139,8 +139,10 @@ class EngineCoreOutput(
     kv_transfer_params: dict[str, Any] | None = None
 
     trace_headers: Mapping[str, str] | None = None
-    # The number of tokens with prefix cache hits.
+    # The number of tokens with prefix cache hits (local + external).
     num_cached_tokens: int = 0
+    # The number of tokens computed remotely (original count from connector).
+    num_external_computed_tokens: int = 0
     routed_experts: np.ndarray | None = None
     # The number of NaNs in logits.
     # A value greater than 0 indicates that the output is corrupted.


### PR DESCRIPTION
## Summary
Add labeled Prometheus metrics for P/D disaggregation to distinguish prompt token sources (local compute, KV transfer, cache hit).


## Purpose

Add labeled Prometheus metrics to distinguish where prompt tokens come from in P/D disaggregated deployments.

In P/D disaggregation, decode instances receive KV cache from prefill instances. Currently, decode reports inflated prompt throughput because it counts all prompt tokens as "computed", even though most were transferred.

This PR adds labeled metrics so users can understand actual compute work vs transferred work:

```
vllm:prompt_tokens_by_source_total{source="local_compute"}        # Tokens prefilled locally
vllm:prompt_tokens_by_source_total{source="external_kv_transfer"} # Tokens received via KV transfer  
vllm:prompt_tokens_by_source_total{source="local_cache_hit"}      # Tokens from local prefix cache
vllm:prompt_tokens_cached_total                                    # Total cached (local + external, -1 when all cached)
```

> **Note:** The `-1` adjustment is applied by the scheduler when all prompt tokens are cached (from local cache or KV transfer). This forces the model to recompute the last prompt token locally, since the model needs at least one input token to run a forward pass.

Fixes #33289
Related: PR #27569

## Test Plan

1. P/D disaggregation setup using `examples/online_serving/disaggregated_prefill.sh`
   - Model: `Qwen/Qwen3-0.6B`
2. Send a request:
   - Prompt: 10 tokens
   - Max output tokens: 20
3. Verify metrics via Prometheus endpoint:
```bash
# Check prefill instance metrics
curl localhost:<prefill-port>/metrics 

# Check decode instance metrics  
curl localhost:<decode-port>/metrics 
```


## Test Result
<img width="579" height="357" alt="Screenshot 2026-01-28 at 5 43 55 PM" src="https://github.com/user-attachments/assets/aa468dd6-46ce-4e54-8895-8dd058f115a1" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
