### PR TITLE
[compile] Remove runner type from ignored caching factor list.

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -107,8 +107,8 @@ class ModelConfig:
     content for `model_name` tag in metrics output when `served_model_name` is
     not specified."""
     model_weights: str = ""
-    """Original model weights path. Used when the model is pulled from object 
-    storage (e.g., RunAI) to preserve the original URI while `model` points to 
+    """Original model weights path. Used when the model is pulled from object
+    storage (e.g., RunAI) to preserve the original URI while `model` points to
     the local directory."""
     runner: RunnerOption = "auto"
     """The type of model runner to use. Each vLLM instance only supports one
@@ -326,7 +326,6 @@ class ModelConfig:
         the final hidden states.
         """
         ignored_factors = {
-            "runner",
             "convert",
             "tokenizer",
             "tokenizer_mode",


### PR DESCRIPTION
Summary:

Draft runner should be compiled separartely. Currently it's ignored from caching factor which results in draft models reusing the same dynamo artifacts which causes issues in https://github.com/pytorch/pytorch/issues/173546

Test Plan:

pytest tests/v1/e2e/test_spec_decode.py::test_draft_model_correctness -v -k "False-args0"
