### PR TITLE
[Misc] Clean up HIDDEN_DEPRECATED_METRICS after metric removal

### DIFF
--- a/tests/entrypoints/instrumentator/test_metrics.py
+++ b/tests/entrypoints/instrumentator/test_metrics.py
@@ -231,11 +231,7 @@ EXPECTED_METRICS_MM = [
     "vllm:mm_cache_hits",
 ]
 
-HIDDEN_DEPRECATED_METRICS: list[str] = [
-    "vllm:gpu_cache_usage_perc",
-    "vllm:gpu_prefix_cache_queries",
-    "vllm:gpu_prefix_cache_hits",
-]
+HIDDEN_DEPRECATED_METRICS: list[str] = []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose

Clean up the `HIDDEN_DEPRECATED_METRICS` list in the metrics test file after the deprecated metrics were removed in #29330.

The following metrics were removed in #29330:
- `vllm:gpu_cache_usage_perc`
- `vllm:gpu_prefix_cache_queries`
- `vllm:gpu_prefix_cache_hits`

Since these metrics are now fully removed, they no longer need to be tracked in `HIDDEN_DEPRECATED_METRICS`.

## Test Plan

No new tests needed - this is a test file cleanup.

## Test Result

Existing tests pass.