### PR TITLE
[Draft] Move Harmony encoding to renderer layer and add gRPC render server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,7 +234,10 @@ ep_kernels_workspace/
 # Allow tracked library source folders under submodules (e.g., benchmarks/lib)
 !vllm/benchmarks/lib/
 
-# Generated gRPC protobuf files (compiled at build time from vllm_engine.proto)
+# Generated gRPC protobuf files (compiled at build time from *.proto)
 vllm/grpc/vllm_engine_pb2.py
 vllm/grpc/vllm_engine_pb2_grpc.py
 vllm/grpc/vllm_engine_pb2.pyi
+vllm/grpc/render_pb2.py
+vllm/grpc/render_pb2_grpc.py
+vllm/grpc/render_pb2.pyi

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -17,6 +17,7 @@ def main():
     import vllm.entrypoints.cli.benchmark.main
     import vllm.entrypoints.cli.collect_env
     import vllm.entrypoints.cli.openai
+    import vllm.entrypoints.cli.render
     import vllm.entrypoints.cli.run_batch
     import vllm.entrypoints.cli.serve
     from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG, cli_env_setup
@@ -25,6 +26,7 @@ def main():
     CMD_MODULES = [
         vllm.entrypoints.cli.openai,
         vllm.entrypoints.cli.serve,
+        vllm.entrypoints.cli.render,
         vllm.entrypoints.cli.benchmark.main,
         vllm.entrypoints.cli.collect_env,
         vllm.entrypoints.cli.run_batch,

--- a/vllm/entrypoints/cli/render.py
+++ b/vllm/entrypoints/cli/render.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+CLI subcommand for the vLLM Render gRPC server.
+
+Usage:
+    vllm render --model <model_path>
+"""
+
+import argparse
+
+import uvloop
+
+from vllm.entrypoints.cli.types import CLISubcommand
+from vllm.entrypoints.render_server import serve_render
+from vllm.logger import init_logger
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+logger = init_logger(__name__)
+
+DESCRIPTION = """Launch a gRPC server for tokenization and chat message rendering.
+
+This is a lightweight server that only handles input preprocessing (tokenization,
+chat template rendering) without any LLM inference capabilities. It is useful for
+separating the rendering/tokenization layer from the inference layer.
+
+Example:
+    vllm render --model meta-llama/Llama-2-7b-hf --port 50052
+"""
+
+
+class RenderSubcommand(CLISubcommand):
+    """The `render` subcommand for the vLLM CLI."""
+
+    name = "render"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        # If model is specified as positional arg, use it
+        if hasattr(args, "model_tag") and args.model_tag is not None:
+            args.model = args.model_tag
+
+        # Run the render server
+        uvloop.run(serve_render(args))
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        parser = subparsers.add_parser(
+            self.name,
+            help="Start a gRPC server for tokenization and chat rendering",
+            description=DESCRIPTION,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            usage="vllm render [options] [model]",
+        )
+
+        # Positional argument for model (optional)
+        parser.add_argument(
+            "model_tag",
+            type=str,
+            nargs="?",
+            help="Model path or HuggingFace model ID",
+        )
+
+        # Server args
+        parser.add_argument(
+            "--host",
+            type=str,
+            default="0.0.0.0",
+            help="Host to bind gRPC server to (default: 0.0.0.0)",
+        )
+        parser.add_argument(
+            "--port",
+            type=int,
+            default=50052,
+            help="Port to bind gRPC server to (default: 50052)",
+        )
+
+        # Model args
+        parser.add_argument(
+            "--model",
+            type=str,
+            default=None,
+            help="Model path or HuggingFace model ID",
+        )
+        parser.add_argument(
+            "--tokenizer",
+            type=str,
+            default=None,
+            help="Tokenizer path (defaults to model path)",
+        )
+        parser.add_argument(
+            "--tokenizer-mode",
+            type=str,
+            default="auto",
+            choices=["auto", "hf", "mistral"],
+            help="Tokenizer mode (default: auto)",
+        )
+        parser.add_argument(
+            "--trust-remote-code",
+            action="store_true",
+            help="Trust remote code from HuggingFace",
+        )
+        parser.add_argument(
+            "--revision",
+            type=str,
+            default=None,
+            help="Model revision",
+        )
+        parser.add_argument(
+            "--tokenizer-revision",
+            type=str,
+            default=None,
+            help="Tokenizer revision",
+        )
+        parser.add_argument(
+            "--max-model-len",
+            type=int,
+            default=None,
+            help="Maximum model context length",
+        )
+        parser.add_argument(
+            "--trust-request-chat-template",
+            action="store_true",
+            help="Trust chat templates from requests",
+        )
+
+        return parser
+
+    def validate(self, args: argparse.Namespace) -> None:
+        # Ensure model is specified
+        model = getattr(args, "model", None) or getattr(args, "model_tag", None)
+        if not model:
+            raise ValueError(
+                "Model is required. Specify via positional argument or --model flag."
+            )
+
+
+def cmd_init() -> list[CLISubcommand]:
+    """Initialize and return the render subcommand."""
+    return [RenderSubcommand()]

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -32,6 +32,7 @@ from vllm.entrypoints.openai.engine.serving import (
     clamp_prompt_logprobs,
 )
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.preprocess import preprocess_completion
 from vllm.entrypoints.utils import get_max_tokens, should_include_usage
 from vllm.exceptions import VLLMValidationError
 from vllm.inputs.data import EmbedsPrompt, TokensPrompt
@@ -109,7 +110,9 @@ class OpenAIServingCompletion(OpenAIServing):
             )
 
         try:
-            engine_prompts = await self._preprocess_completion(
+            engine_prompts = await preprocess_completion(
+                self.renderer,
+                self.model_config,
                 request,
                 prompt_input=request.prompt,
                 prompt_embeds=request.prompt_embeds,

--- a/vllm/entrypoints/pooling/classify/serving.py
+++ b/vllm/entrypoints/pooling/classify/serving.py
@@ -20,6 +20,7 @@ from vllm.entrypoints.pooling.classify.protocol import (
     ClassificationRequest,
     ClassificationResponse,
 )
+from vllm.entrypoints.preprocess import preprocess_chat, preprocess_completion
 from vllm.logger import init_logger
 from vllm.outputs import ClassificationOutput
 from vllm.pooling_params import PoolingParams
@@ -75,7 +76,9 @@ class ServingClassification(OpenAIServing):
                 if error_check_ret:
                     return error_check_ret
 
-                _, ctx.engine_prompts = await self._preprocess_chat(
+                _, ctx.engine_prompts = await preprocess_chat(
+                    self.renderer,
+                    self.model_config,
                     ctx.request,
                     ctx.request.messages,
                     default_template=self.chat_template,
@@ -83,7 +86,9 @@ class ServingClassification(OpenAIServing):
                     default_template_kwargs=None,
                 )
             elif isinstance(ctx.request, ClassificationCompletionRequest):
-                ctx.engine_prompts = await self._preprocess_completion(
+                ctx.engine_prompts = await preprocess_completion(
+                    self.renderer,
+                    self.model_config,
                     ctx.request,
                     prompt_input=ctx.request.input,
                     prompt_embeds=None,

--- a/vllm/entrypoints/pooling/embed/serving.py
+++ b/vllm/entrypoints/pooling/embed/serving.py
@@ -22,6 +22,7 @@ from vllm.entrypoints.pooling.embed.protocol import (
     EmbeddingResponse,
     EmbeddingResponseData,
 )
+from vllm.entrypoints.preprocess import preprocess_chat, preprocess_completion
 from vllm.inputs.data import EmbedsPrompt, TokensPrompt
 from vllm.logger import init_logger
 from vllm.outputs import PoolingOutput, PoolingRequestOutput
@@ -92,7 +93,9 @@ class OpenAIServingEmbedding(OpenAIServing):
                 if error_check_ret is not None:
                     return error_check_ret
 
-                _, ctx.engine_prompts = await self._preprocess_chat(
+                _, ctx.engine_prompts = await preprocess_chat(
+                    self.renderer,
+                    self.model_config,
                     ctx.request,
                     ctx.request.messages,
                     default_template=self.chat_template,
@@ -100,7 +103,9 @@ class OpenAIServingEmbedding(OpenAIServing):
                     default_template_kwargs=None,
                 )
             elif isinstance(ctx.request, EmbeddingCompletionRequest):
-                ctx.engine_prompts = await self._preprocess_completion(
+                ctx.engine_prompts = await preprocess_completion(
+                    self.renderer,
+                    self.model_config,
                     ctx.request,
                     prompt_input=ctx.request.input,
                     prompt_embeds=None,

--- a/vllm/entrypoints/pooling/pooling/serving.py
+++ b/vllm/entrypoints/pooling/pooling/serving.py
@@ -27,6 +27,7 @@ from vllm.entrypoints.pooling.pooling.protocol import (
     PoolingResponse,
     PoolingResponseData,
 )
+from vllm.entrypoints.preprocess import preprocess_chat, preprocess_completion
 from vllm.logger import init_logger
 from vllm.outputs import PoolingRequestOutput
 from vllm.tasks import PoolingTask, SupportedTask
@@ -122,7 +123,9 @@ class OpenAIServingPooling(OpenAIServing):
                 if error_check_ret is not None:
                     return error_check_ret
 
-                _, engine_prompts = await self._preprocess_chat(
+                _, engine_prompts = await preprocess_chat(
+                    self.renderer,
+                    self.model_config,
                     request,
                     request.messages,
                     default_template=self.chat_template,
@@ -130,7 +133,9 @@ class OpenAIServingPooling(OpenAIServing):
                     default_template_kwargs=None,
                 )
             elif isinstance(request, PoolingCompletionRequest):
-                engine_prompts = await self._preprocess_completion(
+                engine_prompts = await preprocess_completion(
+                    self.renderer,
+                    self.model_config,
                     request,
                     prompt_input=request.input,
                     prompt_embeds=None,

--- a/vllm/entrypoints/preprocess.py
+++ b/vllm/entrypoints/preprocess.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Shared preprocessing functions for chat and completion requests.
+
+These functions extract the preprocessing logic from serving classes
+so it can be shared between different serving layers (OpenAI HTTP, gRPC, etc.).
+"""
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Protocol
+
+from vllm.config import ModelConfig
+from vllm.entrypoints.chat_utils import (
+    ChatCompletionMessageParam,
+    ChatTemplateContentFormatOption,
+    ConversationMessage,
+)
+from vllm.inputs import EmbedsPrompt, TokensPrompt
+from vllm.renderers import BaseRenderer, ChatParams, TokenizeParams, merge_kwargs
+from vllm.tokenizers import TokenizerLike
+
+if TYPE_CHECKING:
+    from vllm.tool_parsers import ToolParser
+
+
+class RendererRequest(Protocol):
+    """Protocol for requests that can build tokenization parameters."""
+
+    def build_tok_params(self, model_config: ModelConfig) -> TokenizeParams:
+        raise NotImplementedError
+
+
+class RendererChatRequest(RendererRequest, Protocol):
+    """Protocol for chat requests that can build chat and tokenization parameters."""
+
+    def build_chat_params(
+        self,
+        default_template: str | None,
+        default_template_content_format: ChatTemplateContentFormatOption,
+    ) -> ChatParams:
+        raise NotImplementedError
+
+
+async def preprocess_chat(
+    renderer: BaseRenderer,
+    model_config: ModelConfig,
+    request: RendererChatRequest,
+    messages: list[ChatCompletionMessageParam],
+    default_template: str | None,
+    default_template_content_format: ChatTemplateContentFormatOption,
+    default_template_kwargs: dict[str, Any] | None,
+    tool_dicts: list[dict[str, Any]] | None = None,
+    tool_parser: Callable[[TokenizerLike], "ToolParser"] | None = None,
+) -> tuple[list[ConversationMessage], list[TokensPrompt | EmbedsPrompt]]:
+    """
+    Preprocess chat messages for inference.
+
+    This is the shared preprocessing logic used by both OpenAI HTTP serving
+    and gRPC serving layers.
+
+    Args:
+        renderer: The BaseRenderer instance
+        model_config: The model configuration
+        request: Request object implementing RendererChatRequest protocol
+        messages: List of chat messages
+        default_template: Default chat template
+        default_template_content_format: Content format for chat template
+        default_template_kwargs: Default kwargs for chat template
+        tool_dicts: Tool definitions
+        tool_parser: Optional tool parser factory
+
+    Returns:
+        Tuple of (conversation, engine_prompts)
+    """
+    from vllm.tokenizers.mistral import MistralTokenizer
+
+    default_template_kwargs = merge_kwargs(
+        default_template_kwargs,
+        dict(
+            tools=tool_dicts,
+            tokenize=isinstance(renderer.tokenizer, MistralTokenizer),
+        ),
+    )
+
+    tok_params = request.build_tok_params(model_config)
+    chat_params = request.build_chat_params(
+        default_template, default_template_content_format
+    ).with_defaults(default_template_kwargs)
+
+    conversation, prompt = await renderer.render_messages_async(messages, chat_params)
+    engine_prompt = await renderer.tokenize_prompt_async(prompt, tok_params)
+
+    extra_items = {
+        k: v
+        for k in ("mm_processor_kwargs", "cache_salt")
+        if (v := getattr(request, k, None)) is not None
+    }
+    engine_prompt.update(extra_items)  # type: ignore
+
+    # tool parsing is done only if a tool_parser has been set and if
+    # tool_choice is not "none" (if tool_choice is "none" but a tool_parser
+    # is set, we want to prevent parsing a tool_call hallucinated by the LLM
+    if tool_parser is not None:
+        from vllm.entrypoints.openai.chat_completion.protocol import (
+            ChatCompletionRequest,
+        )
+        from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+        tool_choice = getattr(request, "tool_choice", "none")
+        if tool_choice != "none":
+            if not isinstance(request, ChatCompletionRequest | ResponsesRequest):
+                msg = (
+                    "Tool usage is only supported for Chat Completions API "
+                    "or Responses API requests."
+                )
+                raise NotImplementedError(msg)
+
+            # TODO: Update adjust_request to accept ResponsesRequest
+            tokenizer = renderer.get_tokenizer()
+            request = tool_parser(tokenizer).adjust_request(request=request)  # type: ignore[arg-type]
+
+    return conversation, [engine_prompt]
+
+
+async def preprocess_completion(
+    renderer: BaseRenderer,
+    model_config: ModelConfig,
+    request: RendererRequest,
+    prompt_input: str | list[str] | list[int] | list[list[int]] | None,
+    prompt_embeds: bytes | list[bytes] | None,
+) -> list[TokensPrompt | EmbedsPrompt]:
+    """
+    Preprocess completion inputs for inference.
+
+    This is the shared preprocessing logic used by both OpenAI HTTP serving
+    and gRPC serving layers.
+
+    Args:
+        renderer: The BaseRenderer instance
+        model_config: The model configuration
+        request: Request object implementing RendererRequest protocol
+        prompt_input: Text or token inputs
+        prompt_embeds: Embedding inputs
+
+    Returns:
+        List of tokenized engine prompts
+    """
+    tok_params = request.build_tok_params(model_config)
+
+    in_prompts = await renderer.render_completions_async(prompt_input, prompt_embeds)
+    engine_prompts = await renderer.tokenize_prompts_async(in_prompts, tok_params)
+
+    extra_items = {
+        k: v
+        for k in ("mm_processor_kwargs", "cache_salt")
+        if (v := getattr(request, k, None)) is not None
+    }
+    for prompt in engine_prompts:
+        prompt.update(extra_items)  # type: ignore
+
+    return engine_prompts

--- a/vllm/entrypoints/render_server.py
+++ b/vllm/entrypoints/render_server.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# mypy: ignore-errors
+"""
+vLLM Render gRPC Server
+
+A lightweight gRPC server for tokenization and chat message rendering.
+This server does not run LLM inference - it only handles input preprocessing.
+
+Usage:
+    python -m vllm.entrypoints.render_server --model <model_path>
+
+Example:
+    python -m vllm.entrypoints.render_server \
+        --model meta-llama/Llama-2-7b-hf \
+        --host 0.0.0.0 \
+        --port 50052
+"""
+
+import argparse
+import asyncio
+import signal
+import sys
+import time
+from typing import Any
+
+import grpc
+import uvloop
+from grpc_reflection.v1alpha import reflection
+
+from vllm.config import ModelConfig
+from vllm.engine.arg_utils import EngineArgs
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+from vllm.entrypoints.preprocess import preprocess_chat, preprocess_completion
+from vllm.grpc import render_pb2, render_pb2_grpc
+from vllm.logger import init_logger
+from vllm.renderers import BaseRenderer, renderer_from_config
+from vllm.tokenizers.mistral import (
+    MistralTokenizer,
+    maybe_serialize_tool_calls,
+    truncate_tool_call_ids,
+    validate_request_params,
+)
+from vllm.usage.usage_lib import UsageContext
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+from vllm.version import __version__ as VLLM_VERSION
+
+logger = init_logger(__name__)
+
+
+def grpc_to_chat_request(
+    grpc_request: render_pb2.RenderChatRequest,
+    messages: list[dict[str, Any]],
+) -> ChatCompletionRequest:
+    """
+    Convert gRPC RenderChatRequest to ChatCompletionRequest.
+
+    This allows the gRPC server to use the same preprocessing logic
+    (build_tok_params, build_chat_params) as the OpenAI HTTP serving layer.
+    """
+    # Convert documents
+    documents = None
+    if grpc_request.documents:
+        documents = [
+            {"title": doc.title, "text": doc.text} for doc in grpc_request.documents
+        ]
+
+    # Convert reasoning_effort
+    reasoning_effort = None
+    if grpc_request.HasField("reasoning_effort"):
+        reasoning_effort = grpc_request.reasoning_effort  # type: ignore[assignment]
+
+    return ChatCompletionRequest(
+        messages=messages,  # type: ignore[arg-type]
+        chat_template=grpc_request.chat_template
+        if grpc_request.HasField("chat_template")
+        else None,
+        chat_template_kwargs=dict(grpc_request.chat_template_kwargs)
+        if grpc_request.chat_template_kwargs
+        else None,
+        add_generation_prompt=grpc_request.add_generation_prompt,
+        continue_final_message=grpc_request.continue_final_message,
+        add_special_tokens=grpc_request.add_special_tokens,
+        max_completion_tokens=grpc_request.max_completion_tokens
+        if grpc_request.HasField("max_completion_tokens")
+        else None,
+        truncate_prompt_tokens=grpc_request.truncate_prompt_tokens
+        if grpc_request.HasField("truncate_prompt_tokens")
+        else None,
+        documents=documents,
+        reasoning_effort=reasoning_effort,
+    )
+
+
+def grpc_to_completion_request(
+    grpc_request: render_pb2.RenderCompletionRequest,
+    prompt: str | list[int],
+) -> CompletionRequest:
+    """
+    Convert gRPC RenderCompletionRequest to CompletionRequest.
+
+    This allows the gRPC server to use the same preprocessing logic
+    (build_tok_params) as the OpenAI HTTP serving layer.
+    """
+    return CompletionRequest(
+        prompt=prompt,  # type: ignore[arg-type]
+        max_tokens=grpc_request.max_output_tokens or None,
+        truncate_prompt_tokens=grpc_request.truncate_prompt_tokens
+        if grpc_request.HasField("truncate_prompt_tokens")
+        else None,
+        add_special_tokens=grpc_request.add_special_tokens
+        if grpc_request.HasField("add_special_tokens")
+        else True,
+    )
+
+
+class RenderServicer(render_pb2_grpc.RenderServiceServicer):
+    """
+    gRPC servicer implementing the RenderService.
+
+    Handles 6 RPCs:
+    - RenderChat: Render chat messages to tokenized prompt
+    - RenderCompletion: Render completion input to tokenized prompt
+    - Tokenize: Tokenize text
+    - Detokenize: Detokenize token IDs
+    - GetInfo: Get renderer information
+    - HealthCheck: Health probe
+    """
+
+    def __init__(
+        self,
+        renderer: BaseRenderer,
+        model_config: ModelConfig,
+        trust_request_chat_template: bool = False,
+    ):
+        """
+        Initialize the servicer.
+
+        Args:
+            renderer: The BaseRenderer instance
+            model_config: The model configuration
+            trust_request_chat_template: Whether to trust chat templates from requests
+        """
+        self.renderer = renderer
+        self.model_config = model_config
+        self.trust_request_chat_template = trust_request_chat_template
+        logger.info("RenderServicer initialized")
+
+    async def RenderChat(
+        self,
+        request: render_pb2.RenderChatRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> render_pb2.RenderChatResponse:
+        """
+        Render chat messages to tokenized prompt.
+
+        Args:
+            request: The RenderChatRequest protobuf
+            context: gRPC context
+
+        Returns:
+            RenderChatResponse protobuf
+        """
+        logger.debug("RenderChat request received")
+
+        try:
+            # Convert protobuf messages to dict format
+            messages = self._convert_messages(request.messages)
+            tool_dicts = self._convert_tools(request.tools) if request.tools else None
+
+            # Convert gRPC request to ChatCompletionRequest
+            chat_request = grpc_to_chat_request(request, messages)
+
+            # Preprocess for specific tokenizers
+            tokenizer = self.renderer.tokenizer
+            if isinstance(tokenizer, MistralTokenizer):
+                maybe_serialize_tool_calls(chat_request)
+                truncate_tool_call_ids(chat_request)
+                validate_request_params(chat_request)
+
+            if self.renderer.uses_harmony:
+                maybe_serialize_tool_calls(chat_request)
+            conversation, engine_prompts = await preprocess_chat(
+                self.renderer,
+                self.model_config,
+                chat_request,
+                messages,
+                default_template=None,
+                default_template_content_format="auto",
+                default_template_kwargs={"tools": tool_dicts},
+            )
+            engine_prompt = engine_prompts[0]
+
+            # Get token IDs
+            prompt_token_ids = engine_prompt.get("prompt_token_ids", [])
+            prompt_text = engine_prompt.get("prompt", "")
+
+            # Convert conversation to protobuf
+            conv_messages = [
+                render_pb2.ConversationMessage(
+                    role=msg.get("role", ""),
+                    content=str(msg.get("content", "")),
+                )
+                for msg in conversation
+            ]
+
+            return render_pb2.RenderChatResponse(
+                prompt_token_ids=prompt_token_ids,
+                prompt_text=prompt_text,
+                num_tokens=len(prompt_token_ids),
+                conversation=conv_messages,
+            )
+
+        except Exception as e:
+            logger.exception("Error in RenderChat")
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
+
+    async def RenderCompletion(
+        self,
+        request: render_pb2.RenderCompletionRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> render_pb2.RenderCompletionResponse:
+        """
+        Render completion input to tokenized prompt.
+
+        Args:
+            request: The RenderCompletionRequest protobuf
+            context: gRPC context
+
+        Returns:
+            RenderCompletionResponse protobuf
+        """
+        logger.debug("RenderCompletion request received")
+
+        try:
+            # Get input
+            input_type = request.WhichOneof("input")
+            if input_type == "text":
+                prompt_input: str | list[int] = request.text
+            elif input_type == "tokens":
+                prompt_input = list(request.tokens.token_ids)
+            else:
+                await context.abort(
+                    grpc.StatusCode.INVALID_ARGUMENT, "No input provided"
+                )
+                return
+
+            # Convert gRPC request to CompletionRequest and preprocess
+            completion_request = grpc_to_completion_request(request, prompt_input)
+            engine_prompts = await preprocess_completion(
+                self.renderer,
+                self.model_config,
+                completion_request,
+                prompt_input,
+                None,  # prompt_embeds
+            )
+            engine_prompt = engine_prompts[0]
+            prompt_token_ids = engine_prompt.get("prompt_token_ids", [])
+
+            return render_pb2.RenderCompletionResponse(
+                prompt_token_ids=prompt_token_ids,
+                num_tokens=len(prompt_token_ids),
+            )
+
+        except Exception as e:
+            logger.exception("Error in RenderCompletion")
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
+
+    async def Tokenize(
+        self,
+        request: render_pb2.TokenizeRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> render_pb2.TokenizeResponse:
+        """
+        Tokenize text.
+
+        Args:
+            request: The TokenizeRequest protobuf
+            context: gRPC context
+
+        Returns:
+            TokenizeResponse protobuf
+        """
+        logger.debug("Tokenize request received")
+
+        try:
+            tokenizer = self.renderer.get_tokenizer()
+
+            # Build encode kwargs
+            encode_kwargs: dict[str, Any] = {
+                "add_special_tokens": request.add_special_tokens,
+            }
+            if request.HasField("truncation"):
+                encode_kwargs["truncation"] = True
+                encode_kwargs["max_length"] = request.truncation
+
+            token_ids = tokenizer.encode(request.text, **encode_kwargs)
+
+            return render_pb2.TokenizeResponse(
+                token_ids=token_ids,
+                num_tokens=len(token_ids),
+            )
+
+        except Exception as e:
+            logger.exception("Error in Tokenize")
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
+
+    async def Detokenize(
+        self,
+        request: render_pb2.DetokenizeRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> render_pb2.DetokenizeResponse:
+        """
+        Detokenize token IDs to text.
+
+        Args:
+            request: The DetokenizeRequest protobuf
+            context: gRPC context
+
+        Returns:
+            DetokenizeResponse protobuf
+        """
+        logger.debug("Detokenize request received")
+
+        try:
+            tokenizer = self.renderer.get_tokenizer()
+            text = tokenizer.decode(
+                list(request.token_ids),
+                skip_special_tokens=request.skip_special_tokens,
+            )
+
+            return render_pb2.DetokenizeResponse(text=text)
+
+        except Exception as e:
+            logger.exception("Error in Detokenize")
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
+
+    async def GetInfo(
+        self,
+        request: render_pb2.GetInfoRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> render_pb2.GetInfoResponse:
+        """
+        Get renderer information.
+
+        Args:
+            request: The GetInfoRequest protobuf
+            context: gRPC context
+
+        Returns:
+            GetInfoResponse protobuf
+        """
+        logger.debug("GetInfo request received")
+
+        tokenizer = self.renderer.tokenizer
+        has_chat_template = (
+            hasattr(tokenizer, "chat_template") and tokenizer.chat_template is not None
+        )
+
+        # Get special tokens
+        special_tokens = []
+        if tokenizer is not None:
+            for attr in ["bos_token", "eos_token", "pad_token", "unk_token"]:
+                token = getattr(tokenizer, attr, None)
+                if token is not None:
+                    special_tokens.append(token)
+
+        return render_pb2.GetInfoResponse(
+            model_path=self.model_config.model,
+            max_model_len=self.model_config.max_model_len,
+            vocab_size=self.model_config.get_vocab_size(),
+            tokenizer_mode=self.model_config.tokenizer_mode,
+            has_chat_template=has_chat_template,
+            special_tokens=special_tokens,
+            uses_harmony=self.renderer.uses_harmony,
+        )
+
+    async def HealthCheck(
+        self,
+        request: render_pb2.HealthCheckRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> render_pb2.HealthCheckResponse:
+        """
+        Handle health check requests.
+
+        Args:
+            request: The HealthCheckRequest protobuf
+            context: gRPC context
+
+        Returns:
+            HealthCheckResponse protobuf
+        """
+        logger.debug("HealthCheck request received")
+
+        return render_pb2.HealthCheckResponse(
+            healthy=True,
+            message="Healthy",
+        )
+
+    # ========== Helper methods ==========
+
+    @staticmethod
+    def _convert_messages(
+        messages: list[render_pb2.ChatMessage],
+    ) -> list[dict[str, Any]]:
+        """Convert protobuf messages to dict format."""
+        result = []
+        for msg in messages:
+            m: dict[str, Any] = {
+                "role": msg.role,
+                "content": msg.content,
+            }
+            if msg.HasField("name"):
+                m["name"] = msg.name
+            if msg.HasField("tool_call_id"):
+                m["tool_call_id"] = msg.tool_call_id
+            if msg.HasField("reasoning"):
+                m["reasoning"] = msg.reasoning
+            if msg.tool_calls:
+                m["tool_calls"] = [
+                    {
+                        "id": tc.id,
+                        "type": tc.type,
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        },
+                    }
+                    for tc in msg.tool_calls
+                ]
+            result.append(m)
+        return result
+
+    @staticmethod
+    def _convert_tools(
+        tools: list[render_pb2.ToolDefinition],
+    ) -> list[dict[str, Any]]:
+        """Convert protobuf tools to dict format."""
+        result = []
+        for tool in tools:
+            t: dict[str, Any] = {
+                "type": tool.type,
+                "function": {
+                    "name": tool.function.name,
+                },
+            }
+            if tool.function.HasField("description"):
+                t["function"]["description"] = tool.function.description
+            if tool.function.HasField("parameters"):
+                import json
+
+                t["function"]["parameters"] = json.loads(tool.function.parameters)
+            result.append(t)
+        return result
+
+
+async def serve_render(args: argparse.Namespace):
+    """
+    Main serving function.
+
+    Args:
+        args: Parsed command line arguments
+    """
+    logger.info("vLLM Render gRPC server version: %s", VLLM_VERSION)
+    logger.info("Model: %s", args.model)
+    logger.info("vLLM Render gRPC server args: %s", args)
+
+    start_time = time.time()
+
+    # Create engine args for model config
+    engine_args = EngineArgs(
+        model=args.model,
+        tokenizer=getattr(args, "tokenizer", None),
+        tokenizer_mode=getattr(args, "tokenizer_mode", "auto"),
+        trust_remote_code=getattr(args, "trust_remote_code", False),
+        revision=getattr(args, "revision", None),
+        max_model_len=getattr(args, "max_model_len", None),
+    )
+
+    # Create vLLM config
+    vllm_config = engine_args.create_engine_config(
+        usage_context=UsageContext.OPENAI_API_SERVER
+    )
+    model_config = vllm_config.model_config
+
+    # Create renderer
+    renderer = renderer_from_config(model_config)
+
+    # Create servicer
+    servicer = RenderServicer(
+        renderer=renderer,
+        model_config=model_config,
+        trust_request_chat_template=args.trust_request_chat_template,
+    )
+
+    # Create gRPC server
+    server = grpc.aio.server(
+        options=[
+            ("grpc.max_send_message_length", -1),
+            ("grpc.max_receive_message_length", -1),
+        ],
+    )
+
+    # Add servicer to server
+    render_pb2_grpc.add_RenderServiceServicer_to_server(servicer, server)
+
+    # Enable reflection for grpcurl and other tools
+    service_names = (
+        render_pb2.DESCRIPTOR.services_by_name["RenderService"].full_name,
+        reflection.SERVICE_NAME,
+    )
+    reflection.enable_server_reflection(service_names, server)
+
+    # Bind to address
+    address = f"{args.host}:{args.port}"
+    server.add_insecure_port(address)
+
+    # Start server
+    await server.start()
+    logger.info("vLLM Render gRPC server started on %s", address)
+    logger.info("Server is ready to accept requests")
+
+    # Handle shutdown signals
+    loop = asyncio.get_running_loop()
+    stop_event = asyncio.Event()
+
+    def signal_handler():
+        logger.info("Received shutdown signal")
+        stop_event.set()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, signal_handler)
+
+    # Serve until shutdown signal
+    try:
+        await stop_event.wait()
+    except KeyboardInterrupt:
+        logger.info("Interrupted by user")
+    finally:
+        logger.info("Shutting down vLLM Render gRPC server...")
+
+        # Stop gRPC server
+        await server.stop(grace=5.0)
+        logger.info("gRPC server stopped")
+
+        elapsed = time.time() - start_time
+        logger.info("Shutdown complete (uptime: %.1f seconds)", elapsed)
+
+
+def main():
+    """Main entry point."""
+    parser = FlexibleArgumentParser(
+        description="vLLM Render gRPC Server",
+    )
+
+    # Server args
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="0.0.0.0",
+        help="Host to bind gRPC server to",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=50052,
+        help="Port to bind gRPC server to",
+    )
+
+    # Model args
+    parser.add_argument(
+        "--model",
+        type=str,
+        required=True,
+        help="Model path or HuggingFace model ID",
+    )
+    parser.add_argument(
+        "--tokenizer",
+        type=str,
+        default=None,
+        help="Tokenizer path (defaults to model path)",
+    )
+    parser.add_argument(
+        "--tokenizer-mode",
+        type=str,
+        default="auto",
+        choices=["auto", "hf", "mistral"],
+        help="Tokenizer mode",
+    )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Trust remote code from HuggingFace",
+    )
+    parser.add_argument(
+        "--revision",
+        type=str,
+        default=None,
+        help="Model revision",
+    )
+    parser.add_argument(
+        "--tokenizer-revision",
+        type=str,
+        default=None,
+        help="Tokenizer revision",
+    )
+    parser.add_argument(
+        "--max-model-len",
+        type=int,
+        default=None,
+        help="Maximum model context length",
+    )
+    parser.add_argument(
+        "--trust-request-chat-template",
+        action="store_true",
+        help="Trust chat templates from requests",
+    )
+
+    args = parser.parse_args()
+
+    # Run server
+    try:
+        uvloop.run(serve_render(args))
+    except Exception as e:
+        logger.exception("Server failed: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/entrypoints/serve/disagg/serving.py
+++ b/vllm/entrypoints/serve/disagg/serving.py
@@ -24,6 +24,7 @@ from vllm.entrypoints.openai.engine.protocol import (
 )
 from vllm.entrypoints.openai.engine.serving import OpenAIServing, clamp_prompt_logprobs
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.preprocess import preprocess_completion
 from vllm.entrypoints.serve.disagg.protocol import (
     GenerateRequest,
     GenerateResponse,
@@ -101,7 +102,9 @@ class ServingTokens(OpenAIServing):
 
         # TODO(NickLucche): Change to EngineCoreRequest once Renderer work is
         # completed
-        engine_prompts = await self._preprocess_completion(
+        engine_prompts = await preprocess_completion(
+            self.renderer,
+            self.model_config,
             request,
             prompt_input=request.token_ids,
             prompt_embeds=None,

--- a/vllm/entrypoints/serve/tokenize/serving.py
+++ b/vllm/entrypoints/serve/tokenize/serving.py
@@ -12,6 +12,7 @@ from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.openai.engine.serving import OpenAIServing
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.preprocess import preprocess_chat, preprocess_completion
 from vllm.entrypoints.serve.tokenize.protocol import (
     DetokenizeRequest,
     DetokenizeResponse,
@@ -78,7 +79,9 @@ class OpenAIServingTokenization(OpenAIServing):
                 if error_check_ret is not None:
                     return error_check_ret
 
-                _, engine_prompts = await self._preprocess_chat(
+                _, engine_prompts = await preprocess_chat(
+                    self.renderer,
+                    self.model_config,
                     request,
                     request.messages,
                     default_template=self.chat_template,
@@ -87,7 +90,9 @@ class OpenAIServingTokenization(OpenAIServing):
                     tool_dicts=tool_dicts,
                 )
             else:
-                engine_prompts = await self._preprocess_completion(
+                engine_prompts = await preprocess_completion(
+                    self.renderer,
+                    self.model_config,
                     request,
                     prompt_input=request.prompt,
                     prompt_embeds=None,

--- a/vllm/grpc/compile_protos.py
+++ b/vllm/grpc/compile_protos.py
@@ -5,11 +5,11 @@
 Compile vLLM protobuf definitions into Python code.
 
 This script uses grpcio-tools to generate *_pb2.py, *_pb2_grpc.py, and
-*_pb2.pyi (type stubs) files from the vllm_engine.proto definition.
+*_pb2.pyi (type stubs) files from the proto definitions.
 
 NOTE: Proto compilation happens automatically during package build (via setup.py).
 This script is provided for developers who want to regenerate protos manually,
-e.g., after modifying vllm_engine.proto.
+e.g., after modifying vllm_engine.proto or render.proto.
 
 Usage:
     python vllm/grpc/compile_protos.py
@@ -22,64 +22,74 @@ import sys
 from pathlib import Path
 
 
-def compile_protos():
-    """Compile protobuf definitions."""
-    # Get the vllm package root directory
-    script_dir = Path(__file__).parent
-    vllm_package_root = script_dir.parent.parent  # vllm/vllm/grpc -> vllm/
+def compile_proto(proto_name: str, script_dir: Path, vllm_package_root: Path) -> int:
+    """Compile a single proto file."""
+    from grpc_tools import protoc
 
-    proto_file = script_dir / "vllm_engine.proto"
+    proto_file = script_dir / f"{proto_name}.proto"
 
     if not proto_file.exists():
         print(f"Error: Proto file not found at {proto_file}")
         return 1
 
     print(f"Compiling protobuf: {proto_file}")
+
+    result = protoc.main(
+        [
+            "grpc_tools.protoc",
+            f"--proto_path={vllm_package_root}",
+            f"--python_out={vllm_package_root}",
+            f"--grpc_python_out={vllm_package_root}",
+            f"--pyi_out={vllm_package_root}",
+            str(proto_file),
+        ]
+    )
+
+    if result != 0:
+        print(f"Error: protoc returned {result}")
+        return result
+
+    # Add SPDX headers to generated files
+    spdx_header = (
+        "# SPDX-License-Identifier: Apache-2.0\n"
+        "# SPDX-FileCopyrightText: Copyright contributors to the vLLM project\n"
+    )
+
+    for suffix in ["_pb2.py", "_pb2_grpc.py", "_pb2.pyi"]:
+        generated_file = script_dir / f"{proto_name}{suffix}"
+        if generated_file.exists():
+            content = generated_file.read_text()
+            if not content.startswith("# SPDX-License-Identifier"):
+                header = spdx_header + "# mypy: ignore-errors\n"
+                generated_file.write_text(header + content)
+
+    print(f"  Generated: {script_dir / f'{proto_name}_pb2.py'}")
+    print(f"  Generated: {script_dir / f'{proto_name}_pb2_grpc.py'}")
+    print(f"  Generated: {script_dir / f'{proto_name}_pb2.pyi'} (type stubs)")
+
+    return 0
+
+
+def compile_protos():
+    """Compile all protobuf definitions."""
+    # Get the vllm package root directory
+    script_dir = Path(__file__).parent
+    vllm_package_root = script_dir.parent.parent  # vllm/vllm/grpc -> vllm/
+
     print(f"Output directory: {script_dir}")
 
-    # Compile the proto file
-    # We use vllm/vllm as the proto_path so that the package is vllm.grpc.engine
+    proto_files = ["vllm_engine", "render"]
+
     try:
-        from grpc_tools import protoc
+        from grpc_tools import protoc  # noqa: F401
 
-        result = protoc.main(
-            [
-                "grpc_tools.protoc",
-                f"--proto_path={vllm_package_root}",
-                f"--python_out={vllm_package_root}",
-                f"--grpc_python_out={vllm_package_root}",
-                f"--pyi_out={vllm_package_root}",  # Generate type stubs
-                str(script_dir / "vllm_engine.proto"),
-            ]
-        )
+        for proto_name in proto_files:
+            result = compile_proto(proto_name, script_dir, vllm_package_root)
+            if result != 0:
+                return result
 
-        if result == 0:
-            # Add SPDX headers to generated files
-            spdx_header = (
-                "# SPDX-License-Identifier: Apache-2.0\n"
-                "# SPDX-FileCopyrightText: Copyright contributors to the vLLM project\n"
-            )
-
-            for generated_file in [
-                script_dir / "vllm_engine_pb2.py",
-                script_dir / "vllm_engine_pb2_grpc.py",
-                script_dir / "vllm_engine_pb2.pyi",
-            ]:
-                if generated_file.exists():
-                    content = generated_file.read_text()
-                    if not content.startswith("# SPDX-License-Identifier"):
-                        # Add mypy ignore-errors comment for all generated files
-                        header = spdx_header + "# mypy: ignore-errors\n"
-                        generated_file.write_text(header + content)
-
-            print("✓ Protobuf compilation successful!")
-            print(f"  Generated: {script_dir / 'vllm_engine_pb2.py'}")
-            print(f"  Generated: {script_dir / 'vllm_engine_pb2_grpc.py'}")
-            print(f"  Generated: {script_dir / 'vllm_engine_pb2.pyi'} (type stubs)")
-            return 0
-        else:
-            print(f"Error: protoc returned {result}")
-            return result
+        print("✓ All protobuf compilations successful!")
+        return 0
 
     except ImportError:
         print("Error: grpcio-tools not installed")

--- a/vllm/grpc/render.proto
+++ b/vllm/grpc/render.proto
@@ -1,0 +1,177 @@
+syntax = "proto3";
+
+package vllm.grpc.render;
+
+// RenderService provides tokenization and chat message rendering.
+// This is a lightweight service that only handles input preprocessing,
+// without any LLM inference capabilities.
+service RenderService {
+  // Render chat messages to tokenized prompt
+  rpc RenderChat(RenderChatRequest) returns (RenderChatResponse);
+
+  // Render completion input to tokenized prompt
+  rpc RenderCompletion(RenderCompletionRequest) returns (RenderCompletionResponse);
+
+  // Tokenize text
+  rpc Tokenize(TokenizeRequest) returns (TokenizeResponse);
+
+  // Detokenize token IDs to text
+  rpc Detokenize(DetokenizeRequest) returns (DetokenizeResponse);
+
+  // Get renderer information
+  rpc GetInfo(GetInfoRequest) returns (GetInfoResponse);
+
+  // Health check
+  rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
+}
+
+// =====================
+// Chat Message Types
+// =====================
+
+message ChatMessage {
+  string role = 1;  // "system", "user", "assistant", "tool"
+  string content = 2;
+  optional string name = 3;
+  repeated ToolCall tool_calls = 4;
+  optional string tool_call_id = 5;
+  optional string reasoning = 6;
+}
+
+message ToolCall {
+  string id = 1;
+  string type = 2;  // "function"
+  FunctionCall function = 3;
+}
+
+message FunctionCall {
+  string name = 1;
+  string arguments = 2;  // JSON string
+}
+
+message ToolDefinition {
+  string type = 1;  // "function"
+  FunctionDefinition function = 2;
+}
+
+message FunctionDefinition {
+  string name = 1;
+  optional string description = 2;
+  optional string parameters = 3;  // JSON schema string
+}
+
+message Document {
+  string title = 1;
+  string text = 2;
+}
+
+// =====================
+// RenderChat
+// =====================
+
+message RenderChatRequest {
+  repeated ChatMessage messages = 1;
+  repeated ToolDefinition tools = 2;
+  optional string tool_choice = 3;
+  optional string reasoning_effort = 4;
+
+  // Template options
+  optional string chat_template = 5;
+  map<string, string> chat_template_kwargs = 6;
+
+  // Generation options
+  bool add_generation_prompt = 7;
+  bool continue_final_message = 8;
+  bool add_special_tokens = 9;
+
+  // Truncation
+  optional int32 max_completion_tokens = 10;
+  optional int32 truncate_prompt_tokens = 11;
+
+  // RAG documents
+  repeated Document documents = 12;
+}
+
+message RenderChatResponse {
+  repeated int32 prompt_token_ids = 1;
+  string prompt_text = 2;
+  int32 num_tokens = 3;
+  repeated ConversationMessage conversation = 4;
+}
+
+message ConversationMessage {
+  string role = 1;
+  string content = 2;
+}
+
+// =====================
+// RenderCompletion
+// =====================
+
+message RenderCompletionRequest {
+  oneof input {
+    string text = 1;
+    TokensInput tokens = 2;
+  }
+
+  optional int32 max_total_tokens = 3;
+  int32 max_output_tokens = 4;
+  optional int32 truncate_prompt_tokens = 5;
+  optional bool add_special_tokens = 6;
+}
+
+message TokensInput {
+  repeated int32 token_ids = 1;
+}
+
+message RenderCompletionResponse {
+  repeated int32 prompt_token_ids = 1;
+  int32 num_tokens = 2;
+}
+
+// =====================
+// Tokenize / Detokenize
+// =====================
+
+message TokenizeRequest {
+  string text = 1;
+  bool add_special_tokens = 2;
+  optional int32 truncation = 3;
+}
+
+message TokenizeResponse {
+  repeated int32 token_ids = 1;
+  int32 num_tokens = 2;
+}
+
+message DetokenizeRequest {
+  repeated int32 token_ids = 1;
+  bool skip_special_tokens = 2;
+}
+
+message DetokenizeResponse {
+  string text = 1;
+}
+
+// =====================
+// Info / Health
+// =====================
+
+message GetInfoRequest {}
+
+message GetInfoResponse {
+  string model_path = 1;
+  int32 max_model_len = 2;
+  int32 vocab_size = 3;
+  string tokenizer_mode = 4;
+  bool has_chat_template = 5;
+  repeated string special_tokens = 6;
+  bool uses_harmony = 7;
+}
+
+message HealthCheckRequest {}
+
+message HealthCheckResponse {
+  bool healthy = 1;
+  string message = 2;
+}

--- a/vllm/renderers/protocol.py
+++ b/vllm/renderers/protocol.py
@@ -38,6 +38,13 @@ class BaseRenderer(ABC):
         # Lazy initialization since offline LLM doesn't use async
         self._async_tokenizer: AsyncMicrobatchTokenizer | None = None
 
+        # Check if this model uses Harmony encoding (GPT-OSS)
+        hf_config = getattr(config, "hf_config", None)
+        self.uses_harmony: bool = (
+            hf_config is not None
+            and getattr(hf_config, "model_type", None) == "gpt_oss"
+        )
+
     @property
     @abstractmethod
     def tokenizer(self) -> TokenizerLike | None:


### PR DESCRIPTION
Background
I’ve concluded that integrating Harmony into the Renderer layer is essential for a complete and functional [render implementation](https://github.com/vllm-project/vllm/issues/32648#issuecomment-3774625001). I’ve opened this Draft PR to verify if this proposed final architecture aligns with the project's direction.

If the direction is confirmed, I plan to break this down into smaller, manageable PRs.

Changes
1. Added uses_harmony property (9e6a89e)
  - Introduced the uses_harmony property to BaseRenderer.
  - Updated chat_completion/serving.py and responses/serving.py to use self.renderer.uses_harmony instead of self.use_harmony.
2. Migrated Harmony encoding logic to the Renderer layer ([80ce4a6](https://github.com/vllm-project/vllm/pull/33693/commits/80ce4a61a0fafef6df9da8b1cd4d65560299bae3))
  - Added the _render_messages_harmony method to vllm/renderers/hf.py.
  - Removed _make_request_with_harmony from responses/serving.py.
  - Harmony system messages are now passed via default_template_kwargs.
3. Extracted shared preprocessing modules ([80ce4a6](https://github.com/vllm-project/vllm/pull/33693/commits/80ce4a61a0fafef6df9da8b1cd4d65560299bae3))
  - Created vllm/entrypoints/preprocess.py to consolidate logic.
  - Defined RendererRequest and RendererChatRequest protocols.
  - Extracted preprocess_chat() and preprocess_completion() functions.
  - Refactored OpenAIServing by removing _preprocess_chat and _preprocess_completion methods.
  - Updated various serving components to use these shared functions, including:
    - chat_completion/serving.py, completion/serving.py, responses/serving.py
    - Pooling services (embed, classify, pooling)
    - serve/tokenize/serving.py, serve/disagg/serving.py
4. Added gRPC Render Server (3e869d7)
  - vllm/grpc/render.proto: Defined the gRPC service.
    - RenderChat: Chat messages → Tokenized prompt.
    - RenderCompletion: Completion input → Tokenized prompt.
    - Added Tokenize, Detokenize, GetInfo, and HealthCheck endpoints.
  - vllm/entrypoints/render_server.py: Implemented the gRPC server.
  - vllm/entrypoints/cli/render.py: Added the vllm render CLI subcommand.