### PR TITLE
[MoE Refactor] Improve Oracle for Backend Specific Defaults

### DIFF
--- a/vllm/model_executor/layers/fused_moe/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_cutlass_moe.py
@@ -139,7 +139,9 @@ class FlashInferExperts(mk.FusedMoEPermuteExpertsUnpermute):
         # work with SP. This will be removed in follow up after we get
         # rid of the FlashInfer specific P/F function.
         # TODO: the per-tensor fp8 kernels don't work with MNNVL FI A2As.
-        return not moe_parallel_config.is_sequence_parallel
+        return moe_parallel_config.use_ep and (
+            not moe_parallel_config.is_sequence_parallel
+        )
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:


### PR DESCRIPTION
## Purpose

We found in 0.15.0 release the default fp8 MoE backend is change to `FLASHINFER_CUTLASS`, previously on Hopper the default was `TRITON`. `FLASHINFER_CUTLASS` is about 30% slower than `TRITON` on Hopper. So this PR move `TRITON` higher in priority than `FLASHINFER_CUTLASS` for Hopper.

Note that this is based on benchmark numbers on Hopper. I don't have a Blackwell to test. If `FLASHINFER_CUTLASS` is also slower than `TRITON` on Blackwell, I can unify the priority list. Please let me know if it works. Thanks!

## Benchmark

Benchmarked on H200.

```
vllm serve deepseek-ai/DeepSeek-R1-0528 \
    --tensor-parallel-size 8 \
    --max-num-seqs 16 \
    --trust-remote-code \
    --compilation-config '{"compile_sizes": [1, 2, 4, 8, 16]}' \
    --no-enable-prefix-caching
```

```
vllm bench serve \
  --model deepseek-ai/DeepSeek-R1-0528 \
  --dataset-name sharegpt \
  --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
  --sharegpt-output-len 300 \
  --max-concurrency 16 \
  --num-prompts 1000 \
  --num-warmups 50 \
  --ignore-eos
```

TRITON:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  412.30    
Total input tokens:                      229418    
Total generated tokens:                  300000    
Request throughput (req/s):              2.43      
Output token throughput (tok/s):         727.63    
Peak output token throughput (tok/s):    816.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          1284.06   
---------------Time to First Token----------------
Mean TTFT (ms):                          332.40    
Median TTFT (ms):                        290.73    
P99 TTFT (ms):                           1214.02   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          20.81     
Median TPOT (ms):                        20.77     
P99 TPOT (ms):                           23.42     
---------------Inter-token Latency----------------
Mean ITL (ms):                           20.81     
Median ITL (ms):                         20.41     
P99 ITL (ms):                            21.08     
==================================================
```

FLASHINFER_CUTLASS:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  545.54    
Total input tokens:                      229418    
Total generated tokens:                  300000    
Request throughput (req/s):              1.83      
Output token throughput (tok/s):         549.92    
Peak output token throughput (tok/s):    608.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          970.45    
---------------Time to First Token----------------
Mean TTFT (ms):                          418.78    
Median TTFT (ms):                        335.73    
P99 TTFT (ms):                           4879.00   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          27.61     
Median TPOT (ms):                        27.50     
P99 TPOT (ms):                           28.59     
---------------Inter-token Latency----------------
Mean ITL (ms):                           27.61     
Median ITL (ms):                         27.18     
P99 ITL (ms):                            27.82     
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

cc @robertgshaw2-redhat 