### PR TITLE
[Perf] Disable clean_logits in deepgemm fp8_mqa_logits kernel

### DIFF
--- a/tests/kernels/test_top_k_per_row.py
+++ b/tests/kernels/test_top_k_per_row.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
 
 # Test parameters
 NUM_ROWS = [1, 32, 2050]
@@ -134,6 +135,7 @@ def test_top_k_per_row(
     """
     Test top_k_per_row.
     """
+    set_random_seed(0)
     torch.set_default_device("cuda:0")
 
     # Create test data
@@ -188,7 +190,11 @@ def _run_top_k_per_row_decode_test(
     # Create test data
     num_rows = batch_size * next_n
     seq_lens = torch.randint(
-        vocab_size, (batch_size,), dtype=torch.int32, device="cuda"
+        low=next_n,
+        high=vocab_size,
+        size=(batch_size,),
+        dtype=torch.int32,
+        device="cuda",
     )
     row_starts = torch.zeros(num_rows, dtype=torch.int32, device="cuda")
     row_indices = torch.arange(num_rows, device="cuda") // next_n
@@ -246,6 +252,7 @@ def test_top_k_per_row_decode(
     """
     Test top_k_per_row with seq_lens tensor.
     """
+    set_random_seed(0)
     vocab_size = 20000
     _run_top_k_per_row_decode_test(
         top_k, batch_size, next_n, vocab_size, clean_logits, data_generation
@@ -259,6 +266,7 @@ def test_top_k_per_row_decode_large_vocab_size(clean_logits: bool) -> None:
     """
     Test top_k_per_row_decode with large vocabulary size.
     """
+    set_random_seed(0)
     top_k = 2048
     batch_size = 2
     next_n = 2

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -108,6 +108,7 @@ def sparse_attn_indexer(
                 weights[chunk.token_start : chunk.token_end],
                 chunk.cu_seqlen_ks,
                 chunk.cu_seqlen_ke,
+                clean_logits=False,
             )
             num_rows = logits.shape[0]
 
@@ -157,6 +158,7 @@ def sparse_attn_indexer(
             decode_metadata.block_table,
             decode_metadata.schedule_metadata,
             max_model_len=max_model_len,
+            clean_logits=False,
         )
 
         num_rows = logits.shape[0]

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -242,6 +242,7 @@ def fp8_mqa_logits(
     weights: torch.Tensor,
     cu_seqlen_ks: torch.Tensor,
     cu_seqlen_ke: torch.Tensor,
+    clean_logits: bool,
 ) -> torch.Tensor:
     """Compute FP8 MQA logits for a single sequence without KV paging.
 
@@ -256,6 +257,7 @@ def fp8_mqa_logits(
             shape [M], dtype int32.
         cu_seqlen_ke: End indices (exclusive) for valid K per query position,
             shape [M], dtype int32.
+        clean_logits: Whether to clean the unfilled logits into `-inf`.
 
     Returns:
         Logits tensor of shape [M, N], dtype `torch.float32`.
@@ -263,7 +265,9 @@ def fp8_mqa_logits(
     _lazy_init()
     if _fp8_mqa_logits_impl is None:
         return _missing()
-    return _fp8_mqa_logits_impl(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke)
+    return _fp8_mqa_logits_impl(
+        q, kv, weights, cu_seqlen_ks, cu_seqlen_ke, clean_logits=clean_logits
+    )
 
 
 def get_paged_mqa_logits_metadata(
@@ -295,6 +299,7 @@ def fp8_paged_mqa_logits(
     block_tables: torch.Tensor,
     schedule_metadata: torch.Tensor,
     max_model_len: int,
+    clean_logits: bool,
 ) -> torch.Tensor:
     """Compute FP8 MQA logits using paged KV-cache.
 
@@ -312,6 +317,7 @@ def fp8_paged_mqa_logits(
         schedule_metadata: Returned by `get_paged_mqa_logits_metadata`;
             used to distribute work across SMs.
         max_model_len: Maximum sequence length used to size the logits output.
+        clean_logits: Whether to clean the unfilled logits into `-inf`.
 
     Returns:
         Logits tensor of shape [B * next_n, max_model_len], dtype
@@ -328,7 +334,7 @@ def fp8_paged_mqa_logits(
         block_tables,
         schedule_metadata,
         max_model_len,
-        clean_logits=True,
+        clean_logits=clean_logits,
     )
 
 


### PR DESCRIPTION
## Purpose

I noticed in DeepSeek V3.2 sparse_attn_indexer, `deep_gemm::smxx_clean_logits` kernel was launched following `deep_gemm::sm90_fp8_mqa_logits`, because `clean_logits` is set to true in https://github.com/vllm-project/vllm/blob/v0.16.0rc0/vllm/utils/deep_gemm.py#L331.

The purpose of `deep_gemm::smxx_clean_logits` kernel is to fill the padding value of MQA logits with -inf, see https://github.com/deepseek-ai/DeepGEMM/blob/v2.1.1/README.md?plain=1#L124. However, I found clean_logits is not necessary.

* For decode, the downstream `topKPerRowDecode` kernel read the row within the `rowEnd` range https://github.com/vllm-project/vllm/blob/v0.16.0rc0/csrc/sampler.cu#L575-L578, so it doesn't read padding values, therefore it is not necessary to enable clean_logits and fill padding values with -inf.
* Similarly for prefill, `topKPerRowPrefill` kernel doesn't read padding values https://github.com/vllm-project/vllm/blob/v0.16.0rc0/csrc/sampler.cu#L551-L553, so clean_logits is not necessary.
* Since `deep_gemm::smxx_clean_logits` kernel is not necessary and takes long time, eliminating launching this kernel would improve latency. So this PR disable clean_logits to improve performance.
* e2e output token throughput improves 15% on H200.

## Test Plan

Added test cases in `test_deepgemm_attention.py` and `test_top_k_per_row.py`

```
pytest -s -v tests/kernels/attention/test_deepgemm_attention.py
```

```
pytest -s -v tests/kernels/test_top_k_per_row.py
```

## Test Result

Unit tests passed.

## Profiling

* Prefill

Main:

<img width="1430" height="560" alt="543894508-14921f00-81ad-4859-97ed-fff5b092e1a2" src="https://github.com/user-attachments/assets/f22dd435-a363-4ba6-b1ab-b094ec26df6e" />

PR:

<img width="1428" height="555" alt="543894111-b00e47e3-2a01-4494-9c86-22dcf453933c" src="https://github.com/user-attachments/assets/2c37744e-442b-4463-8f28-dab122d775b9" />

* Decode

Main:

<img width="1430" height="559" alt="Screenshot 2026-02-01 at 10 20 33 PM" src="https://github.com/user-attachments/assets/2adf2c27-61e5-4f3b-902b-3b15180dc134" />

PR:

<img width="1429" height="557" alt="Screenshot 2026-02-01 at 9 21 15 PM" src="https://github.com/user-attachments/assets/a7fec3d7-6415-429a-aead-0184e9d67c5c" />

Main: `deep_gemm::smxx_clean_logits` kernel was launched.

PR: There's no `deep_gemm::smxx_clean_logits` kernel launched.

## Benchmark

Benchmarked on H200.

* DeepSeek V3.2

```
vllm serve deepseek-ai/DeepSeek-V3.2-Exp \
    --tensor-parallel-size 8 \
    --max-num-seqs 16 \
    --enable-expert-parallel \
    --trust-remote-code \
    --no-enable-prefix-caching
```
```
vllm bench serve \
  --model deepseek-ai/DeepSeek-V3.2-Exp \
  --dataset-name sharegpt \
  --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
  --sharegpt-output-len 300 \
  --max-concurrency 16 \
  --num-prompts 1000 \
  --num-warmups 50 \
  --ignore-eos
```

Main:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  661.38    
Total input tokens:                      229418    
Total generated tokens:                  300000    
Request throughput (req/s):              1.51      
Output token throughput (tok/s):         453.60    
Peak output token throughput (tok/s):    528.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          800.48    
---------------Time to First Token----------------
Mean TTFT (ms):                          1359.93   
Median TTFT (ms):                        477.05    
P99 TTFT (ms):                           11613.21  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          30.63     
Median TPOT (ms):                        30.46     
P99 TPOT (ms):                           31.99     
---------------Inter-token Latency----------------
Mean ITL (ms):                           30.63     
Median ITL (ms):                         30.47     
P99 ITL (ms):                            31.05     
==================================================

```

PR:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  576.87    
Total input tokens:                      229418    
Total generated tokens:                  300000    
Request throughput (req/s):              1.73      
Output token throughput (tok/s):         520.05    
Peak output token throughput (tok/s):    560.00    
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          917.74    
---------------Time to First Token----------------
Mean TTFT (ms):                          433.33    
Median TTFT (ms):                        441.39    
P99 TTFT (ms):                           760.42    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          29.21     
Median TPOT (ms):                        29.19     
P99 TPOT (ms):                           30.44     
---------------Inter-token Latency----------------
Mean ITL (ms):                           29.21     
Median ITL (ms):                         29.20     
P99 ITL (ms):                            29.77     
==================================================
```

e2e output token throughput improves 15%.

* DeepSeek V3.2 MTP

```
vllm serve deepseek-ai/DeepSeek-V3.2-Exp \
    --tensor-parallel-size 8 \
    --max-num-seqs 16 \
    --enable-expert-parallel \
    --trust-remote-code \
    --no-enable-prefix-caching \
    --speculative-config '{"method": "mtp", "num_speculative_tokens": 1}'
```

Main:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  608.06    
Total input tokens:                      229418    
Total generated tokens:                  300000    
Request throughput (req/s):              1.64      
Output token throughput (tok/s):         493.37    
Peak output token throughput (tok/s):    432.00    
Peak concurrent requests:                22.00     
Total token throughput (tok/s):          870.66    
---------------Time to First Token----------------
Mean TTFT (ms):                          214.83    
Median TTFT (ms):                        241.03    
P99 TTFT (ms):                           387.68    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          31.57     
Median TPOT (ms):                        31.30     
P99 TPOT (ms):                           38.15     
---------------Inter-token Latency----------------
Mean ITL (ms):                           43.81     
Median ITL (ms):                         38.05     
P99 ITL (ms):                            171.86    
---------------Speculative Decoding---------------
Acceptance rate (%):                     38.90     
Acceptance length:                       1.39      
Drafts:                                  215488    
Draft tokens:                            215488    
Accepted tokens:                         83823     
Per-position acceptance (%):
  Position 0:                            38.90     
==================================================
```

PR:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  588.06    
Total input tokens:                      229418    
Total generated tokens:                  300000    
Request throughput (req/s):              1.70      
Output token throughput (tok/s):         510.15    
Peak output token throughput (tok/s):    448.00    
Peak concurrent requests:                22.00     
Total token throughput (tok/s):          900.27    
---------------Time to First Token----------------
Mean TTFT (ms):                          210.88    
Median TTFT (ms):                        235.50    
P99 TTFT (ms):                           378.23    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          30.54     
Median TPOT (ms):                        30.34     
P99 TPOT (ms):                           37.12     
---------------Inter-token Latency----------------
Mean ITL (ms):                           42.37     
Median ITL (ms):                         36.72     
P99 ITL (ms):                            168.50    
---------------Speculative Decoding---------------
Acceptance rate (%):                     38.90     
Acceptance length:                       1.39      
Drafts:                                  215496    
Draft tokens:                            215496    
Accepted tokens:                         83830     
Per-position acceptance (%):
  Position 0:                            38.90     
==================================================
```

## Accuracy Testing

* DeepSeek V3.2

```
python3 -m lm_eval --model local-completions \
  --model_args model=deepseek-ai/DeepSeek-V3.2-Exp,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=16 \
  --tasks gsm8k
```

Main:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9560|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9538|±  |0.0058|
```

PR:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9568|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9560|±  |0.0056|
```

* DeepSeek V3.2 MTP

Main:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9591|±  |0.0055|
|     |       |strict-match    |     5|exact_match|↑  |0.9583|±  |0.0055|
```

PR:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9591|±  |0.0055|
|     |       |strict-match    |     5|exact_match|↑  |0.9583|±  |0.0055|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

