### PR TITLE
Add shutdown timeout CLI and changed shutdown function to send SIGTERM to worker processes before SIGKILL

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -443,6 +443,7 @@ class EngineArgs:
     logprobs_mode: LogprobsMode = ModelConfig.logprobs_mode
     disable_log_stats: bool = False
     aggregate_engine_logging: bool = False
+    shutdown_timeout: float = 5.0
     revision: str | None = ModelConfig.revision
     code_revision: str | None = ModelConfig.code_revision
     hf_token: bool | str | None = ModelConfig.hf_token
@@ -1202,6 +1203,13 @@ class EngineArgs:
             action="store_true",
             help="Log aggregate rather than per-engine statistics "
             "when using data parallelism.",
+        )
+
+        parser.add_argument(
+            "--shutdown-timeout",
+            type=float,
+            default=EngineArgs.shutdown_timeout,
+            help="Timeout in seconds for graceful shutdown of processes.",
         )
         return parser
 

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -205,6 +205,7 @@ def run_headless(args: argparse.Namespace):
         handshake_address=handshake_address,
         executor_class=Executor.get_class(vllm_config),
         log_stats=not engine_args.disable_log_stats,
+        shutdown_timeout=getattr(args, 'shutdown_timeout', 5.0),
     )
 
     try:
@@ -246,7 +247,8 @@ def run_multi_api_server(args: argparse.Namespace):
     api_server_manager: APIServerProcessManager | None = None
 
     with launch_core_engines(
-        vllm_config, executor_class, log_stats, num_api_servers
+        vllm_config, executor_class, log_stats, num_api_servers,
+        shutdown_timeout=getattr(args, 'shutdown_timeout', 5.0)
     ) as (local_engine_manager, coordinator, addresses):
         # Construct common args for the APIServerProcessManager up-front.
         api_server_manager_kwargs = dict(

--- a/vllm/utils/system_utils.py
+++ b/vllm/utils/system_utils.py
@@ -220,6 +220,31 @@ def decorate_logs(process_name: str | None = None) -> None:
     _add_prefix(sys.stderr, process_name, pid)
 
 
+def terminate_process_tree(pid: int):
+    """
+    Terminates all descendant processes of the given pid by sending SIGTERM.
+
+    Args:
+        pid (int): Process ID of the parent process
+    """
+    try:
+        parent = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return
+
+    # Get all children recursively
+    children = parent.children(recursive=True)
+
+    # Send SIGTERM to all children first
+    for child in children:
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(child.pid, signal.SIGTERM)
+
+    # Finally terminate the parent
+    with contextlib.suppress(ProcessLookupError):
+        os.kill(pid, signal.SIGTERM)
+
+
 def kill_process_tree(pid: int):
     """
     Kills all descendant processes of the given pid by sending SIGKILL.

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -56,7 +56,8 @@ class DPCoordinator:
     """
 
     def __init__(
-        self, parallel_config: ParallelConfig, enable_wave_coordination: bool = True
+        self, parallel_config: ParallelConfig, enable_wave_coordination: bool = True,
+        shutdown_timeout: float = 5.0
     ):
         dp_size = parallel_config.data_parallel_size
         assert dp_size > 1, "Coordinator only used for data parallel"
@@ -92,7 +93,7 @@ class DPCoordinator:
         self.stats_publish_address = front_publish_address
         self.coord_in_address = back_publish_address
         self.coord_out_address = back_output_address
-        self._finalizer = weakref.finalize(self, shutdown, [self.proc])
+        self._finalizer = weakref.finalize(self, shutdown, [self.proc], shutdown_timeout)
 
     def get_stats_publish_address(self) -> str:
         return self.stats_publish_address

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -59,6 +59,7 @@ class LLMEngine:
         mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
         use_cached_outputs: bool = False,
         multiprocess_mode: bool = False,
+        shutdown_timeout: float = 5.0,
     ) -> None:
         self.vllm_config = vllm_config
         self.observability_config = vllm_config.observability_config
@@ -110,6 +111,7 @@ class LLMEngine:
             vllm_config=vllm_config,
             executor_class=executor_class,
             log_stats=self.log_stats,
+            shutdown_timeout=shutdown_timeout,
         )
 
         self.logger_manager: StatLoggerManager | None = None
@@ -177,6 +179,7 @@ class LLMEngine:
             usage_context=usage_context,
             stat_loggers=stat_loggers,
             multiprocess_mode=enable_multiprocessing,
+            shutdown_timeout=engine_args.shutdown_timeout,
         )
 
     def get_num_unfinished_requests(self) -> int:


### PR DESCRIPTION
## Purpose

Make vLLM v1 compatible with profiling tools like the rocprofiler-sdk. Currently, the shutdown function results in processes getting killed after 5 seconds after a SIGTERM signal is sent to parent processes. This does not give the rocprofiler-sdk enough time to output all files after benchmarks are completed resulting in no output being written when it is attached. This PR adds a CLI argument to change the timeout duration before the SIGKILL signal is sent and modifies the shutdown function to send SIGTERM signals to the worker processes in addition to the Executor processes.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

