### PR TITLE
[Bugfix] Fix torchrun PP broadcast deadlock with async scheduling

### DIFF
--- a/tests/distributed/test_torchrun_example.py
+++ b/tests/distributed/test_torchrun_example.py
@@ -32,9 +32,6 @@ llm = LLM(
     gpu_memory_utilization=random.uniform(0.7, 0.9),
     swap_space=random.randint(1, 4),
     seed=0,
-    # FIXME(Isotr0py): async scheduling causes deadlock
-    # on torchrun with PP, need to investigate further.
-    async_scheduling=False,
 )
 
 outputs = llm.generate(prompts, sampling_params)

--- a/tests/distributed/test_torchrun_example_moe.py
+++ b/tests/distributed/test_torchrun_example_moe.py
@@ -39,9 +39,6 @@ llm = LLM(
     gpu_memory_utilization=random.uniform(0.7, 0.9),
     swap_space=random.randint(1, 4),
     seed=0,
-    # FIXME(Isotr0py): async scheduling causes deadlock
-    # on torchrun with PP, need to investigate further.
-    async_scheduling=False,
 )
 
 outputs = llm.generate(prompts, sampling_params)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3666,6 +3666,9 @@ class GPUModelRunner(
         )
         if self.use_async_scheduling:
             pp = get_pp_group()
+            # For torchrun external_launcher PP mode with broadcast_pp_output=True,
+            # PP outputs have been broadcasted to all ranks at logits computation.
+            # Therefore, here is no need to send sampled token ids again in this case.
             if not self.broadcast_pp_output and pp.world_size > 1 and pp.is_last_rank:
                 self._pp_broadcast_prev_sampled_token_ids(
                     sampler_output.sampled_token_ids

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3666,7 +3666,7 @@ class GPUModelRunner(
         )
         if self.use_async_scheduling:
             pp = get_pp_group()
-            if pp.world_size > 1 and pp.is_last_rank:
+            if not self.broadcast_pp_output and pp.world_size > 1 and pp.is_last_rank:
                 self._pp_broadcast_prev_sampled_token_ids(
                     sampler_output.sampled_token_ids
                 )


### PR DESCRIPTION

## Purpose
- Following PR for #33650
- Fix root issue of https://github.com/vllm-project/vllm/issues/33533
- `torchrun` with PP has already broadcast PP outputs during logits computation, so there is no need to boardcast sampled tokens again.
https://github.com/vllm-project/vllm/blob/4bc913aeeca39a304e4ace51febf55f142c8c86e/vllm/v1/worker/gpu_model_runner.py#L3551-L3599

## Test Plan
```
VLLM_LOGGING_LEVEL=DEBUG PP_SIZE=2 torchrun --nproc-per-node=4 distributed/test_torchrun_example.py
```

## Test Result
Test should still pass after enabling async scheduling:
```
Processed prompts: 100%|███████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 11.16it/s, est. speed input: 72.59 toks/s, output: 178.67 toks/s]
Processed prompts: 100%|███████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 12.92it/s, est. speed input: 84.04 toks/s, output: 206.87 toks/s]
Rank 0, Prompt: 'Hello, my name is', Generated text: ' Joel, my dad is my friend and we are in a relationship. I am'
Rank 1, Prompt: 'Hello, my name is', Generated text: ' Joel, my dad is my friend and we are in a relationship. I am'
Rank 0, Prompt: 'The president of the United States is', Generated text: ' speaking out against the release of some State Department documents which show the Russians were involved'
Rank 1, Prompt: 'The president of the United States is', Generated text: ' speaking out against the release of some State Department documents which show the Russians were involved'
Rank 0, Prompt: 'The capital of France is', Generated text: ' known as the “Bear Capital Capital of the World”. It is'
Rank 1, Prompt: 'The capital of France is', Generated text: ' known as the “Bear Capital Capital of the World”. It is'
Rank 0, Prompt: 'The future of AI is', Generated text: ' coming to smartphones\nThe future of AI is coming to smartphones, and this will'
Rank 1, Prompt: 'The future of AI is', Generated text: ' coming to smartphones\nThe future of AI is coming to smartphones, and this will'
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

