### PR TITLE
[Docs] Do not build the document if there are no docs changes

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,9 +16,9 @@ build:
         if [ "$READTHEDOCS_VERSION_TYPE" != "external" ] || ! git diff --quiet origin/main -- \
             docs/ \
             examples/ \
-            .readthedocs.yaml \
             '*.md' \
-            requirements/docs.txt;
+            requirements/docs.txt \
+            $(python tools/fetch_api_files.py);
         then
           # changes detected, proceed with doc generation
           exit 0;

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,38 @@ build:
   jobs:
     post_checkout:
       - git fetch --unshallow || true
+    post_install:
+      - |
+        set -ex
+        if [ "$READTHEDOCS_VERSION_TYPE" != "external" ] || ! git diff --quiet origin/main -- \
+            docs/ \
+            examples/ \
+            .readthedocs.yaml \
+            '*.md' \
+            requirements/docs.txt;
+        then
+          # changes detected, proceed with doc generation
+          exit 0;
+        fi
+        # no changes detected, verify generated docs are up to date
+        COMMIT=$(git rev-parse HEAD)
+        # generate docs on current branch
+        python docs/mkdocs/hooks/generate_argparse.py
+        python docs/mkdocs/hooks/generate_metrics.py
+        rm -rf /tmp/generated
+        mkdir -p /tmp/generated
+        mv docs/generated /tmp/generated/current
+        # go back to last commit
+        git checkout HEAD~
+        python docs/mkdocs/hooks/generate_argparse.py
+        python docs/mkdocs/hooks/generate_metrics.py
+        mv docs/generated /tmp/generated/last
+        if diff -r /tmp/generated/last /tmp/generated/current; then
+          echo "Generated docs are up to date, skipping update."
+          exit 183
+        fi
+        rm -rf /tmp/generated/
+        git checkout $COMMIT --force
 
 mkdocs:
   configuration: mkdocs.yaml

--- a/docs/mkdocs/hooks/generate_argparse.py
+++ b/docs/mkdocs/hooks/generate_argparse.py
@@ -22,6 +22,9 @@ ARGPARSE_DOC_DIR = ROOT_DIR / "docs/generated/argparse"
 
 sys.path.insert(0, str(ROOT_DIR))
 
+# make sure --request-id-prefix docs are consistent
+sys.modules["uuid"] = MagicMock(uuid4=lambda: MagicMock(hex="{uuid}"))
+
 
 def mock_if_no_torch(mock_module: str, mock: MagicMock):
     if not importlib.util.find_spec("torch"):
@@ -43,7 +46,6 @@ mock_if_no_torch("vllm.model_executor.custom_op", MagicMock(CustomOp=MockCustomO
 mock_if_no_torch(
     "vllm.utils.torch_utils", MagicMock(direct_register_custom_op=lambda *a, **k: None)
 )
-
 
 # Mock any version checks by reading from compiled CI requirements
 with open(ROOT_DIR / "requirements/test.txt") as f:
@@ -85,7 +87,7 @@ def auto_mock(module_name: str, attr: str, max_mocks: int = 100):
             logger.info("Mocking %s for argparse doc generation", e.name)
             sys.modules[e.name] = PydanticMagicMock(name=e.name)
         except Exception:
-            logger.exception("Failed to import %s.%s: %s", module_name, attr)
+            logger.exception("Failed to import %s.%s", module_name, attr)
 
     raise ImportError(
         f"Failed to import {module_name}.{attr} after mocking {max_mocks} imports"

--- a/docs/mkdocs/hooks/generate_metrics.py
+++ b/docs/mkdocs/hooks/generate_metrics.py
@@ -147,3 +147,7 @@ def on_startup(command: Literal["build", "gh-deploy", "serve"], dirty: bool):
         total_metrics,
         len(METRIC_SOURCE_FILES),
     )
+
+
+if __name__ == "__main__":
+    on_startup("build", False)

--- a/tools/fetch_api_files.py
+++ b/tools/fetch_api_files.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import importlib.metadata
+import importlib.util
+import inspect
+import logging
+import os
+import sys
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import regex as re
+from pydantic_core import core_schema
+
+os.environ["VLLM_LOGGING_LEVEL"] = "error"
+logger = logging.getLogger("fetch_api_files")
+
+ROOT_DIR = Path(__file__).parent.parent
+
+sys.path.insert(0, str(ROOT_DIR))
+
+
+def mock_if_no_torch(mock_module: str, mock: MagicMock):
+    if not importlib.util.find_spec("torch"):
+        sys.modules[mock_module] = mock
+
+
+# Mock custom op code
+class MockCustomOp:
+    @staticmethod
+    def register(name):
+        def decorator(cls):
+            return cls
+
+        return decorator
+
+
+mock_if_no_torch("vllm._C", MagicMock())
+mock_if_no_torch("vllm.model_executor.custom_op", MagicMock(CustomOp=MockCustomOp))
+mock_if_no_torch(
+    "vllm.utils.torch_utils", MagicMock(direct_register_custom_op=lambda *a, **k: None)
+)
+mock_if_no_torch("vllm.platforms", MagicMock(current_platform=MagicMock()))
+
+# Mock any version checks by reading from compiled CI requirements
+with open(ROOT_DIR / "requirements/test.txt") as f:
+    VERSIONS = dict(line.strip().split("==") for line in f if "==" in line)
+importlib.metadata.version = lambda name: VERSIONS.get(name) or "0.0.0"
+
+
+# Make torch.nn.Parameter safe to inherit from
+mock_if_no_torch("torch.nn", MagicMock(Parameter=object))
+mock_if_no_torch("tokenizers", MagicMock(__version__="0.0.0"))
+
+
+class PydanticMagicMock(MagicMock):
+    """`MagicMock` that's able to generate pydantic-core schemas."""
+
+    def __init__(self, *args, **kwargs):
+        name = kwargs.pop("name", None)
+        super().__init__(*args, **kwargs)
+        self.__spec__ = ModuleSpec(name, None)
+
+    def __get_pydantic_core_schema__(self, source_type, handler):
+        return core_schema.any_schema()
+
+
+def auto_mock(module_name: str, attr: str, max_mocks: int = 100):
+    """Function that automatically mocks missing modules during imports."""
+    logger.info("Importing %s from %s", attr, module_name)
+
+    for i in range(max_mocks):
+        try:
+            module = importlib.import_module(module_name)
+
+            # First treat attr as an attr, then as a submodule
+            if hasattr(module, attr):
+                return getattr(module, attr)
+
+            return importlib.import_module(f"{module_name}.{attr}")
+        except ModuleNotFoundError as e:
+            assert e.name is not None
+            logger.info("Mocking %s for argparse doc generation: %d: %s", e.name, i, e)
+            sys.modules[e.name] = PydanticMagicMock(name=e.name)
+        except Exception:
+            logger.exception("Failed to import %s.%s", module_name, attr)
+
+    raise ImportError(
+        f"Failed to import {module_name}.{attr} after mocking {max_mocks} imports"
+    )
+
+
+with open(Path(ROOT_DIR, "docs/api/README.md")) as f:
+    files = set()
+    for line in f:
+        m = re.match(r"- \[(vllm\..+)\]\[\]", line)
+        if m is not None:
+            full_name = m.group(1)
+            for i in range(2):
+                module_name, attr = full_name.rsplit(".", 1)
+                # if full_name != "vllm.LLM":
+                #     continue
+                x = auto_mock(module_name, attr, max_mocks=1000)
+                try:
+                    p = Path(inspect.getfile(x))
+                    files.add(p.relative_to(ROOT_DIR).as_posix())
+                    break
+                except TypeError:
+                    # try to fetch from parent module
+                    full_name = module_name
+print("\n".join(sorted(files)))


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Right now, `the docs/readthedocs.org:vllm` job runs for every PR, which causes Read the Docs to frequently report `Maximum concurrency limit reached`. Most PRs don’t touch documentation, so this ends up blocking the CI builds for PRs that do modify docs, delaying feedback and wasting time.

This PR adds a mechanism to skip Read the Docs builds when there are no documentation changes, avoiding unnecessary builds and improving overall CI efficiency.

See https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html#how-it-works

## Test Plan

This is the first commit does not includes the `.readthedocs.yaml` file, and this PR is used to validate that it works as expected.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

