### PR TITLE
Update context length in error message when prompt + max_tokens exceeds limit

### DIFF
--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -727,6 +727,7 @@ class OpenAIServingCompletion(OpenAIServing):
         max_input_tokens_len = self.max_model_len - (request.max_tokens or 0)
         return RenderConfig(
             max_length=max_input_tokens_len,
+            max_model_len=self.max_model_len,
             truncate_prompt_tokens=request.truncate_prompt_tokens,
             add_special_tokens=request.add_special_tokens,
             cache_salt=request.cache_salt,


### PR DESCRIPTION
When len(prompt) + max_tokens > max_model_len, the error message incorrectly reported max_model_len - max_tokens as the 'maximum context length' instead of the actual max_model_len.

Pass max_model_len through RenderConfig to use in error messages while keeping max_length for the actual validation check.

Fixes #33418

<!-- markdownlint-disable -->

## Purpose

Fixes #33418

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

