### PR TITLE
Fix Anthropic image format handling in serving endpoint

### DIFF
--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -117,10 +117,25 @@ class AnthropicServingMessages(OpenAIServingChat):
                     if block.type == "text" and block.text:
                         content_parts.append({"type": "text", "text": block.text})
                     elif block.type == "image" and block.source:
+                        # Handle Anthropic image format:
+                        # - base64: {"type": "base64", "media_type": "...", "data": "..."}
+                        # - url: {"type": "url", "url": "..."}
+                        source_type = block.source.get("type", "")
+                        if source_type == "url":
+                            # URL-based image
+                            image_url = block.source.get("url", "")
+                        elif source_type == "base64":
+                            # Base64-encoded image - construct data URL
+                            media_type = block.source.get("media_type", "image/jpeg")
+                            base64_data = block.source.get("data", "")
+                            image_url = f"data:{media_type};base64,{base64_data}"
+                        else:
+                            # Fallback for legacy format where data contains the URL directly
+                            image_url = block.source.get("data", "")
                         content_parts.append(
                             {
                                 "type": "image_url",
-                                "image_url": {"url": block.source.get("data", "")},
+                                "image_url": {"url": image_url},
                             }
                         )
                     elif block.type == "tool_use":


### PR DESCRIPTION
Handle both URL and base64 image formats in the Anthropic Messages API. The Anthropic API supports two image source formats:
  - URL-based: {"type": "url", "url": "..."}
  - Base64: {"type": "base64", "media_type": "...", "data": "..."}

  Previously, the code only handled the legacy format which doesn't work with claude code anymore. This change properly processes both formats and converts base64 images to data URLs for OpenAI-compatible processing.

  ## Purpose

  Fix the Anthropic Messages API endpoint to properly handle both URL-based and base64-encoded image formats according to the official Anthropic API specification. The existing implementation only supported a legacy format, which is incompatible with current Claude Code and other Anthropic API clients.

  ## Test Plan

  Test with both image source formats:
  1. URL-based images: Send a request with `{"type": "image", "source": {"type": "url", "url": "https://example.com/image.jpg"}}`
  2. Base64 images: Send a request with `{"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "<base64-string>"}}`
  3. Verify that both formats are correctly converted to OpenAI-compatible image_url format
  4. Confirm backward compatibility with any existing legacy format usage

  ## Test Result

  The change has been tested with Claude Code which uses the base64 image format. Images are now properly processed and converted to data URLs for downstream OpenAI-compatible handling.

  ---
  <details>
  <summary> Essential Elements of an Effective PR Description Checklist </summary>

  - [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
  - [x] The test plan, such as providing test command.
  - [x] The test results, such as pasting the results comparison before and after, or e2e results
  - [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
  - [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
  </details>