### PR TITLE
[Misc] Algin Qwen3-VL-embedding image example outputs with HF repo example

### DIFF
--- a/examples/pooling/embed/vision_embedding_offline.py
+++ b/examples/pooling/embed/vision_embedding_offline.py
@@ -17,8 +17,8 @@ from PIL.Image import Image
 from vllm import LLM, EngineArgs
 from vllm.multimodal.utils import fetch_image
 
-image_url = "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg"
-text = "A woman shares a joyful moment with her golden retriever on a sun-drenched beach at sunset, as the dog offers its paw in a heartwarming display of companionship and trust."
+image_url = "https://vllm-public-assets.s3.us-west-2.amazonaws.com/multimodal_asset/cat_snow.jpg"
+text = "A cat standing in the snow."
 multi_modal_data = {"image": fetch_image(image_url)}
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- The `Qwen3VLEmbedder` in hf repo example uses `qwen_vl_utils` for preprocessing, which can cause different resizing comparing HF processor.
- This PR aligned the processor usage logic to avoid user confusing.

## Test Plan
**HF scripts**
```python3
from scripts.qwen3_vl_embedding import Qwen3VLEmbedder

# Specify the model path
model_name_or_path = "Qwen/Qwen3-VL-Embedding-2B"

# Initialize the Qwen3VLEmbedder model
model = Qwen3VLEmbedder(model_name_or_path=model_name_or_path)

# Combine queries and documents into a single input list
# inputs = queries + documents
inputs = [
    {"image": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg"},
]

# Process the inputs to get embeddings
embeddings = model.process(inputs)
print(embeddings[0][:16].float().tolist())
```

**vLLM command**
```
python examples/pooling/embed/vision_embedding_offline.py --model qwen3_vl
```

## Test Result
**HF outputs**
```
Text: ["<|im_start|>system\nRepresent the user's input.<|im_end|>\n<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n<|im_start|>assistant\n"]
[-0.07177734375, -0.01806640625, 0.010009765625, -0.00555419921875, -0.049560546875, 0.1103515625, -0.0361328125, -0.0260009765625, -0.0031890869140625, -0.006072998046875, 0.04052734375, 0.0244140625, 0.03857421875, -0.00701904296875, 0.01019287109375, -0.002532958984375
```

**vLLM outputs without `qwen-vl-utils`**
```
Text embedding output:
Embeddings: [-0.07404562085866928, -0.045382801443338394, 0.006829813122749329, -0.017988907173275948, ...] (size=2048)
Image embedding output:
Embeddings: [-0.06790971010923386, -0.0233911219984293, 0.012525568716228008, -0.006451422348618507, ...] (size=2048)
Image+Text embedding output:
Embeddings: [-0.0838722512125969, -0.048776768147945404, 0.0012733264593407512, -0.0028068949468433857, ...] (size=2048)
```

**vLLM outputs with `qwen-vl-utils`**
```
INFO 01-30 21:32:33 [llm.py:343] Supported tasks: ['embed', 'token_embed']
Text embedding output:
Embeddings: [-0.07404562085866928, -0.045382801443338394, 0.006829813122749329, -0.017988907173275948, ...] (size=2048)
Image embedding output:
Embeddings: [-0.0713614746928215, -0.018141470849514008, 0.010538613423705101, -0.010764441452920437, ...] (size=2048)
Image+Text embedding output:
Embeddings: [-0.08855126798152924, -0.04427563399076462, 0.006685917731374502, -0.0076516615226864815, ...] (size=2048)
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

