### PR TITLE
[ROCm][AITER] KV cache split causes large accuracy regression

### DIFF
--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -53,6 +53,9 @@ class AttentionBackend(ABC):
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.float16, torch.bfloat16]
     supported_kv_cache_dtypes: ClassVar[list["CacheDType"]] = ["auto"]
 
+    # Does attention's forward() include kv cache update?
+    forward_includes_kv_cache_update: bool = True
+
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
         return [MultipleOf(1)]


### PR DESCRIPTION
## Summary
This PR mirrors the KV-cache update separation for the ROCm AITER unified attention backend. In practice, this causes a **large accuracy regression** vs main on lm_eval, indicating the ROCm AITER path is not safe for KV-cache split yet (likely missing metadata/slot mapping or correct update op).

Related to #32335.

## What I tested
Model: `Qwen/Qwen3-1.7B`  
Tasks: `hellaswag`, `arc_easy`, `arc_challenge`  
Command (both main/branch):
```
lm_eval \
  --model vllm \
  --model_args pretrained=Qwen/Qwen3-1.7B,trust_remote_code=True,tensor_parallel_size=1,dtype=auto \
  --tasks hellaswag,arc_easy,arc_challenge \
  --num_fewshot 0 \
  --batch_size auto \
  --output_path lmeval_results_*.json
```

## Exported env vars
```
VLLM_TARGET_DEVICE=rocm
ROCM_HOME=/opt/rocm
VLLM_ROCM_USE_AITER=1
VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1
VLLM_ROCM_USE_AITER_RMSNORM=0
VLLM_ATTENTION_BACKEND=ROCM_AITER_UNIFIED_ATTN
VLLM_V1_USE_PREFILL_DECODE_ATTENTION=0
PYTHONPATH=/workspace/aiter:$PYTHONPATH
```

## Environment
- GPU: AMD Instinct MI300X (gfx942)
- ROCm: 6.4.43484
- PyTorch: 2.9.1+rocm6.4
- Python: 3.12.4
- OS: Ubuntu 20.04.6
- transformers: 4.57.6

## Accuracy (lm_eval acc_norm)
| Task | Main | Branch | Δ (Branch‑Main) |
|---|---:|---:|---:|
| hellaswag | 0.60496 | 0.26359 | -0.34137 |
| arc_easy | 0.69781 | 0.24958 | -0.44823 |
| arc_challenge | 0.42491 | 0.27048 | -0.15444 |

## Throughput (req/s, higher is better)
| Metric | Main (mean) | Main (median) | Branch (mean) | Branch (median) | Δ (Branch‑Main) |
|---|---:|---:|---:|---:|---:|
| requests_per_second | 60.098 | 60.037 | 57.745 | 61.433 | -3.92% |

## Latency (seconds, lower is better)
| Metric | Main (mean) | Main (median) | Branch (mean) | Branch (median) | Δ (Branch‑Main) |
|---|---:|---:|---:|---:|---:|
| avg_latency | 0.45154 | 0.45257 | 0.42832 | 0.42732 | -5.14% |

## Attached files
I attached the full JSON outputs for reproducibility:
- `lmeval_results_main.json`
- `lmeval_results_branch.json`
- `latency_main_1.json`, `latency_main_2.json`, `latency_main_3.json`
- `latency_branch_1.json`, `latency_branch_2.json`, `latency_branch_3.json`
- `throughput_main_1.json`, `throughput_main_2.json`, `throughput_main_3.json`
- `throughput_branch_1.json`, `throughput_branch_2.json`, `throughput_branch_3.json`

[branch.zip](https://github.com/user-attachments/files/24977287/branch.zip)

 [main.zip](https://github.com/user-attachments/files/24977289/main.zip)


## Notes / Observations
- Main results are stable and reproducible; branch consistently regresses.
- Suggests ROCm AITER unified attention does not yet support KV-cache split safely.
- Recommendation: keep ROCm AITER unified attention on the original path (forward includes KV update) until a correct split path exists.

## Ask
- Guidance on the correct ROCm AITER KV-cache update path when split.
- Is there an expected update op (e.g., unified_kv_cache_update) we should use?
- Should ROCm AITER remain unsplit for now?
