### PR TITLE
[Bugfix] Fix incorrect variable in pooling model LoRA module name check

### DIFF
--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -590,7 +590,7 @@ class LoRAModelManager:
             # HACK Temporary solution for the pool model.
             if self.is_pooling_model and not lora_model.check_lora_name(module_name):
                 replaced_module_name = module_name.replace("model.", "")
-                if lora_model.check_lora_name(module_name):
+                if lora_model.check_lora_name(replaced_module_name):
                     module_name = replaced_module_name
             if module_name.endswith(".experts"):
                 if self._is_non_gated_moe and len(replacement_loras) > 0:


### PR DESCRIPTION
## Purpose
Fix a bug in pooling model LoRA module name checking logic.

## Problem
In `LoRAModelManager._pack_loras()`, the condition on line 593 checks `module_name` instead of `replaced_module_name`, making the inner if-block unreachable:

```python
# Before (buggy):
if self.is_pooling_model and not lora_model.check_lora_name(module_name):
    replaced_module_name = module_name.replace("model.", "")
    if lora_model.check_lora_name(module_name):  # Always False!
        module_name = replaced_module_name
```

The outer condition requires `module_name` to NOT exist, but the inner condition then checks if `module_name` DOES exist - these are mutually exclusive conditions, so the assignment `module_name = replaced_module_name` can never execute.

## Fix
Change `module_name` to `replaced_module_name` in the inner check:

```python
if lora_model.check_lora_name(replaced_module_name):  # Check the new name
    module_name = replaced_module_name
```

## Related
This bug was introduced in PR #14935 (March 2025).

FIX #12808 (partial - improves the fix from #14935)

Made with [Cursor](https://cursor.com)