### PR TITLE
[Bugfix] Lazy tokenizer init to prevent semaphore leak in multiprocess mode

### DIFF
--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -64,7 +64,14 @@ class StructuredOutputManager:
             max_workers = max(1, min(multiprocessing.cpu_count() // 2, 8))
             self.executor_for_fillmask = ThreadPoolExecutor(max_workers=max_workers)
 
-        if not self.vllm_config.model_config.skip_tokenizer_init:
+        # Defer tokenizer initialization until first use. For GGUF models
+        # in multiprocess mode, eager tokenizer init during __init__ causes
+        # a semaphore leak: the tokenizer builds BPE merges using
+        # multiprocessing primitives that don't clean up in subprocesses,
+        # eventually exhausting the system semaphore limit and hanging.
+        self._tokenizer = None
+        self._skip_tokenizer = self.vllm_config.model_config.skip_tokenizer_init
+        if not self._skip_tokenizer:
             # The default max_workers if not specified is the number of
             # CPUs * 5, which is way too high since these tasks are CPU-bound,
             # not I/O bound. We also know we would never dominate CPU usage
@@ -72,27 +79,43 @@ class StructuredOutputManager:
             # of CPUs.
             max_workers = max(1, (multiprocessing.cpu_count() + 1) // 2)
             self.executor = ThreadPoolExecutor(max_workers=max_workers)
-            self.tokenizer = cached_tokenizer_from_config(
-                model_config=self.vllm_config.model_config
-            )
-            reasoning_parser_plugin = (
-                self.vllm_config.structured_outputs_config.reasoning_parser_plugin
-            )
-            if reasoning_parser_plugin and len(reasoning_parser_plugin) > 3:
-                ReasoningParserManager.import_reasoning_parser(reasoning_parser_plugin)
-
-            reasoning_parser = (
-                self.vllm_config.structured_outputs_config.reasoning_parser
-            )
-            if reasoning_parser:
-                reasoner_cls = ReasoningParserManager.get_reasoning_parser(
-                    reasoning_parser
-                )
-                self.reasoner = reasoner_cls(tokenizer=self.tokenizer)
 
         self.enable_in_reasoning = (
             self.vllm_config.structured_outputs_config.enable_in_reasoning
         )
+
+    @property
+    def tokenizer(self):
+        """Lazily initialize tokenizer on first access.
+
+        Deferring tokenizer init prevents semaphore leaks when
+        StructuredOutputManager is instantiated in forked subprocesses
+        (e.g., during GGUF model loading with multiprocessing).
+        """
+        if self._tokenizer is None:
+            if self._skip_tokenizer:
+                raise RuntimeError(
+                    "Structured output requires a tokenizer, but "
+                    "skip_tokenizer_init is enabled."
+                )
+            self._tokenizer = cached_tokenizer_from_config(
+                model_config=self.vllm_config.model_config
+            )
+            self._init_reasoning_parser()
+        return self._tokenizer
+
+    def _init_reasoning_parser(self) -> None:
+        """Initialize reasoning parser after tokenizer is available."""
+        reasoning_parser_plugin = (
+            self.vllm_config.structured_outputs_config.reasoning_parser_plugin
+        )
+        if reasoning_parser_plugin and len(reasoning_parser_plugin) > 3:
+            ReasoningParserManager.import_reasoning_parser(reasoning_parser_plugin)
+
+        reasoning_parser = self.vllm_config.structured_outputs_config.reasoning_parser
+        if reasoning_parser:
+            reasoner_cls = ReasoningParserManager.get_reasoning_parser(reasoning_parser)
+            self.reasoner = reasoner_cls(tokenizer=self._tokenizer)
 
     def grammar_init(self, request: "Request") -> None:
         if request.structured_output_request is None:


### PR DESCRIPTION
## Summary

Supersedes #30409 (rebased and rewritten against current main).

Defers tokenizer initialization in `StructuredOutputManager` from `__init__` to first access via a `@property`. This prevents semaphore exhaustion when GGUF models are loaded in multiprocess mode.

## Problem

When `StructuredOutputManager.__init__` eagerly calls `cached_tokenizer_from_config()`, the tokenizer builds BPE merges using `multiprocessing` primitives. In forked subprocesses (multiprocess model loading for GGUF), these primitives leak POSIX semaphores that aren't cleaned up, eventually exhausting the system limit (`/proc/sys/kernel/sem`) and causing the server to hang.

## Changes

- Replace eager `self.tokenizer = cached_tokenizer_from_config(...)` with a `@property` that initializes on first access
- Reasoning parser init is also deferred (depends on tokenizer)
- `ThreadPoolExecutor` for grammar compilation is still created eagerly (no multiprocessing primitives)
- `skip_tokenizer_init` check moved to the property, raising a clear error if structured output is used without a tokenizer

## Testing

Tested with repeated GGUF model load/unload cycles in multiprocess mode — no semaphore exhaustion.