### PR TITLE
fix: correct typo in error message for Swiglu limit assertion

### DIFF
--- a/vllm/model_executor/models/step3p5.py
+++ b/vllm/model_executor/models/step3p5.py
@@ -351,7 +351,7 @@ class FusedMoEBlock(nn.Module):
         if swiglu_limit not in (None, 0):
             swiglu_limit = float(swiglu_limit)
             assert swiglu_limit == 7.0, (
-                "Swiglu limit in fused moe block only suport 7.0 now."
+                "Swiglu limit in fused moe block only support 7.0 now."
             )
             activation = "swiglustep"
             logger.debug(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix a typo in the error message for Swiglu limit assertion in FusedMoEBlock.

## Test Plan

No functional changes. This is a documentation/message fix only.

## Test Result

N/A (typo fix only)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

