### PR TITLE
[Feature] Support manually enabling the cumem allocator

### DIFF
--- a/docs/features/nixl_connector_usage.md
+++ b/docs/features/nixl_connector_usage.md
@@ -211,6 +211,10 @@ The `kv_load_failure_policy` setting controls how the system handles failures wh
 !!! warning
     Using `kv_load_failure_policy="recompute"` can lead to performance degradation in production deployments. When KV loads fail, the decode instance will execute prefill work with decode-optimized configurations, which is inefficient and defeats the purpose of disaggregated prefilling. This also increases tail latency for other ongoing decode requests.
 
+### For NVIDIA GB-series GPUs
+
+GB-series GPUs support multi-node NVLink. NIXL supports this capability, but KVCache must be registered as VMM during KVCache registration. To enable this feature, you need to set `--enable-cumem-allocator` or `--enable-sleep-mode` flags, and set `UCX_CUDA_IPC_ENABLE_MNNVL: 'y'` env. Otherwise, NIXL can only use RDMA/TCP for cross-node KVCache transfers.
+
 ## Experimental Feature
 
 ### Heterogeneous KV Layout support

--- a/tests/v1/kv_connector/unit/test_config.py
+++ b/tests/v1/kv_connector/unit/test_config.py
@@ -66,7 +66,10 @@ def test_kv_connector(
 
 
 def _build_config(
-    *, kv_connector: str | None, enable_sleep_mode: bool = False
+    *,
+    kv_connector: str | None,
+    enable_sleep_mode: bool = False,
+    enable_cumem_allocator: bool = False,
 ) -> VllmConfig:
     """Build a VllmConfig that exercises _verify_kv_transfer_compat without
     requiring a real model (avoids HF downloads in CI)."""
@@ -79,7 +82,10 @@ def _build_config(
     )
     cfg = VllmConfig.__new__(VllmConfig)
     cfg.kv_transfer_config = kv_transfer_config
-    cfg.model_config = SimpleNamespace(enable_sleep_mode=enable_sleep_mode)
+    cfg.model_config = SimpleNamespace(
+        enable_sleep_mode=enable_sleep_mode,
+        enable_cumem_allocator=(enable_cumem_allocator or enable_sleep_mode),
+    )
     cfg._verify_kv_transfer_compat()
     return cfg
 
@@ -103,6 +109,14 @@ def test_kv_connector_allows_expandable_segments_with_sleep_mode(monkeypatch):
     auto-disables expandable_segments (see #40812)."""
     monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
     _build_config(kv_connector="NixlConnector", enable_sleep_mode=True)
+
+
+def test_kv_connector_allows_expandable_segments_with_cumem_allocator(
+    monkeypatch,
+):
+    """Manual CuMem allocation must also bypass expandable_segments."""
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    _build_config(kv_connector="NixlConnector", enable_cumem_allocator=True)
 
 
 def test_kv_connector_allows_other_alloc_conf(monkeypatch):

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -80,6 +80,16 @@ else:
 
 logger = init_logger(__name__)
 
+
+def is_cumem_allocator_available() -> bool:
+    try:
+        from vllm.device_allocator.cumem import cumem_available
+    except ImportError:
+        return False
+
+    return cumem_available
+
+
 RunnerOption = Literal["auto", RunnerType]
 ConvertType = Literal["none", "embed", "classify"]
 ConvertOption = Literal["auto", ConvertType]
@@ -295,6 +305,13 @@ class ModelConfig:
     enable_sleep_mode: bool = False
     """Enable sleep mode for the engine (only cuda and
     hip platforms are supported)."""
+    enable_cumem_allocator: bool = False
+    """Enable the custom cumem allocator to leverage advanced GPU memory
+    allocation features such as multi-node NVLink support.
+
+    Sleep mode automatically enables this allocator. Only cuda and hip
+    platforms are supported.
+    """
     model_impl: str | ModelImpl = "auto"
     """Which implementation of the model to use:
 
@@ -510,8 +527,16 @@ class ModelConfig:
                 stacklevel=2,
             )
 
-        if self.enable_sleep_mode and not current_platform.is_sleep_mode_available():
-            raise ValueError("Sleep mode is not supported on current platform.")
+        if self.enable_sleep_mode:
+            if not current_platform.is_sleep_mode_available():
+                raise ValueError("Sleep mode is not supported on current platform.")
+            if not self.enable_cumem_allocator:
+                logger.info_once(
+                    "Enabling cumem allocator because sleep mode requires it."
+                )
+                self.enable_cumem_allocator = True
+        if self.enable_cumem_allocator and not is_cumem_allocator_available():
+            raise ValueError("cumem allocator is not supported on current platform.")
 
         hf_config = get_config(
             self.hf_config_path or self.model,

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -790,7 +790,7 @@ class VllmConfig:
         # pins memory, so we conservatively reject the combination whenever
         # any KV connector is configured.
         #
-        # Sleep mode is exempt: CuMemAllocator.use_memory_pool toggles
+        # CuMem allocator is exempt: CuMemAllocator.use_memory_pool toggles
         # expandable_segments off around its pool (see #40812), so the KV
         # cache allocated within that context lands on stable physical pages
         # even when the env var is set.
@@ -798,17 +798,18 @@ class VllmConfig:
             "PYTORCH_CUDA_ALLOC_CONF", ""
         ):
             return
-        if self.model_config is not None and self.model_config.enable_sleep_mode:
+        if self.model_config is not None and (self.model_config.enable_cumem_allocator):
             return
 
         raise ValueError(
             f"KV connector {self.kv_transfer_config.kv_connector} is "
             "incompatible with PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True "
-            "unless enable_sleep_mode is also enabled. PyTorch's CUDA VMM "
+            "unless enable_cumem_allocator is also enabled. PyTorch's CUDA VMM "
             "allocator can remap KV cache virtual addresses to different "
             "physical pages, invalidating any pinned/registered KV memory "
             "(e.g. IB memory regions registered by NIXL or Mooncake). Either "
-            "unset expandable_segments:True or enable sleep mode (which "
+            "unset expandable_segments:True or enable the cumem allocator "
+            "(sleep mode does this automatically and also "
             "routes KV allocations through CuMemAllocator's pool, where "
             "expandable_segments is automatically disabled)."
         )

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -655,6 +655,7 @@ class EngineArgs:
 
     generation_config: str = ModelConfig.generation_config
     enable_sleep_mode: bool = ModelConfig.enable_sleep_mode
+    enable_cumem_allocator: bool = ModelConfig.enable_cumem_allocator
     override_generation_config: dict[str, Any] = get_field(
         ModelConfig, "override_generation_config"
     )
@@ -838,6 +839,9 @@ class EngineArgs:
         )
         model_group.add_argument(
             "--enable-sleep-mode", **model_kwargs["enable_sleep_mode"]
+        )
+        model_group.add_argument(
+            "--enable-cumem-allocator", **model_kwargs["enable_cumem_allocator"]
         )
         model_group.add_argument("--model-impl", **model_kwargs["model_impl"])
         model_group.add_argument(
@@ -1590,6 +1594,7 @@ class EngineArgs:
             generation_config=self.generation_config,
             override_generation_config=self.override_generation_config,
             enable_sleep_mode=self.enable_sleep_mode,
+            enable_cumem_allocator=self.enable_cumem_allocator,
             model_impl=self.model_impl,
             override_attention_dtype=self.override_attention_dtype,
             logits_processors=self.logits_processors,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -199,7 +199,7 @@ class Worker(WorkerBase):
             self.model_runner.post_kv_cache_wake_up()
 
     def _maybe_get_memory_pool_context(self, tag: str) -> AbstractContextManager:
-        if not self.vllm_config.model_config.enable_sleep_mode:
+        if not self.vllm_config.model_config.enable_cumem_allocator:
             return nullcontext()
 
         from vllm.device_allocator.cumem import CuMemAllocator
@@ -207,7 +207,7 @@ class Worker(WorkerBase):
         allocator = CuMemAllocator.get_instance()
         if tag == "weights":
             assert allocator.get_current_usage() == 0, (
-                "Sleep mode can only be used for one instance per process."
+                "CuMem allocator can only be used for one instance per process."
             )
         return allocator.use_memory_pool(tag=tag)
 
@@ -550,13 +550,7 @@ class Worker(WorkerBase):
         # related to kv cache connector (e.g. kv cache sharing layers).
         ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
 
-        if self.vllm_config.model_config.enable_sleep_mode:
-            from vllm.device_allocator.cumem import CuMemAllocator
-
-            allocator = CuMemAllocator.get_instance()
-            with allocator.use_memory_pool(tag="kv_cache"):
-                self.model_runner.initialize_kv_cache(kv_cache_config)
-        else:
+        with self._maybe_get_memory_pool_context(tag="kv_cache"):
             self.model_runner.initialize_kv_cache(kv_cache_config)
 
         if self.model_config.enable_return_routed_experts:


### PR DESCRIPTION
## Purpose

Follow up: https://github.com/vllm-project/vllm/pull/33540#issuecomment-3834388477

Adding the `--enable-cumem-allocator` parameter allows users to manually enable the cumem allocator without sleep mode, which is important when using Nixl for PD isolation in the GB series.
I have run tests on GB200 and H200, and both are working properly.

## Test Plan

GB200:

```
# Prefill - Tray 0
export VLLM_NIXL_SIDE_CHANNEL_HOST=10.0.8.10
vllm serve --gpu-memory-utilization=0.85 --tokenizer-mode=deepseek_v32 --no-enable-expert-parallel --model /home/ubuntu/DeepSeek-V3.2 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cuda"}' --enable-sleep-mode -tp 2 -dp 4 -dpl 2 -dpa 10.0.8.10 -dpr 0 --enable-cumem-allocator
...

# Decode - Tray 2
export VLLM_NIXL_SIDE_CHANNEL_HOST=10.0.8.14
vllm serve --gpu-memory-utilization=0.85 --tokenizer-mode=deepseek_v32 --no-enable-expert-parallel --model /home/ubuntu/DeepSeek-V3.2 --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cuda"}' --enable-sleep-mode -tp 2 -dp 4 -dpl 2 -dpa 10.0.8.14 -dpr 0 --enable-cumem-allocator
...

#Router
python tests/v1/kv_connector/nixl_integration/toy_proxy_server.py --prefiller-hosts 10.0.8.10 --decoder-hosts 10.0.8.14 --prefiller-ports 8000 --decoder-ports 8000 --port 8000
```

Bench:

```
vllm bench serve --save-detailed --trust-remote-code --model /home/ubuntu/DeepSeek-V3.2 --seed 8961287 --dataset-name random --num-prompts 1024 --save-result --ignore-eos --max-concurrency 256 --random-input-len 4000 --random-output-len 1 --request-rate 32
```

H200:

```
CUDA_VISIBLE_DEVICES=0 vllm serve /gpfs/rd/models/Qwen3-8B --enable-cumem-allocator --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_buffer_device":"cuda"}' --port 8001 --gpu-memory-utilization 0.8
```

## Test Result

GB200

```
============ Serving Benchmark Result ============
Successful requests:                     1024
Failed requests:                         0
Maximum request concurrency:             256
Request rate configured (RPS):           32.00
Benchmark duration (s):                  60.05
Total input tokens:                      4096000
Total generated tokens:                  1024
Request throughput (req/s):              17.05
Output token throughput (tok/s):         17.05
Peak output token throughput (tok/s):    35.00
Peak concurrent requests:                286.00
Total token throughput (tok/s):          68232.01
---------------Time to First Token----------------
Mean TTFT (ms):                          11682.56
Median TTFT (ms):                        12974.94
P99 TTFT (ms):                           14961.34
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00
Median TPOT (ms):                        0.00
P99 TPOT (ms):                           0.00
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00
Median ITL (ms):                         0.00
P99 ITL (ms):                            0.00
==================================================
```

H200:

Started successfully, PD working properly.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

