### PR TITLE
Change defaults for vllm bench startup

### DIFF
--- a/vllm/benchmarks/startup.py
+++ b/vllm/benchmarks/startup.py
@@ -159,19 +159,19 @@ def add_cli_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--num-iters-cold",
         type=int,
-        default=5,
+        default=3,
         help="Number of cold startup iterations.",
     )
     parser.add_argument(
         "--num-iters-warmup",
         type=int,
-        default=3,
+        default=1,
         help="Number of warmup iterations before benchmarking warm startups.",
     )
     parser.add_argument(
         "--num-iters-warm",
         type=int,
-        default=5,
+        default=3,
         help="Number of warm startup iterations.",
     )
     parser.add_argument(


### PR DESCRIPTION
The defaults are too large to be practical, I changed them such that `vllm bench startup` actually completes in a reasonable time.

cc @desertfire @zou3519