### PR TITLE
[Core] SWA-specific KV cache optimizations for prefix caching

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -271,13 +271,12 @@ def test_prefill(hash_fn):
     # All blocks should be available.
     assert free_block_queue.num_free_blocks == 10
     # The order should be
+    # [fresh/unique_req1 (5), fresh/unique_req0 (4)]  (prepended, no hash)
     # [unallocated (6, 7, 8, 9, 10)]
-    # [unique_req0 (4)]
-    # [unique_req1 (5)]
-    # [common (3, 2, 1)]
+    # [common (3, 2, 1)]  (appended, have hash for prefix cache)
     assert [
         b.block_id for b in manager.block_pool.free_block_queue.get_all_free_blocks()
-    ] == [6, 7, 8, 9, 10, 4, 5, 3, 2, 1]
+    ] == [5, 4, 6, 7, 8, 9, 10, 3, 2, 1]
 
     # Cache hit in the common prefix when the original block is already free.
     # Incomplete 1 block (6 tokens)
@@ -291,7 +290,7 @@ def test_prefill(hash_fn):
     blocks = manager.allocate_slots(
         req2, num_new_tokens, len(computed_blocks.blocks[0]) * 16, computed_blocks
     )
-    assert blocks is not None and blocks.get_block_ids() == ([6],)
+    assert blocks is not None and blocks.get_block_ids() == ([5],)
 
     # Although we only have 6 free blocks, we have 8 blocks in
     # the free block queue due to lazy removal.
@@ -310,8 +309,9 @@ def test_prefill(hash_fn):
         req3, 16 * 10, len(computed_blocks.blocks[0]) * 16, computed_blocks
     )
     # This block ID order also checks the eviction order.
+    # Fresh blocks (no hash) are prepended, cached blocks appended.
     assert blocks is not None and blocks.get_block_ids() == (
-        [7, 8, 9, 10, 4, 5, 6, 3, 2, 1],
+        [5, 4, 6, 7, 8, 9, 10, 3, 2, 1],
     )
 
     assert free_block_queue.num_free_blocks == 0
@@ -1039,13 +1039,12 @@ def test_prefill_plp():
     # All blocks should be available.
     assert manager.block_pool.free_block_queue.num_free_blocks == 10
     # The order should be
+    # [fresh/unique_req1 (5), fresh/unique_req0 (4)]  (prepended, no hash)
     # [unallocated (6, 7, 8, 9, 10)]
-    # [unique_req0 (4)]
-    # [unique_req1 (5)]
-    # [common (3, 2, 1)]
+    # [common (3, 2, 1)]  (appended, have hash for prefix cache)
     assert [
         b.block_id for b in manager.block_pool.free_block_queue.get_all_free_blocks()
-    ] == [6, 7, 8, 9, 10, 4, 5, 3, 2, 1]
+    ] == [5, 4, 6, 7, 8, 9, 10, 3, 2, 1]
 
     # Request #2 is a prompt-logprobs request:
     # NO cache hit in the common prefix; duplicates request #0 cached blocks
@@ -1178,7 +1177,7 @@ def test_evict():
     assert manager.block_pool.free_block_queue.num_free_blocks == 10
     assert [
         b.block_id for b in manager.block_pool.free_block_queue.get_all_free_blocks()
-    ] == [10, 6, 5, 4, 3, 2, 1, 9, 8, 7]
+    ] == [6, 10, 5, 4, 3, 2, 1, 9, 8, 7]
 
     # Touch the first 2 blocks.
     req2 = make_request("2", list(range(2 * 16 + 3)), block_size, sha256)
@@ -1188,7 +1187,7 @@ def test_evict():
     blocks = manager.allocate_slots(
         req2, 3, len(computed_blocks.blocks[0]) * 16, computed_blocks
     )
-    assert blocks is not None and blocks.get_block_ids() == ([10],)
+    assert blocks is not None and blocks.get_block_ids() == ([6],)
     assert manager.block_pool.free_block_queue.num_free_blocks == 7
 
 

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -417,6 +417,8 @@ class BlockPool:
         fresh_blocks = [b for b in freeable if b.block_hash is None]
         cached_blocks = [b for b in freeable if b.block_hash is not None]
 
+        # Fresh blocks go to front of queue (used first during allocation),
+        # cached blocks go to back (preserved longer for prefix cache hits).
         if fresh_blocks:
             self.free_block_queue.prepend_n(fresh_blocks)
         if cached_blocks:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -344,6 +344,38 @@ class FreeKVCacheBlockQueue:
 
         self.num_free_blocks += len(blocks)
 
+    def prepend_n(self, blocks: list[KVCacheBlock]) -> None:
+        """Put a list of blocks at the FRONT of the free list.
+
+        This is used to prioritize fresh blocks (without cached hashes) over
+        cached blocks, so that cached blocks are preserved longer.
+
+        Args:
+            blocks: The blocks to prepend.
+        """
+        if len(blocks) == 0:
+            return
+
+        first_block = self.fake_free_list_head.next_free_block
+        assert first_block is not None, (
+            "next_free_block of fake_free_list_head should always exist"
+        )
+
+        # Connect the fake head to the first block of <blocks>
+        self.fake_free_list_head.next_free_block = blocks[0]
+        blocks[0].prev_free_block = self.fake_free_list_head
+
+        # Add inter-connections between consecutive blocks
+        for i in range(len(blocks) - 1):
+            blocks[i].next_free_block = blocks[i + 1]
+            blocks[i + 1].prev_free_block = blocks[i]
+
+        # Connect the last block of <blocks> to the original first block
+        blocks[-1].next_free_block = first_block
+        first_block.prev_free_block = blocks[-1]
+
+        self.num_free_blocks += len(blocks)
+
     def get_all_free_blocks(self) -> list[KVCacheBlock]:
         """Get all free blocks in the free list. Mainly used for testing.
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -932,6 +932,7 @@ class Scheduler(SchedulerInterface):
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
         for req_id, num_scheduled_token in num_scheduled_tokens.items():
             request = self.requests[req_id]
+            old_computed = request.num_computed_tokens
             request.num_computed_tokens += num_scheduled_token
             request.is_prefill_chunk = request.num_computed_tokens < (
                 request.num_tokens + request.num_output_placeholders
@@ -939,6 +940,17 @@ class Scheduler(SchedulerInterface):
             scheduler_output.has_structured_output_requests |= (
                 request.use_structured_output
             )
+
+            # Immediately free SWA out-of-window blocks after prefill completes.
+            # This ensures block pool capacity is reclaimed for concurrent
+            # requests, rather than waiting until the next scheduling cycle.
+            if (
+                old_computed < request.num_prompt_tokens
+                and request.num_computed_tokens >= request.num_prompt_tokens
+            ):
+                self.kv_cache_manager.remove_skipped_blocks(
+                    request.request_id, request.num_computed_tokens
+                )
 
             # NOTE: _free_encoder_inputs relies on num_computed_tokens, which
             # may be updated again in _update_from_output for speculative

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -386,6 +386,11 @@ class SingleTypeKVCacheManager(ABC):
             removed_blocks.append(blocks[i])
             blocks[i] = self._null_block
         self.block_pool.free_blocks(removed_blocks)
+        # Evict hashes of freed SWA blocks from the prefix cache.
+        # These blocks are outside the sliding window and will never be
+        # looked up again, so keeping their hashes wastes cache capacity
+        # and causes LRU eviction of actually-reusable hashes.
+        self.block_pool.evict_blocks({b.block_id for b in removed_blocks})
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
         """
@@ -581,13 +586,65 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         attention computation since they are outside the sliding window.
         Thus, get_num_skipped_tokens(7) == 4.
 
+        Note: When prefix caching is enabled, we keep one extra block to ensure
+        cache hit compatibility. The lookup uses max_length = num_tokens - 1
+        (from full attention), causing an off-by-one with the eviction boundary.
+        By keeping one extra block, the lookup can find enough contiguous blocks.
+
         Args:
             num_computed_tokens: The number of tokens that have been computed.
 
         Returns:
             The number of tokens that will be skipped for attention computation.
         """
-        return max(0, num_computed_tokens - self.sliding_window + 1)
+        skipped = max(0, num_computed_tokens - self.sliding_window + 1)
+        # Keep one extra block for prefix cache hit compatibility.
+        # Lookup starts at max_num_blocks-1 due to full attention's
+        # max_cache_hit_length = num_tokens-1, creating an off-by-one
+        # with the eviction boundary.
+        if skipped > 0 and self.enable_caching:
+            skipped = max(0, skipped - self.block_size)
+        return skipped
+
+    def cache_blocks(self, request: Request, num_tokens: int) -> None:
+        """
+        Cache only the blocks within the sliding window for prefix caching.
+
+        For SWA, only the last `sliding_window_blocks` blocks are useful for
+        prefix cache lookup (since find_longest_cache_hit searches from right
+        to left and only needs contiguous blocks within the window).
+        Caching earlier blocks wastes hash table capacity and causes LRU
+        eviction of actually-reusable hashes (e.g., full attention blocks).
+        """
+        num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
+        num_full_blocks = num_tokens // self.block_size
+
+        if num_cached_blocks >= num_full_blocks:
+            return
+
+        # Only cache blocks within the sliding window.
+        # Earlier blocks will be freed by remove_skipped_blocks anyway.
+        # Cache one extra block at the beginning to account for the off-by-one
+        # in cache hit lookup: lookup starts at max_num_blocks-1 (excluding the
+        # incomplete last block), so we need sliding_window_blocks + 1 cached
+        # blocks to achieve sliding_window_blocks contiguous hits.
+        sliding_window_blocks = cdiv(self.sliding_window, self.block_size)
+        start_cache_block = max(
+            num_cached_blocks, num_full_blocks - sliding_window_blocks - 1
+        )
+
+        if start_cache_block < num_full_blocks:
+            self.block_pool.cache_full_blocks(
+                request=request,
+                blocks=self.req_to_blocks[request.request_id],
+                num_cached_blocks=start_cache_block,
+                num_full_blocks=num_full_blocks,
+                block_size=self.block_size,
+                kv_cache_group_id=self.kv_cache_group_id,
+            )
+
+        # Mark all blocks up to num_full_blocks as processed (even if skipped).
+        self.num_cached_block[request.request_id] = num_full_blocks
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         """

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -606,46 +606,6 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             skipped = max(0, skipped - self.block_size)
         return skipped
 
-    def cache_blocks(self, request: Request, num_tokens: int) -> None:
-        """
-        Cache only the blocks within the sliding window for prefix caching.
-
-        For SWA, only the last `sliding_window_blocks` blocks are useful for
-        prefix cache lookup (since find_longest_cache_hit searches from right
-        to left and only needs contiguous blocks within the window).
-        Caching earlier blocks wastes hash table capacity and causes LRU
-        eviction of actually-reusable hashes (e.g., full attention blocks).
-        """
-        num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
-        num_full_blocks = num_tokens // self.block_size
-
-        if num_cached_blocks >= num_full_blocks:
-            return
-
-        # Only cache blocks within the sliding window.
-        # Earlier blocks will be freed by remove_skipped_blocks anyway.
-        # Cache one extra block at the beginning to account for the off-by-one
-        # in cache hit lookup: lookup starts at max_num_blocks-1 (excluding the
-        # incomplete last block), so we need sliding_window_blocks + 1 cached
-        # blocks to achieve sliding_window_blocks contiguous hits.
-        sliding_window_blocks = cdiv(self.sliding_window, self.block_size)
-        start_cache_block = max(
-            num_cached_blocks, num_full_blocks - sliding_window_blocks - 1
-        )
-
-        if start_cache_block < num_full_blocks:
-            self.block_pool.cache_full_blocks(
-                request=request,
-                blocks=self.req_to_blocks[request.request_id],
-                num_cached_blocks=start_cache_block,
-                num_full_blocks=num_full_blocks,
-                block_size=self.block_size,
-                kv_cache_group_id=self.kv_cache_group_id,
-            )
-
-        # Mark all blocks up to num_full_blocks as processed (even if skipped).
-        self.num_cached_block[request.request_id] = num_full_blocks
-
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         """
         NOTE(Chen): The prefix blocks are null blocks for sliding window layers.


### PR DESCRIPTION
## Summary
Optimize sliding window attention (SWA) layers for better prefix cache efficiency.

**Changes:**
1. **Immediate SWA block eviction after prefill**
   - Free out-of-window blocks right when prefill completes
   - Faster block pool capacity reclaim for concurrent requests
   - Evict hashes from prefix cache (they won't be looked up again)

2. **Modified `get_num_skipped_tokens()` for prefix cache compatibility**
   - Keep one extra block to handle off-by-one in cache hit lookup
   - Lookup uses `max_length = num_tokens - 1`, creating boundary mismatch

3. **New `cache_blocks()` for SWA-aware selective caching**
   - Only cache blocks within the sliding window
   - Skip caching earlier blocks (they get evicted anyway)
   - Avoids wasting hash table capacity on non-reusable blocks

## Motivation
For SWA models with prefix caching, caching blocks outside the sliding window wastes hash table capacity and causes LRU eviction of actually-reusable hashes from full attention layers.

## Test plan
- Existing SWA + prefix caching tests should pass
- Manual verification with SWA models (e.g., Mistral)

## Dependencies
- Depends on PR #33710 (block reuse enhancement) for the `prepend_n()` method

## Related
This is split from PR #33125 per reviewer request. See also PR #33710 for the general block reuse enhancement.