### PR TITLE
[CI][Bugfix] Fix flaky `tests/v1/kv_connector/unit/test_multi_connector.py::test_multi_example_connector_consistency`

### DIFF
--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -151,7 +151,8 @@ def test_multi_example_connector_consistency():
         kv_transfer_config=kv_transfer_config,
     )
     # Run generation - this should trigger saving KV cache
-    _ = llm.generate(PROMPTS, SAMPLING_PARAMS)
+    # Use a single prompt to avoid race conditions depending on the order of scheduling
+    _ = llm.generate(PROMPTS[0], SAMPLING_PARAMS)
 
     # --- Verification ---
 
@@ -221,7 +222,7 @@ def test_multi_example_connector_consistency():
 
     # Run generation again - this should trigger loading from the first
     # connector.
-    _ = llm.generate(PROMPTS, SAMPLING_PARAMS)
+    _ = llm.generate(PROMPTS[1], SAMPLING_PARAMS)
 
     events = get_connector_events()
     # get_num_new_matched_tokens will return new tokens from the first
@@ -247,7 +248,7 @@ def test_multi_example_connector_consistency():
 
     # Run generation again - this should trigger loading from the first
     # connector.
-    _ = llm.generate(PROMPTS, SAMPLING_PARAMS)
+    _ = llm.generate(PROMPTS[0], SAMPLING_PARAMS)
 
     events = get_connector_events()
     # get_num_new_matched_tokens will be called for both connectors but will


### PR DESCRIPTION
This test may fail depending on whether the two prompts are scheduled in the same batch or one after another.
Fix https://vllm-dev.slack.com/archives/C07R5PAL2L9/p1769997334501999
