### PR TITLE
fix(rocm): use correct kv_cache_layout in extend_for_sliding_window

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -755,6 +755,11 @@ class AiterFlashAttentionImpl(AttentionImpl):
                 "Encoder self-attention is not implemented for FlashAttentionImpl"
             )
 
+    @property
+    def _kv_cache_layout_str(self) -> str:
+        """Get the KV cache layout string based on shuffle setting."""
+        return "SHUFFLE" if rocm_aiter_ops.is_shuffle_kv_cache_enabled() else "NHD"
+
     def extend_for_sliding_window(
         self,
         attn_metadata: AiterFlashAttentionMetadata,
@@ -794,7 +799,7 @@ class AiterFlashAttentionImpl(AttentionImpl):
             token_to_batch=swa_token_to_batch,
             seq_starts=swa_seq_starts,
             dequant=self.kv_cache_dtype.startswith("fp8"),
-            kv_cache_layout="NHD",
+            kv_cache_layout=self._kv_cache_layout_str,
             total_tokens=swa_total_tokens,
         )
 
@@ -889,9 +894,7 @@ class AiterFlashAttentionImpl(AttentionImpl):
                 token_to_batch=token_to_batch[chunk_idx],
                 seq_starts=chunk_starts[chunk_idx],
                 dequant=self.kv_cache_dtype.startswith("fp8"),
-                kv_cache_layout="SHUFFLE"
-                if rocm_aiter_ops.is_shuffle_kv_cache_enabled()
-                else "NHD",
+                kv_cache_layout=self._kv_cache_layout_str,
                 total_tokens=total_token_per_batch[chunk_idx],
             )
 


### PR DESCRIPTION
## Summary

Fixes #33123 - Non-deterministic prefix caching output on ROCm with AITER backend.

## Root Cause

When shuffle KV cache is enabled via `rocm_aiter_ops.is_shuffle_kv_cache_enabled()`, the `cp_mha_gather_cache` triton kernel must use `"SHUFFLE"` layout. However, `extend_for_sliding_window()` was hardcoded to use `"NHD"`, causing a layout mismatch when reading cached KV pairs.

This mismatch caused the triton kernel to read memory with incorrect indexing, producing garbage values that varied based on memory state - explaining the observed non-determinism.

## Changes

1. **Bug fix**: Use `self._kv_cache_layout_str` property instead of hardcoded `"NHD"` in both `extend_for_sliding_window()` and `extend_forward()` 

2. **Refactor**: Consolidated duplicated conditional logic into a `_kv_cache_layout_str` property to prevent similar bugs

```python
@property
def _kv_cache_layout_str(self) -> str:
    """Get the KV cache layout string based on shuffle setting."""
    return "SHUFFLE" if rocm_aiter_ops.is_shuffle_kv_cache_enabled() else "NHD"
```

## Testing

- Syntax validation passed
- Requires ROCm hardware testing (vLLM CI has ROCm runners)

## Related

- Supersedes #33759 (DCO issues with that PR)