### PR TITLE
[Models]: lfm2_siglip2 return intermediate encoder layers

### DIFF
--- a/vllm/model_executor/models/lfm2_siglip2.py
+++ b/vllm/model_executor/models/lfm2_siglip2.py
@@ -424,10 +424,21 @@ class Siglip2VisionTransformer(nn.Module):
         # Normalize select_layer to 0-indexed layer output
         # select_layer=-1 means last layer (index num_layers-1)
         # select_layer=-2 means second-to-last (index num_layers-2)
-        target_layer_idx = select_layer if select_layer >= 0 else num_layers + select_layer
+        target_layer_idx = (
+            select_layer if select_layer >= 0 else num_layers + select_layer
+        )
+
+        if not 0 <= target_layer_idx < num_layers:
+            raise ValueError(
+                f"select_layer index ({select_layer}) is out of range for "
+                f"{num_layers} layers. The valid range is "
+                f"[-{num_layers}, {num_layers - 1}]."
+            )
 
         # Only pass return_layer_idx if we need an intermediate layer
-        return_layer_idx = None if target_layer_idx == num_layers - 1 else target_layer_idx
+        return_layer_idx = (
+            None if target_layer_idx == num_layers - 1 else target_layer_idx
+        )
 
         encoder_outputs = self.encoder(
             inputs_embeds=hidden_states,


### PR DESCRIPTION
## Purpose
 
Adds select_layers parameter to Siglip2Model and Siglip2VisionTransformer to allow returning hidden states from any encoder layers. Siglip2Encoder parameter return_all_hidden_states to collect intermediate outputs. Useful for VLM architectures that use intermediate vision encoder outputs instead of the final layer.

select_layers=None: last layer with post_layernorm (default)
select_layers=[-2]: second-to-last without post_layernorm
Multiple layers supported (e.g., [-2, -1]) - outputs are concatenated
Positive indices also supported for direct layer selection
Also adds num_hidden_layers_override to instantiate partial encoders when full depth isn't needed.

No breaking change - default behavior unchanged.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

