### PR TITLE
[Bugfix][Model] Fix DeepSeek-OCR-2 chat template to include BOS token

### DIFF
--- a/vllm/transformers_utils/configs/deepseek_vl2.py
+++ b/vllm/transformers_utils/configs/deepseek_vl2.py
@@ -119,8 +119,9 @@ class DeepseekVLV2Config(PretrainedConfig):
         self.candidate_resolutions = candidate_resolutions
         self.vocab_size = self.text_config.vocab_size
 
-        # update model_type for OCR model
-        if "DeepseekOCRForCausalLM" in (
-            self.architectures or kwargs.get("architectures", [])
-        ):
+        # update model_type for OCR models
+        architectures = self.architectures or kwargs.get("architectures", [])
+        if "DeepseekOCRForCausalLM" in architectures:
             self.model_type = "deepseek_ocr"
+        elif "DeepseekOCR2ForCausalLM" in architectures:
+            self.model_type = "deepseek_ocr2"


### PR DESCRIPTION
## Summary

This PR fixes an issue where DeepSeek-OCR-2 models return empty responses when using the `/v1/chat/completions` endpoint.

## Root Cause

DeepSeek-OCR-2 models have `model_type="deepseek_vl_v2"` but require a BOS token for proper inference. The existing mapping used `template_deepseek_vl2.jinja` which does not include the BOS token, causing the model to produce no output.

## Fix

Added `_get_deepseek_vl_v2_chat_template_fallback()` function in `vllm/transformers_utils/chat_templates/registry.py` which:
- Returns `template_deepseek_ocr.jinja` for OCR models (contains `{{ bos_token }}`)
- Returns `template_deepseek_vl2.jinja` for standard VL2 models

The function checks if "ocr" is in the tokenizer name to distinguish OCR models from VL2 models.

## Testing

Tested locally with `unsloth/DeepSeek-OCR-2`:
- `/v1/chat/completions` with image: Returns correct OCR text ✅
- `/v1/completions` with text: Returns correct completions ✅
- Python `generate()` API: Works as expected ✅

## Affected Models
- `deepseek-ai/DeepSeek-OCR-2`
- `unsloth/DeepSeek-OCR-2`

## Checklist
- [x] Pre-commit checks pass
- [x] DCO Signed-off-by included
- [x] PR title follows `[Bugfix][Model]` convention
- [x] Minimal change (15 lines added, 1 line modified)
