### PR TITLE
[FIX] guidance: use max(vocab_size, len(tokenizer)) for n_vocab

### DIFF
--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -93,7 +93,7 @@ class GuidanceBackend(StructuredOutputBackend):
         )
 
         self.ll_tokenizer = llguidance_hf.from_tokenizer(
-            self.tokenizer, self.vocab_size
+            self.tokenizer, max(self.vocab_size, len(self.tokenizer))
         )
 
     def compile_grammar(


### PR DESCRIPTION
Hi there, thanks for the amazing work on guided decoding in VLLM @russellb @jeejeelee @hmellor @yewentao256 @mgoin  and many more.


## Purpose

I've observed the following:
Models like Gemma 3 1B have `len(tokenizer) > config.vocab_size` due to added special tokens not counted in config.

* `GuidanceBackend.__post_init__` passes `self.vocab_size` (from model config) as `n_vocab` to [`llguidance_hf.from_tokenizer()`](https://github.com/vllm-project/vllm/blob/b5f8c3092d1e1466b2b9c516fb39e5b2c15e774b/vllm/v1/structured_output/backend_guidance.py#L95-L96)
* For Gemma 3 1B and smaller versions, `config.vocab_size == 262144` but `len(tokenizer) == 262145`.
* llguidance [hard-errors on n_vocab < actual token count](https://github.com/guidance-ai/llguidance/blob/7c400340c2daa2f3bd6c5f6a24808871dc66f077/toktrie_hf_tokenizers/src/lib.rs#L216-L218)
* Other models affected from what a quick search showed: Llama 3.2 / CodeLlama 34B have an extra vision token, Gemma has the `<image_soft_token>`


llguidance's own [`hf.py` says](https://github.com/guidance-ai/llguidance/blob/7c400340c2daa2f3bd6c5f6a24808871dc66f077/python/llguidance/hf.py#L40-L42) `n_vocab` should be unnecessary and correctly retrieves `get_vocab_size(with_added_tokens=True)` when n_vocab is missing.
However, sending larger `n_vocab` from vllm side is a wanted feature when looking for TP/GPU padding (Deepseek, Qwen)

The root cause is HuggingFace's three different vocab sizes I believe:                                                                
 | Property | Meaning | Gemma 3 1B/270m etc. |
|---|---|---|
| `config.vocab_size` | Embedding matrix rows (may be padded) | 262144 |
| `tokenizer.vocab_size` | Base vocab only (excludes added tokens) | 262144 |
| `len(tokenizer)` | Base + added tokens | 262145 |

Which leads to confusion

Error Trace:

```
  File "backend_guidance.py", line 95, in __post_init__                                                                                 
      self.ll_tokenizer = llguidance_hf.from_tokenizer(                                                                                 
  File "llguidance/hf.py", line 45, in from_tokenizer                                                                                   
      return LLTokenizer(s, n_vocab=n_vocab, eos_token=eos_token, slices=slices)                                                        
  ValueError: vocab size too small; 262144 vs 262145
```

note `--structured-outputs-config '{"backend":"guidance"}'`, also note xgrammar drops these extra tokens already gracefully. Found a [huggingface discussion](https://huggingface.co/google/gemma-3-1b-it/discussions/17)

## Proposed Fix

`max(self.vocab_size, len(self.tokenizer))` pads up for TP-aligned models, doesn't choke when tokenizer has more tokens than config claims.

## Test Plan

The current guided decoding tests contain no model with the issue

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>