### PR TITLE
[Bugfix] Fix broken GLM-OCR initialization

### DIFF
--- a/vllm/model_executor/models/glm_ocr.py
+++ b/vllm/model_executor/models/glm_ocr.py
@@ -249,7 +249,7 @@ class GlmOcrPatchMerger(Glm4vPatchMerger):
 class GlmOcrVisionTransformer(Glm4vVisionTransformer):
     def __init__(
         self,
-        vision_config: GlmOcrVisionConfig,
+        vision_config: "GlmOcrVisionConfig",
         norm_eps: float = 1e-5,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- The GLM-OCR model is broken actually, because `GlmOcrVisionConfig` is only imported at type checking
https://github.com/vllm-project/vllm/blob/c6e7404cc5713a926e8b6c187b5f197a5436e9ff/vllm/model_executor/models/glm_ocr.py#L36-L39
```
NameError: name 'GlmOcrVisionConfig' is not defined. Did you mean: 'GlmOcrVisionMLP'?
```

## Test Plan

## Test Result
- Model should be able to start now.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

