### PR TITLE
[Kernel] Support Flashinfer trtllm fused MoE non gated FP8 & NVFP4

### DIFF
--- a/tests/kernels/moe/test_flashinfer.py
+++ b/tests/kernels/moe/test_flashinfer.py
@@ -124,6 +124,7 @@ class TestData:
         layer.w2_input_scale = a2_scale
         layer.w13_weight_scale = w13_weight_scale
         layer.w2_weight_scale = w2_weight_scale
+        layer.activation = activation
         # Setup dummy config.
         layer.moe_parallel_config = mk.FusedMoEParallelConfig.make_no_parallel()
 
@@ -131,7 +132,7 @@ class TestData:
         layer.w13_weight.data = swap_w13_to_w31(layer.w13_weight.data)
         if is_trtllm:
             rotate_weights_for_fi_trtllm_fp8_per_tensor_moe(
-                layer.w13_weight, layer.w2_weight
+                layer.w13_weight, layer.w2_weight, is_gated
             )
             register_scales_for_trtllm_fp8_per_tensor_moe(
                 layer,
@@ -146,7 +147,6 @@ class TestData:
         layer.intermediate_size_per_partition = n
         layer.ep_rank = 0
         layer.local_num_experts = e
-        layer.activation = activation
 
         return TestData(
             hidden_states=hidden_states,

--- a/tests/kernels/moe/test_flashinfer.py
+++ b/tests/kernels/moe/test_flashinfer.py
@@ -129,7 +129,6 @@ class TestData:
 
         # Scale to fp8
         _, a1_scale = input_to_float8(hidden_states)
-        a1_scale = a1_scale.max()
         a2_scale = torch.scalar_tensor(1.0).to(device="cuda").to(dtype=torch.float32)
         w13_quantized, w13_weight_scale = quant_fp8_per_tensor_batches(w13)
         w2_quantized, w2_weight_scale = quant_fp8_per_tensor_batches(w2)

--- a/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
@@ -291,8 +291,8 @@ def fi_trtllm_fp8_per_tensor_moe(
     local_num_experts: int,
     use_routing_scales_on_input: bool,
     routing_method_type: int,
+    activation_type: int,
     routed_scaling_factor: float = 1.0,
-    activation_type: int = 3,  # Swiglu
 ) -> torch.Tensor:
     num_expert_group = num_expert_group if num_expert_group is not None else 0
     topk_group = topk_group if topk_group is not None else 0
@@ -352,8 +352,8 @@ def fi_trtllm_fp8_per_tensor_moe_fake(
     local_num_experts: int,
     use_routing_scales_on_input: bool,
     routing_method_type: int,
+    activation_type: int,
     routed_scaling_factor: float = 1.0,
-    activation_type: int = 3,  # Swiglu
 ) -> torch.Tensor:
     return torch.empty_like(hidden_states)
 

--- a/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
@@ -292,6 +292,7 @@ def fi_trtllm_fp8_per_tensor_moe(
     use_routing_scales_on_input: bool,
     routing_method_type: int,
     routed_scaling_factor: float = 1.0,
+    activation_type: int = 7,
 ) -> torch.Tensor:
     num_expert_group = num_expert_group if num_expert_group is not None else 0
     topk_group = topk_group if topk_group is not None else 0
@@ -326,9 +327,7 @@ def fi_trtllm_fp8_per_tensor_moe(
         routed_scaling_factor=routed_scaling_factor,
         use_routing_scales_on_input=use_routing_scales_on_input,
         routing_method_type=routing_method_type,
-        # TODO: Required for flashinfer==0.6.3, remove with update
-        # https://github.com/flashinfer-ai/flashinfer/pull/2508
-        activation_type=ActivationType.Swiglu,
+        activation_type=ActivationType(activation_type),
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
@@ -292,7 +292,7 @@ def fi_trtllm_fp8_per_tensor_moe(
     use_routing_scales_on_input: bool,
     routing_method_type: int,
     routed_scaling_factor: float = 1.0,
-    activation_type: int = 7,
+    activation_type: int = 3,  # Swiglu
 ) -> torch.Tensor:
     num_expert_group = num_expert_group if num_expert_group is not None else 0
     topk_group = topk_group if topk_group is not None else 0

--- a/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
@@ -35,8 +35,8 @@ def _supports_current_device() -> bool:
 
 
 def _supports_no_act_and_mul() -> bool:
-    """Does not support non-gated MoE (i.e. Nanotron-Mini)."""
-    return False
+    """Supports non-gated MoE."""
+    return True
 
 
 def _supports_quant_scheme(
@@ -52,8 +52,7 @@ def _supports_quant_scheme(
 
 
 def _supports_activation(activation: MoEActivation) -> bool:
-    """Supports silu activation only."""
-    return activation == MoEActivation.SILU
+    return activation in [MoEActivation.SILU, MoEActivation.RELU2_NO_MUL]
 
 
 def _supports_routing_method(
@@ -74,6 +73,7 @@ def _supports_routing_method(
     elif (weight_key, activation_key) == (kFp8StaticTensorSym, kFp8StaticTensorSym):
         # NOTE(dbari): as above, potentially allow others here.
         return routing_method in [
+            RoutingMethodType.DeepSeekV3,
             RoutingMethodType.Llama4,
             RoutingMethodType.Renormalize,
             RoutingMethodType.RenormalizeNaive,

--- a/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
@@ -327,6 +327,8 @@ def fi_trtllm_fp8_per_tensor_moe(
         routed_scaling_factor=routed_scaling_factor,
         use_routing_scales_on_input=use_routing_scales_on_input,
         routing_method_type=routing_method_type,
+        # TODO: enum type Required for flashinfer==0.6.3, remove with update
+        # https://github.com/flashinfer-ai/flashinfer/pull/2508
         activation_type=ActivationType(activation_type),
     )
 
@@ -351,6 +353,7 @@ def fi_trtllm_fp8_per_tensor_moe_fake(
     use_routing_scales_on_input: bool,
     routing_method_type: int,
     routed_scaling_factor: float = 1.0,
+    activation_type: int = 3,  # Swiglu
 ) -> torch.Tensor:
     return torch.empty_like(hidden_states)
 

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -939,8 +939,8 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
         # time in the oracle rather than here.
         SUPPORTED_ACTIVATIONS = [MoEActivation.SILU, MoEActivation.RELU2_NO_MUL]
         assert layer.activation in SUPPORTED_ACTIVATIONS, (
-            f"Expected one of {SUPPORTED_ACTIVATIONS} activations but got "
-            + layer.activation
+            f"Only {SUPPORTED_ACTIVATIONS} activations are supported for FlashInfer "
+            f"TRTLLM FP4 MoE, {layer.activation} found instead."
         )
         return apply_fi_trtllm_fp8_per_tensor_moe(
             layer=layer,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -942,7 +942,6 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
             f"Expected one of {SUPPORTED_ACTIVATIONS} activations but got "
             + layer.activation
         )
-        assert not layer.renormalize
         return apply_fi_trtllm_fp8_per_tensor_moe(
             layer=layer,
             hidden_states=x,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -937,8 +937,10 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
             )
         # TODO(rob): this validation should happen at kernel selection
         # time in the oracle rather than here.
-        assert layer.activation == MoEActivation.SILU, (
-            f"Expected 'silu' activation but got {layer.activation}"
+        SUPPORTED_ACTIVATIONS = [MoEActivation.SILU, MoEActivation.RELU2_NO_MUL]
+        assert layer.activation in SUPPORTED_ACTIVATIONS, (
+            f"Expected one of {SUPPORTED_ACTIVATIONS} activations but got "
+            + layer.activation
         )
         assert not layer.renormalize
         return apply_fi_trtllm_fp8_per_tensor_moe(
@@ -1239,6 +1241,15 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             weight_key=kNvfp4Static,
             activation_key=kNvfp4Dynamic,
         )
+        # TODO: move this type of check into the oracle.
+        if not self.moe.is_act_and_mul and self.nvfp4_backend not in {
+            NvFp4MoeBackend.FLASHINFER_CUTLASS,
+            NvFp4MoeBackend.FLASHINFER_TRTLLM,
+        }:
+            raise NotImplementedError(
+                "Non-gated activations are only supported by FlashInfer "
+                "CUTLASS and TRTLLM NvFP4 MoE backends."
+            )
 
         self.use_global_sf = is_global_sf_supported_for_nvfp4_backend(
             self.nvfp4_backend
@@ -1509,7 +1520,11 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             self.nvfp4_backend == NvFp4MoeBackend.FLASHINFER_TRTLLM
             and not layer.enable_eplb
         )
-
+        SUPPORTED_ACTIVATIONS = ["silu", "relu2_no_mul"]
+        assert layer.activation in SUPPORTED_ACTIVATIONS, (
+            f"Expected one of {SUPPORTED_ACTIVATIONS} activations but got "
+            + layer.activation
+        )
         return flashinfer_trtllm_fp4_moe(
             layer=layer,
             x=x,
@@ -1536,6 +1551,11 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         # EPLB path
         if self.nvfp4_backend == NvFp4MoeBackend.FLASHINFER_TRTLLM:
             assert layer.enable_eplb
+            SUPPORTED_ACTIVATIONS = ["silu", "relu2_no_mul"]
+            assert layer.activation in SUPPORTED_ACTIVATIONS, (
+                f"Expected one of {SUPPORTED_ACTIVATIONS} activations but got "
+                + layer.activation
+            )
             return flashinfer_trtllm_fp4_routed_moe(
                 layer=layer,
                 x=x,

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -164,26 +164,26 @@ def prepare_static_weights_for_trtllm_fp4_moe(
     _cache_permute_indices: dict[torch.Size, torch.Tensor] = {}
     """Prepare quantized weights for kernel (done offline with weights)."""
     epilogue_tile_m = 128  # FIXME: this depends on the kernel internals
-    actual_intermediate_size = 2 * intermediate_size
+    gemm1_intermediate_size = (
+        2 * intermediate_size if is_gated_activation else intermediate_size
+    )
 
     # Convert quantized weights to proper formats
     gemm1_weights_fp4 = gemm1_weights.view(torch.float8_e4m3fn).reshape(
-        num_experts, actual_intermediate_size, hidden_size // 2
+        num_experts, gemm1_intermediate_size, hidden_size // 2
     )  # packed fp4
     gemm1_scales_linear_fp4 = gemm1_scales_linear_fp4_bytes.view(
         torch.float8_e4m3fn
     ).reshape(
-        num_experts, actual_intermediate_size, hidden_size // 16
+        num_experts, gemm1_intermediate_size, hidden_size // 16
     )  # fp8 scaling factors
 
     gemm2_weights_fp4 = gemm2_weights.view(torch.float8_e4m3fn).reshape(
-        num_experts, hidden_size, actual_intermediate_size // 2
+        num_experts, hidden_size, intermediate_size // 2
     )  # packed fp4
     gemm2_scales_linear_fp4 = gemm2_scales_linear_fp4_bytes.view(
         torch.float8_e4m3fn
-    ).reshape(
-        num_experts, hidden_size, actual_intermediate_size // 16
-    )  # fp8 scaling factors
+    ).reshape(num_experts, hidden_size, intermediate_size // 16)  # fp8 scaling factors
 
     gemm1_weights_fp4_shuffled = []
     gemm1_scales_fp4_shuffled = []
@@ -255,14 +255,14 @@ def prepare_static_weights_for_trtllm_fp4_moe(
     gemm1_scales_fp4_shuffled = (
         torch.stack(gemm1_scales_fp4_shuffled)
         .view(torch.float8_e4m3fn)
-        .reshape(num_experts, actual_intermediate_size, hidden_size // 16)
+        .reshape(num_experts, gemm1_intermediate_size, hidden_size // 16)
     )
 
     gemm2_weights_fp4_shuffled = torch.stack(gemm2_weights_fp4_shuffled)
     gemm2_scales_fp4_shuffled = (
         torch.stack(gemm2_scales_fp4_shuffled)
         .view(torch.float8_e4m3fn)
-        .reshape(num_experts, hidden_size, actual_intermediate_size // 16)
+        .reshape(num_experts, hidden_size, intermediate_size // 16)
     )
     return (
         gemm1_weights_fp4_shuffled,
@@ -528,10 +528,10 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
             w2,
             w13_scale,
             w2_scale,
-            w2.size(-2),  # hidden_size
-            w13.size(-2) // 2,  # intermediate_size
-            w13.size(0),  # num_experts
-            is_gated,  # is_gated_activation
+            hidden_size=w2.size(-2),
+            intermediate_size=w13.size(-2) // 2 if is_gated else w13.size(-2),
+            num_experts=w13.size(0),
+            is_gated_activation=is_gated,
         )
 
         # We do not need to make this a parameter, because

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -308,8 +308,8 @@ def flashinfer_trtllm_fp4_moe(
 
     SUPPORTED_ACTIVATIONS = [MoEActivation.SILU, MoEActivation.RELU2_NO_MUL]
     assert activation in SUPPORTED_ACTIVATIONS, (
-        "Only SiLU and ReLU2_NO_MUL activations are supported for FlashInfer TRTLLM FP4 MoE. "
-        f"{activation} found instead."
+        f"Only {SUPPORTED_ACTIVATIONS} activations are supported for FlashInfer "
+        f"TRTLLM FP4 MoE, {activation} found instead."
     )
 
     # Quantize input to FP4

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -15,6 +15,10 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEParallelConfig,
     RoutingMethodType,
 )
+from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
+    activation_to_flashinfer_int,
+    align_fp4_moe_weights_for_fi,
+)
 from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
     swizzle_blockscale,
 )
@@ -150,6 +154,7 @@ def prepare_static_weights_for_trtllm_fp4_moe(
     hidden_size,
     intermediate_size,
     num_experts,
+    is_gated_activation: bool,
 ):
     from flashinfer import nvfp4_block_scale_interleave
     from flashinfer.fused_moe.core import (
@@ -172,11 +177,13 @@ def prepare_static_weights_for_trtllm_fp4_moe(
     )  # fp8 scaling factors
 
     gemm2_weights_fp4 = gemm2_weights.view(torch.float8_e4m3fn).reshape(
-        num_experts, hidden_size, intermediate_size // 2
+        num_experts, hidden_size, 2 * intermediate_size // 2
     )  # packed fp4
     gemm2_scales_linear_fp4 = gemm2_scales_linear_fp4_bytes.view(
         torch.float8_e4m3fn
-    ).reshape(num_experts, hidden_size, intermediate_size // 16)  # fp8 scaling factors
+    ).reshape(
+        num_experts, hidden_size, 2 * intermediate_size // 16
+    )  # fp8 scaling factors
 
     gemm1_weights_fp4_shuffled = []
     gemm1_scales_fp4_shuffled = []
@@ -191,6 +198,7 @@ def prepare_static_weights_for_trtllm_fp4_moe(
             _cache_permute_indices,
             gemm1_weights_fp4[i].view(torch.uint8),
             epilogue_tile_m,
+            is_gated_act_gemm=is_gated_activation,
         )
         gemm1_weights_fp4_shuffled.append(
             gemm1_weights_fp4[i]
@@ -203,6 +211,7 @@ def prepare_static_weights_for_trtllm_fp4_moe(
             gemm1_scales_linear_fp4[i].view(torch.uint8),
             epilogue_tile_m,
             num_elts_per_sf=16,
+            is_gated_act_gemm=is_gated_activation,
         )
         gemm1_scales_fp4_shuffled.append(
             nvfp4_block_scale_interleave(
@@ -253,7 +262,7 @@ def prepare_static_weights_for_trtllm_fp4_moe(
     gemm2_scales_fp4_shuffled = (
         torch.stack(gemm2_scales_fp4_shuffled)
         .view(torch.float8_e4m3fn)
-        .reshape(num_experts, hidden_size, intermediate_size // 16)
+        .reshape(num_experts, hidden_size, 2 * intermediate_size // 16)
     )
     return (
         gemm1_weights_fp4_shuffled,
@@ -296,8 +305,8 @@ def flashinfer_trtllm_fp4_moe(
     import flashinfer
 
     from vllm.model_executor.models.llama4 import Llama4MoE
+    from vllm.utils.flashinfer import FlashinferActivationType
 
-    # https://github.com/flashinfer-ai/flashinfer/blob/f0277fd1bff90e309e5c19cab36c5dae056d685d/flashinfer/fused_moe/core.py#L2404
     assert activation == MoEActivation.SILU, (
         "Only SiLU activation is supported for FlashInfer TRTLLM FP4 MoE. "
         f"{activation} found instead."
@@ -326,6 +335,7 @@ def flashinfer_trtllm_fp4_moe(
     )
 
     # Call TRT-LLM FP4 block-scale MoE kernel
+    activation_type = activation_to_flashinfer_int(layer.activation)
     out = flashinfer.fused_moe.trtllm_fp4_block_scale_moe(
         routing_logits=router_logits,
         routing_bias=e_score_correction_bias,
@@ -355,6 +365,7 @@ def flashinfer_trtllm_fp4_moe(
         routed_scaling_factor=None,
         routing_method_type=routing_method_type,
         do_finalize=True,
+        activation_type=activation_type,
     )[0]
 
     return out
@@ -479,10 +490,16 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
     ]
 
     # Reorder [w1, w3] to [w3, w1] for FI NVFP4 MoE kernels.
-    if is_act_and_mul and backend in [
-        NvFp4MoeBackend.FLASHINFER_CUTLASS,
-        NvFp4MoeBackend.FLASHINFER_TRTLLM,
-    ]:
+    is_gated = layer.activation.is_gated
+    if (
+        is_gated
+        and is_act_and_mul
+        and backend
+        in [
+            NvFp4MoeBackend.FLASHINFER_CUTLASS,
+            NvFp4MoeBackend.FLASHINFER_TRTLLM,
+        ]
+    ):
         w13, w13_scale = reorder_w1w3_to_w3w1(w13, w13_scale)
 
     # For some FI kernels, the input scales are shared by all experts.
@@ -495,6 +512,17 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
 
     # Shuffle weights and scales for FI TRTLLM NVFP4 MoE kernels.
     if backend == NvFp4MoeBackend.FLASHINFER_TRTLLM:
+        # Align weights for FI NVFP4 MoE kernels.
+        block_quant = (
+            hasattr(layer, "weight_block_size") and layer.weight_block_size is not None
+        )
+        if not block_quant:
+            w13, w13_scale, w2, w2_scale, padded_intermediate = (
+                align_fp4_moe_weights_for_fi(
+                    w13, w13_scale, w2, w2_scale, is_act_and_mul, min_alignment=128
+                )
+            )
+            layer.intermediate_size_per_partition = padded_intermediate
         w13, w13_scale, w2, w2_scale = prepare_static_weights_for_trtllm_fp4_moe(
             w13,
             w2,
@@ -503,11 +531,15 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
             w2.size(-2),  # hidden_size
             w13.size(-2) // 2,  # intermediate_size
             w13.size(0),  # num_experts
+            is_gated,  # is_gated_activation
         )
 
         # We do not need to make this a parameter, because
         # it is not used during the weight (re)-loading process.
-        layer.g1_scale_c = a13_scale * w13_scale_2 / a2_scale
+        if is_gated:
+            layer.g1_scale_c = a13_scale * w13_scale_2 / a2_scale
+        else:
+            layer.g1_scale_c = torch.ones_like(a13_scale) / a2_scale
         layer.a1_gscale = 1.0 / a13_scale
         layer.g1_alphas = a13_scale * w13_scale_2
         layer.g2_alphas = a2_scale * w2_scale_2

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -303,12 +303,13 @@ def flashinfer_trtllm_fp4_moe(
         Output tensor from the MoE layer
     """
     import flashinfer
+    from flashinfer.fused_moe.core import ActivationType
 
     from vllm.model_executor.models.llama4 import Llama4MoE
-    from vllm.utils.flashinfer import FlashinferActivationType
 
-    assert activation == MoEActivation.SILU, (
-        "Only SiLU activation is supported for FlashInfer TRTLLM FP4 MoE. "
+    SUPPORTED_ACTIVATIONS = [MoEActivation.SILU, MoEActivation.RELU2_NO_MUL]
+    assert activation in SUPPORTED_ACTIVATIONS, (
+        "Only SiLU and ReLU2_NO_MUL activations are supported for FlashInfer TRTLLM FP4 MoE. "
         f"{activation} found instead."
     )
 
@@ -367,7 +368,7 @@ def flashinfer_trtllm_fp4_moe(
         routed_scaling_factor=None,
         routing_method_type=routing_method_type,
         do_finalize=True,
-        activation_type=activation_type,
+        activation_type=ActivationType(activation_type),
     )[0]
 
     return out

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -334,8 +334,10 @@ def flashinfer_trtllm_fp4_moe(
         else router_logits
     )
 
-    # Call TRT-LLM FP4 block-scale MoE kernel
+    # Determine activation type
     activation_type = activation_to_flashinfer_int(layer.activation)
+
+    # Call TRT-LLM FP4 block-scale MoE kernel
     out = flashinfer.fused_moe.trtllm_fp4_block_scale_moe(
         routing_logits=router_logits,
         routing_bias=e_score_correction_bias,

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -303,7 +303,6 @@ def flashinfer_trtllm_fp4_moe(
         Output tensor from the MoE layer
     """
     import flashinfer
-    from flashinfer.fused_moe.core import ActivationType
 
     from vllm.model_executor.models.llama4 import Llama4MoE
 
@@ -368,7 +367,7 @@ def flashinfer_trtllm_fp4_moe(
         routed_scaling_factor=None,
         routing_method_type=routing_method_type,
         do_finalize=True,
-        activation_type=ActivationType(activation_type),
+        activation_type=activation_type,
     )[0]
 
     return out

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -519,9 +519,10 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
             hasattr(layer, "weight_block_size") and layer.weight_block_size is not None
         )
         if not block_quant:
+            min_alignment = 16 if is_gated else 128
             w13, w13_scale, w2, w2_scale, padded_intermediate = (
                 align_fp4_moe_weights_for_fi(
-                    w13, w13_scale, w2, w2_scale, is_act_and_mul, min_alignment=128
+                    w13, w13_scale, w2, w2_scale, is_act_and_mul, min_alignment
                 )
             )
             layer.intermediate_size_per_partition = padded_intermediate

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -515,17 +515,14 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
     # Shuffle weights and scales for FI TRTLLM NVFP4 MoE kernels.
     if backend == NvFp4MoeBackend.FLASHINFER_TRTLLM:
         # Align weights for FI NVFP4 MoE kernels.
-        block_quant = (
-            hasattr(layer, "weight_block_size") and layer.weight_block_size is not None
-        )
-        if not block_quant:
-            min_alignment = 16 if is_gated else 128
-            w13, w13_scale, w2, w2_scale, padded_intermediate = (
-                align_fp4_moe_weights_for_fi(
-                    w13, w13_scale, w2, w2_scale, is_act_and_mul, min_alignment
-                )
+        min_alignment = 16 if is_gated else 128
+        w13, w13_scale, w2, w2_scale, padded_intermediate = (
+            align_fp4_moe_weights_for_fi(
+                w13, w13_scale, w2, w2_scale, is_act_and_mul, min_alignment
             )
-            layer.intermediate_size_per_partition = padded_intermediate
+        )
+        layer.intermediate_size_per_partition = padded_intermediate
+
         w13, w13_scale, w2, w2_scale = prepare_static_weights_for_trtllm_fp4_moe(
             w13,
             w2,

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -123,6 +123,13 @@ def apply_fi_trtllm_fp8_per_tensor_moe(
     import vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe  # noqa: E501, F401
     from vllm.model_executor.models.llama4 import Llama4MoE
 
+    # Added to the layer by: register_scales_for_trtllm_fp8_per_tensor_moe
+    assert (
+        hasattr(layer, "output1_scales_scalar")
+        and hasattr(layer, "output1_scales_gate_scalar")
+        and hasattr(layer, "output2_scales_scalar")
+    )
+
     if layer.routing_method_type == RoutingMethodType.Llama4:
         assert (
             not layer.renormalize

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -20,15 +20,15 @@ class FlashinferMoeBackend(Enum):
 
 
 def activation_to_flashinfer_int(activation: MoEActivation) -> int:
-    from vllm.utils.flashinfer import FlashinferActivationType
+    from flashinfer.fused_moe.core import ActivationType
 
     # silu and gelu are mapped to their gated versions SwiGLU and GeGLU respectively
     ACTIVATION_TO_FI_ACTIVATION = {
-        MoEActivation.SILU_NO_MUL: FlashinferActivationType.Silu,
-        MoEActivation.GELU_NO_MUL: FlashinferActivationType.Gelu,
-        MoEActivation.SILU: FlashinferActivationType.Swiglu,
-        MoEActivation.GELU: FlashinferActivationType.Geglu,
-        MoEActivation.RELU2_NO_MUL: FlashinferActivationType.Relu2,
+        MoEActivation.SILU_NO_MUL: ActivationType.Silu,
+        MoEActivation.GELU_NO_MUL: ActivationType.Gelu,
+        MoEActivation.SILU: ActivationType.Swiglu,
+        MoEActivation.GELU: ActivationType.Geglu,
+        MoEActivation.RELU2_NO_MUL: ActivationType.Relu2,
     }
     return ACTIVATION_TO_FI_ACTIVATION[activation].value
 

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -19,12 +19,21 @@ class FlashinferMoeBackend(Enum):
     CUTEDSL = "CUTEDSL"
 
 
+def is_gated_activation(activation: str) -> bool:
+    NON_GATED_ACTIVATION_NAMES = {"relu2_no_mul"}
+    return activation not in NON_GATED_ACTIVATION_NAMES
+
+
 def activation_to_flashinfer_int(activation: MoEActivation) -> int:
+    from vllm.utils.flashinfer import FlashinferActivationType
+
+    # silu and gelu are mapped to their gated versions SwiGLU and GeGLU respectively
     ACTIVATION_TO_FI_ACTIVATION = {
-        MoEActivation.SILU: 2,  # FlashInfer ActivationType.SiLU
-        MoEActivation.RELU2_NO_MUL: 6,  # FlashInfer ActivationType.ReLU2NoMul
+        MoEActivation.SILU: FlashinferActivationType.Swiglu,
+        MoEActivation.GELU: FlashinferActivationType.Geglu,
+        MoEActivation.RELU2_NO_MUL: FlashinferActivationType.Relu2,
     }
-    return ACTIVATION_TO_FI_ACTIVATION[activation]
+    return ACTIVATION_TO_FI_ACTIVATION[activation].value
 
 
 def swap_w13_to_w31(x: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -6,6 +6,7 @@ import torch
 
 from vllm import envs
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import round_up
 
@@ -18,6 +19,14 @@ class FlashinferMoeBackend(Enum):
     CUTEDSL = "CUTEDSL"
 
 
+def activation_to_flashinfer_int(activation: MoEActivation) -> int:
+    ACTIVATION_TO_FI_ACTIVATION = {
+        MoEActivation.SILU: 2,  # FlashInfer ActivationType.SiLU
+        MoEActivation.RELU2_NO_MUL: 6,  # FlashInfer ActivationType.ReLU2NoMul
+    }
+    return ACTIVATION_TO_FI_ACTIVATION[activation]
+
+
 def swap_w13_to_w31(x: torch.Tensor) -> torch.Tensor:
     return (
         x.reshape(-1, 2, x.shape[-2] // 2, x.shape[-1]).flip(dims=[1]).reshape(x.shape)
@@ -25,7 +34,7 @@ def swap_w13_to_w31(x: torch.Tensor) -> torch.Tensor:
 
 
 def rotate_weights_for_fi_trtllm_fp8_per_tensor_moe(
-    gemm1_weights: torch.Tensor, gemm2_weights: torch.Tensor
+    gemm1_weights: torch.Tensor, gemm2_weights: torch.Tensor, is_gated_activation: bool
 ):
     """Shuffle weights for for FI TRT-LLM Format"""
     from flashinfer import reorder_rows_for_gated_act_gemm, shuffle_matrix_a
@@ -40,6 +49,8 @@ def rotate_weights_for_fi_trtllm_fp8_per_tensor_moe(
     for i in range(num_experts):
         gemm1_weights_fp8_interleaved.append(
             reorder_rows_for_gated_act_gemm(gemm1_weights[i])
+            if is_gated_activation
+            else gemm1_weights[i]
         )
 
     # Stack weights and scales for all experts
@@ -86,7 +97,13 @@ def register_scales_for_trtllm_fp8_per_tensor_moe(
     )
     layer.w2_input_scale_inv = 1.0 / w2_input_scale
     layer.output1_scales_gate_scalar = g1_alphas
-    layer.output1_scales_scalar = g1_alphas * layer.w2_input_scale_inv
+
+    if layer.activation.is_gated:
+        layer.output1_scales_scalar = g1_alphas * layer.w2_input_scale_inv
+    else:
+        layer.output1_scales_scalar = (
+            torch.ones_like(g1_alphas) * layer.w2_input_scale_inv
+        )
     layer.output2_scales_scalar = g2_alphas
 
 
@@ -106,13 +123,6 @@ def apply_fi_trtllm_fp8_per_tensor_moe(
     import vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe  # noqa: E501, F401
     from vllm.model_executor.models.llama4 import Llama4MoE
 
-    # Added to the layer by: register_scales_for_trtllm_fp8_per_tensor_moe
-    assert (
-        hasattr(layer, "output1_scales_scalar")
-        and hasattr(layer, "output1_scales_gate_scalar")
-        and hasattr(layer, "output2_scales_scalar")
-    )
-
     if layer.routing_method_type == RoutingMethodType.Llama4:
         assert (
             not layer.renormalize
@@ -125,6 +135,7 @@ def apply_fi_trtllm_fp8_per_tensor_moe(
         assert layer.custom_routing_function is None, (
             "Custom routing function is only supported for Llama4"
         )
+    activation_type = activation_to_flashinfer_int(layer.activation)
 
     return torch.ops.vllm.fi_trtllm_fp8_per_tensor_moe(
         routing_logits=router_logits,
@@ -145,6 +156,7 @@ def apply_fi_trtllm_fp8_per_tensor_moe(
         local_num_experts=layer.local_num_experts,
         use_routing_scales_on_input=apply_router_weight_on_input,
         routing_method_type=layer.routing_method_type,
+        activation_type=activation_type,
     )
 
 
@@ -274,8 +286,64 @@ def convert_moe_weights_to_flashinfer_trtllm_block_layout(
     return w13_weights_shuffled_tensor, w2_weights_shuffled_tensor
 
 
+def align_fp4_moe_weights_for_fi(
+    w13: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2: torch.Tensor,
+    w2_scale: torch.Tensor,
+    is_act_and_mul: bool,
+    min_alignment: int = 16,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Pad intermediate size so FlashInfer kernels' alignment constraints hold.
+
+    Some FlashInfer FP4 MoE kernels require the intermediate size
+    used for GEMM to be divisible by a small alignment value. When this is
+    not satisfied (e.g. with certain tensor-parallel sizes), we pad the
+    gate/up and down projection weights along the intermediate dim.
+    """
+
+    # Current local intermediate size (per partition) is the K dimension of
+    # the down projection.
+    num_experts, hidden_size, intermediate = w2.shape
+    intermediate *= 2  # because of packed FP4
+
+    padded_intermediate = round_up(intermediate, min_alignment)
+
+    if padded_intermediate == intermediate:
+        return w13, w13_scale, w2, w2_scale, intermediate
+
+    logger.info_once(
+        "Padding intermediate size from %d to %d for up/down projection weights.",
+        intermediate,
+        padded_intermediate,
+        scope="local",
+    )
+
+    up_mult = 2 if is_act_and_mul else 1
+    padded_gate_up_dim = up_mult * padded_intermediate
+
+    # Pad w13 and w2 along its intermediate dimension.
+    padded_w13 = w13.new_zeros((num_experts, padded_gate_up_dim, hidden_size // 2))
+    padded_w13[:, : w13.shape[1], :] = w13
+
+    padded_w2 = w2.new_zeros((num_experts, hidden_size, padded_intermediate // 2))
+    padded_w2[:, :, : w2.shape[2]] = w2
+
+    padded_w13_scale = w13_scale.new_zeros(
+        (num_experts, padded_gate_up_dim, hidden_size // 16)
+    )
+    padded_w13_scale[:, : w13_scale.shape[1], :] = w13_scale
+
+    padded_w2_scale = w2_scale.new_zeros(
+        (num_experts, hidden_size, padded_intermediate // 16)
+    )
+    padded_w2_scale[:, :, : w2_scale.shape[2]] = w2_scale
+
+    return padded_w13, padded_w13_scale, padded_w2, padded_w2_scale, padded_intermediate
+
+
 def align_fp8_moe_weights_for_fi(
-    w13: torch.Tensor, w2: torch.Tensor, is_act_and_mul: bool
+    w13: torch.Tensor, w2: torch.Tensor, is_act_and_mul: bool, min_alignment: int = 16
 ) -> tuple[torch.Tensor, torch.Tensor, int]:
     """Pad intermediate size so FlashInfer kernels' alignment constraints hold.
 
@@ -289,7 +357,6 @@ def align_fp8_moe_weights_for_fi(
     # the down projection.
     num_experts, hidden_size, intermediate = w2.shape
 
-    min_alignment = 16
     padded_intermediate = round_up(intermediate, min_alignment)
 
     if padded_intermediate == intermediate:
@@ -342,11 +409,14 @@ def prepare_fp8_moe_layer_for_fi(
 
     # Some FI MoE kernels require internal alignment of 16
     # for the gate-up proj. Pad the weights to respect this.
+    is_gated = layer.activation.is_gated
     if not block_quant:
+        min_alignment = 16 if is_gated else 128
         w13, w2, new_intermediate = align_fp8_moe_weights_for_fi(
             w13,
             w2,
             layer.moe_config.is_act_and_mul,
+            min_alignment,
         )
         layer.intermediate_size_per_partition = new_intermediate
 
@@ -363,7 +433,7 @@ def prepare_fp8_moe_layer_for_fi(
         assert w13_input_scale is not None
         assert w2_input_scale is not None
 
-        rotate_weights_for_fi_trtllm_fp8_per_tensor_moe(w13, w2)
+        rotate_weights_for_fi_trtllm_fp8_per_tensor_moe(w13, w2, is_gated)
         register_scales_for_trtllm_fp8_per_tensor_moe(
             layer,
             w13_scale=w13_scale,

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -19,16 +19,13 @@ class FlashinferMoeBackend(Enum):
     CUTEDSL = "CUTEDSL"
 
 
-def is_gated_activation(activation: str) -> bool:
-    NON_GATED_ACTIVATION_NAMES = {"relu2_no_mul"}
-    return activation not in NON_GATED_ACTIVATION_NAMES
-
-
 def activation_to_flashinfer_int(activation: MoEActivation) -> int:
     from vllm.utils.flashinfer import FlashinferActivationType
 
     # silu and gelu are mapped to their gated versions SwiGLU and GeGLU respectively
     ACTIVATION_TO_FI_ACTIVATION = {
+        MoEActivation.SILU_NO_MUL: FlashinferActivationType.Silu,
+        MoEActivation.GELU_NO_MUL: FlashinferActivationType.Gelu,
         MoEActivation.SILU: FlashinferActivationType.Swiglu,
         MoEActivation.GELU: FlashinferActivationType.Geglu,
         MoEActivation.RELU2_NO_MUL: FlashinferActivationType.Relu2,

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -82,21 +82,23 @@ def _get_submodule(module_name: str) -> Any | None:
         return None
 
 
+@functools.cache
+def _lazy_import_attr(module_name: str, attr_name: str):
+    """Create a lazy import wrapper for a specific attribute."""
+    if not has_flashinfer():
+        return None
+    mod = _get_submodule(module_name)
+    return getattr(mod, attr_name, None) if mod else None
+
+
 # General lazy import wrapper
 def _lazy_import_wrapper(
     module_name: str, attr_name: str, fallback_fn: Callable[..., Any] = _missing
 ):
     """Create a lazy import wrapper for a specific function."""
 
-    @functools.cache
-    def _get_impl():
-        if not has_flashinfer():
-            return None
-        mod = _get_submodule(module_name)
-        return getattr(mod, attr_name, None) if mod else None
-
     def wrapper(*args, **kwargs):
-        impl = _get_impl()
+        impl = _lazy_import_attr(module_name, attr_name)
         if impl is None:
             return fallback_fn(*args, **kwargs)
         return impl(*args, **kwargs)
@@ -134,6 +136,8 @@ nvfp4_block_scale_interleave = _lazy_import_wrapper(
 trtllm_fp4_block_scale_moe = _lazy_import_wrapper(
     "flashinfer", "trtllm_fp4_block_scale_moe"
 )
+FlashinferActivationType = _lazy_import_attr("flashinfer", "ActivationType")
+
 # Special case for autotune since it returns a context manager
 autotune = _lazy_import_wrapper(
     "flashinfer.autotuner",


### PR DESCRIPTION
## Purpose

Add support for Flashinfer trtllm fused MoE non-gated activation for FP8 and for NVFP4.

Changes:
- Pass `activation_type` argument to FlashInfer trtllm fused MoE FP8 and NVFP4.
- Add DeepSeek routing to supported routing list of Flashinfer trtllm fused MoE FP8
- Add support to non-gated flow in Flashinfer trtllm fused MoE NVFP4
- Use `min_alignment=128` (padding) for non-gated activation in Flashinfer trtllm fused MoE
- Fix `tests/kernels/moe/test_flashinfer.py` and expand it to also test `relu2_no_mul` activation for both cutlass and trtllm kernels.

`lm_eval` on `Nemotron 3 Nano FP8`:

```
export VLLM_USE_FLASHINFER_MOE_FP8=1
export VLLM_FLASHINFER_MOE_BACKEND=latency

LLM_FLASHINFER_MOE_BACKEND="backend" lm_eval --model vllm --model_args pretrained=nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4,\ 
tensor_parallel_size=1,max_model_len=2048,kv_cache_dtype=auto \ 
--gen_kwargs temperature=0.0 --limit 500 --trust_remote_code \ 
--tasks gsm8k --num_fewshot 5 --batch_size 200 
```
Outputs:
```
vllm ({'pretrained': 'nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8', 'tensor_parallel_size': 1, 'max_model_len': 2048, 'kv_cache_dtype': 'auto'}), gen_kwargs: ({'temperature': 0.0}), limit: 500.0, num_fewshot: 5, batch_size: 200
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.568|±  |0.0222|
|     |       |strict-match    |     5|exact_match|↑  |0.848|±  |0.0161|
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

