### PR TITLE
[Core] Expose detailed scheduler stats

### DIFF
--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -168,6 +168,15 @@ class SchedulerStats:
     num_running_reqs: int = 0
     num_waiting_reqs: int = 0
 
+    # Scheduling visibility: how many requests/tokens were actually scheduled
+    # this step
+    num_scheduled_reqs: int = 0
+    num_scheduled_tokens: int = 0
+    num_stopped_reqs: int = 0
+    num_scheduled_new_reqs: int = 0
+    num_scheduled_resumed_reqs: int = 0
+    num_scheduled_running_reqs: int = 0
+
     # These are used for internal DP load-balancing.
     step_counter: int = 0
     current_wave: int = 0


### PR DESCRIPTION
We are optimizing multi-turn e2e perf and would need following metrics to further understand scheduler decisions such as token budget usage and prefill vs decode mix for running workload.

Request metrics:
* num_scheduled_reqs - scheduled at schedule time
* num_stopped_reqs - finished this step, will be removed
* num_scheduled_new_reqs - new prefill requests
* num_scheduled_resumed_reqs - preempted & resumed prefill
* num_scheduled_running_reqs - decode requests

Token metrics:
* num_scheduled_tokens - directly track scheduled tokens

Run them and see example queries like below:
<img width="2138" height="1200" alt="image" src="https://github.com/user-attachments/assets/97478098-1ad6-41aa-bbe7-fcd01042245e" />
<img width="2138" height="1182" alt="image" src="https://github.com/user-attachments/assets/fc116ddf-3d04-45c9-b90c-40693d679699" />



<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

