### PR TITLE
[Chore] Remove `use_data_parallel` kwargs from ViT implementation 

### DIFF
--- a/vllm/model_executor/models/idefics2_vision_model.py
+++ b/vllm/model_executor/models/idefics2_vision_model.py
@@ -39,7 +39,7 @@ from vllm.model_executor.layers.linear import (
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
-from .vision import run_dp_sharded_vision_model
+from .vision import is_vit_use_data_parallel, run_dp_sharded_vision_model
 
 
 class Idefics2VisionEmbeddings(nn.Module):
@@ -126,9 +126,9 @@ class Idefics2VisionAttention(nn.Module):
         config: Idefics2VisionConfig,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ) -> None:
         super().__init__()
+        use_data_parallel = is_vit_use_data_parallel()
         self.config = config
         self.embed_dim = config.hidden_size
         self.num_heads = config.num_attention_heads
@@ -187,11 +187,12 @@ class Idefics2VisionMLP(nn.Module):
         config: Idefics2VisionConfig,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ) -> None:
         super().__init__()
         self.config = config
         self.activation_fn = get_act_fn(config.hidden_act)
+
+        use_data_parallel = is_vit_use_data_parallel()
         self.fc1 = ColumnParallelLinear(
             config.hidden_size,
             config.intermediate_size,
@@ -222,7 +223,6 @@ class Idefics2EncoderLayer(nn.Module):
         config: Idefics2Config,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ) -> None:
         super().__init__()
         self.embed_dim = config.hidden_size
@@ -230,14 +230,12 @@ class Idefics2EncoderLayer(nn.Module):
             config,
             quant_config=quant_config,
             prefix=f"{prefix}.self_attn",
-            use_data_parallel=use_data_parallel,
         )
         self.layer_norm1 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
         self.mlp = Idefics2VisionMLP(
             config,
             quant_config=quant_config,
             prefix=f"{prefix}.mlp",
-            use_data_parallel=use_data_parallel,
         )
         self.layer_norm2 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
 
@@ -279,7 +277,6 @@ class Idefics2Encoder(nn.Module):
         *,
         num_hidden_layers_override: int | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ) -> None:
         super().__init__()
 
@@ -296,7 +293,6 @@ class Idefics2Encoder(nn.Module):
                     config,
                     quant_config=quant_config,
                     prefix=f"{prefix}.layers.{layer_idx}",
-                    use_data_parallel=use_data_parallel,
                 )
                 for layer_idx in range(num_hidden_layers)
             ]
@@ -331,20 +327,18 @@ class Idefics2VisionTransformer(nn.Module):
         num_hidden_layers_override: int | None = None,
         require_post_norm: bool = True,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ) -> None:
         super().__init__()
 
         embed_dim = config.hidden_size
         self.config = config
-        self.use_data_parallel = use_data_parallel
+        self.use_data_parallel = is_vit_use_data_parallel()
         self.embeddings = Idefics2VisionEmbeddings(config)
         self.encoder = Idefics2Encoder(
             config,
             quant_config=quant_config,
             num_hidden_layers_override=num_hidden_layers_override,
             prefix=f"{prefix}.encoder",
-            use_data_parallel=use_data_parallel,
         )
 
         num_hidden_layers = config.num_hidden_layers

--- a/vllm/model_executor/models/intern_vit.py
+++ b/vllm/model_executor/models/intern_vit.py
@@ -167,7 +167,7 @@ class InternParallelAttention(nn.Module):
         # we also disable Attention's TP
         tp_size = 1 if use_data_parallel else get_tensor_model_parallel_world_size()
         use_data_parallel = (
-            use_data_parallel or (self.num_heads + num_dummy_heads) % self.tp_size != 0
+            use_data_parallel or (self.num_heads + num_dummy_heads) % tp_size != 0
         )
         self.tp_size = 1 if use_data_parallel else tp_size
         self.tp_rank = 0 if use_data_parallel else get_tensor_model_parallel_rank()

--- a/vllm/model_executor/models/internvl.py
+++ b/vllm/model_executor/models/internvl.py
@@ -1153,7 +1153,6 @@ class InternVLChatModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA)
                 quant_config=quant_config,
                 num_hidden_layers_override=num_hidden_layers,
                 prefix=prefix,
-                use_data_parallel=self.use_data_parallel,
             )
         else:
             return InternVisionPatchModel(config.vision_config)

--- a/vllm/model_executor/models/kimi_vl.py
+++ b/vllm/model_executor/models/kimi_vl.py
@@ -81,7 +81,7 @@ from vllm.transformers_utils.configs import KimiVLConfig, MoonViTConfig
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
 from .utils import AutoWeightsLoader, init_vllm_registered_model, maybe_prefix
-from .vision import run_dp_sharded_mrope_vision_model
+from .vision import is_vit_use_data_parallel, run_dp_sharded_mrope_vision_model
 
 
 # For dummy input only
@@ -93,10 +93,12 @@ class MaxImageTokenMeta:
 
 class KimiVLMultiModalProjector(nn.Module):
     def __init__(
-        self, config: KimiVLConfig, use_data_parallel: bool = False, prefix: str = ""
+        self,
+        config: KimiVLConfig,
+        prefix: str = "",
     ):
         super().__init__()
-        self.use_data_parallel = use_data_parallel
+        self.use_data_parallel = is_vit_use_data_parallel()
 
         self.hidden_size = (
             config.vision_config.hidden_size
@@ -321,7 +323,6 @@ class KimiVLForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
             )
             self.multi_modal_projector = KimiVLMultiModalProjector(
                 config=config,
-                use_data_parallel=self.use_data_parallel,
                 prefix=maybe_prefix(prefix, "multi_modal_projector"),
             )
 

--- a/vllm/model_executor/models/lfm2_vl.py
+++ b/vllm/model_executor/models/lfm2_vl.py
@@ -612,7 +612,6 @@ class Lfm2VLForConditionalGeneration(
 
             self.multi_modal_projector = Lfm2VLMultiModalProjector(
                 config=config,
-                use_data_parallel=self.use_data_parallel,
                 prefix=maybe_prefix(prefix, "multi_modal_projector"),
             )
 

--- a/vllm/model_executor/models/lfm2_vl.py
+++ b/vllm/model_executor/models/lfm2_vl.py
@@ -57,6 +57,7 @@ from .utils import (
     init_vllm_registered_model,
     maybe_prefix,
 )
+from .vision import is_vit_use_data_parallel
 
 
 class Lfm2VLImagePixelInputs(TensorSchema):
@@ -428,10 +429,12 @@ class Lfm2VLMultiModalProcessor(BaseMultiModalProcessor[Lfm2VLProcessingInfo]):
 
 class Lfm2VLMultiModalProjector(nn.Module):
     def __init__(
-        self, config: Lfm2VlConfig, use_data_parallel: bool = False, prefix: str = ""
+        self,
+        config: Lfm2VlConfig,
+        prefix: str = "",
     ):
         super().__init__()
-        self.use_data_parallel = use_data_parallel
+        self.use_data_parallel = is_vit_use_data_parallel()
 
         in_channels = config.vision_config.hidden_size * (config.downsample_factor**2)
         self.factor = config.downsample_factor

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -1337,7 +1337,6 @@ class MiniCPMV2_5(MiniCPMVBaseModel, SupportsLoRA):
             config.vision_config,
             quant_config=quant_config,
             prefix=prefix,
-            use_data_parallel=self.use_data_parallel,
         )
         if self.config.drop_vision_last_layer:
             model.encoder.layers = model.encoder.layers[:-1]
@@ -1430,7 +1429,6 @@ class MiniCPMV2_6(MiniCPMVBaseModel, SupportsLoRA):
             config.vision_config,
             quant_config=quant_config,
             prefix=prefix,
-            use_data_parallel=self.use_data_parallel,
         )
         if self.config.drop_vision_last_layer:
             model.encoder.layers = model.encoder.layers[:-1]
@@ -1528,7 +1526,6 @@ class MiniCPMV4_0(MiniCPMVBaseModel, SupportsLoRA):
             config.vision_config,
             quant_config=quant_config,
             prefix=prefix,
-            use_data_parallel=self.use_data_parallel,
         )
         if self.config.drop_vision_last_layer:
             model.encoder.layers = model.encoder.layers[:-1]
@@ -1626,7 +1623,6 @@ class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA):
             config.vision_config,
             quant_config=quant_config,
             prefix=prefix,
-            use_data_parallel=self.use_data_parallel,
         )
         if self.config.drop_vision_last_layer:
             model.encoder.layers = model.encoder.layers[:-1]

--- a/vllm/model_executor/models/step3_vl.py
+++ b/vllm/model_executor/models/step3_vl.py
@@ -54,7 +54,7 @@ from .utils import (
     init_vllm_registered_model,
     maybe_prefix,
 )
-from .vision import run_dp_sharded_vision_model
+from .vision import is_vit_use_data_parallel, run_dp_sharded_vision_model
 
 
 class Step3VLImagePixelInputs(TensorSchema):
@@ -724,7 +724,6 @@ class Step3VisionAttention(nn.Module):
         config,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ):
         super().__init__()
         self.config = config
@@ -734,6 +733,7 @@ class Step3VisionAttention(nn.Module):
 
         self.scale = self.head_dim**-0.5
 
+        use_data_parallel = is_vit_use_data_parallel()
         tp_size = 1 if use_data_parallel else get_tensor_model_parallel_world_size()
         assert self.total_num_heads % tp_size == 0
         self.num_heads = self.total_num_heads // tp_size
@@ -786,11 +786,11 @@ class Step3VisionMLP(nn.Module):
         config,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ):
         super().__init__()
         self.config = config
         self.activation_fn = get_act_fn(config.hidden_act)
+        use_data_parallel = is_vit_use_data_parallel()
         self.fc1 = ColumnParallelLinear(
             config.hidden_size,
             config.intermediate_size,
@@ -821,23 +821,19 @@ class Step3VisionEncoderLayer(nn.Module):
         config: Step3VisionEncoderConfig,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ):
         super().__init__()
-        self.use_data_parallel = use_data_parallel
         self.embed_dim = config.hidden_size
         self.self_attn = Step3VisionAttention(
             config,
             quant_config,
             prefix=f"{prefix}.self_attn",
-            use_data_parallel=self.use_data_parallel,
         )
         self.layer_norm1 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
         self.mlp = Step3VisionMLP(
             config,
             quant_config,
             prefix=f"{prefix}.mlp",
-            use_data_parallel=self.use_data_parallel,
         )
         self.layer_norm2 = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_eps)
 
@@ -856,18 +852,15 @@ class Step3VisionEncoder(nn.Module):
         config: Step3VisionEncoderConfig,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ):
         super().__init__()
         self.config = config
-        self.use_data_parallel = use_data_parallel
         self.layers = nn.ModuleList(
             [
                 Step3VisionEncoderLayer(
                     config,
                     quant_config,
                     prefix=f"{prefix}.layers.{i}",
-                    use_data_parallel=self.use_data_parallel,
                 )
                 for i in range(config.num_hidden_layers)
             ]
@@ -889,18 +882,16 @@ class Step3VisionTransformer(nn.Module):
         config: Step3VisionEncoderConfig,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ):
         super().__init__()
         self.config = config
-        self.use_data_parallel = use_data_parallel
+        self.use_data_parallel = is_vit_use_data_parallel()
         self.image_size = config.image_size
         self.embeddings = Step3VisionEmbeddings(config)
         self.transformer = Step3VisionEncoder(
             config,
             quant_config,
             prefix=f"{prefix}.transformer",
-            use_data_parallel=self.use_data_parallel,
         )
 
     def forward(
@@ -952,7 +943,6 @@ class Step3VLForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP)
                 config.vision_config,
                 None,
                 prefix=maybe_prefix(prefix, "vision_model"),
-                use_data_parallel=self.use_data_parallel,
             )
             self.vit_downsampler = Conv2dLayer(
                 config.vision_config.hidden_size,

--- a/vllm/model_executor/models/step_vl.py
+++ b/vllm/model_executor/models/step_vl.py
@@ -24,7 +24,7 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 
 from .step3_vl import Step3VLForConditionalGeneration
 from .utils import WeightsMapper, init_vllm_registered_model, maybe_prefix
-from .vision import run_dp_sharded_vision_model
+from .vision import is_vit_use_data_parallel, run_dp_sharded_vision_model
 
 _DEFAULT_NORM_LAYER = partial(nn.LayerNorm, eps=1e-5)
 
@@ -151,9 +151,9 @@ class PerceptionEncoderMLP(nn.Module):
         act_layer: Callable[[], nn.Module],
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ):
         super().__init__()
+        use_data_parallel = is_vit_use_data_parallel()
         self.fc1 = ColumnParallelLinear(
             input_dim,
             hidden_dim,
@@ -189,7 +189,6 @@ class PerceptionEncoderVisionAttention(nn.Module):
         use_cls_token: bool = False,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ):
         super().__init__()
         self.embed_dim = embed_dim
@@ -197,6 +196,7 @@ class PerceptionEncoderVisionAttention(nn.Module):
         self.head_dim = embed_dim // num_heads
         self.scale = self.head_dim**-0.5
 
+        use_data_parallel = is_vit_use_data_parallel()
         tp_size = 1 if use_data_parallel else get_tensor_model_parallel_world_size()
         assert self.total_num_heads % tp_size == 0, (
             "embed_dim must be divisible by num_heads"
@@ -258,7 +258,6 @@ class PerceptionEncoderVisionBlock(nn.Module):
         use_cls_token: bool = False,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ):
         super().__init__()
         self.attn = PerceptionEncoderVisionAttention(
@@ -269,7 +268,6 @@ class PerceptionEncoderVisionBlock(nn.Module):
             use_cls_token=use_cls_token,
             quant_config=quant_config,
             prefix=f"{prefix}.attn",
-            use_data_parallel=use_data_parallel,
         )
         self.ls_1 = (
             PerceptionEncoderLayerScale(d_model, ls_init_value)
@@ -290,7 +288,6 @@ class PerceptionEncoderVisionBlock(nn.Module):
             act_layer,
             quant_config=quant_config,
             prefix=f"{prefix}.mlp",
-            use_data_parallel=use_data_parallel,
         )
 
     def forward(self, x: torch.Tensor, grid_hw: tuple[int, int]):
@@ -314,7 +311,6 @@ class PerceptionEncoderVisionTransformer(nn.Module):
         use_cls_token: bool = False,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ):
         super().__init__()
         self.width = width
@@ -333,7 +329,6 @@ class PerceptionEncoderVisionTransformer(nn.Module):
                     use_cls_token=use_cls_token,
                     quant_config=quant_config,
                     prefix=f"{prefix}.resblocks.{i}",
-                    use_data_parallel=use_data_parallel,
                 )
                 for i in range(layers)
             ]
@@ -353,7 +348,6 @@ class PerceptionEncoder(nn.Module):
         norm_layer: Callable = _DEFAULT_NORM_LAYER,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        use_data_parallel: bool = False,
     ):
         super().__init__()
         self.patch_size = config.patch_size
@@ -394,7 +388,6 @@ class PerceptionEncoder(nn.Module):
             use_cls_token=self.use_cls_token,
             quant_config=quant_config,
             prefix=f"{prefix}.transformer",
-            use_data_parallel=use_data_parallel,
         )
 
         self.vit_downsampler1 = Conv2dLayer(
@@ -511,7 +504,6 @@ class StepVLForConditionalGeneration(Step3VLForConditionalGeneration):
                 get_act_fn(config.vision_config.hidden_act),
                 quant_config=quant_config,
                 prefix=maybe_prefix(prefix, "vision_model"),
-                use_data_parallel=self.use_data_parallel,
             )
             self.vit_large_projector = ColumnParallelLinear(
                 config.vision_config.width * 4,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Clean up `use_data_parallel` from ViT model implementation 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

