### PR TITLE
[Misc] Apply PEP 563 to replace quoted union types with unquoted ones

### DIFF
--- a/vllm/beam_search.py
+++ b/vllm/beam_search.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -27,7 +29,7 @@ class BeamSearchSequence:
     text: str | None = None
     finish_reason: str | None = None
     stop_reason: int | str | None = None
-    multi_modal_data: "MultiModalDataDict | None" = None
+    multi_modal_data: MultiModalDataDict | None = None
     mm_processor_kwargs: dict[str, Any] | None = None
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 import importlib
 from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
@@ -42,9 +44,9 @@ class KVConnectorFactory:
     @classmethod
     def create_connector(
         cls,
-        config: "VllmConfig",
+        config: VllmConfig,
         role: KVConnectorRole,
-        kv_cache_config: "KVCacheConfig | None" = None,
+        kv_cache_config: KVCacheConfig | None = None,
     ) -> KVConnectorBase:
         kv_transfer_config = config.kv_transfer_config
         if kv_transfer_config is None:
@@ -101,7 +103,7 @@ class KVConnectorFactory:
 
     @classmethod
     def _get_connector_class_with_compat(
-        cls, kv_transfer_config: "KVTransferConfig"
+        cls, kv_transfer_config: KVTransferConfig
     ) -> tuple[type[KVConnectorBaseType], bool]:
         connector_name = kv_transfer_config.kv_connector
         if connector_name is None:
@@ -132,7 +134,7 @@ class KVConnectorFactory:
 
     @classmethod
     def get_connector_class(
-        cls, kv_transfer_config: "KVTransferConfig"
+        cls, kv_transfer_config: KVTransferConfig
     ) -> type[KVConnectorBaseType]:
         """Get the connector class by name."""
         connector_cls, _ = cls._get_connector_class_with_compat(kv_transfer_config)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -38,6 +38,8 @@ The class provides the following primitives:
             ids of requests that have completed async sending/recving.
 """
 
+from __future__ import annotations
+
 import enum
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
@@ -89,7 +91,7 @@ class SupportsHMA(ABC):
     @abstractmethod
     def request_finished_all_groups(
         self,
-        request: "Request",
+        request: Request,
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
         """
@@ -159,9 +161,9 @@ class KVConnectorBase_V1(ABC):
 
     def __init__(
         self,
-        vllm_config: "VllmConfig",
+        vllm_config: VllmConfig,
         role: KVConnectorRole,
-        kv_cache_config: "KVCacheConfig | None" = None,
+        kv_cache_config: KVCacheConfig | None = None,
     ):
         logger.warning(
             "Initializing KVConnectorBase_V1. This API is experimental and "
@@ -242,7 +244,7 @@ class KVConnectorBase_V1(ABC):
         return
 
     def register_cross_layers_kv_cache(
-        self, kv_cache: torch.Tensor, attn_backend: type["AttentionBackend"]
+        self, kv_cache: torch.Tensor, attn_backend: type[AttentionBackend]
     ):
         """
         Initialize with a single KV cache tensor used by all layers.
@@ -273,7 +275,7 @@ class KVConnectorBase_V1(ABC):
         return
 
     @abstractmethod
-    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
+    def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
         """
         Start loading the KV cache from the connector to vLLM's paged
         KV buffer. This is called from the forward context before the
@@ -309,7 +311,7 @@ class KVConnectorBase_V1(ABC):
         self,
         layer_name: str,
         kv_layer: torch.Tensor,
-        attn_metadata: "AttentionMetadata",
+        attn_metadata: AttentionMetadata,
         **kwargs: Any,
     ) -> None:
         """
@@ -383,13 +385,13 @@ class KVConnectorBase_V1(ABC):
         """
         return None
 
-    def get_kv_connector_stats(self) -> "KVConnectorStats | None":
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
         """
         Get the KV connector stats collected during the last interval.
         """
         return None
 
-    def get_kv_connector_kv_cache_events(self) -> "KVConnectorKVEvents | None":
+    def get_kv_connector_kv_cache_events(self) -> KVConnectorKVEvents | None:
         """
         Get the KV connector kv cache events collected during the last interval.
         This function should be called by the model runner every time after the
@@ -416,7 +418,7 @@ class KVConnectorBase_V1(ABC):
     @abstractmethod
     def get_num_new_matched_tokens(
         self,
-        request: "Request",
+        request: Request,
         num_computed_tokens: int,
     ) -> tuple[int | None, bool]:
         """
@@ -450,7 +452,7 @@ class KVConnectorBase_V1(ABC):
 
     @abstractmethod
     def update_state_after_alloc(
-        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
         """
         Update KVConnector state after block allocation.
@@ -496,7 +498,7 @@ class KVConnectorBase_V1(ABC):
 
     def request_finished(
         self,
-        request: "Request",
+        request: Request,
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
         """
@@ -515,7 +517,7 @@ class KVConnectorBase_V1(ABC):
         """
         return False, None
 
-    def take_events(self) -> Iterable["KVCacheEvent"]:
+    def take_events(self) -> Iterable[KVCacheEvent]:
         """
         Take the KV cache events from the connector.
 
@@ -525,7 +527,7 @@ class KVConnectorBase_V1(ABC):
         return ()
 
     @classmethod
-    def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:
+    def get_required_kvcache_layout(cls, vllm_config: VllmConfig) -> str | None:
         """
         Get the required KV cache layout for this connector.
         Args:
@@ -558,7 +560,7 @@ class KVConnectorBase_V1(ABC):
     @classmethod
     def build_kv_connector_stats(
         cls, data: dict[str, Any] | None = None
-    ) -> "KVConnectorStats | None":
+    ) -> KVConnectorStats | None:
         """
         KVConnectorStats resolution method. This method allows dynamically
         registered connectors to return their own KVConnectorStats object,
@@ -580,11 +582,11 @@ class KVConnectorBase_V1(ABC):
     @classmethod
     def build_prom_metrics(
         cls,
-        vllm_config: "VllmConfig",
-        metric_types: dict[type["PromMetric"], type["PromMetricT"]],
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
         labelnames: list[str],
         per_engine_labelvalues: dict[int, list[object]],
-    ) -> "KVConnectorPromMetrics | None":
+    ) -> KVConnectorPromMetrics | None:
         """
         Create a KVConnectorPromMetrics subclass which should register
         per-connector Prometheus metrics and implement observe() to

--- a/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
@@ -31,6 +31,8 @@ Usage:
           Set to 0 for constant values, >0 for random sampling
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -82,9 +84,9 @@ class DecodeBenchConnector(KVConnectorBase_V1):
 
     def __init__(
         self,
-        vllm_config: "VllmConfig",
+        vllm_config: VllmConfig,
         role: KVConnectorRole,
-        kv_cache_config: "KVCacheConfig | None" = None,
+        kv_cache_config: KVCacheConfig | None = None,
     ):
         super().__init__(vllm_config, role, kv_cache_config)
 
@@ -104,7 +106,7 @@ class DecodeBenchConnector(KVConnectorBase_V1):
         assert self.connector_worker is not None
         self.connector_worker.register_kv_caches(kv_caches)
 
-    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
+    def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
         assert self.connector_worker is not None
         assert isinstance(self._connector_metadata, DecodeBenchConnectorMetadata)
         self.connector_worker.start_fill_kv(self._connector_metadata)
@@ -133,7 +135,7 @@ class DecodeBenchConnector(KVConnectorBase_V1):
 
     def get_num_new_matched_tokens(
         self,
-        request: "Request",
+        request: Request,
         num_computed_tokens: int,
     ) -> tuple[int | None, bool]:
         assert self.connector_scheduler is not None
@@ -142,7 +144,7 @@ class DecodeBenchConnector(KVConnectorBase_V1):
         )
 
     def update_state_after_alloc(
-        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.update_state_after_alloc(
@@ -150,14 +152,14 @@ class DecodeBenchConnector(KVConnectorBase_V1):
         )
 
     def build_connector_meta(
-        self, scheduler_output: "SchedulerOutput"
+        self, scheduler_output: SchedulerOutput
     ) -> KVConnectorMetadata:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.build_connector_meta(scheduler_output)
 
     def request_finished(
         self,
-        request: "Request",
+        request: Request,
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
         assert self.connector_scheduler is not None
@@ -168,7 +170,7 @@ class DecodeBenchConnector(KVConnectorBase_V1):
 class DecodeBenchConnectorScheduler:
     """Scheduler-side implementation for DecodeBenchConnector."""
 
-    def __init__(self, vllm_config: "VllmConfig"):
+    def __init__(self, vllm_config: VllmConfig):
         self.vllm_config = vllm_config
         self.block_size = vllm_config.cache_config.block_size
 
@@ -183,7 +185,7 @@ class DecodeBenchConnectorScheduler:
 
     def get_num_new_matched_tokens(
         self,
-        request: "Request",
+        request: Request,
         num_computed_tokens: int,
     ) -> tuple[int, bool]:
         """
@@ -216,7 +218,7 @@ class DecodeBenchConnectorScheduler:
         return num_tokens_to_fill, False
 
     def update_state_after_alloc(
-        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
         """
         Called after blocks are allocated. Store the block IDs so we can
@@ -263,7 +265,7 @@ class DecodeBenchConnectorScheduler:
         )
 
     def build_connector_meta(
-        self, scheduler_output: "SchedulerOutput"
+        self, scheduler_output: SchedulerOutput
     ) -> KVConnectorMetadata:
         """
         Build metadata containing information about which blocks to fill
@@ -276,7 +278,7 @@ class DecodeBenchConnectorScheduler:
 
         return meta
 
-    def request_finished(self, request: "Request"):
+    def request_finished(self, request: Request):
         """
         Called when a request has finished. Clean up any state.
         """
@@ -286,7 +288,7 @@ class DecodeBenchConnectorScheduler:
 class DecodeBenchConnectorWorker:
     """Worker-side implementation for DecodeBenchConnector."""
 
-    def __init__(self, vllm_config: "VllmConfig"):
+    def __init__(self, vllm_config: VllmConfig):
         self.vllm_config = vllm_config
         self.block_size = vllm_config.cache_config.block_size
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_connector.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -45,7 +47,7 @@ class ReqMeta:
         block_size: int,
         is_store: bool,
         mm_hashes: list[str],
-    ) -> "ReqMeta":
+    ) -> ReqMeta:
         valid_num_tokens = align_to_block_size(len(token_ids), block_size)
         token_ids_tensor = torch.tensor(token_ids)[:valid_num_tokens]
         block_ids_tensor = torch.tensor(block_ids)
@@ -89,9 +91,9 @@ class ExampleConnector(KVConnectorBase_V1):
 
     def __init__(
         self,
-        vllm_config: "VllmConfig",
+        vllm_config: VllmConfig,
         role: KVConnectorRole,
-        kv_cache_config: "KVCacheConfig | None" = None,
+        kv_cache_config: KVCacheConfig | None = None,
     ):
         super().__init__(
             vllm_config=vllm_config,
@@ -106,7 +108,7 @@ class ExampleConnector(KVConnectorBase_V1):
         logger.info(self._kv_transfer_config)
         logger.info("Shared storage path is %s", self._storage_path)
 
-    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
+    def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
         """Start loading the KV cache from the connector buffer to vLLM's
         paged KV buffer.
 
@@ -256,7 +258,7 @@ class ExampleConnector(KVConnectorBase_V1):
 
     def get_num_new_matched_tokens(
         self,
-        request: "Request",
+        request: Request,
         num_computed_tokens: int,
     ) -> tuple[int | None, bool]:
         """
@@ -292,7 +294,7 @@ class ExampleConnector(KVConnectorBase_V1):
         return num_tokens_to_check - num_computed_tokens, False
 
     def update_state_after_alloc(
-        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
         """
         Update KVConnector state after block allocation.
@@ -385,7 +387,7 @@ class ExampleConnector(KVConnectorBase_V1):
 
     def _found_match_for_request(
         self,
-        request: "Request",
+        request: Request,
     ) -> bool:
         """Check if the cache is hit for the request."""
         return self._found_match_for_prompt(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Standard
+from __future__ import annotations
+
 import os
 import uuid
 from collections.abc import Generator
@@ -140,7 +142,7 @@ class RequestTracker:
 
     # Multimodal hashes and positions
     mm_hashes: list[str] | None = None
-    mm_positions: list["PlaceholderRange"] | None = None
+    mm_positions: list[PlaceholderRange] | None = None
 
     # The configs of the request, includes tags and other configs
     request_configs: dict | None = None
@@ -155,11 +157,11 @@ class RequestTracker:
     @staticmethod
     def from_new_request(
         lmcache_config: LMCacheEngineConfig,
-        new_request: "NewRequestData",
+        new_request: NewRequestData,
         num_tokens_to_compute: int,
         lmcache_cached_tokens: int,
         skip_save: bool,
-    ) -> "RequestTracker":
+    ) -> RequestTracker:
         """Create the request tracker from a new request.
 
         Args:
@@ -274,7 +276,7 @@ class ReqMeta:
         load_spec: LoadSpec | None = None,
         discard_partial_chunks: bool = True,
         save_decode_cache: bool = False,
-    ) -> "ReqMeta | None":
+    ) -> ReqMeta | None:
         """Create the request metadata from a request tracker.
 
         Args:
@@ -432,7 +434,7 @@ def _calculate_mtp_layers(vllm_config, model_config):
 
 def _init_lmcache_engine(
     lmcache_config: LMCacheEngineConfig,
-    vllm_config: "VllmConfig",
+    vllm_config: VllmConfig,
 ) -> LMCacheEngine:
     """Initialize the LMCache engine by the given model config and parallel
     config. This function will check the environment variable
@@ -570,7 +572,7 @@ class LMCacheConnectorMetadata(KVConnectorMetadata):
 class LMCacheConnectorV1Impl:
     def __init__(
         self,
-        vllm_config: "VllmConfig",
+        vllm_config: VllmConfig,
         role: KVConnectorRole,
         parent: KVConnectorBase_V1,
     ):
@@ -770,7 +772,7 @@ class LMCacheConnectorV1Impl:
         return VLLM_VERSION
 
     @_lmcache_nvtx_annotate
-    def _init_kv_caches_from_forward_context(self, forward_context: "ForwardContext"):
+    def _init_kv_caches_from_forward_context(self, forward_context: ForwardContext):
         for layer_name in forward_context.no_compile_layers:
             attn_layer = forward_context.no_compile_layers[layer_name]
             if not hasattr(attn_layer, "kv_cache"):
@@ -797,7 +799,7 @@ class LMCacheConnectorV1Impl:
             self.lmcache_engine.post_init(kvcaches=kvcaches)
 
     @_lmcache_nvtx_annotate
-    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
+    def start_load_kv(self, forward_context: ForwardContext, **kwargs) -> None:
         """Start loading the KV cache from the connector buffer to vLLM's
         paged KV buffer.
 
@@ -1142,7 +1144,7 @@ class LMCacheConnectorV1Impl:
     @_lmcache_nvtx_annotate
     def get_num_new_matched_tokens(
         self,
-        request: "Request",
+        request: Request,
         num_computed_tokens: int,
     ) -> int | None:
         """
@@ -1230,7 +1232,7 @@ class LMCacheConnectorV1Impl:
         return need_to_allocate
 
     @_lmcache_nvtx_annotate
-    def update_state_after_alloc(self, request: "Request", num_external_tokens: int):
+    def update_state_after_alloc(self, request: Request, num_external_tokens: int):
         """
         Update KVConnector state after temporary buffer alloc.
 
@@ -1411,7 +1413,7 @@ class LMCacheConnectorV1Impl:
     @_lmcache_nvtx_annotate
     def request_finished(
         self,
-        request: "Request",
+        request: Request,
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
         params = (

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import enum
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -131,7 +133,7 @@ def create_worker_adapter(
 
 
 def convert_block_hashes_to_bytes(
-    block_hashes: list["BlockHash"],
+    block_hashes: list[BlockHash],
 ) -> list[bytes]:
     return cast(list[bytes], block_hashes)
 
@@ -157,7 +159,7 @@ class LMCacheMPRequestTracker:
 
     # Read-only lists to track the token ids and block hashes
     all_token_ids: ConstantList[int]
-    block_hashes: ConstantList["BlockHash"]
+    block_hashes: ConstantList[BlockHash]
 
     # Block ids and hashes will be updated at update_states_after_alloc and
     # during the generation
@@ -179,7 +181,7 @@ class LMCacheMPRequestTracker:
     # Main state
     state: LMCacheMPRequestState = LMCacheMPRequestState.PREFETCHING
 
-    def __init__(self, request: "Request"):
+    def __init__(self, request: Request):
         self.request_id = request.request_id
         self.all_token_ids = request.all_token_ids
         self.block_hashes = ConstantList(request.block_hashes)
@@ -259,7 +261,7 @@ class LMCacheMPRequestMetadata:
         tracker: LMCacheMPRequestTracker,
         blocks_in_chunk: int,
         vllm_block_size: int,
-    ) -> "LMCacheMPRequestMetadata | None":
+    ) -> LMCacheMPRequestMetadata | None:
         """
         Generate the store metadata for the current request tracker.
 
@@ -303,7 +305,7 @@ class LMCacheMPRequestMetadata:
     def GetRetrieveMetadata(
         tracker: LMCacheMPRequestTracker,
         blocks_in_chunk: int,
-    ) -> "LMCacheMPRequestMetadata | None":
+    ) -> LMCacheMPRequestMetadata | None:
         """
         Generate the retrieve metadata for the current request tracker.
 
@@ -383,9 +385,9 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
     def __init__(
         self,
-        vllm_config: "VllmConfig",
+        vllm_config: VllmConfig,
         role: KVConnectorRole,
-        kv_cache_config: "KVCacheConfig | None" = None,
+        kv_cache_config: KVCacheConfig | None = None,
     ):
         super().__init__(vllm_config, role, kv_cache_config)
 
@@ -446,7 +448,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         self.worker_adapter.register_kv_caches(kv_caches)
         return
 
-    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
+    def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
         """
         Start loading the KV cache from the connector to vLLM's paged
         KV buffer. This is called from the forward context before the
@@ -595,7 +597,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             self.worker_adapter.shutdown()
         return None
 
-    def get_kv_connector_stats(self) -> "KVConnectorStats | None":
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
         """
         Get the KV connector stats collected during the last interval.
         """
@@ -607,7 +609,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
     def get_num_new_matched_tokens(
         self,
-        request: "Request",
+        request: Request,
         num_computed_tokens: int,
     ) -> tuple[int | None, bool]:
         """
@@ -674,7 +676,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         return need_to_load, need_to_load > 0
 
     def update_state_after_alloc(
-        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
         """
         Update KVConnector state after block allocation.
@@ -747,7 +749,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
     def request_finished(
         self,
-        request: "Request",
+        request: Request,
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
         """
@@ -768,7 +770,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         self._cleanup_request_tracker(request.request_id)
         return True, None
 
-    def take_events(self) -> Iterable["KVCacheEvent"]:
+    def take_events(self) -> Iterable[KVCacheEvent]:
         """
         Take the KV cache events from the connector.
 
@@ -778,7 +780,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         return ()
 
     @classmethod
-    def get_required_kvcache_layout(cls, vllm_config: "VllmConfig") -> str | None:
+    def get_required_kvcache_layout(cls, vllm_config: VllmConfig) -> str | None:
         """
         Get the required KV cache layout for this connector.
         Args:
@@ -810,7 +812,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
     @classmethod
     def build_kv_connector_stats(
         cls, data: dict[str, Any] | None = None
-    ) -> "KVConnectorStats | None":
+    ) -> KVConnectorStats | None:
         """
         KVConnectorStats resolution method. This method allows dynamically
         registered connectors to return their own KVConnectorStats object,
@@ -821,11 +823,11 @@ class LMCacheMPConnector(KVConnectorBase_V1):
     @classmethod
     def build_prom_metrics(
         cls,
-        vllm_config: "VllmConfig",
-        metric_types: dict[type["PromMetric"], type["PromMetricT"]],
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
         labelnames: list[str],
         per_engine_labelvalues: dict[int, list[object]],
-    ) -> "KVConnectorPromMetrics | None":
+    ) -> KVConnectorPromMetrics | None:
         """
         Create a KVConnectorPromMetrics subclass which should register
         per-connector Prometheus metrics and implement observe() to
@@ -905,7 +907,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         return self.request_trackers[request_id]
 
     def _get_or_create_request_tracker(
-        self, request: "Request"
+        self, request: Request
     ) -> LMCacheMPRequestTracker:
         request_id = request.request_id
         # Remove the old trackers that is created before the preemption

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake_connector.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import asyncio
 import threading
 import time
@@ -115,7 +117,7 @@ class MooncakeConnector(KVConnectorBase_V1):
         self,
         vllm_config: VllmConfig,
         role: KVConnectorRole,
-        kv_cache_config: "KVCacheConfig | None" = None,
+        kv_cache_config: KVCacheConfig | None = None,
     ):
         super().__init__(vllm_config, role, kv_cache_config)
 
@@ -137,7 +139,7 @@ class MooncakeConnector(KVConnectorBase_V1):
     ############################################################
 
     def get_num_new_matched_tokens(
-        self, request: "Request", num_computed_tokens: int
+        self, request: Request, num_computed_tokens: int
     ) -> tuple[int, bool]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.get_num_new_matched_tokens(
@@ -145,7 +147,7 @@ class MooncakeConnector(KVConnectorBase_V1):
         )
 
     def update_state_after_alloc(
-        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.update_state_after_alloc(
@@ -161,7 +163,7 @@ class MooncakeConnector(KVConnectorBase_V1):
 
     def request_finished(
         self,
-        request: "Request",
+        request: Request,
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
         assert self.connector_scheduler is not None
@@ -181,7 +183,7 @@ class MooncakeConnector(KVConnectorBase_V1):
         assert self.connector_worker is not None
         return self.connector_worker.get_finished()
 
-    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
+    def start_load_kv(self, forward_context: ForwardContext, **kwargs) -> None:
         assert self.connector_worker is not None
         assert isinstance(self._connector_metadata, MooncakeConnectorMetadata)
         self.connector_worker.start_load_kv(self._connector_metadata)
@@ -224,7 +226,7 @@ class MooncakeConnectorScheduler:
         self._reqs_need_send: dict[ReqId, list[int]] = {}
 
     def get_num_new_matched_tokens(
-        self, request: "Request", num_computed_tokens: int
+        self, request: Request, num_computed_tokens: int
     ) -> tuple[int, bool]:
         """
         For remote prefill, pull all prompt blocks from remote
@@ -260,7 +262,7 @@ class MooncakeConnectorScheduler:
         return 0, False
 
     def update_state_after_alloc(
-        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
         params = request.kv_transfer_params
         logger.debug(
@@ -328,7 +330,7 @@ class MooncakeConnectorScheduler:
 
     def request_finished(
         self,
-        request: "Request",
+        request: Request,
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
         """

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import contextlib
 import threading
 import time
@@ -101,14 +103,14 @@ class MoRIIOAgentMetadata(
 class RoleManager:
     """Manages role state across the connector."""
 
-    _instance: "RoleManager | None" = None
+    _instance: RoleManager | None = None
     _lock = threading.Lock()
 
     def __init__(self) -> None:
         self._role: ROLE = ROLE.NOTINIT
 
     @classmethod
-    def get_instance(cls) -> "RoleManager":
+    def get_instance(cls) -> RoleManager:
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
@@ -187,7 +189,7 @@ class MoRIIOConfig:
     tp_size: int
 
     @classmethod
-    def from_vllm_config(cls, vllm_config: VllmConfig) -> "MoRIIOConfig":
+    def from_vllm_config(cls, vllm_config: VllmConfig) -> MoRIIOConfig:
         # Port Configuration:
         # local_ping_port   -> Outgoing heartbeat to proxy
         # proxy_ping_port   -> Remote proxy's heartbeat ingress port

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import logging
 import math
 import queue
@@ -90,7 +92,7 @@ class MoRIIOConnector(KVConnectorBase_V1):
         self,
         vllm_config: VllmConfig,
         role: KVConnectorRole,
-        kv_cache_config: "KVCacheConfig | None" = None,
+        kv_cache_config: KVCacheConfig | None = None,
     ):
         super().__init__(vllm_config, role)
         assert vllm_config.kv_transfer_config is not None, (
@@ -138,7 +140,7 @@ class MoRIIOConnector(KVConnectorBase_V1):
             extra_config["notify_port"] = MoRIIOConstants.DEFAULT_NOTIFY_PORT
 
     def get_num_new_matched_tokens(
-        self, request: "Request", num_computed_tokens: int
+        self, request: Request, num_computed_tokens: int
     ) -> tuple[int, bool]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.get_num_new_matched_tokens(
@@ -146,7 +148,7 @@ class MoRIIOConnector(KVConnectorBase_V1):
         )
 
     def update_state_after_alloc(
-        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.update_state_after_alloc(
@@ -162,7 +164,7 @@ class MoRIIOConnector(KVConnectorBase_V1):
 
     def request_finished(
         self,
-        request: "Request",
+        request: Request,
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
         assert self.connector_scheduler is not None
@@ -180,7 +182,7 @@ class MoRIIOConnector(KVConnectorBase_V1):
         assert self.connector_worker is not None
         return self.connector_worker.get_finished()
 
-    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
+    def start_load_kv(self, forward_context: ForwardContext, **kwargs) -> None:
         assert self.connector_worker is not None
         if self.mode == MoRIIOMode.WRITE and get_role() == ROLE.CONSUMER:
             self.connector_worker.moriio_wrapper.async_wait_reqid()
@@ -195,7 +197,7 @@ class MoRIIOConnector(KVConnectorBase_V1):
         self,
         layer_name: str,
         kv_layer: torch.Tensor,
-        attn_metadata: "AttentionMetadata",
+        attn_metadata: AttentionMetadata,
         **kwargs,
     ) -> None:
         # Only producer/prefill saves KV Cache
@@ -280,7 +282,7 @@ class MoRIIOConnectorScheduler:
 
     def get_num_new_matched_tokens(
         self,
-        request: "Request",
+        request: Request,
         num_computed_tokens: int,
     ) -> tuple[int, bool]:
         """
@@ -330,10 +332,10 @@ class MoRIIOConnectorScheduler:
 
     def update_state_after_alloc(
         self,
-        request: "Request",
-        blocks: "KVCacheBlocks",
+        request: Request,
+        blocks: KVCacheBlocks,
         num_external_tokens: int,
-        connector_worker: "MoRIIOConnectorWorker | None" = None,
+        connector_worker: MoRIIOConnectorWorker | None = None,
     ):
         params = request.kv_transfer_params
         if not params:
@@ -498,7 +500,7 @@ class MoRIIOConnectorScheduler:
 
     def request_finished(
         self,
-        request: "Request",
+        request: Request,
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
         """
@@ -1217,7 +1219,7 @@ class MoRIIOConnectorWorker:
         metadata: MoRIIOConnectorMetadata,
         layer_name: str,
         kv_layer: torch.Tensor,
-        attn_metadata: "AttentionMetadata",
+        attn_metadata: AttentionMetadata,
         **kwargs,
     ):
         if not self.is_producer:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import threading
 from typing import TYPE_CHECKING, Any
 from weakref import ref as weakref_ref
@@ -63,7 +65,7 @@ class MoRIIOWriter:
     Implements distributed KV cache transfer using the MoRIIO library
     for RDMA-based communication between prefill and decode instances."""
 
-    def __init__(self, worker: "MoRIIOConnectorWorker"):
+    def __init__(self, worker: MoRIIOConnectorWorker):
         """Initialize the writer.
 
         Args:
@@ -76,7 +78,7 @@ class MoRIIOWriter:
         self._deferred_tasks: list[WriteTask] = []
 
     @property
-    def worker(self) -> "MoRIIOConnectorWorker":
+    def worker(self) -> MoRIIOConnectorWorker:
         """Get the worker instance.
 
         Returns:
@@ -340,7 +342,7 @@ class MoRIIOWrapper:
 
     def __init__(
         self,
-        moriio_engine: "IOEngine | None" = None,
+        moriio_engine: IOEngine | None = None,
         tp_rank: int = 0,
         dp_rank: int = 0,
     ):

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 import contextlib
 import copy
 import logging
@@ -302,7 +304,7 @@ class NixlConnector(KVConnectorBase_V1):
         self,
         vllm_config: VllmConfig,
         role: KVConnectorRole,
-        kv_cache_config: "KVCacheConfig | None" = None,
+        kv_cache_config: KVCacheConfig | None = None,
     ):
         super().__init__(vllm_config, role, kv_cache_config)
 
@@ -346,7 +348,7 @@ class NixlConnector(KVConnectorBase_V1):
     ############################################################
 
     def get_num_new_matched_tokens(
-        self, request: "Request", num_computed_tokens: int
+        self, request: Request, num_computed_tokens: int
     ) -> tuple[int | None, bool]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.get_num_new_matched_tokens(
@@ -354,7 +356,7 @@ class NixlConnector(KVConnectorBase_V1):
         )
 
     def update_state_after_alloc(
-        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.update_state_after_alloc(
@@ -370,7 +372,7 @@ class NixlConnector(KVConnectorBase_V1):
 
     def request_finished(
         self,
-        request: "Request",
+        request: Request,
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
         assert self.connector_scheduler is not None
@@ -436,7 +438,7 @@ class NixlConnector(KVConnectorBase_V1):
             vllm_config, metric_types, labelnames, per_engine_labelvalues
         )
 
-    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
+    def start_load_kv(self, forward_context: ForwardContext, **kwargs) -> None:
         assert self.connector_worker is not None
         assert isinstance(self._connector_metadata, NixlConnectorMetadata)
         self.connector_worker.start_load_kv(self._connector_metadata)
@@ -604,7 +606,7 @@ class NixlConnectorScheduler:
                 sock.send_multipart((identity, b"", encoded_data[target_tp_rank]))
 
     def get_num_new_matched_tokens(
-        self, request: "Request", num_computed_tokens: int
+        self, request: Request, num_computed_tokens: int
     ) -> tuple[int, bool]:
         """
         For remote prefill, pull all prompt blocks from remote
@@ -640,7 +642,7 @@ class NixlConnectorScheduler:
         return 0, False
 
     def update_state_after_alloc(
-        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
         params = request.kv_transfer_params
         logger.debug(
@@ -751,7 +753,7 @@ class NixlConnectorScheduler:
 
     def request_finished(
         self,
-        request: "Request",
+        request: Request,
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
         """
@@ -2529,7 +2531,7 @@ class NixlKVConnectorStats(KVConnectorStats):
         """Record a request that had its KV blocks expire."""
         self.data["num_kv_expired_reqs"].append(1)
 
-    def clone_and_reset(self) -> "NixlKVConnectorStats":
+    def clone_and_reset(self) -> NixlKVConnectorStats:
         old = copy.copy(self)
         self.reset()
         return old

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -43,7 +45,7 @@ class ReqMeta:
     @staticmethod
     def make_meta(
         request_id: str, token_ids: list[int], block_ids: list[int], block_size: int
-    ) -> "ReqMeta":
+    ) -> ReqMeta:
         block_ids_tensor = torch.tensor(block_ids)
         return ReqMeta(
             request_id=request_id,
@@ -74,9 +76,9 @@ class P2pNcclConnectorMetadata(KVConnectorMetadata):
 class P2pNcclConnector(KVConnectorBase_V1):
     def __init__(
         self,
-        vllm_config: "VllmConfig",
+        vllm_config: VllmConfig,
         role: KVConnectorRole,
-        kv_cache_config: "KVCacheConfig | None" = None,
+        kv_cache_config: KVCacheConfig | None = None,
     ):
         super().__init__(
             vllm_config=vllm_config,
@@ -108,7 +110,7 @@ class P2pNcclConnector(KVConnectorBase_V1):
     # Worker-side methods
     # ==============================
 
-    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
+    def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
         """Start loading the KV cache from the connector buffer to vLLM's
         paged KV buffer.
 
@@ -336,7 +338,7 @@ class P2pNcclConnector(KVConnectorBase_V1):
 
     def get_num_new_matched_tokens(
         self,
-        request: "Request",
+        request: Request,
         num_computed_tokens: int,
     ) -> tuple[int, bool]:
         """
@@ -364,7 +366,7 @@ class P2pNcclConnector(KVConnectorBase_V1):
         return num_external_tokens, False
 
     def update_state_after_alloc(
-        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+        self, request: Request, blocks: KVCacheBlocks, num_external_tokens: int
     ):
         """
         Update KVConnector state after block allocation.
@@ -477,7 +479,7 @@ class P2pNcclConnector(KVConnectorBase_V1):
 
     def request_finished(
         self,
-        request: "Request",
+        request: Request,
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
         """

--- a/vllm/distributed/kv_transfer/kv_transfer_state.py
+++ b/vllm/distributed/kv_transfer/kv_transfer_state.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from vllm.distributed.kv_transfer.kv_connector.base import KVConnectorBaseType
@@ -49,7 +51,7 @@ def is_v1_kv_transfer_group(connector: KVConnectorBaseType | None = None) -> boo
 
 
 def ensure_kv_transfer_initialized(
-    vllm_config: "VllmConfig", kv_cache_config: "KVCacheConfig | None" = None
+    vllm_config: VllmConfig, kv_cache_config: KVCacheConfig | None = None
 ) -> None:
     """
     Initialize KV cache transfer parallel group.

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -23,6 +23,8 @@ If you only need to use the distributed environment without model/pipeline
  steps.
 """
 
+from __future__ import annotations
+
 import contextlib
 import gc
 import pickle
@@ -106,10 +108,10 @@ def _get_unique_name(name: str) -> str:
     return newname
 
 
-_groups: dict[str, Callable[[], "GroupCoordinator | None"]] = {}
+_groups: dict[str, Callable[[], GroupCoordinator | None]] = {}
 
 
-def _register_group(group: "GroupCoordinator") -> None:
+def _register_group(group: GroupCoordinator) -> None:
     _groups[group.unique_name] = weakref.ref(group)
 
 
@@ -784,7 +786,7 @@ class GroupCoordinator:
         self,
         tensor_dict: dict[str, torch.Tensor | Any],
         dst: int | None = None,
-        all_gather_group: "GroupCoordinator | None" = None,
+        all_gather_group: GroupCoordinator | None = None,
         all_gather_tensors: dict[str, bool] | None = None,
     ) -> dict[str, torch.Tensor | Any] | None:
         """Send the input tensor dictionary.
@@ -871,7 +873,7 @@ class GroupCoordinator:
     def recv_tensor_dict(
         self,
         src: int | None = None,
-        all_gather_group: "GroupCoordinator | None" = None,
+        all_gather_group: GroupCoordinator | None = None,
         all_gather_tensors: dict[str, bool] | None = None,
     ) -> dict[str, torch.Tensor | Any] | None:
         """Recv the input tensor dictionary.

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Pydantic models for Anthropic API protocol"""
 
+from __future__ import annotations
+
 import time
 from typing import Any, Literal
 
@@ -135,7 +137,7 @@ class AnthropicStreamEvent(BaseModel):
         "ping",
         "error",
     ]
-    message: "AnthropicMessagesResponse | None" = None
+    message: AnthropicMessagesResponse | None = None
     delta: AnthropicDelta | None = None
     content_block: AnthropicContentBlock | None = None
     index: int | None = None

--- a/vllm/lora/lora_weights.py
+++ b/vllm/lora/lora_weights.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from collections.abc import Sequence as GenericSequence
 
 import torch
@@ -33,7 +35,7 @@ class LoRALayerWeights:
         else:
             self.scaling = scaling
 
-    def optimize(self) -> "LoRALayerWeights":
+    def optimize(self) -> LoRALayerWeights:
         """Optimize the LoRA by merging the scaling into lora_b."""
         if self.scaling == 1:
             return self
@@ -58,7 +60,7 @@ class LoRALayerWeights:
         cls,
         module_name: str,
         peft_helper: PEFTHelper,
-    ) -> "LoRALayerWeights":
+    ) -> LoRALayerWeights:
         # lora_a and lora_b are set to None for config-based construction
         return cls(
             module_name,
@@ -78,7 +80,7 @@ class LoRALayerWeights:
         rank: int,
         dtype: torch.dtype,
         device: torch.types.Device,
-    ) -> "LoRALayerWeights":
+    ) -> LoRALayerWeights:
         pin_memory = str(device) == "cpu" and is_pin_memory_available()
         lora_a = torch.zeros(
             [rank, input_dim], dtype=dtype, device=device, pin_memory=pin_memory
@@ -125,8 +127,8 @@ class PackedLoRALayerWeights(LoRALayerWeights):
 
     @classmethod
     def pack(
-        cls, loras: GenericSequence["LoRALayerWeights | None"]
-    ) -> "PackedLoRALayerWeights":
+        cls, loras: GenericSequence[LoRALayerWeights | None]
+    ) -> PackedLoRALayerWeights:
         """Pack a list of LoRAs into a single LoRA.
 
         If LoRA is None, it signifies that the submodule does not have a LoRA.
@@ -154,10 +156,10 @@ class PackedLoRALayerWeights(LoRALayerWeights):
     @classmethod
     def pack_moe(
         cls,
-        loras: GenericSequence["LoRALayerWeights | None"],
+        loras: GenericSequence[LoRALayerWeights | None],
         module_name: str,
         is_non_gated_moe: bool = False,
-    ) -> "PackedLoRALayerWeights":
+    ) -> PackedLoRALayerWeights:
         """Pack a list of LoRAs into a single LoRA.
 
         If LoRA is None, it signifies that the submodule does not have a LoRA.
@@ -227,7 +229,7 @@ class PackedLoRALayerWeights(LoRALayerWeights):
         )
         return obj
 
-    def optimize(self) -> "PackedLoRALayerWeights":
+    def optimize(self) -> PackedLoRALayerWeights:
         """Optimize the LoRA by merging the scaling into lora_b."""
         for i in range(len(self.lora_b)):
             if self.scaling[i] == 1 or self.lora_b[i] is None:  # type: ignore

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 import os
 from typing import TYPE_CHECKING
 
@@ -103,8 +105,8 @@ def from_layer(
 
 
 def from_layer_logits_processor(
-    layer: "LogitsProcessor",
-    lm_head: "ParallelLMHead",
+    layer: LogitsProcessor,
+    lm_head: ParallelLMHead,
     max_loras: int,
     lora_config: LoRAConfig,
     model_config: PretrainedConfig | None = None,
@@ -131,7 +133,7 @@ def replace_submodule(
 
 
 def parse_fine_tuned_lora_name(
-    name: str, weights_mapper: "WeightsMapper | None" = None
+    name: str, weights_mapper: WeightsMapper | None = None
 ) -> tuple[str, bool]:
     """Parse the name of lora weights.
 

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Union
 
 import torch
 
@@ -147,7 +148,7 @@ class FusedMoEQuantDesc:
 
     # Quantization scales.
     # TODO(bnell): maybe put PrecisionConfigs in subclass of QuantDesc?
-    scale: Union[torch.Tensor, "PrecisionConfig", None] = None
+    scale: torch.Tensor | PrecisionConfig | None = None
 
     # Quantization alphas or gscales, used for nvfp4 types.
     # W4A8 FP8: used for per-channel scales
@@ -284,7 +285,7 @@ class FusedMoEQuantConfig:
         return self._w1.bias
 
     @property
-    def w1_precision(self) -> "PrecisionConfig | None":
+    def w1_precision(self) -> PrecisionConfig | None:
         assert self._w1.scale is None or isinstance(self._w1.scale, PrecisionConfig)
         return self._w1.scale
 
@@ -306,7 +307,7 @@ class FusedMoEQuantConfig:
         return self._w2.bias
 
     @property
-    def w2_precision(self) -> "PrecisionConfig | None":
+    def w2_precision(self) -> PrecisionConfig | None:
         assert self._w2.scale is None or isinstance(self._w2.scale, PrecisionConfig)
         return self._w2.scale
 
@@ -429,8 +430,8 @@ class FusedMoEQuantConfig:
         per_act_token_quant: bool = False,
         per_out_ch_quant: bool = False,
         block_shape: list[int] | None = None,
-        w1_scale: Union[torch.Tensor, "PrecisionConfig", None] = None,
-        w2_scale: Union[torch.Tensor, "PrecisionConfig", None] = None,
+        w1_scale: torch.Tensor | PrecisionConfig | None = None,
+        w2_scale: torch.Tensor | PrecisionConfig | None = None,
         a1_scale: torch.Tensor | None = None,
         a2_scale: torch.Tensor | None = None,
         g1_alphas: torch.Tensor | None = None,
@@ -442,7 +443,7 @@ class FusedMoEQuantConfig:
         w1_zp: torch.Tensor | None = None,
         w2_zp: torch.Tensor | None = None,
         weight_dtype: torch.dtype | str | None = None,
-    ) -> "FusedMoEQuantConfig":
+    ) -> FusedMoEQuantConfig:
         """
         General builder function for a FusedMoEQuantConfig.
         - quant_dtype: Optional quantization type. None if activations are
@@ -599,8 +600,8 @@ def gptq_marlin_moe_quant_config(
 
 
 def mxfp4_w4a16_moe_quant_config(
-    w1_scale: Union[torch.Tensor, "PrecisionConfig"],
-    w2_scale: Union[torch.Tensor, "PrecisionConfig"],
+    w1_scale: torch.Tensor | PrecisionConfig,
+    w2_scale: torch.Tensor | PrecisionConfig,
     w1_bias: torch.Tensor | None = None,
     w2_bias: torch.Tensor | None = None,
 ) -> FusedMoEQuantConfig:
@@ -616,8 +617,8 @@ def mxfp4_w4a16_moe_quant_config(
 
 
 def mxfp4_mxfp8_moe_quant_config(
-    w1_scale: Union[torch.Tensor, "PrecisionConfig"],
-    w2_scale: Union[torch.Tensor, "PrecisionConfig"],
+    w1_scale: torch.Tensor | PrecisionConfig,
+    w2_scale: torch.Tensor | PrecisionConfig,
     a1_scale: torch.Tensor | None = None,
     a2_scale: torch.Tensor | None = None,
     w1_bias: torch.Tensor | None = None,
@@ -637,8 +638,8 @@ def mxfp4_mxfp8_moe_quant_config(
 
 def ocp_mx_moe_quant_config(
     quant_dtype: str,
-    w1_scale: Union[torch.Tensor, "PrecisionConfig"],
-    w2_scale: Union[torch.Tensor, "PrecisionConfig"],
+    w1_scale: torch.Tensor | PrecisionConfig,
+    w2_scale: torch.Tensor | PrecisionConfig,
     weight_dtype: str | None = None,
     a1_scale: torch.Tensor | None = None,
     a2_scale: torch.Tensor | None = None,
@@ -920,7 +921,7 @@ class FusedMoEParallelConfig:
         pcp_size_: int,
         dp_size_: int,
         vllm_parallel_config: ParallelConfig,
-    ) -> "FusedMoEParallelConfig":
+    ) -> FusedMoEParallelConfig:
         """
         Determine MoE parallel configuration. Based on the input `tp_size_`,
         `dp_size_` and vllm's parallel config, determine what
@@ -1045,7 +1046,7 @@ class FusedMoEParallelConfig:
         )
 
     @classmethod
-    def make_no_parallel(cls) -> "FusedMoEParallelConfig":
+    def make_no_parallel(cls) -> FusedMoEParallelConfig:
         """For usage in CI/CD and testing."""
         return FusedMoEParallelConfig(
             tp_size=1,

--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -112,7 +114,7 @@ class AWQMarlinConfig(QuantizationConfig):
         )
 
     @classmethod
-    def get_name(cls) -> "QuantizationMethods":
+    def get_name(cls) -> QuantizationMethods:
         return "awq_marlin"
 
     @classmethod
@@ -128,7 +130,7 @@ class AWQMarlinConfig(QuantizationConfig):
         return ["quantize_config.json"]
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "AWQMarlinConfig":
+    def from_config(cls, config: dict[str, Any]) -> AWQMarlinConfig:
         weight_bits = cls.get_from_keys(config, ["bits"])
         group_size = cls.get_from_keys(config, ["group_size"])
         zero_point = cls.get_from_keys(config, ["zero_point"])
@@ -148,7 +150,7 @@ class AWQMarlinConfig(QuantizationConfig):
     @classmethod
     def override_quantization_method(
         cls, hf_quant_cfg, user_quant
-    ) -> "QuantizationMethods | None":
+    ) -> QuantizationMethods | None:
         can_convert = cls.is_awq_marlin_compatible(hf_quant_cfg)
         is_valid_user_quant = (
             user_quant is None or user_quant == "marlin" or user_quant == "awq_marlin"
@@ -173,7 +175,7 @@ class AWQMarlinConfig(QuantizationConfig):
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
-    ) -> "QuantizeMethodBase | None":
+    ) -> QuantizeMethodBase | None:
         if isinstance(layer, LinearBase) or (
             isinstance(layer, ParallelLMHead) and self.lm_head_quantized
         ):
@@ -243,7 +245,7 @@ class AWQMarlinConfig(QuantizationConfig):
             quant_type=cls.TYPE_MAP[num_bits], group_size=group_size, has_zp=zero_point
         )
 
-    def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper):
         if self.modules_to_not_convert:
             self.modules_to_not_convert = hf_to_vllm_mapper.apply_list(
                 self.modules_to_not_convert

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from contextlib import suppress
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -110,7 +112,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         else:
             self.transform_config = None
 
-    def get_linear_method(self) -> "CompressedTensorsLinearMethod":
+    def get_linear_method(self) -> CompressedTensorsLinearMethod:
         return CompressedTensorsLinearMethod(self)
 
     def get_supported_act_dtypes(cls) -> list[torch.dtype]:
@@ -123,7 +125,7 @@ class CompressedTensorsConfig(QuantizationConfig):
     def get_name(self) -> QuantizationMethods:
         return "compressed-tensors"
 
-    def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper):
         """
         Transform layer paths in config targets to match vLLM's naming.
 
@@ -160,7 +162,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         self,
         layer: torch.nn.Module,
         prefix: str,
-    ) -> "QuantizeMethodBase | None":
+    ) -> QuantizeMethodBase | None:
         if isinstance(layer, LinearBase):
             # collect schemes
             quant_scheme = self.get_scheme(layer=layer, layer_name=prefix)
@@ -206,7 +208,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         self.target_scheme_map["FusedMoE"] = self.target_scheme_map["Linear"]
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "CompressedTensorsConfig":
+    def from_config(cls, config: dict[str, Any]) -> CompressedTensorsConfig:
         # We keep only config groups which are not doing Attention quantization
         # because Attention quantization on its own is not supported by vLLM.
         # It is coupled with KV-cache quantization, and if scales are present in the
@@ -588,7 +590,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         input_quant: QuantizationArgs,
         format: str | None = None,
         layer_name: str | None = None,
-    ) -> "CompressedTensorsScheme":
+    ) -> CompressedTensorsScheme:
         # use the per-layer format if defined, otherwise, use global format
         format = format if format is not None else self.quant_format
 
@@ -691,7 +693,7 @@ class CompressedTensorsConfig(QuantizationConfig):
 
     def get_scheme(
         self, layer: torch.nn.Module, layer_name: str | None = None
-    ) -> "CompressedTensorsScheme | None":
+    ) -> CompressedTensorsScheme | None:
         """
         compressed-tensors supports non uniform in the following way:
 

--- a/vllm/model_executor/layers/quantization/cpu_wna16.py
+++ b/vllm/model_executor/layers/quantization/cpu_wna16.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from typing import Any
 
 import torch
@@ -69,7 +71,7 @@ class CPUAWQConfig(QuantizationConfig):
         )
 
     @classmethod
-    def get_name(cls) -> "QuantizationMethods":
+    def get_name(cls) -> QuantizationMethods:
         return "cpu_awq"
 
     @classmethod
@@ -85,7 +87,7 @@ class CPUAWQConfig(QuantizationConfig):
         return ["quantize_config.json"]
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "CPUAWQConfig":
+    def from_config(cls, config: dict[str, Any]) -> CPUAWQConfig:
         weight_bits = cls.get_from_keys(config, ["bits"])
         group_size = cls.get_from_keys(config, ["group_size"])
         zero_point = cls.get_from_keys(config, ["zero_point"])
@@ -105,7 +107,7 @@ class CPUAWQConfig(QuantizationConfig):
     @classmethod
     def override_quantization_method(
         cls, hf_quant_cfg, user_quant
-    ) -> "QuantizationMethods | None":
+    ) -> QuantizationMethods | None:
         quant_method = hf_quant_cfg.get("quant_method", "").lower()
         if current_platform.is_cpu() and (quant_method == "awq"):
             return cls.get_name()
@@ -113,7 +115,7 @@ class CPUAWQConfig(QuantizationConfig):
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
-    ) -> "QuantizeMethodBase | None":
+    ) -> QuantizeMethodBase | None:
         if isinstance(layer, LinearBase) or (
             isinstance(layer, ParallelLMHead) and self.lm_head_quantized
         ):
@@ -127,7 +129,7 @@ class CPUAWQConfig(QuantizationConfig):
             return CPUAWQLinearMethod(self)
         return None
 
-    def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper):
         if self.modules_to_not_convert:
             self.modules_to_not_convert = hf_to_vllm_mapper.apply_list(
                 self.modules_to_not_convert

--- a/vllm/model_executor/layers/quantization/experts_int8.py
+++ b/vllm/model_executor/layers/quantization/experts_int8.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from typing import Any
 
 import torch
@@ -47,12 +49,12 @@ class ExpertsInt8Config(QuantizationConfig):
         return []
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "ExpertsInt8Config":
+    def from_config(cls, config: dict[str, Any]) -> ExpertsInt8Config:
         return cls()
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
-    ) -> "QuantizeMethodBase | None":
+    ) -> QuantizeMethodBase | None:
         if isinstance(layer, LinearBase):
             return UnquantizedLinearMethod()
         elif isinstance(layer, FusedMoE):

--- a/vllm/model_executor/layers/quantization/fbgemm_fp8.py
+++ b/vllm/model_executor/layers/quantization/fbgemm_fp8.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from typing import Any
 
 import torch
@@ -71,14 +73,14 @@ class FBGEMMFp8Config(QuantizationConfig):
         return []
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "FBGEMMFp8Config":
+    def from_config(cls, config: dict[str, Any]) -> FBGEMMFp8Config:
         ignore_list = cls.get_from_keys(config, ["modules_to_not_convert"])
         input_scale_ub = cls.get_from_keys(config, ["activation_scale_ub"])
         return cls(ignore_list=ignore_list, input_scale_ub=input_scale_ub)
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
-    ) -> "QuantizeMethodBase | None":
+    ) -> QuantizeMethodBase | None:
         if isinstance(layer, LinearBase):
             if is_layer_skipped(
                 prefix=prefix,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -158,12 +160,12 @@ class Fp8Config(QuantizationConfig):
     def get_config_filenames(cls) -> list[str]:
         return []
 
-    def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper):
         if self.ignored_layers is not None:
             self.ignored_layers = hf_to_vllm_mapper.apply_list(self.ignored_layers)
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "Fp8Config":
+    def from_config(cls, config: dict[str, Any]) -> Fp8Config:
         quant_method = cls.get_from_keys(config, ["quant_method"])
         is_checkpoint_fp8_serialized = "fp8" in quant_method
         activation_scheme = cls.get_from_keys(config, ["activation_scheme"])
@@ -182,7 +184,7 @@ class Fp8Config(QuantizationConfig):
 
     def get_xpu_quant_method(
         self, layer: torch.nn.Module, prefix: str
-    ) -> "QuantizeMethodBase | None":
+    ) -> QuantizeMethodBase | None:
         from vllm.model_executor.layers.quantization.ipex_quant import (
             XPUFp8LinearMethod,
             XPUFp8MoEMethod,
@@ -218,7 +220,7 @@ class Fp8Config(QuantizationConfig):
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
-    ) -> "QuantizeMethodBase | None":
+    ) -> QuantizeMethodBase | None:
         if current_platform.is_xpu():
             return self.get_xpu_quant_method(layer, prefix)
         if isinstance(layer, LinearBase):

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Any
@@ -72,12 +74,12 @@ class GGUFConfig(QuantizationConfig):
         return []  # no extra configs.
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "GGUFConfig":
+    def from_config(cls, config: dict[str, Any]) -> GGUFConfig:
         return cls()
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
-    ) -> "QuantizeMethodBase | None":
+    ) -> QuantizeMethodBase | None:
         if isinstance(layer, LinearBase):
             if is_layer_skipped_gguf(
                 prefix, self.unquantized_modules, self.packed_modules_mapping
@@ -95,7 +97,7 @@ class GGUFConfig(QuantizationConfig):
             return GGUFMoEMethod(self, layer.moe_config)
         return None
 
-    def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper):
         """
         Interface for models to update module names referenced in
         quantization configs in order to reflect the vllm model structure

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from copy import deepcopy
 from typing import Any
 
@@ -64,7 +66,7 @@ logger = init_logger(__name__)
 
 
 def get_moe_quant_method(
-    config: "GPTQMarlinConfig",
+    config: GPTQMarlinConfig,
     layer: torch.nn.Module,
     prefix: str,
     moe_method_cls: type,
@@ -188,7 +190,7 @@ class GPTQMarlinConfig(QuantizationConfig):
         return ["quantize_config.json"]
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "GPTQMarlinConfig":
+    def from_config(cls, config: dict[str, Any]) -> GPTQMarlinConfig:
         dynamic = cls.get_from_keys_or(config, ["dynamic"], default={})
         dynamic = {} if dynamic is None else dynamic
 
@@ -240,7 +242,7 @@ class GPTQMarlinConfig(QuantizationConfig):
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
-    ) -> "QuantizeMethodBase | None":
+    ) -> QuantizeMethodBase | None:
         if isinstance(layer, FusedMoE):
             from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Config
 

--- a/vllm/model_executor/layers/quantization/inc.py
+++ b/vllm/model_executor/layers/quantization/inc.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from fractions import Fraction
 from typing import TYPE_CHECKING, Any
 
@@ -111,7 +113,7 @@ class INCConfig(QuantizationConfig):
         return ["quantization_config.json"]
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "INCConfig":
+    def from_config(cls, config: dict[str, Any]) -> INCConfig:
         return cls(
             weight_bits=cls.get_from_keys(config, ["bits"]),
             group_size=cls.get_from_keys(config, ["group_size"]),
@@ -216,7 +218,7 @@ class INCConfig(QuantizationConfig):
     def check_quantized(self, weight_bits: int) -> bool:
         return weight_bits < 16
 
-    def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper):
         if self.block_name_to_quantize is not None:
             self.block_name_to_quantize = hf_to_vllm_mapper.apply_list(
                 self.block_name_to_quantize
@@ -456,7 +458,7 @@ class INCConfig(QuantizationConfig):
     @classmethod
     def override_quantization_method(
         cls, hf_quant_cfg, user_quant
-    ) -> "QuantizationMethods | None":
+    ) -> QuantizationMethods | None:
         """Override the `auto-round` method to `inc`."""
         is_auto_round_format = hf_quant_cfg.get("quant_method", None) == "auto-round"
         if is_auto_round_format:

--- a/vllm/model_executor/layers/quantization/ipex_quant.py
+++ b/vllm/model_executor/layers/quantization/ipex_quant.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from typing import Any
 
 import torch
@@ -100,7 +102,7 @@ class IPEXConfig(QuantizationConfig):
         ]
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "IPEXConfig":
+    def from_config(cls, config: dict[str, Any]) -> IPEXConfig:
         method = cls.get_from_keys(config, ["quant_method"]).lower()
         if method == "awq":
             weight_bits = cls.get_from_keys(config, ["w_bit", "bits"])
@@ -144,7 +146,7 @@ class IPEXConfig(QuantizationConfig):
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
-    ) -> "LinearMethodBase | None":
+    ) -> LinearMethodBase | None:
         if isinstance(layer, LinearBase):
             if self.method == "awq":
                 if is_layer_skipped(

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Any
 
@@ -125,7 +127,7 @@ class ModelOptFp8KVCacheMethod(BaseKVCacheMethod):
     Supports loading kv-cache scaling factors from FP8 checkpoints.
     """
 
-    def __init__(self, quant_config: "ModelOptQuantConfigBase"):
+    def __init__(self, quant_config: ModelOptQuantConfigBase):
         super().__init__(quant_config)
 
 
@@ -181,7 +183,7 @@ class ModelOptQuantConfigBase(QuantizationConfig):
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
-    ) -> "QuantizeMethodBase | None":
+    ) -> QuantizeMethodBase | None:
         # handle kv-cache first so we can focus only on weight quantization thereafter
         if isinstance(layer, Attention):
             return self.KVCacheMethodCls(self)
@@ -216,7 +218,7 @@ class ModelOptQuantConfigBase(QuantizationConfig):
 
         return None
 
-    def apply_vllm_mapper(self, hf_to_vllm_mapper: "WeightsMapper"):
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper):
         if len(self.exclude_modules) > 0:
             # This is a workaround for the weights remapping issue:
             # https://github.com/vllm-project/vllm/issues/28072
@@ -250,11 +252,11 @@ class ModelOptQuantConfigBase(QuantizationConfig):
         exclude_modules: list[str],
         original_config: dict[str, Any],
         group_size: int | None,
-    ) -> "ModelOptQuantConfigBase":
+    ) -> ModelOptQuantConfigBase:
         raise NotImplementedError("Please implement this function in sub classes")
 
     @classmethod
-    def from_config(cls, config: dict[str, Any]) -> "ModelOptQuantConfigBase":
+    def from_config(cls, config: dict[str, Any]) -> ModelOptQuantConfigBase:
         # Handle both ModelOpt format and compressed-tensors style format
         if "quantization" in config:
             # Traditional ModelOpt format:
@@ -418,7 +420,7 @@ class ModelOptFp8Config(ModelOptQuantConfigBase):
         exclude_modules: list[str],
         original_config: dict[str, Any],
         **kwargs: Any,
-    ) -> "ModelOptFp8Config":
+    ) -> ModelOptFp8Config:
         is_checkpoint_fp8_serialized = "FP8" in quant_method
 
         return cls(
@@ -1066,7 +1068,7 @@ class ModelOptNvFp4Config(ModelOptQuantConfigBase):
         original_config: dict[str, Any],
         group_size: int | None,
         **kwargs: Any,
-    ) -> "ModelOptNvFp4Config":
+    ) -> ModelOptNvFp4Config:
         is_checkpoint_nvfp4_serialized = "NVFP4" in quant_method
 
         if group_size is None:


### PR DESCRIPTION
## Purpose

This PR adds `from __future__ import annotations` to files that use quoted union types like `"X | None"` and replaces them with unquoted `X | None`. This is a follow-up to #33332 as suggested by @DarkLight1337.

PEP 563 (postponed evaluation of annotations) makes all annotations strings by default, allowing forward references without quotes. This improves code readability and consistency.

## Test Plan

Pre-commit hooks pass (ruff, mypy, etc.)

## Test Result

```
ruff check..........................................................................................Passed
ruff format.........................................................................................Passed
typos...............................................................................................Passed
Run mypy locally for lowest supported Python version................................................Passed
Check SPDX headers..................................................................................Passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>