### PR TITLE
[config] fix error occurs when loading local mode(starting with /)

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -1041,6 +1041,10 @@ def try_get_safetensors_metadata(
     *,
     revision: str | None = None,
 ):
+    # Skip HF Hub API calls for local paths (absolute or relative)
+    if not model or os.path.isabs(model) or model.startswith(("./", "../")):
+        return None
+
     get_safetensors_metadata_partial = partial(
         get_safetensors_metadata, model, revision=revision
     )


### PR DESCRIPTION
## Purpose

vllm serve /data/models/Qwen/Qwen3-ASR-1.7B --served-model-name Qwen/Qwen3-ASR-1.7B

```                                        
(APIServer pid=3185427) ERROR 02-02 14:28:39 [repo_utils.py:47] Error retrieving safetensors: Repo id must be in the form 'repo_name' or 'namespace/repo_name'
: '/data/models/Qwen/Qwen3-ASR-1.7B'. Use `repo_type` argument if needed., retrying 1 of 2                                                                    
(APIServer pid=3185427) ERROR 02-02 14:28:41 [repo_utils.py:45] Error retrieving safetensors: Repo id must be in the form 'repo_name' or 'namespace/repo_name'
: '/data/models/Qwen/Qwen3-ASR-1.7B'. Use `repo_type` argument if needed.      
```

Error occurs when loading local models: "Repo id must be in the form 'repo_name' or 'namespace/repo_name'"，Although this isn't strictly a bug, the error message feels uncomfortable.


Skip HF Hub API calls for local paths，local model loading no longer triggers irrelevant  calls

## Test Plan

## Test Result

