### PR TITLE
[Bugfix] Disable torch.compile for batch invariance on Blackwell to ensure determinism

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -773,6 +773,18 @@ class VllmConfig:
                 # override related settings when enforce eager
                 self.compilation_config.max_cudagraph_capture_size = 0
                 self.compilation_config.cudagraph_capture_sizes = []
+            elif current_platform.is_cuda_alike:
+                from vllm.model_executor.layers.batch_invariant import (
+                    batch_invariance_requires_eager_mode,
+                )
+
+                if batch_invariance_requires_eager_mode():
+                    self.compilation_config.mode = CompilationMode.NONE
+                    self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+                    self.compilation_config.max_cudagraph_capture_size = 0
+                    self.compilation_config.cudagraph_capture_sizes = []
+                else:
+                    self.compilation_config.cudagraph_num_of_warmups = 1
             else:
                 self.compilation_config.cudagraph_num_of_warmups = 1
 

--- a/vllm/model_executor/layers/batch_invariant.py
+++ b/vllm/model_executor/layers/batch_invariant.py
@@ -1049,6 +1049,25 @@ def override_envs_for_invariance(
     os.environ["VLLM_USE_AOT_COMPILE"] = "0"
 
 
+def batch_invariance_requires_eager_mode() -> bool:
+    """
+    Check if batch invariance requires eager mode (no torch.compile).
+    On Blackwell, batch invariance fails with torch.compile enabled.
+    See: https://github.com/vllm-project/vllm/issues/32992
+    """
+    if not vllm_is_batch_invariant():
+        return False
+
+    if current_platform.is_cuda_alike and current_platform.has_device_capability(100):
+        logger.warning(
+            "Batch invariance on Blackwell requires disabling torch.compile. "
+            "See: https://github.com/vllm-project/vllm/issues/32992"
+        )
+        return True
+
+    return False
+
+
 def init_batch_invariance(
     attention_backend: AttentionBackendEnum | None,
 ):


### PR DESCRIPTION
## Purpose

Fix batch invariance failing on Blackwell (B200) GPUs when `torch.compile` is enabled.

Fixes #32992

### Observation

- Batch invariance works on Blackwell with `enforce_eager=True`
- Batch invariance fails on Blackwell with `torch.compile` enabled
- Batch invariance works on Hopper (H100/H200) with or without `torch.compile`

### Alternatives Tried

- `torch.use_deterministic_algorithms(True)` - causes hang during CUDA graph capture
- `custom_ops=["all"]` - still fails
- Disabling Inductor autotuning (`TORCHINDUCTOR_MAX_AUTOTUNE=0`, `TORCHINDUCTOR_COORDINATE_DESCENT_TUNING=0`, `benchmark_combo_kernel=False`) - still fails

## Test Plan

```bash
VLLM_BATCH_INVARIANT=1 \
VLLM_TEST_MODEL="Qwen/Qwen2.5-7B-Instruct" \
pytest tests/v1/determinism/test_batch_invariance.py -v -s
```

## Test Result

Before fix, batch invariance tests fail on Blackwell with both FLASH_ATTN and FLASHINFER backends.

After fix, all batch invariance tests pass on Blackwell with FLASH_ATTN and FLASHINFER backends:

- `test_v1_generation_is_deterministic_across_batch_sizes_with_needle[FLASH_ATTN]`
- `test_v1_generation_is_deterministic_across_batch_sizes_with_needle[FLASHINFER]`
- `test_logprobs_bitwise_batch_invariance_bs1_vs_bsN[FLASH_ATTN]`
- `test_logprobs_bitwise_batch_invariance_bs1_vs_bsN[FLASHINFER]`
- `test_simple_generation[FLASH_ATTN]`
- `test_simple_generation[FLASHINFER]`
- `test_logprobs_without_batch_invariance_should_fail[FLASH_ATTN]`
- `test_logprobs_without_batch_invariance_should_fail[FLASHINFER]`
- `test_decode_logprobs_match_prefill_logprobs[FLASH_ATTN]`


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

