### PR TITLE
fix(rocm): Use correct kv_cache_layout for sliding window with shuffle KV cache

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -794,7 +794,9 @@ class AiterFlashAttentionImpl(AttentionImpl):
             token_to_batch=swa_token_to_batch,
             seq_starts=swa_seq_starts,
             dequant=self.kv_cache_dtype.startswith("fp8"),
-            kv_cache_layout="NHD",
+            kv_cache_layout="SHUFFLE"
+                if rocm_aiter_ops.is_shuffle_kv_cache_enabled()
+                else "NHD",
             total_tokens=swa_total_tokens,
         )
 

--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -755,6 +755,11 @@ class AiterFlashAttentionImpl(AttentionImpl):
                 "Encoder self-attention is not implemented for FlashAttentionImpl"
             )
 
+    @property
+    def _kv_cache_layout_str(self) -> str:
+        """Get the KV cache layout string based on shuffle setting."""
+        return "SHUFFLE" if rocm_aiter_ops.is_shuffle_kv_cache_enabled() else "NHD"
+
     def extend_for_sliding_window(
         self,
         attn_metadata: AiterFlashAttentionMetadata,
@@ -794,9 +799,7 @@ class AiterFlashAttentionImpl(AttentionImpl):
             token_to_batch=swa_token_to_batch,
             seq_starts=swa_seq_starts,
             dequant=self.kv_cache_dtype.startswith("fp8"),
-            kv_cache_layout="SHUFFLE"
-                if rocm_aiter_ops.is_shuffle_kv_cache_enabled()
-                else "NHD",
+            kv_cache_layout=self._kv_cache_layout_str,
             total_tokens=swa_total_tokens,
         )
 
@@ -891,9 +894,7 @@ class AiterFlashAttentionImpl(AttentionImpl):
                 token_to_batch=token_to_batch[chunk_idx],
                 seq_starts=chunk_starts[chunk_idx],
                 dequant=self.kv_cache_dtype.startswith("fp8"),
-                kv_cache_layout="SHUFFLE"
-                if rocm_aiter_ops.is_shuffle_kv_cache_enabled()
-                else "NHD",
+                kv_cache_layout=self._kv_cache_layout_str,
                 total_tokens=total_token_per_batch[chunk_idx],
             )
 


### PR DESCRIPTION
## Summary

Fixes #33123

The `extend_for_sliding_window` method in the ROCm AITER Flash Attention backend was using a hardcoded `kv_cache_layout="NHD"` while the actual storage path uses SHUFFLE layout when `rocm_aiter_ops.is_shuffle_kv_cache_enabled()` returns True.

## Root Cause

When KV cache is stored with shuffle layout enabled (line 1010-1018), it uses the memory pattern:
- K: `[num_blocks, num_heads, head_dim // x, page_size, x]`
- V: `[num_blocks, num_heads, page_size // x, head_dim, x]`

But `extend_for_sliding_window` (line 797) was telling `cp_mha_gather_cache` to read using NHD layout:
- K: `[num_blocks, page_size, num_heads, head_dim]`
- V: `[num_blocks, page_size, num_heads, head_dim]`

This layout mismatch causes the triton kernel to compute incorrect memory offsets, reading garbage data and producing non-deterministic attention output.

## Fix

Changed line 797 to use the same conditional pattern already present at line 892 in `extend_forward`:

```python
kv_cache_layout="SHUFFLE"
    if rocm_aiter_ops.is_shuffle_kv_cache_enabled()
    else "NHD",
```

## Testing

This is a minimal 3-line fix copying an existing pattern from the same file. The fix ensures the read path matches the write path layout selection logic.

- [ ] CI should test on ROCm hardware with prefix caching + sliding window enabled
- [ ] Reproducer from issue #33123 should produce deterministic output

Signed-off-by: Tim Payne <timpayne@ripersigma.com>