### PR TITLE
[Deprecation] Remove `_get_data_parser` in MM processor

### DIFF
--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -991,8 +991,8 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         if hasattr(self, "_get_data_parser"):
             raise ValueError(
                 "BaseMultiModalProcessor._get_data_parser has been "
-                "moved to `info.build_data_parser in v0.16. "
-                "You should override `info.build_data_parser` instead."
+                "moved to `BaseProcessingInfo.build_data_parser` in v0.16. "
+                "You should override `BaseProcessingInfo.build_data_parser` instead."
             )
 
         self.data_parser = self.info.get_data_parser()

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -988,6 +988,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         self.dummy_inputs = dummy_inputs
         self.cache = cache
 
+        # TODO: Remove in v0.18
         if hasattr(self, "_get_data_parser"):
             raise ValueError(
                 "BaseMultiModalProcessor._get_data_parser has been "

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -989,15 +989,13 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         self.cache = cache
 
         if hasattr(self, "_get_data_parser"):
-            logger.warning_once(
-                "BaseMultiModalProcessor._get_data_parser is deprecated "
-                "and will be removed in v0.16."
+            raise ValueError(
+                "BaseMultiModalProcessor._get_data_parser has been "
+                "moved to `info.build_data_parser in v0.16. "
                 "You should override `info.build_data_parser` instead."
             )
 
-            self.data_parser = self._get_data_parser()  # type: ignore
-        else:
-            self.data_parser = self.info.get_data_parser()
+        self.data_parser = self.info.get_data_parser()
 
     @property
     @deprecated("Will be removed in v0.17. Use `info.supported_mm_limits` instead.")


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The dev-facing back-compatibility code of https://github.com/vllm-project/vllm/pull/33396 no longer works because https://github.com/vllm-project/vllm/pull/33408 now parses the MM data without using the processor at all. So it's better to just raise an explicit error message.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

