### PR TITLE
feat: Use an executor to parallelize load of deepseek v2 based models (kimi, etc)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1174,10 +1174,7 @@ class FusedMoE(CustomOp):
             "CompressedTensorsWNA16MarlinMoEMethod",
             "CompressedTensorsWNA16MoEMethod",
         ):
-            if is_transposed:
-                loaded_weight = loaded_weight.t().contiguous()
-            else:
-                loaded_weight = loaded_weight
+            loaded_weight = loaded_weight.t() if is_transposed else loaded_weight
 
         if shard_id not in ("w1", "w2", "w3"):
             raise ValueError(f"shard_id must be ['w1','w2','w3'] but got {shard_id}.")


### PR DESCRIPTION
## Purpose

Loading the large deepseek models and derivatives is very slow. By parallelizing the model load, the CPU and I/O can be properly saturated.

Also removes an expensive call to contiguous that was unnecessary as the transfer to device handles this automatically and faster.

Improves load time by ~5x on tested systems.

Hide whitespace while reviewing the diff. The size of this change is misleading otherwise.

## Test Plan

Test Kimi 2.5 and Deepseek v2.

## Test Result

Models load much faster, generation is still correct.


```
Loading Kimi K2.5
Pre-patch: 600s
+executor fix: 180s
+executor+contiguous fix: 90s
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

