### PR TITLE
[BugFix][Spec Decoding] Fix negative accepted tokens metric crash

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1276,7 +1276,7 @@ class Scheduler(SchedulerInterface):
             scheduled_spec_token_ids = (
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id)
             )
-            if scheduled_spec_token_ids:
+            if scheduled_spec_token_ids and generated_token_ids:
                 num_draft_tokens = len(scheduled_spec_token_ids)
                 num_accepted = len(generated_token_ids) - 1
                 num_rejected = num_draft_tokens - num_accepted


### PR DESCRIPTION
In some cases it's possible for no tokens to be generated in a step for a request which had spec decode tokens.

It's actually not clear cut whether we should record 0 accepted tokens in this case or not record at all, it depends on the specific purpose / definition of acceptance rate. For now I am just not recording it, this case should happen relatively infrequently anyhow.

Fixes https://github.com/vllm-project/vllm/issues/26372.