### PR TITLE
[Bugfix] Fix swapped engine_ids in NIXL Llama 4 local attention path

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -2279,15 +2279,15 @@ class NixlConnectorWorker:
 
                 # Get descs ids for the layer.
                 layer_local_desc_ids = self._get_block_descs_ids(
-                    dst_engine_id,
+                    self.engine_id,
                     layer_local_block_ids,
                     layer_idx,
+                    block_size_ratio=block_size_ratio,
                 )
                 layer_remote_desc_ids = self._get_block_descs_ids(
-                    self.engine_id,
+                    dst_engine_id,
                     layer_remote_block_ids,
                     layer_idx,
-                    block_size_ratio=block_size_ratio,
                 )
 
                 local_descs_list.append(layer_local_desc_ids)


### PR DESCRIPTION
The Llama 4 local attention optimization code path in `_read_blocks` had the engine_ids swapped when calling `_get_block_descs_ids`:
- `layer_local_desc_ids` was incorrectly using `dst_engine_id`
- `layer_remote_desc_ids` was incorrectly using `self.engine_id`

This caused the wrong `num_blocks` to be used when computing descriptor IDs, resulting in "remote index out of range" errors during NIXL KV cache transfers with heterogeneous tensor parallelism (e.g., prefill TP=2, decode TP=4).

The fix swaps the engine_ids to match the correct pattern used in the default (global attention) code path:
- Local descriptors use `self.engine_id` (local engine's num_blocks)
- Remote descriptors use `dst_engine_id` (remote engine's num_blocks)
