### PR TITLE
[Core][Bugfix] Add logprobs_mode_override capability for request-level fine-grained control over logprob computation

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -82,6 +82,7 @@ ModelDType = Literal["auto", "half", "float16", "bfloat16", "float", "float32"]
 LogprobsMode = Literal[
     "raw_logits", "raw_logprobs", "processed_logits", "processed_logprobs"
 ]
+LogprobsList = list[LogprobsMode | None]
 HfOverrides = dict[str, Any] | Callable[[PretrainedConfig], PretrainedConfig]
 ModelImpl = Literal["auto", "vllm", "transformers", "terratorch"]
 LayerBlockType = Literal["attention", "linear_attention", "mamba"]

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -647,6 +647,7 @@ class LLM:
             logprobs=2 * beam_width,
             max_tokens=1,
             temperature=temperature,
+            logprobs_mode_override="processed_logprobs",
             skip_clone=True,  # Internal beam search, safe to skip clone
         )
         instances: list[BeamSearchInstance] = []

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -341,6 +341,7 @@ class OpenAIServing:
             logprobs=logprobs_num,
             max_tokens=1,
             temperature=temperature,
+            logprobs_mode_override="processed_logprobs",
         )
         all_beams = [
             BeamSearchSequence(

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -11,12 +11,12 @@ from typing import Annotated, Any
 import msgspec
 from pydantic.dataclasses import dataclass
 
+from vllm.config.model import LogprobsMode
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.logits_process import LogitsProcessor
 from vllm.tokenizers import TokenizerLike
 from vllm.v1.serial_utils import PydanticMsgspecMixin
-from vllm.config.model import LogprobsMode
 
 logger = init_logger(__name__)
 

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -255,7 +255,7 @@ class SamplingParams(
 
     """Override logprobs_mode for this request.
     If set, this will override the logprobs_mode for this request.
-    If None, the logprobs_mode will be determined by in `ModelConfig`."""
+    If None, the logprobs_mode will be determined by the engine's configuration."""
     logprobs_mode_override: LogprobsMode | None = None
 
     @staticmethod

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -16,6 +16,7 @@ from vllm.logger import init_logger
 from vllm.logits_process import LogitsProcessor
 from vllm.tokenizers import TokenizerLike
 from vllm.v1.serial_utils import PydanticMsgspecMixin
+from vllm.config.model import LogprobsMode
 
 logger = init_logger(__name__)
 
@@ -252,6 +253,11 @@ class SamplingParams(
 
     skip_reading_prefix_cache: bool | None = None
 
+    """Override logprobs_mode for this request.
+    If set, this will override the logprobs_mode for this request.
+    If None, the logprobs_mode will be determined by in `ModelConfig`."""
+    logprobs_mode_override: LogprobsMode | None = None
+
     @staticmethod
     def from_optional(
         n: int | None = 1,
@@ -282,6 +288,7 @@ class SamplingParams(
         logit_bias: dict[int, float] | dict[str, float] | None = None,
         allowed_token_ids: list[int] | None = None,
         extra_args: dict[str, Any] | None = None,
+        logprobs_mode_override: LogprobsMode | None = None,
         skip_clone: bool = False,
     ) -> "SamplingParams":
         if logit_bias is not None:
@@ -323,6 +330,7 @@ class SamplingParams(
             logit_bias=logit_bias,
             allowed_token_ids=allowed_token_ids,
             extra_args=extra_args,
+            logprobs_mode_override=logprobs_mode_override,
             skip_clone=skip_clone,
         )
 
@@ -632,3 +640,4 @@ class BeamSearchParams(
     temperature: float = 0.0
     length_penalty: float = 1.0
     include_stop_str_in_output: bool = False
+    logprobs_mode_override: LogprobsMode | None = None

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -45,4 +45,4 @@ class SamplingMetadata:
     spec_token_ids: list[list[int]] | None = None
 
     # Override the logprobs_mode
-    logprobs_mode_override: list[LogprobsMode] | None = None
+    logprobs_mode_override: LogprobsMode | list[LogprobsMode] | None = None

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 
 import torch
 
-from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.config.model import LogprobsMode
+from vllm.v1.sample.logits_processor import LogitsProcessors
 
 
 @dataclass

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import torch
 
 from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.config.model import LogprobsMode
 
 
 @dataclass
@@ -42,3 +43,6 @@ class SamplingMetadata:
 
     # Speculative token ids
     spec_token_ids: list[list[int]] | None = None
+
+    # Override the logprobs_mode
+    logprobs_mode_override: list[LogprobsMode] | None = None

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -45,4 +45,4 @@ class SamplingMetadata:
     spec_token_ids: list[list[int]] | None = None
 
     # Override the logprobs_mode
-    logprobs_mode_override: LogprobsMode | list[LogprobsMode] | None = None
+    logprobs_mode_override: LogprobsMode | list[LogprobsMode | None] | None = None

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 import torch
 
-from vllm.config.model import LogprobsMode
+from vllm.config.model import LogprobsList, LogprobsMode
 from vllm.v1.sample.logits_processor import LogitsProcessors
 
 
@@ -45,4 +45,4 @@ class SamplingMetadata:
     spec_token_ids: list[list[int]] | None = None
 
     # Override the logprobs_mode
-    logprobs_mode_override: LogprobsMode | list[LogprobsMode | None] | None = None
+    logprobs_mode_override: LogprobsMode | LogprobsList | None = None

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -103,13 +103,13 @@ class RejectionSampler(nn.Module):
             sampling_metadata=replace(
                 sampling_metadata,
                 max_num_logprobs=-1,
+                # Override the logprobs mode to return logits because they are
+                # needed later to compute the accepted token logprobs.
+                logprobs_mode_override="processed_logits"
+                if self.is_processed_logprobs_mode
+                else "raw_logits",
             ),
             predict_bonus_token=True,
-            # Override the logprobs mode to return logits because they are
-            # needed later to compute the accepted token logprobs.
-            logprobs_mode_override="processed_logits"
-            if self.is_processed_logprobs_mode
-            else "raw_logits",
         )
         bonus_token_ids = bonus_sampler_output.sampled_token_ids
 

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -5,7 +5,7 @@
 import torch
 import torch.nn as nn
 
-from vllm.config.model import LogprobsMode
+from vllm.config.model import LogprobsList, LogprobsMode
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.outputs import LogprobsTensors, SamplerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -73,9 +73,7 @@ class Sampler(nn.Module):
         # Use float32 for the logits.
         logits = logits.to(torch.float32)
 
-        logprobs_mode: (
-            list[LogprobsMode | None] | LogprobsMode | None
-        ) = self.logprobs_mode
+        logprobs_mode: LogprobsList | LogprobsMode | None = self.logprobs_mode
         if sampling_metadata.logprobs_mode_override is not None:
             logprobs_mode = sampling_metadata.logprobs_mode_override
             if isinstance(logprobs_mode, list):
@@ -179,9 +177,7 @@ class Sampler(nn.Module):
         may update the logits tensor in-place.
         """
 
-        logprobs_mode: (
-            list[LogprobsMode | None] | LogprobsMode | None
-        ) = self.logprobs_mode
+        logprobs_mode: LogprobsList | LogprobsMode | None = self.logprobs_mode
         if sampling_metadata.logprobs_mode_override is not None:
             logprobs_mode = sampling_metadata.logprobs_mode_override
             if isinstance(logprobs_mode, list):

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -99,9 +99,7 @@ class Sampler(nn.Module):
                 raw_logprobs = logits.clone()
 
                 raw_logprobs_indices = [
-                    i
-                    for i, mode in enumerate(logprobs_mode)
-                    if mode == "raw_logprobs"
+                    i for i, mode in enumerate(logprobs_mode) if mode == "raw_logprobs"
                 ]
                 if raw_logprobs_indices:
                     selected_logits = logits[raw_logprobs_indices]
@@ -109,9 +107,7 @@ class Sampler(nn.Module):
                     raw_logprobs[raw_logprobs_indices] = computed
                 
                 raw_indices = raw_logprobs_indices + [
-                    i
-                    for i, mode in enumerate(logprobs_mode)
-                    if mode == "raw_logits"
+                    i for i, mode in enumerate(logprobs_mode) if mode == "raw_logits"
                 ]
 
         logits = self.apply_logits_processors(

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -73,14 +73,15 @@ class Sampler(nn.Module):
         # Use float32 for the logits.
         logits = logits.to(torch.float32)
 
-        logprobs_mode: list[LogprobsMode | None] | LogprobsMode | None = self.logprobs_mode
+        logprobs_mode: (
+            list[LogprobsMode | None] | LogprobsMode | None
+        ) = self.logprobs_mode
         if sampling_metadata.logprobs_mode_override is not None:
             logprobs_mode = sampling_metadata.logprobs_mode_override
             if isinstance(logprobs_mode, list):
                 for i in range(len(logprobs_mode)):
                     if logprobs_mode[i] is None:
                         logprobs_mode[i] = self.logprobs_mode
-        # logger.info(f"sampling_metadata: {sampling_metadata}")
         # NOTE(woosuk): Use the original logits (before any penalties or
         # temperature scaling) for the top-k logprobs.
         # This is different from the V0 sampler, which uses the logits that
@@ -178,7 +179,9 @@ class Sampler(nn.Module):
         may update the logits tensor in-place.
         """
 
-        logprobs_mode: list[LogprobsMode | None] | LogprobsMode | None = self.logprobs_mode
+        logprobs_mode: (
+            list[LogprobsMode | None] | LogprobsMode | None
+        ) = self.logprobs_mode
         if sampling_metadata.logprobs_mode_override is not None:
             logprobs_mode = sampling_metadata.logprobs_mode_override
             if isinstance(logprobs_mode, list):

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -73,7 +73,7 @@ class Sampler(nn.Module):
         # Use float32 for the logits.
         logits = logits.to(torch.float32)
 
-        logprobs_mode = self.logprobs_mode
+        logprobs_mode: list[LogprobsMode] | LogprobsMode = self.logprobs_mode
         if sampling_metadata.logprobs_mode_override is not None:
             logprobs_mode = sampling_metadata.logprobs_mode_override
             if isinstance(logprobs_mode, list):
@@ -105,7 +105,7 @@ class Sampler(nn.Module):
                     selected_logits = logits[raw_logprobs_indices]
                     computed = self.compute_logprobs(selected_logits)
                     raw_logprobs[raw_logprobs_indices] = computed
-                
+
                 raw_indices = raw_logprobs_indices + [
                     i for i, mode in enumerate(logprobs_mode) if mode == "raw_logits"
                 ]
@@ -178,7 +178,7 @@ class Sampler(nn.Module):
         may update the logits tensor in-place.
         """
 
-        logprobs_mode = self.logprobs_mode
+        logprobs_mode: list[LogprobsMode] | LogprobsMode = self.logprobs_mode
         if sampling_metadata.logprobs_mode_override is not None:
             logprobs_mode = sampling_metadata.logprobs_mode_override
             if isinstance(logprobs_mode, list):

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -73,7 +73,7 @@ class Sampler(nn.Module):
         # Use float32 for the logits.
         logits = logits.to(torch.float32)
 
-        logprobs_mode: list[LogprobsMode] | LogprobsMode = self.logprobs_mode
+        logprobs_mode: list[LogprobsMode | None] | LogprobsMode | None = self.logprobs_mode
         if sampling_metadata.logprobs_mode_override is not None:
             logprobs_mode = sampling_metadata.logprobs_mode_override
             if isinstance(logprobs_mode, list):
@@ -178,7 +178,7 @@ class Sampler(nn.Module):
         may update the logits tensor in-place.
         """
 
-        logprobs_mode: list[LogprobsMode] | LogprobsMode = self.logprobs_mode
+        logprobs_mode: list[LogprobsMode | None] | LogprobsMode | None = self.logprobs_mode
         if sampling_metadata.logprobs_mode_override is not None:
             logprobs_mode = sampling_metadata.logprobs_mode_override
             if isinstance(logprobs_mode, list):

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -8,6 +8,7 @@ from typing import cast
 import numpy as np
 import torch
 
+from vllm.config.model import LogprobsMode
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
@@ -24,7 +25,6 @@ from vllm.v1.sample.logits_processor import (
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.utils import copy_slice
 from vllm.v1.worker.block_table import MultiGroupBlockTable
-from vllm.config.model import LogprobsMode
 
 
 @dataclass
@@ -1043,8 +1043,7 @@ class InputBatch:
 
     @property
     def logprobs_mode_override(self) -> LogprobsMode | list[LogprobsMode] | None:
-        if self.non_default_logprobs_mode==0:
+        if self.non_default_logprobs_mode == 0:
             return None
-        logprobs_mode = self.logprobs_mode[:self.num_reqs]
-        return (logprobs_mode[0] if len(set(logprobs_mode))==1
-            else logprobs_mode)
+        logprobs_mode = self.logprobs_mode[: self.num_reqs]
+        return logprobs_mode[0] if len(set(logprobs_mode)) == 1 else logprobs_mode

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -8,7 +8,7 @@ from typing import cast
 import numpy as np
 import torch
 
-from vllm.config.model import LogprobsMode
+from vllm.config.model import LogprobsList, LogprobsMode
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
@@ -224,9 +224,7 @@ class InputBatch:
 
         self.num_logprobs: dict[str, int] = {}
 
-        self.logprobs_mode: list[LogprobsMode | None] = [
-            None for _ in range(max_num_reqs)
-        ]
+        self.logprobs_mode: LogprobsList = [None for _ in range(max_num_reqs)]
         self.non_default_logprobs_mode: int = 0
 
         # To accumulate prompt logprobs tensor chunks across prefill steps.
@@ -1044,7 +1042,7 @@ class InputBatch:
         return len(self.has_allowed_token_ids) == 0
 
     @property
-    def logprobs_mode_override(self) -> LogprobsMode | list[LogprobsMode | None] | None:
+    def logprobs_mode_override(self) -> LogprobsMode | LogprobsList | None:
         if self.non_default_logprobs_mode == 0:
             return None
         logprobs_mode = self.logprobs_mode[: self.num_reqs]

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -1042,7 +1042,7 @@ class InputBatch:
         return len(self.has_allowed_token_ids) == 0
 
     @property
-    def logprobs_mode_override(self) -> list | None:
+    def logprobs_mode_override(self) -> LogprobsMode | list[LogprobsMode] | None:
         if self.non_default_logprobs_mode==0:
             return None
         logprobs_mode = self.logprobs_mode[:self.num_reqs]

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -224,7 +224,7 @@ class InputBatch:
 
         self.num_logprobs: dict[str, int] = {}
 
-        self.logprobs_mode: list[LogprobsMode] = [None for _ in range(max_num_reqs)]
+        self.logprobs_mode: list[LogprobsMode | None] = [None for _ in range(max_num_reqs)]
         self.non_default_logprobs_mode: int = 0
 
         # To accumulate prompt logprobs tensor chunks across prefill steps.

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -224,7 +224,9 @@ class InputBatch:
 
         self.num_logprobs: dict[str, int] = {}
 
-        self.logprobs_mode: list[LogprobsMode | None] = [None for _ in range(max_num_reqs)]
+        self.logprobs_mode: list[LogprobsMode | None] = [
+            None for _ in range(max_num_reqs)
+        ]
         self.non_default_logprobs_mode: int = 0
 
         # To accumulate prompt logprobs tensor chunks across prefill steps.
@@ -1042,7 +1044,7 @@ class InputBatch:
         return len(self.has_allowed_token_ids) == 0
 
     @property
-    def logprobs_mode_override(self) -> LogprobsMode | list[LogprobsMode] | None:
+    def logprobs_mode_override(self) -> LogprobsMode | list[LogprobsMode | None] | None:
         if self.non_default_logprobs_mode == 0:
             return None
         logprobs_mode = self.logprobs_mode[: self.num_reqs]


### PR DESCRIPTION
## Purpose
[Bugfix]
Current beam search implementation uses output logprobs to maintain beam states.
However, the default `logprobs_mode` in vLLM is `raw_logprobs`. This creates an inconsistency when a logits processor (e.g., for constrained decoding) is applied.

Beam search continues to use the raw, unprocessed log probabilities for beam scoring and selection, rather than the post-processed log probabilities. This can lead to suboptimal or incorrect beam trajectories, as the search is not guided by the actual constrained distribution.


https://github.com/vllm-project/vllm/blob/9432ed8c7e158def084e0770fd02838292bf57e4/vllm/entrypoints/llm.py#L588

https://github.com/vllm-project/vllm/blob/9432ed8c7e158def084e0770fd02838292bf57e4/vllm/entrypoints/openai/engine/serving.py#L283


[Core]
Currently, vLLM's logprobs_mode is applied uniformly to the entire batch during sampling. This design lacks the flexibility to specify an independent logprobs_mode for a single request. 

Therefore, I have introduced related control variables to `InputBatch`, `SamplingMetadata`, `BeamSearchParams`, and `SamplingParams`. This will enable controls over logprobs_mode at the granularity of individual requests. 

## Test Plan

vllm serve /workspace/Qwen3-0.6B --served-model-name Qwen3-0.6B --logprobs-mode raw_logits --logits-processors constrained_processor:ConstrainedLogitsProcessor

Send a large number of following requests concurrently:

```
curl -X POST http://localhost:8000/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "Qwen3-0.6B",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user", 
        "content": "Who are you?"
      }
    ],
    "stream": false,
    "max_tokens": 1,
    "use_beam_search": true,
    "n": 5,
    "logprobs": true,
    "top_logprobs": 5,
    "temperature": 0
  }'
```
```
curl -X POST http://localhost:8000/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "Qwen3-0.6B",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user", 
        "content": "Who are you?"
      }
    ],
    "stream": false,
    "max_tokens": 1,
    "logprobs": true,
    "top_logprobs": 5,
    "temperature": 0
  }'
```

## Test Result


Whether these two types of requests are sent separately or together, the normal requests always return raw_logits while beam search requests always return processed_logprobs constrained by the logits-processor.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

