### PR TITLE
Remove custom ops for TRTLLM block/tensor FP8 and BF16 MoEs

### DIFF
--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -355,11 +355,13 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
         x: torch.Tensor,
         router_logits: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        import vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe  # noqa: F401
+        from vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe import (
+            flashinfer_trtllm_fused_moe_bf16,
+        )
 
         assert self.unquantized_backend == UnquantizedMoeBackend.FLASHINFER_TRTLLM
 
-        return torch.ops.vllm.flashinfer_fused_moe_bf16(
+        return flashinfer_trtllm_fused_moe_bf16(
             routing_logits=router_logits,
             routing_bias=layer.e_score_correction_bias,
             hidden_states=x,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -1025,7 +1025,7 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
 
         if self.block_quant:
             from vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe import (
-                flashinfer_trtllm_fused_moe_blockscale_fp8,  # noqa: E501, F401
+                flashinfer_trtllm_fused_moe_blockscale_fp8,
             )
 
             return flashinfer_trtllm_fused_moe_blockscale_fp8(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -1024,9 +1024,11 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         assert layer.activation == "silu"
 
         if self.block_quant:
-            import vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe  # noqa: E501, F401
+            from vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe import (
+                flashinfer_trtllm_fused_moe_blockscale_fp8,  # noqa: E501, F401
+            )
 
-            return torch.ops.vllm.flashinfer_fused_moe_blockscale_fp8(
+            return flashinfer_trtllm_fused_moe_blockscale_fp8(
                 routing_logits=router_logits,
                 routing_bias=layer.e_score_correction_bias,
                 x=x,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -977,9 +977,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         )
 
         if self.block_quant:
-            import vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe  # noqa: E501, F401
+            from vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe import (
+                flashinfer_trtllm_fused_moe_blockscale_fp8,
+            )
 
-            return torch.ops.vllm.flashinfer_fused_moe_blockscale_fp8(
+            assert self.weight_block_size is not None
+            return flashinfer_trtllm_fused_moe_blockscale_fp8(
                 routing_logits=router_logits,
                 routing_bias=layer.e_score_correction_bias,
                 x=x,

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
@@ -103,7 +103,9 @@ def apply_fi_trtllm_fp8_per_tensor_moe(
 ) -> torch.Tensor:
     from flashinfer.fused_moe import RoutingMethodType
 
-    import vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe  # noqa: E501, F401
+    from vllm.model_executor.layers.fused_moe.flashinfer_trtllm_moe import (
+        fi_trtllm_fp8_per_tensor_moe,
+    )
     from vllm.model_executor.models.llama4 import Llama4MoE
 
     # Added to the layer by: register_scales_for_trtllm_fp8_per_tensor_moe
@@ -126,7 +128,7 @@ def apply_fi_trtllm_fp8_per_tensor_moe(
             "Custom routing function is only supported for Llama4"
         )
 
-    return torch.ops.vllm.fi_trtllm_fp8_per_tensor_moe(
+    return fi_trtllm_fp8_per_tensor_moe(
         routing_logits=router_logits,
         routing_bias=routing_bias,
         hidden_states=hidden_states,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

There were comments that mentioned it was not understood why these needed to be wrapped in custom ops, so I tried unwrapping them. 

## Test Plan

## Test Result

```
# flashinfer_trtllm_fp8_block_scale_moe
vllm serve Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
python tests/evals/gsm8k/gsm8k_eval.py --port 8000
## Before:
Results:
Accuracy: 0.892
Invalid responses: 0.000
Total latency: 20.834 s
Questions per second: 63.310
Total output tokens: 194886
Output tokens per second: 9354.254

## After:
Results:
Accuracy: 0.895
Invalid responses: 0.000
Total latency: 20.903 s
Questions per second: 63.102
Total output tokens: 194689
Output tokens per second: 9314.096
```

```
# flashinfer_trtllm_fp8_per_tensor_scale_moe
vllm serve nvidia/Llama-4-Scout-17B-16E-Instruct-FP8 --max-model-len 10k
python tests/evals/gsm8k/gsm8k_eval.py --port 8000
## Before:
Results:
Accuracy: 0.920
Invalid responses: 0.000
Total latency: 33.886 s
Questions per second: 38.925
Total output tokens: 125424
Output tokens per second: 3701.367

## After:
Results:
Accuracy: 0.920
Invalid responses: 0.000
Total latency: 33.962 s
Questions per second: 38.838
Total output tokens: 124731
Output tokens per second: 3672.668
```

```
# flashinfer_trtllm_bf16_moe
VLLM_USE_FLASHINFER_MOE_FP16=1 vllm serve Qwen/Qwen3-30B-A3B
python tests/evals/gsm8k/gsm8k_eval.py --port 8000
## Before:
Results:
Accuracy: 0.890
Invalid responses: 0.000
Total latency: 19.233 s
Questions per second: 68.581
Total output tokens: 151854
Output tokens per second: 7895.608

## After:
Results:
Accuracy: 0.890
Invalid responses: 0.000
Total latency: 19.079 s
Questions per second: 69.132
Total output tokens: 151700
Output tokens per second: 7950.979
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

