### PR TITLE
[Critical] Revert #33110

### DIFF
--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -35,7 +35,6 @@ from vllm.tokenizers import TokenizerLike
 from vllm.tokenizers.mistral import MistralTokenizer
 from vllm.utils import length_from_prompt_token_ids_or_embeds, random_uuid
 from vllm.utils.torch_utils import set_default_torch_num_threads
-from vllm.v1.core.encoder_cache_manager import compute_mm_encoder_budget
 from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.metrics.stats import MultiModalCacheStats
 from vllm.v1.structured_output.backend_guidance import (
@@ -69,17 +68,6 @@ class InputProcessor:
 
         self.mm_registry = mm_registry
         self.mm_processor_cache = mm_registry.processor_cache_from_config(vllm_config)
-        self.mm_encoder_cache_size = None
-        if (
-            self.mm_registry.supports_multimodal_inputs(self.model_config)
-            and not self.model_config.skip_tokenizer_init
-        ):
-            max_tokens_by_modality = mm_registry.get_max_tokens_per_item_by_modality(
-                self.model_config
-            )
-            _, self.mm_encoder_cache_size = compute_mm_encoder_budget(
-                self.vllm_config.scheduler_config, max_tokens_by_modality
-            )
 
         self.input_preprocessor = InputPreprocessor(
             self.model_config,
@@ -754,25 +742,6 @@ class InputProcessor:
                 f"requested output tokens (at least 1) is longer than the maximum "
                 f"model length of {max_prompt_len}. {suggestion}"
             )
-
-        if (
-            prompt_type == "decoder"
-            and prompt_inputs["type"] == "multimodal"
-            and self.mm_encoder_cache_size is not None
-        ):
-            decoder_mm_positions = prompt_inputs["mm_placeholders"]
-            for modality, mm_positions in decoder_mm_positions.items():
-                for mm_position in mm_positions:
-                    embed_length = mm_position.get_num_embeds
-                    if embed_length > self.mm_encoder_cache_size:
-                        raise ValueError(
-                            f"The {prompt_type} prompt contains a(n) {modality} item "
-                            f"with length {embed_length}, which exceeds the "
-                            f"pre-allocated encoder cache size "
-                            f"{self.mm_encoder_cache_size}. Please reduce the input "
-                            f"size or increase the encoder cache size "
-                            f"by setting --limit-mm-per-prompt at startup."
-                        )
 
     def stat_mm_cache(self) -> MultiModalCacheStats | None:
         return self.input_preprocessor.stat_mm_cache()


### PR DESCRIPTION
This reverts commit 27cb2f678f7567b14a13a2f7e085137dca1a4129.


## Purpose

We found that calling `get_max_tokens_per_item_by_modality` during initialization (introduced by #33110) causes startup to hang indefinitely for MM models. While moving the call to a lazy initialization fixes the issue, doing so would cause the first request to take much longer than normal. Let's revert this PR for now and find a better solution for this.

Example command that triggers the issue:

```
python3 examples/offline_inference/audio_language.py --seed 0
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

