### PR TITLE
[BugFix] Fix cold start compilation time

### DIFF
--- a/tests/compile/test_fusion_attn.py
+++ b/tests/compile/test_fusion_attn.py
@@ -390,6 +390,10 @@ def test_attention_quant_pattern(
         forward_ctx = get_forward_context()
         forward_ctx.attn_metadata = model_unfused.build_attn_metadata(batch_size)
 
+        # Need to set to None for testing, otherwise vLLM
+        # assumes the forward gets run once under the forward_context.
+        forward_ctx.all_attention_layers = None
+
         # Run model directly without fusion
         # Still compile so query QuantFP8 has closer numerics
         compiled_unfused = torch.compile(model_unfused, fullgraph=True)


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/25954 caused a regression in cold start compilation times in all models (MOE and Dense). This PR fixes it. The regression is that #25954 causes strings to appear in the graph and messes with the number of total unique subgraphs that need to be compiled. In general a model has some number of layers and should have 3-5 unique subgraphs, the change made it so that there is approx one subgraph per layer.

Benchmarks:
```
# vLLM 0.14.1
gpt-oss-120b # torch.compile takes 39.89 s in total
llama3.1-70b # torch.compile takes 23.85 s in total

# before this PR (should be similar to vLLM 0.15.0)
gpt-oss-120b # torch.compile takes 46.94 s in total
llama3.1-70b # torch.compile takes 87.60 s in total

# after this PR
gpt-oss-120b # torch.compile takes 28.47 s in total
llama3.1-70b # torch.compile takes 24.65 s in total
```

I will figure out how to write a better test for this so that we don't regress, we can probably reuse some torch.compile helpers for identify number of cache hits/cache misses.
