### PR TITLE
[Core] Add option to allocate CUDA Fabric memory (required for MNNVL)

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -207,6 +207,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16: bool = True
     VLLM_ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB: int | None = None
     VLLM_NIXL_ABORT_REQUEST_TIMEOUT: int = 480
+    VLLM_CUDA_FABRIC_MEMORY: bool = False
     VLLM_MORIIO_CONNECTOR_READ_MODE: bool = False
     VLLM_MORIIO_QP_PER_TRANSFER: int = 1
     VLLM_MORIIO_POST_BATCH_SIZE: int = -1
@@ -1412,6 +1413,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # disaggregated decode-prefill setup.
     "VLLM_NIXL_ABORT_REQUEST_TIMEOUT": lambda: int(
         os.getenv("VLLM_NIXL_ABORT_REQUEST_TIMEOUT", "480")
+    ),
+    # Enable CUDA Fabric memory for the custom allocator (required for MNNVL).
+    # The KV cache will use this allocator when enabled.
+    "VLLM_CUDA_FABRIC_MEMORY": lambda: bool(
+        os.getenv("VLLM_CUDA_FABRIC_MEMORY", "False").lower() in ("true", "1")
     ),
     # Controls the read mode for the Mori-IO connector
     "VLLM_MORIIO_CONNECTOR_READ_MODE": lambda: (

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -402,7 +402,10 @@ class Worker(WorkerBase):
         # related to kv cache connector (e.g. kv cache sharing layers).
         ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
 
-        if self.vllm_config.model_config.enable_sleep_mode:
+        if (
+            self.vllm_config.model_config.enable_sleep_mode
+            or envs.VLLM_CUDA_FABRIC_MEMORY
+        ):
             from vllm.device_allocator.cumem import CuMemAllocator
 
             allocator = CuMemAllocator.get_instance()


### PR DESCRIPTION
## Purpose
Enable MNNVL for KV cache transfers. Fixes vLLM #33539. Similar to PR #33540. Originally discussed in https://github.com/ai-dynamo/nixl/issues/1240.

## Test Plan
Basic run as done in #33540. Need to run with `VLLM_CUDA_FABRIC_MEMORY=true` to enable KV cache transfers with MNNVL on NIXL connector.

## Test Result
Threefold increase as per #33539.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>