### PR TITLE
Fix offline test for Transformers v5

### DIFF
--- a/tests/entrypoints/offline_mode/test_offline_mode.py
+++ b/tests/entrypoints/offline_mode/test_offline_mode.py
@@ -103,10 +103,14 @@ def test_offline_mode(monkeypatch: pytest.MonkeyPatch):
 
 def _re_import_modules():
     hf_hub_module_names = [k for k in sys.modules if k.startswith("huggingface_hub")]
+    is_transformers = lambda name: name.startswith("transformers")
+    is_remote_code = lambda name: name.startswith("transformers_modules")
+    aliased_modules = ["tokenization_utils", "tokenization_utils_fast"]
+    is_alias = lambda name: any(f".{name}".endswith(alias) for alias in aliased_modules)
     transformers_module_names = [
         k
         for k in sys.modules
-        if k.startswith("transformers") and not k.startswith("transformers_modules")
+        if is_transformers(k) and not is_remote_code(k) and not is_alias(k)
     ]
 
     reload_exception = None

--- a/tests/entrypoints/offline_mode/test_offline_mode.py
+++ b/tests/entrypoints/offline_mode/test_offline_mode.py
@@ -114,7 +114,7 @@ def _re_import_modules():
 
     reload_exception = None
     for module_name in hf_hub_module_names + transformers_module_names:
-        if any(module_name.endswith(alias) for alias in aliased_modules):
+        if any(module_name.endswith(f".{alias}") for alias in aliased_modules):
             # Remove from sys.modules so they are re-aliased on next import
             del sys.modules[module_name]
             continue


### PR DESCRIPTION
As described in https://github.com/huggingface/transformers/blob/main/MIGRATION_GUIDE_V5.md#remote-code-incompatibility, `tokenization_utils` and `tokenization_utils_fast` have been removed and are aliased for backward compatibility.

The re-import logic in the offline tests is incompatible with these aliases so we ensure that they are deleted during reloading so that they will be re-aliased on next import.