### PR TITLE
[BugFix] Set opencv-python-headless <= 4.12.0.88 for FIPS Compliance

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -32,7 +32,7 @@ pyzmq >= 25.0.0
 msgspec
 gguf >= 0.17.0
 mistral_common[image] >= 1.9.0
-opencv-python-headless >= 4.13.0    # required for video IO
+opencv-python-headless >= 4.12.0, <= 4.12.0.88 # required for video IO and FIPS compliant: https://github.com/opencv/opencv-python/issues/1191
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=77.0.3,<81.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -25,7 +25,7 @@ transformers_stream_generator # required for qwen-vl test
 matplotlib # required for qwen-vl test
 mistral_common[image,audio] >= 1.9.0 # required for voxtral test
 num2words # required for smolvlm test
-opencv-python-headless >= 4.13.0 # required for video test
+opencv-python-headless >= 4.12.0, <= 4.12.0.88 # required for video test and FIPS Compliant
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]>=0.4.9.2 # required for model evaluation test
 mteb>=1.38.11, <2 # required for mteb test

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -33,7 +33,7 @@ matplotlib # required for qwen-vl test
 mistral_common[image,audio] >= 1.9.0 # required for voxtral test
 num2words # required for smolvlm test
 open_clip_torch==2.32.0 # Required for nemotron_vl test, Nemotron Parse in test_common.py
-opencv-python-headless >= 4.13.0 # required for video test
+opencv-python-headless >= 4.12.0, <= 4.12.0.88 # required for video test and FIPS Compliant
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]>=0.4.9.2 # required for model evaluation test
 mteb[bm25s]>=2, <3 # required for mteb test

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -643,7 +643,7 @@ opencensus==0.11.4
     # via ray
 opencensus-context==0.1.3
     # via opencensus
-opencv-python-headless==4.13.0.90
+opencv-python-headless==4.12.0.88 #Latest FIPS Compliant version: https://github.com/opencv/opencv-python/issues/1191
     # via
     #   -r requirements/test.in
     #   albucore


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
VLLM >= 0.14.0 is not FIPS Compliant. This is because opencv-python-headless==4.13.0.90 is not FIPS Compliant

Issues addressed:
* [x] https://github.com/vllm-project/vllm/issues/33147#issuecomment-3821766067

opencv-python-headless also recognizes this issue: https://github.com/opencv/opencv-python/issues/1184

## Test Plan
Installed opencv-python-headless equal == 4.12.0.88 on an vllm 0.15.0 system
## Test Result
Verified the vllm instance was running on FIPS machine.

<details>
<summary>VLLM 0.15.0 Output with opencv-python-headless==4.13.0.90</summary>

```bash
crypto/fips/fips.c:154: OpenSSL internal error: FATAL FIPS SELFTEST FAILURE
Aborted (core dumped)
```
</details>

<details>
<summary>VLLM 0.15.0 Output after installing  opencv-python-headless==4.12.0.88</summary>

```bash
Using Python 3.12.12 environment at: /usr
Resolved 2 packages in 255ms
Downloading opencv-python-headless (51.5MiB)
 Downloaded opencv-python-headless
Prepared 1 package in 808ms
Uninstalled 1 package in 5ms
Installed 1 package in 38ms
 - opencv-python-headless==4.13.0.90
 + opencv-python-headless==4.12.0.88
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 18:57:45 [utils.py:325] 
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 18:57:45 [utils.py:325]        â–ˆ     â–ˆ     â–ˆâ–„   â–„â–ˆ
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 18:57:45 [utils.py:325]  â–„â–„ â–„â–ˆ â–ˆ     â–ˆ     â–ˆ â–€â–„â–€ â–ˆ  version 0.15.0
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 18:57:45 [utils.py:325]   â–ˆâ–„â–ˆâ–€ â–ˆ     â–ˆ     â–ˆ     â–ˆ  model   openai/gpt-oss-120b
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 18:57:45 [utils.py:325]    â–€â–€  â–€â–€â–€â–€â–€ â–€â–€â–€â–€â–€ â–€     â–€
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 18:57:45 [utils.py:325] 
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 18:57:45 [utils.py:261] non-default args: {'model_tag': 'openai/gpt-oss-120b', 'api_server_count': 1, 'enable_auto_tool_choice': True, 'tool_call_parser': 'openai', 'model': 'openai/gpt-oss-120b', 'async_scheduling': True}
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 18:57:50 [model.py:541] Resolved architecture: GptOssForCausalLM
^[[0;36m(APIServer pid=31)^[[0;0m 
Parse safetensors files:   0%|          | 0/15 [00:00<?, ?it/s]
Parse safetensors files:   7%|â–‹         | 1/15 [00:01<00:17,  1.28s/it]
Parse safetensors files: 100%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ| 15/15 [00:01<00:00, 11.71it/s]
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 18:57:52 [model.py:1561] Using max model len 131072
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 18:57:52 [scheduler.py:226] Chunked prefill is enabled with max_num_batched_tokens=8192.
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 18:57:52 [config.py:314] Overriding max cuda graph capture size to 1024 for performance.
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 18:57:52 [vllm.py:624] Asynchronous scheduling is enabled.
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:57:57 [core.py:96] Initializing a V1 LLM engine (v0.15.0) with config: model='openai/gpt-oss-120b', speculative_config=None, tokenizer='openai/gpt-oss-120b', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=131072, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=mxfp4, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='openai_gptoss', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=openai/gpt-oss-120b, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512, 528, 544, 560, 576, 592, 608, 624, 640, 656, 672, 688, 704, 720, 736, 752, 768, 784, 800, 816, 832, 848, 864, 880, 896, 912, 928, 944, 960, 976, 992, 1008, 1024], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 1024, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': True}, 'local_cache_dir': None}
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:57:58 [parallel_state.py:1212] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://10.130.0.253:33247 backend=nccl
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:57:58 [parallel_state.py:1423] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:57:59 [gpu_model_runner.py:4021] Starting to load model openai/gpt-oss-120b...
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:58:10 [cuda.py:364] Using FLASH_ATTN attention backend out of potential backends: ('FLASH_ATTN', 'TRITON_ATTN')
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:58:10 [mxfp4.py:164] Using Triton backend
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:   0% Completed | 0/15 [00:00<?, ?it/s]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:   7% Completed | 1/15 [00:09<02:16,  9.72s/it]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:  13% Completed | 2/15 [00:20<02:13, 10.27s/it]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:  20% Completed | 3/15 [00:24<01:30,  7.58s/it]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:  27% Completed | 4/15 [00:25<00:51,  4.70s/it]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:  33% Completed | 5/15 [00:25<00:31,  3.12s/it]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:  40% Completed | 6/15 [00:25<00:19,  2.15s/it]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:  47% Completed | 7/15 [00:25<00:12,  1.54s/it]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:  53% Completed | 8/15 [00:26<00:07,  1.14s/it]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:  60% Completed | 9/15 [00:26<00:05,  1.15it/s]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:  67% Completed | 10/15 [00:26<00:03,  1.44it/s]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:  73% Completed | 11/15 [00:27<00:02,  1.75it/s]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:  80% Completed | 12/15 [00:27<00:01,  2.08it/s]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:  87% Completed | 13/15 [00:27<00:00,  2.40it/s]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards:  93% Completed | 14/15 [00:27<00:00,  2.63it/s]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards: 100% Completed | 15/15 [00:28<00:00,  2.76it/s]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Loading safetensors checkpoint shards: 100% Completed | 15/15 [00:28<00:00,  1.88s/it]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:58:39 [default_loader.py:291] Loading weights took 28.29 seconds
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:58:42 [gpu_model_runner.py:4118] Model loading took 64.38 GiB memory and 43.062880 seconds
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:58:45 [backends.py:805] Using cache directory: /root/.cache/vllm/torch_compile_cache/9051cdbf81/rank_0_0/backbone for vLLM's torch.compile
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:58:45 [backends.py:865] Dynamo bytecode transform time: 2.77 s
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:58:50 [backends.py:302] Cache the graph of compile range (1, 8192) for later use
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:59:17 [backends.py:319] Compiling a graph for compile range (1, 8192) takes 29.37 s
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:59:17 [monitor.py:34] torch.compile takes 32.14 s in total
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:59:18 [gpu_worker.py:356] Available KV cache memory: 53.94 GiB
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:59:18 [kv_cache_utils.py:1307] GPU KV cache size: 785,600 tokens
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 18:59:18 [kv_cache_utils.py:1312] Maximum concurrency for 131,072 tokens per request: 11.27x
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 2026-02-03 18:59:18,635 - INFO - autotuner.py:256 - flashinfer.jit: [Autotuner]: Autotuning process starts ...
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 2026-02-03 18:59:18,673 - INFO - autotuner.py:262 - flashinfer.jit: [Autotuner]: Autotuning process ends
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   0%|          | 0/83 [00:00<?, ?it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   1%|          | 1/83 [00:01<01:43,  1.27s/it]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   4%|â–Ž         | 3/83 [00:02<00:51,  1.56it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   6%|â–Œ         | 5/83 [00:02<00:39,  2.00it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   8%|â–Š         | 7/83 [00:04<00:43,  1.75it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  11%|â–ˆ         | 9/83 [00:05<00:42,  1.72it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  13%|â–ˆâ–Ž        | 11/83 [00:06<00:36,  1.97it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  16%|â–ˆâ–Œ        | 13/83 [00:06<00:32,  2.16it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  18%|â–ˆâ–Š        | 15/83 [00:07<00:29,  2.31it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  20%|â–ˆâ–ˆ        | 17/83 [00:08<00:27,  2.42it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  23%|â–ˆâ–ˆâ–Ž       | 19/83 [00:09<00:25,  2.51it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  25%|â–ˆâ–ˆâ–Œ       | 21/83 [00:09<00:24,  2.58it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  28%|â–ˆâ–ˆâ–Š       | 23/83 [00:10<00:22,  2.63it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  30%|â–ˆâ–ˆâ–ˆ       | 25/83 [00:11<00:21,  2.66it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  33%|â–ˆâ–ˆâ–ˆâ–Ž      | 27/83 [00:11<00:20,  2.69it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  35%|â–ˆâ–ˆâ–ˆâ–^M      | 29/83 [00:12<00:19,  2.70it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  37%|â–ˆâ–ˆâ–ˆâ–‹      | 31/83 [00:13<00:19,  2.72it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  39%|â–ˆâ–ˆâ–ˆâ–Š      | 32/83 [00:14<00:21,  2.43it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  40%|â–ˆâ–ˆâ–ˆâ–‰      | 33/83 [00:14<00:23,  2.16it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  42%|â–ˆâ–ˆâ–ˆâ–ˆâ–^O     | 35/83 [00:15<00:25,  1.90it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  45%|â–ˆâ–ˆâ–ˆâ–ˆâ–^M     | 37/83 [00:16<00:21,  2.12it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  47%|â–ˆâ–ˆâ–ˆâ–ˆâ–‹     | 39/83 [00:17<00:19,  2.30it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  49%|â–ˆâ–ˆâ–ˆâ–ˆâ–‰     | 41/83 [00:18<00:17,  2.42it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  52%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^O    | 43/83 [00:18<00:16,  2.49it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  54%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^M    | 45/83 [00:19<00:14,  2.57it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  57%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‹    | 47/83 [00:20<00:13,  2.62it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  59%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‰    | 49/83 [00:21<00:12,  2.65it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  60%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ    | 50/83 [00:22<00:17,  1.87it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  63%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Ž   | 52/83 [00:22<00:11,  2.68it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  64%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^M   | 53/83 [00:23<00:12,  2.32it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  65%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Œ   | 54/83 [00:23<00:14,  1.95it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  67%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‹   | 56/83 [00:24<00:09,  2.95it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  69%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Š   | 57/83 [00:24<00:10,  2.44it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  70%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‰   | 58/83 [00:25<00:12,  2.05it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  72%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^O  | 60/83 [00:25<00:07,  3.14it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  73%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Ž  | 61/83 [00:26<00:08,  2.51it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  75%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^M  | 62/83 [00:26<00:09,  2.16it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  77%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‹  | 64/83 [00:27<00:05,  3.34it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  78%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Š  | 65/83 [00:27<00:06,  2.60it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  80%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‰  | 66/83 [00:28<00:07,  2.20it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  82%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^O | 68/83 [00:28<00:04,  3.39it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  83%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Ž | 69/83 [00:29<00:05,  2.61it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  84%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^M | 70/83 [00:29<00:05,  2.22it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  87%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‹ | 72/83 [00:30<00:03,  3.43it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  88%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Š | 73/83 [00:30<00:03,  2.65it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  89%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‰ | 74/83 [00:31<00:04,  2.23it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  92%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^O| 76/83 [00:31<00:02,  3.46it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  93%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Ž| 77/83 [00:32<00:02,  2.34it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  94%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^M| 78/83 [00:33<00:02,  1.81it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  96%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‹| 80/83 [00:33<00:01,  2.83it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  99%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‰| 82/83 [00:33<00:00,  3.38it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ| 83/83 [00:35<00:00,  1.60it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ| 83/83 [00:35<00:00,  2.32it/s]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m 
Capturing CUDA graphs (decode, FULL):   0%|          | 0/83 [00:00<?, ?it/s]
Capturing CUDA graphs (decode, FULL):   1%|          | 1/83 [00:00<00:13,  6.21it/s]
Capturing CUDA graphs (decode, FULL):   2%|â–^O         | 2/83 [00:00<00:12,  6.33it/s]
Capturing CUDA graphs (decode, FULL):   5%|â–^M         | 4/83 [00:00<00:08,  9.44it/s]
Capturing CUDA graphs (decode, FULL):   7%|â–‹         | 6/83 [00:00<00:06, 11.09it/s]
Capturing CUDA graphs (decode, FULL):  10%|â–‰         | 8/83 [00:00<00:06, 12.05it/s]
Capturing CUDA graphs (decode, FULL):  12%|â–ˆâ–^O        | 10/83 [00:00<00:05, 12.74it/s]
Capturing CUDA graphs (decode, FULL):  14%|â–ˆâ–^M        | 12/83 [00:01<00:05, 13.33it/s]
Capturing CUDA graphs (decode, FULL):  17%|â–ˆâ–‹        | 14/83 [00:01<00:05, 13.73it/s]
Capturing CUDA graphs (decode, FULL):  19%|â–ˆâ–‰        | 16/83 [00:01<00:04, 14.11it/s]
Capturing CUDA graphs (decode, FULL):  22%|â–ˆâ–ˆâ–^O       | 18/83 [00:01<00:04, 14.51it/s]
Capturing CUDA graphs (decode, FULL):  24%|â–ˆâ–ˆâ–^M       | 20/83 [00:01<00:04, 14.84it/s]
Capturing CUDA graphs (decode, FULL):  27%|â–ˆâ–ˆâ–‹       | 22/83 [00:01<00:04, 15.21it/s]
Capturing CUDA graphs (decode, FULL):  29%|â–ˆâ–ˆâ–‰       | 24/83 [00:01<00:03, 15.57it/s]
Capturing CUDA graphs (decode, FULL):  31%|â–ˆâ–ˆâ–ˆâ–^O      | 26/83 [00:01<00:03, 15.94it/s]
Capturing CUDA graphs (decode, FULL):  34%|â–ˆâ–ˆâ–ˆâ–Ž      | 28/83 [00:02<00:03, 16.20it/s]
Capturing CUDA graphs (decode, FULL):  36%|â–ˆâ–ˆâ–ˆâ–Œ      | 30/83 [00:02<00:03, 16.51it/s]
Capturing CUDA graphs (decode, FULL):  39%|â–ˆâ–ˆâ–ˆâ–Š      | 32/83 [00:02<00:03, 16.55it/s]
Capturing CUDA graphs (decode, FULL):  41%|â–ˆâ–ˆâ–ˆâ–ˆ      | 34/83 [00:02<00:02, 16.37it/s]
Capturing CUDA graphs (decode, FULL):  43%|â–ˆâ–ˆâ–ˆâ–ˆâ–Ž     | 36/83 [00:02<00:02, 16.34it/s]
Capturing CUDA graphs (decode, FULL):  46%|â–ˆâ–ˆâ–ˆâ–ˆâ–Œ     | 38/83 [00:02<00:02, 16.50it/s]
Capturing CUDA graphs (decode, FULL):  48%|â–ˆâ–ˆâ–ˆâ–ˆâ–Š     | 40/83 [00:02<00:02, 16.71it/s]
Capturing CUDA graphs (decode, FULL):  51%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆ     | 42/83 [00:02<00:02, 17.13it/s]
Capturing CUDA graphs (decode, FULL):  53%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Ž    | 44/83 [00:02<00:02, 17.41it/s]
Capturing CUDA graphs (decode, FULL):  55%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Œ    | 46/83 [00:03<00:02, 17.70it/s]
Capturing CUDA graphs (decode, FULL):  58%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Š    | 48/83 [00:03<00:01, 17.98it/s]
Capturing CUDA graphs (decode, FULL):  60%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ    | 50/83 [00:03<00:01, 18.13it/s]
Capturing CUDA graphs (decode, FULL):  63%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Ž   | 52/83 [00:03<00:01, 18.25it/s]
Capturing CUDA graphs (decode, FULL):  65%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–Œ   | 54/83 [00:03<00:01, 18.31it/s]
Capturing CUDA graphs (decode, FULL):  67%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‹   | 56/83 [00:03<00:01, 18.33it/s]
Capturing CUDA graphs (decode, FULL):  70%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‰   | 58/83 [00:03<00:01, 18.26it/s]
Capturing CUDA graphs (decode, FULL):  72%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^O  | 60/83 [00:03<00:01, 18.25it/s]
Capturing CUDA graphs (decode, FULL):  75%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^M  | 62/83 [00:03<00:01, 18.22it/s]
Capturing CUDA graphs (decode, FULL):  77%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‹  | 64/83 [00:04<00:01, 18.24it/s]
Capturing CUDA graphs (decode, FULL):  80%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‰  | 66/83 [00:04<00:00, 18.23it/s]
Capturing CUDA graphs (decode, FULL):  82%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^O | 68/83 [00:04<00:00, 18.10it/s]
Capturing CUDA graphs (decode, FULL):  84%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^M | 70/83 [00:04<00:00, 18.13it/s]
Capturing CUDA graphs (decode, FULL):  87%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‹ | 72/83 [00:04<00:00, 18.20it/s]
Capturing CUDA graphs (decode, FULL):  89%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‰ | 74/83 [00:04<00:00, 18.23it/s]
Capturing CUDA graphs (decode, FULL):  92%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^O| 76/83 [00:04<00:00, 17.94it/s]
Capturing CUDA graphs (decode, FULL):  94%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–^M| 78/83 [00:04<00:00, 18.12it/s]
Capturing CUDA graphs (decode, FULL):  96%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‹| 80/83 [00:04<00:00, 18.28it/s]
Capturing CUDA graphs (decode, FULL):  99%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‰| 82/83 [00:05<00:00, 18.37it/s]
Capturing CUDA graphs (decode, FULL): 100%|â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆ| 83/83 [00:05<00:00, 16.23it/s]
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 19:00:00 [gpu_model_runner.py:5051] Graph capturing finished in 42 secs, took 1.97 GiB
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 19:00:00 [core.py:272] init engine (profile, create kv cache, warmup model) took 77.53 seconds
^[[0;36m(EngineCore_DP0 pid=185)^[[0;0m INFO 02-03 19:00:02 [vllm.py:624] Asynchronous scheduling is enabled.
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:02 [api_server.py:665] Supported tasks: ['generate']
^[[0;36m(APIServer pid=31)^[[0;0m WARNING 02-03 19:00:02 [serving.py:242] For gpt-oss, we ignore --enable-auto-tool-choice and always enable tool use.
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:03 [serving.py:273] "auto" tool choice has been enabled.
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:03 [serving.py:273] "auto" tool choice has been enabled.
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:04 [serving.py:177] Warming up chat template processing...
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [hf.py:310] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [serving.py:212] Chat template warmup completed in 1456.3ms
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [serving.py:273] "auto" tool choice has been enabled.
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [api_server.py:946] Starting vLLM API server 0 on http://0.0.0.0:8000
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:38] Available routes are:
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /openapi.json, Methods: HEAD, GET
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /docs, Methods: HEAD, GET
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: HEAD, GET
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /redoc, Methods: HEAD, GET
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /tokenize, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /detokenize, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /pause, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /resume, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /is_paused, Methods: GET
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /metrics, Methods: GET
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /health, Methods: GET
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/responses, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/audio/transcriptions, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/audio/translations, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/completions, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/completions/render, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/messages, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/models, Methods: GET
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /load, Methods: GET
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /version, Methods: GET
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /ping, Methods: GET
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /ping, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /invocations, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /classify, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/embeddings, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /score, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/score, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /rerank, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v1/rerank, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /v2/rerank, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:00:05 [launcher.py:46] Route: /pooling, Methods: POST
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     Started server process [31]
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     Waiting for application startup.
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     Application startup complete.
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.0.2:59396 - "GET /health HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.0.2:59400 - "GET /health HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.0.2:43368 - "GET /health HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.0.2:43384 - "GET /health HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.0.2:33962 - "GET /health HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.0.2:33970 - "GET /health HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.0.2:57654 - "GET /health HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.0.2:57652 - "GET /health HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.0.2:46940 - "GET /health HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.0.2:46928 - "GET /health HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.0.2:56778 - "GET /health HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.0.2:56764 - "GET /health HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.3.123:46216 - "POST /v1/chat/completions HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.3.123:46232 - "GET /v1/models HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:04:46 [loggers.py:257] Engine 000: Avg prompt throughput: 104.0 tokens/s, Avg generation throughput: 19.9 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
^[[0;36m(APIServer pid=31)^[[0;0m INFO:     10.130.3.123:46248 - "POST /v1/chat/completions HTTP/1.1" 200 OK
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:04:56 [loggers.py:257] Engine 000: Avg prompt throughput: 91.5 tokens/s, Avg generation throughput: 31.3 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 18.0%
^[[0;36m(APIServer pid=31)^[[0;0m INFO 02-03 19:05:06 [loggers.py:257] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 18.0%
```
</details> 


---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

