### PR TITLE
[Core] Improve KV cache block reuse for prefix caching

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -271,13 +271,12 @@ def test_prefill(hash_fn):
     # All blocks should be available.
     assert free_block_queue.num_free_blocks == 10
     # The order should be
+    # [fresh/unique_req1 (5), fresh/unique_req0 (4)]  (prepended, no hash)
     # [unallocated (6, 7, 8, 9, 10)]
-    # [unique_req0 (4)]
-    # [unique_req1 (5)]
-    # [common (3, 2, 1)]
+    # [common (3, 2, 1)]  (appended, have hash for prefix cache)
     assert [
         b.block_id for b in manager.block_pool.free_block_queue.get_all_free_blocks()
-    ] == [6, 7, 8, 9, 10, 4, 5, 3, 2, 1]
+    ] == [5, 4, 6, 7, 8, 9, 10, 3, 2, 1]
 
     # Cache hit in the common prefix when the original block is already free.
     # Incomplete 1 block (6 tokens)
@@ -291,7 +290,7 @@ def test_prefill(hash_fn):
     blocks = manager.allocate_slots(
         req2, num_new_tokens, len(computed_blocks.blocks[0]) * 16, computed_blocks
     )
-    assert blocks is not None and blocks.get_block_ids() == ([6],)
+    assert blocks is not None and blocks.get_block_ids() == ([5],)
 
     # Although we only have 6 free blocks, we have 8 blocks in
     # the free block queue due to lazy removal.
@@ -310,8 +309,9 @@ def test_prefill(hash_fn):
         req3, 16 * 10, len(computed_blocks.blocks[0]) * 16, computed_blocks
     )
     # This block ID order also checks the eviction order.
+    # Fresh blocks (no hash) are prepended, cached blocks appended.
     assert blocks is not None and blocks.get_block_ids() == (
-        [7, 8, 9, 10, 4, 5, 6, 3, 2, 1],
+        [5, 4, 6, 7, 8, 9, 10, 3, 2, 1],
     )
 
     assert free_block_queue.num_free_blocks == 0
@@ -1039,13 +1039,12 @@ def test_prefill_plp():
     # All blocks should be available.
     assert manager.block_pool.free_block_queue.num_free_blocks == 10
     # The order should be
+    # [fresh/unique_req1 (5), fresh/unique_req0 (4)]  (prepended, no hash)
     # [unallocated (6, 7, 8, 9, 10)]
-    # [unique_req0 (4)]
-    # [unique_req1 (5)]
-    # [common (3, 2, 1)]
+    # [common (3, 2, 1)]  (appended, have hash for prefix cache)
     assert [
         b.block_id for b in manager.block_pool.free_block_queue.get_all_free_blocks()
-    ] == [6, 7, 8, 9, 10, 4, 5, 3, 2, 1]
+    ] == [5, 4, 6, 7, 8, 9, 10, 3, 2, 1]
 
     # Request #2 is a prompt-logprobs request:
     # NO cache hit in the common prefix; duplicates request #0 cached blocks
@@ -1178,7 +1177,7 @@ def test_evict():
     assert manager.block_pool.free_block_queue.num_free_blocks == 10
     assert [
         b.block_id for b in manager.block_pool.free_block_queue.get_all_free_blocks()
-    ] == [10, 6, 5, 4, 3, 2, 1, 9, 8, 7]
+    ] == [6, 10, 5, 4, 3, 2, 1, 9, 8, 7]
 
     # Touch the first 2 blocks.
     req2 = make_request("2", list(range(2 * 16 + 3)), block_size, sha256)
@@ -1188,7 +1187,7 @@ def test_evict():
     blocks = manager.allocate_slots(
         req2, 3, len(computed_blocks.blocks[0]) * 16, computed_blocks
     )
-    assert blocks is not None and blocks.get_block_ids() == ([10],)
+    assert blocks is not None and blocks.get_block_ids() == ([6],)
     assert manager.block_pool.free_block_queue.num_free_blocks == 7
 
 

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -407,6 +407,8 @@ class BlockPool:
                 else:
                     cached_blocks.append(block)
 
+        # Fresh blocks go to front of queue (used first during allocation),
+        # cached blocks go to back (preserved longer for prefix cache hits).
         if fresh_blocks:
             self.free_block_queue.prepend_n(fresh_blocks)
         if cached_blocks:

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -259,7 +259,18 @@ class BlockPool:
             # align mode. We skip null blocks here.
             if blk.is_null:
                 continue
-            assert blk.block_hash is None
+            if blk.block_hash is not None:
+                # Block already cached (from prefix cache hit).
+                # Verify it has the correct hash for this position.
+                expected_hash = make_block_hash_with_group_id(
+                    new_block_hashes[i], kv_cache_group_id
+                )
+                assert blk.block_hash == expected_hash, (
+                    "Cached block has wrong hash: "
+                    f"{blk.block_hash!r} != {expected_hash!r}. "
+                    "This indicates the wrong block was assigned from prefix cache."
+                )
+                continue
             block_hash = new_block_hashes[i]
 
             # Update and added the full block to the cache.
@@ -398,9 +409,24 @@ class BlockPool:
         blocks_list = list(ordered_blocks)
         for block in blocks_list:
             block.ref_cnt -= 1
-        self.free_block_queue.append_n(
-            [block for block in blocks_list if block.ref_cnt == 0 and not block.is_null]
-        )
+
+        # Separate blocks into fresh (no hash) and cached (has hash).
+        # Fresh blocks go to front of queue (used first during allocation),
+        # cached blocks go to back (preserved longer for prefix cache hits).
+        # Partition in a single pass to avoid creating intermediate list.
+        fresh_blocks = []
+        cached_blocks = []
+        for b in blocks_list:
+            if b.ref_cnt == 0 and not b.is_null:
+                if b.block_hash is None:
+                    fresh_blocks.append(b)
+                else:
+                    cached_blocks.append(b)
+
+        if fresh_blocks:
+            self.free_block_queue.prepend_n(fresh_blocks)
+        if cached_blocks:
+            self.free_block_queue.append_n(cached_blocks)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -344,6 +344,38 @@ class FreeKVCacheBlockQueue:
 
         self.num_free_blocks += len(blocks)
 
+    def prepend_n(self, blocks: list[KVCacheBlock]) -> None:
+        """Put a list of blocks at the FRONT of the free list.
+
+        This is used to prioritize fresh blocks (without cached hashes) over
+        cached blocks, so that cached blocks are preserved longer.
+
+        Args:
+            blocks: The blocks to prepend.
+        """
+        if len(blocks) == 0:
+            return
+
+        first_block = self.fake_free_list_head.next_free_block
+        assert first_block is not None, (
+            "next_free_block of fake_free_list_head should always exist"
+        )
+
+        # Connect the fake head to the first block of <blocks>
+        self.fake_free_list_head.next_free_block = blocks[0]
+        blocks[0].prev_free_block = self.fake_free_list_head
+
+        # Add inter-connections between consecutive blocks
+        for i in range(len(blocks) - 1):
+            blocks[i].next_free_block = blocks[i + 1]
+            blocks[i + 1].prev_free_block = blocks[i]
+
+        # Connect the last block of <blocks> to the original first block
+        blocks[-1].next_free_block = first_block
+        first_block.prev_free_block = blocks[-1]
+
+        self.num_free_blocks += len(blocks)
+
     def get_all_free_blocks(self) -> list[KVCacheBlock]:
         """Get all free blocks in the free list. Mainly used for testing.
 


### PR DESCRIPTION
## Summary
Optimize KV cache block allocation to preserve cached blocks longer, improving prefix cache hit rates.

**Changes:**
1. **Add `prepend_n()` method** to `FreeKVCacheBlockQueue` for inserting blocks at the front of the free list

2. **Modify `free_blocks()`** to separate fresh vs cached blocks:
   - Fresh blocks (no hash) → front of queue (reused first)
   - Cached blocks (has hash) → back of queue (preserved longer)

~3. **Add hash validation** in `cache_full_blocks()` to verify blocks from prefix cache hits have the expected hash~

## Motivation
When blocks are freed, those with cached hashes should be preserved longer so they can be reused for prefix cache hits. Fresh blocks (never cached) should be allocated first since they have no reuse value.

## Test plan
- Existing prefix caching tests should pass
- Manual verification with prefix caching workloads

## Related
This is split from PR #33125 per reviewer request. The SWA-specific optimizations will follow in a separate PR.