### PR TITLE
[LoRA] Add TMA support to quantized fused_moe_lora kernel

### DIFF
--- a/vllm/lora/ops/triton_ops/fused_moe_lora_fp8_op.py
+++ b/vllm/lora/ops/triton_ops/fused_moe_lora_fp8_op.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-
-from typing import List  # noqa: UP035
-
 import torch
 
 from vllm.distributed import (
@@ -11,9 +8,10 @@ from vllm.distributed import (
     tensor_model_parallel_all_reduce,
 )
 from vllm.triton_utils import tl, triton
+from vllm.triton_utils.allocation import set_triton_allocator
 from vllm.utils.torch_utils import direct_register_custom_op
 
-from .utils import supports_pdl
+from .utils import supports_pdl, supports_tma
 
 
 @triton.jit
@@ -73,6 +71,37 @@ def _get_token_offs(
         )
 
 
+@triton.jit
+def _get_c_ptrs(
+    cur_c_ptr,
+    lora_id,
+    pid_m,
+    offs,
+    offs_token,
+    offs_cn,
+    stride_cm,
+    stride_cn,
+    EM: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    sort_c: tl.constexpr,
+):
+    # When sort_c is true, store the output in c_ptr using token order defined
+    # in sorted_token_ids_ptr; otherwise, use the original token order from the prompt
+    if sort_c:
+        offs_token_id = pid_m * BLOCK_SIZE_M + offs
+        c_ptrs = (
+            cur_c_ptr
+            + lora_id * EM * stride_cm
+            + stride_cm * offs_token_id[:, None]
+            + stride_cn * offs_cn[None, :]
+        )
+    else:
+        c_ptrs = (
+            cur_c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+        )
+    return c_ptrs
+
+
 _LORA_PTR_DICT: dict[tuple[int, ...], torch.tensor] = {}
 
 
@@ -128,7 +157,9 @@ def _adjust_kernel_inputs(
 )
 def _fused_moe_lora_kernel_fp8(
     a_ptr,
+    a_desc,
     b_ptr,
+    b_desc,
     c_ptr,
     a_scale_ptr,
     b_scale_ptr,
@@ -191,6 +222,18 @@ def _fused_moe_lora_kernel_fp8(
     USE_GDC: tl.constexpr,
     launch_pdl: tl.constexpr,
     IS_PRIMARY: tl.constexpr,
+    USE_TMA: tl.constexpr,
+    # sort_c determines whether tokens are stored in C in the order determined
+    # by sorted_token_ids to enable later TMA loads from this tensor.
+    #
+    # When USE_TMA is enabled, the parameter combinations are:
+    #   a_desc  | b_desc  | sort_c | Use Case
+    #   --------|---------|--------|-----------------------------
+    #   yes     | yes     | False  | expand kernel (num_slices=1)
+    #   no      | yes     | True   | shrink kernel (num_slices=1)
+    #   yes     | no      | False  | expand kernel (num_slices>1)
+    #   no      | no      | True   | shrink kernel (num_slices>1)
+    sort_c: tl.constexpr,
     use_fp8_w8a8: tl.constexpr,
     use_int8_w8a8: tl.constexpr,
     use_int8_w8a16: tl.constexpr,
@@ -273,19 +316,48 @@ def _fused_moe_lora_kernel_fp8(
     offs_k = pid_sk * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
     token_mask = offs_token < num_valid_tokens
 
-    # get a_ptrs,b_ptrs
-    a_ptrs = cur_a_ptr + (
-        offs_token[:, None] // token_mapping_factor * stride_am
-        + offs_k[None, :] * stride_ak
-    )
+    if USE_TMA and a_desc is not None:
+        # Expand path - with TMA enabled, load from A using TMA descriptor
+        offs_am = (
+            slice_id * max_loras * EM
+            + lora_id * EM
+            + pid_m * BLOCK_SIZE_M // token_mapping_factor
+        )
+        offs_ak = pid_sk * BLOCK_SIZE_K
+    else:
+        # Shrink path - load hidden states based on order defined in
+        # 'sorted_token_ids_ptr' then store them in c_ptr in this same sorted order
+        tl.static_assert(a_desc is None, "a_desc must be none")
+        cur_a_ptr = a_ptr + (slice_id % num_slice_a) * slice_a_size
+        a_ptrs = cur_a_ptr + (
+            offs_token[:, None] // token_mapping_factor * stride_am
+            + offs_k[None, :] * stride_ak
+        )
 
-    b_ptrs = (
-        cur_b_ptr
-        + lora_id * stride_bl
-        + expert_id * stride_be
-        + offs_k[:, None] * stride_bk
-        + offs_bn[None, :] * stride_bn
-    )
+    if USE_TMA:
+        offs_bn = pid_n * BLOCK_SIZE_N
+        offs_bk = pid_sk * BLOCK_SIZE_K
+        if b_desc is None:
+            # Note - Allocation of TMA descriptors on-device
+            # can cause conflicts when running in parallel via PDL
+            if USE_GDC and not IS_PRIMARY:
+                tl.extra.cuda.gdc_wait()
+
+            b_desc = tl.make_tensor_descriptor(
+                cur_b_ptr,
+                shape=[max_loras, num_experts, N, K],
+                strides=[stride_bl, stride_be, stride_bn, stride_bk],
+                block_shape=[1, 1, BLOCK_SIZE_N, BLOCK_SIZE_K],
+            )
+    else:
+        offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int32)
+        b_ptrs = (
+            cur_b_ptr
+            + lora_id * stride_bl
+            + expert_id * stride_be
+            + offs_k[:, None] * stride_bk
+            + offs_bn[None, :] * stride_bn
+        )
 
     if USE_GDC and IS_PRIMARY:
         # GDC launch dependents hints the runtime system to launch dependent kernels.
@@ -298,28 +370,38 @@ def _fused_moe_lora_kernel_fp8(
         tl.extra.cuda.gdc_wait()
 
     for k in range(0, grid_k):
-        k_remaining = K - k * (BLOCK_SIZE_K * SPLIT_K)
+        cur_k_offset = k * (BLOCK_SIZE_K * SPLIT_K)
+        k_remaining = K - cur_k_offset
         # GDC wait waits for ALL programs in the prior kernel to complete
         # before continuing.
         # pre-fetch lora weight
         # add (offs_bn < N) mask; optional .ca for B
-        b_mask = (offs_k[:, None] < k_remaining) & (offs_bn[None, :] < N)
-        if USE_B_L2_CACHE:
-            b = tl.load(b_ptrs, mask=b_mask, other=0.0, cache_modifier=".ca")
+        if b_desc is not None:
+            b = (
+                b_desc.load([lora_id, expert_id, offs_bn, offs_bk + cur_k_offset])
+                .reshape(BLOCK_SIZE_N, BLOCK_SIZE_K)
+                .T
+            )
         else:
-            b = tl.load(b_ptrs, mask=b_mask, other=0.0)
+            # add (offs_bn < N) mask; optional .ca for B
+            b_mask = (offs_k[:, None] < k_remaining) & (offs_bn[None, :] < N)
+            if USE_B_L2_CACHE:
+                b = tl.load(b_ptrs, mask=b_mask, other=0.0, cache_modifier=".ca")
+            else:
+                b = tl.load(b_ptrs, mask=b_mask, other=0.0)
+            b_ptrs += BLOCK_SIZE_K * SPLIT_K * stride_bk
 
-        if USE_GDC and not IS_PRIMARY:
-            tl.extra.cuda.gdc_wait()
-        a = tl.load(
-            a_ptrs,
-            mask=token_mask[:, None] & (offs_k[None, :] < k_remaining),
-            other=0.0,
-        )
-        accumulator += tl.dot(a, b)
-        # Advance the ptrs to the next K block.
-        a_ptrs += BLOCK_SIZE_K * SPLIT_K * stride_ak
-        b_ptrs += BLOCK_SIZE_K * SPLIT_K * stride_bk
+        if a_desc is not None:
+            a = a_desc.load([offs_am, offs_ak + cur_k_offset])
+        else:
+            a = tl.load(
+                a_ptrs,
+                mask=token_mask[:, None] & (offs_k[None, :] < k_remaining),
+                other=0.0,
+            )
+            a_ptrs += BLOCK_SIZE_K * SPLIT_K * stride_ak
+
+        accumulator = tl.dot(a, b, acc=accumulator)
 
     if MUL_ROUTED_WEIGHT:
         moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0.0)
@@ -327,7 +409,19 @@ def _fused_moe_lora_kernel_fp8(
     accumulator = accumulator.to(c_ptr.dtype.element_ty)
     # Write back the block of the output
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    c_ptrs = cur_c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+    c_ptrs = _get_c_ptrs(
+        cur_c_ptr,
+        lora_id,
+        pid_m,
+        offs,
+        offs_token,
+        offs_cn,
+        stride_cm,
+        stride_cn,
+        EM,
+        BLOCK_SIZE_M,
+        sort_c,
+    )
     c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
 
     if SPLIT_K == 1:
@@ -373,15 +467,16 @@ def _fused_moe_lora_shrink_fp8(
     num_stages: int,
     split_k: int,
     num_active_loras: int,
-    lora_a_scale_stacked: list[torch.Tensor],
+    lora_a_scale_stacked: list[torch.Tensor] | None = None,
     mul_routed_weight: bool = False,
     use_gdc: bool = False,
+    use_tma: bool = False,
     act_scale: torch.Tensor | None = None,
     use_fp8_w8a8: bool = False,
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     per_channel_quant: bool = False,
-    block_shape: List[int] | None = None,  # noqa: UP006, UP007
+    block_shape: list[int] | None = None,
 ) -> None:
     if use_fp8_w8a8 or use_int8_w8a8:
         assert lora_a_scale_stacked is not None, (
@@ -426,6 +521,7 @@ def _fused_moe_lora_shrink_fp8(
         "SPLIT_K": split_k,
         "USE_GDC": use_gdc,
         "launch_pdl": use_gdc,  # triton kernel metadata
+        "USE_TMA": use_tma,
     }
 
     b_ptr = _get_ptr(lora_a_stacked, device)
@@ -441,9 +537,19 @@ def _fused_moe_lora_shrink_fp8(
         len(lora_a_stacked),
         grid_lora_dim,
     )
+    a_desc = None
+    b_desc = None
+    if use_tma and num_slices == 1:
+        b_desc = triton.tools.tensor_descriptor.TensorDescriptor.from_tensor(
+            lora_a_stacked[0],
+            [1, 1, shrink_config["BLOCK_SIZE_N"], shrink_config["BLOCK_SIZE_K"]],
+        )
+
     _fused_moe_lora_kernel_fp8[grid](
         qcurr_hidden_states,
+        a_desc,
         b_ptr,
+        b_desc,
         a_intermediate_cache1,
         act_scale,
         b_scale_ptr if lora_a_scale_stacked is not None else None,
@@ -467,8 +573,8 @@ def _fused_moe_lora_shrink_fp8(
         w1_lora_a_stacked.stride(1),
         w1_lora_a_stacked.stride(3),
         w1_lora_a_stacked.stride(2),
-        a_intermediate_cache1.stride(2),
-        a_intermediate_cache1.stride(3),
+        a_intermediate_cache1.stride(-2),
+        a_intermediate_cache1.stride(-1),
         stride_tl,
         stride_el,
         act_scale.stride(0) if act_scale is not None and act_scale.ndim == 2 else 0,
@@ -496,6 +602,7 @@ def _fused_moe_lora_shrink_fp8(
         MUL_ROUTED_WEIGHT=False,
         ADD_INPUTS=False,
         USE_B_L2_CACHE=True,  # new
+        sort_c=use_tma and sorted_token_ids is not None,
         IS_PRIMARY=True,
         use_fp8_w8a8=use_fp8_w8a8,
         use_int8_w8a8=use_int8_w8a8,
@@ -539,16 +646,17 @@ def _fused_moe_lora_expand_fp8(
     num_stages: int,
     split_k: int,
     num_active_loras: int,
-    lora_b_scale_stacked: list[torch.Tensor],
+    lora_b_scale_stacked: list[torch.Tensor] | None = None,
     mul_routed_weight: bool = False,
     offset: int = 0,
     use_gdc: bool = False,
+    use_tma: bool = False,
     act_scale: torch.Tensor | None = None,
     use_fp8_w8a8: bool = False,
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     per_channel_quant: bool = False,
-    block_shape: List[int] | None = None,  # noqa: UP006, UP007
+    block_shape: list[int] | None = None,
 ) -> None:
     if use_fp8_w8a8 or use_int8_w8a8:
         assert lora_b_scale_stacked is not None, (
@@ -589,7 +697,7 @@ def _fused_moe_lora_expand_fp8(
     w1_lora_b_stacked = lora_b_stacked[0]
 
     a_intermediate_cache1 = a_intermediate_cache1.view(
-        -1, a_intermediate_cache1.shape[3]
+        -1, a_intermediate_cache1.shape[-1]
     )
 
     expand_config = {
@@ -602,6 +710,7 @@ def _fused_moe_lora_expand_fp8(
         "SPLIT_K": 1,  # Set split_k = 1 for expand calls
         "USE_GDC": use_gdc,
         "launch_pdl": use_gdc,  # triton kernel metadata
+        "USE_TMA": use_tma,
     }
 
     grid_lora_dim, stride_tl, stride_el = _adjust_kernel_inputs(
@@ -618,9 +727,27 @@ def _fused_moe_lora_expand_fp8(
     out_view = output[:, :, offset : offset + num_slices * N]
     slice_c_size = N * out_view.stride(2)
 
+    a_desc = None
+    b_desc = None
+    if use_tma:
+        if sorted_token_ids is not None:
+            a_desc = triton.tools.tensor_descriptor.TensorDescriptor.from_tensor(
+                a_intermediate_cache1,
+                [expand_config["BLOCK_SIZE_M"], expand_config["BLOCK_SIZE_K"]],
+            )
+        if num_slices == 1:
+            b_desc = triton.tools.tensor_descriptor.TensorDescriptor.from_tensor(
+                lora_b_stacked[0],
+                [1, 1, expand_config["BLOCK_SIZE_N"], expand_config["BLOCK_SIZE_K"]],
+            )
+    else:
+        b_desc = None
+
     _fused_moe_lora_kernel_fp8[grid](
         a_intermediate_cache1,
+        a_desc,
         b_ptr,
+        b_desc,
         out_view,
         act_scale,
         b_scale_ptr if lora_b_scale_stacked is not None else None,
@@ -673,6 +800,7 @@ def _fused_moe_lora_expand_fp8(
         MUL_ROUTED_WEIGHT=mul_routed_weight,
         ADD_INPUTS=True,
         USE_B_L2_CACHE=True,  # new
+        sort_c=False,
         IS_PRIMARY=False,
         use_fp8_w8a8=use_fp8_w8a8,
         use_int8_w8a8=use_int8_w8a8,
@@ -716,8 +844,8 @@ def _fused_moe_lora_fp8(
     expand_num_warps: int,
     expand_num_stages: int,
     expand_split_k: int,
-    lora_a_scale_stacked: list[torch.Tensor],
-    lora_b_scale_stacked: list[torch.Tensor],
+    lora_a_scale_stacked: list[torch.Tensor] | None = None,
+    lora_b_scale_stacked: list[torch.Tensor] | None = None,
     shrink_act_scale: torch.Tensor | None = None,
     expand_act_scale: torch.Tensor | None = None,
     mul_routed_weight: bool = False,
@@ -727,7 +855,7 @@ def _fused_moe_lora_fp8(
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     per_channel_quant: bool = False,
-    block_shape: List[int] | None = None,  # noqa: UP006, UP007
+    block_shape: list[int] | None = None,
 ) -> None:
     assert len(lora_a_stacked) == len(lora_b_stacked) > 0
     assert topk_weights.dim() == qcurr_hidden_states.dim() == 2
@@ -766,8 +894,34 @@ def _fused_moe_lora_fp8(
         else num_tokens * shrink_block_size_m
     )
 
+    # TMA is not currently compatible with fully_sharded due to the non-determinism
+    # of token id sorting across ranks.
+    use_tma = supports_tma(device) and not fully_sharded
+
+    intermediate_cache_shape = (
+        num_slices,
+        M,
+        top_k_num,
+        max_lora_rank,
+    )
+    if use_tma:
+        if num_slices > 1:
+            # if num_slices > 1, we construct TMA descriptors for LoRA
+            # weights within the kernel, which requires us to first set an allocator
+            set_triton_allocator(device)
+
+        # When storing intermediate data in sorted order for TMA, we
+        # need an extra 'num_active_loras' dim in the cache to avoid conflicts
+        if sorted_token_ids is not None:
+            intermediate_cache_shape = (
+                num_slices,
+                sorted_token_ids.shape[0],
+                EM,
+                max_lora_rank,
+            )
+
     a_intermediate_cache1 = torch.zeros(
-        (num_slices, M, top_k_num, max_lora_rank),
+        intermediate_cache_shape,
         dtype=output.dtype,
         device=device,
     )
@@ -805,6 +959,7 @@ def _fused_moe_lora_fp8(
         lora_a_scale_stacked,
         mul_routed_weight=mul_routed_weight,
         use_gdc=use_gdc,
+        use_tma=use_tma,
         act_scale=shrink_act_scale,
         use_fp8_w8a8=use_fp8_w8a8,
         use_int8_w8a8=use_int8_w8a8,
@@ -861,6 +1016,7 @@ def _fused_moe_lora_fp8(
         mul_routed_weight=mul_routed_weight,
         offset=offset,
         use_gdc=use_gdc,
+        use_tma=use_tma,
         act_scale=expand_act_scale,
         use_fp8_w8a8=use_fp8_w8a8,
         use_int8_w8a8=use_int8_w8a8,
@@ -899,18 +1055,18 @@ def _fused_moe_lora_fp8_fake(
     expand_num_warps: int,
     expand_num_stages: int,
     expand_split_k: int,
-    lora_a_scale_stacked: list[torch.Tensor],
-    lora_b_scale_stacked: list[torch.Tensor],
+    lora_a_scale_stacked: list[torch.Tensor] | None = None,
+    lora_b_scale_stacked: list[torch.Tensor] | None = None,
+    shrink_act_scale: torch.Tensor | None = None,
+    expand_act_scale: torch.Tensor | None = None,
     mul_routed_weight: bool = False,
     fully_sharded: bool = False,
     offset: int = 0,
-    shrink_act_scale: torch.Tensor | None = None,
-    expand_act_scale: torch.Tensor | None = None,
     use_fp8_w8a8: bool = False,
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     per_channel_quant: bool = False,
-    block_shape: List[int] | None = None,  # noqa: UP006, UP007
+    block_shape: list[int] | None = None,
 ) -> None:
     return
 
@@ -943,15 +1099,16 @@ def _fused_moe_lora_shrink_fp8_fake(
     num_stages: int,
     split_k: int,
     num_active_loras: int,
-    lora_a_scale_stacked: list[torch.Tensor],
+    lora_a_scale_stacked: list[torch.Tensor] | None = None,
     mul_routed_weight: bool = False,
     use_gdc: bool = False,
+    use_tma: bool = False,
     act_scale: torch.Tensor | None = None,
     use_fp8_w8a8: bool = False,
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     per_channel_quant: bool = False,
-    block_shape: List[int] | None = None,  # noqa: UP006, UP007
+    block_shape: list[int] | None = None,
 ) -> None:
     return
 
@@ -986,16 +1143,17 @@ def _fused_moe_lora_expand_fp8_fake(
     num_stages: int,
     split_k: int,
     num_active_loras: int,
-    act_scale: torch.Tensor,
-    lora_b_scale_stacked: list[torch.Tensor],
+    lora_b_scale_stacked: list[torch.Tensor] | None = None,
     mul_routed_weight: bool = False,
     offset: int = 0,
+    use_gdc: bool = False,
+    use_tma: bool = False,
+    act_scale: torch.Tensor | None = None,
     use_fp8_w8a8: bool = False,
     use_int8_w8a8: bool = False,
     use_int8_w8a16: bool = False,
     per_channel_quant: bool = False,
-    block_shape: List[int] | None = None,  # noqa: UP006, UP007
-    use_gdc: bool = False,
+    block_shape: list[int] | None = None,
 ) -> None:
     return
 

--- a/vllm/lora/ops/triton_ops/fused_moe_lora_op.py
+++ b/vllm/lora/ops/triton_ops/fused_moe_lora_op.py
@@ -740,7 +740,7 @@ def _fused_moe_lora(
         else num_tokens * shrink_block_size_m
     )
 
-    # TMA is not currently compatiple with fully_sharded due to the non-determinism
+    # TMA is not currently compatible with fully_sharded due to the non-determinism
     # of token id sorting across ranks.
     use_tma = supports_tma(device) and not fully_sharded
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR adds TMA support for FP8-quantized fused_moe_lora kernels. Depends on #35555

## Test Plan

```
pytest -s -v tests/lora/test_fused_moe_lora_kernel.py
```

## Test Result

Unit tests passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

