### PR TITLE
[Release] patch step3p5 attention class in v0.15.1 release

### DIFF
--- a/vllm/model_executor/models/step3p5.py
+++ b/vllm/model_executor/models/step3p5.py
@@ -21,7 +21,7 @@ from vllm.distributed import (
 )
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import SiluAndMul, SwigluStepAndMul
-from vllm.model_executor.layers.attention import Attention
+from vllm.attention.layer import Attention
 from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.fused_moe.shared_fused_moe import SharedFusedMoE
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm


### PR DESCRIPTION
CI is failing with https://buildkite.com/vllm/ci/builds/49559#019c1ddd-a724-42fe-8a50-930c9504c1f0/L1169
The reason is model support PR is behind attention class refactoring: https://github.com/vllm-project/vllm/pull/32064
```
pytest tests/models/test_registry.py
========================================= test session starts ==========================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /mnt/ephemeral/zhewen/repos/vllm-fork
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0, hydra-core-1.3.2
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 280 items                                                                                    

tests/models/test_registry.py ................s...........s.............s......................s [ 23%]
...s............................................................................................ [ 57%]
..s..............s......................s...........s.....................................s..... [ 92%]
.....s.sss.ss.........                                                                           [100%]

=========================================== warnings summary ===========================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/models/test_registry.py::test_registry_imports[BagelForConditionalGeneration]
  /mnt/ephemeral/zhewen/repos/vllm-fork/.venv/lib/python3.12/site-packages/transformers/models/auto/image_processing_auto.py:647: FutureWarning: The image_processor_class argument is deprecated and will be removed in v4.42. Please use `slow_image_processor_class`, or `fast_image_processor_class` instead
    warnings.warn(

tests/models/test_registry.py::test_registry_model_property[LlamaForCausalLM-False-False-False]
tests/models/test_registry.py::test_registry_model_property[LlavaForConditionalGeneration-True-True-False]
tests/models/test_registry.py::test_registry_model_property[BertForSequenceClassification-False-False-True]
tests/models/test_registry.py::test_registry_model_property[RobertaForSequenceClassification-False-False-True]
tests/models/test_registry.py::test_registry_model_property[XLMRobertaForSequenceClassification-False-False-True]
tests/models/test_registry.py::test_registry_is_pp[DeepseekV2ForCausalLM-True-False]
tests/models/test_registry.py::test_registry_is_pp[Qwen2VLForConditionalGeneration-True-True]
  /mnt/ephemeral/zhewen/repos/vllm-fork/tests/utils.py:928: DeprecationWarning: This process (pid=3800925) is multi-threaded, use of fork() may lead to deadlocks in the child.
    pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 264 passed, 16 skipped, 10 warnings in 94.60s (0:01:34) ========================
```
