### PR TITLE
[Backport] [Kimi-K2.5] Replace torch.cuda with current_platform for d…

### DIFF
--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -58,12 +58,11 @@ from vllm.multimodal.processing import (
     PromptReplacement,
     PromptUpdate,
 )
+from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs import KimiK25Config
 from vllm.transformers_utils.processor import cached_get_image_processor
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
-
-from vllm.platforms import current_platform
 
 from .utils import PPMissingLayer, is_pp_missing_parameter, maybe_prefix
 

--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -63,6 +63,8 @@ from vllm.transformers_utils.configs import KimiK25Config
 from vllm.transformers_utils.processor import cached_get_image_processor
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
+from vllm.platforms import current_platform
+
 from .utils import PPMissingLayer, is_pp_missing_parameter, maybe_prefix
 
 logger = init_logger(__name__)
@@ -320,7 +322,7 @@ class KimiK25ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP)
             model_config.multimodal_config.mm_encoder_tp_mode == "data"
         )
         self.hidden_size = config.text_config.hidden_size
-        self.device = torch.cuda.current_device()
+        self.device = current_platform.current_device()
         # Build vision tower directly with KimiK25VisionConfig
         self.vision_tower = MoonViT3dPretrainedModel(
             config.vision_config,


### PR DESCRIPTION

commit msg: 
Replaced the hardcoded `torch.cuda.current_device()` with `current_platform.current_device()` in the `KimiK25ForConditionalGeneration` initialization. This change enhances platform compatibility, allowing the model to run on non-CUDA devices (e.g., NPU, ROCm) supported by vLLM.

<!-- markdownlint-disable -->


## Purpose

Update `KimiK25ForConditionalGeneration` to use `current_platform.current_device()` instead of the hardcoded `torch.cuda.current_device()`.

This modification ensures better platform compatibility, allowing the Kimi-K2.5 model to be properly initialized and deployed on non-CUDA backends supported by vLLM (such as Huawei Ascend NPUs, AMD ROCm, etc.), where `torch.cuda` might not be applicable or optimal.

## Test Plan
Code Review: Verify that `current_platform` is correctly imported and used.
Initialization Test: specific checks to ensure the model loads without device-related errors on the target platform.
```
vllm serve moonshotai/Kimi-K2.5 -tp 16 \
    --tool-call-parser kimi_k2 \
    --reasoning-parser kimi_k2 \
    --trust-remote-code
```
## Test Result
Successfully ran on 910B NPU using `vllm-ascend`
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

