### PR TITLE
[WIP] Decompose all gather so clone is exposed to graph

### DIFF
--- a/tests/compile/distributed/test_all_gather_decompose.py
+++ b/tests/compile/distributed/test_all_gather_decompose.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+import vllm.envs as envs
+from vllm.compilation.collective_fusion import AllGatherDecomposePass
+from vllm.config import (
+    CompilationConfig,
+    DeviceConfig,
+    VllmConfig,
+    set_current_vllm_config,
+)
+from vllm.distributed import tensor_model_parallel_all_gather
+from vllm.distributed.parallel_state import (
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.utils.system_utils import update_environment_variables
+from vllm.utils.torch_utils import set_random_seed
+
+from ...utils import multi_gpu_test
+from ..backend import TestBackend
+
+
+class AllGatherModel(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        gathered = tensor_model_parallel_all_gather(x, dim=-1)
+        variance = gathered.pow(2).mean(-1, keepdim=True)
+        return gathered * torch.rsqrt(variance + 1e-6)
+
+    def ops_in_model_before(self):
+        return [torch.ops.vllm.all_gather.default]
+
+    def ops_in_model_after(self):
+        return [torch.ops.vllm.all_gather_raw.default]
+
+
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.skipif(
+    envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA"
+)
+def test_all_gather_decompose_pass():
+    torch.multiprocessing.spawn(
+        _test_worker,
+        args=(2,),
+        nprocs=2,
+    )
+
+
+def _test_worker(local_rank: int, world_size: int):
+    set_random_seed(0)
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    torch.set_default_device(device)
+
+    update_environment_variables({
+        "RANK": str(local_rank),
+        "LOCAL_RANK": str(local_rank),
+        "WORLD_SIZE": str(world_size),
+        "MASTER_ADDR": "localhost",
+        "MASTER_PORT": "12346",
+    })
+
+    init_distributed_environment()
+    initialize_model_parallel(tensor_model_parallel_size=world_size)
+
+    vllm_config = VllmConfig()
+    vllm_config.compilation_config = CompilationConfig()
+    vllm_config.device_config = DeviceConfig(device=torch.device("cuda"))
+
+    decompose_pass = AllGatherDecomposePass(vllm_config)
+
+    with set_current_vllm_config(vllm_config):
+        backend = TestBackend(decompose_pass)
+        model = AllGatherModel()
+
+        x = torch.randn((8, 16, 16), dtype=torch.float16)
+
+        # Get eager reference output
+        with torch.no_grad():
+            eager_out = model(x)
+
+        # Compile and run
+        compiled_model = torch.compile(model, backend=backend)
+        compiled_out = compiled_model(x)
+
+        # Check correctness
+        torch.testing.assert_close(compiled_out, eager_out, rtol=1e-2, atol=1e-2)
+
+        # Check ops were transformed
+        backend.check_before_ops(model.ops_in_model_before())
+        backend.check_after_ops(model.ops_in_model_after())

--- a/vllm/compilation/collective_fusion.py
+++ b/vllm/compilation/collective_fusion.py
@@ -7,8 +7,14 @@ import torch
 import torch._inductor.pattern_matcher as pm
 import torch.fx as fx
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
-from torch._inductor.pattern_matcher import PatternMatcherPass
+from torch._inductor.pattern_matcher import (
+    CallFunctionVarArgs,
+    Match,
+    PatternMatcherPass,
+    register_graph_pattern,
+)
 from torch.distributed._symmetric_memory import enable_symm_mem_for_group
+from torch.fx.operator_schemas import normalize_function
 
 from vllm.config import VllmConfig
 from vllm.config.utils import Range
@@ -1226,3 +1232,83 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
             flashinfer_comm.trtllm_destroy_ipc_workspace_for_all_reduce(
                 self.ipc_handles, self.group
             )
+
+
+def _decompose_all_gather(match: Match, *args, **kwargs) -> None:
+    """
+    Decompose all_gather(dim!=0) to expose reshape for Inductor fusion.
+
+        all_gather -> all_gather_raw + movedim + reshape
+
+    This enables Inductor to fuse the reshape operations with subsequent
+    compute (e.g., RMSNorm), reducing memory traffic.
+    """
+    node = match.nodes[0]
+
+    # Only decompose for CUDA tensors (other communicators don't have raw op)
+    x_node = node.args[0]
+    if "val" in x_node.meta:
+        if x_node.meta["val"].device.type != "cuda":
+            return
+
+    # Normalize args to get named parameters
+    normalized = normalize_function(
+        node.target, node.args, node.kwargs, normalize_to_only_use_kwargs=True
+    )
+    if normalized is None:
+        logger.warning("Failed to normalize all_gather args")
+        return
+
+    _, norm_kwargs = normalized
+    dim = norm_kwargs["dim"]
+    world_size = norm_kwargs["world_size"]
+    group_name = norm_kwargs["group_name"]
+
+    # Skip decomposition for dim=0 (already native format)
+    if dim == 0:
+        return
+
+    def repl(x: torch.Tensor) -> torch.Tensor:
+        # Normalize negative dim
+        d = dim
+        if d < 0:
+            d = d + x.dim()
+        input_size = x.shape
+        # all_gather_raw returns [world_size, *input_shape]
+        raw = torch.ops.vllm.all_gather_raw.default(x, world_size, group_name)
+        # movedim(0, d) moves world_size dim to gather position
+        moved = raw.movedim(0, d)
+        # reshape merges the world_size dim with the original gather dim
+        output_shape = (
+            input_size[:d] + (world_size * input_size[d],) + input_size[d + 1:]
+        )
+        return moved.reshape(output_shape)
+
+    match.replace_by_example(repl, [node.args[0]])
+
+
+class AllGatherDecomposePass(VllmInductorPass):
+    """
+    Decomposes all_gather(dim!=0) to expose reshape for Inductor fusion.
+
+        all_gather -> all_gather_raw + movedim + reshape
+
+    Runs after fusion passes so they get first chance to match.
+    """
+
+    def __init__(self, config: VllmConfig) -> None:
+        super().__init__(config)
+        self.patterns: PatternMatcherPass = PatternMatcherPass(
+            pass_name="all_gather_decompose"
+        )
+        # Register the pattern with the pass
+        register_graph_pattern(
+            CallFunctionVarArgs(torch.ops.vllm.all_gather.default),
+            pass_dict=self.patterns,
+        )(_decompose_all_gather)
+
+    @VllmInductorPass.time_and_log
+    def __call__(self, graph: fx.Graph) -> None:
+        self.matched_count = self.patterns.apply(graph)
+        if self.matched_count > 0:
+            logger.debug("Decomposed %s all_gather ops", self.matched_count)

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -150,6 +150,8 @@ class PassConfig:
         }, where key is the device capability"""
     enable_qk_norm_rope_fusion: bool = False
     """Enable fused Q/K RMSNorm + RoPE pass."""
+    decompose_all_gather: bool = True
+    """Decompose all_gather to expose reshape for Inductor fusion."""
 
     # TODO(luka) better pass enabling system.
 


### PR DESCRIPTION
Decomposes all_gather after other distributed passes to expose reshape + clone for Inductor fusion.

As shown in [this benchmark](https://gist.github.com/eellison/3baf13492d8c9d496243db87f9835c93), inductor can codegen this more performantly than eager, as well as potentially fuse into the rest of the graph. 

On b200, the benchmark for a reshape + clone is 2.5x faster with inductor than using eager (using cudagraphs to normalize overhead). 

Tests added in both tests/compile/distributed/test_all_gather_decompose.py and tests/distributed/test_comm_ops.py.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

