### PR TITLE
Fix Gemma3n audio encoder for Transformers v5

### DIFF
--- a/vllm/model_executor/models/gemma3n_mm.py
+++ b/vllm/model_executor/models/gemma3n_mm.py
@@ -622,7 +622,7 @@ class Gemma3nForConditionalGeneration(
         input_features = audio_input["input_features_padded"].squeeze(1)
         input_features_mask = audio_input["input_features_mask"].squeeze(1)
         audio_outputs, audio_mask = self.audio_tower(
-            input_features, ~input_features_mask
+            input_features, ~input_features_mask, return_dict=False
         )
         audio_features = self.embed_audio(inputs_embeds=audio_outputs)
 


### PR DESCRIPTION
https://github.com/huggingface/transformers/pull/42564 updated all the multimodal feature getting methods to return `BaseModelOutputWithPooling` (which is a `dict`) by default. This is a welcome change as it standardises these methods across all models in Transformers.

However, this caused issues for Gemma3n in vLLM because it instantiates the `audio_tower` using `from_config` (therefore using the `forward` method from Transformers) and expects it to return a tuple.

This PR handles the output of `audio_tower.forward` differently depending on if it is a `tuple`.