### PR TITLE
[Bugfix] Define router_logits_dtype for remaining MoE models

### DIFF
--- a/vllm/model_executor/models/afmoe.py
+++ b/vllm/model_executor/models/afmoe.py
@@ -142,6 +142,7 @@ class AfmoeMoE(nn.Module):
             e_score_correction_bias=self.expert_bias,
             enable_eplb=self.enable_eplb,
             num_redundant_experts=self.n_redundant_experts,
+            router_logits_dtype=torch.float32,
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/models/bailing_moe.py
+++ b/vllm/model_executor/models/bailing_moe.py
@@ -300,6 +300,7 @@ class BailingMoE(nn.Module):
             num_expert_group=self.n_group,
             topk_group=self.topk_group,
             use_grouped_topk=self.use_grouped_topk,
+            router_logits_dtype=self.router_dtype,
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/models/flex_olmo.py
+++ b/vllm/model_executor/models/flex_olmo.py
@@ -71,7 +71,6 @@ class FlexOlmoMoE(nn.Module):
             prefix=f"{prefix}.gate",
         )
 
-        # Gate always runs at half / full precision for now.
         self.experts = FusedMoE(
             num_experts=hf_config.num_experts,
             top_k=hf_config.num_experts_per_tok,
@@ -82,6 +81,7 @@ class FlexOlmoMoE(nn.Module):
             quant_config=None,
             tp_size=tp_size,
             prefix=f"{prefix}.experts",
+            router_logits_dtype=torch.float32,
         )
 
         self.top_k = hf_config.num_experts_per_tok

--- a/vllm/model_executor/models/longcat_flash.py
+++ b/vllm/model_executor/models/longcat_flash.py
@@ -236,9 +236,9 @@ class FlashMLP(nn.Module):
 class LongcatRouter(nn.Module):
     def __init__(
         self,
-        config,
-        zero_expert_num=0,
-        rounter_params_dtype=torch.bfloat16,
+        config: FlashConfig,
+        zero_expert_num: int,
+        rounter_params_dtype: torch.dtype,
         prefix: str = "",
     ):
         super().__init__()
@@ -309,6 +309,7 @@ class LongcatMoe(nn.Module):
             prefix=f"{prefix}.experts",
             enable_eplb=enable_eplb,
             routed_scaling_factor=config.routed_scaling_factor,
+            router_logits_dtype=self.rounter_params_dtype,
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/models/mimo_v2_flash.py
+++ b/vllm/model_executor/models/mimo_v2_flash.py
@@ -174,6 +174,7 @@ class MiMoV2MoE(nn.Module):
             num_expert_group=config.n_group,
             topk_group=config.topk_group,
             scoring_func="sigmoid",
+            router_logits_dtype=self.gate_dtype,
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/models/minimax_text_01.py
+++ b/vllm/model_executor/models/minimax_text_01.py
@@ -162,6 +162,7 @@ class MiniMaxText01MoE(nn.Module):
             quant_config=self.quant_config,
             tp_size=self.tp_size,
             prefix=f"{prefix}.experts",
+            router_logits_dtype=torch.float32,
         )
         return
 

--- a/vllm/model_executor/models/minimax_text_01.py
+++ b/vllm/model_executor/models/minimax_text_01.py
@@ -162,7 +162,6 @@ class MiniMaxText01MoE(nn.Module):
             quant_config=self.quant_config,
             tp_size=self.tp_size,
             prefix=f"{prefix}.experts",
-            router_logits_dtype=torch.float32,
         )
         return
 

--- a/vllm/model_executor/models/step3p5.py
+++ b/vllm/model_executor/models/step3p5.py
@@ -388,6 +388,7 @@ class FusedMoEBlock(nn.Module):
             routed_scaling_factor=config.moe_router_scaling_factor,
             enable_eplb=self.enable_eplb,
             num_redundant_experts=self.n_redundant_experts,
+            router_logits_dtype=torch.float32,
         )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

After adding a kernel support check for `router_logits_dtype` in https://github.com/vllm-project/vllm/pull/33613, we still needed to audit remaining model definitions to make sure `router_logits_dtype=torch.float32` was set when need. In this PR, I systematically went through that. Here are my justifications:

* `AfmoeMoE`: `self.gate` is float32 and the forward pass has `router_logits = self.gate(hidden_states.to(dtype=torch.float32))`
* `BailingMoE`: There is a `self.router_dtype` variable already, and the forward pass has `router_logits = self.gate(hidden_states.to(self.router_dtype))`
* `FlexOlmoMoE`: The forward pass has `self.experts(..., router_logits=router_logits.float())`
* `LongcatMoe`: There is a `self.rounter_params_dtype` variable already and the forward pass has `router_logits_full = self.router(hidden_states_padded.to(self.rounter_params_dtype))`
* `MiMoV2MoE`: There is a `self.gate_dtype` variable already and the forward pass has `gate_input = hidden_states.to(self.gate_dtype)`
* `Step3p5MoE`: `self.gate` is float32 and there is an assert on `self.need_fp32_gate`

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

