### PR TITLE
[Bugfix] Fix mm budget setting for Qwen Omni models

### DIFF
--- a/vllm/multimodal/budget.py
+++ b/vllm/multimodal/budget.py
@@ -72,9 +72,14 @@ class MultiModalBudget:
                 mm_counts=dict.fromkeys(active_modalities, 1),
             )
 
+        # Some models (e.g., Qwen3Omni with use_audio_in_video=True) share
+        # placeholders between modalities, so not all active modalities will
+        # have their own entry in the returned dict. We filter to only include
+        # modalities that have independent placeholder tokens.
         mm_max_toks_per_item = {
             modality: all_mm_max_toks_per_item[modality]
             for modality in active_modalities
+            if modality in all_mm_max_toks_per_item
         }
 
         encoder_compute_budget, encoder_cache_size = compute_mm_encoder_budget(


### PR DESCRIPTION

## Purpose
If a model has hybrid-modality setting (e.g., `use_audio_in_video=True` for Qwen Omni model series) then multiple modalities can share the same placeholder in `MultiModalInputs`. This PR makes the modality checking more robust while add a comment to indicate so.

Fixes https://github.com/vllm-project/vllm/issues/33630

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

