### PR TITLE
[Doc]: update paths for Offline/Online/Others example sections

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -2,6 +2,6 @@
 
 vLLM's examples are split into three categories:
 
-- If you are using vLLM from within Python code, see the *Offline Inference* section.
-- If you are using vLLM from an HTTP application or client, see the *Online Serving* section.
-- For examples of using some of vLLM's advanced features (e.g. LMCache or Tensorizer) which are not specific to either of the above use cases, see the *Others* section.
+- If you are using vLLM from within Python code, see [Offline Inference](../../examples/offline_inference)
+- If you are using vLLM from an HTTP application or client, see [Online Serving](../../examples/online_serving)
+- For examples of using some of vLLM's advanced features (e.g. LMCache or Tensorizer), see [Others](../../examples/others)

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -2,6 +2,6 @@
 
 vLLM's examples are split into three categories:
 
-- If you are using vLLM from within Python code, see [Offline Inference](../../examples/offline_inference)
-- If you are using vLLM from an HTTP application or client, see [Online Serving](../../examples/online_serving)
-- For examples of using some of vLLM's advanced features (e.g. LMCache or Tensorizer), see [Others](../../examples/others)
+- If you are using vLLM from within Python code, see the [Offline Inference](../../examples/offline_inference) section.
+- If you are using vLLM from an HTTP application or client, see the [Online Serving](../../examples/online_serving) section.
+- For examples of using some of vLLM's advanced features (e.g. LMCache or Tensorizer) which are not specific to either of the above use cases, see the [Others](../../examples/others) section.


### PR DESCRIPTION
Restores hyperlinks in the examples overview to point to the correct examples/ directory paths.

Previously, links were removed due to broken paths; this updates them to match the current directory structure and removes duplicated plain-text references.

<!-- markdownlint-disable -->

## Purpose
Fixes broken navigation in the examples overview section of the docs. Users can now directly click the links to Offline Inference, Online Serving, and Others examples without confusion.

This addresses the partial removal of links in a prior commit that caused 404s.

## Test Plan

- Verified relative paths from `docs/examples/README.md` to `examples/offline_inference`, `examples/online_serving`, and `examples/others` using `ls ../../examples/...`  
- Opened the Markdown file in VS Code Markdown Preview and confirmed all three links navigate correctly  
- Links on own fork properly navigate to intended paths

## Test Result
- All three links navigate to the correct directories and example files  
- Local Markdown preview shows clickable links and renders correctly

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

