### PR TITLE
[Core] Reduce median/average TTFT by up to ~37% with Inter-Prefill-Budget

### DIFF
--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -57,6 +57,7 @@ def create_scheduler(
     pipeline_parallel_size: int = 1,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
+    inter_prefill_budget: int = 0,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -89,6 +90,7 @@ def create_scheduler(
         enable_chunked_prefill=enable_chunked_prefill,
         async_scheduling=async_scheduling,
         is_encoder_decoder=model_config.is_encoder_decoder,
+        inter_prefill_budget=inter_prefill_budget,
     )
     # Cache config, optionally force APC
     cache_config = CacheConfig(

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -80,6 +80,14 @@ class SchedulerConfig:
     """For chunked prefill, a request is considered long if the prompt is
     longer than this number of tokens."""
 
+    inter_prefill_budget: int = 0
+    """Maximum number of prefill tokens that can be scheduled from separate
+    requests in the same batch. When set to a positive value, after scheduling
+    prefill tokens for one request, subsequent prefill requests in the same
+    batch will be limited to the remaining budget. For example, if set to 2048,
+    and a request with 2000 prefill tokens is scheduled first, the next prefill
+    request can only schedule up to 48 tokens. Set to 0 to disable this limit."""
+
     enable_chunked_prefill: bool = True
     """If True, prefill requests can be chunked based
     on the remaining `max_num_batched_tokens`.

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -86,7 +86,8 @@ class SchedulerConfig:
     prefill tokens for one request, subsequent prefill requests in the same
     batch will be limited to the remaining budget. For example, if set to 2048,
     and a request with 2000 prefill tokens is scheduled first, the next prefill
-    request can only schedule up to 48 tokens. Set to 0 to disable this limit."""
+    request can only schedule up to 48 tokens. Set to 0 to disable this limit.
+    Currently not supported with priority scheduling."""
 
     enable_chunked_prefill: bool = True
     """If True, prefill requests can be chunked based
@@ -255,6 +256,10 @@ class SchedulerConfig:
             )
 
         self.verify_max_model_len(max_model_len)
+        if self.inter_prefill_budget > 0 and self.policy != "fcfs":
+            raise ValueError(
+                "Inter-prefill budget is only supported for FCFS scheduling."
+            )
 
     def verify_max_model_len(self, max_model_len: int) -> Self:
         if (

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -458,6 +458,7 @@ class EngineArgs:
     max_num_partial_prefills: int = SchedulerConfig.max_num_partial_prefills
     max_long_partial_prefills: int = SchedulerConfig.max_long_partial_prefills
     long_prefill_token_threshold: int = SchedulerConfig.long_prefill_token_threshold
+    inter_prefill_budget: int = SchedulerConfig.inter_prefill_budget
     max_num_seqs: int | None = None
     max_logprobs: int = ModelConfig.max_logprobs
     logprobs_mode: LogprobsMode = ModelConfig.logprobs_mode
@@ -1180,6 +1181,10 @@ class EngineArgs:
             "--long-prefill-token-threshold",
             **scheduler_kwargs["long_prefill_token_threshold"],
         )
+        scheduler_group.add_argument(
+            "--inter-prefill-budget",
+            **scheduler_kwargs["inter_prefill_budget"],
+        )
         # multi-step scheduling has been removed; corresponding arguments
         # are no longer supported.
         scheduler_group.add_argument(
@@ -1755,6 +1760,7 @@ class EngineArgs:
             max_num_partial_prefills=self.max_num_partial_prefills,
             max_long_partial_prefills=self.max_long_partial_prefills,
             long_prefill_token_threshold=self.long_prefill_token_threshold,
+            inter_prefill_budget=self.inter_prefill_budget,
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,


### PR DESCRIPTION
## Summary
Introduces `--inter-prefill-budget`, a new scheduling constraint that prevents **Head-of-Line (HoL) blocking** during the prefill stage. This optimization reduces **Median TTFT by up to 37%** on large models (Gemma-3-27B) by preventing compute-saturated batches from being overloaded with redundant prefill requests.

## Purpose
When configuring `max_num_batched_tokens` for chunked prefill, to optimize for high throughput and low TTFT, we want to set a big number to avoid the overhead introduced by chunking a prefill to many chunks.
However configuring this to a big number opens the door to a major inefficiency in how vLLM schedules requests:
Since prefill is compute bound, we easily achieve GPU saturation with a single prefill request that fits in a single batch when `max_num_batched_tokens` is big,  and any additional prefill request we schedule in the same batch would just increase the TTFT of the first request we scheduled, without improving throughput - as we have already saturated the GPU.

For example let's define these assumptions:
* `max_num_batched_tokens=4096`
* A prefill request of 1024 tokens saturates the GPU and takes 1 second to compute
* We receive 2 requests of 1024 tokens each at the same time

With the current scheduler, we would schedule the 2 requests in the same batch, and since it takes a second to compute 1024 tokens and it saturates the GPU, that would mean computing 2 requests of 1024 tokens will take 2 seconds, and we would get TTFT=2 seconds for both requests, resulting in average TTFT of 2 seconds.
WIth `inter_prefill_budget=1024`,  the scheduler will not schedule both requests in the same batch, meaning the first request will have a TTFT of 1 second, and the second one will have a TTFT of 2 seconds, resulting in average TTFT of 1.5 seconds.

### TPOT Increase
Generally speaking the time saved for the first token will be "paid" back in subsequent tokens (meaning TPOT will increase), as the first request that moves to decoding will now be batched with the other prefill request.
However as demonstrated in the benchmark results, the TPOT increase is quite minor for requests with long outputs while the TTFT improvement is significant.
This also means that this optimization is especially strong for disaggregated-prefill scenarios, as we reach first-token faster thus can start KV-Cache transfer faster and improve end-to-end-latency.

### Usage
Just add `--inter-prefill-budget=X` in the vllm serve command.

## Test Plan
For correct functionality, I validated the unit tests, and added some more unit tests.
For performance benchmarks, I used a single A100 node, with Gemma-3-27b-it, and used `vllm bench` and a few load scenarios.

## Test Result
I benchmarked using `vllm bench` and 3 different "load-types".
The biggest improvement I found is in the first load-type, in which the median TTFT decreased from 4213ms to 2648ms - a 37% improvement, while maintaining throughput and slightly increasing TPOT.
| Scenario (Input/Output/Req Count) | Metric | Baseline (v0.15.0) | With Budget (2048) | Change |
| :--- | :--- | :--- | :--- | :--- |
| 1024 / 350 / 16 | Median TTFT | 4213ms | 2648ms | **-37%** |
| 400 / 400 / 20 | Median TTFT | 2020ms | 1319ms | **-35%** |
| 50 / 150 / 100 | Median TTFT | 1269ms | 1194ms | -6% |
| 1024 / 350 / 16 | Mean TTFT | 3974ms | 2633ms | **-34%** |
| 400 / 400 / 20 | Mean TTFT | 1930ms | 1440ms | -25% |
| 50 / 150 / 100 | Mean TTFT | 1127ms | 1088ms | -4% |
| 1024 / 350 / 16 | Mean TPOT | 46ms | 51ms | +10% |
| 400 / 400 / 20 | Mean TPOT | 45ms | 47ms | +4% |
| 50 / 150 / 100 | Mean TPOT | 62ms | 63ms | +1% |


---
Full benchmark commands and outputs in the details secion

<details>
Benchmark results for current vLLM (v0.15.0)

```

vllm bench serve --model google/gemma-3-27b-it --base-url http://localhost:8000 --dataset-name random --random-input-len 1024 --random-output-len 350 --num-prompts 16
============ Serving Benchmark Result ============
Successful requests:                     16
Failed requests:                         0
Benchmark duration (s):                  20.38
Total input tokens:                      16368
Total generated tokens:                  5600
Request throughput (req/s):              0.79
Output token throughput (tok/s):         274.83
Peak output token throughput (tok/s):    352.00
Peak concurrent requests:                16.00
Total token throughput (tok/s):          1078.11
---------------Time to First Token----------------
Mean TTFT (ms):                          3974.59
Median TTFT (ms):                        4213.55
P99 TTFT (ms):                           4218.85
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          46.97
Median TPOT (ms):                        46.29
P99 TPOT (ms):                           55.50
---------------Inter-token Latency----------------
Mean ITL (ms):                           46.97
Median ITL (ms):                         46.28
P99 ITL (ms):                            47.80
==================================================


vllm bench serve --model google/gemma-3-27b-it --base-url http://localhost:8000 --dataset-name random --random-input-len 400 --random-output-len 400 --num-prompts 20
============ Serving Benchmark Result ============
Successful requests:                     20
Failed requests:                         0
Benchmark duration (s):                  20.21
Total input tokens:                      7980
Total generated tokens:                  8000
Request throughput (req/s):              0.99
Output token throughput (tok/s):         395.75
Peak output token throughput (tok/s):    460.00
Peak concurrent requests:                20.00
Total token throughput (tok/s):          790.50
---------------Time to First Token----------------
Mean TTFT (ms):                          1930.24
Median TTFT (ms):                        2020.20
P99 TTFT (ms):                           2025.40
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          45.80
Median TPOT (ms):                        45.58
P99 TPOT (ms):                           49.14
---------------Inter-token Latency----------------
Mean ITL (ms):                           45.80
Median ITL (ms):                         45.57
P99 ITL (ms):                            48.21
==================================================


vllm bench serve --model google/gemma-3-27b-it --base-url http://localhost:8000 --dataset-name random --random-input-len 50 --random-output-len 150 --num-prompts 100
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Benchmark duration (s):                  10.53
Total input tokens:                      4900
Total generated tokens:                  15000
Request throughput (req/s):              9.50
Output token throughput (tok/s):         1424.41
Peak output token throughput (tok/s):    1724.00
Peak concurrent requests:                100.00
Total token throughput (tok/s):          1889.71
---------------Time to First Token----------------
Mean TTFT (ms):                          1127.62
Median TTFT (ms):                        1269.25
P99 TTFT (ms):                           1510.86
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          62.67
Median TPOT (ms):                        61.76
P99 TPOT (ms):                           66.15
---------------Inter-token Latency----------------
Mean ITL (ms):                           62.67
Median ITL (ms):                         60.56
P99 ITL (ms):                            70.83
==================================================

```

Benchmark results for `inter_prefill_budget=2048`

```

vllm bench serve --model google/gemma-3-27b-it --base-url http://localhost:8000 --dataset-name random --random-input-len 1024 --random-output-len 350 --num-prompts 16
============ Serving Benchmark Result ============
Successful requests:                     16
Failed requests:                         0
Benchmark duration (s):                  20.87
Total input tokens:                      16368
Total generated tokens:                  5600
Request throughput (req/s):              0.77
Output token throughput (tok/s):         268.31
Peak output token throughput (tok/s):    352.00
Peak concurrent requests:                16.00
Total token throughput (tok/s):          1052.55
---------------Time to First Token----------------
Mean TTFT (ms):                          2633.55
Median TTFT (ms):                        2648.65
P99 TTFT (ms):                           4610.48
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          51.78
Median TPOT (ms):                        51.75
P99 TPOT (ms):                           57.57
---------------Inter-token Latency----------------
Mean ITL (ms):                           51.78
Median ITL (ms):                         46.55
P99 ITL (ms):                            258.31
==================================================


vllm bench serve --model google/gemma-3-27b-it --base-url http://localhost:8000 --dataset-name random --random-input-len 400 --random-output-len 400 --num-prompts 20
============ Serving Benchmark Result ============
Successful requests:                     20
Failed requests:                         0
Benchmark duration (s):                  20.50
Total input tokens:                      7980
Total generated tokens:                  8000
Request throughput (req/s):              0.98
Output token throughput (tok/s):         390.17
Peak output token throughput (tok/s):    460.00
Peak concurrent requests:                20.00
Total token throughput (tok/s):          779.37
---------------Time to First Token----------------
Mean TTFT (ms):                          1440.81
Median TTFT (ms):                        1319.98
P99 TTFT (ms):                           2219.73
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          47.59
Median TPOT (ms):                        47.87
P99 TPOT (ms):                           50.18
---------------Inter-token Latency----------------
Mean ITL (ms):                           47.59
Median ITL (ms):                         45.83
P99 ITL (ms):                            47.92
==================================================



vllm bench serve --model google/gemma-3-27b-it --base-url http://localhost:8000 --dataset-name random --random-input-len 50 --random-output-len 150 --num-prompts 100
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Benchmark duration (s):                  10.65
Total input tokens:                      4900
Total generated tokens:                  15000
Request throughput (req/s):              9.39
Output token throughput (tok/s):         1408.08
Peak output token throughput (tok/s):    1700.00
Peak concurrent requests:                100.00
Total token throughput (tok/s):          1868.05
---------------Time to First Token----------------
Mean TTFT (ms):                          1088.47
Median TTFT (ms):                        1194.68
P99 TTFT (ms):                           1519.75
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          63.71
Median TPOT (ms):                        63.04
P99 TPOT (ms):                           66.46
---------------Inter-token Latency----------------
Mean ITL (ms):                           63.71
Median ITL (ms):                         61.10
P99 ITL (ms):                            69.16
==================================================

```
</details>

