### PR TITLE
[Bugfix] Enable Kimi k25 processor test

### DIFF
--- a/examples/offline_inference/vision_language.py
+++ b/examples/offline_inference/vision_language.py
@@ -968,6 +968,7 @@ def run_kimi_k25(questions: list[str], modality: str) -> ModelRequestData:
         trust_remote_code=True,
         max_model_len=4096,
         limit_mm_per_prompt={modality: 1},
+        tensor_parallel_size=4,
     )
 
     return ModelRequestData(
@@ -2090,6 +2091,7 @@ model_example_map = {
     "keye_vl": run_keye_vl,
     "keye_vl1_5": run_keye_vl1_5,
     "kimi_vl": run_kimi_vl,
+    "kimi_k2_vl": run_kimi_k25,
     "lightonocr": run_lightonocr,
     "lfm2_vl": run_lfm2_vl,
     "llama4": run_llama4,

--- a/examples/offline_inference/vision_language.py
+++ b/examples/offline_inference/vision_language.py
@@ -2091,7 +2091,7 @@ model_example_map = {
     "keye_vl": run_keye_vl,
     "keye_vl1_5": run_keye_vl1_5,
     "kimi_vl": run_kimi_vl,
-    "kimi_k2_vl": run_kimi_k25,
+    "kimi_k25": run_kimi_k25,
     "lightonocr": run_lightonocr,
     "lfm2_vl": run_lfm2_vl,
     "llama4": run_llama4,

--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -214,6 +214,28 @@ def get_text_token_prompts(
     return text_prompt, token_prompt
 
 
+def random_vision_chunk(
+    rng: np.random.RandomState,
+    min_wh: int,
+    max_wh: int,
+    min_frames: int,
+    max_frames: int,
+) -> dict:
+    num_frames = rng.randint(min_frames, max_frames + 1)
+    if num_frames == 1:
+        # Single image chunk
+        wh = rng.randint(min_wh, max_wh + 1)
+        image = random_image(rng, wh, wh + 1)
+        return {"type": "image", "image": image}
+    frames = []
+    for _ in range(num_frames):
+        wh = rng.randint(min_wh, max_wh + 1)
+        frame = rng.randint(0, 256, size=(wh, wh, 3), dtype=np.uint8)
+        frames.append(frame)
+    video_array = np.stack(frames, axis=0)
+    return {"type": "video_chunk", "video_chunk": video_array}
+
+
 def _test_processing_correctness(
     model_id_or_arch: str,
     hit_rate: float,
@@ -291,6 +313,7 @@ def _test_processing_correctness(
         "image": Image.new("RGB", size=(128, 128)),
         "video": np.zeros((4, 128, 128, 3), dtype=np.uint8),
         "audio": (np.zeros((512,)), 16000),
+        "vision_chunk": {"type": "image", "image": Image.new("RGB", size=(128, 128))},
     }
     input_factory = {
         "image": partial(random_image, rng, min_wh=128, max_wh=256),
@@ -298,6 +321,9 @@ def _test_processing_correctness(
             random_video, rng, min_frames=2, max_frames=16, min_wh=128, max_wh=256
         ),
         "audio": partial(random_audio, rng, min_len=512, max_len=1024, sr=16000),
+        "vision_chunk": partial(
+            random_vision_chunk, rng, min_wh=128, max_wh=256, min_frames=1, max_frames=1
+        ),
     }
 
     for batch_idx in range(num_batches):
@@ -412,11 +438,6 @@ def test_processing_correctness(
         pytest.skip(
             "Qwen-VL tokenizer requires downloading a font file from "
             "servers that often refuse connections in CI"
-        )
-    if model_id == "moonshotai/Kimi-K2.5":
-        # FIXME(Isaac): Fix Kimi-K2.5's offline inference about vision chunks.
-        pytest.skip(
-            "Kimi-K2.5's offline inference has issues about vision chunks. Fix later."
         )
 
     _test_processing_correctness(

--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -105,7 +105,7 @@ class MoonshotKimiVAutoProcessor(ProcessorMixin):
         self,
         vision_chunks: list[VisionChunk] | None = None,
         *,
-        text: list[int],
+        text: list[int] | str,
         **kwargs,
     ) -> BatchFeature:
         """
@@ -122,6 +122,8 @@ class MoonshotKimiVAutoProcessor(ProcessorMixin):
             - **grid_thws** -- list of image 3D grid in LLM. Returned when `vision_chunks` is not `None`.
         """
         mm_inputs = {}
+        if isinstance(text, str):
+            text = self.tokenizer.encode(text)
         if vision_chunks is not None:
             assert isinstance(vision_chunks, list)
             mm_inputs = self.media_processor.preprocess(vision_chunks)

--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -196,7 +196,7 @@ class KimiK25DummyInputsBuilder(BaseDummyInputsBuilder[KimiK25ProcessingInfo]):
         self.media_token_id = self.info.media_token_id
         self.frame_per_chunk = self.info.media_processor.num_frames_per_chunk
 
-    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> list[int]:
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
         num_media = mm_counts.get("vision_chunk", 0)
         return "<|media_pad|>" * num_media
 

--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -178,7 +178,7 @@ class KimiK25DummyInputsBuilder(BaseDummyInputsBuilder[KimiK25ProcessingInfo]):
 
     def get_dummy_text(self, mm_counts: Mapping[str, int]) -> list[int]:
         num_media = mm_counts.get("vision_chunk", 0)
-        return [self.media_token_id] * num_media
+        return "<|media_pad|>" * num_media
 
     def get_dummy_mm_items(self):
         dummy_videos = self._get_dummy_images(

--- a/vllm/multimodal/parse.py
+++ b/vllm/multimodal/parse.py
@@ -668,6 +668,8 @@ class MultiModalDataParser:
             return None
         if self.is_embeddings(data):
             raise ValueError("Do not support embedding data for vision_chunk right now")
+        if isinstance(data, dict):
+            data = [data]
         return VisionChunkProcessorItems(data)
 
     def _get_subparsers(self) -> Mapping[str, ModalityDataParser]:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Enable Kimi-K2.5 processor test
- Add vision chunk to vision example

## Test Plan
```
pytest -s -v tests/models/multimodal/processing/test_common.py -k Kimi-K2.5
```

## Test Result
Test should pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

