### PR TITLE
[BUGFIX][XPU] fix memory check after XPU reuse GPU_worker 

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -330,7 +330,7 @@ class Worker(WorkerBase):
         free_gpu_memory = profile_result.after_profile.free_memory
         # NOTE(woosuk): Here we assume that the other processes using the same
         # GPU did not change their memory usage during the profiling.
-        assert self.init_snapshot.free_memory > free_gpu_memory, (
+        assert self.init_snapshot.free_memory >= free_gpu_memory, (
             "Error in memory profiling. "
             f"Initial free memory {format_gib(self.init_snapshot.free_memory)} GiB, "
             f"current free memory {format_gib(free_gpu_memory)} GiB. "


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

**Fix a bug as below:**
```
File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 333, in determine_available_memory
(EngineCore_DP0 pid=418) ERROR 01-29 15:38:21 [core.py:946]     assert self.init_snapshot.free_memory > free_gpu_memory, (
(EngineCore_DP0 pid=418) ERROR 01-29 15:38:21 [core.py:946]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=418) ERROR 01-29 15:38:21 [core.py:946] AssertionError: Error in memory profiling. Initial free memory 30.3 GiB, current free memory 30.3 GiB. This happens when other processes sharing the same container release GPU memory while vLLM is profiling during initialization. To fix this, ensure consistent GPU memory allocation or isolate vLLM in its own container.
```

**Root Cause:**

XPU before and after profile_run, memory size is exact same. 

**Solution:**

update GPU_worker to allow '>=' instead of '>'


## Test Plan

validated by XPU and now it runs OK.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

