### PR TITLE
Fix mistral sliding window parsing

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -224,19 +224,6 @@ class MistralConfigParser(ConfigParserBase):
 
         config = adapt_config_dict(config_dict, defaults=hf_config_dict)
 
-        # Mistral configs may define sliding_window as list[int]. Convert it
-        # to int and add the layer_types list[str] to make it HF compatible
-        if (sliding_window := getattr(config, "sliding_window", None)) and isinstance(
-            sliding_window, list
-        ):
-            pattern_repeats = config.num_hidden_layers // len(sliding_window)
-            layer_types = sliding_window * pattern_repeats
-            config.layer_types = [
-                "full_attention" if layer_type is None else "sliding_attention"
-                for layer_type in layer_types
-            ]
-            config.sliding_window = next(filter(None, sliding_window), None)
-
         return config_dict, config
 
 

--- a/vllm/transformers_utils/configs/mistral.py
+++ b/vllm/transformers_utils/configs/mistral.py
@@ -163,29 +163,24 @@ def _remap_general_mistral_args(config: dict) -> dict:
 
 
 def _remap_mistral_sliding_window(config: dict) -> dict:
-    # Remap ragged_attention -> sliding_window
-    if ragged_attention_str := config.pop("ragged_attention", None):
-        # E.g. "None,32,32,32" -> [None, 32, 32, 32]
-        assert isinstance(ragged_attention_str, str)
-        ragged_pattern = [
-            None if s == "None" else int(s) for s in ragged_attention_str.split(",")
-        ]
-        assert len(set(ragged_pattern) - {None}) <= 1, ragged_pattern
-        config["sliding_window"] = ragged_pattern
-
-    # Remap sliding_window -> layer_types + sliding window for HF compatibility
+    # Remap sliding_window (list) -> layer_types (list) + sliding window (int)
+    # for HF compatibility
     # Mistral configs may define sliding_window as list[int]. Convert it
     # to int and add the layer_types list[str] to make it HF compatible
     if sliding_window := config.get("sliding_window"):
-        assert isinstance(sliding_window, list)
-        pattern_repeats = config["num_hidden_layers"] // len(sliding_window)
-        layer_types = sliding_window * pattern_repeats
-        config["layer_types"] = [
-            "full_attention" if layer_type is None else "sliding_attention"
-            for layer_type in layer_types
-        ]
-        assert len(set(sliding_window) - {None}) <= 1, sliding_window
-        config["sliding_window"] = next(filter(None, sliding_window), None)
+        if isinstance(sliding_window, list):
+            pattern_repeats = config["num_hidden_layers"] // len(sliding_window)
+            layer_types = sliding_window * pattern_repeats
+            config["layer_types"] = [
+                "full_attention" if layer_type is None else "sliding_attention"
+                for layer_type in layer_types
+            ]
+            assert len(set(sliding_window) - {None}) <= 1, sliding_window
+            config["sliding_window"] = next(filter(None, sliding_window), None)
+        elif isinstance(sliding_window, int) and config.get("layer_types") is None:
+            config["layer_types"] = ["sliding_attention"] * config["num_hidden_layers"]
+        else:
+            raise ValueError(f"Unsupported sliding_window type: {sliding_window}")
 
     return config
 

--- a/vllm/transformers_utils/configs/mistral.py
+++ b/vllm/transformers_utils/configs/mistral.py
@@ -219,14 +219,6 @@ def _remap_mistral_audio_args(config: dict) -> dict:
     else:
         block_pool_size = 1
 
-    _maybe_sliding_window = encoder_args.get("ragged_attention", None)
-    if _maybe_sliding_window is None:
-        sliding_window = None
-    elif _maybe_sliding_window.isdigit():
-        sliding_window = int(_maybe_sliding_window)
-    else:
-        raise NotImplementedError(f"Unsupported: {_maybe_sliding_window=}")
-
     architecture = (
         "VoxtralRealtimeGeneration"
         if encoder_args.get("causal")
@@ -253,7 +245,7 @@ def _remap_mistral_audio_args(config: dict) -> dict:
             max_source_positions=encoder_args["max_source_positions"],
             is_encoder_decoder=False,  # Override WhisperConfig default
             is_causal=encoder_args.get("causal", False),
-            sliding_window=sliding_window,
+            sliding_window=encoder_args.get("sliding_window", None),
             block_pool_size=block_pool_size,
             pos_embed=encoder_args.get("pos_embed", "sinusoidal"),
             # only needed for RoPE

--- a/vllm/transformers_utils/configs/mistral.py
+++ b/vllm/transformers_utils/configs/mistral.py
@@ -14,6 +14,7 @@ def adapt_config_dict(
     defaults: dict[str, Any],
 ) -> PretrainedConfig:
     config_dict = _remap_general_mistral_args(config_dict)
+    config_dict = _remap_mistral_sliding_window(config_dict)
 
     if bool(config_dict.get("quantization")):
         config_dict = _remap_mistral_quantization_args(config_dict)
@@ -157,6 +158,34 @@ def _remap_general_mistral_args(config: dict) -> dict:
 
     for new_key, (key, default_value) in top_level_mapping_with_default.items():
         config[new_key] = config.pop(key, default_value)
+
+    return config
+
+
+def _remap_mistral_sliding_window(config: dict) -> dict:
+    # Remap ragged_attention -> sliding_window
+    if ragged_attention_str := config.pop("ragged_attention", None):
+        # E.g. "None,32,32,32" -> [None, 32, 32, 32]
+        assert isinstance(ragged_attention_str, str)
+        ragged_pattern = [
+            None if s == "None" else int(s) for s in ragged_attention_str.split(",")
+        ]
+        assert len(set(ragged_pattern) - {None}) <= 1, ragged_pattern
+        config["sliding_window"] = ragged_pattern
+
+    # Remap sliding_window -> layer_types + sliding window for HF compatibility
+    # Mistral configs may define sliding_window as list[int]. Convert it
+    # to int and add the layer_types list[str] to make it HF compatible
+    if sliding_window := config.get("sliding_window"):
+        assert isinstance(sliding_window, list)
+        pattern_repeats = config["num_hidden_layers"] // len(sliding_window)
+        layer_types = sliding_window * pattern_repeats
+        config["layer_types"] = [
+            "full_attention" if layer_type is None else "sliding_attention"
+            for layer_type in layer_types
+        ]
+        assert len(set(sliding_window) - {None}) <= 1, sliding_window
+        config["sliding_window"] = next(filter(None, sliding_window), None)
 
     return config
 


### PR DESCRIPTION
We are not correctly parsing the sliding window for `voxtral_streaming.py` (it is falling back to full attention instead of sliding window). This is because the `sliding_window` attribute lives within `config["text_config"]["sliding_window"]` rather than `config["sliding_window"]`, so the check in `vllm/transformers_utils/config.py` is by-passed. Moving the logic into `adapt_config_dict` to fix this issue.
