### PR TITLE
[CI/Build] Investigate torchrun distributed tests hanging issue

### DIFF
--- a/tests/distributed/test_torchrun_example.py
+++ b/tests/distributed/test_torchrun_example.py
@@ -32,6 +32,9 @@ llm = LLM(
     gpu_memory_utilization=random.uniform(0.7, 0.9),
     swap_space=random.randint(1, 4),
     seed=0,
+    # FIXME(Isotr0py): async scheduling causes deadlock
+    # on torchrun with PP, need to investigate further.
+    async_scheduling=False,
 )
 
 outputs = llm.generate(prompts, sampling_params)

--- a/tests/distributed/test_torchrun_example_moe.py
+++ b/tests/distributed/test_torchrun_example_moe.py
@@ -39,6 +39,9 @@ llm = LLM(
     gpu_memory_utilization=random.uniform(0.7, 0.9),
     swap_space=random.randint(1, 4),
     seed=0,
+    # FIXME(Isotr0py): async scheduling causes deadlock
+    # on torchrun with PP, need to investigate further.
+    async_scheduling=False,
 )
 
 outputs = llm.generate(prompts, sampling_params)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Fix #33533
- When enabling async scheduling, `get_pp_group().send_tensor_dict(...)` will stuck when enabling PP:
https://github.com/vllm-project/vllm/blob/b95cc5014dc7b260e5c70ae33d1b30c54d11306d/vllm/v1/worker/gpu_model_runner.py#L3582-L3586

## Test Plan
```
PP_SIZE=2 torchrun --nproc-per-node=4 distributed/test_torchrun_example.py
```

## Test Result
Test should pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

