### PR TITLE
Fix DeepSeek RoPE initialization error

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
@@ -75,7 +75,6 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbeddingBase):
                 self.rotary_dim,
                 2,
                 dtype=torch.float,
-                device="cpu",
             )
             / self.rotary_dim
         )
@@ -104,7 +103,6 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbeddingBase):
         inv_freq = self._compute_inv_freq(self.scaling_factor)
         t = torch.arange(
             self.max_position_embeddings * self.scaling_factor,
-            device="cpu",
             dtype=torch.float32,
         )
         freqs = torch.einsum("i,j -> ij", t, inv_freq)

--- a/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
@@ -75,11 +75,7 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbeddingBase):
                 self.rotary_dim,
                 2,
                 dtype=torch.float,
-                # NOTE(catswe): for tpu, allocates on cpu as xla currently
-                # lacks support for 'aten::empty.memory_format'
-                device="cpu"
-                if current_platform.is_tpu()
-                else current_platform.device_type,
+                device="cpu",
             )
             / self.rotary_dim
         )
@@ -108,9 +104,7 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbeddingBase):
         inv_freq = self._compute_inv_freq(self.scaling_factor)
         t = torch.arange(
             self.max_position_embeddings * self.scaling_factor,
-            # NOTE(catswe): for tpu, allocates on cpu as xla currently
-            # lacks support for 'aten::empty.memory_format'
-            device="cpu" if current_platform.is_tpu() else current_platform.device_type,
+            device="cpu",
             dtype=torch.float32,
         )
         freqs = torch.einsum("i,j -> ij", t, inv_freq)

--- a/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
@@ -75,7 +75,8 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbeddingBase):
                 self.rotary_dim,
                 2,
                 dtype=torch.float,
-                # NOTE(catswe): for tpu, allocates on cpu as xla currently lacks support for 'aten::empty.memory_format'
+                # NOTE(catswe): for tpu, allocates on cpu as xla currently
+                # lacks support for 'aten::empty.memory_format'
                 device="cpu"
                 if current_platform.is_tpu()
                 else current_platform.device_type,
@@ -107,7 +108,8 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbeddingBase):
         inv_freq = self._compute_inv_freq(self.scaling_factor)
         t = torch.arange(
             self.max_position_embeddings * self.scaling_factor,
-            # NOTE(catswe): for tpu, allocates on cpu as xla currently lacks support for 'aten::empty.memory_format'
+            # NOTE(catswe): for tpu, allocates on cpu as xla currently
+            # lacks support for 'aten::empty.memory_format'
             device="cpu" if current_platform.is_tpu() else current_platform.device_type,
             dtype=torch.float32,
         )

--- a/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
@@ -75,7 +75,8 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbeddingBase):
                 self.rotary_dim,
                 2,
                 dtype=torch.float,
-                device=current_platform.device_type,
+                # NOTE(catswe): for tpu, allocates on cpu as xla currently lacks support for 'aten::empty.memory_format'
+                device="cpu" if current_platform.is_tpu() else current_platform.device_type,
             )
             / self.rotary_dim
         )
@@ -104,7 +105,8 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbeddingBase):
         inv_freq = self._compute_inv_freq(self.scaling_factor)
         t = torch.arange(
             self.max_position_embeddings * self.scaling_factor,
-            device=current_platform.device_type,
+            # NOTE(catswe): for tpu, allocates on cpu as xla currently lacks support for 'aten::empty.memory_format'
+            device="cpu" if current_platform.is_tpu() else current_platform.device_type,
             dtype=torch.float32,
         )
         freqs = torch.einsum("i,j -> ij", t, inv_freq)

--- a/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
@@ -76,7 +76,9 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbeddingBase):
                 2,
                 dtype=torch.float,
                 # NOTE(catswe): for tpu, allocates on cpu as xla currently lacks support for 'aten::empty.memory_format'
-                device="cpu" if current_platform.is_tpu() else current_platform.device_type,
+                device="cpu"
+                if current_platform.is_tpu()
+                else current_platform.device_type,
             )
             / self.rotary_dim
         )

--- a/vllm/model_executor/models/lfm2_siglip2.py
+++ b/vllm/model_executor/models/lfm2_siglip2.py
@@ -22,7 +22,11 @@ from vllm.model_executor.layers.linear import (
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
-from .vision import is_vit_use_data_parallel, should_torch_compile_mm_vit
+from .vision import (
+    is_vit_use_data_parallel,
+    resolve_visual_encoder_outputs,
+    should_torch_compile_mm_vit,
+)
 
 
 class Siglip2VisionEmbeddings(nn.Module):
@@ -331,10 +335,17 @@ class Siglip2Encoder(nn.Module):
         self,
         config: Siglip2VisionConfig,
         quant_config: QuantizationConfig | None = None,
+        num_hidden_layers_override: int | None = None,
         prefix: str = "",
     ):
         super().__init__()
         self.config = config
+
+        if num_hidden_layers_override is None:
+            num_hidden_layers = config.num_hidden_layers
+        else:
+            num_hidden_layers = num_hidden_layers_override
+
         self.layers = nn.ModuleList(
             [
                 Siglip2EncoderLayer(
@@ -342,7 +353,7 @@ class Siglip2Encoder(nn.Module):
                     quant_config=quant_config,
                     prefix=f"{prefix}.layers.{idx}",
                 )
-                for idx in range(config.num_hidden_layers)
+                for idx in range(num_hidden_layers)
             ]
         )
 
@@ -351,15 +362,21 @@ class Siglip2Encoder(nn.Module):
         inputs_embeds: torch.Tensor,
         cu_seqlens: torch.Tensor,
         max_seqlen: int | torch.Tensor,
-    ) -> torch.Tensor:
+        return_all_hidden_states: bool = False,
+    ) -> torch.Tensor | list[torch.Tensor]:
+        hidden_states_pool = [inputs_embeds]
         hidden_states = inputs_embeds
+
         for encoder_layer in self.layers:
-            layer_outputs = encoder_layer(
+            hidden_states = encoder_layer(
                 hidden_states,
                 cu_seqlens=cu_seqlens,
                 max_seqlen=max_seqlen,
             )
-            hidden_states = layer_outputs
+            if return_all_hidden_states:
+                hidden_states_pool.append(hidden_states)
+        if return_all_hidden_states:
+            return hidden_states_pool
         return hidden_states
 
 
@@ -368,6 +385,8 @@ class Siglip2VisionTransformer(nn.Module):
         self,
         config: Siglip2VisionConfig,
         quant_config: QuantizationConfig | None = None,
+        num_hidden_layers_override: int | None = None,
+        require_post_norm: bool | None = None,
         prefix: str = "",
     ):
         super().__init__()
@@ -381,6 +400,7 @@ class Siglip2VisionTransformer(nn.Module):
             self.encoder = Siglip2Encoder(
                 config,
                 quant_config=quant_config,
+                num_hidden_layers_override=num_hidden_layers_override,
                 prefix=f"{prefix}.encoder",
             )
         num_hidden_layers = config.num_hidden_layers
@@ -390,7 +410,13 @@ class Siglip2VisionTransformer(nn.Module):
                 f"layers, but you requested {len(self.encoder.layers)} layers."
             )
 
-        self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
+        if require_post_norm is None:
+            require_post_norm = len(self.encoder.layers) == num_hidden_layers
+
+        if require_post_norm:
+            self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
+        else:
+            self.post_layernorm = None
 
     def get_input_embeddings(self):
         return self.embeddings
@@ -401,19 +427,34 @@ class Siglip2VisionTransformer(nn.Module):
         spatial_shapes: torch.LongTensor,
         cu_seqlens: torch.Tensor,
         max_seqlen: torch.Tensor,
+        select_layers: list[int] | None = None,
     ) -> torch.Tensor:
         r"""
         spatial_shapes (`torch.LongTensor` of shape `(batch_size, 2)`):
             Tensor containing the spatial dimensions (height, width)
         of the input images.
+        select_layers (`list[int]` or `None`, defaults to `None`):
+            Layer indices to select hidden states from. Supports negative
+            indices (e.g., -1 for last layer, -2 for second-to-last).
+            If None, returns the last layer output.
         """
         hidden_states = self.embeddings(pixel_values_packed, spatial_shapes)
+
         encoder_outputs = self.encoder(
             inputs_embeds=hidden_states,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
+            return_all_hidden_states=select_layers is not None,
         )
-        return self.post_layernorm(encoder_outputs)
+
+        encoder_outputs = resolve_visual_encoder_outputs(
+            encoder_outputs,
+            self.post_layernorm,
+            select_layers=select_layers,
+            max_possible_layers=self.config.num_hidden_layers,
+        )
+
+        return encoder_outputs
 
 
 class Siglip2Model(torch.nn.Module):
@@ -421,6 +462,8 @@ class Siglip2Model(torch.nn.Module):
         self,
         config: Siglip2VisionConfig,
         quant_config: QuantizationConfig | None = None,
+        num_hidden_layers_override: int | None = None,
+        require_post_norm: bool | None = None,
         prefix: str = "",
     ):
         super().__init__()
@@ -428,6 +471,8 @@ class Siglip2Model(torch.nn.Module):
         self.vision_model = Siglip2VisionTransformer(
             config,
             quant_config=quant_config,
+            num_hidden_layers_override=num_hidden_layers_override,
+            require_post_norm=require_post_norm,
             prefix=f"{prefix}.vision_model",
         )
 
@@ -437,12 +482,22 @@ class Siglip2Model(torch.nn.Module):
         spatial_shapes: torch.LongTensor,
         cu_seqlens: torch.Tensor,
         max_seqlen: torch.Tensor,
+        select_layers: list[int] | None = None,
     ) -> torch.Tensor:
+        """Forward pass through the vision model.
+
+        Args:
+            select_layers: Layer indices to select hidden states from.
+                Supports negative indices (e.g., [-2] for second-to-last).
+                If None, returns the last layer output with post_layernorm.
+                Multiple layers can be selected and will be concatenated.
+        """
         return self.vision_model(
             pixel_values_packed=pixel_values_packed,
             spatial_shapes=spatial_shapes,
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
+            select_layers=select_layers,
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
@@ -454,8 +509,22 @@ class Siglip2Model(torch.nn.Module):
         ]
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        layer_count = len(self.vision_model.encoder.layers)
 
         for name, loaded_weight in weights:
+            # post_layernorm is optional in Siglip2Model
+            if (
+                name.startswith("vision_model.post_layernorm")
+                and self.vision_model.post_layernorm is None
+            ):
+                continue
+
+            # omit layers when num_hidden_layers_override is set
+            if name.startswith("vision_model.encoder.layers"):
+                layer_idx = int(name.split(".")[3])
+                if layer_idx >= layer_count:
+                    continue
+
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:
                     continue


### PR DESCRIPTION

## Purpose
Fix DeepSeek V2 RoPE initialization error.

Before, one would get the following error output on TPUs
```
(vllm_env2) nhatt@t1v-n-b6d844bb-w-0:~$ cd tpu-inference
(vllm_env2) nhatt@t1v-n-b6d844bb-w-0:~/tpu-inference$ JAX_TRACEBACK_FILTERING=off VLLM_MLA_DISABLE=1 VLLM_LOGGING_LEVEL=DEBUG MODEL_IMPL_TYPE=vllm vllm serve gaunernst/DeepSeek-V2-Lite-Chat-FP8   --max-model-len=4096   --gpu-memory-utilization=0.98  --download-dir /dev/shm
DEBUG 02-01 06:04:54 [plugins/__init__.py:35] No plugins for group vllm.platform_plugins found.
DEBUG 02-01 06:04:54 [platforms/__init__.py:36] Checking if TPU platform is available.
DEBUG 02-01 06:04:54 [platforms/__init__.py:52] Confirmed TPU platform is available.
DEBUG 02-01 06:04:54 [platforms/__init__.py:61] Checking if CUDA platform is available.
DEBUG 02-01 06:04:54 [platforms/__init__.py:88] Exception happens when checking CUDA platform: NVML Shared Library Not Found
DEBUG 02-01 06:04:54 [platforms/__init__.py:105] CUDA platform is not available because: NVML Shared Library Not Found
DEBUG 02-01 06:04:54 [platforms/__init__.py:112] Checking if ROCm platform is available.
DEBUG 02-01 06:04:54 [platforms/__init__.py:126] ROCm platform is not available because: No module named 'amdsmi'
DEBUG 02-01 06:04:54 [platforms/__init__.py:133] Checking if XPU platform is available.
DEBUG 02-01 06:04:54 [platforms/__init__.py:155] XPU platform is not available because: No module named 'intel_extension_for_pytorch'
DEBUG 02-01 06:04:54 [platforms/__init__.py:162] Checking if CPU platform is available.
DEBUG 02-01 06:04:54 [platforms/__init__.py:36] Checking if TPU platform is available.
DEBUG 02-01 06:04:54 [platforms/__init__.py:52] Confirmed TPU platform is available.
DEBUG 02-01 06:04:54 [platforms/__init__.py:227] Automatically detected platform tpu.
INFO 02-01 06:04:54 [__init__.py:59] TPU info: node_name=will-1 | tpu_type=v6e-8 | worker_id=0 | num_chips=8 | num_cores_per_chip=1
WARNING:absl:Tensorflow library not found, tensorflow.io.gfile operations will use native shim calls. GCS paths (i.e. 'gs://...') cannot be accessed.
INFO 02-01 06:04:56 [triton_utils/importing.py:44] Triton is installed but 0 active driver(s) found (expected 1). Disabling Triton to prevent runtime errors.
INFO 02-01 06:04:56 [triton_utils/importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
DEBUG 02-01 06:04:56 [utils/flashinfer.py:55] FlashInfer unavailable since package was not found
WARNING 02-01 06:04:56 [platforms/interface.py:222] Failed to import from vllm._C: ModuleNotFoundError("No module named 'vllm._C'")
INFO 02-01 06:04:56 [tpu_platform.py:87] Automatically using fp8_e5m2 for FP8 KV cache on TPU v6e.
INFO 02-01 06:04:56 [tpu_platform.py:87] Automatically using fp8_e5m2 for FP8 KV cache on TPU v6e.
INFO 02-01 06:04:56 [tpu_platform.py:87] Automatically using fp8_e5m2 for FP8 KV cache on TPU v6e.
INFO 02-01 06:04:56 [tpu_platform.py:87] Automatically using fp8_e5m2 for FP8 KV cache on TPU v6e.
DEBUG 02-01 06:04:57 [entrypoints/utils.py:187] Setting VLLM_WORKER_MULTIPROC_METHOD to 'spawn'
DEBUG 02-01 06:04:57 [plugins/__init__.py:43] Available plugins for group vllm.general_plugins:
DEBUG 02-01 06:04:57 [plugins/__init__.py:45] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
DEBUG 02-01 06:04:57 [plugins/__init__.py:45] - lora_hf_hub_resolver -> vllm.plugins.lora_resolvers.hf_hub_resolver:register_hf_hub_resolver
DEBUG 02-01 06:04:57 [plugins/__init__.py:48] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
(APIServer pid=627866) INFO 02-01 06:04:57 [entrypoints/utils.py:346] 
(APIServer pid=627866) INFO 02-01 06:04:57 [entrypoints/utils.py:346]        █     █     █▄   ▄█
(APIServer pid=627866) INFO 02-01 06:04:57 [entrypoints/utils.py:346]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.16.0rc1.dev20+gae5b7aff2.d20260201
(APIServer pid=627866) INFO 02-01 06:04:57 [entrypoints/utils.py:346]   █▄█▀ █     █     █     █  model   gaunernst/DeepSeek-V2-Lite-Chat-FP8
(APIServer pid=627866) INFO 02-01 06:04:57 [entrypoints/utils.py:346]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=627866) INFO 02-01 06:04:57 [entrypoints/utils.py:346] 
(APIServer pid=627866) INFO 02-01 06:04:57 [entrypoints/utils.py:282] non-default args: {'model_tag': 'gaunernst/DeepSeek-V2-Lite-Chat-FP8', 'api_server_count': 1, 'model': 'gaunernst/DeepSeek-V2-Lite-Chat-FP8', 'max_model_len': 4096, 'download_dir': '/dev/shm', 'gpu_memory_utilization': 0.98}
(APIServer pid=627866) `rope_scaling`'s factor field must be a float >= 1, got 40
(APIServer pid=627866) `rope_scaling`'s beta_fast field must be a float, got 32
(APIServer pid=627866) `rope_scaling`'s beta_slow field must be a float, got 1
(APIServer pid=627866) DEBUG 02-01 06:04:58 [model_executor/models/registry.py:743] Loaded model info for class vllm.model_executor.models.deepseek_v2.DeepseekV2ForCausalLM from cache
(APIServer pid=627866) DEBUG 02-01 06:04:58 [logging_utils/log_time.py:29] Registry inspect model class: Elapsed time 0.0003713 secs
(APIServer pid=627866) INFO 02-01 06:04:58 [config/model.py:541] Resolved architecture: DeepseekV2ForCausalLM
(APIServer pid=627866) INFO 02-01 06:04:58 [config/model.py:1559] Using max model len 4096
(APIServer pid=627866) DEBUG 02-01 06:04:58 [_ipex_ops.py:15] Import error msg: No module named 'intel_extension_for_pytorch'
(APIServer pid=627866) DEBUG 02-01 06:04:58 [config/model.py:1623] Generative models support chunked prefill.
(APIServer pid=627866) DEBUG 02-01 06:04:58 [config/model.py:1681] Generative models support prefix caching.
(APIServer pid=627866) DEBUG 02-01 06:04:58 [engine/arg_utils.py:1890] Enabling chunked prefill by default
(APIServer pid=627866) DEBUG 02-01 06:04:58 [engine/arg_utils.py:1920] Enabling prefix caching by default
(APIServer pid=627866) DEBUG 02-01 06:04:58 [engine/arg_utils.py:1998] Defaulting max_num_batched_tokens to 2048 for OPENAI_API_SERVER usage context.
(APIServer pid=627866) DEBUG 02-01 06:04:58 [engine/arg_utils.py:2008] Defaulting max_num_seqs to 256 for OPENAI_API_SERVER usage context.
(APIServer pid=627866) DEBUG 02-01 06:04:58 [config/parallel.py:712] Disabled the custom all-reduce kernel because it is not supported on current platform.
(APIServer pid=627866) INFO 02-01 06:04:58 [config/scheduler.py:226] Chunked prefill is enabled with max_num_batched_tokens=2048.
(APIServer pid=627866) DEBUG 02-01 06:04:58 [config/parallel.py:712] Disabled the custom all-reduce kernel because it is not supported on current platform.
(APIServer pid=627866) INFO 02-01 06:04:58 [config/vllm.py:669] Asynchronous scheduling is enabled.
(APIServer pid=627866) INFO 02-01 06:04:58 [tpu_platform.py:125] Initialized sharding configuration: ShardingConfigManager(total_devices=1, sharding_strategy=ShardingStrategy(tensor_parallelism=1, expert_parallelism=1, sequence_parallelism=1, data_parallelism=1, attention_data_parallelism=1), device_indexes=None)
(APIServer pid=627866) INFO 02-01 06:04:58 [tpu_platform.py:176] Force using UniProcExecutor for JAX on single host without pipeline parallelism.
(APIServer pid=627866) DEBUG 02-01 06:04:58 [plugins/__init__.py:35] No plugins for group vllm.stat_logger_plugins found.
(APIServer pid=627866) DEBUG 02-01 06:04:58 [renderers/registry.py:51] Loading HfRenderer for renderer_mode='hf'
(APIServer pid=627866) DEBUG 02-01 06:04:59 [plugins/io_processors/__init__.py:33] No IOProcessor plugins requested by the model
(APIServer pid=627866) WARNING 02-01 06:04:59 [tpu_platform.py:217] Pin memory is not supported on TPU.
DEBUG 02-01 06:05:01 [plugins/__init__.py:35] No plugins for group vllm.platform_plugins found.
DEBUG 02-01 06:05:01 [platforms/__init__.py:36] Checking if TPU platform is available.
DEBUG 02-01 06:05:01 [platforms/__init__.py:52] Confirmed TPU platform is available.
DEBUG 02-01 06:05:01 [platforms/__init__.py:61] Checking if CUDA platform is available.
DEBUG 02-01 06:05:01 [platforms/__init__.py:88] Exception happens when checking CUDA platform: NVML Shared Library Not Found
DEBUG 02-01 06:05:01 [platforms/__init__.py:105] CUDA platform is not available because: NVML Shared Library Not Found
DEBUG 02-01 06:05:01 [platforms/__init__.py:112] Checking if ROCm platform is available.
DEBUG 02-01 06:05:01 [platforms/__init__.py:126] ROCm platform is not available because: No module named 'amdsmi'
DEBUG 02-01 06:05:01 [platforms/__init__.py:133] Checking if XPU platform is available.
DEBUG 02-01 06:05:01 [platforms/__init__.py:155] XPU platform is not available because: No module named 'intel_extension_for_pytorch'
DEBUG 02-01 06:05:01 [platforms/__init__.py:162] Checking if CPU platform is available.
DEBUG 02-01 06:05:01 [platforms/__init__.py:36] Checking if TPU platform is available.
DEBUG 02-01 06:05:01 [platforms/__init__.py:52] Confirmed TPU platform is available.
DEBUG 02-01 06:05:01 [platforms/__init__.py:227] Automatically detected platform tpu.
INFO 02-01 06:05:01 [__init__.py:59] TPU info: node_name=will-1 | tpu_type=v6e-8 | worker_id=0 | num_chips=8 | num_cores_per_chip=1
WARNING:absl:Tensorflow library not found, tensorflow.io.gfile operations will use native shim calls. GCS paths (i.e. 'gs://...') cannot be accessed.
INFO 02-01 06:05:03 [triton_utils/importing.py:44] Triton is installed but 0 active driver(s) found (expected 1). Disabling Triton to prevent runtime errors.
INFO 02-01 06:05:03 [triton_utils/importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
DEBUG 02-01 06:05:04 [utils/flashinfer.py:55] FlashInfer unavailable since package was not found
WARNING 02-01 06:05:04 [platforms/interface.py:222] Failed to import from vllm._C: ModuleNotFoundError("No module named 'vllm._C'")
INFO 02-01 06:05:04 [tpu_platform.py:87] Automatically using fp8_e5m2 for FP8 KV cache on TPU v6e.
INFO 02-01 06:05:04 [tpu_platform.py:87] Automatically using fp8_e5m2 for FP8 KV cache on TPU v6e.
INFO 02-01 06:05:04 [tpu_platform.py:87] Automatically using fp8_e5m2 for FP8 KV cache on TPU v6e.
INFO 02-01 06:05:04 [tpu_platform.py:87] Automatically using fp8_e5m2 for FP8 KV cache on TPU v6e.
(EngineCore_DP0 pid=628168) DEBUG 02-01 06:05:05 [v1/engine/core.py:861] Waiting for init message from front-end.
(APIServer pid=627866) DEBUG 02-01 06:05:05 [v1/engine/utils.py:1093] HELLO from local core engine process 0.
(EngineCore_DP0 pid=628168) DEBUG 02-01 06:05:05 [v1/engine/core.py:872] Received init message: EngineHandshakeMetadata(addresses=EngineZmqAddresses(inputs=['ipc:///tmp/2bd89855-2d54-4ed7-be16-910162c4fa26'], outputs=['ipc:///tmp/ac3979f3-7288-467a-af25-729cfc8c827f'], coordinator_input=None, coordinator_output=None, frontend_stats_publish_address=None), parallel_config={})
(EngineCore_DP0 pid=628168) DEBUG 02-01 06:05:05 [v1/engine/core.py:676] Has DP Coordinator: False, stats publish address: None
(EngineCore_DP0 pid=628168) DEBUG 02-01 06:05:05 [plugins/__init__.py:43] Available plugins for group vllm.general_plugins:
(EngineCore_DP0 pid=628168) DEBUG 02-01 06:05:05 [plugins/__init__.py:45] - lora_filesystem_resolver -> vllm.plugins.lora_resolvers.filesystem_resolver:register_filesystem_resolver
(EngineCore_DP0 pid=628168) DEBUG 02-01 06:05:05 [plugins/__init__.py:45] - lora_hf_hub_resolver -> vllm.plugins.lora_resolvers.hf_hub_resolver:register_hf_hub_resolver
(EngineCore_DP0 pid=628168) DEBUG 02-01 06:05:05 [plugins/__init__.py:48] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
(EngineCore_DP0 pid=628168) INFO 02-01 06:05:05 [v1/engine/core.py:96] Initializing a V1 LLM engine (v0.16.0rc1.dev20+gae5b7aff2.d20260201) with config: model='gaunernst/DeepSeek-V2-Lite-Chat-FP8', speculative_config=None, tokenizer='gaunernst/DeepSeek-V2-Lite-Chat-FP8', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=4096, download_dir='/dev/shm', load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=True, quantization=fp8, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=None, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=gaunernst/DeepSeek-V2-Lite-Chat-FP8, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.DYNAMO_TRACE_ONCE: 2>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'openxla', 'custom_ops': ['+quant_fp8', 'all', '+quant_fp8'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': None, 'compile_ranges_split_points': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': None, 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': True, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': None, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=628168) WARNING 02-01 06:05:05 [tpu_platform.py:217] Pin memory is not supported on TPU.
(EngineCore_DP0 pid=628168) DEBUG 02-01 06:05:13 [distributed/parallel_state.py:1192] world_size=1 rank=0 local_rank=0 distributed_init_method=file:///tmp/tmp_hfgbk5h backend=gloo
(EngineCore_DP0 pid=628168) INFO 02-01 06:05:13 [distributed/parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=file:///tmp/tmp_hfgbk5h backend=gloo
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore_DP0 pid=628168) DEBUG 02-01 06:05:13 [distributed/parallel_state.py:1278] Detected 1 nodes in the distributed environment
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore_DP0 pid=628168) INFO 02-01 06:05:13 [distributed/parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0
(EngineCore_DP0 pid=628168) INFO 02-01 06:05:13 [tpu_runner.py:297] Init mesh | mesh=Mesh('data': 1, 'model': 1, axis_types=(Auto, Auto))
(EngineCore_DP0 pid=628168) INFO 02-01 06:05:13 [utils.py:94] Prepared token paddings: [16, 32, 64, 128, 256, 512, 1024, 2048]
(EngineCore_DP0 pid=628168) INFO 02-01 06:05:14 [utils.py:60] Prepared request paddings: [8, 16, 32, 64, 128, 256]
(EngineCore_DP0 pid=628168) INFO 02-01 06:05:14 [compilation_manager.py:52] Enabling JAX compile cache.
(EngineCore_DP0 pid=628168) INFO 02-01 06:05:14 [tpu_worker.py:247] Init worker | rank=0 | is_first_rank=True | is_last_rank=True | topology_order_id=0 | is_driver_worker=True | hbm=[(0.0, 31.25)]GiB |self.devices=[TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0)] | total devices=[TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0), TpuDevice(id=1, process_index=0, coords=(1,0,0), core_on_chip=0), TpuDevice(id=2, process_index=0, coords=(0,1,0), core_on_chip=0), TpuDevice(id=3, process_index=0, coords=(1,1,0), core_on_chip=0), TpuDevice(id=4, process_index=0, coords=(0,2,0), core_on_chip=0), TpuDevice(id=5, process_index=0, coords=(1,2,0), core_on_chip=0), TpuDevice(id=6, process_index=0, coords=(0,3,0), core_on_chip=0), TpuDevice(id=7, process_index=0, coords=(1,3,0), core_on_chip=0)] | local_devices=[TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0), TpuDevice(id=1, process_index=0, coords=(1,0,0), core_on_chip=0), TpuDevice(id=2, process_index=0, coords=(0,1,0), core_on_chip=0), TpuDevice(id=3, process_index=0, coords=(1,1,0), core_on_chip=0), TpuDevice(id=4, process_index=0, coords=(0,2,0), core_on_chip=0), TpuDevice(id=5, process_index=0, coords=(1,2,0), core_on_chip=0), TpuDevice(id=6, process_index=0, coords=(0,3,0), core_on_chip=0), TpuDevice(id=7, process_index=0, coords=(1,3,0), core_on_chip=0)]
(EngineCore_DP0 pid=628168) DEBUG 02-01 06:05:14 [compilation/decorators.py:202] Inferred dynamic dimensions for forward method of <class 'vllm.model_executor.models.deepseek_v2.DeepseekV2Model'>: ['input_ids', 'positions', 'intermediate_tensors', 'inputs_embeds']
(EngineCore_DP0 pid=628168) INFO 02-01 06:05:14 [model_loader.py:370] Loading model with MODEL_IMPL_TYPE=vllm
(EngineCore_DP0 pid=628168) DEBUG 02-01 06:05:14 [_ipex_ops.py:15] Import error msg: No module named 'intel_extension_for_pytorch'
(EngineCore_DP0 pid=628168) DEBUG 02-01 06:05:14 [utils/deep_gemm.py:86] DeepGEMM E8M0 disabled: DeepGEMM not supported on this system.
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] EngineCore failed to start.
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] Traceback (most recent call last):
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/core.py", line 937, in run_engine_core
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/core.py", line 691, in __init__
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     super().__init__(
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/core.py", line 105, in __init__
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     self.model_executor = executor_class(vllm_config)
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/executor/abstract.py", line 101, in __init__
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     self._init_executor()
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/executor/uniproc_executor.py", line 48, in _init_executor
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     self.driver_worker.load_model()
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/tpu-inference/tpu_inference/worker/tpu_worker.py", line 364, in load_model
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     self.model_runner.load_model()
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/tpu-inference/tpu_inference/runner/tpu_runner.py", line 498, in load_model
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     self.model_fn, self.compute_logits_fn, self.combine_hidden_states_fn, multimodal_fns, self.state, self.lora_manager, self.model = get_model(
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]                                                                                                                                       ^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/tpu-inference/tpu_inference/models/common/model_loader.py", line 394, in get_model
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     return get_vllm_model(vllm_config, rng, mesh)
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/tpu-inference/tpu_inference/models/common/model_loader.py", line 354, in get_vllm_model
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     params, lora_manager = model.load_weights()
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]                            ^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/tpu-inference/tpu_inference/models/vllm/vllm_model_wrapper.py", line 166, in load_weights
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     vllm_model = vllm_get_model(vllm_config=vllm_config_for_load)
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/model_loader/__init__.py", line 135, in get_model
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     return loader.load_model(
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]            ^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/model_loader/base_loader.py", line 50, in load_model
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     model = initialize_model(
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]             ^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/model_loader/utils.py", line 48, in initialize_model
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     return model_class(vllm_config=vllm_config, prefix=prefix)
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/deepseek_v2.py", line 1210, in __init__
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     self.model = self.model_cls(
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]                  ^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/compilation/decorators.py", line 305, in __init__
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     old_init(self, **kwargs)
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/deepseek_v2.py", line 1067, in __init__
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     self.start_layer, self.end_layer, self.layers = make_layers(
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]                                                     ^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/utils.py", line 706, in make_layers
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     + [
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]       ^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/utils.py", line 707, in <listcomp>
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     maybe_offload_to_cpu(layer_fn(prefix=f"{prefix}.{idx}"))
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/deepseek_v2.py", line 1069, in <lambda>
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     lambda prefix: DeepseekV2DecoderLayer(
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]                    ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/deepseek_v2.py", line 941, in __init__
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     self.self_attn = attn_cls(
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]                      ^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/deepseek_v2.py", line 490, in __init__
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     self.rotary_emb = get_rope(
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]                       ^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/layers/rotary_embedding/__init__.py", line 256, in get_rope
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     rotary_emb = DeepseekScalingRotaryEmbedding(
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py", line 67, in __init__
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     super().__init__(
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/layers/rotary_embedding/base.py", line 49, in __init__
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     cache = self._compute_cos_sin_cache()
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py", line 104, in _compute_cos_sin_cache
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     inv_freq = self._compute_inv_freq(self.scaling_factor)
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py", line 73, in _compute_inv_freq
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     torch.arange(
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]   File "/mnt/disks/persist/nhatt/vllm_env2/lib/python3.11/site-packages/torch/utils/_device.py", line 103, in __torch_function__
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]     return func(*args, **kwargs)
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] NotImplementedError: Could not run 'aten::empty.memory_format' with arguments from the 'XLA' backend. This could be because the operator doesn't exist for this backend, or was omitted during the selective/custom build process (if using custom build). If you are a Facebook employee using PyTorch on mobile, please visit https://fburl.com/ptmfixes for possible resolutions. 'aten::empty.memory_format' is only available for these backends: [CPU, CUDA, Meta, QuantizedCPU, QuantizedCUDA, QuantizedMeta, MkldnnCPU, SparseCPU, SparseCUDA, SparseMeta, SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta, BackendSelect, Python, FuncTorchDynamicLayerBackMode, Functionalize, Named, Conjugate, Negative, ZeroTensor, ADInplaceOrView, AutogradOther, AutogradCPU, AutogradCUDA, AutogradHIP, AutogradXLA, AutogradMPS, AutogradIPU, AutogradXPU, AutogradHPU, AutogradVE, AutogradLazy, AutogradMTIA, AutogradMAIA, AutogradPrivateUse1, AutogradPrivateUse2, AutogradPrivateUse3, AutogradMeta, AutogradNestedTensor, Tracer, AutocastCPU, AutocastMTIA, AutocastMAIA, AutocastXPU, AutocastMPS, AutocastCUDA, FuncTorchBatched, BatchedNestedTensor, FuncTorchVmapMode, Batched, VmapMode, FuncTorchGradWrapper, PythonTLSSnapshot, FuncTorchDynamicLayerFrontMode, PreDispatch, PythonDispatcher].
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] 
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] CPU: registered at /pytorch/build/aten/src/ATen/RegisterCPU_1.cpp:2515 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] CUDA: registered at /pytorch/build/aten/src/ATen/RegisterCUDA_0.cpp:9338 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] Meta: registered at /pytorch/build/aten/src/ATen/RegisterMeta_0.cpp:5426 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] QuantizedCPU: registered at /pytorch/build/aten/src/ATen/RegisterQuantizedCPU_0.cpp:302 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] QuantizedCUDA: registered at /pytorch/build/aten/src/ATen/RegisterQuantizedCUDA_0.cpp:185 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] QuantizedMeta: registered at /pytorch/build/aten/src/ATen/RegisterQuantizedMeta_0.cpp:107 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] MkldnnCPU: registered at /pytorch/build/aten/src/ATen/RegisterMkldnnCPU_0.cpp:221 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] SparseCPU: registered at /pytorch/build/aten/src/ATen/RegisterSparseCPU_0.cpp:834 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] SparseCUDA: registered at /pytorch/build/aten/src/ATen/RegisterSparseCUDA_0.cpp:872 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] SparseMeta: registered at /pytorch/build/aten/src/ATen/RegisterSparseMeta_0.cpp:178 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] SparseCsrCPU: registered at /pytorch/build/aten/src/ATen/RegisterSparseCsrCPU_0.cpp:728 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] SparseCsrCUDA: registered at /pytorch/build/aten/src/ATen/RegisterSparseCsrCUDA_0.cpp:826 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] SparseCsrMeta: registered at /pytorch/build/aten/src/ATen/RegisterSparseCsrMeta_0.cpp:693 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] BackendSelect: registered at /pytorch/build/aten/src/ATen/RegisterBackendSelect.cpp:792 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] Python: registered at /pytorch/aten/src/ATen/core/PythonFallbackKernel.cpp:194 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] FuncTorchDynamicLayerBackMode: registered at /pytorch/aten/src/ATen/functorch/DynamicLayer.cpp:479 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] Functionalize: registered at /pytorch/aten/src/ATen/FunctionalizeFallbackKernel.cpp:387 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] Named: registered at /pytorch/aten/src/ATen/core/NamedRegistrations.cpp:7 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] Conjugate: fallthrough registered at /pytorch/aten/src/ATen/ConjugateFallback.cpp:21 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] Negative: fallthrough registered at /pytorch/aten/src/ATen/native/NegateFallback.cpp:22 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] ZeroTensor: fallthrough registered at /pytorch/aten/src/ATen/ZeroTensorFallback.cpp:119 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] ADInplaceOrView: fallthrough registered at /pytorch/aten/src/ATen/core/VariableFallbackKernel.cpp:104 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradOther: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradCPU: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradCUDA: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradHIP: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradXLA: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradMPS: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradIPU: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradXPU: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradHPU: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradVE: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradLazy: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradMTIA: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradMAIA: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradPrivateUse1: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradPrivateUse2: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradPrivateUse3: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradMeta: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutogradNestedTensor: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] Tracer: registered at /pytorch/torch/csrc/autograd/generated/TraceType_2.cpp:17917 [kernel]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutocastCPU: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:324 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutocastMTIA: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:468 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutocastMAIA: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:506 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutocastXPU: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:544 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutocastMPS: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:209 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] AutocastCUDA: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:165 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] FuncTorchBatched: registered at /pytorch/aten/src/ATen/functorch/LegacyBatchingRegistrations.cpp:731 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] BatchedNestedTensor: registered at /pytorch/aten/src/ATen/functorch/LegacyBatchingRegistrations.cpp:758 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] FuncTorchVmapMode: fallthrough registered at /pytorch/aten/src/ATen/functorch/VmapModeRegistrations.cpp:27 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] Batched: registered at /pytorch/aten/src/ATen/LegacyBatchingRegistrations.cpp:1075 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] VmapMode: fallthrough registered at /pytorch/aten/src/ATen/VmapModeRegistrations.cpp:33 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] FuncTorchGradWrapper: registered at /pytorch/aten/src/ATen/functorch/TensorWrapper.cpp:210 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] PythonTLSSnapshot: registered at /pytorch/aten/src/ATen/core/PythonFallbackKernel.cpp:202 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] FuncTorchDynamicLayerFrontMode: registered at /pytorch/aten/src/ATen/functorch/DynamicLayer.cpp:475 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] PreDispatch: registered at /pytorch/aten/src/ATen/core/PythonFallbackKernel.cpp:206 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] PythonDispatcher: registered at /pytorch/aten/src/ATen/core/PythonFallbackKernel.cpp:198 [backend fallback]
(EngineCore_DP0 pid=628168) ERROR 02-01 06:05:14 [v1/engine/core.py:946] 
(EngineCore_DP0 pid=628168) Process EngineCore_DP0:
(EngineCore_DP0 pid=628168) Traceback (most recent call last):
(EngineCore_DP0 pid=628168)   File "/usr/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore_DP0 pid=628168)     self.run()
(EngineCore_DP0 pid=628168)   File "/usr/lib/python3.11/multiprocessing/process.py", line 108, in run
(EngineCore_DP0 pid=628168)     self._target(*self._args, **self._kwargs)
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/core.py", line 950, in run_engine_core
(EngineCore_DP0 pid=628168)     raise e
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/core.py", line 937, in run_engine_core
(EngineCore_DP0 pid=628168)     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore_DP0 pid=628168)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/core.py", line 691, in __init__
(EngineCore_DP0 pid=628168)     super().__init__(
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/core.py", line 105, in __init__
(EngineCore_DP0 pid=628168)     self.model_executor = executor_class(vllm_config)
(EngineCore_DP0 pid=628168)                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/executor/abstract.py", line 101, in __init__
(EngineCore_DP0 pid=628168)     self._init_executor()
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/executor/uniproc_executor.py", line 48, in _init_executor
(EngineCore_DP0 pid=628168)     self.driver_worker.load_model()
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/tpu-inference/tpu_inference/worker/tpu_worker.py", line 364, in load_model
(EngineCore_DP0 pid=628168)     self.model_runner.load_model()
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/tpu-inference/tpu_inference/runner/tpu_runner.py", line 498, in load_model
(EngineCore_DP0 pid=628168)     self.model_fn, self.compute_logits_fn, self.combine_hidden_states_fn, multimodal_fns, self.state, self.lora_manager, self.model = get_model(
(EngineCore_DP0 pid=628168)                                                                                                                                       ^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/tpu-inference/tpu_inference/models/common/model_loader.py", line 394, in get_model
(EngineCore_DP0 pid=628168)     return get_vllm_model(vllm_config, rng, mesh)
(EngineCore_DP0 pid=628168)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/tpu-inference/tpu_inference/models/common/model_loader.py", line 354, in get_vllm_model
(EngineCore_DP0 pid=628168)     params, lora_manager = model.load_weights()
(EngineCore_DP0 pid=628168)                            ^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/tpu-inference/tpu_inference/models/vllm/vllm_model_wrapper.py", line 166, in load_weights
(EngineCore_DP0 pid=628168)     vllm_model = vllm_get_model(vllm_config=vllm_config_for_load)
(EngineCore_DP0 pid=628168)                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/model_loader/__init__.py", line 135, in get_model
(EngineCore_DP0 pid=628168)     return loader.load_model(
(EngineCore_DP0 pid=628168)            ^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/model_loader/base_loader.py", line 50, in load_model
(EngineCore_DP0 pid=628168)     model = initialize_model(
(EngineCore_DP0 pid=628168)             ^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/model_loader/utils.py", line 48, in initialize_model
(EngineCore_DP0 pid=628168)     return model_class(vllm_config=vllm_config, prefix=prefix)
(EngineCore_DP0 pid=628168)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/deepseek_v2.py", line 1210, in __init__
(EngineCore_DP0 pid=628168)     self.model = self.model_cls(
(EngineCore_DP0 pid=628168)                  ^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/compilation/decorators.py", line 305, in __init__
(EngineCore_DP0 pid=628168)     old_init(self, **kwargs)
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/deepseek_v2.py", line 1067, in __init__
(EngineCore_DP0 pid=628168)     self.start_layer, self.end_layer, self.layers = make_layers(
(EngineCore_DP0 pid=628168)                                                     ^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/utils.py", line 706, in make_layers
(EngineCore_DP0 pid=628168)     + [
(EngineCore_DP0 pid=628168)       ^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/utils.py", line 707, in <listcomp>
(EngineCore_DP0 pid=628168)     maybe_offload_to_cpu(layer_fn(prefix=f"{prefix}.{idx}"))
(EngineCore_DP0 pid=628168)                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/deepseek_v2.py", line 1069, in <lambda>
(EngineCore_DP0 pid=628168)     lambda prefix: DeepseekV2DecoderLayer(
(EngineCore_DP0 pid=628168)                    ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/deepseek_v2.py", line 941, in __init__
(EngineCore_DP0 pid=628168)     self.self_attn = attn_cls(
(EngineCore_DP0 pid=628168)                      ^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/models/deepseek_v2.py", line 490, in __init__
(EngineCore_DP0 pid=628168)     self.rotary_emb = get_rope(
(EngineCore_DP0 pid=628168)                       ^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/layers/rotary_embedding/__init__.py", line 256, in get_rope
(EngineCore_DP0 pid=628168)     rotary_emb = DeepseekScalingRotaryEmbedding(
(EngineCore_DP0 pid=628168)                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py", line 67, in __init__
(EngineCore_DP0 pid=628168)     super().__init__(
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/layers/rotary_embedding/base.py", line 49, in __init__
(EngineCore_DP0 pid=628168)     cache = self._compute_cos_sin_cache()
(EngineCore_DP0 pid=628168)             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py", line 104, in _compute_cos_sin_cache
(EngineCore_DP0 pid=628168)     inv_freq = self._compute_inv_freq(self.scaling_factor)
(EngineCore_DP0 pid=628168)                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py", line 73, in _compute_inv_freq
(EngineCore_DP0 pid=628168)     torch.arange(
(EngineCore_DP0 pid=628168)   File "/mnt/disks/persist/nhatt/vllm_env2/lib/python3.11/site-packages/torch/utils/_device.py", line 103, in __torch_function__
(EngineCore_DP0 pid=628168)     return func(*args, **kwargs)
(EngineCore_DP0 pid=628168)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=628168) NotImplementedError: Could not run 'aten::empty.memory_format' with arguments from the 'XLA' backend. This could be because the operator doesn't exist for this backend, or was omitted during the selective/custom build process (if using custom build). If you are a Facebook employee using PyTorch on mobile, please visit https://fburl.com/ptmfixes for possible resolutions. 'aten::empty.memory_format' is only available for these backends: [CPU, CUDA, Meta, QuantizedCPU, QuantizedCUDA, QuantizedMeta, MkldnnCPU, SparseCPU, SparseCUDA, SparseMeta, SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta, BackendSelect, Python, FuncTorchDynamicLayerBackMode, Functionalize, Named, Conjugate, Negative, ZeroTensor, ADInplaceOrView, AutogradOther, AutogradCPU, AutogradCUDA, AutogradHIP, AutogradXLA, AutogradMPS, AutogradIPU, AutogradXPU, AutogradHPU, AutogradVE, AutogradLazy, AutogradMTIA, AutogradMAIA, AutogradPrivateUse1, AutogradPrivateUse2, AutogradPrivateUse3, AutogradMeta, AutogradNestedTensor, Tracer, AutocastCPU, AutocastMTIA, AutocastMAIA, AutocastXPU, AutocastMPS, AutocastCUDA, FuncTorchBatched, BatchedNestedTensor, FuncTorchVmapMode, Batched, VmapMode, FuncTorchGradWrapper, PythonTLSSnapshot, FuncTorchDynamicLayerFrontMode, PreDispatch, PythonDispatcher].
(EngineCore_DP0 pid=628168) 
(EngineCore_DP0 pid=628168) CPU: registered at /pytorch/build/aten/src/ATen/RegisterCPU_1.cpp:2515 [kernel]
(EngineCore_DP0 pid=628168) CUDA: registered at /pytorch/build/aten/src/ATen/RegisterCUDA_0.cpp:9338 [kernel]
(EngineCore_DP0 pid=628168) Meta: registered at /pytorch/build/aten/src/ATen/RegisterMeta_0.cpp:5426 [kernel]
(EngineCore_DP0 pid=628168) QuantizedCPU: registered at /pytorch/build/aten/src/ATen/RegisterQuantizedCPU_0.cpp:302 [kernel]
(EngineCore_DP0 pid=628168) QuantizedCUDA: registered at /pytorch/build/aten/src/ATen/RegisterQuantizedCUDA_0.cpp:185 [kernel]
(EngineCore_DP0 pid=628168) QuantizedMeta: registered at /pytorch/build/aten/src/ATen/RegisterQuantizedMeta_0.cpp:107 [kernel]
(EngineCore_DP0 pid=628168) MkldnnCPU: registered at /pytorch/build/aten/src/ATen/RegisterMkldnnCPU_0.cpp:221 [kernel]
(EngineCore_DP0 pid=628168) SparseCPU: registered at /pytorch/build/aten/src/ATen/RegisterSparseCPU_0.cpp:834 [kernel]
(EngineCore_DP0 pid=628168) SparseCUDA: registered at /pytorch/build/aten/src/ATen/RegisterSparseCUDA_0.cpp:872 [kernel]
(EngineCore_DP0 pid=628168) SparseMeta: registered at /pytorch/build/aten/src/ATen/RegisterSparseMeta_0.cpp:178 [kernel]
(EngineCore_DP0 pid=628168) SparseCsrCPU: registered at /pytorch/build/aten/src/ATen/RegisterSparseCsrCPU_0.cpp:728 [kernel]
(EngineCore_DP0 pid=628168) SparseCsrCUDA: registered at /pytorch/build/aten/src/ATen/RegisterSparseCsrCUDA_0.cpp:826 [kernel]
(EngineCore_DP0 pid=628168) SparseCsrMeta: registered at /pytorch/build/aten/src/ATen/RegisterSparseCsrMeta_0.cpp:693 [kernel]
(EngineCore_DP0 pid=628168) BackendSelect: registered at /pytorch/build/aten/src/ATen/RegisterBackendSelect.cpp:792 [kernel]
(EngineCore_DP0 pid=628168) Python: registered at /pytorch/aten/src/ATen/core/PythonFallbackKernel.cpp:194 [backend fallback]
(EngineCore_DP0 pid=628168) FuncTorchDynamicLayerBackMode: registered at /pytorch/aten/src/ATen/functorch/DynamicLayer.cpp:479 [backend fallback]
(EngineCore_DP0 pid=628168) Functionalize: registered at /pytorch/aten/src/ATen/FunctionalizeFallbackKernel.cpp:387 [backend fallback]
(EngineCore_DP0 pid=628168) Named: registered at /pytorch/aten/src/ATen/core/NamedRegistrations.cpp:7 [backend fallback]
(EngineCore_DP0 pid=628168) Conjugate: fallthrough registered at /pytorch/aten/src/ATen/ConjugateFallback.cpp:21 [kernel]
(EngineCore_DP0 pid=628168) Negative: fallthrough registered at /pytorch/aten/src/ATen/native/NegateFallback.cpp:22 [kernel]
(EngineCore_DP0 pid=628168) ZeroTensor: fallthrough registered at /pytorch/aten/src/ATen/ZeroTensorFallback.cpp:119 [kernel]
(EngineCore_DP0 pid=628168) ADInplaceOrView: fallthrough registered at /pytorch/aten/src/ATen/core/VariableFallbackKernel.cpp:104 [backend fallback]
(EngineCore_DP0 pid=628168) AutogradOther: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradCPU: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradCUDA: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradHIP: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradXLA: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradMPS: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradIPU: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradXPU: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradHPU: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradVE: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradLazy: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradMTIA: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradMAIA: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradPrivateUse1: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradPrivateUse2: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradPrivateUse3: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradMeta: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) AutogradNestedTensor: registered at /pytorch/torch/csrc/autograd/generated/VariableType_2.cpp:20142 [autograd kernel]
(EngineCore_DP0 pid=628168) Tracer: registered at /pytorch/torch/csrc/autograd/generated/TraceType_2.cpp:17917 [kernel]
(EngineCore_DP0 pid=628168) AutocastCPU: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:324 [backend fallback]
(EngineCore_DP0 pid=628168) AutocastMTIA: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:468 [backend fallback]
(EngineCore_DP0 pid=628168) AutocastMAIA: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:506 [backend fallback]
(EngineCore_DP0 pid=628168) AutocastXPU: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:544 [backend fallback]
(EngineCore_DP0 pid=628168) AutocastMPS: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:209 [backend fallback]
(EngineCore_DP0 pid=628168) AutocastCUDA: fallthrough registered at /pytorch/aten/src/ATen/autocast_mode.cpp:165 [backend fallback]
(EngineCore_DP0 pid=628168) FuncTorchBatched: registered at /pytorch/aten/src/ATen/functorch/LegacyBatchingRegistrations.cpp:731 [backend fallback]
(EngineCore_DP0 pid=628168) BatchedNestedTensor: registered at /pytorch/aten/src/ATen/functorch/LegacyBatchingRegistrations.cpp:758 [backend fallback]
(EngineCore_DP0 pid=628168) FuncTorchVmapMode: fallthrough registered at /pytorch/aten/src/ATen/functorch/VmapModeRegistrations.cpp:27 [backend fallback]
(EngineCore_DP0 pid=628168) Batched: registered at /pytorch/aten/src/ATen/LegacyBatchingRegistrations.cpp:1075 [backend fallback]
(EngineCore_DP0 pid=628168) VmapMode: fallthrough registered at /pytorch/aten/src/ATen/VmapModeRegistrations.cpp:33 [backend fallback]
(EngineCore_DP0 pid=628168) FuncTorchGradWrapper: registered at /pytorch/aten/src/ATen/functorch/TensorWrapper.cpp:210 [backend fallback]
(EngineCore_DP0 pid=628168) PythonTLSSnapshot: registered at /pytorch/aten/src/ATen/core/PythonFallbackKernel.cpp:202 [backend fallback]
(EngineCore_DP0 pid=628168) FuncTorchDynamicLayerFrontMode: registered at /pytorch/aten/src/ATen/functorch/DynamicLayer.cpp:475 [backend fallback]
(EngineCore_DP0 pid=628168) PreDispatch: registered at /pytorch/aten/src/ATen/core/PythonFallbackKernel.cpp:206 [backend fallback]
(EngineCore_DP0 pid=628168) PythonDispatcher: registered at /pytorch/aten/src/ATen/core/PythonFallbackKernel.cpp:198 [backend fallback]
(EngineCore_DP0 pid=628168) 
(APIServer pid=627866) DEBUG 02-01 06:05:15 [v1/engine/utils.py:982] Waiting for 1 local, 0 remote core engine proc(s) to start.
(APIServer pid=627866) Traceback (most recent call last):
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm_env2/bin/vllm", line 8, in <module>
(APIServer pid=627866)     sys.exit(main())
(APIServer pid=627866)              ^^^^^^
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm/vllm/entrypoints/cli/main.py", line 73, in main
(APIServer pid=627866)     args.dispatch_function(args)
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm/vllm/entrypoints/cli/serve.py", line 111, in cmd
(APIServer pid=627866)     uvloop.run(run_server(args))
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm_env2/lib/python3.11/site-packages/uvloop/__init__.py", line 92, in run
(APIServer pid=627866)     return runner.run(wrapper())
(APIServer pid=627866)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=627866)   File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
(APIServer pid=627866)     return self._loop.run_until_complete(task)
(APIServer pid=627866)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=627866)   File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm_env2/lib/python3.11/site-packages/uvloop/__init__.py", line 48, in wrapper
(APIServer pid=627866)     return await main
(APIServer pid=627866)            ^^^^^^^^^^
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm/vllm/entrypoints/openai/api_server.py", line 431, in run_server
(APIServer pid=627866)     await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm/vllm/entrypoints/openai/api_server.py", line 450, in run_server_worker
(APIServer pid=627866)     async with build_async_engine_client(
(APIServer pid=627866)   File "/usr/lib/python3.11/contextlib.py", line 210, in __aenter__
(APIServer pid=627866)     return await anext(self.gen)
(APIServer pid=627866)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm/vllm/entrypoints/openai/api_server.py", line 92, in build_async_engine_client
(APIServer pid=627866)     async with build_async_engine_client_from_engine_args(
(APIServer pid=627866)   File "/usr/lib/python3.11/contextlib.py", line 210, in __aenter__
(APIServer pid=627866)     return await anext(self.gen)
(APIServer pid=627866)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm/vllm/entrypoints/openai/api_server.py", line 133, in build_async_engine_client_from_engine_args
(APIServer pid=627866)     async_llm = AsyncLLM.from_vllm_config(
(APIServer pid=627866)                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/async_llm.py", line 216, in from_vllm_config
(APIServer pid=627866)     return cls(
(APIServer pid=627866)            ^^^^
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/async_llm.py", line 143, in __init__
(APIServer pid=627866)     self.engine_core = EngineCoreClient.make_async_mp_client(
(APIServer pid=627866)                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/core_client.py", line 122, in make_async_mp_client
(APIServer pid=627866)     return AsyncMPClient(*client_args)
(APIServer pid=627866)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/core_client.py", line 819, in __init__
(APIServer pid=627866)     super().__init__(
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/core_client.py", line 479, in __init__
(APIServer pid=627866)     with launch_core_engines(vllm_config, executor_class, log_stats) as (
(APIServer pid=627866)   File "/usr/lib/python3.11/contextlib.py", line 144, in __exit__
(APIServer pid=627866)     next(self.gen)
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/utils.py", line 933, in launch_core_engines
(APIServer pid=627866)     wait_for_engine_startup(
(APIServer pid=627866)   File "/mnt/disks/persist/nhatt/vllm/vllm/v1/engine/utils.py", line 992, in wait_for_engine_startup
(APIServer pid=627866)     raise RuntimeError(
(APIServer pid=627866) RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
```
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

