### PR TITLE
[Misc] Remove deprecated profiler environment variables

### DIFF
--- a/vllm/config/profiler.py
+++ b/vllm/config/profiler.py
@@ -8,7 +8,6 @@ from pydantic import Field, model_validator
 from pydantic.dataclasses import dataclass
 from typing_extensions import Self
 
-import vllm.envs as envs
 from vllm.config.utils import config
 from vllm.logger import init_logger
 from vllm.utils.hashing import safe_hash
@@ -102,88 +101,8 @@ class ProfilerConfig:
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 
-    def _get_from_env_if_set(self, field_name: str, env_var_name: str) -> None:
-        """Get field from env var if set, with deprecation warning."""
-
-        if envs.is_set(env_var_name):
-            value = getattr(envs, env_var_name)
-            logger.warning_once(
-                "Using %s environment variable is deprecated and will be removed in "
-                "v0.15.0 or v1.0.0, whichever is soonest. Please use "
-                "--profiler-config.%s command line argument or "
-                "ProfilerConfig(%s=...) config field instead.",
-                env_var_name,
-                field_name,
-                field_name,
-            )
-            return value
-        return None
-
-    def _set_from_env_if_set(
-        self,
-        field_name: str,
-        env_var_name: str,
-        to_bool: bool = True,
-        to_int: bool = False,
-    ) -> None:
-        """Set field from env var if set, with deprecation warning."""
-        value = self._get_from_env_if_set(field_name, env_var_name)
-        if value is not None:
-            if to_bool:
-                value = value == "1"
-            if to_int:
-                value = int(value)
-            setattr(self, field_name, value)
-
     @model_validator(mode="after")
     def _validate_profiler_config(self) -> Self:
-        maybe_use_cuda_profiler = self._get_from_env_if_set(
-            "profiler", "VLLM_TORCH_CUDA_PROFILE"
-        )
-        if maybe_use_cuda_profiler is not None:
-            self.profiler = "cuda" if maybe_use_cuda_profiler == "1" else None
-        else:
-            self._set_from_env_if_set(
-                "torch_profiler_dir", "VLLM_TORCH_PROFILER_DIR", to_bool=False
-            )
-            if self.torch_profiler_dir:
-                self.profiler = "torch"
-                self._set_from_env_if_set(
-                    "torch_profiler_record_shapes",
-                    "VLLM_TORCH_PROFILER_RECORD_SHAPES",
-                )
-                self._set_from_env_if_set(
-                    "torch_profiler_with_memory",
-                    "VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY",
-                )
-                self._set_from_env_if_set(
-                    "torch_profiler_with_stack",
-                    "VLLM_TORCH_PROFILER_WITH_STACK",
-                )
-                self._set_from_env_if_set(
-                    "torch_profiler_with_flops",
-                    "VLLM_TORCH_PROFILER_WITH_FLOPS",
-                )
-                self._set_from_env_if_set(
-                    "ignore_frontend",
-                    "VLLM_TORCH_PROFILER_DISABLE_ASYNC_LLM",
-                )
-                self._set_from_env_if_set(
-                    "torch_profiler_use_gzip",
-                    "VLLM_TORCH_PROFILER_USE_GZIP",
-                )
-                self._set_from_env_if_set(
-                    "torch_profiler_dump_cuda_time_total",
-                    "VLLM_TORCH_PROFILER_DUMP_CUDA_TIME_TOTAL",
-                )
-
-        self._set_from_env_if_set(
-            "delay_iterations", "VLLM_PROFILER_DELAY_ITERS", to_bool=False, to_int=True
-        )
-        self._set_from_env_if_set(
-            "max_iterations", "VLLM_PROFILER_MAX_ITERS", to_bool=False, to_int=True
-        )
-
         has_delay_or_limit = self.delay_iterations > 0 or self.max_iterations > 0
         if self.profiler == "torch" and has_delay_or_limit and not self.ignore_frontend:
             logger.warning_once(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -88,20 +88,6 @@ if TYPE_CHECKING:
     VLLM_PLUGINS: list[str] | None = None
     VLLM_LORA_RESOLVER_CACHE_DIR: str | None = None
     VLLM_LORA_RESOLVER_HF_REPO_LIST: str | None = None
-    # Deprecated env variables for profiling, kept for backward compatibility
-    # See also vllm/config/profiler.py and `--profiler-config` argument
-    VLLM_TORCH_CUDA_PROFILE: str | None = None
-    VLLM_TORCH_PROFILER_DIR: str | None = None
-    VLLM_TORCH_PROFILER_RECORD_SHAPES: str | None = None
-    VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY: str | None = None
-    VLLM_TORCH_PROFILER_DISABLE_ASYNC_LLM: str | None = None
-    VLLM_TORCH_PROFILER_WITH_STACK: str | None = None
-    VLLM_TORCH_PROFILER_WITH_FLOPS: str | None = None
-    VLLM_TORCH_PROFILER_USE_GZIP: str | None = None
-    VLLM_TORCH_PROFILER_DUMP_CUDA_TIME_TOTAL: str | None = None
-    VLLM_PROFILER_DELAY_ITERS: str | None = None
-    VLLM_PROFILER_MAX_ITERS: str | None = None
-    # End of deprecated env variables for profiling
     VLLM_USE_AOT_COMPILE: bool = False
     VLLM_USE_BYTECODE_HOOK: bool = False
     VLLM_FORCE_AOT_LOAD: bool = False


### PR DESCRIPTION
## Purpose

Remove deprecated environment variables for profiler configuration that were scheduled for removal in v0.15.0. The deprecation warning stated:

> "Using %s environment variable is deprecated and will be removed in v0.15.0 or v1.0.0, whichever is soonest."

Since v0.15.0 has been released, it's time to clean up these deprecated environment variables.

## Changes

### `vllm/config/profiler.py`
- Removed `_get_from_env_if_set()` method
- Removed `_set_from_env_if_set()` method
- Simplified `_validate_profiler_config()` validator by removing all environment variable reading logic
- Removed `import vllm.envs as envs`

### `vllm/envs.py`
Removed 11 deprecated environment variables:
- `VLLM_TORCH_CUDA_PROFILE`
- `VLLM_TORCH_PROFILER_DIR`
- `VLLM_TORCH_PROFILER_RECORD_SHAPES`
- `VLLM_TORCH_PROFILER_WITH_PROFILE_MEMORY`
- `VLLM_TORCH_PROFILER_DISABLE_ASYNC_LLM`
- `VLLM_TORCH_PROFILER_WITH_STACK`
- `VLLM_TORCH_PROFILER_WITH_FLOPS`
- `VLLM_TORCH_PROFILER_USE_GZIP`
- `VLLM_TORCH_PROFILER_DUMP_CUDA_TIME_TOTAL`
- `VLLM_PROFILER_DELAY_ITERS`
- `VLLM_PROFILER_MAX_ITERS`

## Migration

Users should migrate to using:
- Command-line arguments: `--profiler-config.torch_profiler_dir=/path/to/dir`
- Direct config: `ProfilerConfig(torch_profiler_dir="/path/to/dir")`

## Test Plan

- [x] pre-commit checks pass
- [x] Python syntax validation passes

## Test Result

All pre-commit hooks passed successfully.