### PR TITLE
[Quant] Fix FP8 block quantization for non-aligned dimensions

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -424,6 +424,24 @@ class W8A8BlockFp8LinearOp:
         weight: torch.Tensor,
         weight_scale: torch.Tensor,
     ) -> torch.Tensor:
+        # Pad K dimension to multiple of block size if needed.
+        # This handles models like DeepSeek-V2-Lite where intermediate_size
+        # (10944) is not divisible by the block size (128).
+        block_k = self.act_quant_group_shape.col
+        k = input_2d.shape[-1]
+        if k % block_k != 0:
+            pad_k = block_k - (k % block_k)
+            input_2d = torch.nn.functional.pad(input_2d, (0, pad_k))
+            weight = torch.nn.functional.pad(weight, (0, pad_k))
+            # Pad weight scale for the new K blocks
+            orig_k_blocks = triton.cdiv(k, block_k)
+            new_k_blocks = triton.cdiv(k + pad_k, block_k)
+            extra_k_blocks = new_k_blocks - orig_k_blocks
+            if extra_k_blocks > 0:
+                weight_scale = torch.nn.functional.pad(
+                    weight_scale, (0, extra_k_blocks)
+                )
+
         if DeepGemmQuantScaleFMT.from_oracle() == DeepGemmQuantScaleFMT.UE8M0:
             q_input, input_scale = per_token_group_quant_fp8_packed_for_deepgemm(
                 input_2d,
@@ -452,6 +470,23 @@ class W8A8BlockFp8LinearOp:
     ) -> torch.Tensor:
         assert input_scale is None
         assert self.input_quant_op is not None
+
+        # Pad K dimension to multiple of block size if needed.
+        block_k = self.act_quant_group_shape.col
+        k = input_2d.shape[-1]
+        if k % block_k != 0:
+            pad_k = block_k - (k % block_k)
+            input_2d = torch.nn.functional.pad(input_2d, (0, pad_k))
+            weight = torch.nn.functional.pad(weight, (0, pad_k))
+            # Pad weight scale for the new K blocks
+            orig_k_blocks = triton.cdiv(k, block_k)
+            new_k_blocks = triton.cdiv(k + pad_k, block_k)
+            extra_k_blocks = new_k_blocks - orig_k_blocks
+            if extra_k_blocks > 0:
+                weight_scale = torch.nn.functional.pad(
+                    weight_scale, (0, extra_k_blocks)
+                )
+
         q_input, input_scale = self.input_quant_op(input_2d)
         if self.is_hopper:
             return torch.ops.vllm.padded_cutlass(
@@ -565,6 +600,22 @@ class W8A8BlockFp8LinearOp:
         This backend uses TensorRT-LLM's FP8 block-scale GEMM kernels
         and supports FP8+FP8 (W8A8 full quantization) on SM90+ (Hopper).
         """
+        # Pad K dimension to multiple of block size if needed.
+        block_k = self.act_quant_group_shape.col
+        k = input_2d.shape[-1]
+        if k % block_k != 0:
+            pad_k = block_k - (k % block_k)
+            input_2d = torch.nn.functional.pad(input_2d, (0, pad_k))
+            weight = torch.nn.functional.pad(weight, (0, pad_k))
+            # Pad weight scale for the new K blocks
+            orig_k_blocks = triton.cdiv(k, block_k)
+            new_k_blocks = triton.cdiv(k + pad_k, block_k)
+            extra_k_blocks = new_k_blocks - orig_k_blocks
+            if extra_k_blocks > 0:
+                weight_scale = torch.nn.functional.pad(
+                    weight_scale, (0, extra_k_blocks)
+                )
+
         # Now call FlashInfer with BF16 input + FP8 weight, input will be
         # quantized with FlashInfer kernel (W8A8)
         output = torch.ops.vllm.flashinfer_fp8_blockscale_gemm(


### PR DESCRIPTION
## Summary

Fixes FP8 block quantization for models with dimensions not divisible by block size (128).

Tested with `bdellabe/DeepSeek-V2-Lite-FP8-BLOCK` where `intermediate_size=10944`.

## Changes

1. **Validation fix** - Skip partition alignment check for merged weights when TP=1
2. **Scale shard fix** - Compute scale boundaries correctly using `ceil(offset+size) - ceil(offset)` 
3. **K-dimension padding** - Pad K dimension at runtime for all FP8 block quant execution paths:
   - `_run_triton` (Ada/consumer GPUs)
   - `_run_cutlass` (Hopper datacenter GPUs)
   - `_run_deepgemm` (Hopper with DeepGEMM enabled)
   - `_run_flashinfer` (Hopper with FlashInfer enabled)

## Test Results

### RTX 4090 (Ada - Triton path)

**Generation Test:**
```
The capital of France is one of the most popular cities in the world and a great place for students to visit. 
Paris is home to a number of world-famous universities and institutes...
```

**lm_eval Benchmark:**
| Task | Metric | Value | Stderr |
|------|--------|-------|--------|
| HellaSwag | acc_norm | 0.69 | ±0.047 |

### H100 SXM (Hopper - CUTLASS path)

```bash
python -c "
from vllm import LLM, SamplingParams
llm = LLM('bdellabe/DeepSeek-V2-Lite-FP8-BLOCK', trust_remote_code=True, max_model_len=2048, enforce_eager=True)
print(llm.generate(['The capital of France is'], SamplingParams(max_tokens=50))[0].outputs[0].text)
"
```

**Output:**
```
one of the most popular cities in the world and a great place for students to visit. 
Paris is home to a number of world-famous universities and institutes...
```

### H100 SXM (Hopper - DeepGEMM path)

```bash
VLLM_USE_DEEP_GEMM=1 python -c "
from vllm import LLM, SamplingParams
llm = LLM('bdellabe/DeepSeek-V2-Lite-FP8-BLOCK', trust_remote_code=True, max_model_len=2048, enforce_eager=True)
print(llm.generate(['The capital of France is'], SamplingParams(max_tokens=50))[0].outputs[0].text)
"
```

**Logs:**
```
INFO [deep_gemm.py:98] DeepGEMM E8M0 enabled on current platform.
INFO [fp8.py:137] Using DeepGEMM backend for FP8 MoE
DeepGEMM warmup: 100%|██████████| 1664/1664
Model loaded successfully!
```

**Output:**
```
of course crazy Paris, recognized for its artistic and cultural heritage...
```

## Related

- vllm-project/llm-compressor#2290
- vllm-project/compressed-tensors#547