### PR TITLE
[Bugfix] Fix illegal memory access in AWQ-Marlin with CUDA graphs (Fixes #32834)

### DIFF
--- a/scripts/test_awq_marlin_cudagraph.py
+++ b/scripts/test_awq_marlin_cudagraph.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Reproducer script for AWQ-Marlin CUDA Graph issue #32834
+
+This script helps verify the fix for illegal memory access when using
+AWQ-Marlin quantization with CUDA graphs.
+"""
+
+import argparse
+import sys
+
+from vllm import LLM, SamplingParams
+
+
+def test_awq_marlin_cudagraph(
+    model: str = "robertgshaw2/tinyllama-awq-marlin",
+    num_iterations: int = 10,
+    enforce_eager: bool = False,
+):
+    """Test AWQ-Marlin with CUDA graphs
+
+    Args:
+        model: Model name or path (should be AWQ-quantized)
+        num_iterations: Number of generation iterations
+        enforce_eager: If True, disable CUDA graphs (safer but slower)
+    """
+    print(f"\n{'=' * 70}")
+    print("Testing AWQ-Marlin Quantization with CUDA Graphs")
+    print(f"{'=' * 70}")
+    print(f"Model: {model}")
+    print(f"Iterations: {num_iterations}")
+    print(f"Enforce Eager: {enforce_eager}")
+    print(f"{'=' * 70}\n")
+
+    try:
+        # Initialize LLM with AWQ-Marlin
+        llm = LLM(
+            model=model,
+            quantization="awq_marlin",
+            max_model_len=512,
+            gpu_memory_utilization=0.8,
+            enforce_eager=enforce_eager,
+        )
+
+        print("[OK] Model loaded successfully")
+
+        # Test with multiple iterations to trigger graph capture and replay
+        prompts = [
+            "Write a short sentence about artificial intelligence.",
+            "Explain what CUDA graphs are in one sentence.",
+            "What is quantization in machine learning?",
+        ] * (num_iterations // 3 + 1)
+        prompts = prompts[:num_iterations]
+
+        sampling_params = SamplingParams(temperature=0.0, max_tokens=32)
+
+        print(f"\nRunning {num_iterations} generation iterations...")
+
+        outputs = llm.generate(prompts, sampling_params)
+
+        print(f"[OK] Successfully generated {len(outputs)} outputs")
+
+        # Display first few outputs as sanity check
+        print("\nSample outputs:")
+        for i, output in enumerate(outputs[:3]):
+            text = output.outputs[0].text
+            print(f"  [{i + 1}] {text[:80]}...")
+
+        print(f"\n{'=' * 70}")
+        print("TEST PASSED: No crashes detected!")
+        print(f"{'=' * 70}\n")
+
+        return True
+
+    except Exception as e:
+        print(f"\n{'=' * 70}")
+        print(f"TEST FAILED: {type(e).__name__}")
+        print(f"{'=' * 70}")
+        print(f"Error: {str(e)}")
+        print(
+            "\nIf you see 'illegal memory access' errors, this indicates "
+            "the AWQ-Marlin CUDA graph safety fix may not be working properly."
+        )
+        print(f"{'=' * 70}\n")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test AWQ-Marlin quantization with CUDA graphs (Issue #32834)"
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="robertgshaw2/tinyllama-awq-marlin",
+        help="Model name or path (default: robertgshaw2/tinyllama-awq-marlin)",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=10,
+        help="Number of generation iterations (default: 10)",
+    )
+    parser.add_argument(
+        "--enforce-eager",
+        action="store_true",
+        help="Disable CUDA graphs (use eager mode)",
+    )
+
+    args = parser.parse_args()
+
+    success = test_awq_marlin_cudagraph(
+        model=args.model,
+        num_iterations=args.iterations,
+        enforce_eager=args.enforce_eager,
+    )
+
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -119,6 +119,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
     VLLM_DISABLE_COMPILE_CACHE: bool = False
+    VLLM_AWQ_MARLIN_UNSAFE_CUDAGRAPH: bool = False
     Q_SCALE_CONSTANT: int = 200
     K_SCALE_CONSTANT: int = 200
     V_SCALE_CONSTANT: int = 100
@@ -747,6 +748,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Default is 8
     "VLLM_MEDIA_LOADING_THREAD_COUNT": lambda: int(
         os.getenv("VLLM_MEDIA_LOADING_THREAD_COUNT", "8")
+    ),
+    # Allow AWQ-Marlin to run with CUDA graphs without automatic safety
+    # mitigations. This is an advanced option that may cause illegal memory
+    # access. Only use if you understand the implications. Related: #32834
+    "VLLM_AWQ_MARLIN_UNSAFE_CUDAGRAPH": lambda: bool(
+        int(os.getenv("VLLM_AWQ_MARLIN_UNSAFE_CUDAGRAPH", "0"))
     ),
     # Maximum filesize in MB for a single audio file when processing
     # speech-to-text requests. Files larger than this will be rejected.


### PR DESCRIPTION
This PR fixes issue #32834 where AWQ-Marlin quantization causes illegal memory access when used with CUDA graphs.

## Problem
AWQ-Marlin kernels use workspace buffers allocated during model loading. The pointers to these buffers are captured during CUDA graph creation, but the buffers themselves can be reallocated or moved, making the captured pointers stale. When the CUDA graph replays, it uses these stale pointers, resulting in illegal memory access errors.

## Solution
Automatically enable `cudagraph_copy_inputs=True` when:
- Model uses `awq_marlin` quantization
- CUDA graphs are enabled
- User hasn't already set `cudagraph_copy_inputs=True`

This ensures input tensors and their associated buffer pointers are copied before graph replay, maintaining pointer stability.

## Changes
- Added `VLLM_AWQ_MARLIN_UNSAFE_CUDAGRAPH` environment variable to allow users to disable the automatic safety fix
- Added safety check in `VllmConfig.__post_init__` that detects the problematic configuration and applies the fix
- Included a reproducer script for testing at `scripts/test_awq_marlin_cudagraph.py`

Note: This PR includes formatting changes from ruff. Use GitHub's "Hide whitespace" option (⚙️) to view only functional changes (152 lines).

## Performance Impact
The fix adds minor overhead from copying inputs but is significantly faster than using `--enforce-eager`. For most workloads, the performance difference is negligible compared to the stability gained.