### PR TITLE
[KVConnector] Fix data race when we have both local and external cache hit

### DIFF
--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -341,6 +341,10 @@ class KVCacheManager:
             new_computed_block_list is not self.empty_kv_cache_blocks.blocks
             or num_external_computed_tokens > 0
         ):
+            # Touch the new computed blocks before allocating blocks for external
+            # computed tokens to avoid them being evicted.
+            for new_computed_blocks_one_group in new_computed_block_list:
+                self.block_pool.touch(new_computed_blocks_one_group)
             # Append the new computed blocks to the request blocks until now to
             # avoid the case where the new blocks cannot be allocated.
             self.coordinator.allocate_new_computed_blocks(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

We should do this:

```
for all groups:
    touch(new_computed_blocks_one_group)

for all groups:
    allocate_blocks_for_external_tokens()
```

so that the blocks allocated for external tokens don't contain those in computed blocks

But current main do this:
```
for all groups:
    touch(new_computed_blocks_one_group)
    allocate_blocks_for_external_tokens()
```
so `allocate_blocks_for_external_tokens` of group i may use `new_computed_blocks_one_group` of another group j > i

## Test Plan
A new test `test_cache_hit_local_and_external`
## Test Result
can pass the test

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

