### PR TITLE
[CI][AMD][BugFix] Ensure VLLM_ROCM_USE_AITER is set so test_rocm_aiter_topk.py can run correctly

### DIFF
--- a/tests/kernels/moe/test_rocm_aiter_topk.py
+++ b/tests/kernels/moe/test_rocm_aiter_topk.py
@@ -18,7 +18,7 @@ import torch
 from vllm.platforms import current_platform
 
 if not current_platform.is_rocm():
-    pytest.skip("This test can only run on ROCm", allow_module_level=True)
+    pytest.skip("This test can only run on ROCm.", allow_module_level=True)
 
 # This environment variable must be set so ops will be registered.
 os.environ["VLLM_ROCM_USE_AITER"] = "1"
@@ -31,7 +31,7 @@ import vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe  # noqa: F401
 aiter_available = importlib.util.find_spec("aiter") is not None
 
 if not aiter_available:
-    pytest.skip("These tests require AITER to run", allow_module_level=True)
+    pytest.skip("These tests require AITER to run.", allow_module_level=True)
 
 
 def test_rocm_aiter_biased_grouped_topk_custom_op_registration():

--- a/tests/kernels/moe/test_rocm_aiter_topk.py
+++ b/tests/kernels/moe/test_rocm_aiter_topk.py
@@ -34,13 +34,8 @@ if not aiter_available:
     pytest.skip("These tests require AITER to run", allow_module_level=True)
 
 
-def test_rocm_aiter_biased_grouped_topk_custom_op_registration(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_rocm_aiter_biased_grouped_topk_custom_op_registration():
     """Test that the custom op is correctly registered."""
-    importlib.reload("vllm._aiter_ops")
-    importlib.reload("torch.ops.vllm")
-    importlib.reload("vllm")
     # Check if the op exists in torch.ops.vllm
     assert hasattr(torch.ops.vllm, "rocm_aiter_biased_grouped_topk")
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This [PR ](https://github.com/vllm-project/vllm/pull/32902/ )introduced changes that broke many tests, including `test_rocm_aiter_topk.py`.

Either an environment variable or backend must be selected for AITER ops to be properly imported.

This PR updates the test to set VLLM_ROCM_USE_AITER to 1 so loading of AITER ops will occur and the test can check that the ops were correctly loaded.

## Test Plan
`pytest -sv  kernels/moe/test_rocm_aiter_topk.py`
## Test Result

`4 passed, 3 warnings`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

