### PR TITLE
Fix empty content when max_tokens truncates reasoning end token

### DIFF
--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -169,7 +169,10 @@ class BaseThinkingReasoningParser(ReasoningParser):
         # For models that may not generate start token,
         # assume the reasoning content is always at the start.
         if self.end_token not in model_output:
-            return model_output, None
+            # If end token not found, treat output as content since reasoning
+            # was not properly closed (likely truncated by max_tokens).
+            # This ensures users see output even when generation is cut off.
+            return None, model_output
         else:
             reasoning, _, content = model_output.partition(self.end_token)
             # If generation stops right after end-of-think, return null content


### PR DESCRIPTION
When max_tokens is too small (e.g., < 330 for Kimi-K2.5), the end token may be cut off during generation. Previously, this caused the parser to treat all output as reasoning and return None for content, resulting in empty responses.

This fix changes the behavior when the end token is missing: instead of treating truncated output as reasoning, it now returns None for reasoning and the output as content. This ensures users see the generated text even when generation is cut off by max_tokens.

Changes:
- basic_parsers.py: Return (None, model_output) when end token is missing instead of (model_output, None)
- test_base_thinking_reasoning_parser.py: Update tests to match new behavior for truncated output cases

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

