### PR TITLE
[BUGFIX] Make HF input preprocessing async to prevent frontend event loop blocking

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -141,9 +141,9 @@ class AsyncLLM(EngineClient):
             self.model_config.io_processor_plugin,
         )
 
-        # Single-threaded executor for running process_inputs() in background
-        # to avoid blocking the asyncio event loop during CPU-intensive preprocessing.
-        # Using max_workers=1 ensures sequential execution, eliminating the need for locks.
+        # Single-thread for running process_inputs() in background
+        # to avoid blocking the asyncio event loop during preprocessing.
+        # max_workers=1 ensures sequential execution, no need for locks.
         self._input_processor_executor = ThreadPoolExecutor(max_workers=1)
 
         # OutputProcessor (converts EngineCoreOutputs --> RequestOutput).


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Improve the issue where the frontend process event loop becomes blocked under medium to high concurrency with multimodal requests, due to preprocessing in the Hugging Face (HF) processor. This improvement helps enhance the performance of the vLLM framework in multimodal scenarios.

In addition, this change is critical for concurrent testing in the downstream framework vllm-omni. In multi-stage orchestration, the frontend process is responsible for forwarding the computation results of each stage to the next one. If the event loop is blocked, forwarding is delayed, leading to severe pipeline stalls.

## Test Plan

The service was deployed on 2× A800 GPUs (tp=2) using Kubernetes, and end-to-end stress tests were conducted under production-like conditions. To eliminate network latency jitter, the client and server communicated via ClusterIP within the cluster.

The test data distribution consisted of 40% text-only, 30% video, and 30% image requests. Samples were drawn with replacement from a large dataset, making cache hits unlikely.

Tests were conducted at QPS = 5, 10, 20, and 50, with the client sending requests at intervals following a Poisson distribution. Each test lasted 10 seconds. The server pod was restarted between tests to eliminate caching effects.

(Test files are not included in this PR. If needed, I can add them to the PR or share them through other means.)

## Test Result
Under moderate concurrency (QPS = 20), this simple fix resulted in a 25% reduction in average TTFT and a 37% reduction in p99 TTFT.
Under high concurrency (QPS = 50), it eliminated ServerTimeoutError issues caused by frontend process blocking. With a timeout threshold of 10 seconds, 11.83% of requests triggered this network error in the original implementation.

  QPS : 20.0              | before bugfix |  after bugfix  
------------------------------------------------------------
Throughput (tok/s)        | 139.98        | 152.79
Avg TTFT (ms)             | 3455.25       | 2611.99  
P99 TTFT (ms)             | 7226.91       | 4604.19 
Error Rate                | 0.00%         | 0.00%  
------------------------------------------------------------

  QPS : 50.0              | before bugfix |  after bugfix  
------------------------------------------------------------
Throughput (tok/s)        | 156.83        | 150.32 
Avg TTFT (ms)             | 10621.45      | 10669.77
P99 TTFT (ms)             | 18253.06      | 18711.43 
Error Rate                | 11.83%        | 0.00%  
------------------------------------------------------------
This is a minimal-change solution and is not performance-optimal. To ensure thread safety under multi-threaded execution and to keep all changes contained within a single file for easier review, I intentionally chose a relatively coarse lock granularity.

If you are interested in further improving performance in this scenario, I would be happy to propose an RFC to address it.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

