### PR TITLE
[Bugfix] Support `RotaryEmbedding` CustomOp for gpt-oss

### DIFF
--- a/tests/compile/test_rotary_embedding_compile.py
+++ b/tests/compile/test_rotary_embedding_compile.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+import vllm.envs as envs
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import (
+    CompilationConfig,
+    ModelConfig,
+    VllmConfig,
+    set_current_vllm_config,
+)
+from vllm.config.compilation import CompilationMode, CUDAGraphMode
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.platforms import current_platform
+
+
+@support_torch_compile
+class RotaryEmbeddingCompileModule(torch.nn.Module):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        self.rotary_emb = get_rope(
+            head_size=32,
+            max_position=128,
+            dtype=torch.float32,
+            rope_parameters={"rope_type": "default", "rope_theta": 10000},
+            is_neox_style=True,
+        )
+
+    def forward(
+        self, positions: torch.Tensor, query: torch.Tensor, key: torch.Tensor
+    ) -> torch.Tensor:
+        q_rot, k_rot = self.rotary_emb(positions, query, key)
+        return q_rot + k_rot
+
+
+@pytest.mark.skipif(current_platform.is_cpu(), reason="Requires GPU for torch.compile")
+def test_rotary_embedding_torch_compile_with_custom_op(monkeypatch):
+    # Ensure env toggles take effect for this test only.
+    # The bytecode hook is required to detect buffer mutation in compiled code,
+    # and AOT compile bypasses that hook entirely.
+    envs.disable_envs_cache()
+    monkeypatch.setenv("VLLM_USE_BYTECODE_HOOK", "1")
+    monkeypatch.setenv("VLLM_USE_AOT_COMPILE", "0")
+
+    device = "cuda"
+    positions = torch.arange(16, device=device)
+    query = torch.randn(16, 32, device=device, dtype=torch.bfloat16)
+    key = torch.randn(16, 32, device=device, dtype=torch.bfloat16)
+
+    vllm_config = VllmConfig(
+        model_config=ModelConfig(dtype=torch.bfloat16),
+        compilation_config=CompilationConfig(
+            mode=CompilationMode.VLLM_COMPILE,
+            backend="inductor",
+            custom_ops=["+rotary_embedding"],
+            cudagraph_mode=CUDAGraphMode.NONE,
+            cudagraph_num_of_warmups=0,
+        ),
+    )
+
+    with set_current_vllm_config(vllm_config):
+        model = RotaryEmbeddingCompileModule(vllm_config=vllm_config)
+        model(positions, query, key)
+        assert model._compiled_bytecode is not None
+        assert "update" not in model._compiled_bytecode.co_names

--- a/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
+++ b/vllm/model_executor/layers/rotary_embedding/deepseek_scaling_rope.py
@@ -120,14 +120,14 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbeddingBase):
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """PyTorch-native implementation equivalent to forward()."""
         assert key is not None
-        self._match_cos_sin_cache_dtype(query)
+        cos_sin_cache = self._match_cos_sin_cache_dtype(query)
         query_rot = query[..., : self.rotary_dim]
         key_rot = key[..., : self.rotary_dim]
         if self.rotary_dim < self.head_size:
             query_pass = query[..., self.rotary_dim :]
             key_pass = key[..., self.rotary_dim :]
 
-        cos_sin = self.cos_sin_cache[
+        cos_sin = cos_sin_cache[
             torch.add(positions, offsets) if offsets is not None else positions
         ]
         cos, sin = cos_sin.chunk(2, dim=-1)

--- a/vllm/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/mrope.py
@@ -277,9 +277,9 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
         assert positions.ndim == 1 or positions.ndim == 2
         assert key is not None
 
-        self._match_cos_sin_cache_dtype(query)
+        cos_sin_cache = self._match_cos_sin_cache_dtype(query)
         num_tokens = positions.shape[-1]
-        cos_sin = self.cos_sin_cache[positions]
+        cos_sin = cos_sin_cache[positions]
         cos, sin = cos_sin.chunk(2, dim=-1)
         if positions.ndim == 2:
             assert self.mrope_section
@@ -329,9 +329,9 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
         assert positions.ndim == 1 or positions.ndim == 2
         assert key is not None
 
-        self._match_cos_sin_cache_dtype(query)
+        cos_sin_cache = self._match_cos_sin_cache_dtype(query)
         num_tokens = positions.shape[-1]
-        cos_sin = self.cos_sin_cache[positions]
+        cos_sin = cos_sin_cache[positions]
         cos, sin = cos_sin.chunk(2, dim=-1)
         query_shape = query.shape
         key_shape = key.shape


### PR DESCRIPTION

Fixes #33663.

## Purpose

Prevent RoPE’s `cos_sin_cache` buffer from being mutated during `torch.compile` with cudagraphs, which caused gpt-oss with `+rotary_embedding` to fail at startup. The fix keeps the cache immutable during compilation and uses a casted view instead, and adds a regression test that inspects compiled bytecode to ensure no buffer mutation occurs.

## Test Plan

1. Run `vllm serve openai/gpt-oss-120b --compilation-config '{"custom_ops": ["+rotary_embedding"]}'`
2. Run `pytest tests/compile/test_rotary_embedding_compile.py`

## Test Result

On this branch: API server starts correctly (see logs below). `pytest tests/compile/test_rotary_embedding_compile.py` passes.
```
(EngineCore_DP0 pid=162223) INFO 02-04 15:58:35 [default_loader.py:291] Loading weights took 27.59 seconds
(EngineCore_DP0 pid=162223) INFO 02-04 15:58:35 [gpu_model_runner.py:4216] Model loading took 67.7 GiB memory and 28.156410 seconds
(EngineCore_DP0 pid=162223) INFO 02-04 15:58:36 [decorators.py:459] Directly load AOT compilation from path /root/.cache/vllm/torch_aot_compile/3b875bbfde309685542af3efc3db71833eeb0edb2b302f0257ce8d71a549c3b5/rank_0_0/model
(EngineCore_DP0 pid=162223) INFO 02-04 15:58:36 [backends.py:882] Using cache directory: /root/.cache/vllm/torch_compile_cache/6d4f9827d4/rank_0_0/backbone for vLLM's torch.compile
(EngineCore_DP0 pid=162223) INFO 02-04 15:58:36 [backends.py:942] Dynamo bytecode transform time: 1.36 s
(EngineCore_DP0 pid=162223) INFO 02-04 15:58:37 [backends.py:322] Cache the graph of compile range (1, 8192) for later use
(EngineCore_DP0 pid=162223) INFO 02-04 15:58:41 [backends.py:339] Compiling a graph for compile range (1, 8192) takes 3.64 s
(EngineCore_DP0 pid=162223) INFO 02-04 15:58:41 [monitor.py:34] torch.compile takes 5.00 s in total
(EngineCore_DP0 pid=162223) INFO 02-04 15:58:41 [gpu_worker.py:359] Available KV cache memory: 96.82 GiB
(EngineCore_DP0 pid=162223) INFO 02-04 15:58:41 [kv_cache_utils.py:1307] GPU KV cache size: 1,410,096 tokens
(EngineCore_DP0 pid=162223) INFO 02-04 15:58:41 [kv_cache_utils.py:1312] Maximum concurrency for 131,072 tokens per request: 20.23x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|████████████████████████████████████| 83/83 [00:10<00:00,  7.93it/s]
Capturing CUDA graphs (decode, FULL): 100%|███████████████████████████████████████████████████████| 83/83 [00:10<00:00,  7.98it/s]
(EngineCore_DP0 pid=162223) INFO 02-04 15:59:03 [gpu_model_runner.py:5230] Graph capturing finished in 21 secs, took 0.75 GiB
(EngineCore_DP0 pid=162223) INFO 02-04 15:59:03 [core.py:272] init engine (profile, create kv cache, warmup model) took 27.92 seconds
(EngineCore_DP0 pid=162223) INFO 02-04 15:59:04 [vllm.py:666] Asynchronous scheduling is enabled.
(APIServer pid=162115) INFO 02-04 15:59:04 [api_server.py:455] Supported tasks: ['generate']
(APIServer pid=162115) WARNING 02-04 15:59:04 [serving.py:249] For gpt-oss, we ignore --enable-auto-tool-choice and always enable tool use.
(APIServer pid=162115) INFO 02-04 15:59:05 [serving.py:186] Warming up chat template processing...
(APIServer pid=162115) INFO 02-04 15:59:06 [hf.py:317] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=162115) INFO 02-04 15:59:06 [serving.py:211] Chat template warmup completed in 956.8ms
(APIServer pid=162115) INFO 02-04 15:59:06 [api_server.py:460] Starting vLLM API server 0 on http://0.0.0.0:8000
(APIServer pid=162115) INFO 02-04 15:59:06 [launcher.py:38] Available routes are:
(APIServer pid=162115) INFO 02-04 15:59:06 [launcher.py:47] Route: /openapi.json, Methods: GET, HEAD
...
```

On main: `pytest tests/compile/test_rotary_embedding_compile.py` fails because compiled bytecode includes `update`.

```
        with set_current_vllm_config(vllm_config):
            model = RotaryEmbeddingCompileModule(vllm_config=vllm_config)
            model(positions, query, key)
            assert model._compiled_bytecode is not None
>           assert "update" not in model._compiled_bytecode.co_names
E           assert 'update' not in ('rotary_emb', '__import_torch_dot_nn_dot_modules_dot_module', '__import_vllm', '__import_inspect', '__import_torch_dot__dynamo_dot_polyfills', '__import_torch_dot__dynamo_dot_polyfills_dot_builtins', ...)
E            +  where ('rotary_emb', '__import_torch_dot_nn_dot_modules_dot_module', '__import_vllm', '__import_inspect', '__import_torch_dot__dynamo_dot_polyfills', '__import_torch_dot__dynamo_dot_polyfills_dot_builtins', ...) = <code object forward at 0x30520340, file "/root/vllm/tests/compile/test_rotary_embedding_compile.py", line 26>.co_names
E            +    where <code object forward at 0x30520340, file "/root/vllm/tests/compile/test_rotary_embedding_compile.py", line 26> = RotaryEmbeddingCompileModule(\n  (rotary_emb): RotaryEmbedding(\n    head_size=32, rotary_dim=32, max_position_embeddings=128, base=10000, is_neox_style=True\n    (apply_rotary_emb): ApplyRotaryEmb(is_neox_style=True, enable_fp32_compute=False)\n  )\n)._compiled_bytecode

tests/compile/test_rotary_embedding_compile.py:58: AssertionError
```

Server fails on main, albeit with a slightly different error than reported in the issue:
```
(EngineCore_DP0 pid=162583) INFO 02-04 16:00:35 [gpu_worker.py:359] Available KV cache memory: 96.81 GiB
(EngineCore_DP0 pid=162583) INFO 02-04 16:00:35 [kv_cache_utils.py:1307] GPU KV cache size: 1,409,888 tokens
(EngineCore_DP0 pid=162583) INFO 02-04 16:00:35 [kv_cache_utils.py:1312] Maximum concurrency for 131,072 tokens per request: 20.23x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   1%|▍                                    | 1/83 [00:00<00:17,  4.64it/s]
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] EngineCore failed to start.
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] Traceback (most recent call last):
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/tmp/torchinductor_root/gd/cgdxp7oz45a6d7yg7e422etew6ofmuz2lxhdwo6cgk6wpv2j6sl3.py", line 746, in call
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     buf7 = torch.ops.vllm.moe_forward.default(buf6, buf5, 'from_forward_context')
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/_ops.py", line 819, in __call__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return self._op(*args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 2058, in moe_forward
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return self.forward_impl(hidden_states, router_logits)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 1915, in forward_impl
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     final_hidden_states = self.quant_method.apply_monolithic(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/model_executor/layers/quantization/mxfp4.py", line 1086, in apply_monolithic
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return triton_kernel_moe_forward(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py", line 100, in triton_kernel_moe_forward
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return triton_kernel_fused_experts(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py", line 189, in triton_kernel_fused_experts
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     matmul_ogs(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/triton_kernels/matmul_ogs.py", line 490, in matmul_ogs
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     (kernels._p_matmul_ogs if opt_flags.is_persistent else kernels._matmul_ogs)[(grid,)](
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/triton/runtime/jit.py", line 393, in <lambda>
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/triton/runtime/jit.py", line 623, in run
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/triton/backends/amd/driver.py", line 647, in __call__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     self.launch(self.launch_cooperative_grid, gridX, gridY, gridZ, stream, function, profile_scratch, *args)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] RuntimeError: Triton Error [HIP]:  Code: 700, Messsage: an illegal memory access was encountered
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] During handling of the above exception, another exception occurred:
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] Traceback (most recent call last):
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/distributed/parallel_state.py", line 476, in graph_capture
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     yield graph_capture_context
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/distributed/parallel_state.py", line 1171, in graph_capture
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     yield context
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/v1/worker/gpu_model_runner.py", line 5207, in capture_model
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     self._capture_cudagraphs(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/v1/worker/gpu_model_runner.py", line 5299, in _capture_cudagraphs
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     dummy_run(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return func(*args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/v1/worker/gpu_model_runner.py", line 4861, in _dummy_run
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     outputs = self.model(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]               ^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/compilation/cuda_graph.py", line 222, in __call__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return self.runnable(*args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/model_executor/models/gpt_oss.py", line 722, in forward
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/compilation/decorators.py", line 402, in __call__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return self.aot_compiled_fn(self, *args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/_dynamo/aot_compile.py", line 124, in __call__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return self.fn(*args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/model_executor/models/gpt_oss.py", line 276, in forward
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     def forward(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/compilation/caching.py", line 185, in __call__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return self.optimized_call(*args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/fx/graph_module.py", line 936, in call_wrapped
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return self._wrapped_call(self, *args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/fx/graph_module.py", line 455, in __call__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     raise e
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/fx/graph_module.py", line 442, in __call__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return super(self.cls, obj).__call__(*args, **kwargs)  # type: ignore[misc]
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "<eval_with_key>.76", line 327, in forward
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     submod_8 = self.submod_8(getitem_19, s72, l_self_modules_layers_modules_3_modules_attn_modules_o_proj_parameters_weight_, l_self_modules_layers_modules_3_modules_attn_modules_o_proj_parameters_bias_, l_self_modules_layers_modules_3_modules_post_attention_layernorm_parameters_weight_, getitem_20, l_self_modules_layers_modules_3_modules_mlp_modules_router_parameters_weight_, l_self_modules_layers_modules_3_modules_mlp_modules_router_parameters_bias_, l_self_modules_layers_modules_4_modules_input_layernorm_parameters_weight_, l_self_modules_layers_modules_4_modules_attn_modules_qkv_proj_parameters_weight_, l_self_modules_layers_modules_4_modules_attn_modules_qkv_proj_parameters_bias_, l_positions_, s80, getitem_5);  getitem_19 = l_self_modules_layers_modules_3_modules_attn_modules_o_proj_parameters_weight_ = l_self_modules_layers_modules_3_modules_attn_modules_o_proj_parameters_bias_ = l_self_modules_layers_modules_3_modules_post_attention_layernorm_parameters_weight_ = getitem_20 = l_self_modules_layers_modules_3_modules_mlp_modules_router_parameters_weight_ = l_self_modules_layers_modules_3_modules_mlp_modules_router_parameters_bias_ = l_self_modules_layers_modules_4_modules_input_layernorm_parameters_weight_ = l_self_modules_layers_modules_4_modules_attn_modules_qkv_proj_parameters_weight_ = l_self_modules_layers_modules_4_modules_attn_modules_qkv_proj_parameters_bias_ = None
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/compilation/cuda_graph.py", line 222, in __call__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return self.runnable(*args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/compilation/piecewise_backend.py", line 333, in __call__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return range_entry.runnable(*args)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/compilation/compiler_interface.py", line 318, in compiled_graph_wrapper
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     graph_output = inductor_compiled_graph(*args)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/_inductor/standalone_compile.py", line 122, in __call__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return self._compiled_fn(*args)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/_inductor/standalone_compile.py", line 215, in <lambda>
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return CacheCompiledArtifact(lambda *args: compiled_fn(list(args)), None)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]                                                ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 357, in runtime_wrapper
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     all_outs = call_func_at_runtime_with_args(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/utils.py", line 134, in call_func_at_runtime_with_args
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     out = normalize_as_list(f(args))
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]                             ^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 531, in wrapper
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return compiled_fn(runtime_args)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/_inductor/output_code.py", line 638, in __call__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return self.current_callable(inputs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/_inductor/utils.py", line 3220, in run
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     out = model(new_inputs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]           ^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/tmp/torchinductor_root/gd/cgdxp7oz45a6d7yg7e422etew6ofmuz2lxhdwo6cgk6wpv2j6sl3.py", line 715, in call
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     with torch.cuda._DeviceGuard(0):
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py", line 533, in __exit__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     self.idx = torch.cuda._maybe_exchange_device(self.prev_idx)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] torch.AcceleratorError: HIP error: an illegal memory access was encountered
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] Search for `hipErrorIllegalAddress' in https://rocm.docs.amd.com/projects/HIP/en/latest/index.html for more information.
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] HIP kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] For debugging consider passing AMD_SERIALIZE_KERNEL=3
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] Compile with `TORCH_USE_HIP_DSA` to enable device-side assertions.
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] During handling of the above exception, another exception occurred:
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] Traceback (most recent call last):
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/distributed/parallel_state.py", line 476, in graph_capture
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     yield graph_capture_context
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/distributed/parallel_state.py", line 1170, in graph_capture
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     with get_tp_group().graph_capture(context), get_pp_group().graph_capture(context):
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     self.gen.throw(value)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/distributed/parallel_state.py", line 475, in graph_capture
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     with torch.cuda.stream(stream), maybe_ca_context:
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py", line 706, in __exit__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     torch.cuda.set_stream(self.src_prev_stream)  # type: ignore[arg-type]
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/utils/torch_utils.py", line 519, in _patched_set_stream
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     prev_set_stream(stream)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py", line 748, in set_stream
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     _set_stream_by_id(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py", line 730, in _set_stream_by_id
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     torch._C._cuda_setStream(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] torch.AcceleratorError: HIP error: an illegal memory access was encountered
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] Search for `hipErrorIllegalAddress' in https://rocm.docs.amd.com/projects/HIP/en/latest/index.html for more information.
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] HIP kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] For debugging consider passing AMD_SERIALIZE_KERNEL=3
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] Compile with `TORCH_USE_HIP_DSA` to enable device-side assertions.
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] During handling of the above exception, another exception occurred:
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] Traceback (most recent call last):
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/v1/engine/core.py", line 957, in run_engine_core
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/v1/engine/core.py", line 711, in __init__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     super().__init__(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/v1/engine/core.py", line 112, in __init__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/v1/engine/core.py", line 269, in _initialize_kv_caches
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     self.model_executor.initialize_from_config(kv_cache_configs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/v1/executor/abstract.py", line 116, in initialize_from_config
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     self.collective_rpc("compile_or_warm_up_model")
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/v1/executor/uniproc_executor.py", line 75, in collective_rpc
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     result = run_method(self.driver_worker, method, args, kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/v1/serial_utils.py", line 459, in run_method
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     return func(*args, **kwargs)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/v1/worker/gpu_worker.py", line 455, in compile_or_warm_up_model
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     cuda_graph_memory_bytes = self.model_runner.capture_model()
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/v1/worker/gpu_model_runner.py", line 5200, in capture_model
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     with freeze_gc(), graph_capture(device=self.device):
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     self.gen.throw(value)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/distributed/parallel_state.py", line 1170, in graph_capture
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     with get_tp_group().graph_capture(context), get_pp_group().graph_capture(context):
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     self.gen.throw(value)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/distributed/parallel_state.py", line 475, in graph_capture
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     with torch.cuda.stream(stream), maybe_ca_context:
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py", line 706, in __exit__
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     torch.cuda.set_stream(self.src_prev_stream)  # type: ignore[arg-type]
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/vllm/utils/torch_utils.py", line 519, in _patched_set_stream
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     prev_set_stream(stream)
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py", line 748, in set_stream
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     _set_stream_by_id(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]   File "/root/vllm/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py", line 730, in _set_stream_by_id
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]     torch._C._cuda_setStream(
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] torch.AcceleratorError: HIP error: an illegal memory access was encountered
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] Search for `hipErrorIllegalAddress' in https://rocm.docs.amd.com/projects/HIP/en/latest/index.html for more information.
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] HIP kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] For debugging consider passing AMD_SERIALIZE_KERNEL=3
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966] Compile with `TORCH_USE_HIP_DSA` to enable device-side assertions.
(EngineCore_DP0 pid=162583) ERROR 02-04 16:00:36 [core.py:966]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

