### PR TITLE
[KVConnector] Allow connector to protect GPU blocks from eviction

### DIFF
--- a/tests/v1/engine/test_engine_core.py
+++ b/tests/v1/engine/test_engine_core.py
@@ -179,11 +179,11 @@ def test_engine_core():
     req0.request_id = req1.request_id = "test"
     engine_core.add_request(*engine_core.preprocess_add_request(req0))
 
-    while engine_core.scheduler.has_requests():
+    while engine_core.scheduler.has_work():
         engine_core.step_fn()
 
     engine_core.add_request(*engine_core.preprocess_add_request(req1))
-    while engine_core.scheduler.has_requests():
+    while engine_core.scheduler.has_work():
         engine_core.step_fn()
 
     assert len(engine_core.scheduler.waiting) == 0
@@ -222,7 +222,7 @@ def test_engine_core_advanced_sampling():
         assert len(engine_core.scheduler.waiting) == 1
         assert len(engine_core.scheduler.running) == 0
         # Loop through until they are all done.
-        while engine_core.scheduler.has_requests():
+        while engine_core.scheduler.has_work():
             engine_core.step_fn()
         assert len(engine_core.scheduler.waiting) == 0
         assert len(engine_core.scheduler.running) == 0

--- a/tests/v1/kv_connector/unit/utils.py
+++ b/tests/v1/kv_connector/unit/utils.py
@@ -24,6 +24,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    KVConnectorSchedulerOutput,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.example_connector import (  # noqa
     ExampleConnector,
@@ -358,6 +359,7 @@ class MockKVConnector(KVConnectorBase_V1):
             matched_tokens=extra_config["matched_tokens"],
             is_async=extra_config["is_async"],
         )
+        self.kv_connector_scheduler_output: KVConnectorSchedulerOutput | None = None
 
     def get_num_new_matched_tokens(
         self,
@@ -401,6 +403,9 @@ class MockKVConnector(KVConnectorBase_V1):
 
     def wait_for_save(self):
         pass
+
+    def report_to_scheduler(self) -> KVConnectorSchedulerOutput | None:
+        return self.kv_connector_scheduler_output
 
 
 KVConnectorFactory.register_connector(

--- a/vllm/v1/core/sched/interface.py
+++ b/vllm/v1/core/sched/interface.py
@@ -162,10 +162,17 @@ class SchedulerInterface(ABC):
         """
         raise NotImplementedError
 
-    def has_requests(self) -> bool:
-        """Returns True if there are unfinished requests, or finished requests
-        not yet returned in SchedulerOutputs."""
-        return self.has_unfinished_requests() or self.has_finished_requests()
+    def has_work(self) -> bool:
+        """Returns True if one of the below exist:
+        1. Unfinished requests
+        2. Finished requests not yet returned in SchedulerOutputs
+        3. KV Connector work (e.g. KV blocks being transferred)
+        """
+        return (
+            self.has_unfinished_requests()
+            or self.has_finished_requests()
+            or self.has_kv_connector_work()
+        )
 
     @abstractmethod
     def reset_prefix_cache(
@@ -203,3 +210,9 @@ class SchedulerInterface(ABC):
 
     def get_kv_connector(self) -> Optional["KVConnectorBase_V1"]:
         return None
+
+    def has_kv_connector_work(self) -> bool:
+        """Returns True if there's KV Connector work
+        (e.g. KV blocks being transferred)
+        """
+        return False

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -373,9 +373,9 @@ class EngineCore:
         was executed.
         """
 
-        # Check for any requests remaining in the scheduler - unfinished,
-        # or finished and not yet removed from the batch.
-        if not self.scheduler.has_requests():
+        # Check for any work remaining in the scheduler - unfinished requests,
+        # finished requests and not yet removed from the batch, or KV connector work.
+        if not self.scheduler.has_work():
             return {}, False
         scheduler_output = self.scheduler.schedule()
         future = self.model_executor.execute_model(scheduler_output, non_block=True)
@@ -433,7 +433,7 @@ class EngineCore:
 
         model_executed = False
         deferred_scheduler_output = None
-        if self.scheduler.has_requests():
+        if self.scheduler.has_work():
             scheduler_output = self.scheduler.schedule()
             exec_future = self.model_executor.execute_model(
                 scheduler_output, non_block=True
@@ -971,7 +971,7 @@ class EngineCoreProc(EngineCore):
         waited = False
         while (
             not self.engines_running
-            and not self.scheduler.has_requests()
+            and not self.scheduler.has_work()
             and not self.batch_queue
         ):
             if self.input_queue.empty():


### PR DESCRIPTION
This PR introduces a new connector API allowing the scheduler-side connector to increase GPU blocks ref-counts, in order to prevent them from evicting.
In particular, this is necessary for the case of async offloading of sliding window KV data, as it is automatically freed by the KV cache manager as the window progresses.