### PR TITLE
[Bugfix] Add SM110/SM120 device capability checks for NVFP4 MoE backends

### DIFF
--- a/vllm/model_executor/layers/fused_moe/flashinfer_cutedsl_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_cutedsl_moe.py
@@ -19,7 +19,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kNvfp4Dynamic,
     kNvfp4Static,
 )
-from vllm.platforms import current_platform
+from vllm.platforms import is_blackwell_cuda
 from vllm.utils.flashinfer import (
     flashinfer_cutedsl_grouped_gemm_nt_masked,
     scaled_fp4_grouped_quantize,
@@ -54,8 +54,8 @@ class FlashInferCuteDSLExperts(mk.FusedMoEPermuteExpertsUnpermute):
 
     @staticmethod
     def _supports_current_device() -> bool:
-        p = current_platform
-        return p.is_cuda() and p.is_device_capability_family(100)
+        """Supports Blackwell-family GPUs (SM100/110/120)."""
+        return is_blackwell_cuda()
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:

--- a/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
@@ -19,7 +19,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Static128BlockSym,
     kFp8StaticTensorSym,
 )
-from vllm.platforms import current_platform
+from vllm.platforms import is_blackwell_cuda
 from vllm.utils.torch_utils import direct_register_custom_op
 
 #
@@ -28,9 +28,8 @@ from vllm.utils.torch_utils import direct_register_custom_op
 
 
 def _supports_current_device() -> bool:
-    """Supports only Blackwell-family GPUs."""
-    p = current_platform
-    return p.is_cuda() and p.is_device_capability_family(100)
+    """Supports Blackwell-family GPUs (SM100/110/120)."""
+    return is_blackwell_cuda()
 
 
 def _supports_no_act_and_mul() -> bool:

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -22,7 +22,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kNvfp4Dynamic,
     kNvfp4Static,
 )
-from vllm.platforms import current_platform
+from vllm.platforms import is_blackwell_cuda
 
 if TYPE_CHECKING:
     from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
@@ -42,9 +42,8 @@ __all__ = [
 
 
 def _supports_current_device() -> bool:
-    """Supports only Blackwell-family GPUs."""
-    p = current_platform
-    return p.is_cuda() and p.is_device_capability_family(100)
+    """Supports Blackwell-family GPUs (SM100/110/120)."""
+    return is_blackwell_cuda()
 
 
 def _supports_no_act_and_mul() -> bool:

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -6,7 +6,7 @@ import torch
 
 from vllm import envs
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
+from vllm.platforms import current_platform, is_blackwell_cuda
 from vllm.utils.math_utils import round_up
 
 logger = init_logger(__name__)
@@ -169,10 +169,7 @@ def get_flashinfer_moe_backend() -> FlashinferMoeBackend:
 
     flashinfer_moe_backend = envs.VLLM_FLASHINFER_MOE_BACKEND
     if flashinfer_moe_backend in backend_map:
-        if (
-            flashinfer_moe_backend == "latency"
-            and not current_platform.is_device_capability_family(100)
-        ):
+        if flashinfer_moe_backend == "latency" and not is_blackwell_cuda():
             logger.info_once(
                 "Flashinfer TRTLLM MOE backend is only supported on "
                 "SM100 and later, using CUTLASS backend instead",

--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -276,4 +276,27 @@ def __setattr__(name: str, value):
         raise AttributeError(f"No attribute named '{name}' exists in {__name__}.")
 
 
-__all__ = ["Platform", "PlatformEnum", "current_platform", "CpuArchEnum", "_init_trace"]
+def is_blackwell_cuda() -> bool:
+    """Check if running on a Blackwell-family CUDA GPU (SM100/110/120).
+
+    This includes:
+    - SM100: Data center Blackwell (B100, B200)
+    - SM110: Future Blackwell variant
+    - SM120: Consumer Blackwell (RTX 5090)
+    - SM121: DGX Spark (GB10)
+    """
+    # Access current_platform via __getattr__ by using globals()
+    p = __getattr__("current_platform")
+    return p.is_cuda() and any(
+        p.is_device_capability_family(sm) for sm in (100, 110, 120)
+    )
+
+
+__all__ = [
+    "Platform",
+    "PlatformEnum",
+    "current_platform",
+    "CpuArchEnum",
+    "_init_trace",
+    "is_blackwell_cuda",
+]


### PR DESCRIPTION
## Summary

Extend device capability checks to include SM110 and SM120 GPU families in NVFP4 MoE backend selection code that was missed in PR #33417.

## Problem

After PR #33417, NVFP4 MoE models still fail on RTX Blackwell GPUs (SM120) and DGX Spark (SM121) with errors like:
```
RuntimeError: FlashInfer-CUTLASS MoE kernel does not support current device
```

## Root Cause

PR #33417 updated `flashinfer_cutlass_moe.py` and `cutlass_moe.py` but missed these files which still only check for SM100:
- `flashinfer_fp4_moe.py`
- `flashinfer_trtllm_moe.py`
- `flashinfer_cutedsl_moe.py`
- `flashinfer_utils.py`

## Solution

Add explicit family checks for SM100/110/120, matching the approach in the files updated by #33417:
```python
p.is_device_capability_family(100)
or p.is_device_capability_family(110)
or p.is_device_capability_family(120)
```

This enables support for:
- SM100-109: Blackwell data center (B100, B200)
- SM110-119: Future Blackwell variants
- SM120-129: Blackwell consumer/workstation (RTX 5090, DGX Spark GB10)

## Files Changed

- `vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py`
- `vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py`
- `vllm/model_executor/layers/fused_moe/flashinfer_cutedsl_moe.py`
- `vllm/model_executor/layers/quantization/utils/flashinfer_utils.py`

## Testing

Tested on RTX 5090 (SM120) and DGX Spark GB10 (SM121) with `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4`

## Related Issues

Fixes #31085
Fixes #30135
Fixes #29141
Related to #28589