### PR TITLE
[BUGFIX] Pixtral cannot be loaded with --limit-mm-per-prompt 0

### DIFF
--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -70,7 +70,7 @@ from .interfaces import (
     SupportsPP,
 )
 from .module_mapping import MultiModelKeys
-from .utils import init_vllm_registered_model, maybe_prefix
+from .utils import StageMissingLayer, init_vllm_registered_model, maybe_prefix
 from .vision import (
     VisionEncoderInfo,
     VisionFeatureSelectStrategy,
@@ -91,6 +91,10 @@ except ImportError:
     USE_XFORMERS_OPS = False
 
 PATCH_MERGE = "patch_merge"
+
+
+def _is_layer_none_or_staged(layer: nn.Module) -> bool:
+    return layer is None or isinstance(layer, StageMissingLayer)
 
 
 class PixtralImagePixelInputs(TensorSchema):
@@ -542,7 +546,7 @@ class PixtralForConditionalGeneration(
             # Single pass over weights
             for name, w in weights:
                 if is_vision_encoder_weights((name, w)):
-                    if self.vision_encoder is None:
+                    if _is_layer_none_or_staged(self.vision_encoder):
                         continue
                     # Load vision encoder weights directly
                     trimmed_name = ".".join(name.split(".")[1:])
@@ -551,7 +555,7 @@ class PixtralForConditionalGeneration(
                         with torch.no_grad():
                             default_weight_loader(param, w)
                 elif is_patch_merger((name, w)):
-                    if self.patch_merger is None:
+                    if _is_layer_none_or_staged(self.patch_merger):
                         continue
                     # Load vision patch merger weights directly
                     trimmed_name = ".".join(name.split(".")[1:])
@@ -559,7 +563,7 @@ class PixtralForConditionalGeneration(
                     with torch.no_grad():
                         default_weight_loader(param, w)
                 elif is_pre_mm_projector_norm((name, w)):
-                    if self.pre_mm_projector_norm is None:
+                    if _is_layer_none_or_staged(self.pre_mm_projector_norm):
                         continue
                     # Load vision pre_mm_projector_norm weights directly
                     trimmed_name = ".".join(name.split(".")[1:])
@@ -567,7 +571,7 @@ class PixtralForConditionalGeneration(
                     with torch.no_grad():
                         default_weight_loader(param, w)
                 elif is_vision_lang_adapter_weights((name, w)):
-                    if self.vision_language_adapter is None:
+                    if _is_layer_none_or_staged(self.vision_language_adapter):
                         continue
                     # Load vision-language adapter weights directly
                     trimmed_name = ".".join(name.split(".")[1:])


### PR DESCRIPTION
## Purpose

This PR fixes the loading of Pixtral model when the `--limit-mm-per-prompt` is set to 0 for images.

In such cases, the vision part is no longer `None` but `StageMissingLayer`. However as the vision weights exist the loading weight functions still try to load them in a non-existent module.

Fix #32959 in place of https://github.com/vllm-project/vllm/pull/33006 or https://github.com/vllm-project/vllm/pull/33008.

Thanks @dbary for informing me that the error was still present. I believe this PR should also be used for https://github.com/vllm-project/vllm/pull/33174. LMK if it works out for you :smile: 

## Test Plan

I checked it works for `mistralai/Mistral-Large-3-675B-Instruct-2512` and `mistralai/Devstral-Small-2-24B-Instruct-2512` for `--limit-mm-per-prompt` in [0,1].

## Test Result

Model is successfully loaded.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results