### PR TITLE
[Bugfix][Kernel] Fix negative memory offset in GDN Triton kernel

### DIFF
--- a/vllm/model_executor/layers/fla/ops/fused_recurrent.py
+++ b/vllm/model_executor/layers/fla/ops/fused_recurrent.py
@@ -106,13 +106,14 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
                 i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
             else:
                 i_t = 0
-            p_h0 = (
-                h0
-                + tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
-                    tl.int64
-                )
-                * stride_init_state_token
+            # Load state index and check for PAD_SLOT_ID (-1)
+            state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
+                tl.int64
             )
+            # Skip if state index is invalid (PAD_SLOT_ID = -1)
+            if state_idx < 0:
+                return
+            p_h0 = h0 + state_idx * stride_init_state_token
         else:
             p_h0 = h0 + bos * HV * K * V
         p_h0 = p_h0 + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
@@ -149,17 +150,19 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
 
         # keep the states for multi-query tokens
         if INPLACE_FINAL_STATE:
-            p_ht = (
-                ht
-                + tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
-                    tl.int64
-                )
-                * stride_final_state_token
-            )
+            # Load state index and check for PAD_SLOT_ID (-1)
+            final_state_idx = tl.load(
+                ssm_state_indices + i_n * stride_indices_seq + i_t
+            ).to(tl.int64)
+            # Only store if state index is valid (not PAD_SLOT_ID)
+            if final_state_idx >= 0:
+                p_ht = ht + final_state_idx * stride_final_state_token
+                p_ht = p_ht + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
+                tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
         else:
             p_ht = ht + (bos + i_t) * stride_final_state_token
-        p_ht = p_ht + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
-        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+            p_ht = p_ht + i_hv * K * V + o_k[:, None] * V + o_v[None, :]
+            tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
 
         p_q += H * K
         p_k += H * K


### PR DESCRIPTION

## Purpose

Fix illegal memory access (`cudaErrorIllegalAddress`) when running Qwen3-Next models with MTP speculative decoding and CUDA Graphs enabled.

Fixes #31186

cc @vadiklyutiy
### Root Cause

The Triton kernel `fused_recurrent_gated_delta_rule_fwd_kernel` in GDN attention did not check for `PAD_SLOT_ID = -1` values in `ssm_state_indices`. When CUDA Graph pads unused slots with `-1`, the kernel computes negative memory offsets, causing illegal memory access.

### Fix

Add boundary checks in `fused_recurrent.py` to skip processing when `state_idx < 0`, consistent with how Flash Attention's cache kernels handle invalid slot indices.

**Modified file**: `vllm/model_executor/layers/fla/ops/fused_recurrent.py`

**Change 1** - Initial state loading (line ~109-115):
```python
state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(tl.int64)
# Skip if state index is invalid (PAD_SLOT_ID = -1)
if state_idx < 0:
    return
p_h0 = h0 + state_idx * stride_init_state_token
```

**Change 2** - Final state storage (line ~152-159):
```python
final_state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(tl.int64)
# Only store if state index is valid (not PAD_SLOT_ID)
if final_state_idx >= 0:
    p_ht = ht + final_state_idx * stride_final_state_token
    # ... store state
```

**Reference** - Flash Attention already handles this correctly:
```cpp
// csrc/attention/cache_kernels.cu
if (slot_idx < 0) {
    return;
}
```

## Test Plan

1. Start vLLM server with Qwen3-Next MTP:

```bash
VLLM_ATTENTION_BACKEND=FLASH_ATTN \
python3 -m vllm.entrypoints.openai.api_server \
  --model Qwen/Qwen3-Next-80B-A3B-Instruct-FP8 \
  --tensor-parallel-size 4 \
  --no-enable-chunked-prefill \
  --no-enable-prefix-caching \
  --speculative-config '{"method": "qwen3_next_mtp", "num_speculative_tokens": 2}'
```

2. Run high-concurrency GSM8K benchmark (crash previously occurred on 2nd request batch):

```bash
lm_eval --model local-completions --tasks gsm8k \
  --model_args base_url=http://localhost:8000/v1/completions,model=Qwen/Qwen3-Next-80B-A3B-Instruct-FP8,num_concurrent=512
```

## Test Result

### Before Fix
- 100% crash on second request batch
- Error: `cudaErrorIllegalAddress` at `cuda_graph.py:308` (`cudagraph.replay()`)

### After Fix

| Test Run | Result | Coredump |
|----------|--------|----------|
| Run 1-10 | ✅ All Pass | None |

GSM8K Benchmark Results:
| Metric | Value | Stderr |
|--------|-------|--------|
| flexible-extract | 0.8347 | 0.0102 |
| strict-match | 0.7945 | 0.0111 |

Accuracy is consistent with expected performance, confirming functional correctness.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

