### PR TITLE
Fix Gemma3 GGUF for Transformers v5

### DIFF
--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -250,7 +250,7 @@ def maybe_patch_hf_config_from_gguf(
         text_config = hf_config.get_text_config()
         is_gemma3 = hf_config.model_type in ("gemma3", "gemma3_text")
         if vision_config is not None and is_gemma3:
-            new_hf_config = Gemma3Config.from_text_vision_configs(
+            new_hf_config = Gemma3Config(
                 text_config=text_config,
                 vision_config=vision_config,
                 architectures=["Gemma3ForConditionalGeneration"],


### PR DESCRIPTION
https://github.com/huggingface/transformers/pull/41314 removed `from_text_vision_configs` as it's a long deprecated method which serves no purpose (you can just use `__init__`).

This PR updates the `Gemma3Config` instantiation for GGUF models to use `__init__` so that they may continue to work with Transformers v5.