### PR TITLE
fix: allow LFM2 MoE prefix caching (align)

### DIFF
--- a/vllm/model_executor/models/lfm2_moe.py
+++ b/vllm/model_executor/models/lfm2_moe.py
@@ -651,9 +651,11 @@ class Lfm2MoeForCausalLM(
         quant_config = vllm_config.quant_config
         cache_config = vllm_config.cache_config
 
-        assert not cache_config.enable_prefix_caching, (
-            "Lfm2Moe currently does not support prefix caching"
-        )
+        if cache_config.mamba_cache_mode == "all":
+            raise NotImplementedError(
+                "Lfm2Moe currently does not support 'all' prefix caching, "
+                "please use '--mamba-cache-mode=align' instead"
+            )
 
         super().__init__()
         self.config = config

--- a/vllm/model_executor/models/lfm2_vl.py
+++ b/vllm/model_executor/models/lfm2_vl.py
@@ -22,6 +22,8 @@ from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.forward_context import set_forward_context
 from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateCopyFunc,
+    MambaStateCopyFuncCalculator,
     MambaStateDtypeCalculator,
     MambaStateShapeCalculator,
 )
@@ -583,6 +585,10 @@ class Lfm2VLForConditionalGeneration(
             intermediate_size=hf_language_config.hidden_size,
             conv_kernel=hf_language_config.conv_L_cache,
         )
+
+    @classmethod
+    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc]:
+        return MambaStateCopyFuncCalculator.short_conv_state_copy_func()
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "model"):
         super().__init__()


### PR DESCRIPTION
## Summary
- allow LFM2 MoE prefix caching in `align` mode
- add LFM2-VL Mamba state copy-func for prefix cache
- keep `mamba-cache-mode=all` restriction

## Testing
- ./run_lfm_vllm_benchmark.sh --wait 150 --prewarm-bench --work-dir eval_outputs/outputs_run_1769727159 \
  --model LiquidAI/LFM2-VL-8B-A1B-3096689 --served-model lfm2-vl-8b-a1b \
  --vllm-arg --enable-prefix-caching --vllm-arg --mamba-cache-mode --vllm-arg align \
  --vllm-arg --mm-processor-cache-type --vllm-arg shm --vllm-arg --async-scheduling \
  --vllm-arg --compilation-config --vllm-arg '{"max_cudagraph_capture_size": 8192, "compile_mm_encoder": true}'

## Results
- MMStar Overall: 0.5633333333333334
- Formal run: 1500 samples in 00:18 (~79.60 it/s)
- Spinup time: 147s
