### PR TITLE
[Spec Decode] Add hidden states extraction system

### DIFF
--- a/examples/offline_inference/extract_hidden_states.py
+++ b/examples/offline_inference/extract_hidden_states.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from safetensors import safe_open
 
 from vllm import LLM, SamplingParams

--- a/examples/offline_inference/extract_hidden_states.py
+++ b/examples/offline_inference/extract_hidden_states.py
@@ -21,7 +21,6 @@ llm = LLM(
             }
         },
     },
-    enforce_eager=True,
     kv_transfer_config={
         "kv_connector": "ExampleHiddenStatesConnector",
         "kv_role": "kv_producer",
@@ -31,7 +30,7 @@ llm = LLM(
     },
 )
 
-prompts = ["Generate a sentence with hidden states"]
+prompts = ["Generate a sentence with hidden states", "Write a python function"]
 sampling_params = SamplingParams(max_tokens=1)
 outputs = llm.generate(prompts, sampling_params)
 

--- a/examples/offline_inference/extract_hidden_states.py
+++ b/examples/offline_inference/extract_hidden_states.py
@@ -1,55 +1,58 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import tempfile
+
 from safetensors import safe_open
 
 from vllm import LLM, SamplingParams
 
-# Example: Using the custom "extract_hidden_states" speculator method
-# This method uses the ExampleHiddenStatesConnector to extract and save hidden states
+# Example: Using the custom "extract_hidden_states" speculator method and
+# ExampleHiddenStatesConnector to extract and save hidden states from vllm
 
-llm = LLM(
-    model="Qwen/Qwen3-8B",  # Your target model
-    speculative_config={
-        "method": "extract_hidden_states",
-        "num_speculative_tokens": 1,
-        "draft_model_config": {
-            "hf_config": {
-                "eagle_aux_hidden_state_layer_ids": [  # Target model layer indices
-                    1,
-                    2,
-                    3,
-                    4,
-                ],
-            }
+with tempfile.TemporaryDirectory() as tmpdirname:
+    llm = LLM(
+        model="Qwen/Qwen3-8B",  # Your target model
+        speculative_config={
+            "method": "extract_hidden_states",
+            "num_speculative_tokens": 1,
+            "draft_model_config": {
+                "hf_config": {
+                    "eagle_aux_hidden_state_layer_ids": [  # Target model layer indices
+                        1,
+                        2,
+                        3,
+                        4,
+                    ],
+                }
+            },
         },
-    },
-    kv_transfer_config={
-        "kv_connector": "ExampleHiddenStatesConnector",
-        "kv_role": "kv_producer",
-        "kv_connector_extra_config": {
-            "shared_storage_path": "/tmp/hidden_states",
+        kv_transfer_config={
+            "kv_connector": "ExampleHiddenStatesConnector",
+            "kv_role": "kv_producer",
+            "kv_connector_extra_config": {
+                "shared_storage_path": tmpdirname,
+            },
         },
-    },
-)
+    )
 
-prompts = ["Generate a sentence with hidden states", "Write a python function"]
-sampling_params = SamplingParams(max_tokens=1)
-outputs = llm.generate(prompts, sampling_params)
+    prompts = ["Generate a sentence with hidden states", "Write a python function"]
+    sampling_params = SamplingParams(max_tokens=1)
+    outputs = llm.generate(prompts, sampling_params)
 
-for output in outputs:
-    print("\nPrompt:", output.prompt)
-    print("Prompt token ids:", output.prompt_token_ids)
+    for output in outputs:
+        print("\nPrompt:", output.prompt)
+        print("Prompt token ids:", output.prompt_token_ids)
 
-    hidden_states_path = output.kv_transfer_params.get("hidden_states_path")
-    assert hidden_states_path is not None
-    print("Prompt hidden states path:", hidden_states_path)
+        hidden_states_path = output.kv_transfer_params.get("hidden_states_path")
+        assert hidden_states_path is not None
+        print("Prompt hidden states path:", hidden_states_path)
 
-    with safe_open(hidden_states_path, "pt") as f:
-        token_ids = f.get_tensor("token_ids")
-        hidden_states = f.get_tensor("hidden_states")
+        with safe_open(hidden_states_path, "pt") as f:
+            token_ids = f.get_tensor("token_ids")
+            hidden_states = f.get_tensor("hidden_states")
 
-        print("Extracted token ids:", token_ids)  # Matches prompt token ids
-        print(
-            "Extracted hidden states shape:", hidden_states.shape
-        )  # [num_hidden_layers, prompt len, hidden size]
-        print("Extracted hidden states:", hidden_states)
+            print("Extracted token ids:", token_ids)  # Matches prompt token ids
+            print(
+                "Extracted hidden states shape:", hidden_states.shape
+            )  # [num_hidden_layers, prompt len, hidden size]
+            print("Extracted hidden states:", hidden_states)

--- a/examples/offline_inference/extract_hidden_states.py
+++ b/examples/offline_inference/extract_hidden_states.py
@@ -1,0 +1,42 @@
+from vllm import LLM, SamplingParams
+
+# Example: Using the custom "extract_hidden_states" speculator method
+# This method uses the ExampleHiddenStatesConnector to extract and save hidden states
+
+llm = LLM(
+    model="Qwen/Qwen3-8B",  # Your target model
+    speculative_config={
+        "method": "extract_hidden_states",
+        "num_speculative_tokens": 1,
+        "draft_model_config": {
+            "hf_config": {
+                "eagle_aux_hidden_state_layer_ids": [  # Target model layer indices
+                    1,
+                    2,
+                    3,
+                    4,
+                ],
+            }
+        },
+    },
+    enforce_eager=True,
+    kv_transfer_config={
+        "kv_connector": "ExampleHiddenStatesConnector",
+        "kv_role": "kv_producer",
+        "kv_connector_extra_config": {
+            "shared_storage_path": "/tmp/hidden_states",
+        },
+    },
+)
+
+prompts = ["Generate a sentence with hidden states"]
+sampling_params = SamplingParams(max_tokens=1)
+outputs = llm.generate(prompts, sampling_params)
+
+for output in outputs:
+    print("\nPrompt:", output.prompt)
+    print("Prompt token ids:", output.prompt_token_ids)
+    print(
+        "Prompt hidden states path:",
+        output.kv_transfer_params.get("hidden_states_path"),
+    )

--- a/examples/offline_inference/extract_hidden_states.py
+++ b/examples/offline_inference/extract_hidden_states.py
@@ -1,3 +1,5 @@
+from safetensors import safe_open
+
 from vllm import LLM, SamplingParams
 
 # Example: Using the custom "extract_hidden_states" speculator method
@@ -36,7 +38,17 @@ outputs = llm.generate(prompts, sampling_params)
 for output in outputs:
     print("\nPrompt:", output.prompt)
     print("Prompt token ids:", output.prompt_token_ids)
-    print(
-        "Prompt hidden states path:",
-        output.kv_transfer_params.get("hidden_states_path"),
-    )
+
+    hidden_states_path = output.kv_transfer_params.get("hidden_states_path")
+    assert hidden_states_path is not None
+    print("Prompt hidden states path:", hidden_states_path)
+
+    with safe_open(hidden_states_path, "pt") as f:
+        token_ids = f.get_tensor("token_ids")
+        hidden_states = f.get_tensor("hidden_states")
+
+        print("Extracted token ids:", token_ids)  # Matches prompt token ids
+        print(
+            "Extracted hidden states shape:", hidden_states.shape
+        )  # [num_hidden_layers, prompt len, hidden size]
+        print("Extracted hidden states:", hidden_states)

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -108,7 +108,7 @@ class _HfExamplesInfo:
 
     use_original_num_layers: bool = False
     """
-    If True, use the original number of layers from the model config 
+    If True, use the original number of layers from the model config
     instead of minimal layers for testing.
     """
 
@@ -1159,6 +1159,10 @@ _SPECULATIVE_DECODING_EXAMPLE_MODELS = {
         "LGAI-EXAONE/K-EXAONE-236B-A23B",
         speculative_model="LGAI-EXAONE/K-EXAONE-236B-A23B",
         min_transformers_version="5.1.0",
+    ),
+    "ExtractHiddenStatesModel": _HfExamplesInfo(
+        "Qwen/Qwen3-8B",
+        speculative_method="extract_hidden_states",
     ),
     "Glm4MoeMTPModel": _HfExamplesInfo(
         "zai-org/GLM-4.5",

--- a/tests/v1/kv_connector/extract_hidden_states_integration/predictable_llama.py
+++ b/tests/v1/kv_connector/extract_hidden_states_integration/predictable_llama.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Predictable dummy model for testing extract_hidden_states.
+
+Subclasses LlamaForCausalLM but overrides the model to produce deterministic
+hidden states: layer i outputs values equal to (i).
+"""
+
+from collections.abc import Iterable
+
+import torch
+import torch.nn as nn
+
+from vllm.config import VllmConfig
+from vllm.model_executor.models.llama import LlamaForCausalLM
+from vllm.sequence import IntermediateTensors
+
+
+class PredictableLlamaModel(nn.Module):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        self.config = vllm_config.model_config.hf_config
+        self.aux_hidden_state_layers = tuple[int, ...]()
+
+        # Create minimal embed_tokens for embedding
+        from vllm.model_executor.layers.vocab_parallel_embedding import (
+            VocabParallelEmbedding,
+        )
+
+        self.embed_tokens = VocabParallelEmbedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+        )
+
+        # Required for pipeline parallelism
+        from vllm.model_executor.models.utils import (
+            make_empty_intermediate_tensors_factory,
+        )
+
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], self.config.hidden_size
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """Embed input IDs."""
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None,
+        inputs_embeds: torch.Tensor | None = None,
+        **extra_layer_kwargs,
+    ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
+        """Forward pass that produces predictable outputs.
+
+        Returns:
+            If aux_hidden_state_layers is set: (hidden_states, aux_hidden_states)
+            Otherwise: hidden_states
+        """
+        # Determine sequence length
+        if inputs_embeds is not None:
+            seq_len = inputs_embeds.shape[0]
+            device = inputs_embeds.device
+        elif input_ids is not None:
+            seq_len = input_ids.shape[0] if input_ids.ndim == 1 else input_ids.shape[-1]
+            device = input_ids.device
+        else:
+            raise ValueError("Either input_ids or inputs_embeds must be provided")
+
+        # Final hidden states (last layer value)
+        hidden_states = torch.full(
+            (seq_len, self.config.hidden_size),
+            fill_value=float(self.config.num_hidden_layers),
+            device=device,
+            dtype=torch.bfloat16,
+        )
+
+        # Check if we need auxiliary hidden states
+        if len(self.aux_hidden_state_layers) > 0:
+            aux_hidden_states = []
+            for layer_idx in self.aux_hidden_state_layers:
+                # Fill with (layer_idx) for predictability
+                layer_hidden = torch.full(
+                    (seq_len, self.config.hidden_size),
+                    fill_value=float(layer_idx),
+                    device=device,
+                    dtype=torch.bfloat16,
+                )
+                aux_hidden_states.append(layer_hidden)
+
+            return hidden_states, aux_hidden_states
+
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Skip weight loading."""
+        return set()
+
+
+class PredictableLlamaForCausalLM(LlamaForCausalLM):
+    """Predictable Llama model for testing.
+
+    Overrides _init_model to use PredictableLlamaModel instead of LlamaModel.
+    """
+
+    def _init_model(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        layer_type: type[nn.Module] | None = None,
+    ):
+        """Initialize with predictable model."""
+        return PredictableLlamaModel(vllm_config=vllm_config, prefix=prefix)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Skip weight loading for dummy model."""
+        return set()

--- a/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
+++ b/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import gc
+import os
+
+import pytest
+import torch
+from safetensors import safe_open
+
+from tests.utils import large_gpu_mark
+from vllm import LLM, ModelRegistry, SamplingParams
+
+
+def get_and_check_output(output, expected_shape):
+    assert output.kv_transfer_params is not None
+    hidden_states_path = output.kv_transfer_params.get("hidden_states_path")
+    assert hidden_states_path is not None
+    assert os.path.exists(hidden_states_path)
+
+    # Load and verify the saved tensors
+    with safe_open(hidden_states_path, "pt") as f:
+        # Check that token_ids and hidden_states are present
+        tensor_names = f.keys()
+        assert "token_ids" in tensor_names
+        assert "hidden_states" in tensor_names
+
+        token_ids = f.get_tensor("token_ids")
+        hidden_states = f.get_tensor("hidden_states")
+
+        prompt_token_ids = output.prompt_token_ids
+        assert torch.equal(token_ids, torch.tensor(prompt_token_ids))
+
+        assert hidden_states.shape == expected_shape
+
+        # Verify hidden_states are not all zeros (i.e., they were actually computed)
+        assert not torch.allclose(hidden_states, torch.zeros_like(hidden_states))
+
+    return token_ids, hidden_states
+
+
+@pytest.fixture(scope="module")
+def predictable_llama_config_path(tmp_path_factory):
+    """Create a minimal LlamaConfig for PredictableLlamaForCausalLM."""
+    from transformers import LlamaConfig, LlamaTokenizerFast
+
+    config_dir = tmp_path_factory.mktemp("predictable_llama")
+
+    # Create a minimal Llama config with small dimensions
+    config = LlamaConfig(
+        vocab_size=1000,
+        hidden_size=256,
+        intermediate_size=512,
+        num_hidden_layers=24,  # Enough layers to test various layer_ids
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=128,
+        architectures=["PredictableLlamaForCausalLM"],
+    )
+
+    # Save config
+    config.save_pretrained(config_dir)
+
+    # Create a simple tokenizer
+    tokenizer = LlamaTokenizerFast.from_pretrained(
+        "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+        cache_dir=os.path.expanduser("~/.cache/huggingface"),
+    )
+    tokenizer.save_pretrained(config_dir)
+
+    return str(config_dir)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def register_predictable_model():
+    """Register the PredictableLlamaForCausalLM model."""
+    from .predictable_llama import PredictableLlamaForCausalLM
+
+    if "PredictableLlamaForCausalLM" not in ModelRegistry.get_supported_archs():
+        ModelRegistry.register_model(
+            "PredictableLlamaForCausalLM", PredictableLlamaForCausalLM
+        )
+    yield
+
+
+@large_gpu_mark(min_gb=16)
+def test_extract_hidden_states_with_predictable_dummy_model(
+    predictable_llama_config_path, tmp_path
+):
+    """Comprehensive test using a predictable dummy model with synthetic weights.
+
+    The PredictableLlamaForCausalLM outputs deterministic hidden states where
+    each layer produces values equal to (layer_index). This test verifies:
+    1. Hidden states are correctly extracted from requested layers
+    2. Values match the expected predictable pattern
+    3. Layer ordering is preserved correctly (non-sequential layer IDs)
+    4. Multiple prompts of different lengths produce consistent layer values
+    """
+    # Test with non-sequential layer ordering to verify correct association
+    layer_ids = [5, 2, 10]
+    num_layers = len(layer_ids)
+
+    llm = LLM(
+        model=predictable_llama_config_path,
+        speculative_config={
+            "method": "extract_hidden_states",
+            "num_speculative_tokens": 1,
+            "draft_model_config": {
+                "hf_config": {"eagle_aux_hidden_state_layer_ids": layer_ids}
+            },
+        },
+        kv_transfer_config={
+            "kv_connector": "ExampleHiddenStatesConnector",
+            "kv_role": "kv_producer",
+            "kv_connector_extra_config": {"shared_storage_path": tmp_path},
+        },
+        max_model_len=128,
+        enforce_eager=True,
+        trust_remote_code=True,
+        load_format="dummy",  # Don't try to load real weights
+    )
+
+    # Test with multiple prompts of different lengths
+    prompts = [
+        "Short",
+        "Medium length",
+        "Much longer prompt with many tokens",
+        "Much longer prompt with many tokens",  # repeated prompt
+    ]
+    sampling_params = SamplingParams(max_tokens=1, temperature=0.0)
+    hidden_size = llm.llm_engine.model_config.get_hidden_size()
+    outputs = llm.generate(prompts, sampling_params)
+    del llm
+    gc.collect()
+
+    assert len(outputs) == len(prompts)
+
+    for output in outputs:
+        # hidden_states shape is [prompt_len, num_hidden_layers, hidden_size]
+        expected_shape = (
+            len(output.prompt_token_ids),
+            num_layers,
+            hidden_size,
+        )
+        _token_ids, hidden_states = get_and_check_output(output, expected_shape)
+
+        for idx, layer_id in enumerate(layer_ids):
+            layer_hidden = hidden_states[:, idx, :]
+            assert torch.allclose(
+                layer_hidden,
+                torch.full_like(layer_hidden, layer_id),
+                atol=1e-5,
+            ), (
+                f"Layer {layer_id} at position {idx} should output {float(layer_id)}, "
+                f"but got mean={layer_hidden.mean():.3f}, "
+                f"min={layer_hidden.min():.3f}, max={layer_hidden.max():.3f}"
+            )

--- a/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
+++ b/tests/v1/kv_connector/extract_hidden_states_integration/test_extraction.py
@@ -8,7 +8,6 @@ import pytest
 import torch
 from safetensors import safe_open
 
-from tests.utils import large_gpu_mark
 from vllm import LLM, ModelRegistry, SamplingParams
 
 
@@ -83,7 +82,6 @@ def register_predictable_model():
     yield
 
 
-@large_gpu_mark(min_gb=16)
 def test_extract_hidden_states_with_predictable_dummy_model(
     predictable_llama_config_path, tmp_path
 ):

--- a/tests/v1/spec_decode/test_extract_hidden_states.py
+++ b/tests/v1/spec_decode/test_extract_hidden_states.py
@@ -1,0 +1,346 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest import mock
+
+import pytest
+import torch
+
+from tests.v1.attention.utils import (
+    BatchSpec,
+    create_common_attn_metadata,
+)
+from vllm.config import (
+    AttentionConfig,
+    CacheConfig,
+    DeviceConfig,
+    ModelConfig,
+    ParallelConfig,
+    SchedulerConfig,
+    SpeculativeConfig,
+    VllmConfig,
+)
+from vllm.config.load import LoadConfig
+from vllm.platforms import current_platform
+from vllm.v1.spec_decode.extract_hidden_states import ExtractHiddenStatesProposer
+from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
+
+model_dir = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+
+
+def _create_proposer(
+    num_speculative_tokens: int = 1,
+    layer_ids: list[int] | None = None,
+) -> ExtractHiddenStatesProposer:
+    """Create an ExtractHiddenStatesProposer for testing."""
+    if layer_ids is None:
+        layer_ids = [1, 2, 3, 4]
+
+    model_config = ModelConfig(model=model_dir, runner="generate", max_model_len=100)
+
+    speculative_config = SpeculativeConfig(
+        target_model_config=model_config,
+        target_parallel_config=ParallelConfig(),
+        method="extract_hidden_states",
+        num_speculative_tokens=num_speculative_tokens,
+        draft_model_config={
+            "hf_config": {
+                "eagle_aux_hidden_state_layer_ids": layer_ids,
+            }
+        },
+    )
+
+    device = current_platform.device_type
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        cache_config=CacheConfig(),
+        speculative_config=speculative_config,
+        device_config=DeviceConfig(device=device),
+        parallel_config=ParallelConfig(),
+        load_config=LoadConfig(),
+        scheduler_config=SchedulerConfig(
+            max_model_len=model_config.max_model_len,
+            is_encoder_decoder=model_config.is_encoder_decoder,
+        ),
+        attention_config=AttentionConfig(),
+    )
+
+    return ExtractHiddenStatesProposer(vllm_config=vllm_config, device=device)
+
+
+def test_proposer_initialization():
+    """Test that the proposer initializes correctly with the right parameters."""
+    layer_ids = [1, 2, 3, 4]
+    proposer = _create_proposer(num_speculative_tokens=1, layer_ids=layer_ids)
+
+    assert proposer.num_hidden_states == len(layer_ids)
+    assert proposer.vllm_config.speculative_config is not None
+    assert proposer.vllm_config.speculative_config.num_speculative_tokens == 1
+
+    # Verify the hidden states buffer is correctly shaped
+    expected_shape = (
+        proposer.max_num_tokens,
+        len(layer_ids),
+        proposer.hidden_size,
+    )
+    assert proposer.hidden_states.shape == expected_shape
+
+
+def test_proposer_initialization_missing_layer_ids():
+    """Test that initialization fails when layer_ids are not provided."""
+    model_config = ModelConfig(model=model_dir, runner="generate", max_model_len=100)
+
+    speculative_config = SpeculativeConfig(
+        target_model_config=model_config,
+        target_parallel_config=ParallelConfig(),
+        method="extract_hidden_states",
+        num_speculative_tokens=1,
+        draft_model_config={
+            "hf_config": {}  # Missing eagle_aux_hidden_state_layer_ids
+        },
+    )
+
+    device = current_platform.device_type
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        cache_config=CacheConfig(),
+        speculative_config=speculative_config,
+        device_config=DeviceConfig(device=device),
+        parallel_config=ParallelConfig(),
+        load_config=LoadConfig(),
+        scheduler_config=SchedulerConfig(
+            max_model_len=model_config.max_model_len,
+            is_encoder_decoder=model_config.is_encoder_decoder,
+        ),
+        attention_config=AttentionConfig(),
+    )
+
+    with pytest.raises(
+        ValueError, match="eagle_aux_hidden_state_layer_ids must be set"
+    ):
+        ExtractHiddenStatesProposer(vllm_config=vllm_config, device=device)
+
+
+def test_prepare_next_token_ids_padded():
+    """
+    Test for prepare_next_token_ids_padded with extract_hidden_states.
+
+    Since num_speculative_tokens == 1, sampled_token_ids has shape (batch_size, 1).
+    For each request we either use the sampled token (if valid and not discarded)
+    or a backup token from the request state.
+    """
+    device = torch.device(current_platform.device_type)
+
+    num_requests = 4
+    batch_spec = BatchSpec(
+        seq_lens=[5] * num_requests,
+        query_lens=[5] * num_requests,
+    )
+
+    req_ids = [f"req_{i + 1}" for i in range(num_requests)]
+    mock_input_batch = mock.MagicMock(spec=InputBatch)
+    mock_input_batch.req_ids = req_ids
+    mock_input_batch.num_reqs = num_requests
+    mock_input_batch.vocab_size = 100
+
+    mock_requests = {}
+    for req_id in req_ids:
+        mock_request = mock.MagicMock(spec=CachedRequestState)
+        # Each request will have a backup next token id of 10, 20, 30, 40
+        mock_request.get_token_id.return_value = int(req_id.split("_")[1]) * 10
+        mock_requests[req_id] = mock_request
+
+    # explicitly discard the last request
+    discarded_req_mask = torch.tensor(
+        [False, False, False, True], dtype=torch.bool, device=device
+    )
+
+    # With num_speculative_tokens=1, sampled_token_ids has shape [batch_size, 1]
+    sampled_token_ids = torch.tensor(
+        [
+            [1],  # valid, use 1
+            [4],  # valid, use 4
+            [-1],  # invalid, use backup token "30"
+            [2],  # explicitly discarded, use backup token "40"
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+
+    expected_next_token_ids_cpu = [1, 4, 30, 40]
+    expected_next_token_ids_tensor = torch.tensor(
+        expected_next_token_ids_cpu, dtype=torch.int32, device=device
+    )
+
+    proposer = _create_proposer(num_speculative_tokens=1)
+
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec,
+        block_size=16,
+        device=device,
+    )
+
+    # valid_sampled_tokens_count tracks if token is valid (not -1 and in vocab range)
+    # It doesn't depend on whether the request is discarded
+    expected_valid_sampled_tokens_count = torch.tensor(
+        [1, 1, 0, 1], dtype=torch.int32, device=device
+    )
+
+    next_token_ids, valid_sampled_tokens_count = proposer.prepare_next_token_ids_padded(
+        common_attn_metadata,
+        sampled_token_ids,
+        mock_requests,
+        mock_input_batch,
+        discarded_req_mask,
+    )
+
+    assert torch.equal(next_token_ids, expected_next_token_ids_tensor)
+    assert torch.equal(valid_sampled_tokens_count, expected_valid_sampled_tokens_count)
+
+
+def test_propose():
+    """
+    Test the propose() method of ExtractHiddenStatesProposer.
+
+    This should:
+    1. Accept target hidden states and sampled token IDs
+    2. Return the sampled tokens as "draft" tokens (shape [batch_size, 1])
+    3. Cache the hidden states in the model's KV cache
+    """
+    device = torch.device(current_platform.device_type)
+
+    # Setup test parameters
+    batch_size = 2
+    num_tokens = 5
+    num_hidden_layers = 4
+
+    proposer = _create_proposer(
+        num_speculative_tokens=1, layer_ids=list(range(num_hidden_layers))
+    )
+    hidden_size = proposer.hidden_size
+
+    # Create mock model
+    model_mock = mock.MagicMock()
+    proposer.model = model_mock
+
+    # Mock attention layer names
+    proposer.attn_layer_names = ["cache_only_layers.28"]
+
+    # Mock attention metadata builder
+    mock_attn_metadata = mock.MagicMock()
+    mock_attn_metadata_builder = mock.MagicMock()
+    mock_attn_metadata_builder.build_for_drafting.return_value = mock_attn_metadata
+    proposer.attn_metadata_builder = mock_attn_metadata_builder
+
+    # Create input tensors
+    batch_spec = BatchSpec(
+        seq_lens=[3, 2],
+        query_lens=[3, 2],
+    )
+
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec,
+        block_size=16,
+        device=device,
+    )
+
+    # Create target hidden states: list of tensors, one per layer
+    # Each tensor has shape [num_tokens, hidden_size]
+    target_hidden_states = [
+        torch.randn(num_tokens, hidden_size, dtype=proposer.dtype, device=device)
+        for _ in range(num_hidden_layers)
+    ]
+
+    # Sampled token IDs from target model
+    sampled_token_ids = torch.tensor([42, 60], dtype=torch.int32, device=device)
+
+    # Mock scheduler output
+    mock_scheduler_output = mock.MagicMock()
+
+    # Call propose
+    with mock.patch(
+        "vllm.v1.spec_decode.extract_hidden_states.has_kv_transfer_group"
+    ) as mock_has_kv:
+        mock_has_kv.return_value = False
+
+        draft_tokens, kv_connector_output = proposer.propose(
+            sampled_token_ids=sampled_token_ids,
+            target_hidden_states=target_hidden_states,
+            common_attn_metadata=common_attn_metadata,
+            scheduler_output=mock_scheduler_output,
+            slot_mappings=None,
+        )
+
+    # Verify draft tokens match sampled tokens
+    # Shape should be [batch_size, 1] for num_speculative_tokens=1
+    assert draft_tokens.shape == (batch_size, 1)
+    assert torch.equal(draft_tokens[:, 0], sampled_token_ids)
+
+    # Verify the model was called
+    model_mock.assert_called_once()
+
+    # Verify hidden states were copied to the buffer The stacked hidden states
+    # should have shape [num_tokens, num_hidden_layers, hidden_size]
+    expected_stacked = torch.stack(target_hidden_states, dim=1)
+    assert torch.allclose(
+        proposer.hidden_states[:num_tokens], expected_stacked, atol=1e-6
+    )
+
+
+@pytest.mark.parametrize("num_hidden_layers", [1, 4, 8])
+def test_propose_different_layer_counts(num_hidden_layers):
+    """Test that propose works correctly with different numbers of hidden layers."""
+    device = torch.device(current_platform.device_type)
+
+    batch_size = 2
+    num_tokens = 5
+
+    proposer = _create_proposer(
+        num_speculative_tokens=1, layer_ids=list(range(num_hidden_layers))
+    )
+    hidden_size = proposer.hidden_size
+
+    # Setup mocks
+    model_mock = mock.MagicMock()
+    proposer.model = model_mock
+    proposer.attn_layer_names = ["cache_only_layers.28"]
+
+    mock_attn_metadata_builder = mock.MagicMock()
+    mock_attn_metadata_builder.build_for_drafting.return_value = mock.MagicMock()
+    proposer.attn_metadata_builder = mock_attn_metadata_builder
+
+    batch_spec = BatchSpec(
+        seq_lens=[3, 2],
+        query_lens=[3, 2],
+    )
+
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec,
+        block_size=16,
+        device=device,
+    )
+
+    # Create target hidden states
+    target_hidden_states = [
+        torch.randn(num_tokens, hidden_size, dtype=proposer.dtype, device=device)
+        for _ in range(num_hidden_layers)
+    ]
+
+    sampled_token_ids = torch.tensor([42, 60], dtype=torch.int32, device=device)
+    mock_scheduler_output = mock.MagicMock()
+
+    with mock.patch(
+        "vllm.v1.spec_decode.extract_hidden_states.has_kv_transfer_group"
+    ) as mock_has_kv:
+        mock_has_kv.return_value = False
+
+        draft_tokens, _ = proposer.propose(
+            sampled_token_ids=sampled_token_ids,
+            target_hidden_states=target_hidden_states,
+            common_attn_metadata=common_attn_metadata,
+            scheduler_output=mock_scheduler_output,
+            slot_mappings=None,
+        )
+
+    assert draft_tokens.shape == (batch_size, 1)
+    assert torch.equal(draft_tokens[:, 0], sampled_token_ids)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -794,8 +794,8 @@ class SpeculativeConfig:
             )
         ):
             raise ValueError(
-                f"{self.method} is only supported for {aux_hidden_states_supported} models. "
-                f"Got {self.target_model_config.hf_text_config.model_type=}"
+                f"{self.method} is only supported for {aux_hidden_states_supported}"
+                f" models. Got {self.target_model_config.hf_text_config.model_type=}"
             )
         self.verify_equal_vocab_size_if_draft_model()
         return self

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -435,20 +435,7 @@ class SpeculativeConfig:
             self.draft_model_config.hf_config = ExtractHiddenStatesConfig(
                 self.draft_model_config.hf_config, **hf_config
             )
-            # ExtractHiddenStatesConfig updates architectures, so update
-            # all architectures-related fields in draft_model_config
-            self.draft_model_config.hf_text_config = get_hf_text_config(
-                self.draft_model_config.hf_config
-            )
-            self.draft_model_config.model_arch_config = (
-                self.draft_model_config.get_model_arch_config()
-            )
-            model_info, arch = self.draft_model_config.registry.inspect_model_cls(
-                self.draft_model_config.architectures,
-                self.draft_model_config,
-            )
-            self.draft_model_config._model_info = model_info
-            self.draft_model_config._architecture = arch
+            self.update_arch_()
             self.draft_parallel_config = self.target_parallel_config
 
         else:
@@ -535,23 +522,8 @@ class SpeculativeConfig:
                             method=self.method,
                             model_type="eagle",
                         )
-                        # EAGLEConfig primarily updates architectures, so update
-                        # all architectures-related fields in draft_model_config
                         self.draft_model_config.hf_config = eagle_config
-                        self.draft_model_config.hf_text_config = get_hf_text_config(
-                            self.draft_model_config.hf_config
-                        )
-                        self.draft_model_config.model_arch_config = (
-                            self.draft_model_config.get_model_arch_config()
-                        )
-                        model_info, arch = (
-                            self.draft_model_config.registry.inspect_model_cls(
-                                self.draft_model_config.architectures,
-                                self.draft_model_config,
-                            )
-                        )
-                        self.draft_model_config._model_info = model_info
-                        self.draft_model_config._architecture = arch
+                        self.update_arch_()
 
                 if self.num_speculative_tokens is not None and hasattr(
                     self.draft_model_config.hf_config, "num_lookahead_tokens"
@@ -727,6 +699,24 @@ class SpeculativeConfig:
                 f"other value than 1 or target model tensor_parallel_size"
             )
         return speculative_draft_tensor_parallel_size
+
+    def update_arch_(self):
+        """
+        EagleConfig and ExtractHiddenStatesConfig update architectures, so update all
+        architectures-related fields in self.draft_model_config
+        """
+        self.draft_model_config.hf_text_config = get_hf_text_config(
+            self.draft_model_config.hf_config
+        )
+        self.draft_model_config.model_arch_config = (
+            self.draft_model_config.get_model_arch_config()
+        )
+        model_info, arch = self.draft_model_config.registry.inspect_model_cls(
+            self.draft_model_config.architectures,
+            self.draft_model_config,
+        )
+        self.draft_model_config._model_info = model_info
+        self.draft_model_config._architecture = arch
 
     @staticmethod
     def create_draft_parallel_config(

--- a/vllm/distributed/kv_events.py
+++ b/vllm/distributed/kv_events.py
@@ -209,6 +209,10 @@ class KVConnectorKVEvents(ABC):
     def clear_events(self) -> None:
         raise NotImplementedError
 
+    def merge(self, other: "KVConnectorKVEvents") -> "KVConnectorKVEvents":
+        self.add_events(other.get_all_events())
+        return self
+
 
 class EventPublisher(ABC):
     """Lightweight publisher for EventBatch batches with data parallelism

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -150,6 +150,12 @@ KVConnectorFactory.register_connector(
 )
 
 KVConnectorFactory.register_connector(
+    "ExampleHiddenStatesConnector",
+    "vllm.distributed.kv_transfer.kv_connector.v1.example_hidden_states_connector",
+    "ExampleHiddenStatesConnector",
+)
+
+KVConnectorFactory.register_connector(
     "P2pNcclConnector",
     "vllm.distributed.kv_transfer.kv_connector.v1.p2p.p2p_nccl_connector",
     "P2pNcclConnector",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Optional
+
+import safetensors
+import torch
+
+from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadata
+from vllm.model_executor.models.extract_hidden_states import CacheOnlyAttentionLayer
+from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.sched.output import SchedulerOutput
+
+if TYPE_CHECKING:
+    from vllm.forward_context import ForwardContext
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+
+def reshape_hidden_states_for_kv_cache(
+    hidden_states: torch.Tensor, head_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # hidden_states shape: [batch_size, hidden_size * num_hidden_states]
+    # e.g. hidden_states = torch.cat([h_1, h_2, ..., h_n], dim=1)
+    # where h_i is a hidden state of shape [batch_size, hidden_size]
+
+    # Assuming num_hidden_states is a multiple of 2 for now
+
+    batch_size = hidden_states.shape[0]
+    split_size = hidden_states.shape[1] // 2
+    key, value = torch.split(hidden_states, [split_size, split_size], dim=1)
+    # key/value shape: [batch_size, hidden_size * num_hidden_states / 2]
+
+    key = key.view(batch_size, -1, head_size)
+    value = value.view(batch_size, -1, head_size)
+    return key, value
+
+
+def reshape_hidden_states_from_kv_cache(
+    kv: torch.Tensor, num_hidden_states: int
+) -> torch.Tensor:
+    # kv shape: [2, batch_size, hidden_size / head_size * num_hidden_states / 2, head_size]
+    kv = kv.flatten(2)
+    # kv shape: [2, batch_size, hidden_size * num_hidden_states / 2]
+
+    hidden_states = torch.cat([kv[0], kv[1]], dim=1)
+    # hidden_states shape: [batch_size, hidden_size * num_hidden_states]
+
+    split_size = hidden_states.shape[1] // num_hidden_states
+    hidden_states = hidden_states.split(split_size, dim=1)
+
+    return torch.stack(hidden_states, dim=0)
+
+
+@dataclass
+class ReqMeta:
+    # Request ID
+    req_id: str
+    # Request filename
+    filename: str
+    # Request tokens
+    token_ids: torch.Tensor
+    # Slot mappings, should have the same length as token_ids
+    slot_mapping: torch.Tensor
+
+    @staticmethod
+    def make_meta(
+        req_id: str,
+        filename: str,
+        token_ids: list[int],
+        block_ids: list[int],
+        block_size: int,
+    ) -> "ReqMeta":
+        token_ids_tensor = torch.tensor(token_ids)
+        block_ids_tensor = torch.tensor(block_ids)
+        num_blocks = block_ids_tensor.shape[0]
+        block_offsets = torch.arange(0, block_size)
+        slot_mapping = (
+            block_offsets.reshape((1, block_size))
+            + block_ids_tensor.reshape((num_blocks, 1)) * block_size
+        )
+        slot_mapping = slot_mapping.flatten()
+        return ReqMeta(
+            req_id=req_id,
+            filename=filename,
+            token_ids=token_ids_tensor,
+            slot_mapping=slot_mapping,
+        )
+
+
+@dataclass
+class ExampleHiddenStatesConnectorMetadata(KVConnectorMetadata):
+    requests: list[ReqMeta] = field(default_factory=list)
+
+    def add_request(
+        self,
+        req_id: str,
+        filename: str,
+        token_ids: list[int],
+        block_ids: list[int],
+        block_size: int,
+    ) -> None:
+        self.requests.append(
+            ReqMeta.make_meta(req_id, filename, token_ids, block_ids, block_size)
+        )
+
+
+class ExampleHiddenStatesConnector(KVConnectorBase_V1):
+    # NOTE: This is Simple debug implementation of the KV connector.
+    # It save / load the KV cache to / from the disk.
+    # It does extra work which will overwrite the existing prefix-cache in GPU
+    # - to remove the overhead, need to add some "mask" in the ReqMeta class
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        role: KVConnectorRole,
+        kv_cache_config: Optional["KVCacheConfig"] = None,
+    ):
+        super().__init__(
+            vllm_config=vllm_config,
+            role=role,
+            kv_cache_config=kv_cache_config,
+        )
+        self._block_size = vllm_config.cache_config.block_size
+        self._storage_path = self._kv_transfer_config.get_from_extra_config(
+            "shared_storage_path", "/tmp"
+        )
+        self.cache_layers = []
+        logger.info(self._kv_transfer_config)
+        logger.info("Shared storage path is %s", self._storage_path)
+
+        spec_config = self._vllm_config.speculative_config.draft_model_config.hf_config
+        self.num_hidden_states = len(
+            getattr(spec_config, "eagle_aux_hidden_state_layer_ids", [])
+        )
+
+        self._request_filenames: dict[str, str] = {}
+
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        # Filter layers to only include CacheOnlyAttentionLayers
+        layers = get_layers_from_vllm_config(
+            self._vllm_config, CacheOnlyAttentionLayer, kv_caches.keys()
+        )
+        self.cache_layers = list(layers.keys())
+        logger.info(f"Found {len(self.cache_layers)} CacheOnlyAttentionLayers")
+
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs: Any) -> None:
+        """Start loading the KV cache from the connector buffer to vLLM's
+        paged KV buffer.
+
+        Args:
+            forward_context (ForwardContext): the forward context.
+            **kwargs: additional arguments for the load operation
+
+        Note:
+            The number of elements in kv_caches and layer_names should be
+            the same.
+        """
+        pass
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        """Blocking until the KV for a specific layer is loaded into vLLM's
+        paged buffer.
+
+        This interface will be useful for layer-by-layer pipelining.
+
+        Args:
+            layer_name: the name of that layer
+        """
+        return
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        **kwargs: Any,
+    ) -> None:
+        """Start saving the KV cache of the layer from vLLM's paged buffer
+        to the connector.
+
+        Args:
+            layer_name (str): the name of the layer.
+            kv_layer (torch.Tensor): the paged KV buffer of the current
+                layer in vLLM.
+            attn_metadata (AttentionMetadata): the attention metadata.
+            **kwargs: additional arguments for the save operation.
+        """
+        if layer_name not in self.cache_layers:
+            return
+
+        def extract_kv_from_layer(
+            layer: torch.Tensor,
+            slot_mapping: torch.Tensor,
+            num_tokens: int,
+        ) -> torch.Tensor:
+            """Extract the KV cache from the layer.
+
+            Assume the shape of the layer is (2, num_pages, page_size, xxx)
+            if MLA is not used, and (num_pages, page_size, xxx) otherwise.
+            """
+            if isinstance(attn_metadata, MLACommonMetadata):
+                num_pages, page_size = layer.shape[0], layer.shape[1]
+                return layer.reshape(num_pages * page_size, -1)[slot_mapping, ...]
+            num_pages, page_size = layer.shape[1], layer.shape[2]
+            padded_kv = layer.reshape(2, num_pages * page_size, -1)[
+                :, slot_mapping, ...
+            ]
+            return padded_kv[:, :num_tokens, ...]
+
+        connector_metadata = self._get_connector_metadata()
+        assert isinstance(connector_metadata, ExampleHiddenStatesConnectorMetadata)
+        os.makedirs(self._storage_path, exist_ok=True)
+        for request in connector_metadata.requests:
+            kv_cache = extract_kv_from_layer(
+                kv_layer, request.slot_mapping, request.token_ids.shape[0]
+            )
+            hidden_states = reshape_hidden_states_from_kv_cache(
+                kv_cache, self.num_hidden_states
+            )
+            tensors = {
+                "hidden_states": hidden_states.detach().cpu(),
+                "token_ids": request.token_ids.detach().cpu(),
+            }
+            safetensors.torch.save_file(tensors, request.filename)
+
+    def wait_for_save(self):
+        return
+
+    def get_num_new_matched_tokens(
+        self,
+        request: "Request",
+        num_computed_tokens: int,
+    ) -> tuple[int | None, bool]:
+        """
+        Get number of new tokens that can be loaded from the
+        external KV cache beyond the num_computed_tokens.
+
+        Args:
+            request (Request): the request object.
+            num_computed_tokens (int): the number of locally
+                computed tokens for this request
+
+        Returns:
+            the number of tokens that can be loaded from the
+            external KV cache beyond what is already computed.
+        """
+        # This connector is store-only, so we don't need to load any tokens
+        return 0, False
+
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ):
+        """
+        Update KVConnector state after block allocation.
+
+        If blocks were allocated, add to _requests_need_load,
+        such that we load the KVs in the next forward pass.
+        """
+        pass
+
+    def build_connector_meta(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> KVConnectorMetadata:
+        """Build the connector metadata for this step.
+
+        This function should NOT modify any fields in the scheduler_output.
+        Also, calling this function will reset the state of the connector.
+
+        Args:
+            scheduler_output (SchedulerOutput): the scheduler output object.
+        """
+        meta = ExampleHiddenStatesConnectorMetadata()
+
+        for new_req in scheduler_output.scheduled_new_reqs:
+            token_ids = new_req.prompt_token_ids or []
+            filename = os.path.join(self._storage_path, f"{new_req.req_id}.safetensors")
+            meta.add_request(
+                new_req.req_id,
+                filename=filename,
+                token_ids=token_ids,
+                block_ids=new_req.block_ids[0],
+                block_size=self._block_size,
+            )
+            self._request_filenames[new_req.req_id] = filename
+
+        return meta
+
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """
+        Called exactly once when a request has finished, before its blocks are
+        freed.
+
+        The connector may assumes responsibility for freeing the blocks
+        asynchronously by returning True.
+
+        Returns:
+            True if the request is being saved/sent asynchronously and blocks
+            should not be freed until the request_id is returned from
+            get_finished().
+            Optional KVTransferParams to be included in the request outputs
+            returned by the engine.
+        """
+        req_id = request.request_id
+        req_filename = self._request_filenames.pop(req_id, None)
+
+        return False, {"hidden_states_path": req_filename}

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -31,13 +31,14 @@ logger = init_logger(__name__)
 def reshape_hidden_states_from_kv_cache(
     kv: torch.Tensor, num_hidden_states: int
 ) -> torch.Tensor:
-    # kv shape: [2, batch_size, hidden_size / head_size * num_hidden_states / 2, head_size]
+    # kv shape: [2, batch_size, num_heads, head_size]
     kv = kv.flatten(2)
-    # kv shape: [2, batch_size, hidden_size * num_hidden_states / 2]
+    # kv shape: [2, batch_size, num_heads * head_size]
 
     hidden_states = torch.cat([kv[0], kv[1]], dim=1)
     # hidden_states shape: [batch_size, hidden_size * num_hidden_states]
 
+    assert hidden_states.shape[1] % num_hidden_states == 0
     split_size = hidden_states.shape[1] // num_hidden_states
     hidden_states = hidden_states.split(split_size, dim=1)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -28,25 +28,6 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-def reshape_hidden_states_for_kv_cache(
-    hidden_states: torch.Tensor, head_size: int
-) -> tuple[torch.Tensor, torch.Tensor]:
-    # hidden_states shape: [batch_size, hidden_size * num_hidden_states]
-    # e.g. hidden_states = torch.cat([h_1, h_2, ..., h_n], dim=1)
-    # where h_i is a hidden state of shape [batch_size, hidden_size]
-
-    # Assuming num_hidden_states is a multiple of 2 for now
-
-    batch_size = hidden_states.shape[0]
-    split_size = hidden_states.shape[1] // 2
-    key, value = torch.split(hidden_states, [split_size, split_size], dim=1)
-    # key/value shape: [batch_size, hidden_size * num_hidden_states / 2]
-
-    key = key.view(batch_size, -1, head_size)
-    value = value.view(batch_size, -1, head_size)
-    return key, value
-
-
 def reshape_hidden_states_from_kv_cache(
     kv: torch.Tensor, num_hidden_states: int
 ) -> torch.Tensor:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -124,7 +124,7 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
         self._storage_path = self._kv_transfer_config.get_from_extra_config(
             "shared_storage_path", "/tmp"
         )
-        self.cache_layers = []  # set by self.register_kv_caches
+        self.cache_layers: list[str] = []  # set by self.register_kv_caches
         logger.info(self._kv_transfer_config)
         logger.info("Shared storage path is %s", self._storage_path)
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -128,6 +128,10 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
         logger.info(self._kv_transfer_config)
         logger.info("Shared storage path is %s", self._storage_path)
 
+        assert self._vllm_config.speculative_config is not None, (
+            "ExampleHiddenStatesConnector only works when using "
+            "'extract_hidden_states' speculative method"
+        )
         spec_config = self._vllm_config.speculative_config.draft_model_config.hf_config
         self.num_hidden_states = len(
             getattr(spec_config, "eagle_aux_hidden_state_layer_ids", [])

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py
@@ -138,6 +138,15 @@ class ExampleHiddenStatesConnector(KVConnectorBase_V1):
     # ==============================
     # Worker-side methods
     # ==============================
+    def start_load_kv(self, *args, **kwargs: Any) -> None:
+        pass  # Empty implementation of abstract method
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        pass  # Empty implementation of abstract method
+
+    def wait_for_save(self):
+        pass  # Empty implementation of abstract method
+
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         from vllm.model_executor.models.extract_hidden_states import (
             CacheOnlyAttentionLayer,

--- a/vllm/model_executor/models/extract_hidden_states.py
+++ b/vllm/model_executor/models/extract_hidden_states.py
@@ -8,6 +8,7 @@ without performing actual token generation. It's used with the
 extract_hidden_states speculative decoding method.
 """
 
+from collections.abc import Iterable
 from typing import ClassVar
 
 import torch
@@ -91,7 +92,6 @@ def basic_cache(
 ######### CacheOnlyAttentionBackend ########
 
 
-@register_backend(AttentionBackendEnum.CUSTOM)
 class CacheOnlyAttentionBackend(AttentionBackend):
     """Attention backend that only caches KV without computing attention."""
 
@@ -109,7 +109,7 @@ class CacheOnlyAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_name() -> str:
-        return "CUSTOM"
+        return "CACHE_ONLY_ATTN"
 
     @classmethod
     def supports_attn_type(cls, attn_type: str) -> bool:
@@ -390,6 +390,6 @@ class ExtractHiddenStatesModel(nn.Module):
         # Output is ignored - we only care about the KV cache side effects
         _ = self.cache_only_layers[str(self.target_num_hidden_layers)](hidden_states)
 
-    def load_weights(self, weights):
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         """No weights to load for this dummy model."""
-        return None
+        return set()

--- a/vllm/model_executor/models/extract_hidden_states.py
+++ b/vllm/model_executor/models/extract_hidden_states.py
@@ -300,11 +300,12 @@ class CacheOnlyAttentionLayer(nn.Module, AttentionLayerBase):
             raise ValueError(f"Duplicate layer name: {prefix}")
         compilation_config.static_forward_context[prefix] = self
 
-    def forward(self, to_cache: torch.Tensor):
+    def forward(self, to_cache: torch.Tensor) -> torch.Tensor:
         """Cache hidden states as KV pairs without computing attention.
 
         Args:
-            hidden_states: shape [num_tokens, num_heads, head_size]
+            to_cache: The tensor to insert into the kv cache.
+                shape [num_tokens, num_heads, head_size]
 
         Returns:
             Dummy output tensor (not used)

--- a/vllm/model_executor/models/extract_hidden_states.py
+++ b/vllm/model_executor/models/extract_hidden_states.py
@@ -1,0 +1,544 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Hidden States Extractor Model.
+
+This model extracts and caches hidden states from the target model
+without performing actual token generation. It's used with the
+extract_hidden_states speculative decoding method.
+"""
+
+from typing import ClassVar
+
+import torch
+import torch.nn as nn
+from triton import cdiv
+
+from vllm.config import CacheConfig, VllmConfig
+from vllm.config.cache import CacheDType
+from vllm.distributed.kv_transfer import (
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+    is_v1_kv_transfer_group,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.layers.attention.attention import (
+    get_attention_context,
+    set_default_quant_scales,
+)
+from vllm.model_executor.layers.attention.kv_transfer_utils import (
+    maybe_transfer_kv_layer,
+)
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.models.utils import maybe_prefix
+from vllm.utils.torch_utils import kv_cache_dtype_str_to_dtype
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionImpl,
+    AttentionMetadataBuilder,
+    AttentionType,
+    CommonAttentionMetadata,
+    is_quantized_kv_cache,
+)
+from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
+from vllm.v1.kv_cache_interface import AttentionSpec, FullAttentionSpec, KVCacheSpec
+
+logger = init_logger(__name__)
+
+
+def reshape_hidden_states_for_kv_cache(
+    hidden_states: torch.Tensor, head_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reshape hidden states into key and value tensors for KV cache.
+
+    Args:
+        hidden_states: shape [batch_size, hidden_size * num_hidden_states]
+            e.g. hidden_states = torch.cat([h_1, h_2, ..., h_n], dim=1)
+        head_size: Size of each attention head
+
+    Returns:
+        key, value: each of shape [batch_size, num_kv_heads, head_size]
+    """
+    batch_size = hidden_states.shape[0]
+    # Split into two equal parts for key and value
+    split_size = hidden_states.shape[1] // 2
+    key, value = torch.split(hidden_states, [split_size, split_size], dim=1)
+    # key/value shape: [batch_size, hidden_size * num_hidden_states / 2]
+
+    # Reshape to attention head format
+    key = key.view(batch_size, -1, head_size)
+    value = value.view(batch_size, -1, head_size)
+    return key, value
+
+
+@register_backend(AttentionBackendEnum.CUSTOM)
+class CacheOnlyAttentionBackend(AttentionBackend):
+    """Attention backend that only caches KV without computing attention."""
+
+    accept_output_buffer: bool = False
+    supported_dtypes: ClassVar[list[torch.dtype]] = [
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+    ]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["auto"]
+
+    @staticmethod
+    def get_name() -> str:
+        return "CUSTOM"
+
+    @classmethod
+    def supports_attn_type(cls, attn_type: str) -> bool:
+        return attn_type == AttentionType.DECODER
+
+    @classmethod
+    def supports_mm_prefix(cls) -> bool:
+        return True
+
+    @staticmethod
+    def get_impl_cls() -> type["CacheOnlyAttentionImpl"]:
+        return CacheOnlyAttentionImpl
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        return (2, num_blocks, block_size, num_kv_heads, head_size)
+
+    @staticmethod
+    def get_builder_cls() -> type["CacheOnlyAttentionMetadataBuilder"]:
+        return CacheOnlyAttentionMetadataBuilder
+
+    @staticmethod
+    def use_cascade_attention(*args, **kwargs) -> bool:
+        return False
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        return []
+
+
+class CacheOnlyAttentionMetadata:
+    """Metadata for cache-only attention operations."""
+
+    def __init__(
+        self,
+        causal: bool,
+        num_actual_tokens: int,
+        max_query_len: int,
+        query_start_loc: torch.Tensor,
+        max_seq_len: int,
+        seq_lens: torch.Tensor,
+        block_table: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        use_cascade: bool,
+        common_prefix_len: int,
+        cu_prefix_query_lens: torch.Tensor | None,
+        prefix_kv_lens: torch.Tensor | None,
+        suffix_kv_lens: torch.Tensor | None,
+        num_reqs: int,
+        num_input_tokens: int = 0,
+    ):
+        self.causal = causal
+        self.num_actual_tokens = num_actual_tokens
+        self.max_query_len = max_query_len
+        self.query_start_loc = query_start_loc
+        self.max_seq_len = max_seq_len
+        self.seq_lens = seq_lens
+        self.block_table = block_table
+        self.slot_mapping = slot_mapping
+        self.use_cascade = use_cascade
+        self.common_prefix_len = common_prefix_len
+        self.cu_prefix_query_lens = cu_prefix_query_lens
+        self.prefix_kv_lens = prefix_kv_lens
+        self.suffix_kv_lens = suffix_kv_lens
+        self.num_reqs = num_reqs
+        self.num_input_tokens = num_input_tokens
+
+        assert self.use_cascade is False, "Cascade not supported"
+        assert self.common_prefix_len == 0, "Common prefix not supported"
+
+
+class CacheOnlyAttentionMetadataBuilder(
+    AttentionMetadataBuilder[CacheOnlyAttentionMetadata]
+):
+    """Builder for cache-only attention metadata."""
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ):
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self.model_config = vllm_config.model_config
+        self.parallel_config = vllm_config.parallel_config
+        self.cache_config = vllm_config.cache_config
+        self.block_size = kv_cache_spec.block_size
+        self.kv_cache_spec = kv_cache_spec
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> CacheOnlyAttentionMetadata:
+        num_reqs = common_attn_metadata.num_reqs
+        num_actual_tokens = common_attn_metadata.num_actual_tokens
+        max_query_len = common_attn_metadata.max_query_len
+        max_seq_len = common_attn_metadata.max_seq_len
+        query_start_loc = common_attn_metadata.query_start_loc
+        seq_lens = common_attn_metadata.seq_lens
+        block_table_tensor = common_attn_metadata.block_table_tensor
+        slot_mapping = common_attn_metadata.slot_mapping
+
+        use_cascade = common_prefix_len > 0
+        if use_cascade:
+            raise NotImplementedError("Cascade attention not supported")
+
+        return CacheOnlyAttentionMetadata(
+            causal=common_attn_metadata.causal,
+            num_actual_tokens=num_actual_tokens,
+            max_query_len=max_query_len,
+            query_start_loc=query_start_loc,
+            max_seq_len=max_seq_len,
+            seq_lens=seq_lens,
+            block_table=block_table_tensor,
+            slot_mapping=slot_mapping,
+            use_cascade=use_cascade,
+            common_prefix_len=common_prefix_len,
+            cu_prefix_query_lens=None,
+            prefix_kv_lens=None,
+            suffix_kv_lens=None,
+            num_reqs=num_reqs,
+        )
+
+    def use_cascade_attention(self, *args, **kwargs) -> bool:
+        return False
+
+
+class CacheOnlyAttentionImpl(AttentionImpl):
+    """Attention implementation that only caches KV states."""
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: list[float] | None,
+        sliding_window: int | None,
+        kv_cache_dtype: str,
+        logits_soft_cap: float | None = None,
+        attn_type: AttentionType = AttentionType.DECODER,
+        kv_sharing_target_layer_name: str | None = None,
+        **kwargs,
+    ) -> None:
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.scale = float(scale)
+        self.num_kv_heads = num_kv_heads
+        self.attn_type = attn_type
+        self.sliding_window = sliding_window
+        self.kv_cache_dtype = kv_cache_dtype
+        self.logits_soft_cap = logits_soft_cap
+        self.alibi_slopes = None
+
+        if attn_type != AttentionType.DECODER:
+            raise NotImplementedError(f"Unsupported attention type: {attn_type}")
+        if alibi_slopes is not None:
+            raise NotImplementedError("ALiBi slopes not supported")
+        if logits_soft_cap is not None:
+            raise NotImplementedError("Logits soft cap not supported")
+        if kv_sharing_target_layer_name is not None:
+            raise NotImplementedError("KV sharing not supported")
+        if is_quantized_kv_cache(self.kv_cache_dtype):
+            raise NotImplementedError("Quantized KV cache not supported")
+
+        assert self.num_heads % self.num_kv_heads == 0
+        self.num_queries_per_kv = self.num_heads // self.num_kv_heads
+
+    def forward(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: CacheOnlyAttentionMetadata,
+        output: torch.Tensor | None = None,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Cache key/value states without computing attention.
+
+        Args:
+            layer: Attention layer module
+            query: Not used (can be None)
+            key: shape = [num_tokens, num_kv_heads, head_size]
+            value: shape = [num_tokens, num_kv_heads, head_size]
+            kv_cache: shape = [2, num_blocks, block_size, num_kv_heads, head_size]
+            attn_metadata: Metadata for caching
+            output: Output tensor (filled with zeros)
+
+        Returns:
+            output tensor filled with zeros
+        """
+        assert output is not None, "Output tensor required"
+        if output_scale is not None or output_block_scale is not None:
+            raise NotImplementedError("Fused output quantization not supported")
+
+        if attn_metadata is None:
+            # Profiling run
+            return output.fill_(0)
+
+        assert attn_metadata.causal, "Non-causal attention not supported"
+        assert self.attn_type == AttentionType.DECODER
+
+        # Cache the key/value states
+        key_cache, value_cache = kv_cache.unbind(0)
+        torch.ops._C_cache_ops.reshape_and_cache_flash(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            attn_metadata.slot_mapping,
+            self.kv_cache_dtype,
+            layer._k_scale,
+            layer._v_scale,
+        )
+
+        # Return dummy output (not used)
+        return output.fill_(0)
+
+
+class CacheOnlyAttentionLayer(nn.Module, AttentionLayerBase):
+    """Attention layer that only caches key/value states without computing attention."""
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        attn_type: str = AttentionType.DECODER,
+        num_hidden_states: int = 1,
+        **extra_impl_args,
+    ):
+        super().__init__()
+
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.quant_config = quant_config
+        self.layer_name = prefix
+
+        # Get vllm config
+        from vllm.config import get_current_vllm_config
+
+        vllm_config = get_current_vllm_config()
+
+        # KV cache configuration
+        cache_config = cache_config or vllm_config.cache_config
+        if cache_config is not None:
+            kv_cache_dtype = cache_config.cache_dtype
+            self.block_size = cache_config.block_size
+        else:
+            kv_cache_dtype = "auto"
+            self.block_size = 16
+
+        self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(
+            kv_cache_dtype, vllm_config.model_config
+        )
+
+        # Initialize KV cache quantization attributes
+        set_default_quant_scales(self, register_buffer=True)
+
+        # Default dtype
+        dtype = torch.get_default_dtype()
+        self.dtype = dtype
+
+        # Attention backend
+        self.attn_backend = CacheOnlyAttentionBackend
+        impl_cls = self.attn_backend.get_impl_cls()
+        self.impl = impl_cls(
+            num_heads,
+            head_size,
+            1.0,  # scale
+            num_heads,  # num kv heads
+            None,  # alibi_slopes
+            None,  # sliding_window
+            kv_cache_dtype,
+            None,  # logits_soft_cap
+            attn_type,
+            None,  # kv_sharing_target_layer_name
+            **extra_impl_args,
+        )
+
+        # Placeholder KV cache (replaced by bind_kv_cache)
+        self.kv_cache = [
+            torch.tensor([])
+            for _ in range(vllm_config.parallel_config.pipeline_parallel_size)
+        ]
+
+        # Register in compilation context
+        compilation_config = vllm_config.compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        output_shape: torch.Size | None = None,
+    ):
+        """Cache hidden states as KV pairs without computing attention.
+
+        Args:
+            hidden_states: shape [num_tokens, hidden_size * num_hidden_states]
+            output_shape: Optional output shape
+
+        Returns:
+            Dummy output tensor (not used)
+        """
+        output_dtype = hidden_states.dtype
+        if output_shape is None:
+            num_tokens = hidden_states.shape[0]
+            output_shape = torch.Size((num_tokens, self.num_heads * self.head_size))
+
+        output = torch.empty(
+            output_shape, dtype=output_dtype, device=hidden_states.device
+        )
+        output = output.view(-1, self.num_heads, self.head_size)
+
+        # Reshape hidden states into key/value format
+        key, value = reshape_hidden_states_for_kv_cache(hidden_states, self.head_size)
+
+        # Cache the KV states (with optional KV transfer)
+        cache_only_attention_with_kv_transfer(None, key, value, output, self.layer_name)
+
+        return output.view(-1, output_shape[-1])
+
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return self.attn_backend
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        return FullAttentionSpec(
+            block_size=self.block_size,
+            num_kv_heads=self.num_heads,
+            head_size=self.head_size,
+            dtype=self.kv_cache_torch_dtype,
+        )
+
+
+@maybe_transfer_kv_layer
+def cache_only_attention_with_kv_transfer(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+    output_scale: torch.Tensor | None = None,
+    output_block_scale: torch.Tensor | None = None,
+) -> None:
+    """Cache KV states with optional KV transfer support."""
+    attn_metadata, self, kv_cache = get_attention_context(layer_name)
+
+    self.impl.forward(
+        self,
+        query,
+        key,
+        value,
+        kv_cache,
+        attn_metadata,
+        output=output,
+        output_scale=output_scale,
+        output_block_scale=output_block_scale,
+    )
+
+
+class ExtractHiddenStatesModel(nn.Module):
+    """Model that extracts and caches hidden states without token generation.
+
+    This model is used with the extract_hidden_states speculative decoding method.
+    It processes hidden states from the target model and caches them via a
+    cache-only attention mechanism, optionally transferring them to external storage.
+    """
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.hidden_size = vllm_config.model_config.get_hidden_size()
+        self.target_num_hidden_layers = (
+            vllm_config.model_config.get_total_num_hidden_layers()
+        )
+        self.num_hidden_states = len(
+            getattr(self.config, "eagle_aux_hidden_state_layer_ids", [])
+        )
+
+        # Attention configuration from draft config
+        self.head_size = self.config.head_dim
+        cache_config = vllm_config.cache_config
+
+        assert self.hidden_size % self.head_size == 0
+
+        self.num_kv_heads = (
+            self.hidden_size // self.head_size
+        ) * self.num_hidden_states
+
+        # Create a single cache-only attention layer
+        # Note: We double the heads to match the combined hidden states format
+        self.cache_only_layers = nn.ModuleDict(
+            {
+                str(self.target_num_hidden_layers): CacheOnlyAttentionLayer(
+                    num_heads=self.num_kv_heads,
+                    head_size=self.head_size,
+                    cache_config=cache_config,
+                    prefix=maybe_prefix(
+                        prefix, f"cache_only_layers.{self.target_num_hidden_layers}"
+                    ),
+                )
+            }
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Process and cache hidden states.
+
+        Args:
+            input_ids: Input token IDs (not used)
+            positions: Token positions (not used)
+            hidden_states: Hidden states from target model
+                          shape: [num_tokens, hidden_size * num_hidden_states]
+            inputs_embeds: Input embeddings (not used)
+
+        Returns:
+            Tuple of (dummy_output, dummy_output) - both unused
+        """
+        # Cache the hidden states
+        cache_layer = self.cache_only_layers[str(self.target_num_hidden_layers)]
+        # Output is ignored - we only care about the KV cache side effects
+        # TODO(fynn): Confirm this doesn't get optimized away when compiled
+        cache_layer(hidden_states)
+
+        # Return dummy outputs (required by interface but not used)
+        dummy_output = hidden_states.new_zeros(
+            (hidden_states.shape[0], hidden_states.shape[1] // self.num_hidden_states)
+        )
+        return dummy_output, dummy_output
+
+    def load_weights(self, weights):
+        """No weights to load for this dummy model."""
+        return None

--- a/vllm/model_executor/models/extract_hidden_states.py
+++ b/vllm/model_executor/models/extract_hidden_states.py
@@ -32,7 +32,6 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     is_quantized_kv_cache,
 )
-from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVCacheSpec,

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -512,6 +512,7 @@ _MULTIMODAL_MODELS = {
 }
 
 _SPECULATIVE_DECODING_MODELS = {
+    "ExtractHiddenStatesModel": ("extract_hidden_states", "ExtractHiddenStatesModel"),
     "MiMoMTPModel": ("mimo_mtp", "MiMoMTP"),
     "EagleLlamaForCausalLM": ("llama_eagle", "EagleLlamaForCausalLM"),
     "EagleLlama4ForCausalLM": ("llama4_eagle", "EagleLlama4ForCausalLM"),

--- a/vllm/transformers_utils/configs/extract_hidden_states.py
+++ b/vllm/transformers_utils/configs/extract_hidden_states.py
@@ -18,15 +18,20 @@ class ExtractHiddenStatesConfig(PretrainedConfig):
         assert method == "extract_hidden_states"
 
         if isinstance(model, dict):
-            for k, v in model.items():
-                if k != "architectures":
-                    kwargs[k] = v
+            model_dict = model
         elif isinstance(model, PretrainedConfig):
-            kwargs.update(model.to_dict())
+            model_dict = model.to_dict()
+        else:
+            model_dict = {}
 
-        kwargs["architectures"] = ["ExtractHiddenStatesModel"]
+        # Combine: model_dict first, then kwargs override
+        combined = {**model_dict, **kwargs}
+        # Remove architectures from the base, we'll set it explicitly
+        combined = {k: v for k, v in combined.items() if k != "architectures"}
 
-        super().__init__(**kwargs)
+        combined["architectures"] = ["ExtractHiddenStatesModel"]
+
+        super().__init__(**combined)
 
     @classmethod
     def from_pretrained(
@@ -41,6 +46,6 @@ class ExtractHiddenStatesConfig(PretrainedConfig):
 
     def to_json_string(self, use_diff: bool = True) -> str:
         # we override use_diff to False as initializing
-        # EAGLEConfig with default arguments is not supported
+        # ExtractHiddenStatesConfig with default arguments is not supported
         del use_diff
         return super().to_json_string(use_diff=False)

--- a/vllm/transformers_utils/configs/extract_hidden_states.py
+++ b/vllm/transformers_utils/configs/extract_hidden_states.py
@@ -7,9 +7,6 @@ import os
 
 from transformers import PretrainedConfig
 
-from vllm.config import ModelConfig
-from vllm.transformers_utils.config import get_hf_text_config
-
 
 class ExtractHiddenStatesConfig(PretrainedConfig):
     model_type = "extract_hidden_states"

--- a/vllm/transformers_utils/configs/extract_hidden_states.py
+++ b/vllm/transformers_utils/configs/extract_hidden_states.py
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Config definitions for ExtractHiddenStatesModel, to be used with
+the extract_hidden_states spec decoding method."""
 
 import os
 
 from transformers import PretrainedConfig
+
+from vllm.config import ModelConfig
+from vllm.transformers_utils.config import get_hf_text_config
 
 
 class ExtractHiddenStatesConfig(PretrainedConfig):

--- a/vllm/transformers_utils/configs/extract_hidden_states.py
+++ b/vllm/transformers_utils/configs/extract_hidden_states.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+
+from transformers import PretrainedConfig
+
+
+class ExtractHiddenStatesConfig(PretrainedConfig):
+    model_type = "extract_hidden_states"
+
+    def __init__(
+        self,
+        model: PretrainedConfig | dict | None = None,
+        method: str | None = "extract_hidden_states",
+        **kwargs,
+    ):
+        assert method == "extract_hidden_states"
+
+        if isinstance(model, dict):
+            for k, v in model.items():
+                if k != "architectures":
+                    kwargs[k] = v
+        elif isinstance(model, PretrainedConfig):
+            kwargs.update(model.to_dict())
+
+        kwargs["architectures"] = ["ExtractHiddenStatesModel"]
+
+        super().__init__(**kwargs)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str | os.PathLike,
+        **kwargs,
+    ) -> "ExtractHiddenStatesConfig":
+        config_dict, kwargs = cls.get_config_dict(
+            pretrained_model_name_or_path, **kwargs
+        )
+        return cls.from_dict(config_dict, **kwargs)
+
+    def to_json_string(self, use_diff: bool = True) -> str:
+        # we override use_diff to False as initializing
+        # EAGLEConfig with default arguments is not supported
+        del use_diff
+        return super().to_json_string(use_diff=False)

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Callable, NamedTuple, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, NamedTuple, TypeAlias, TypeVar
 
 import numpy as np
 import torch
@@ -174,7 +175,7 @@ class KVConnectorOutput:
             [output.kv_connector_stats for output in outputs],
         )
         kv_cache_events = _combine_non_none(
-            lambda x, y: x.add_events(y.get_all_events()),
+            lambda x, y: x.merge(y),
             [output.kv_cache_events for output in outputs],
         )
         invalid_block_ids = _combine_non_none(

--- a/vllm/v1/spec_decode/extract_hidden_states.py
+++ b/vllm/v1/spec_decode/extract_hidden_states.py
@@ -105,8 +105,8 @@ class ExtractHiddenStatesProposer:
 
         Returns:
             Tuple of:
-              - Draft tokens matching sampled tokens, shape [batch_size, 1]
-              - KV connector output (if KV transfer is active), else None
+                - Draft tokens matching sampled tokens, shape [batch_size, 1]
+                - KV connector output (if KV transfer is active), else None
         """
         assert self.model is not None and isinstance(target_hidden_states, list)
 

--- a/vllm/v1/spec_decode/extract_hidden_states.py
+++ b/vllm/v1/spec_decode/extract_hidden_states.py
@@ -347,9 +347,10 @@ class ExtractHiddenStatesProposer:
         """
         # Get the target model's attention layers before loading draft model
         target_attn_layer_names = set(
-            get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase).keys()
+            get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase).keys()  # type: ignore[type-abstract]
         )
 
+        assert self.vllm_config.speculative_config is not None
         draft_model_config = self.vllm_config.speculative_config.draft_model_config
         from vllm.compilation.backends import set_model_tag
 
@@ -360,7 +361,8 @@ class ExtractHiddenStatesProposer:
 
         # Identify draft model's attention layers (difference from target)
         all_attn_layers = get_layers_from_vllm_config(
-            self.vllm_config, AttentionLayerBase
+            self.vllm_config,
+            AttentionLayerBase,  # type: ignore[type-abstract]
         )
         draft_attn_layers = {
             name: layer

--- a/vllm/v1/spec_decode/extract_hidden_states.py
+++ b/vllm/v1/spec_decode/extract_hidden_states.py
@@ -235,6 +235,7 @@ class ExtractHiddenStatesProposer:
         is_graph_capturing: bool = False,
         slot_mappings: dict[str, torch.Tensor] | None = None,
     ) -> None:
+        assert self.model is not None, "Model must be initialized before dummy_run"
         num_tokens_dp_padded, num_tokens_across_dp = self._pad_batch_across_dp(
             num_tokens_unpadded=num_tokens,
             num_tokens_padded=num_tokens,

--- a/vllm/v1/spec_decode/extract_hidden_states.py
+++ b/vllm/v1/spec_decode/extract_hidden_states.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from contextlib import nullcontext
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
+from vllm.distributed.kv_transfer import has_kv_transfer_group
+from vllm.forward_context import set_forward_context
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.v1.attention.backend import AttentionMetadataBuilder, CommonAttentionMetadata
+from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
+from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunnerMixin
+
+PADDING_SLOT_ID = -1
+
+
+class ExtractHiddenStatesProposer:
+    def __init__(self, vllm_config: VllmConfig, device):
+        assert vllm_config.speculative_config is not None
+
+        assert vllm_config.speculative_config.num_speculative_tokens == 1
+        self.vllm_config = vllm_config
+        self.device = device
+        self.dtype = vllm_config.model_config.dtype
+        # Maximum length of the model.
+        self.max_model_len = vllm_config.model_config.max_model_len
+
+        tp_size = vllm_config.parallel_config.tensor_parallel_size
+
+        # Model and attention layer tracking (initialized in load_model)
+        self.model: nn.Module | None = None
+        self.attn_layer_names: list[str] = []
+        self.attn_metadata_builder: AttentionMetadataBuilder | None = None
+
+        # Maximum number of tokens for buffers
+        max_batch_size = vllm_config.scheduler_config.max_num_seqs
+        self.max_num_tokens = (
+            vllm_config.scheduler_config.max_num_batched_tokens + max_batch_size
+        )
+
+        # Persistent buffers for model inputs
+        self.input_ids = torch.zeros(
+            self.max_num_tokens, dtype=torch.int32, device=device
+        )
+        self.positions = torch.zeros(
+            self.max_num_tokens, dtype=torch.int64, device=device
+        )
+
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.num_hidden_states = len(
+            getattr(
+                self.config, "eagle_aux_hidden_state_layer_ids", [0, 0, 0]
+            )  # fallback to 3
+        )
+
+        # Get hidden size from draft model config (will be available after load_model)
+        # For now, we'll set it based on target model and update in load_model if needed
+        self.hidden_size = vllm_config.model_config.get_hidden_size()
+        self.hidden_states = torch.zeros(
+            (self.max_num_tokens, self.hidden_size * self.num_hidden_states),
+            dtype=self.dtype,
+            device=device,
+        )
+
+        # Initialize buffers and attributes needed for slot mapping
+        self.indexer_layer_names: list[str] = []
+        self._slot_mapping_buffer = torch.zeros(
+            self.max_num_tokens, dtype=torch.int64, device=device
+        )
+
+    def propose(
+        self,
+        sampled_token_ids: torch.Tensor,
+        target_hidden_states: list[torch.Tensor],
+        common_attn_metadata: CommonAttentionMetadata,
+        scheduler_output: "SchedulerOutput",
+        slot_mappings: dict[str, torch.Tensor]
+        | list[dict[str, torch.Tensor]]
+        | None = None,
+    ) -> torch.Tensor:
+        """Propose draft tokens by calling the ExtractHiddenStatesModel model.
+
+        The ExtractHiddenStatesModel caches the hidden states in the KV cache
+        without performing actual attention computation. This allows us to
+        extract and store hidden states for later use (e.g., KV transfer).
+
+        This proposer doesn't actually perform speculation - it returns the
+        sampled tokens as "draft" tokens, ensuring they always verify (match).
+        The main purpose is to cache hidden states, not to speculate.
+
+        Args:
+            sampled_token_ids: Sampled token IDs from the target model
+            target_hidden_states: List of hidden state tensors from target model
+                                (one per aux hidden state layer)
+            common_attn_metadata: Attention metadata
+            scheduler_output: Scheduler output for KV connector
+            slot_mappings: Slot mappings for KV cache (unused, provided for
+                          interface compatibility)
+
+        Returns:
+            Draft tokens that match the sampled tokens, shape [batch_size, 1]
+        """
+        # Call the ExtractHiddenStatesModel model to cache hidden states
+        # This triggers the KV cache storage and KV connector API
+        if self.model is not None and isinstance(target_hidden_states, list):
+            # target_hidden_states is a list of tensors (one per layer)
+            # Stack them to create the input for ExtractHiddenStatesModel
+            # Shape: [num_tokens, num_layers * hidden_size]
+            stacked_hidden_states = torch.cat(target_hidden_states, dim=-1)
+            num_tokens = stacked_hidden_states.shape[0]
+
+            # Copy hidden states to buffer
+            self.hidden_states[:num_tokens] = stacked_hidden_states
+
+            # Prepare dummy input_ids and positions
+            self.input_ids[:num_tokens] = 0  # Dummy token IDs
+            self.positions[:num_tokens] = torch.arange(num_tokens, device=self.device)
+
+            # Build attention metadata for drafting
+            if self.attn_metadata_builder is None:
+                self.attn_metadata_builder = self._get_attention_metadata_builder()
+
+            attn_metadata = self.attn_metadata_builder.build_for_drafting(
+                common_attn_metadata=common_attn_metadata, draft_index=0
+            )
+
+            # Build per-layer attention metadata
+            per_layer_attn_metadata = {}
+            for layer_name in self.attn_layer_names:
+                per_layer_attn_metadata[layer_name] = attn_metadata
+
+            # Call model with proper forward context
+            with (
+                set_forward_context(
+                    per_layer_attn_metadata,
+                    self.vllm_config,
+                    num_tokens=num_tokens,
+                    num_tokens_across_dp=num_tokens,  # No DP coordination in eager mode
+                    cudagraph_runtime_mode=CUDAGraphMode.NONE,  # Eager-only execution
+                    slot_mapping=self._get_slot_mapping(
+                        num_tokens, common_attn_metadata.slot_mapping
+                    ),
+                ),
+                (
+                    KVConnectorModelRunnerMixin._get_kv_connector_output(
+                        scheduler_output
+                    )
+                    if has_kv_transfer_group()
+                    else nullcontext()
+                ) as kv_connecter_output,
+            ):
+                # Forward pass: caches hidden states in KV cache
+                # Output is ignored - we only care about the KV cache side effects
+                self.model(
+                    input_ids=self.input_ids[:num_tokens],
+                    positions=self.positions[:num_tokens],
+                    hidden_states=self.hidden_states[:num_tokens],
+                )
+
+        # Return the sampled tokens as "draft" tokens
+        # This ensures they will always verify (match) since they're identical
+        # We're not actually doing speculation - just caching hidden states
+        # Shape: [batch_size, 1] to match num_speculative_tokens=1
+        return sampled_token_ids.unsqueeze(-1)
+
+    def _get_slot_mapping(
+        self,
+        num_tokens: int,
+        slot_mapping: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """Return slot_mapping dict for EAGLE layers.
+
+        If slot_mapping is provided, copies it into the buffer first.
+        """
+        if slot_mapping is not None:
+            num_actual = slot_mapping.shape[0]
+            self._slot_mapping_buffer[:num_actual].copy_(slot_mapping)
+            if num_tokens > num_actual:
+                self._slot_mapping_buffer[num_actual:num_tokens].fill_(PADDING_SLOT_ID)
+
+        view = self._slot_mapping_buffer[:num_tokens]
+        return {name: view for name in self.attn_layer_names + self.indexer_layer_names}
+
+    def _get_attention_metadata_builder(self) -> AttentionMetadataBuilder:
+        """Get the attention metadata builder for the draft model."""
+        # Get the first attention layer to determine the backend
+        if not self.attn_layer_names:
+            raise ValueError("No attention layers found for ExtractHiddenStatesModel")
+
+        # Get the attention layer from the model
+        # Layer names include the prefix (e.g., "drafter.cache_only_layers.32")
+        # We need to skip the prefix part since self.model is already the drafter
+        layer_name = self.attn_layer_names[0]
+        parts = layer_name.split(".")
+        # Skip the first part if it's the prefix (e.g., "drafter")
+        if parts[0] == "drafter":
+            parts = parts[1:]
+
+        layer = self.model
+        for part in parts:
+            layer = getattr(layer, part)
+
+        # Get the attention backend and its metadata builder
+        attn_backend = layer.get_attn_backend()
+        return attn_backend.get_builder_cls()(
+            layer.get_kv_cache_spec(self.vllm_config),
+            self.attn_layer_names,
+            self.vllm_config,
+            self.device,
+        )
+
+    def prepare_next_token_ids_padded(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        sampled_token_ids: torch.Tensor,
+        requests: dict[str, CachedRequestState],
+        gpu_input_batch: InputBatch,
+        discard_request_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        This function is used to prepare the inputs for speculative decoding.
+        It calculates the next token ids and the number of valid sampled tokens
+        for each request, considering the "discarded" requests whose next token
+        is not sampled and comes from `request.get_token_id()` instead. This is denoted
+        the "backup" token id. It also counts rejected tokens via `sampled_token_ids`.
+        """
+
+        batch_size, num_tokens = sampled_token_ids.shape
+        device = sampled_token_ids.device
+        num_reqs = gpu_input_batch.num_reqs
+
+        # 1. Compute backup tokens for discarded requests
+        backup_tokens = []
+        for i in range(num_reqs):
+            req_id = gpu_input_batch.req_ids[i]
+            seq_len = common_attn_metadata.seq_lens_cpu[i].item()
+            token_id = requests[req_id].get_token_id(seq_len)
+            backup_tokens.append(token_id)
+
+        backup_tokens_gpu = torch.tensor(
+            backup_tokens, dtype=torch.int32, device=device
+        )
+
+        # 2. Extract next token IDs
+        # For valid requests: find the LAST VALID token (skipping rejected -1 tokens)
+        # For discarded requests: use backup tokens
+
+        # Create mask for valid tokens (>= 0 and < vocab_size)
+        vocab_size = gpu_input_batch.vocab_size
+        is_valid = (sampled_token_ids >= 0) & (sampled_token_ids < vocab_size)
+
+        # Count valid tokens per request
+        valid_sampled_tokens_count = is_valid.sum(dim=1).to(torch.int32)
+
+        # Find the last valid token for each request
+        next_token_ids = torch.empty(batch_size, dtype=torch.int32, device=device)
+        for i in range(batch_size):
+            if discard_request_mask[i]:
+                # Use backup token for discarded requests
+                next_token_ids[i] = backup_tokens_gpu[i]
+            elif valid_sampled_tokens_count[i] > 0:
+                # Find last valid token index
+                valid_indices = torch.where(is_valid[i])[0]
+                last_valid_idx = valid_indices[-1]
+                next_token_ids[i] = sampled_token_ids[i, last_valid_idx].to(torch.int32)
+            else:
+                # No valid tokens, use backup
+                next_token_ids[i] = backup_tokens_gpu[i]
+
+        return next_token_ids, valid_sampled_tokens_count
+
+    def load_model(self, target_model: nn.Module) -> None:
+        """Load the ExtractHiddenStatesModel model.
+
+        This method instantiates the ExtractHiddenStatesModel model which is used
+        to cache hidden states during speculative decoding. The model uses
+        cache-only attention (no computation, just caching KV states).
+
+        Args:
+            target_model: The target model (passed for compatibility with
+                         EagleProposer interface, but not used here)
+        """
+        # Get the target model's attention layers before loading draft model
+        target_attn_layer_names = set(
+            get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase).keys()
+        )
+
+        # Instantiate ExtractHiddenStatesModel directly
+        # This model only needs to know KV cache shapes from the target model config
+        from vllm.model_executor.models.extract_hidden_states import (
+            ExtractHiddenStatesModel,
+        )
+
+        self.drafter = ExtractHiddenStatesModel(
+            vllm_config=self.vllm_config, prefix="drafter"
+        )
+        self.model = self.drafter
+
+        # Identify draft model's attention layers (difference from target)
+        draft_attn_layer_names = (
+            get_layers_from_vllm_config(self.vllm_config, AttentionLayerBase).keys()
+            - target_attn_layer_names
+        )
+        self.attn_layer_names = list(draft_attn_layer_names)

--- a/vllm/v1/spec_decode/extract_hidden_states.py
+++ b/vllm/v1/spec_decode/extract_hidden_states.py
@@ -130,15 +130,9 @@ class ExtractHiddenStatesProposer:
         for layer_name in self.attn_layer_names:
             per_layer_attn_metadata[layer_name] = attn_metadata
 
-        num_tokens_dp_padded, num_tokens_across_dp = self._pad_batch_across_dp(
-            num_tokens_unpadded=num_tokens,
-            num_tokens_padded=num_tokens,
+        cudagraph_runtime_mode, num_input_tokens, num_tokens_across_dp = (
+            self._determine_batch_execution_and_padding(num_tokens)
         )
-
-        cudagraph_runtime_mode, batch_desc = self.cudagraph_dispatcher.dispatch(
-            num_tokens_dp_padded
-        )
-        num_input_tokens = batch_desc.num_tokens
         if num_tokens_across_dp is not None:
             num_tokens_across_dp[self.dp_rank] = num_input_tokens
 
@@ -185,29 +179,51 @@ class ExtractHiddenStatesProposer:
         view = self._slot_mapping_buffer[:num_tokens]
         return {name: view for name in self.attn_layer_names}
 
-    def _pad_batch_across_dp(
+    def _determine_batch_execution_and_padding(
         self,
-        num_tokens_unpadded: int,
-        num_tokens_padded: int,
-    ) -> tuple[int, torch.Tensor | None]:
-        should_ubatch, num_toks_across_dp, _ = coordinate_batch_across_dp(
-            num_tokens_unpadded=num_tokens_unpadded,
-            parallel_config=self.vllm_config.parallel_config,
-            allow_microbatching=False,
-            allow_dp_padding=self.cudagraph_dispatcher.cudagraph_mode
-            != CUDAGraphMode.NONE,
-            num_tokens_padded=num_tokens_padded,
-            uniform_decode=None,
-            num_scheduled_tokens_per_request=None,
+        num_tokens: int,
+        use_cudagraphs: bool = True,
+    ) -> tuple[CUDAGraphMode, int, torch.Tensor | None]:
+        cudagraph_mode, batch_desc = self.cudagraph_dispatcher.dispatch(
+            num_tokens,
+            valid_modes=({CUDAGraphMode.NONE} if not use_cudagraphs else None),
         )
-        assert not should_ubatch, (
-            "DBO ubatching not implemented for extract_hidden_states"
-        )
+        num_tokens_padded = batch_desc.num_tokens
 
-        num_tokens_dp_padded = num_tokens_padded
-        if num_toks_across_dp is not None:
-            num_tokens_dp_padded = int(num_toks_across_dp[self.dp_rank].item())
-        return num_tokens_dp_padded, num_toks_across_dp
+        # Extra coordination when running data-parallel since we need to
+        # coordinate across ranks
+        # TODO(Flechman): support DBO ubatching
+        should_ubatch, num_tokens_across_dp = False, None
+        if self.vllm_config.parallel_config.data_parallel_size > 1:
+            should_ubatch, num_tokens_across_dp, synced_cudagraph_mode = (
+                coordinate_batch_across_dp(
+                    num_tokens_unpadded=num_tokens,
+                    parallel_config=self.vllm_config.parallel_config,
+                    allow_microbatching=False,
+                    num_tokens_padded=num_tokens_padded,
+                    cudagraph_mode=cudagraph_mode.value,
+                )
+            )
+            assert not should_ubatch, (
+                "DBO ubatching not implemented for extract_hidden_states"
+            )
+
+            # Extract DP-synced values
+            if num_tokens_across_dp is not None:
+                dp_rank = self.dp_rank
+                num_tokens_padded = int(num_tokens_across_dp[dp_rank].item())
+                # Re-dispatch with DP padding so we have the correct
+                # batch_descriptor
+                cudagraph_mode, batch_desc = self.cudagraph_dispatcher.dispatch(
+                    num_tokens_padded,
+                    valid_modes={CUDAGraphMode(synced_cudagraph_mode)},
+                )
+                # Assert to make sure the agreed upon token count is correct
+                # otherwise num_tokens_across_dp will no-longer be valid
+                assert batch_desc.num_tokens == num_tokens_padded
+                num_tokens_across_dp[dp_rank] = num_tokens_padded
+
+        return cudagraph_mode, num_tokens_padded, num_tokens_across_dp
 
     def initialize_cudagraph_keys(self, cudagraph_mode: CUDAGraphMode) -> None:
         """Initialize cudagraph dispatcher keys.
@@ -236,19 +252,11 @@ class ExtractHiddenStatesProposer:
         slot_mappings: dict[str, torch.Tensor] | None = None,
     ) -> None:
         assert self.model is not None, "Model must be initialized before dummy_run"
-        num_tokens_dp_padded, num_tokens_across_dp = self._pad_batch_across_dp(
-            num_tokens_unpadded=num_tokens,
-            num_tokens_padded=num_tokens,
-        )
-
-        if use_cudagraphs:
-            cudagraph_runtime_mode, batch_desc = self.cudagraph_dispatcher.dispatch(
-                num_tokens_dp_padded
+        cudagraph_runtime_mode, num_input_tokens, num_tokens_across_dp = (
+            self._determine_batch_execution_and_padding(
+                num_tokens, use_cudagraphs=use_cudagraphs
             )
-            num_input_tokens = batch_desc.num_tokens
-        else:
-            cudagraph_runtime_mode = CUDAGraphMode.NONE
-            num_input_tokens = num_tokens_dp_padded
+        )
 
         if num_tokens_across_dp is not None:
             num_tokens_across_dp[self.dp_rank] = num_input_tokens

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3700,10 +3700,10 @@ class GPUModelRunner(
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
-        kv_connector_output = self.kv_connector_output
-        self.kv_connector_output = None
 
         if self.execute_model_state is None:
+            kv_connector_output = self.kv_connector_output
+            self.kv_connector_output = None
             # receive sampled token ids from the last PP rank.
             if self.use_async_scheduling and get_pp_group().world_size > 1:
                 self._pp_receive_prev_sampled_token_ids_to_input_batch()
@@ -3853,6 +3853,10 @@ class GPUModelRunner(
 
         with record_function_or_nullcontext("gpu_model_runner: eplb"):
             self.eplb_step()
+
+        # self.kv_connector_output may be modified during drafting
+        kv_connector_output = self.kv_connector_output
+        self.kv_connector_output = None
 
         with record_function_or_nullcontext("gpu_model_runner: ModelRunnerOutput"):
             if self.model_config.enable_return_routed_experts:
@@ -4092,15 +4096,22 @@ class GPUModelRunner(
                 )
             target_hidden_states = [h[:num_scheduled_tokens] for h in aux_hidden_states]
 
-            draft_token_ids, drafter_kv_connector_output = (
-                self.drafter.propose(
-                    sampled_token_ids=sampled_token_ids,
-                    target_hidden_states=target_hidden_states,
-                    common_attn_metadata=common_attn_metadata,
-                    scheduler_output=scheduler_output,
-                    slot_mappings=slot_mappings,
-                )
+            draft_token_ids, drafter_kv_connector_output = self.drafter.propose(
+                sampled_token_ids=sampled_token_ids,
+                target_hidden_states=target_hidden_states,
+                common_attn_metadata=common_attn_metadata,
+                scheduler_output=scheduler_output,
+                slot_mappings=slot_mappings,
             )
+            # Combine KVConnectorOutputs or select the non-empty one
+            if self.kv_connector_output and drafter_kv_connector_output:
+                self.kv_connector_output = KVConnectorOutput.merge(
+                    self.kv_connector_output, drafter_kv_connector_output
+                )
+            else:
+                self.kv_connector_output = (
+                    self.kv_connector_output or drafter_kv_connector_output
+                )
 
             next_token_ids, valid_sampled_tokens_count = (
                 self.drafter.prepare_next_token_ids_padded(
@@ -4998,9 +5009,7 @@ class GPUModelRunner(
             ):
                 assert isinstance(
                     self.drafter,
-                    EagleProposer
-                    | DraftModelProposer
-                    | ExtractHiddenStatesProposer,
+                    EagleProposer | DraftModelProposer | ExtractHiddenStatesProposer,
                 )
                 assert self.speculative_config is not None
                 # Eagle currently only supports PIECEWISE cudagraphs.
@@ -5715,9 +5724,7 @@ class GPUModelRunner(
             self.speculative_config.use_eagle()
             or self.speculative_config.uses_extract_hidden_states()
         ):
-            assert isinstance(
-                self.drafter, EagleProposer | ExtractHiddenStatesProposer
-            )
+            assert isinstance(self.drafter, EagleProposer | ExtractHiddenStatesProposer)
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 
     def calculate_reorder_batch_threshold(self) -> None:
@@ -6088,9 +6095,7 @@ class GPUModelRunner(
         ):
             assert isinstance(
                 self.drafter,
-                EagleProposer
-                | DraftModelProposer
-                | ExtractHiddenStatesProposer,
+                EagleProposer | DraftModelProposer | ExtractHiddenStatesProposer,
             )
             # validate all draft model layers belong to the same kv cache
             # group

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4125,7 +4125,6 @@ class GPUModelRunner(
                 next_token_ids, valid_sampled_tokens_count
             )
 
-            # todo(fynn) combine drafter_kv_connector_output with existing
         elif spec_config.use_eagle() or spec_config.uses_draft_model():
             assert isinstance(self.drafter, EagleProposer | DraftModelProposer)
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -159,6 +159,7 @@ from vllm.v1.sample.rejection_sampler import RejectionSampler
 from vllm.v1.sample.sampler import Sampler
 from vllm.v1.spec_decode.draft_model import DraftModelProposer
 from vllm.v1.spec_decode.eagle import EagleProposer
+from vllm.v1.spec_decode.extract_hidden_states import ExtractHiddenStatesProposer
 from vllm.v1.spec_decode.medusa import MedusaProposer
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.spec_decode.suffix_decoding import SuffixDecodingProposer
@@ -495,6 +496,7 @@ class GPUModelRunner(
                 | EagleProposer
                 | DraftModelProposer
                 | MedusaProposer
+                | ExtractHiddenStatesProposer
             )
             if self.speculative_config.method == "ngram":
                 from vllm.v1.spec_decode.ngram_proposer import NgramProposer
@@ -518,6 +520,11 @@ class GPUModelRunner(
                 self.drafter = MedusaProposer(
                     vllm_config=self.vllm_config, device=self.device
                 )
+            elif self.speculative_config.method == "extract_hidden_states":
+                self.drafter = ExtractHiddenStatesProposer(
+                    vllm_config=self.vllm_config, device=self.device
+                )
+                self.use_aux_hidden_state_outputs = True
             else:
                 raise ValueError(
                     "Unknown speculative decoding method: "
@@ -3778,12 +3785,17 @@ class GPUModelRunner(
                 <= self.effective_drafter_max_model_len
             )
             use_gpu_toks = (
-                spec_config.use_eagle() or spec_config.uses_draft_model()
+                spec_config.use_eagle()
+                or spec_config.uses_draft_model()
+                or spec_config.uses_extract_hidden_states()
             ) and not spec_config.disable_padded_drafter_batch
             if use_gpu_toks:
                 # EAGLE/DraftModel speculative decoding can use the GPU sampled tokens
                 # as inputs, and does not need to wait for bookkeeping to finish.
-                assert isinstance(self.drafter, EagleProposer | DraftModelProposer)
+                assert isinstance(
+                    self.drafter,
+                    EagleProposer | DraftModelProposer | ExtractHiddenStatesProposer,
+                )
                 sampled_token_ids = sampler_output.sampled_token_ids
                 if input_fits_in_drafter:
                     propose_draft_token_ids(sampled_token_ids)
@@ -4068,6 +4080,40 @@ class GPUModelRunner(
                 sampling_metadata=sampling_metadata,
                 slot_mappings=slot_mappings,
             )
+        elif spec_config.uses_extract_hidden_states():
+            assert isinstance(self.drafter, ExtractHiddenStatesProposer)
+            assert isinstance(sampled_token_ids, torch.Tensor), (
+                "sampled_token_ids should be a torch.Tensor for "
+                "extract_hidden_states method."
+            )
+            if not self.use_aux_hidden_state_outputs or aux_hidden_states is None:
+                raise ValueError(
+                    "aux_hidden_states are rquired when using `extract_hidden_states`"
+                )
+            target_hidden_states = [h[:num_scheduled_tokens] for h in aux_hidden_states]
+
+            draft_token_ids = self.drafter.propose(
+                sampled_token_ids=sampled_token_ids,
+                target_hidden_states=target_hidden_states,
+                common_attn_metadata=common_attn_metadata,
+                scheduler_output=scheduler_output,
+                slot_mappings=slot_mappings,
+            )
+
+            next_token_ids, valid_sampled_tokens_count = (
+                self.drafter.prepare_next_token_ids_padded(
+                    common_attn_metadata,
+                    sampled_token_ids,
+                    self.requests,
+                    self.input_batch,
+                    self.discard_request_mask.gpu,
+                )
+            )
+            self._copy_valid_sampled_token_count(
+                next_token_ids, valid_sampled_tokens_count
+            )
+
+            # todo(fynn) combine kv_connector_output with existing
         elif spec_config.use_eagle() or spec_config.uses_draft_model():
             assert isinstance(self.drafter, EagleProposer | DraftModelProposer)
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3700,7 +3700,6 @@ class GPUModelRunner(
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
-
         if self.execute_model_state is None:
             kv_connector_output = self.kv_connector_output
             self.kv_connector_output = None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4088,16 +4088,18 @@ class GPUModelRunner(
             )
             if not self.use_aux_hidden_state_outputs or aux_hidden_states is None:
                 raise ValueError(
-                    "aux_hidden_states are rquired when using `extract_hidden_states`"
+                    "aux_hidden_states are required when using `extract_hidden_states`"
                 )
             target_hidden_states = [h[:num_scheduled_tokens] for h in aux_hidden_states]
 
-            draft_token_ids = self.drafter.propose(
-                sampled_token_ids=sampled_token_ids,
-                target_hidden_states=target_hidden_states,
-                common_attn_metadata=common_attn_metadata,
-                scheduler_output=scheduler_output,
-                slot_mappings=slot_mappings,
+            draft_token_ids, drafter_kv_connector_output = (
+                self.drafter.propose(
+                    sampled_token_ids=sampled_token_ids,
+                    target_hidden_states=target_hidden_states,
+                    common_attn_metadata=common_attn_metadata,
+                    scheduler_output=scheduler_output,
+                    slot_mappings=slot_mappings,
+                )
             )
 
             next_token_ids, valid_sampled_tokens_count = (
@@ -4113,7 +4115,7 @@ class GPUModelRunner(
                 next_token_ids, valid_sampled_tokens_count
             )
 
-            # todo(fynn) combine kv_connector_output with existing
+            # todo(fynn) combine drafter_kv_connector_output with existing
         elif spec_config.use_eagle() or spec_config.uses_draft_model():
             assert isinstance(self.drafter, EagleProposer | DraftModelProposer)
 
@@ -4992,8 +4994,14 @@ class GPUModelRunner(
             if self.speculative_config and (
                 self.speculative_config.use_eagle()
                 or self.speculative_config.uses_draft_model()
+                or self.speculative_config.uses_extract_hidden_states()
             ):
-                assert isinstance(self.drafter, EagleProposer | DraftModelProposer)
+                assert isinstance(
+                    self.drafter,
+                    EagleProposer
+                    | DraftModelProposer
+                    | ExtractHiddenStatesProposer,
+                )
                 assert self.speculative_config is not None
                 # Eagle currently only supports PIECEWISE cudagraphs.
                 # Therefore only use cudagraphs if the main model uses PIECEWISE
@@ -5702,9 +5710,14 @@ class GPUModelRunner(
             cudagraph_mode, self.uniform_decode_query_len
         )
 
-        # Initialize eagle's cudagraph dispatcher if using eagle spec decode.
-        if self.speculative_config and self.speculative_config.use_eagle():
-            assert isinstance(self.drafter, EagleProposer)
+        # Initialize drafter's cudagraph dispatcher if using spec decode.
+        if self.speculative_config and (
+            self.speculative_config.use_eagle()
+            or self.speculative_config.uses_extract_hidden_states()
+        ):
+            assert isinstance(
+                self.drafter, EagleProposer | ExtractHiddenStatesProposer
+            )
             self.drafter.initialize_cudagraph_keys(cudagraph_mode)
 
     def calculate_reorder_batch_threshold(self) -> None:
@@ -6071,8 +6084,14 @@ class GPUModelRunner(
         if self.speculative_config and (
             self.speculative_config.use_eagle()
             or self.speculative_config.uses_draft_model()
+            or self.speculative_config.uses_extract_hidden_states()
         ):
-            assert isinstance(self.drafter, EagleProposer | DraftModelProposer)
+            assert isinstance(
+                self.drafter,
+                EagleProposer
+                | DraftModelProposer
+                | ExtractHiddenStatesProposer,
+            )
             # validate all draft model layers belong to the same kv cache
             # group
             self.drafter.validate_same_kv_cache_group(kv_cache_config)


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
In-tree implementation of hidden states extraction system described in #33118.

FIX #33318

## Components
### Configs
- `vllm/config/speculative.py`: Add handling for `extract_hidden_states` spec method
- `vllm/transformers_utils/configs/extract_hidden_states.py`: ExtractHiddenStatesConfig def

### ExampleHiddenStatesConnector
- `vllm/distributed/kv_transfer/kv_connector/v1/example_hidden_states_connector.py`: Connector definition
- `vllm/distributed/kv_transfer/kv_connector/factory.py`: Registration
This is a custom connector for extracting the hidden states. This is only designed to work when using `extract_hidden_states` as a speculative method. It also only extracts data from `CacheOnlyAttentionLayer`s (which is what the dummy model stores the hidden states in).

This is not the most performant connector, but provides a good debug implementation and starting point for future hidden states connectors.

### KV Connector for ExtractHiddenStates dummy model
- `vllm/v1/outputs.py`: Add support for merging KVConnectorOutputs
- `vllm/distributed/kv_events.py`: Add support for merging KVConnectorEvents
- `vllm/v1/worker/gpu_model_runner.py`: Add KVConnectorOutput merge when using `extract_hidden_states`

Currently, there isn't support for KV Connector + draft models. The KVConnector context is only initialized for the verifier model's forward, but then doesn't exist during the draft model call, preventing the KVConnector from being used. This is a problem beyond this pr, because it prevents P/D disagg w/ spec decoding. 

However, for the scope of this pr, I have developed a temporary solution for this extraction pathway, which is to set up a second KVConnector context when calling the draft model. This is safe to do, because the custom ExampleHiddenStatesConenctor only saves the state from CacheOnlyAttentionLayers which only exist in the drafter. I then merge the two KVConnectorOutputs together so that the scheduler gets complete information from the two contexts.

### ExtractHiddenStatesModel
- `vllm/model_executor/models/extract_hidden_states.py`: Model definition + custom attention backend/layer definitions
- `vllm/model_executor/models/registry.py`: Registration

Dummy "drafter" model that just allocates kv cache space in fake attention layers and then caches its inputs there, while triggering kv connector load/save. 

Note: we set `num_heads` to the number of hidden layers we're saving and `head_size` to the model's `hidden_size` so that the data can be inserted without additional reshaping/splitting across dummy layers.

This model also checks `eagle_aux_hidden_state_layer_ids` to determine how many layers will be cached. 

### ExtractHiddenStatesProposer
- `vllm/v1/spec_decode/extract_hidden_states.py`: Proposer def
- `vllm/v1/worker/gpu_model_runner.py`: Proposer integration (matches if/else integration of existing proposers)

Handles setting up context (kv connector and forward) for call to fake drafter model. Handles "dummy" drafting process (i.e. returning original tokens from target + dummy drafts). 

## Test Plan

- `examples/offline_inference/extract_hidden_states.py`: Example script showing correct usage and how to extract the save path from the model output and load the hidden states.
- `tests/v1/kv_connector/extract_hidden_states_integration/`: Integration tests for hidden states extraction system
- `tests/v1/spec_decode/test_extract_hidden_states.py`: Unit tests for ExtractHiddenStatesProposer

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

