### PR TITLE
[Compile] Add autotune_batch_hint config for dynamic shapes

### DIFF
--- a/tests/compile/test_dynamic_shapes_compilation.py
+++ b/tests/compile/test_dynamic_shapes_compilation.py
@@ -39,6 +39,7 @@ def get_test_models():
 @pytest.mark.parametrize("use_aot_compile", ["0", "1"])
 @pytest.mark.parametrize("use_bytecode_hook", [True, False])
 @pytest.mark.parametrize("evaluate_guards", [False, True])
+@pytest.mark.parametrize("autotune_batch_hint", [None, 256])
 @pytest.mark.skipif(not is_torch_equal_or_newer("2.10.0"), reason="requires torch 2.10")
 def test_dynamic_shapes_compilation(
     monkeypatch,
@@ -47,6 +48,7 @@ def test_dynamic_shapes_compilation(
     use_aot_compile,
     use_bytecode_hook,
     evaluate_guards,
+    autotune_batch_hint,
 ):
     """Test that all dynamic shapes types compile successfully"""
     if use_bytecode_hook and shapes_type == DynamicShapesType.UNBACKED:
@@ -73,6 +75,7 @@ def test_dynamic_shapes_compilation(
             "dynamic_shapes_config": {
                 "type": shapes_type.value,
                 "evaluate_guards": evaluate_guards,
+                "autotune_batch_hint": autotune_batch_hint,
             },
         },
         max_model_len=1024,

--- a/tests/compile/test_dynamic_shapes_compilation.py
+++ b/tests/compile/test_dynamic_shapes_compilation.py
@@ -219,3 +219,98 @@ def test_model_specialization_with_evaluate_guards(
         torch.randn(1, 10).cuda(),
         is_01_specialization=True,
     )
+
+
+@pytest.mark.parametrize(
+    "shapes_type",
+    [DynamicShapesType.BACKED, DynamicShapesType.UNBACKED],
+)
+@pytest.mark.skipif(not is_torch_equal_or_newer("2.10.0"), reason="requires torch 2.10")
+def test_autotune_batch_hint_override(monkeypatch, shapes_type):
+    """Verify that changing autotune_batch_hint produces different Inductor
+    output even when sharing the same cache directory (no stale cache hits)."""
+    from unittest.mock import patch
+
+    from torch._inductor.graph import GraphLowering
+    from torch._inductor.utils import fresh_inductor_cache
+
+    monkeypatch.setenv("VLLM_USE_BYTECODE_HOOK", "0")
+
+    HINT_A = 48
+    HINT_B = 99
+    ACTUAL_BATCH = 256
+    HIDDEN = 32
+
+    @support_torch_compile
+    class ToyModel(torch.nn.Module):
+        def __init__(self, **kwargs):
+            super().__init__()
+            self.linear = torch.nn.Linear(HIDDEN, HIDDEN)
+
+        def forward(self, x: torch.Tensor):
+            return self.linear(x)
+
+    @contextmanager
+    def use_vllm_config(vllm_config: VllmConfig):
+        with set_forward_context({}, vllm_config), set_current_vllm_config(vllm_config):
+            yield
+
+    def compile_and_capture(hint: int, cache_dir: str) -> str:
+        """Compile with the given hint and return the Inductor output code."""
+        torch._dynamo.reset()
+
+        vllm_config = VllmConfig(
+            compilation_config=CompilationConfig(
+                mode=CompilationMode.VLLM_COMPILE,
+                dynamic_shapes_config=DynamicShapesConfig(
+                    type=shapes_type,
+                    autotune_batch_hint=hint,
+                ),
+            ),
+        )
+
+        source_codes: list[str] = []
+
+        def capturing_save(code: str) -> None:
+            source_codes.append(code)
+
+        x = torch.randn(ACTUAL_BATCH, HIDDEN).cuda()
+
+        with (
+            torch.no_grad(),
+            use_vllm_config(vllm_config),
+            patch.object(
+                GraphLowering,
+                "save_output_code",
+                staticmethod(capturing_save),
+            ),
+        ):
+            monkeypatch.setenv("VLLM_CACHE_ROOT", cache_dir)
+            model = ToyModel(vllm_config=vllm_config).eval().cuda()
+            model(x)
+
+        assert len(source_codes) > 0, "No Inductor output code was captured"
+        return "\n".join(source_codes)
+
+    # Use a single shared inductor cache for both compilations so that
+    # a stale cache hit (identical cache keys) would surface as a failure.
+    with fresh_inductor_cache(), tempfile.TemporaryDirectory() as cache_dir:
+        code_a = compile_and_capture(HINT_A, cache_dir)
+        code_b = compile_and_capture(HINT_B, cache_dir)
+
+    def has_rand_strided(code: str, batch: int) -> bool:
+        return f"rand_strided(({batch}," in code or f"rand_strided(({batch}, " in code
+
+    assert has_rand_strided(code_a, HINT_A), (
+        f"Expected rand_strided with batch dim {HINT_A} in first compilation"
+    )
+    assert has_rand_strided(code_b, HINT_B), (
+        f"Expected rand_strided with batch dim {HINT_B} in second compilation"
+    )
+    assert not has_rand_strided(code_a, HINT_B), (
+        f"First compilation (hint={HINT_A}) should not contain batch dim {HINT_B}"
+    )
+    assert not has_rand_strided(code_b, HINT_A), (
+        f"Second compilation (hint={HINT_B}) should not contain batch dim {HINT_A}; "
+        f"likely a stale cache hit"
+    )

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -341,12 +341,19 @@ def _support_torch_compile(
                 if is_torch_equal_or_newer("2.10.0"):
                     for dim in dims:
                         # Use autotune_batch_hint for dim 0 if set, else actual size
-                        hint = autotune_batch_hint if dim == 0 and autotune_batch_hint else arg.size()[dim]
-                        torch._dynamo.decorators.mark_unbacked(arg, dim, hint_override=hint)
+                        hint = (
+                            autotune_batch_hint
+                            if dim == 0 and autotune_batch_hint
+                            else arg.size()[dim]
+                        )
+                        torch._dynamo.decorators.mark_unbacked(
+                            arg, dim, hint_override=hint
+                        )
                 else:
                     torch._dynamo.decorators.mark_unbacked(arg, dims)
             else:
-                # BACKED shapes: pass hint_override if autotune_batch_hint is set for dim 0
+                # BACKED shapes: pass hint_override if autotune_batch_hint
+                # is set for dim 0
                 if is_torch_equal_or_newer("2.10.0.dev") and autotune_batch_hint:
                     for dim in dims:
                         hint = autotune_batch_hint if dim == 0 else None
@@ -386,7 +393,11 @@ def _support_torch_compile(
                         dims = [arg.ndim + dim if dim < 0 else dim for dim in dims]
                         if is_torch_equal_or_newer("2.10.0"):
                             for dim in dims:
-                                hint = autotune_batch_hint if dim == 0 and autotune_batch_hint else arg.size()[dim]
+                                hint = (
+                                    autotune_batch_hint
+                                    if dim == 0 and autotune_batch_hint
+                                    else arg.size()[dim]
+                                )
                                 torch._dynamo.decorators.mark_unbacked(
                                     arg, dim, hint_override=hint
                                 )

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -298,6 +298,19 @@ class DynamicShapesConfig:
     `True` requires PyTorch 2.10+
     """
 
+    autotune_batch_hint: int | None = None
+    """Optional hint for the batch dimension size during autotuning.
+
+    When set, this value is passed as `hint_override` to torch.mark_dynamic()
+    or torch._dynamo.decorators.mark_unbacked() for dimension 0 (batch).
+    This controls what batch size Inductor uses when benchmarking kernel
+    configurations during autotuning.
+
+    If None (default), the behavior is unchanged:
+    - BACKED: uses actual tensor size from first run
+    - UNBACKED: falls back to torch._inductor.config.unbacked_symint_fallback (8192)
+    """
+
     def compute_hash(self) -> str:
         """
         Provide a hash for DynamicShapesConfig

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -311,6 +311,13 @@ class DynamicShapesConfig:
     - UNBACKED: falls back to torch._inductor.config.unbacked_symint_fallback (8192)
     """
 
+    @field_validator("autotune_batch_hint")
+    @classmethod
+    def validate_autotune_batch_hint(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            raise ValueError("autotune_batch_hint must be a positive integer.")
+        return v
+
     def compute_hash(self) -> str:
         """
         Provide a hash for DynamicShapesConfig


### PR DESCRIPTION
## Summary

Add a new config option `autotune_batch_hint` to `DynamicShapesConfig` that allows specifying a hint for the batch dimension size during autotuning.

- When set, this value is passed as `hint_override` to `torch.mark_dynamic()` or `torch._dynamo.decorators.mark_unbacked()` for dimension 0 (batch)
- This controls what batch size Inductor uses when benchmarking kernel configurations during autotuning
- Works with both BACKED and UNBACKED dynamic shapes types
- Default is `None`, which preserves existing behavior