### PR TITLE
fix: only include Authorization header when OPENAI_API_KEY is set

### DIFF
--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -138,6 +138,16 @@ def _update_headers_common(
         headers["x-request-id"] = request_func_input.request_id
 
 
+def _get_headers(content_type: str | None = None) -> dict[str, str]:
+    headers = {}
+    if content_type:
+        headers["Content-Type"] = content_type
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
 async def async_request_openai_completions(
     request_func_input: RequestFuncInput,
     session: aiohttp.ClientSession,
@@ -170,9 +180,7 @@ async def async_request_openai_completions(
     }
     _update_payload_common(payload, request_func_input)
 
-    headers = {
-        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
-    }
+    headers = _get_headers()
     _update_headers_common(headers, request_func_input)
 
     output = RequestFuncOutput()
@@ -301,10 +309,7 @@ async def async_request_openai_chat_completions(
     }
     _update_payload_common(payload, request_func_input)
 
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
-    }
+    headers = _get_headers("application/json")
     _update_headers_common(headers, request_func_input)
 
     output = RequestFuncOutput()
@@ -396,9 +401,7 @@ async def async_request_openai_audio(
     }
     _update_payload_common(payload, request_func_input)
 
-    headers = {
-        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
-    }
+    headers = _get_headers()
     _update_headers_common(headers, request_func_input)
 
     # Send audio file
@@ -537,10 +540,7 @@ async def async_request_openai_embeddings(
     }
     _update_payload_common(payload, request_func_input)
 
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
-    }
+    headers = _get_headers("application/json")
     _update_headers_common(headers, request_func_input)
 
     return await _run_pooling_request(
@@ -576,10 +576,7 @@ async def async_request_vllm_rerank(
         "truncate_prompt_tokens": -1,
     }
 
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
-    }
+    headers = _get_headers("application/json")
     _update_headers_common(headers, request_func_input)
 
     return await _run_pooling_request(
@@ -615,10 +612,7 @@ async def async_request_openai_embeddings_chat(
     }
     _update_payload_common(payload, request_func_input)
 
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
-    }
+    headers = _get_headers("application/json")
     _update_headers_common(headers, request_func_input)
 
     return await _run_pooling_request(
@@ -721,10 +715,7 @@ async def async_request_infinity_embeddings(
 
     _update_payload_common(payload, request_func_input)
 
-    headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
-    }
+    headers = _get_headers("application/json")
     _update_headers_common(headers, request_func_input)
 
     return await _run_pooling_request(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix #33412 , benchmark requests failing with 401 Unauthorized when `OPENAI_API_KEY` is not set.

Previously, `vllm bench serve` always sent `Authorization: Bearer None` header when the environment variable was unset, causing the server to reject requests even when no authentication was required.

## Test Plan

```python
import os

if 'OPENAI_API_KEY' in os.environ:
    del os.environ['OPENAI_API_KEY']

#Before fix
print({"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"})

#After fix
def _get_headers(content_type: str | None = None) -> dict[str, str]:
    headers = {}
    if content_type:
        headers["Content-Type"] = content_type
    api_key = os.environ.get("OPENAI_API_KEY")
    if api_key:
        headers["Authorization"] = f"Bearer {api_key}"
    return headers
print(_get_headers())
print(_get_headers("application/json"))

```

## Test Result

Before fix:
```
{'Authorization': 'Bearer None'}  # Causes 401 error
```

After fix:
```
{}
{'Content-Type': 'application/json'}
```

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

