### PR TITLE
[Bugfix] Fix inconsistent embeddings between AsyncLLM and LLM

### DIFF
--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -591,7 +591,14 @@ class InputProcessor:
             pooling_params = params.clone()
             # Verify pooling params to set default values (e.g., use_activation=True)
             # This ensures consistent behavior between AsyncLLM and LLM
-            task: PoolingTask = pooling_params.task or "embed"
+            task = pooling_params.task
+            if task is None:
+                convert_type = self.model_config.convert_type
+                if convert_type in ("embed", "classify"):
+                    task = cast(PoolingTask, convert_type)
+                else:
+                    # Default to 'embed' for native pooling models ('none') and other cases.
+                    task = "embed"
             pooling_params.verify(task, self.model_config)
 
         # Multimodal related.

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -31,6 +31,7 @@ from vllm.multimodal.utils import argsort_mm_positions
 from vllm.pooling_params import PoolingParams
 from vllm.renderers import RendererLike
 from vllm.sampling_params import _SAMPLING_EPS, SamplingParams
+from vllm.tasks import PoolingTask
 from vllm.tokenizers import TokenizerLike
 from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.utils import length_from_prompt_token_ids_or_embeds, random_uuid
@@ -588,6 +589,10 @@ class InputProcessor:
                 sampling_params.update_from_tokenizer(self.tokenizer)
         else:
             pooling_params = params.clone()
+            # Verify pooling params to set default values (e.g., use_activation=True)
+            # This ensures consistent behavior between AsyncLLM and LLM
+            task: PoolingTask = pooling_params.task or "embed"
+            pooling_params.verify(task, self.model_config)
 
         # Multimodal related.
         mm_features: list[MultiModalFeatureSpec] | None = None


### PR DESCRIPTION
The pooling_params.verify() method was only called in the LLM class path, not in the AsyncLLM (v1) path. This caused default values like use_activation=True to not be set, resulting in different embeddings.

Call verify() in InputProcessor.process_inputs() to ensure consistent behavior across both code paths.

Fixes #33361

