### PR TITLE
Make directory exist ok for ray spinning up multiple replicas on a single instance

### DIFF
--- a/vllm/transformers_utils/runai_utils.py
+++ b/vllm/transformers_utils/runai_utils.py
@@ -59,14 +59,20 @@ class ObjectStorageModel:
                 existing_handler = signal.getsignal(sig)
                 signal.signal(sig, self._close_by_signal(existing_handler))
 
+        # base hash
+        base_hash = hashlib.sha256(str(url).encode()).hexdigest()[:8]
+        # include parent and current pid so concurrent workers get unique dirs
+        parent_pid = os.getppid()
+        my_pid = os.getpid()
+        
         dir_name = os.path.join(
             get_cache_dir(),
             "model_streamer",
-            hashlib.sha256(str(url).encode()).hexdigest()[:8],
+            f"{base_hash}-{parent_pid}-{my_pid}",
         )
         if os.path.exists(dir_name):
             shutil.rmtree(dir_name)
-        os.makedirs(dir_name, exist_ok=True)
+        os.makedirs(dir_name)
         self.dir = dir_name
         logger.debug("Init object storage, model cache path is: %s", dir_name)
 

--- a/vllm/transformers_utils/runai_utils.py
+++ b/vllm/transformers_utils/runai_utils.py
@@ -66,7 +66,7 @@ class ObjectStorageModel:
         )
         if os.path.exists(dir_name):
             shutil.rmtree(dir_name)
-        os.makedirs(dir_name)
+        os.makedirs(dir_name, exist_ok=True)
         self.dir = dir_name
         logger.debug("Init object storage, model cache path is: %s", dir_name)
 

--- a/vllm/transformers_utils/runai_utils.py
+++ b/vllm/transformers_utils/runai_utils.py
@@ -59,41 +59,12 @@ class ObjectStorageModel:
                 existing_handler = signal.getsignal(sig)
                 signal.signal(sig, self._close_by_signal(existing_handler))
 
-        # base hash
-        base_hash = hashlib.sha256(str(url).encode()).hexdigest()[:8]
-
-        # base dir
-        base_dir = os.path.join(get_cache_dir(), "model_streamer")
-        # include parent and current pid so concurrent workers get unique dirs
-        parent_pid = str(os.getppid())
-        my_pid = str(os.getpid())
-
         dir_name = os.path.join(
-            base_dir,
-            f"{base_hash}-{parent_pid}-{my_pid}",
+            get_cache_dir(),
+            "model_streamer",
+            hashlib.sha256(str(url).encode()).hexdigest()[:8],
         )
-        if os.path.exists(dir_name):
-            shutil.rmtree(dir_name)
-
-        # also delete folders from a past run if needed:
-        for entry in os.scandir(base_dir):
-            if (
-                entry.is_dir(follow_symlinks=False)
-                and entry.name.startswith(base_hash)
-                and parent_pid not in entry.name
-            ):
-                try:
-                    shutil.rmtree(entry.path)
-                except FileNotFoundError:
-                    pass  # already deleted by another worker
-                except OSError as e:
-                    logger.warning(
-                        "Failed to remove stale model cache dir: %s, error: %s",
-                        entry.name,
-                        e,
-                    )
-
-        os.makedirs(dir_name)
+        os.makedirs(dir_name, exist_ok=True)
         self.dir = dir_name
         logger.debug("Init object storage, model cache path is: %s", dir_name)
 


### PR DESCRIPTION
## Purpose
When launching ray data llm to spin up multiple replicas of vLLM on a single instance with runai_streamer we get an error because the directory already exists on the instance. Therefore the job will fail since the workers cant spin up. For more details see https://github.com/vllm-project/vllm/issues/33601.

FIX #33601

## Test Plan

Test integration with Ray.

## Test Result

Successfully works as expected.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

