### PR TITLE
[CI] Add DeepSeek V3.2 nightly eval

### DIFF
--- a/tests/evals/gsm8k/configs/DeepSeek-V3.2-DP.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-V3.2-DP.yaml
@@ -1,0 +1,11 @@
+model_name: "deepseek-ai/DeepSeek-V3.2"
+accuracy_threshold: 0.95
+num_questions: 1319
+num_fewshot: 5
+startup_max_wait_seconds: 1200
+server_args: >-
+  --enforce-eager
+  --max-model-len 4096
+  --data-parallel-size 8
+  --enable-expert-parallel
+  --speculative-config '{"method":"mtp","num_speculative_tokens":1}'

--- a/tests/evals/gsm8k/configs/DeepSeek-V3.2-TP.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-V3.2-TP.yaml
@@ -1,0 +1,11 @@
+model_name: "deepseek-ai/DeepSeek-V3.2"
+accuracy_threshold: 0.95
+num_questions: 1319
+num_fewshot: 5
+startup_max_wait_seconds: 1200
+server_args: >-
+  --enforce-eager
+  --max-model-len 4096
+  --tensor-parallel-size 8
+  --enable-expert-parallel
+  --speculative-config '{"method":"mtp","num_speculative_tokens":1}'

--- a/tests/evals/gsm8k/configs/models-h200.txt
+++ b/tests/evals/gsm8k/configs/models-h200.txt
@@ -1,2 +1,4 @@
 DeepSeek-R1-TP.yaml
 DeepSeek-R1-DP.yaml
+DeepSeek-V3.2-TP.yaml
+DeepSeek-V3.2-DP.yaml


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Adds DeepSeek V3.2 to nightly lm eval on H200 to catch issues like https://github.com/vllm-project/vllm/issues/33546

## Test Plan
LM Eval Large Models (H200)

## Test Result
TBD

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

