### PR TITLE
[VoxtralRealtime] Force eager execution by default

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -582,6 +582,29 @@ class NemotronHForCausalLMConfig(VerifyAndUpdateConfig):
             cache_config.mamba_ssm_cache_dtype = mamba_ssm_cache_dtype
 
 
+class VoxtralRealtimeModelConfig(VerifyAndUpdateConfig):
+    @staticmethod
+    def verify_and_update_config(vllm_config: "VllmConfig") -> None:
+        """Disable torch.compile and cudagraphs for VoxtralRealtime models.
+
+        VoxtralRealtime does not support torch.compile or cudagraphs yet,
+        so we force eager mode execution.
+        """
+        from vllm.config.compilation import CompilationMode, CUDAGraphMode
+
+        compilation_config = vllm_config.compilation_config
+        if (
+            compilation_config.mode is None
+            or compilation_config.mode != CompilationMode.NONE
+        ):
+            logger.info(
+                "VoxtralRealtime does not support torch.compile or cudagraphs. "
+                "Setting compilation mode to NONE."
+            )
+            compilation_config.mode = CompilationMode.NONE
+            compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+
+
 MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "GteModel": SnowflakeGteNewModelConfig,
     "GteNewModel": GteNewModelConfig,
@@ -604,4 +627,5 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "DeepseekV32ForCausalLM": DeepseekV32ForCausalLM,
     "NemotronHForCausalLM": NemotronHForCausalLMConfig,
     "NemotronHPuzzleForCausalLM": NemotronHForCausalLMConfig,
+    "VoxtralRealtimeGeneration": VoxtralRealtimeModelConfig,
 }

--- a/vllm/model_executor/models/voxtral_realtime.py
+++ b/vllm/model_executor/models/voxtral_realtime.py
@@ -225,10 +225,6 @@ class VoxtralRealtimeGeneration(VoxtralForConditionalGeneration, SupportsRealtim
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(vllm_config=vllm_config, prefix=prefix)
 
-        assert (
-            not vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs()
-        ), "Voxtral realtime doesn't support full cudagraphs yet. Please use PIECEWISE."
-
         self.time_embedding: TimeEmbedding = TimeEmbedding(
             dim=self.config.text_config.hidden_size
         )


### PR DESCRIPTION
VoxtralRealtime does not support standalone torch.compile yet

```
# main
vllm serve mistralai/Voxtral-Mini-4B-Realtime-2602

(EngineCore_DP0 pid=1961908) ERROR 02-04 17:11:02 [core.py:966]   File "/home/NickLucche/vllm/vllm/model_executor/model_loader/utils.py", line 52, in initialize_model
(EngineCore_DP0 pid=1961908) ERROR 02-04 17:11:02 [core.py:966]     model = model_class(vllm_config=vllm_config, prefix=prefix)
(EngineCore_DP0 pid=1961908) ERROR 02-04 17:11:02 [core.py:966]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1961908) ERROR 02-04 17:11:02 [core.py:966]   File "/home/NickLucche/vllm/vllm/compilation/decorators.py", line 305, in __init__
(EngineCore_DP0 pid=1961908) ERROR 02-04 17:11:02 [core.py:966]     old_init(self, **kwargs)
(EngineCore_DP0 pid=1961908) ERROR 02-04 17:11:02 [core.py:966]   File "/home/NickLucche/vllm/vllm/model_executor/models/voxtral_realtime.py", line 229, in __init__
(EngineCore_DP0 pid=1961908) ERROR 02-04 17:11:02 [core.py:966]     not vllm_config.compilation_config.cudagraph_mode.has_full_cudagraphs()
(EngineCore_DP0 pid=1961908) ERROR 02-04 17:11:02 [core.py:966] AssertionError: Voxtral realtime doesn't support full cudagraphs yet. Please use PIECEWISE.


# This should be used
VLLM_USE_STANDALONE_COMPILE=0 vllm serve mistralai/Voxtral-Mini-4B-Realtime-2602
```