### PR TITLE
Explicitly set `return_dict` for `apply_chat_template`

### DIFF
--- a/examples/offline_inference/prompt_embed_inference.py
+++ b/examples/offline_inference/prompt_embed_inference.py
@@ -38,8 +38,8 @@ def get_prompt_embeds(
     embedding_layer: torch.nn.Module,
 ):
     token_ids = tokenizer.apply_chat_template(
-        chat, add_generation_prompt=True, return_tensors="pt"
-    )
+        chat, add_generation_prompt=True, return_tensors="pt", return_dict=True
+    ).input_ids
     prompt_embeds = embedding_layer(token_ids).squeeze(0)
     return prompt_embeds
 

--- a/examples/online_serving/prompt_embed_inference_with_openai_client.py
+++ b/examples/online_serving/prompt_embed_inference_with_openai_client.py
@@ -49,8 +49,8 @@ def main():
     # Refer to the HuggingFace repo for the correct format to use
     chat = [{"role": "user", "content": "Please tell me about the capital of France."}]
     token_ids = tokenizer.apply_chat_template(
-        chat, add_generation_prompt=True, return_tensors="pt"
-    )
+        chat, add_generation_prompt=True, return_tensors="pt", return_dict=True
+    ).input_ids
 
     embedding_layer = transformers_model.get_input_embeddings()
     prompt_embeds = embedding_layer(token_ids).squeeze(0)

--- a/examples/online_serving/token_generation_client.py
+++ b/examples/online_serving/token_generation_client.py
@@ -27,7 +27,8 @@ def main(client):
         messages,
         add_generation_prompt=True,
         enable_thinking=False,
-    )
+        return_dict=True,
+    ).input_ids
     payload = {
         "model": MODEL_NAME,
         "token_ids": token_ids,

--- a/tests/entrypoints/openai/test_serving_tokens.py
+++ b/tests/entrypoints/openai/test_serving_tokens.py
@@ -92,7 +92,8 @@ async def test_same_response_as_chat_completions(client, tokenizer, messages):
         messages,
         add_generation_prompt=True,
         enable_thinking=False,  # default with Qwen3
-    )
+        return_dict=True,  # default with Transformers v5
+    ).input_ids
 
     for ignore_eos in [True, False]:
         payload = {
@@ -155,7 +156,8 @@ async def test_stop_string_workflow(client, tokenizer, messages):
         messages,
         add_generation_prompt=True,
         enable_thinking=False,  # default with Qwen3
-    )
+        return_dict=True,  # default with Transformers v5
+    ).input_ids
     payload = {
         "model": MODEL_NAME,
         "token_ids": token_ids,
@@ -251,7 +253,8 @@ async def test_generate_with_lora_adapter(client, tokenizer, messages):
         messages,
         add_generation_prompt=True,
         enable_thinking=False,  # default with Qwen3
-    )
+        return_dict=True,  # default with Transformers v5
+    ).input_ids
     payload = {
         "model": "Alice",
         "token_ids": token_ids,

--- a/vllm/model_executor/models/isaac.py
+++ b/vllm/model_executor/models/isaac.py
@@ -759,6 +759,7 @@ class IsaacProcessor:
                 # Regular text message
                 processed_messages.append(message)
 
+        kwargs["return_dict"] = False
         return self.tokenizer.apply_chat_template(
             processed_messages,
             tokenize=tokenize,

--- a/vllm/renderers/deepseek_v32.py
+++ b/vllm/renderers/deepseek_v32.py
@@ -70,6 +70,7 @@ class DeepseekV32Renderer(RendererLike):
             content_format="string",
         )
 
+        kwargs["return_dict"] = False
         prompt_raw = tokenizer.apply_chat_template(
             conversation=conversation,
             messages=messages,
@@ -100,6 +101,7 @@ class DeepseekV32Renderer(RendererLike):
             content_format="string",
         )
 
+        kwargs["return_dict"] = False
         prompt_raw = tokenizer.apply_chat_template(
             conversation=conversation,
             messages=messages,

--- a/vllm/renderers/grok2.py
+++ b/vllm/renderers/grok2.py
@@ -70,6 +70,7 @@ class Grok2Renderer(RendererLike):
             content_format="string",
         )
 
+        kwargs["return_dict"] = False
         prompt_raw = tokenizer.apply_chat_template(
             conversation=conversation,
             messages=messages,
@@ -100,6 +101,7 @@ class Grok2Renderer(RendererLike):
             content_format="string",
         )
 
+        kwargs["return_dict"] = False
         prompt_raw = tokenizer.apply_chat_template(
             conversation=conversation,
             messages=messages,

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -472,6 +472,7 @@ def safe_apply_chat_template(
             tools=tools,  # type: ignore[arg-type]
             chat_template=chat_template,
             tokenize=tokenize,
+            return_dict=False,
             **resolved_kwargs,
         )
     # External library exceptions can sometimes occur despite the framework's

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -465,6 +465,7 @@ def safe_apply_chat_template(
         chat_template=chat_template,
         chat_template_kwargs=kwargs,
     )
+    resolved_kwargs["return_dict"] = False
 
     try:
         return tokenizer.apply_chat_template(
@@ -472,7 +473,6 @@ def safe_apply_chat_template(
             tools=tools,  # type: ignore[arg-type]
             chat_template=chat_template,
             tokenize=tokenize,
-            return_dict=False,
             **resolved_kwargs,
         )
     # External library exceptions can sometimes occur despite the framework's

--- a/vllm/tokenizers/grok2.py
+++ b/vllm/tokenizers/grok2.py
@@ -432,6 +432,7 @@ class Grok2Tokenizer(TokenizerLike):
             raise ValueError(
                 "No chat template available. Provide `chat_template` explicitly."
             )
+        kwargs["return_dict"] = False
         prompt = hf_chat_utils.apply_chat_template(
             conversation=messages,
             chat_template=template,

--- a/vllm/transformers_utils/processors/hunyuan_vl.py
+++ b/vllm/transformers_utils/processors/hunyuan_vl.py
@@ -148,8 +148,8 @@ class HunYuanVLProcessor(ProcessorMixin):
         assert 0
 
     def apply_chat_template(self, *args, **kwargs):
-        token_ids = self.tokenizer.apply_chat_template(*args, **kwargs)
-        return token_ids
+        kwargs["return_dict"] = False
+        return self.tokenizer.apply_chat_template(*args, **kwargs)
 
     def get_imgs_pos(self, doc_ids):
         doc_ids = np.array(doc_ids, dtype=np.int64)

--- a/vllm/transformers_utils/processors/qwen3_asr.py
+++ b/vllm/transformers_utils/processors/qwen3_asr.py
@@ -213,6 +213,7 @@ class Qwen3ASRProcessor(ProcessorMixin):
         return list(_iter())
 
     def apply_chat_template(self, conversations, chat_template=None, **kwargs):
+        kwargs["return_dict"] = False
         return super().apply_chat_template(conversations, chat_template, **kwargs)
 
     @property


### PR DESCRIPTION
In Transformers v5 the default value of `return_dict` for `apply_chat _template` was changed to `True` to match other Tokeniser methods.

This PR explicitly sets:

- `return_dict=True` outside the `vllm/` dir so that users get used to the new/expected behaviour of Transformers
- `return_dict=False` inside the `vllm/` dir so that the internal interfaces of vLLM do not need to change to adapt to the new default