### PR TITLE
[Bugfix] Fix assertion error in flashmla backend with fullgraph enabled

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4766,7 +4766,7 @@ class GPUModelRunner(
 
             pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
             attn_metadata, _ = self._build_attention_metadata(
-                num_tokens=num_tokens_unpadded,
+                num_tokens=num_tokens_padded if pad_attn else num_tokens_unpadded,
                 num_reqs=num_reqs_padded,
                 max_query_len=max_query_len,
                 ubatch_slices=ubatch_slices_padded if pad_attn else ubatch_slices,


### PR DESCRIPTION
## Purpose
Fix an assertion error when using `flashmla` backend with `fullgraph` enabled.

Previously, `_build_attention_metadata` was called with `num_tokens=num_tokens_unpadded`. When `pad_attn=True` (required by `fullgraph` + `flashmla`), this leads to an inconsistency between `num_tokens` and padded attention-related metadata, triggering an assertion failure inside the attention backend.
This PR fixes the issue by passing `num_tokens_padded` when full cudagraph is enabled, ensuring consistency between `num_tokens`
Related to #33384 
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

