### PR TITLE
[Refactor] Move MM item count validation outside of processor

### DIFF
--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -921,7 +921,7 @@ def test_limit_mm_per_prompt_dummy(model_id, limit, num_supported, is_valid):
     )
 
     processor = MULTIMODAL_REGISTRY.create_processor(model_config)
-    processor._supported_mm_limits = {"image": num_supported}
+    processor.info.get_supported_mm_limits = lambda: {"image": num_supported}
 
     exc_ctx = nullcontext() if is_valid else pytest.raises(ValueError, match="At most")
 

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -528,7 +528,7 @@ class BaseMultiModalItemTracker(ABC, Generic[_T]):
         else:
             num_items = len(self._items_by_modality[original_modality]) + 1
 
-        self.mm_processor.validate_num_items(input_modality, num_items)
+        self.mm_processor.info.validate_num_items(input_modality, num_items)
 
         # Track original modality for vision_chunk items
         if use_vision_chunk:

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -176,9 +176,7 @@ class LoRAModelManager:
         )
 
         mm_budget = MultiModalBudget(vllm_config, mm_registry)
-        limit_per_prompt: int = max(
-            self.mm_processor_info.get_allowed_mm_limits().values()
-        )
+        limit_per_prompt = max(self.mm_processor_info.allowed_mm_limits.values())
         num_encoder_tokens = self.model.get_num_mm_encoder_tokens(
             mm_budget.get_encoder_budget()
         )

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -168,7 +168,7 @@ class MultiModalRegistry:
         )
 
         if profiler_limits is None:
-            profiler_limits = processor.allowed_mm_limits
+            profiler_limits = processor.info.allowed_mm_limits
 
         mm_counts = {
             modality: 1 for modality, limit in profiler_limits.items() if limit > 0
@@ -200,7 +200,6 @@ class MultiModalRegistry:
         self,
         model_config: "ModelConfig",
         *,
-        cache: BaseMultiModalProcessorCache | None = None,
         observability_config: ObservabilityConfig | None = None,
     ) -> Mapping[str, int]:
         """
@@ -210,10 +209,8 @@ class MultiModalRegistry:
         if not model_config.is_multimodal_model:
             return {}
 
-        processor = self.create_processor(
-            model_config, observability_config, cache=cache
-        )
-        return processor.allowed_mm_limits
+        info = self._create_processing_info(model_config, observability_config)
+        return info.allowed_mm_limits
 
     def register_processor(
         self,
@@ -324,7 +321,7 @@ class MultiModalRegistry:
                 model_config, observability_config, cache=cache
             )
         if mm_counts is None:
-            mm_counts = processor.allowed_mm_limits
+            mm_counts = processor.info.allowed_mm_limits
 
         processor_inputs = processor.dummy_inputs.get_dummy_processor_inputs(
             seq_len=seq_len,

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -40,7 +40,7 @@ class MultiModalBudget:
         self.max_model_len = model_config.max_model_len
         self.max_num_reqs = scheduler_config.max_num_seqs
 
-        self.mm_limits = mm_registry.get_mm_limits_per_prompt(model_config, cache=cache)
+        self.mm_limits = mm_registry.get_mm_limits_per_prompt(model_config)
 
         max_tokens_by_modality = mm_registry.get_max_tokens_per_item_by_modality(
             model_config,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Move more logic outside of MM processor. In the next PR I will move `_to_mm_items` calls outside of MM processor.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

