### PR TITLE
[Kernel][Helion][1/N] Add Helion kernel for dynamic_per_tensor_scaled_fp8_quant

### DIFF
--- a/tests/kernels/helion/test_dynamic_per_tensor_scaled_fp8_quant.py
+++ b/tests/kernels/helion/test_dynamic_per_tensor_scaled_fp8_quant.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the dynamic_per_token_scaled_fp8_quant helion kernel
+
+Run `pytest tests/kernels/helion/test_dynamic_per_tensor_scaled_fp8_quant.py`.
+"""
+
+from typing import Any
+
+import pytest
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+from tests.kernels.helion.utils import skip_if_platform_unsupported
+from tests.kernels.quant_utils import FP8_DTYPE
+from vllm.kernels.helion.config_manager import ConfigManager
+from vllm.kernels.helion.ops.dynamic_per_tensor_scaled_fp8_quant import (
+    baseline,
+    dynamic_per_tensor_scaled_fp8_quant,
+    pick_config,
+)
+from vllm.utils.import_utils import has_helion
+from vllm.utils.torch_utils import set_random_seed
+
+if not has_helion():
+    pytest.skip(
+        "Helion is not installed. Install with: pip install vllm[helion]",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_config_manager_singleton():
+    ConfigManager.reset_instance()
+    ConfigManager()
+    yield
+    ConfigManager.reset_instance()
+
+
+def _generate_fake_input(num_tokens: int, hidden_size: int) -> tuple[Any, ...]:
+    with FakeTensorMode():
+        input = torch.randn(
+            num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16
+        )
+        result = torch.empty(input.shape, device=input.device, dtype=FP8_DTYPE)
+        scale = torch.empty(1, device=input.device, dtype=torch.float32)
+        args = (result, input, scale)
+        return args
+
+
+class TestDynamicPerTensorScaledFp8QuantConfigPicker:
+    def test_config_picker_exact_match(self):
+        config_keys = [
+            "default",
+            "hidden_size_2048_num_tokens_16",
+            "hidden_size_4096_num_tokens_16",
+        ]
+
+        args = _generate_fake_input(16, 4096)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == "hidden_size_4096_num_tokens_16"
+
+    def test_config_picker_closest_match(self):
+        config_keys = [
+            "default",
+            "hidden_size_2048_num_tokens_16",
+            "hidden_size_2048_num_tokens_32",
+            "hidden_size_4096_num_tokens_16",
+            "hidden_size_4096_num_tokens_32",
+        ]
+
+        args = _generate_fake_input(20, 3000)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == "hidden_size_2048_num_tokens_32"
+
+    def test_config_picker_fallback_to_default(self):
+        config_keys = ["default"]
+
+        args = _generate_fake_input(16, 4096)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == "default"
+
+    def test_config_picker_no_configs(self):
+        config_keys: list[str] = []
+
+        args = _generate_fake_input(16, 4096)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key is None
+
+    def test_config_picker_fallback_to_largest(self):
+        config_keys = [
+            "default",
+            "hidden_size_2048_num_tokens_16",
+            "hidden_size_4096_num_tokens_16",
+        ]
+
+        args = _generate_fake_input(32, 8192)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == "hidden_size_4096_num_tokens_16"
+
+    def test_config_picker_malformed_key_raises(self):
+        config_keys = [
+            "bad_key_4096_bad_key_16",
+        ]
+
+        args = _generate_fake_input(16, 4096)
+        with pytest.raises(ValueError):
+            pick_config(args, config_keys)
+
+
+DTYPES = [torch.bfloat16, torch.float]
+HIDDEN_SIZES = [17, 1024, 1025, 1026, 5137, 8193]
+NUM_TOKENS = [1, 7, 4096]
+SEEDS = [0]
+
+
+class TestDynamicPerTensorScaledFp8QuantCorrectness:
+    @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+    @pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+    @pytest.mark.parametrize("dtype", DTYPES)
+    @pytest.mark.parametrize("seed", SEEDS)
+    def test_dynamic_per_tensor_fp8_quant(
+        self, num_tokens: int, hidden_size: int, dtype: torch.dtype, seed: int
+    ) -> None:
+        skip_if_platform_unsupported("dynamic_per_tensor_scaled_fp8_quant")
+        set_random_seed(seed)
+
+        input = torch.rand(num_tokens, hidden_size, dtype=dtype, device="cuda")
+        ref_out = torch.empty(input.shape, device="cuda", dtype=FP8_DTYPE)
+        ref_scale = torch.empty(1, device=input.device, dtype=torch.float32)
+        ops_out = torch.empty(input.shape, device="cuda", dtype=FP8_DTYPE)
+        ops_scale = torch.empty(1, device=input.device, dtype=torch.float32)
+
+        baseline(ref_out, input, ref_scale)
+        dynamic_per_tensor_scaled_fp8_quant(ops_out, input, ops_scale)
+
+        torch.testing.assert_close(ref_scale, ops_scale)
+        # allow 1 ULP difference
+        assert (
+            ref_out.view(torch.uint8).to(torch.int16)
+            - ops_out.view(torch.uint8).to(torch.int16)
+        ).abs().max() <= 1
+
+
+class TestDynamicPerTensorScaledFp8QuantIntegration:
+    def test_kernel_registration_integration(self):
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered_kernels = get_registered_kernels()
+        assert "dynamic_per_tensor_scaled_fp8_quant" in registered_kernels
+
+        kernel_wrapper = registered_kernels["dynamic_per_tensor_scaled_fp8_quant"]
+        assert kernel_wrapper.op_name == "dynamic_per_tensor_scaled_fp8_quant"
+        assert kernel_wrapper._config_picker is not None
+        assert kernel_wrapper._mutates_args == ["result", "scale"]
+
+    def test_fake_impl_functionality(self):
+        skip_if_platform_unsupported("dynamic_per_tensor_scaled_fp8_quant")
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered_kernels = get_registered_kernels()
+        kernel_wrapper = registered_kernels["dynamic_per_tensor_scaled_fp8_quant"]
+        fake_impl = kernel_wrapper._fake_impl
+
+        args = _generate_fake_input(16, 4096)
+        assert fake_impl(*args) is None

--- a/tests/kernels/helion/test_register.py
+++ b/tests/kernels/helion/test_register.py
@@ -703,6 +703,7 @@ class TestHelionKernelWrapper:
 
         new_op = Mock()
         registered_ops: dict[str, Mock] = {}
+        mutates_args = ["y"]
 
         class MockNamespace:
             def __getattr__(self, name):
@@ -738,6 +739,7 @@ class TestHelionKernelWrapper:
                 raw_kernel_func=sample_kernel,
                 op_name="test_kernel",
                 fake_impl=fake_impl,
+                mutates_args=mutates_args,
                 config_picker=default_picker,
             )
             result = wrapper._get_or_register_custom_op()
@@ -745,6 +747,7 @@ class TestHelionKernelWrapper:
             mock_register.assert_called_once()
             assert result is new_op
             assert mock_register.call_args[1]["op_func"] is mock_decorated
+            assert mock_register.call_args[1]["mutates_args"] is mutates_args
 
 
 class TestKernelRegistry:

--- a/tests/kernels/helion/utils.py
+++ b/tests/kernels/helion/utils.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Helion Kernel test utils"""
+
+import pytest
+import torch
+
+from vllm.kernels.helion.config_manager import ConfigManager
+
+
+def skip_if_platform_unsupported(op_name: str):
+    try:
+        from vllm.kernels.helion.utils import get_canonical_gpu_name
+
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        platform = get_canonical_gpu_name()
+
+        try:
+            config_manager = ConfigManager.get_instance()
+        except RuntimeError:
+            config_manager = ConfigManager()
+
+        configs = config_manager.get_platform_configs(op_name, platform)
+        if len(configs) == 0:
+            pytest.skip(f"Current GPU platform not supported for {op_name} kernel")
+
+    except (ImportError, RuntimeError, KeyError):
+        pytest.skip(f"Error detecting platform support for {op_name} kernel")

--- a/vllm/kernels/helion/configs/dynamic_per_tensor_scaled_fp8_quant/nvidia_b200.json
+++ b/vllm/kernels/helion/configs/dynamic_per_tensor_scaled_fp8_quant/nvidia_b200.json
@@ -1,0 +1,2211 @@
+{
+  "hidden_size_2048_num_tokens_1": {
+    "block_sizes": [
+      1,
+      256,
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      true
+    ],
+    "l2_groupings": [
+      8,
+      16
+    ],
+    "range_unroll_factors": [
+      0,
+      1
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2,
+    "maxnreg": 128
+  },
+  "hidden_size_4096_num_tokens_1": {
+    "block_sizes": [
+      1,
+      4096,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      true
+    ],
+    "l2_groupings": [
+      2,
+      32
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      true,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2,
+    "maxnreg": 64
+  },
+  "hidden_size_8192_num_tokens_1": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      true
+    ],
+    "l2_groupings": [
+      2,
+      4
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [
+      null,
+      null
+    ],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      true,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2
+  },
+  "hidden_size_2048_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      4,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      1
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2
+  },
+  "hidden_size_4096_num_tokens_2": {
+    "block_sizes": [
+      1,
+      128,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      4,
+      1
+    ],
+    "range_unroll_factors": [
+      2,
+      0
+    ],
+    "range_warp_specializes": [
+      false,
+      null
+    ],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      false,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 32,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2,
+    "maxnreg": 128
+  },
+  "hidden_size_8192_num_tokens_2": {
+    "block_sizes": [
+      1,
+      512,
+      2,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      1
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      true,
+      null
+    ],
+    "range_flattens": [
+      false,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2,
+    "maxnreg": 64
+  },
+  "hidden_size_2048_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1024,
+      2,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      1,
+      2
+    ],
+    "range_warp_specializes": [
+      false,
+      null
+    ],
+    "range_multi_buffers": [
+      true,
+      null
+    ],
+    "range_flattens": [
+      true,
+      false
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2
+  },
+  "hidden_size_4096_num_tokens_4": {
+    "block_sizes": [
+      1,
+      4096,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      16
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [
+      false,
+      false
+    ],
+    "range_multi_buffers": [
+      true,
+      true
+    ],
+    "range_flattens": [
+      null,
+      false
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4
+  },
+  "hidden_size_8192_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      1
+    ],
+    "range_warp_specializes": [
+      false,
+      true
+    ],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      false,
+      false
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 32
+  },
+  "hidden_size_2048_num_tokens_8": {
+    "block_sizes": [
+      4,
+      512,
+      4,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      2
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      true,
+      true
+    ],
+    "range_flattens": [
+      true,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 128
+  },
+  "hidden_size_4096_num_tokens_8": {
+    "block_sizes": [
+      8,
+      64,
+      4,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      1
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      true,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2
+  },
+  "hidden_size_8192_num_tokens_8": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      64
+    ],
+    "range_unroll_factors": [
+      4,
+      0
+    ],
+    "range_warp_specializes": [
+      false,
+      true
+    ],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      false,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 256
+  },
+  "hidden_size_2048_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1024,
+      8,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      8
+    ],
+    "range_unroll_factors": [
+      0,
+      1
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      true,
+      false
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 32
+  },
+  "hidden_size_4096_num_tokens_16": {
+    "block_sizes": [
+      1,
+      4096,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      4,
+      8
+    ],
+    "range_unroll_factors": [
+      0,
+      3
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 256
+  },
+  "hidden_size_8192_num_tokens_16": {
+    "block_sizes": [
+      16,
+      64,
+      16,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      32
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      true,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first"
+    ],
+    "num_warps": 1,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 256
+  },
+  "hidden_size_2048_num_tokens_32": {
+    "block_sizes": [
+      1,
+      2048,
+      8,
+      512
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      8
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      true,
+      false
+    ],
+    "range_flattens": [
+      null,
+      false
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 128
+  },
+  "hidden_size_4096_num_tokens_32": {
+    "block_sizes": [
+      1,
+      2048,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      8,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      true,
+      null
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4
+  },
+  "hidden_size_8192_num_tokens_32": {
+    "block_sizes": [
+      1,
+      2048,
+      8,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [
+      null,
+      true
+    ],
+    "range_multi_buffers": [
+      false,
+      null
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 128
+  },
+  "hidden_size_2048_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1024,
+      8,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      1
+    ],
+    "range_unroll_factors": [
+      1,
+      2
+    ],
+    "range_warp_specializes": [
+      false,
+      false
+    ],
+    "range_multi_buffers": [
+      true,
+      null
+    ],
+    "range_flattens": [
+      true,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last"
+    ],
+    "num_warps": 2,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2
+  },
+  "hidden_size_4096_num_tokens_64": {
+    "block_sizes": [
+      1,
+      2048,
+      16,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      1
+    ],
+    "range_unroll_factors": [
+      4,
+      2
+    ],
+    "range_warp_specializes": [
+      false,
+      null
+    ],
+    "range_multi_buffers": [
+      false,
+      null
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 256
+  },
+  "hidden_size_8192_num_tokens_64": {
+    "block_sizes": [
+      1,
+      4096,
+      32,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      32
+    ],
+    "range_unroll_factors": [
+      3,
+      0
+    ],
+    "range_warp_specializes": [
+      false,
+      true
+    ],
+    "range_multi_buffers": [
+      true,
+      true
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2
+  },
+  "hidden_size_2048_num_tokens_128": {
+    "block_sizes": [
+      128,
+      32,
+      32,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      64
+    ],
+    "range_unroll_factors": [
+      0,
+      4
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      null,
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2,
+    "maxnreg": 64
+  },
+  "hidden_size_4096_num_tokens_128": {
+    "block_sizes": [
+      128,
+      64,
+      16,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      64
+    ],
+    "range_unroll_factors": [
+      3,
+      2
+    ],
+    "range_warp_specializes": [
+      null,
+      null
+    ],
+    "range_multi_buffers": [
+      true,
+      null
+    ],
+    "range_flattens": [
+      null,
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2
+  },
+  "hidden_size_8192_num_tokens_128": {
+    "block_sizes": [
+      32,
+      64,
+      128,
+      16
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      64
+    ],
+    "range_unroll_factors": [
+      3,
+      0
+    ],
+    "range_warp_specializes": [
+      null,
+      true
+    ],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      false,
+      false
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 32
+  },
+  "hidden_size_2048_num_tokens_256": {
+    "block_sizes": [
+      4,
+      512,
+      4,
+      512
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      2
+    ],
+    "range_unroll_factors": [
+      0,
+      1
+    ],
+    "range_warp_specializes": [
+      null,
+      null
+    ],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      false,
+      false
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 32
+  },
+  "hidden_size_4096_num_tokens_256": {
+    "block_sizes": [
+      8,
+      2048,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      32
+    ],
+    "range_unroll_factors": [
+      0,
+      4
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      null,
+      false
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4
+  },
+  "hidden_size_8192_num_tokens_256": {
+    "block_sizes": [
+      32,
+      256,
+      64,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      32
+    ],
+    "range_unroll_factors": [
+      1,
+      0
+    ],
+    "range_warp_specializes": [
+      null,
+      true
+    ],
+    "range_multi_buffers": [
+      null,
+      false
+    ],
+    "range_flattens": [
+      true,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2,
+    "maxnreg": 128
+  },
+  "hidden_size_2048_num_tokens_512": {
+    "block_sizes": [
+      4,
+      1024,
+      128,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      32
+    ],
+    "range_unroll_factors": [
+      1,
+      1
+    ],
+    "range_warp_specializes": [
+      false,
+      true
+    ],
+    "range_multi_buffers": [
+      null,
+      false
+    ],
+    "range_flattens": [
+      false,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 256
+  },
+  "hidden_size_4096_num_tokens_512": {
+    "block_sizes": [
+      32,
+      128,
+      2,
+      2048
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      8,
+      4
+    ],
+    "range_unroll_factors": [
+      1,
+      2
+    ],
+    "range_warp_specializes": [
+      false,
+      false
+    ],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 256
+  },
+  "hidden_size_8192_num_tokens_512": {
+    "block_sizes": [
+      32,
+      256,
+      256,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      2,
+      4
+    ],
+    "range_unroll_factors": [
+      0,
+      4
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2,
+    "maxnreg": 256
+  },
+  "hidden_size_2048_num_tokens_1024": {
+    "block_sizes": [
+      64,
+      128,
+      8,
+      2048
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      64
+    ],
+    "range_unroll_factors": [
+      0,
+      4
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4
+  },
+  "hidden_size_4096_num_tokens_1024": {
+    "block_sizes": [
+      32,
+      256,
+      64,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      16
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      true,
+      null
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2,
+    "maxnreg": 256
+  },
+  "hidden_size_8192_num_tokens_1024": {
+    "block_sizes": [
+      512,
+      16,
+      2,
+      4096
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      32
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 2,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 64
+  },
+  "hidden_size_2048_num_tokens_2048": {
+    "block_sizes": [
+      32,
+      256,
+      128,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      4,
+      1
+    ],
+    "range_unroll_factors": [
+      4,
+      1
+    ],
+    "range_warp_specializes": [
+      false,
+      null
+    ],
+    "range_multi_buffers": [
+      true,
+      true
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 32
+  },
+  "hidden_size_4096_num_tokens_2048": {
+    "block_sizes": [
+      4,
+      4096,
+      128,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      4
+    ],
+    "range_unroll_factors": [
+      0,
+      4
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      false,
+      null
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4
+  },
+  "hidden_size_8192_num_tokens_2048": {
+    "block_sizes": [
+      32,
+      128,
+      64,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      3,
+      0
+    ],
+    "range_warp_specializes": [
+      false,
+      false
+    ],
+    "range_multi_buffers": [
+      true,
+      true
+    ],
+    "range_flattens": [
+      null,
+      false
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 64
+  },
+  "hidden_size_2048_num_tokens_4096": {
+    "block_sizes": [
+      8,
+      2048,
+      128,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      2
+    ],
+    "range_unroll_factors": [
+      0,
+      1
+    ],
+    "range_warp_specializes": [
+      null,
+      false
+    ],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      false,
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4
+  },
+  "hidden_size_4096_num_tokens_4096": {
+    "block_sizes": [
+      64,
+      256,
+      128,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      64
+    ],
+    "range_unroll_factors": [
+      2,
+      0
+    ],
+    "range_warp_specializes": [
+      false,
+      true
+    ],
+    "range_multi_buffers": [
+      true,
+      false
+    ],
+    "range_flattens": [
+      true,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4
+  },
+  "hidden_size_8192_num_tokens_4096": {
+    "block_sizes": [
+      32,
+      256,
+      128,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      4,
+      64
+    ],
+    "range_unroll_factors": [
+      0,
+      1
+    ],
+    "range_warp_specializes": [
+      true,
+      null
+    ],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      null,
+      false
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 64
+  }
+}

--- a/vllm/kernels/helion/configs/dynamic_per_tensor_scaled_fp8_quant/nvidia_h100.json
+++ b/vllm/kernels/helion/configs/dynamic_per_tensor_scaled_fp8_quant/nvidia_h100.json
@@ -1,0 +1,2097 @@
+{
+  "hidden_size_2048_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      2
+    ],
+    "range_unroll_factors": [
+      0,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      true,
+      false
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "hidden_size_2048_num_tokens_1024": {
+    "block_sizes": [
+      128,
+      256,
+      16,
+      2048
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      8,
+      1
+    ],
+    "range_unroll_factors": [
+      1,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      false,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 32,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "hidden_size_2048_num_tokens_128": {
+    "block_sizes": [
+      32,
+      128,
+      128,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      64
+    ],
+    "range_unroll_factors": [
+      0,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      null,
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 32
+  },
+  "hidden_size_2048_num_tokens_16": {
+    "block_sizes": [
+      16,
+      128,
+      4,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      1
+    ],
+    "range_unroll_factors": [
+      1,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      null
+    ],
+    "range_flattens": [
+      false,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 128
+  },
+  "hidden_size_2048_num_tokens_2": {
+    "block_sizes": [
+      1,
+      128,
+      2,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      4,
+      32
+    ],
+    "range_unroll_factors": [
+      1,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      null
+    ],
+    "range_flattens": [
+      true,
+      false
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 256
+  },
+  "hidden_size_2048_num_tokens_2048": {
+    "block_sizes": [
+      2048,
+      32,
+      32,
+      2048
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      16
+    ],
+    "range_unroll_factors": [
+      1,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      null,
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "hidden_size_2048_num_tokens_256": {
+    "block_sizes": [
+      64,
+      128,
+      64,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "hidden_size_2048_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1024,
+      8,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      4,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 2,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 64
+  },
+  "hidden_size_2048_num_tokens_4": {
+    "block_sizes": [
+      1,
+      2048,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      64
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      null
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 2,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 256
+  },
+  "hidden_size_2048_num_tokens_4096": {
+    "block_sizes": [
+      1024,
+      64,
+      512,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      2,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      false
+    ],
+    "range_flattens": [
+      true,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 64
+  },
+  "hidden_size_2048_num_tokens_512": {
+    "block_sizes": [
+      64,
+      256,
+      128,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      4,
+      8
+    ],
+    "range_unroll_factors": [
+      1,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 64
+  },
+  "hidden_size_2048_num_tokens_64": {
+    "block_sizes": [
+      1,
+      2048,
+      32,
+      64
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      16
+    ],
+    "range_unroll_factors": [
+      1,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      false,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 64
+  },
+  "hidden_size_2048_num_tokens_8": {
+    "block_sizes": [
+      1,
+      256,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      2,
+      64
+    ],
+    "range_unroll_factors": [
+      1,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 32
+  },
+  "hidden_size_4096_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      4,
+      1
+    ],
+    "range_unroll_factors": [
+      1,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      false,
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2
+  },
+  "hidden_size_4096_num_tokens_1024": {
+    "block_sizes": [
+      64,
+      512,
+      64,
+      512
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      16
+    ],
+    "range_unroll_factors": [
+      3,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      false,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 256
+  },
+  "hidden_size_4096_num_tokens_128": {
+    "block_sizes": [
+      32,
+      256,
+      32,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      null
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "hidden_size_4096_num_tokens_16": {
+    "block_sizes": [
+      16,
+      128,
+      16,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      true
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "hidden_size_4096_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1024,
+      2,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      64
+    ],
+    "range_unroll_factors": [
+      0,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      false,
+      true
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 128
+  },
+  "hidden_size_4096_num_tokens_2048": {
+    "block_sizes": [
+      512,
+      128,
+      128,
+      512
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      4
+    ],
+    "range_unroll_factors": [
+      0,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 32,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "hidden_size_4096_num_tokens_256": {
+    "block_sizes": [
+      4,
+      4096,
+      4,
+      4096
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      1
+    ],
+    "range_unroll_factors": [
+      1,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      false
+    ],
+    "range_flattens": [
+      null,
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 64
+  },
+  "hidden_size_4096_num_tokens_32": {
+    "block_sizes": [
+      1,
+      2048,
+      4,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      8
+    ],
+    "range_unroll_factors": [
+      0,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      false
+    ],
+    "range_flattens": [
+      null,
+      false
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 256
+  },
+  "hidden_size_4096_num_tokens_4": {
+    "block_sizes": [
+      1,
+      2048,
+      4,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      false,
+      false
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 256
+  },
+  "hidden_size_4096_num_tokens_4096": {
+    "block_sizes": [
+      256,
+      256,
+      512,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      1,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 32,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 64
+  },
+  "hidden_size_4096_num_tokens_512": {
+    "block_sizes": [
+      512,
+      64,
+      64,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      1,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "hidden_size_4096_num_tokens_64": {
+    "block_sizes": [
+      4,
+      1024,
+      64,
+      64
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      false,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 128
+  },
+  "hidden_size_4096_num_tokens_8": {
+    "block_sizes": [
+      1,
+      2048,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      32
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      false
+    ],
+    "range_flattens": [
+      false,
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 64
+  },
+  "hidden_size_8192_num_tokens_1": {
+    "block_sizes": [
+      1,
+      4096,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      2,
+      16
+    ],
+    "range_unroll_factors": [
+      0,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      true
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2,
+    "maxnreg": 64
+  },
+  "hidden_size_8192_num_tokens_1024": {
+    "block_sizes": [
+      1024,
+      64,
+      512,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 64
+  },
+  "hidden_size_8192_num_tokens_128": {
+    "block_sizes": [
+      2,
+      8192,
+      128,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      32
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      false,
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 64
+  },
+  "hidden_size_8192_num_tokens_16": {
+    "block_sizes": [
+      16,
+      128,
+      16,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      4
+    ],
+    "range_unroll_factors": [
+      0,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 128
+  },
+  "hidden_size_8192_num_tokens_2": {
+    "block_sizes": [
+      1,
+      512,
+      2,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      16
+    ],
+    "range_unroll_factors": [
+      1,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      false,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 128
+  },
+  "hidden_size_8192_num_tokens_2048": {
+    "block_sizes": [
+      512,
+      128,
+      512,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      4,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 32,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 64
+  },
+  "hidden_size_8192_num_tokens_256": {
+    "block_sizes": [
+      4,
+      8192,
+      256,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      1
+    ],
+    "range_unroll_factors": [
+      1,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "hidden_size_8192_num_tokens_32": {
+    "block_sizes": [
+      32,
+      128,
+      32,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      false
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 128
+  },
+  "hidden_size_8192_num_tokens_4": {
+    "block_sizes": [
+      4,
+      256,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      1,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 32
+  },
+  "hidden_size_8192_num_tokens_4096": {
+    "block_sizes": [
+      256,
+      128,
+      32,
+      2048
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      8,
+      64
+    ],
+    "range_unroll_factors": [
+      1,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      true
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 64
+  },
+  "hidden_size_8192_num_tokens_512": {
+    "block_sizes": [
+      256,
+      128,
+      256,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      1
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 256
+  },
+  "hidden_size_8192_num_tokens_64": {
+    "block_sizes": [
+      1,
+      8192,
+      16,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      32
+    ],
+    "range_unroll_factors": [
+      1,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "hidden_size_8192_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      4
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 128
+  }
+}

--- a/vllm/kernels/helion/configs/dynamic_per_tensor_scaled_fp8_quant/nvidia_h200.json
+++ b/vllm/kernels/helion/configs/dynamic_per_tensor_scaled_fp8_quant/nvidia_h200.json
@@ -1,0 +1,2084 @@
+{
+  "hidden_size_2048_num_tokens_1": {
+    "block_sizes": [
+      1,
+      2,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      true
+    ],
+    "l2_groupings": [
+      4,
+      4
+    ],
+    "range_unroll_factors": [
+      3,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      false,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "hidden_size_4096_num_tokens_1": {
+    "block_sizes": [
+      1,
+      128,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      true
+    ],
+    "l2_groupings": [
+      8,
+      4
+    ],
+    "range_unroll_factors": [
+      2,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      false,
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "hidden_size_8192_num_tokens_1": {
+    "block_sizes": [
+      1,
+      8,
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      true
+    ],
+    "l2_groupings": [
+      2,
+      4
+    ],
+    "range_unroll_factors": [
+      4,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2
+  },
+  "hidden_size_2048_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      8,
+      64
+    ],
+    "range_unroll_factors": [
+      1,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      false
+    ],
+    "range_flattens": [
+      false,
+      true
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8
+  },
+  "hidden_size_4096_num_tokens_2": {
+    "block_sizes": [
+      1,
+      32,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      4
+    ],
+    "range_unroll_factors": [
+      3,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      true
+    ],
+    "range_flattens": [
+      false,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 2,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 16
+  },
+  "hidden_size_8192_num_tokens_2": {
+    "block_sizes": [
+      1,
+      2,
+      2,
+      8
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      true
+    ],
+    "l2_groupings": [
+      8,
+      8
+    ],
+    "range_unroll_factors": [
+      0,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      null
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 128
+  },
+  "hidden_size_2048_num_tokens_4": {
+    "block_sizes": [
+      1,
+      64,
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      64
+    ],
+    "range_unroll_factors": [
+      2,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      null
+    ],
+    "range_flattens": [
+      true,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 64
+  },
+  "hidden_size_4096_num_tokens_4": {
+    "block_sizes": [
+      1,
+      128,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      16
+    ],
+    "range_unroll_factors": [
+      2,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      false,
+      false
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 16
+  },
+  "hidden_size_8192_num_tokens_4": {
+    "block_sizes": [
+      1,
+      16,
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      true
+    ],
+    "l2_groupings": [
+      1,
+      32
+    ],
+    "range_unroll_factors": [
+      4,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      false
+    ],
+    "range_flattens": [
+      true,
+      false
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 256
+  },
+  "hidden_size_2048_num_tokens_8": {
+    "block_sizes": [
+      1,
+      2048,
+      1,
+      8
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      16
+    ],
+    "range_unroll_factors": [
+      1,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      true,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4
+  },
+  "hidden_size_4096_num_tokens_8": {
+    "block_sizes": [
+      1,
+      128,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      2,
+      32
+    ],
+    "range_unroll_factors": [
+      4,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      false,
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4
+  },
+  "hidden_size_8192_num_tokens_8": {
+    "block_sizes": [
+      2,
+      512,
+      4,
+      32
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      true
+    ],
+    "l2_groupings": [
+      8,
+      2
+    ],
+    "range_unroll_factors": [
+      3,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      true,
+      false
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 128
+  },
+  "hidden_size_2048_num_tokens_16": {
+    "block_sizes": [
+      1,
+      32,
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      8
+    ],
+    "range_unroll_factors": [
+      3,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      false
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 64
+  },
+  "hidden_size_4096_num_tokens_16": {
+    "block_sizes": [
+      1,
+      512,
+      8,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      8,
+      32
+    ],
+    "range_unroll_factors": [
+      0,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 32,
+    "maxnreg": 32
+  },
+  "hidden_size_8192_num_tokens_16": {
+    "block_sizes": [
+      1,
+      64,
+      2,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      true
+    ],
+    "l2_groupings": [
+      8,
+      2
+    ],
+    "range_unroll_factors": [
+      1,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      true
+    ],
+    "range_flattens": [
+      null,
+      false
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 16
+  },
+  "hidden_size_2048_num_tokens_32": {
+    "block_sizes": [
+      4,
+      128,
+      2,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      true
+    ],
+    "l2_groupings": [
+      8,
+      16
+    ],
+    "range_unroll_factors": [
+      4,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 16
+  },
+  "hidden_size_4096_num_tokens_32": {
+    "block_sizes": [
+      2,
+      64,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      8,
+      4
+    ],
+    "range_unroll_factors": [
+      1,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      null
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4
+  },
+  "hidden_size_8192_num_tokens_32": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      16
+    ],
+    "range_unroll_factors": [
+      0,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      false
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 1,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 256
+  },
+  "hidden_size_2048_num_tokens_64": {
+    "block_sizes": [
+      1,
+      64,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      4,
+      2
+    ],
+    "range_unroll_factors": [
+      1,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      true,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8
+  },
+  "hidden_size_4096_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      8,
+      2
+    ],
+    "range_unroll_factors": [
+      4,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1
+  },
+  "hidden_size_8192_num_tokens_64": {
+    "block_sizes": [
+      16,
+      16,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      16
+    ],
+    "range_unroll_factors": [
+      1,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 64
+  },
+  "hidden_size_2048_num_tokens_128": {
+    "block_sizes": [
+      1,
+      64,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      8
+    ],
+    "range_unroll_factors": [
+      4,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      true
+    ],
+    "range_flattens": [
+      false,
+      false
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 16
+  },
+  "hidden_size_4096_num_tokens_128": {
+    "block_sizes": [
+      64,
+      16,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      16
+    ],
+    "range_unroll_factors": [
+      3,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      true,
+      false
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 256
+  },
+  "hidden_size_8192_num_tokens_128": {
+    "block_sizes": [
+      1,
+      4096,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      8
+    ],
+    "range_unroll_factors": [
+      3,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      false,
+      false
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last"
+    ],
+    "num_warps": 2,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 16
+  },
+  "hidden_size_2048_num_tokens_256": {
+    "block_sizes": [
+      32,
+      8,
+      2,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      8
+    ],
+    "range_unroll_factors": [
+      3,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      true
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "first"
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 16,
+    "maxnreg": 256
+  },
+  "hidden_size_4096_num_tokens_256": {
+    "block_sizes": [
+      8,
+      64,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      32
+    ],
+    "range_unroll_factors": [
+      0,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8
+  },
+  "hidden_size_8192_num_tokens_256": {
+    "block_sizes": [
+      16,
+      256,
+      64,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      4
+    ],
+    "range_unroll_factors": [
+      0,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2,
+    "maxnreg": 64
+  },
+  "hidden_size_2048_num_tokens_512": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      16
+    ],
+    "range_unroll_factors": [
+      4,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      false
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last"
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 16
+  },
+  "hidden_size_4096_num_tokens_512": {
+    "block_sizes": [
+      16,
+      64,
+      64,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      32,
+      32
+    ],
+    "range_unroll_factors": [
+      4,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      true
+    ],
+    "range_flattens": [
+      true,
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 1,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 128
+  },
+  "hidden_size_8192_num_tokens_512": {
+    "block_sizes": [
+      32,
+      64,
+      64,
+      64
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      64
+    ],
+    "range_unroll_factors": [
+      1,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      false
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8
+  },
+  "hidden_size_2048_num_tokens_1024": {
+    "block_sizes": [
+      16,
+      128,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      8
+    ],
+    "range_unroll_factors": [
+      3,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      false
+    ],
+    "range_flattens": [
+      false,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4
+  },
+  "hidden_size_4096_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      32
+    ],
+    "range_unroll_factors": [
+      2,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true,
+      false
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 16
+  },
+  "hidden_size_8192_num_tokens_1024": {
+    "block_sizes": [
+      32,
+      128,
+      64,
+      64
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      8,
+      1
+    ],
+    "range_unroll_factors": [
+      2,
+      4
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      false
+    ],
+    "range_flattens": [
+      null,
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 16
+  },
+  "hidden_size_2048_num_tokens_2048": {
+    "block_sizes": [
+      32,
+      64,
+      16,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      1
+    ],
+    "range_unroll_factors": [
+      2,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      false,
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 16
+  },
+  "hidden_size_4096_num_tokens_2048": {
+    "block_sizes": [
+      64,
+      64,
+      4,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      8,
+      64
+    ],
+    "range_unroll_factors": [
+      0,
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false,
+      null
+    ],
+    "range_flattens": [
+      true,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8
+  },
+  "hidden_size_8192_num_tokens_2048": {
+    "block_sizes": [
+      16,
+      512,
+      64,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      64,
+      32
+    ],
+    "range_unroll_factors": [
+      1,
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      null,
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 64
+  },
+  "hidden_size_2048_num_tokens_4096": {
+    "block_sizes": [
+      64,
+      64,
+      32,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        0
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      1,
+      16
+    ],
+    "range_unroll_factors": [
+      2,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      null
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 2,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8
+  },
+  "hidden_size_4096_num_tokens_4096": {
+    "block_sizes": [
+      16,
+      256,
+      16,
+      512
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        1,
+        0
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      64
+    ],
+    "range_unroll_factors": [
+      0,
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      true
+    ],
+    "range_flattens": [
+      null,
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 32
+  },
+  "hidden_size_8192_num_tokens_4096": {
+    "block_sizes": [
+      4,
+      1024,
+      8,
+      1024
+    ],
+    "loop_orders": [
+      [
+        0,
+        1
+      ],
+      [
+        0,
+        1
+      ]
+    ],
+    "flatten_loops": [
+      false
+    ],
+    "l2_groupings": [
+      16,
+      32
+    ],
+    "range_unroll_factors": [
+      1,
+      3
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      null,
+      false
+    ],
+    "range_flattens": [
+      null,
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 256
+  }
+}

--- a/vllm/kernels/helion/ops/dynamic_per_tensor_scaled_fp8_quant.py
+++ b/vllm/kernels/helion/ops/dynamic_per_tensor_scaled_fp8_quant.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from itertools import product
+from typing import Any
+
+import helion.language as hl
+import regex as re
+import torch
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    get_fp8_min_max,
+)
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_helion
+
+if not has_helion():
+    raise ImportError(
+        "Helion kernel requires helion to be installed. "
+        "Install it with: pip install helion"
+    )
+
+from vllm.kernels.helion.register import register_kernel
+
+logger = init_logger(__name__)
+
+
+def generate_inputs() -> dict[str, tuple[Any, ...]]:
+    # TODO(xiaohongchen1991): it is difficult for kernel author to cover
+    # all input property combination. Currently, dtypes are fixed. We need
+    # optimization to bucket/skip some combinations
+    num_tokens_list = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
+    hidden_size_list = [2048, 4096, 8192]
+    in_dtype: torch.dtype = torch.bfloat16
+    out_dtype: torch.dtype = current_platform.fp8_dtype()
+    scale_dtype: torch.dtype = torch.float32
+    inputs = {}
+
+    for num_tokens, hidden_size in product(num_tokens_list, hidden_size_list):
+        input = torch.randn(num_tokens, hidden_size, device="cuda", dtype=in_dtype)
+        result = torch.empty(input.shape, device=input.device, dtype=out_dtype)
+        scale = torch.empty(1, device=input.device, dtype=scale_dtype)
+
+        config_key = f"hidden_size_{hidden_size}_num_tokens_{num_tokens}"
+        inputs[config_key] = (result, input, scale)
+
+    return inputs
+
+
+def pick_config(args: tuple[Any, ...], config_keys: list[str]) -> str | None:
+    """Pick the best pre-tuned config for the given input shape.
+
+    Selection strategy:
+      1. Find the closest hidden_size among available configs
+         (exact match preferred).
+      2. Among the num_tokens values tuned for that hidden_size, pick
+         the smallest num_tokens >= the input's num_tokens. If the input is
+         larger than all available num_tokens, fall back to the largest.
+
+    Config keys must be "default" or follow the format
+    "hidden_size_{int}_num_tokens_{int}".
+    """
+
+    if not config_keys:
+        return None
+
+    _, input, _ = args
+    num_tokens, hidden_size = input.shape
+
+    configs: dict[int, list[int]] = {}
+    for key in config_keys:
+        if key == "default":
+            continue
+        match = re.fullmatch(r"hidden_size_(\d+)_num_tokens_(\d+)", key)
+        if not match:
+            raise ValueError(
+                f"Malformed config key '{key}', "
+                f"expected format 'hidden_size_{{int}}_num_tokens_{{int}}'"
+            )
+        hidden_size_str, num_tokens_str = match.groups()
+        configs.setdefault(int(hidden_size_str), []).append(int(num_tokens_str))
+
+    if not configs:
+        return "default" if "default" in config_keys else None
+
+    best_hidden_size = min(configs, key=lambda s: abs(s - hidden_size))
+    available_num_tokens = sorted(configs[best_hidden_size])
+    best_num_tokens = next(
+        (n for n in available_num_tokens if n >= num_tokens), available_num_tokens[-1]
+    )
+
+    return f"hidden_size_{best_hidden_size}_num_tokens_{best_num_tokens}"
+
+
+@register_kernel(
+    mutates_args=["result", "scale"],
+    config_picker=pick_config,
+    input_generator=generate_inputs,
+)  # type: ignore[misc]
+def dynamic_per_tensor_scaled_fp8_quant(
+    result: torch.Tensor,  # [num_tokens, hidden_size]
+    input: torch.Tensor,  # [num_tokens, hidden_size]
+    scale: torch.Tensor,  # [1]
+) -> None:
+    # This code assumes batch_dim and num_tokens are flattened
+    assert input.ndim == 2
+    num_tokens, hidden_size = input.shape
+    hl.specialize(hidden_size)
+
+    assert result.shape == input.shape
+    assert scale.shape[0] == 1
+    assert scale.dtype == torch.float32
+    assert input.stride()[-1] == 1
+    assert result.stride()[-1] == 1
+
+    _, fp8_max = get_fp8_min_max()
+
+    scale.zero_()
+
+    for tile_m, tile_n in hl.tile([num_tokens, hidden_size]):
+        abs_value = torch.abs(input[tile_m, tile_n])
+        # multiple reduction dimensions not supported yet
+        max_value_per_row = torch.amax(abs_value, dim=1)
+        max_value = torch.amax(max_value_per_row).to(dtype=torch.float32)
+        hl.atomic_max(scale, [0], max_value / fp8_max)
+
+    hl.barrier()
+
+    for tile_m, tile_n in hl.tile([num_tokens, hidden_size]):
+        inv_scale = (1.0 / scale[0]).to(dtype=torch.float32)
+        x_blk = input[tile_m, tile_n].to(dtype=torch.float32)
+        result[tile_m, tile_n] = (x_blk * inv_scale).to(result.dtype)
+
+
+def baseline(
+    result: torch.Tensor,  # [num_tokens, hidden_size]
+    input: torch.Tensor,  # [num_tokens, hidden_size]
+    scale: torch.Tensor,  # [1]
+):
+    torch.ops._C.dynamic_scaled_fp8_quant(result, input, scale)

--- a/vllm/kernels/helion/register.py
+++ b/vllm/kernels/helion/register.py
@@ -254,6 +254,7 @@ class HelionKernelWrapper:
         op_name: str,
         fake_impl: Callable,
         config_picker: Callable[[tuple[Any, ...], list[str]], str | None],
+        mutates_args: list[str] | None = None,
         helion_settings: "helion.Settings | None" = None,
         input_generator: Callable[[], dict[str, tuple[Any, ...]]] | None = None,
     ):
@@ -266,6 +267,7 @@ class HelionKernelWrapper:
         self.helion_settings = helion_settings
         self._config_picker = config_picker
         self._input_generator = input_generator
+        self._mutates_args = mutates_args
         self._configured_kernel: ConfiguredHelionKernel | None = None
         # TODO(@gmagogsfm): Remove this disable flag once integrated with vLLM IR,
         # which handles op enablement/disablement.
@@ -415,7 +417,7 @@ class HelionKernelWrapper:
         direct_register_custom_op(
             op_name=self.op_name,
             op_func=configured_kernel._decorated_kernel,
-            mutates_args=None,
+            mutates_args=self._mutates_args,
             fake_impl=self._fake_impl,
             target_lib=vllm_helion_lib,
         )
@@ -460,6 +462,8 @@ def register_kernel(
     *,
     config_picker: Callable[[tuple[Any, ...], list[str]], str | None],
     fake_impl: Callable | None = None,
+    # WARNING: mutates_args will be deprecated later when CustomOp path is removed
+    mutates_args: list[str] | None = None,
     helion_settings: "helion.Settings | None" = None,
     input_generator: Callable[[], dict[str, tuple[Any, ...]]] | None = None,
 ) -> Callable[[Callable], HelionKernelWrapper]:
@@ -521,6 +525,7 @@ def register_kernel(
             op_name=final_op_name,
             fake_impl=final_fake_impl,
             config_picker=config_picker,
+            mutates_args=mutates_args,
             helion_settings=helion_settings,
             input_generator=input_generator,
         )


### PR DESCRIPTION
## Purpose
This PR is to add Helion kernel for ```dynamic_per_tensor_scaled_fp8_quant``` operation. It follows the implementation from the [vllm c version](https://github.com/vllm-project/vllm/blob/10546f925aef5d805e41f0f40c6610d08ff1a037/csrc/quantization/w8a8/fp8/common.cu#L325). 

This is a subtask for https://github.com/vllm-project/vllm/issues/32962.

Autotuning and benchmarking in H200 and B200 were contributed by @gmagogsfm.

### Kernel level benchmark
**Environment**
Python: 3.12.13
PyTorch: 2.10.0+cu129
Cuda: 12.9
Helion: 0.3.0
Triton: 3.6.0
GPU: NVIDIA H100

**Benchmark Setup**
Latency measure: ```triton.testing.do_bench_cudagraph(rep=1000)```
Memory measure: ```torch.cuda.reset_peak_memory_stats()```
Baseline: ```torch.ops._C.dynamic_scaled_fp8_quant```

**Autotuning Setup**
Default "full" autotuning effort. i.e. LFBOTreeSearch with initial_population=FROM_RANDOM, copies=5, max_generations=20, similarity_penalty=1.0.

**Results**
H100
```
case                             | baseline_ms | kernel_ms | speedup(x) | baseline_peak(MB) | kernel_peak(MB) | mem_improve(x)
---------------------------------+-------------+-----------+------------+-------------------+-----------------+---------------
hidden_size_2048_num_tokens_1    | 0.007       | 0.005     | 1.545      | 352.31            | 352.31          | 1.000
hidden_size_4096_num_tokens_1    | 0.008       | 0.005     | 1.797      | 352.31            | 352.31          | 1.000
hidden_size_8192_num_tokens_1    | 0.012       | 0.005     | 2.464      | 352.32            | 352.33          | 1.000
hidden_size_2048_num_tokens_2    | 0.007       | 0.005     | 1.432      | 352.31            | 352.31          | 1.000
hidden_size_4096_num_tokens_2    | 0.009       | 0.005     | 1.800      | 352.32            | 352.33          | 1.000
hidden_size_8192_num_tokens_2    | 0.012       | 0.005     | 2.322      | 352.35            | 352.35          | 1.000
hidden_size_2048_num_tokens_4    | 0.007       | 0.005     | 1.476      | 352.32            | 352.33          | 1.000
hidden_size_4096_num_tokens_4    | 0.009       | 0.005     | 1.695      | 352.35            | 352.35          | 1.000
hidden_size_8192_num_tokens_4    | 0.012       | 0.005     | 2.389      | 352.40            | 352.40          | 1.000
hidden_size_2048_num_tokens_8    | 0.007       | 0.005     | 1.423      | 352.35            | 352.35          | 1.000
hidden_size_4096_num_tokens_8    | 0.009       | 0.005     | 1.754      | 352.40            | 352.40          | 1.000
hidden_size_8192_num_tokens_8    | 0.012       | 0.005     | 2.282      | 352.50            | 352.50          | 1.000
hidden_size_2048_num_tokens_16   | 0.007       | 0.005     | 1.451      | 352.40            | 352.40          | 1.000
hidden_size_4096_num_tokens_16   | 0.009       | 0.005     | 1.759      | 352.50            | 352.50          | 1.000
hidden_size_8192_num_tokens_16   | 0.012       | 0.005     | 2.247      | 352.69            | 352.69          | 1.000
hidden_size_2048_num_tokens_32   | 0.007       | 0.005     | 1.449      | 352.50            | 352.50          | 1.000
hidden_size_4096_num_tokens_32   | 0.009       | 0.005     | 1.745      | 352.69            | 352.69          | 1.000
hidden_size_8192_num_tokens_32   | 0.012       | 0.005     | 2.290      | 353.09            | 353.09          | 1.000
hidden_size_2048_num_tokens_64   | 0.007       | 0.005     | 1.380      | 352.69            | 352.69          | 1.000
hidden_size_4096_num_tokens_64   | 0.009       | 0.005     | 1.667      | 353.09            | 353.09          | 1.000
hidden_size_8192_num_tokens_64   | 0.012       | 0.006     | 2.173      | 353.87            | 353.87          | 1.000
hidden_size_2048_num_tokens_128  | 0.007       | 0.006     | 1.346      | 353.09            | 353.09          | 1.000
hidden_size_4096_num_tokens_128  | 0.009       | 0.006     | 1.583      | 353.87            | 353.87          | 1.000
hidden_size_8192_num_tokens_128  | 0.012       | 0.007     | 1.834      | 355.45            | 355.45          | 1.000
hidden_size_2048_num_tokens_256  | 0.008       | 0.006     | 1.344      | 353.87            | 353.87          | 1.000
hidden_size_4096_num_tokens_256  | 0.009       | 0.007     | 1.409      | 355.45            | 355.45          | 1.000
hidden_size_8192_num_tokens_256  | 0.013       | 0.008     | 1.588      | 358.59            | 358.59          | 1.000
hidden_size_2048_num_tokens_512  | 0.008       | 0.007     | 1.192      | 355.45            | 355.45          | 1.000
hidden_size_4096_num_tokens_512  | 0.010       | 0.008     | 1.268      | 358.59            | 358.59          | 1.000
hidden_size_8192_num_tokens_512  | 0.014       | 0.011     | 1.247      | 364.88            | 364.88          | 1.000
hidden_size_2048_num_tokens_1024 | 0.009       | 0.008     | 1.189      | 358.59            | 358.59          | 1.000
hidden_size_4096_num_tokens_1024 | 0.011       | 0.012     | 0.992      | 364.88            | 364.88          | 1.000
hidden_size_8192_num_tokens_1024 | 0.016       | 0.017     | 0.969      | 377.47            | 377.47          | 1.000
hidden_size_2048_num_tokens_2048 | 0.013       | 0.011     | 1.153      | 364.88            | 364.88          | 1.000
hidden_size_4096_num_tokens_2048 | 0.019       | 0.017     | 1.121      | 377.47            | 377.47          | 1.000
hidden_size_8192_num_tokens_2048 | 0.048       | 0.037     | 1.280      | 402.63            | 402.63          | 1.000
hidden_size_2048_num_tokens_4096 | 0.020       | 0.018     | 1.129      | 377.47            | 377.47          | 1.000
hidden_size_4096_num_tokens_4096 | 0.049       | 0.036     | 1.383      | 402.63            | 402.63          | 1.000
hidden_size_8192_num_tokens_4096 | 0.095       | 0.068     | 1.408      | 452.96            | 452.96          | 1.000
```

Benchmarking on H200 and B200 shows similar level of speedup and results are provided here:
* H200: https://gist.github.com/gmagogsfm/9a8fbd43d39c0ebbddca3d14a8c1d0f0
* B200: https://gist.github.com/gmagogsfm/f022862cb1f9f2881b698b920fc757a1

## Test Plan

- [x] Test correctness
  - Added unit test to cover its correctness
- [x] Benchmark kernel performance 

## Test Result
### Unit test to cover correctness 
All unit test cases to cover its correctness passed. 
```
pytest tests/kernels/helion/test_dynamic_per_tensor_scaled_fp8_quant.py
```

### Kernel benchmarking
See the results above.