### PR TITLE
[Model] Use layer_types config for sliding window selection in GPT-OSS

### DIFF
--- a/vllm/model_executor/models/gpt_oss.py
+++ b/vllm/model_executor/models/gpt_oss.py
@@ -119,8 +119,15 @@ class OAIAttention(nn.Module):
         self.num_local_attention_heads = config.num_attention_heads // tp_size
         self.num_local_key_value_heads = config.num_key_value_heads // tp_size
 
-        # Only apply sliding window to every other layer
-        sliding_window = config.sliding_window if self.layer_idx % 2 == 0 else None
+        # Apply sliding window based on layer_types from config
+        # "sliding_attention" uses sliding window, "full_attention" uses full context
+        layer_types = getattr(config, "layer_types", None)
+        if isinstance(layer_types, (list, tuple)) and self.layer_idx < len(layer_types):
+            use_sliding_window = layer_types[self.layer_idx] == "sliding_attention"
+        else:
+            # Fallback to legacy behavior if layer_types not specified or invalid
+            use_sliding_window = self.layer_idx % 2 == 0
+        sliding_window = config.sliding_window if use_sliding_window else None
         self.attn = Attention(
             self.num_local_attention_heads,
             self.head_dim,


### PR DESCRIPTION
## Summary
- Read layer_types from model config instead of hardcoded even/odd pattern
- sliding_attention layers use sliding window, full_attention uses full context
- Fallback to legacy behavior if layer_types not specified

## Test plan
- [ ] Test with GPT-OSS model that has layer_types in config
- [ ] Verify fallback behavior with model without layer_types