### PR TITLE
[kernel] use fused_topk of flashinfer

### DIFF
--- a/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/grouped_topk_router.py
@@ -57,7 +57,7 @@ def fi_fused_topk_deepseek(
         topk_values,
         topk_indices,
     )
-    return topk_values.to(torch.float32), topk_indices
+    return topk_values, topk_indices
 
 
 def fused_grouped_topk(
@@ -76,6 +76,7 @@ def fused_grouped_topk(
     if scoring_func == "sigmoid":
         # Fully fused kernel path for sigmoid
         if renormalize:
+            # TODO: not sure when to use this kernel
             topk_values, topk_indices = fi_fused_topk_deepseek(
                 gating_output,
                 e_score_correction_bias,


### PR DESCRIPTION
## Purpose
use `fused_topk` of flashinfer

TODO: I don't know when to use this for other models

## Test Plan

```
vllm serve deepseek-ai/DeepSeek-V3 \
--trust-remote-code \
--tensor-parallel-size 8 \
--enable-expert-parallel

vllm bench serve --model deepseek-ai/DeepSeek-V3
```

## Test Result
main
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  149.16    
Total input tokens:                      1023000   
Total generated tokens:                  128000    
Request throughput (req/s):              6.70      
Output token throughput (tok/s):         858.11    
Peak output token throughput (tok/s):    3363.00   
Peak concurrent requests:                1000.00   
Total token throughput (tok/s):          7716.29   
---------------Time to First Token----------------
Mean TTFT (ms):                          64486.97  
Median TTFT (ms):                        57876.35  
P99 TTFT (ms):                           129967.07 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          467.67    
Median TPOT (ms):                        578.27    
P99 TPOT (ms):                           585.65    
---------------Inter-token Latency----------------
Mean ITL (ms):                           467.70    
Median ITL (ms):                         191.74    
P99 ITL (ms):                            912.02    
==================================================
```
This PR
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Benchmark duration (s):                  147.83    
Total input tokens:                      1023000   
Total generated tokens:                  128000    
Request throughput (req/s):              6.76      
Output token throughput (tok/s):         865.85    
Peak output token throughput (tok/s):    3276.00   
Peak concurrent requests:                1000.00   
Total token throughput (tok/s):          7785.84   
---------------Time to First Token----------------
Mean TTFT (ms):                          63815.92  
Median TTFT (ms):                        57212.43  
P99 TTFT (ms):                           128718.71 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          463.94    
Median TPOT (ms):                        572.73    
P99 TPOT (ms):                           580.98    
---------------Inter-token Latency----------------
Mean ITL (ms):                           463.97    
Median ITL (ms):                         191.11    
P99 ITL (ms):                            900.58    
==================================================
```


## Accuracy

```
lm_eval --model local-chat-completions --model_args model=deepseek-ai/DeepSeek-V3,base_url=http://localhost:8000/v1/chat/completions,num_concurrent=280 --tasks gsm8k --apply_chat_template --num_fewshot 5 --trust_remote_code
```
This PR
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9356|±  |0.0068|
|     |       |strict-match    |     5|exact_match|↑  |0.8757|±  |0.0091|
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

