### PR TITLE
fix nixl connector num blocks check logic

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -1768,7 +1768,8 @@ class NixlConnectorWorker:
                 )  # noqa: E501
 
         # TP workers that handhshake with same remote have same #blocks.
-        assert self.dst_num_blocks[remote_engine_id] == nixl_agent_meta.num_blocks
+        if nixl_agent_meta.num_blocks < self.dst_num_blocks[remote_engine_id]:
+            self.dst_num_blocks[remote_engine_id] = nixl_agent_meta.num_blocks
         # Same number of regions/~layers.
         assert len(nixl_agent_meta.kv_caches_base_addr) == len(self.block_len_per_layer)
 


### PR DESCRIPTION
 - **Cause:** When creating a PD split instance, the PD instance calculated inconsistent `num_blocks` values. This inconsistency caused the API call to fail, triggering an assertion failure in the Decode split service and resulting in the service hanging.

<img width="2114" height="167" alt="image" src="https://github.com/user-attachments/assets/d4867249-b967-481e-bd9f-e694770bcb84" />

-  **Modification description:** For the same instance in the NIXL connector, the `num_blocks` value is set to the minimum across different TP ranks, and the unreasonable assertion has been removed.