### PR TITLE
Update `huggingface-hub` pin for the last time before Transformers v5

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -332,7 +332,7 @@ httpx==0.27.2
     #   -r requirements/test.in
     #   perceptron
     #   schemathesis
-huggingface-hub==0.34.3
+huggingface-hub==0.36.0
     # via
     #   accelerate
     #   datasets


### PR DESCRIPTION
Get some bug fixes in to hopefully improve CI reliability before switching to Transformers v5 (when we can update to `huggingface-hub>=1`)