### PR TITLE
[Bugfix] Kimi-K2 grouped_topk usage for Flashinfer monolithic kernels.

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -295,14 +295,6 @@ class DeepseekV2MoE(nn.Module):
                 prefix=f"{prefix}.shared_experts",
             )
 
-        n_group = getattr(config, "n_group", 1)
-        topk_group = getattr(config, "topk_group", 1)
-        use_grouped_topk = True
-        if (n_group, topk_group) == (1, 1):
-            n_group = None
-            topk_group = None
-            use_grouped_topk = False
-
         self.experts = SharedFusedMoE(
             shared_experts=self.shared_experts,
             gate=self.gate,
@@ -313,9 +305,9 @@ class DeepseekV2MoE(nn.Module):
             reduce_results=False,
             renormalize=config.norm_topk_prob,
             quant_config=quant_config,
-            use_grouped_topk=use_grouped_topk,
-            num_expert_group=n_group,
-            topk_group=topk_group,
+            use_grouped_topk=True,
+            num_expert_group=getattr(config, "n_group", 1),
+            topk_group=getattr(config, "topk_group", 1),
             prefix=f"{prefix}.experts",
             scoring_func=getattr(config, "scoring_func", "softmax"),
             # we do scaling outside, set factor to 1.0 to avoid double mul


### PR DESCRIPTION
## Purpose
This PR fixes a bug introduced in  PR #33174 that sets the values for n_group and topk_group to None when they are (1, 1) respectively. This while it fixes Kimi-K2 may introduce an error with Mistral. @dbari Please confirm if this fix is good or if the values need to be passed differently

The marlin path works because it doesn't have monolithic kernel for routing + MOE unlike the INT4 TRTLLM MOE Kernels. 

## Test Plan
GSM8k before and after.

## Test Result
Main `Kimi-K2-Thinking` (Buggy)
```
Marlin:
Accuracy: 0.914
Invalid responses: 0.000
Total latency: 78.938 s
Questions per second: 16.709
Total output tokens: 132921
Output tokens per second: 1683.870

Flashinfer
Accuracy: 0.299
Invalid responses: 0.008
Total latency: 81.379 s
Questions per second: 16.208
Total output tokens: 131721
Output tokens per second: 1618.620
```

With PR - (Fixed) 
```
Marlin: 
Results:
Accuracy: 0.909
Invalid responses: 0.001
Total latency: 81.228 s
Questions per second: 16.238
Total output tokens: 134196
Output tokens per second: 1652.097

Flashinfer:
Results:
Accuracy: 0.917
Invalid responses: 0.000
Total latency: 78.991 s
Questions per second: 16.698
Total output tokens: 130950
Output tokens per second: 1657.787
```

Kimi-K2.5 + Flashinfer
```
Accuracy: 0.945
Invalid responses: 0.000
Total latency: 77.760 s
Questions per second: 16.962
Total output tokens: 131352
Output tokens per second: 1689.195
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

