### PR TITLE
[Feature][Core] Support Fabric detection to adapt the MNNVL protocol for the GB series

### DIFF
--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -129,7 +129,7 @@ void create_and_map(unsigned long long device, ssize_t size, CUdeviceptr d_mem,
   if (ret) {
     if (fab_flag &&
         (ret == CUDA_ERROR_NOT_PERMITTED || ret == CUDA_ERROR_NOT_SUPPORTED)) {
-      // Fabric allocation may fail on architectures other than Blackwell GPU,
+      // Fabric allocation may fail without multi-node nvlink,
       // fallback to POSIX file descriptor
       prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
       CUDA_CHECK(cuMemCreate(p_memHandle, size, &prop, 0));

--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -115,11 +115,28 @@ void create_and_map(unsigned long long device, ssize_t size, CUdeviceptr d_mem,
   if (flag) {  // support GPUDirect RDMA if possible
     prop.allocFlags.gpuDirectRDMACapable = 1;
   }
+  int fab_flag = 0;
+  CUDA_CHECK(cuDeviceGetAttribute(
+      &fab_flag, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, device));
+  if (fab_flag) {  // support fabric handle if possible
+    prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+  }
 #endif
 
 #ifndef USE_ROCM
   // Allocate memory using cuMemCreate
-  CUDA_CHECK(cuMemCreate(p_memHandle, size, &prop, 0));
+  CUresult ret = (CUresult)cuMemCreate(p_memHandle, size, &prop, 0);
+  if (ret) {
+    if (fab_flag &&
+        (ret == CUDA_ERROR_NOT_PERMITTED || ret == CUDA_ERROR_NOT_SUPPORTED)) {
+      // Fabric allocation may fail on architectures other than Blackwell GPU,
+      // fallback to POSIX file descriptor
+      prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+      CUDA_CHECK(cuMemCreate(p_memHandle, size, &prop, 0));
+    } else {
+      CUDA_CHECK(ret);
+    }
+  }
   if (error_code != 0) {
     return;
   }


### PR DESCRIPTION
## Purpose

Fix https://github.com/vllm-project/vllm/issues/33539

Thank you very much for the solution provided by @tvegas1 

## Test Plan

Note that, currently, to use a custom allocator, sleep-mode must to be enabled.

```
# Prefill - Tray 0
export VLLM_NIXL_SIDE_CHANNEL_HOST=10.0.8.10 UCX_CUDA_IPC_ENABLE_MNNVL=y UCX_PROTO_INFO=y
vllm serve --gpu-memory-utilization=0.85 --tokenizer-mode=deepseek_v32 --no-enable-expert-parallel --model /home/ubuntu/DeepSeek-V3.2 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cuda"}' --enable-sleep-mode -tp 2 -dp 4 -dpl 2 -dpa 10.0.8.10 -dpr 0

# Decode - Tray 2
export VLLM_NIXL_SIDE_CHANNEL_HOST=10.0.8.14 UCX_CUDA_IPC_ENABLE_MNNVL=y UCX_PROTO_INFO=y
vllm serve --gpu-memory-utilization=0.85 --tokenizer-mode=deepseek_v32 --no-enable-expert-parallel --model /home/ubuntu/DeepSeek-V3.2 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cuda"}' --enable-sleep-mode -tp 2 -dp 4 -dpl 2 -dpa 10.0.8.14 -dpr 0

#Router
python tests/v1/kv_connector/nixl_integration/toy_proxy_server.py --prefiller-hosts 10.0.8.10 --decoder-hosts 10.0.8.14 --prefiller-ports 8000 --decoder-ports 8000 --port 8000
```

Bench:

```
vllm bench serve --save-detailed --trust-remote-code --model /home/ubuntu/DeepSeek-V3.2 --seed 8961287 --dataset-name random --num-prompts 1024 --save-result --ignore-eos --max-concurrency 256 --random-input-len 4000 --random-output-len 1 --request-rate 32
```

I have tested it on both Hopper and Blackwell GPUs and it passed.

## Test Result

In my env, the throughput increased threefold:

Main:

```
============ Serving Benchmark Result ============
Successful requests:                     1024
Failed requests:                         0
Maximum request concurrency:             256
Request rate configured (RPS):           32.00
Benchmark duration (s):                  249.39
Total input tokens:                      4096000
Total generated tokens:                  1024
Request throughput (req/s):              4.11
Output token throughput (tok/s):         4.11
Peak output token throughput (tok/s):    30.00
Peak concurrent requests:                285.00
Total token throughput (tok/s):          16428.22
---------------Time to First Token----------------
Mean TTFT (ms):                          50253.09
Median TTFT (ms):                        13394.40
P99 TTFT (ms):                           195786.07
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00
Median TPOT (ms):                        0.00
P99 TPOT (ms):                           0.00
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00
Median ITL (ms):                         0.00
P99 ITL (ms):                            0.00
==================================================
```

This PR:
```
============ Serving Benchmark Result ============
Successful requests:                     1024
Failed requests:                         0
Maximum request concurrency:             256
Request rate configured (RPS):           32.00
Benchmark duration (s):                  58.77
Total input tokens:                      4096000
Total generated tokens:                  1024
Request throughput (req/s):              17.42
Output token throughput (tok/s):         17.42
Peak output token throughput (tok/s):    44.00
Peak concurrent requests:                287.00
Total token throughput (tok/s):          69707.43
---------------Time to First Token----------------
Mean TTFT (ms):                          11787.53
Median TTFT (ms):                        12994.56
P99 TTFT (ms):                           14845.10
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00
Median TPOT (ms):                        0.00
P99 TPOT (ms):                           0.00
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00
Median ITL (ms):                         0.00
P99 ITL (ms):                            0.00
==================================================
```

The reason for the improved performance is that my GB200 environment is not configured with RoCE network, resulting in abnormal performance. But at this point, switching directly to the MNNVL protocol will become very stable

From the log, we can clearly see that it has been using `cuda_ipc` (MNNVL) as the cross-node transmission protocol.

```
[1770002852.416649] [XN-GB-Tray-10:3777218:0]   | ucp_context_0 inter-node cfg#2 | remote memory read by ucp_get*(multi) into cuda/GPU3 from cuda/dev[1]    |
[1770002852.416662] [XN-GB-Tray-10:3777218:0]   +--------------------------------+-------------------------------------------------------+------------------+
[1770002852.416662] [XN-GB-Tray-10:3777218:0]   |                              0 | copy-out                                              | rc_mlx5/mlx5_2:1 |
[1770002852.416662] [XN-GB-Tray-10:3777218:0]   |                         1..inf | zero-copy                                             | cuda_ipc/cuda    |
[1770002852.416662] [XN-GB-Tray-10:3777218:0]   +--------------------------------+-------------------------------------------------------+------------------+
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

