### PR TITLE
[KVConnector][LMCache] Enable Support for cross-layer Layout

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
@@ -135,7 +135,7 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
     def register_cross_layers_kv_cache(
         self,
         cross_layers_kv_cache: torch.Tensor,
-        cross_layers_attn_backend: "AttentionBackend",
+        cross_layers_attn_backend: type["AttentionBackend"],
     ):
         """
         Initialize with the KV caches. Useful for pre-registering the
@@ -148,7 +148,7 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
             self._lmcache_engine.register_cross_layers_kv_cache(cross_layers_kv_cache)
         else:
             logger.warning(
-                "LMCache engine does not support register_kv_caches, "
+                "LMCache engine does not support register_cross_layers_kv_cache, "
                 "please check and use the latest version"
             )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_connector.py
@@ -74,7 +74,10 @@ class LMCacheConnectorV1(KVConnectorBase_V1):
     @property
     def prefer_cross_layer_blocks(self) -> bool:
         extra_config = self._kv_transfer_config.kv_connector_extra_config
-        return bool(str(extra_config.get("enable_cross_layers_blocks", "False")))
+        val = extra_config.get("enable_cross_layers_blocks", False)
+        if isinstance(val, str):
+            return val.lower() in ("true", "1", "yes")
+        return bool(val)
 
     def __init__(
         self,


### PR DESCRIPTION

## Purpose
Required for compatibility with the new KV cache shape introduced by vLLM PR [#27743](https://github.com/vllm-project/vllm/pull/27743).

## Test Plan
Note: This change depends on LMCache PR [#2498](https://github.com/LMCache/LMCache/pull/2498).
The implementation has been validated on both:
- Non-MLA model: meta-llama/Llama-3.1-8B-Instruct
- MLA model: deepseek-ai/DeepSeek-V2-Lite-Chat

Command:
```bash
LMCACHE_CHUNK_SIZE=8 CUDA_VISIBLE_DEVICES=3 \
vllm serve <MODEL> \
  --kv-transfer-config \
  '{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both","kv_connector_extra_config":{"enable_cross_layers_blocks":true}}' \
  --port 8177 \
  --no-enable-prefix-caching \
  --enforce-eager
```

## Test Result
```bash
curl http://localhost:8177/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": <MODEL>,
    "prompt": "Qwen3 is the latest generation of large language models in Qwen series, offering a comprehensive suite of dense and mixture-of-experts",
    "max_tokens": 10,
    "temperature": 0
  }'
```

Both models work.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

