### PR TITLE
[Bugfix] Make tensorizer encrypted model output tests deterministic

### DIFF
--- a/tests/model_executor/model_loader/tensorizer_loader/test_tensorizer.py
+++ b/tests/model_executor/model_loader/tensorizer_loader/test_tensorizer.py
@@ -235,6 +235,8 @@ def test_tensorizer_with_tp_path_without_template(vllm_runner, capfd):
 def test_deserialized_encrypted_vllm_model_with_tp_has_same_outputs(
     vllm_runner, tmp_path
 ):
+    # Use deterministic decoding to avoid flaky output divergence with TP.
+    sampling_params = SamplingParams(temperature=0, seed=0)
     model_ref = "EleutherAI/pythia-1.4b"
     # record outputs from un-sharded un-tensorized model
     with vllm_runner(


### PR DESCRIPTION
## Purpose
Fix nondeterministic failures in `tests/model_executor/model_loader/tensorizer_loader/test_tensorizer.py::test_deserialized_encrypted_vllm_model_with_tp_has_same_outputs` by making generation deterministic.
This test compares generated outputs between the original model and the deserialized encrypted model, without explicitly setting sampling parameters, generation can be nondeterministic and lead to intermittent mismatches.

Add deterministic sampling params:
`sampling_params = SamplingParams(temperature=0, seed=0)` so the test validates model equivalence instead of sampling randomness.
## Test Plan
Run the targeted test:
``` sh
pytest -s tests/model_executor/model_loader/tensorizer_loader/test_tensorizer.py -k test_deserialized_encrypted_vllm_model_with_tp_has_same_outputs -vv 
```
## Test Result
Before: test failed (output mismatch).
[pytest.before.log](https://github.com/user-attachments/files/24928602/pytest.before.log)

After: test passed with deterministic sampling params.
[pytest.after.log](https://github.com/user-attachments/files/24928604/pytest.after.log)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

