### PR TITLE
[Misc] Delay deprecation of CommonAttentionMetadata properties

### DIFF
--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -347,7 +347,7 @@ class CommonAttentionMetadata:
         """
     Prefer using device seq_lens directly to avoid implicit H<>D sync.
     If a CPU copy is needed, use `seq_lens.cpu()` instead.
-    Will be removed in a future release (v0.15.0)
+    Will be removed in a future release, please migrate as soon as possible.
     """
     )
     def seq_lens_cpu(self) -> torch.Tensor:
@@ -361,7 +361,7 @@ class CommonAttentionMetadata:
     Prefer using device seq_lens directly to avoid implicit H<>D sync which breaks full
     async scheduling. If a CPU copy is needed, it can be derived from 
     query_start_loc_cpu and seq_lens.
-    Will be removed in a future release (v0.15.0)
+    Will be removed in a future release, please migrate as soon as possible.
     """
     )
     def num_computed_tokens_cpu(self) -> torch.Tensor:


### PR DESCRIPTION
Deprecation is delayed due to snags with performance https://github.com/vllm-project/vllm/pull/33771 and CI instability slowing down https://github.com/vllm-project/vllm/pull/32073

Remove version for now until the timeline becomes more clear