### PR TITLE
[Bugfix] fixed AttributeError: 'FlashMLASparseMetadata' object has no attribute 'num_decodes'

### DIFF
--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -202,6 +202,30 @@ class FlashMLASparseMetadata(AttentionMetadata):
     fp8_extra_metadata: FP8SeparatePrefillDecode | FP8KernelMetadata | None = None
     fp8_use_mixed_batch: bool = False
 
+    @property
+    def num_decodes(self) -> int:
+        if self.fp8_extra_metadata is not None and isinstance(
+            self.fp8_extra_metadata, FlashMLASparseMetadata.FP8SeparatePrefillDecode
+        ):
+            return self.fp8_extra_metadata.num_decodes
+        return self.num_reqs
+
+    @property
+    def num_prefills(self) -> int:
+        if self.fp8_extra_metadata is not None and isinstance(
+            self.fp8_extra_metadata, FlashMLASparseMetadata.FP8SeparatePrefillDecode
+        ):
+            return self.fp8_extra_metadata.num_prefills
+        return 0
+
+    @property
+    def num_decode_tokens(self) -> int:
+        if self.fp8_extra_metadata is not None and isinstance(
+            self.fp8_extra_metadata, FlashMLASparseMetadata.FP8SeparatePrefillDecode
+        ):
+            return self.fp8_extra_metadata.num_decode_tokens
+        return self.num_actual_tokens
+
 
 # Kernel with prefill workspace support
 @triton.jit


### PR DESCRIPTION



## Purpose
FIX https://github.com/vllm-project/vllm/issues/33546
## Test Plan
```
vllm serve /mnt/data4/models/deepseek-ai/DeepSeek-V3___2 -tp=8  --tokenizer-mode deepseek_v32 --enable-auto-tool-choice --tool-call-parser deepseek_v32 --reasoning-parser deepseek_v3
...
...
APIServer pid=2597309) INFO 02-02 15:13:27 [launcher.py:47] Route: /ping, Methods: GET
(APIServer pid=2597309) INFO 02-02 15:13:27 [launcher.py:47] Route: /ping, Methods: POST
(APIServer pid=2597309) INFO 02-02 15:13:27 [launcher.py:47] Route: /invocations, Methods: POST
(APIServer pid=2597309) INFO 02-02 15:13:27 [launcher.py:47] Route: /v1/chat/completions, Methods: POST
(APIServer pid=2597309) INFO 02-02 15:13:27 [launcher.py:47] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=2597309) INFO 02-02 15:13:27 [launcher.py:47] Route: /v1/responses, Methods: POST
(APIServer pid=2597309) INFO 02-02 15:13:27 [launcher.py:47] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=2597309) INFO 02-02 15:13:27 [launcher.py:47] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=2597309) INFO 02-02 15:13:27 [launcher.py:47] Route: /v1/completions, Methods: POST
(APIServer pid=2597309) INFO 02-02 15:13:27 [launcher.py:47] Route: /v1/completions/render, Methods: POST
(APIServer pid=2597309) INFO 02-02 15:13:27 [launcher.py:47] Route: /v1/messages, Methods: POST
(APIServer pid=2597309) INFO:     Started server process [2597309]
(APIServer pid=2597309) INFO:     Waiting for application startup.
(APIServer pid=2597309) INFO:     Application startup complete.
(APIServer pid=2597309) WARNING 02-02 15:15:47 [protocol.py:51] The following fields were present in the request but ignored: {'type'}
(APIServer pid=2597309) INFO:     127.0.0.1:40918 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=2597309) INFO 02-02 15:15:57 [loggers.py:257] Engine 000: Avg prompt throughput: 28.8 tokens/s, Avg generation throughput: 2.1 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=2597309) WARNING 02-02 15:15:59 [protocol.py:51] The following fields were present in the request but ignored: {'type'}
(APIServer pid=2597309) INFO:     127.0.0.1:54468 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

