### PR TITLE
Remove incorrect tokenizer info test

### DIFF
--- a/tests/entrypoints/openai/test_tokenization.py
+++ b/tests/entrypoints/openai/test_tokenization.py
@@ -302,26 +302,6 @@ async def test_tokenizer_info_schema(server: RemoteOpenAIServer):
 
 
 @pytest.mark.asyncio
-async def test_tokenizer_info_added_tokens_structure(
-    server: RemoteOpenAIServer,
-):
-    """Test added_tokens_decoder structure if present."""
-    response = requests.get(server.url_for("tokenizer_info"))
-    response.raise_for_status()
-    result = response.json()
-    added_tokens = result.get("added_tokens_decoder")
-    if added_tokens:
-        for token_id, token_info in added_tokens.items():
-            assert isinstance(token_id, str), "Token IDs should be strings"
-            assert isinstance(token_info, dict), "Token info should be a dict"
-            assert "content" in token_info, "Token info should have content"
-            assert "special" in token_info, "Token info should have special flag"
-            assert isinstance(token_info["special"], bool), (
-                "Special flag should be boolean"
-            )
-
-
-@pytest.mark.asyncio
 async def test_tokenizer_info_consistency_with_tokenize(
     server: RemoteOpenAIServer,
 ):


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/20575 added, what is now called, `/tokenizer_info` endpoint.

It added the following serialisation method that is used before the tokenizer info is sent:

https://github.com/vllm-project/vllm/blob/d95b4be47a3b07d38bccd34b282321f479915de2/vllm/entrypoints/serve/tokenize/serving.py#L186-L195

In this you can see that if an `obj` has the attribute `content` it will only return the `content` from that object. The values of the the `added_tokens_decoder` field are [`AddedToken` objects](https://github.com/huggingface/tokenizers/blame/9c57a8505e6c8afa877fe6f90fde2773b89e8840/bindings/python/py_src/tokenizers/__init__.pyi#L2-L36), which do have the attribute `content`.

This means that, by design, the tokenizer info endpoint was only meant to return the string value of the token. Unfortunately, this is directly contradicted in the test that was added by the same PR

https://github.com/vllm-project/vllm/blob/d95b4be47a3b07d38bccd34b282321f479915de2/tests/entrypoints/openai/test_tokenization.py#L304-L321

This was not noticed because the model used in the test does not have and `added_tokens_decoder` for Transformers v4.

This PR opts to simply remove the test so that:

- The existing API (whether or not it was intended) remains unchanged
- The test does not fail for Transformers v5 where `added_tokens_decoder` are present and the test fails