### PR TITLE
[CI/Bug]Fix multimodal encoder budget KeyError for shared audio placeholders

### DIFF
--- a/vllm/multimodal/budget.py
+++ b/vllm/multimodal/budget.py
@@ -77,9 +77,9 @@ class MultiModalBudget:
         # have their own entry in the returned dict. We filter to only include
         # modalities that have independent placeholder tokens.
         mm_max_toks_per_item = {
-            modality: all_mm_max_toks_per_item[modality]
+            modality: toks_per_item
             for modality in active_modalities
-            if modality in all_mm_max_toks_per_item
+            if (toks_per_item := all_mm_max_toks_per_item.get(modality)) is not None
         }
 
         encoder_compute_budget, encoder_cache_size = compute_mm_encoder_budget(


### PR DESCRIPTION
## Purpose

fix a keyerror in CI https://buildkite.com/vllm/ci/builds/49647/steps/canvas?jid=019c205f-dc84-45ec-949c-ea4fc62d9a54
- the CI is a main branch CI failure.

```

[2026-02-02T22:40:50Z] /usr/local/lib/python3.12/dist-packages/vllm/v1/engine/input_processor.py:79: in __init__
--
[2026-02-02T22:40:50Z]     mm_budget = MultiModalBudget(vllm_config, mm_registry)
[2026-02-02T22:40:50Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
[2026-02-02T22:40:50Z]
[2026-02-02T22:40:50Z] >       modality: all_mm_max_toks_per_item[modality]
[2026-02-02T22:40:50Z]         for modality in active_modalities
[2026-02-02T22:40:50Z]     }
[2026-02-02T22:40:50Z] E   KeyError: 'audio'
[2026-02-02T22:40:50Z]
[2026-02-02T22:40:50Z] /usr/local/lib/python3.12/dist-packages/vllm/multimodal/budget.py:76: KeyError

```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

