### PR TITLE
[Bugfix] Fix tool call streaming for gpt-oss/Harmony models

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -524,6 +524,9 @@ class OpenAIServingChat(OpenAIServing):
                 get_streamable_parser_for_assistant() for _ in range(num_choices)
             ]
             harmony_tools_streamed = [False] * num_choices
+            harmony_tool_call_ids: list[dict[str, tuple[int, str]]] = [
+                {} for _ in range(num_choices)
+            ]
         tools_streamed = [False] * num_choices
 
         if isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam):
@@ -763,6 +766,7 @@ class OpenAIServingChat(OpenAIServing):
                                 token_states=token_states,
                                 prev_recipient=prev_recipient,
                                 include_reasoning=request.include_reasoning,
+                                tool_call_ids=harmony_tool_call_ids[i],
                             )
                         )
                         harmony_tools_streamed[i] |= tools_streamed_flag
@@ -1108,6 +1112,7 @@ class OpenAIServingChat(OpenAIServing):
                                 delta_message, output
                             )
                             and tool_parser
+                            and auto_tools_called
                         ):
                             latest_delta_len = 0
                             if (


### PR DESCRIPTION
## Summary

This PR fixes several issues with tool call handling for gpt-oss models using the Harmony streaming parser:

1. **IndexError in streaming generator**: Added `auto_tools_called` check before accessing `prev_tool_call_arr` to prevent IndexError when the array is empty.

2. **Missing tool call IDs in non-streaming responses**: Added proper ID generation for named tool choice and auto tool choice cases that were missing the required `id` field.

3. **Split tool calls in streaming**: Fixed an issue where a single tool call was being split into multiple entries because:
   - Tool call IDs are now stored by recipient name (e.g., `functions.glob`) instead of index number, since `base_index` changes between streaming calls as messages complete.
   - Continuation chunks now include the same ID as the opening chunk, allowing clients to properly merge them.
   - DeltaToolCalls with the same index are merged before sending to avoid multiple entries in one SSE chunk.

## Test plan

- Tested with opencode client against gpt-oss-120b model
- Tool calls now properly stream with consistent IDs across chunks
- Clients can correctly aggregate streaming tool call arguments

🤖 Generated with [Claude Code](https://claude.ai/code)


This makes opencode tool calls work properly with v1 chat completion api