### PR TITLE
[Kernel][Helion][1/N] Add Helion kernel for static_scaled_fp8_quant

### DIFF
--- a/tests/kernels/helion/test_register.py
+++ b/tests/kernels/helion/test_register.py
@@ -703,6 +703,7 @@ class TestHelionKernelWrapper:
 
         new_op = Mock()
         registered_ops: dict[str, Mock] = {}
+        mutates_args = ["y"]
 
         class MockNamespace:
             def __getattr__(self, name):
@@ -738,6 +739,7 @@ class TestHelionKernelWrapper:
                 raw_kernel_func=sample_kernel,
                 op_name="test_kernel",
                 fake_impl=fake_impl,
+                mutates_args=mutates_args,
                 config_picker=default_picker,
             )
             result = wrapper._get_or_register_custom_op()
@@ -745,6 +747,7 @@ class TestHelionKernelWrapper:
             mock_register.assert_called_once()
             assert result is new_op
             assert mock_register.call_args[1]["op_func"] is mock_decorated
+            assert mock_register.call_args[1]["mutates_args"] is mutates_args
 
 
 class TestKernelRegistry:

--- a/tests/kernels/helion/test_static_scaled_fp8_quant.py
+++ b/tests/kernels/helion/test_static_scaled_fp8_quant.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the dynamic_per_token_scaled_fp8_quant helion kernel
+
+Run `pytest tests/kernels/helion/test_static_scaled_fp8_quant.py`.
+"""
+
+from typing import Any
+
+import pytest
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+from tests.kernels.helion.utils import skip_if_platform_unsupported
+from tests.kernels.quant_utils import FP8_DTYPE
+from vllm.kernels.helion.config_manager import ConfigManager
+from vllm.kernels.helion.ops.static_scaled_fp8_quant import (
+    pick_config,
+    static_scaled_fp8_quant_dispatch,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    scaled_quantize,
+)
+from vllm.utils.import_utils import has_helion
+from vllm.utils.torch_utils import set_random_seed
+
+if not has_helion():
+    pytest.skip(
+        "Helion is not installed. Install with: pip install vllm[helion]",
+        allow_module_level=True,
+    )
+
+
+def _generate_fake_input(
+    num_tokens: int,
+    hidden_size: int,
+    group_shape_m: int,
+    group_shape_n: int,
+) -> tuple[Any, ...]:
+    with FakeTensorMode():
+        input = torch.randn(
+            num_tokens, hidden_size, device="cuda", dtype=torch.bfloat16
+        )
+        result = torch.empty(input.shape, device=input.device, dtype=FP8_DTYPE)
+        group_m = num_tokens if group_shape_m == -1 else int(group_shape_m)
+        group_n = hidden_size if group_shape_n == -1 else int(group_shape_n)
+        num_group_m = num_tokens // group_m
+        num_group_n = hidden_size // group_n
+        scale = torch.randn(
+            num_group_m, num_group_n, device=input.device, dtype=torch.float32
+        )
+
+        args = (result, input, scale, group_m, group_n)
+        return args
+
+
+@pytest.fixture(autouse=True)
+def reset_config_manager_singleton():
+    ConfigManager.reset_instance()
+    ConfigManager()
+    yield
+    ConfigManager.reset_instance()
+
+
+class TestStaticScaledFp8QuantConfigPicker:
+    def test_config_picker_exact_match(self):
+        config_keys = [
+            "default",
+            "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_16",
+            "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_16",
+            "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_16",
+            "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_16",
+        ]
+
+        args = _generate_fake_input(16, 4096, 1, -1)
+        selected_key = pick_config(args, config_keys)
+        assert (
+            selected_key
+            == "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_16"
+        )
+
+    def test_config_picker_closest_match(self):
+        config_keys = [
+            "default",
+            "hidden_size_2048_group_shape_m_32_group_shape_n_64_num_tokens_64",
+            "hidden_size_4096_group_shape_m_32_group_shape_n_64_num_tokens_64",
+            "hidden_size_2048_group_shape_m_256_group_shape_n_512_num_tokens_512",
+            "hidden_size_4096_group_shape_m_256_group_shape_n_512_num_tokens_512",
+        ]
+
+        args = _generate_fake_input(128, 2560, 64, 128)
+        selected_key = pick_config(args, config_keys)
+        assert (
+            selected_key
+            == "hidden_size_2048_group_shape_m_32_group_shape_n_64_num_tokens_64"
+        )
+
+    def test_config_picker_fallback_to_default(self):
+        config_keys = ["default"]
+
+        args = _generate_fake_input(16, 4096, 1, -1)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key == "default"
+
+    def test_config_picker_no_configs(self):
+        config_keys: list[str] = []
+
+        args = _generate_fake_input(16, 4096, 1, -1)
+        selected_key = pick_config(args, config_keys)
+        assert selected_key is None
+
+    def test_config_picker_fallback_to_largest(self):
+        config_keys = [
+            "default",
+            "hidden_size_2048_group_shape_m_64_group_shape_n_64_num_tokens_16",
+            "hidden_size_4096_group_shape_m_64_group_shape_n_64_num_tokens_16",
+            "hidden_size_2048_group_shape_m_128_group_shape_n_128_num_tokens_16",
+            "hidden_size_4096_group_shape_m_128_group_shape_n_128_num_tokens_16",
+        ]
+
+        args = _generate_fake_input(32, 8192, 256, 256)
+        selected_key = pick_config(args, config_keys)
+        assert (
+            selected_key
+            == "hidden_size_4096_group_shape_m_128_group_shape_n_128_num_tokens_16"
+        )
+
+    def test_config_picker_malformed_key_raises(self):
+        config_keys = [
+            "bad_key",
+        ]
+
+        args = _generate_fake_input(16, 4096, 1, -1)
+        with pytest.raises(ValueError):
+            pick_config(args, config_keys)
+
+
+DTYPES = [torch.bfloat16, torch.float]
+SEEDS = [0]
+
+# Test static FP8 quantization with 2D group scales
+GROUP_SHAPES_2D = [
+    (-1, -1),  # Per-tensor
+    (-1, 1),  # Per-channel
+    (1, -1),  # Per-token
+    (-1, 128),  # Per-head quantization
+    (1, 128),  # DeepSeek-style per-token-per-group (group_m=1, group_n=128)
+    (128, 128),  # DeepSeek-style block quantization
+    (1, 64),  # Smaller group size
+    (1, 16),  # Small group (scalar path in kernel)
+    (4, 256),  # Non-trivial both dimensions
+]
+# Use sizes divisible by all group shapes
+NUM_TOKENS_GROUP = [128, 512]
+HIDDEN_SIZES_GROUP = [256, 1024, 2048]
+
+
+class TestStaticScaledFp8QuantCorrectness:
+    @pytest.mark.parametrize("num_tokens", NUM_TOKENS_GROUP)
+    @pytest.mark.parametrize("hidden_size", HIDDEN_SIZES_GROUP)
+    @pytest.mark.parametrize("group_shape", GROUP_SHAPES_2D)
+    @pytest.mark.parametrize("dtype", DTYPES)
+    @pytest.mark.parametrize("seed", SEEDS)
+    def test_static_fp8_quant_group_2d(
+        self,
+        num_tokens: int,
+        hidden_size: int,
+        group_shape: tuple[int, int],
+        dtype: torch.dtype,
+        seed: int,
+    ) -> None:
+        """Test static FP8 quantization with 2D group scales using scaled_quantize."""
+        skip_if_platform_unsupported("static_scaled_fp8_quant")
+        # Normalize group_shape (-1 means full extent)
+        norm_group_m = num_tokens if group_shape[0] == -1 else group_shape[0]
+        norm_group_n = hidden_size if group_shape[1] == -1 else group_shape[1]
+
+        # Skip if sizes are not divisible by group shape
+        if num_tokens % norm_group_m != 0 or hidden_size % norm_group_n != 0:
+            pytest.skip(
+                f"Skipping: ({num_tokens}, {hidden_size}) not divisible by "
+                f"group_shape ({group_shape[0]}, {group_shape[1]})"
+            )
+
+        set_random_seed(seed)
+
+        input = torch.rand(num_tokens, hidden_size, dtype=dtype, device="cuda")
+        ref_out, scale = scaled_quantize(
+            input,
+            group_shape,
+            FP8_DTYPE,
+            compute_dtype=torch.float32,
+        )
+        ops_out = torch.empty(ref_out.shape, device=ref_out.device, dtype=ref_out.dtype)
+        static_scaled_fp8_quant_dispatch(ops_out, input, scale, group_shape)
+
+        torch.testing.assert_close(
+            ref_out.float(), ops_out.float(), rtol=1.2e-1, atol=1e-5
+        )
+
+    @pytest.mark.parametrize("num_tokens", NUM_TOKENS_GROUP)
+    @pytest.mark.parametrize("hidden_size", HIDDEN_SIZES_GROUP)
+    @pytest.mark.parametrize("dtype", DTYPES)
+    @pytest.mark.parametrize("seed", SEEDS)
+    @pytest.mark.parametrize(
+        "group_shape", [(1, -1), (-1, 1)]
+    )  # per-token, per-channel
+    def test_static_fp8_quant_1d_scale(
+        self,
+        num_tokens: int,
+        hidden_size: int,
+        dtype: torch.dtype,
+        seed: int,
+        group_shape: tuple[int, int],
+    ) -> None:
+        """Test static FP8 quantization with 1D scale (per-token or per-channel)."""
+        skip_if_platform_unsupported("static_scaled_fp8_quant")
+        set_random_seed(seed)
+
+        input = torch.rand(num_tokens, hidden_size, dtype=dtype, device="cuda")
+        ref_out, scale_2d = scaled_quantize(
+            input, group_shape, FP8_DTYPE, compute_dtype=torch.float32
+        )
+
+        # Flatten scale to 1D for testing 1D scale path
+        scale_1d = scale_2d.flatten()
+        ops_out = torch.empty(ref_out.shape, device=ref_out.device, dtype=ref_out.dtype)
+        static_scaled_fp8_quant_dispatch(ops_out, input, scale_1d, group_shape)
+
+        torch.testing.assert_close(
+            ref_out.float(), ops_out.float(), rtol=0.12, atol=0.0
+        )
+
+
+class TestStaticScaledFp8QuantIntegration:
+    def test_kernel_registration_integration(self):
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered_kernels = get_registered_kernels()
+        assert "static_scaled_fp8_quant" in registered_kernels
+
+        kernel_wrapper = registered_kernels["static_scaled_fp8_quant"]
+        assert kernel_wrapper.op_name == "static_scaled_fp8_quant"
+        assert kernel_wrapper._config_picker is not None
+        assert kernel_wrapper._mutates_args == ["result"]
+
+    def test_fake_impl_functionality(self):
+        skip_if_platform_unsupported("static_scaled_fp8_quant")
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered_kernels = get_registered_kernels()
+        kernel_wrapper = registered_kernels["static_scaled_fp8_quant"]
+        fake_impl = kernel_wrapper._fake_impl
+
+        args = _generate_fake_input(16, 4096, 1, -1)
+        assert fake_impl(*args) is None

--- a/tests/kernels/helion/utils.py
+++ b/tests/kernels/helion/utils.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Helion Kernel test utils"""
+
+import pytest
+import torch
+
+from vllm.kernels.helion.config_manager import ConfigManager
+
+
+def skip_if_platform_unsupported(op_name: str):
+    try:
+        from vllm.kernels.helion.utils import get_canonical_gpu_name
+
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        platform = get_canonical_gpu_name()
+
+        try:
+            config_manager = ConfigManager.get_instance()
+        except RuntimeError:
+            config_manager = ConfigManager()
+
+        configs = config_manager.get_platform_configs(op_name, platform)
+        if len(configs) == 0:
+            pytest.skip(f"Current GPU platform not supported for {op_name} kernel")
+
+    except (ImportError, RuntimeError, KeyError):
+        pytest.skip(f"Error detecting platform support for {op_name} kernel")

--- a/vllm/kernels/helion/configs/static_scaled_fp8_quant/nvidia_b200.json
+++ b/vllm/kernels/helion/configs/static_scaled_fp8_quant/nvidia_b200.json
@@ -1,0 +1,6566 @@
+{
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "first",
+      "first",
+      "first",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "first",
+      "first",
+      "first",
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        0,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last",
+      "",
+      "first",
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        0,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      true
+    ],
+    "range_multi_buffers": [
+      false
+    ],
+    "range_flattens": [
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last",
+      "",
+      "first",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 128
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "",
+      "last",
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        0,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last",
+      "",
+      "first",
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        2,
+        3,
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "",
+      "last",
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      256,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      1
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_multi_buffers": [
+      true
+    ],
+    "range_flattens": [
+      false
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "last",
+      "last",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        2,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "first",
+      "last",
+      "last",
+      "first",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "first",
+      "last",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "last",
+      "first",
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      2,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1,
+      2,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      16,
+      2,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      2,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1,
+      2,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      16,
+      2,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      2,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1,
+      4,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      512,
+      2,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1,
+      4,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      16,
+      4,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1,
+      4,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      16,
+      4,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1,
+      8,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      16,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      8,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1,
+      8,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      16,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      8,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1,
+      8,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      16,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      8,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      16,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      16,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      16,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      16,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      16,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      16,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      16,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      16,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      16,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      16,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      16,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      1,
+      128,
+      32
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      3
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_multi_buffers": [
+      true
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last",
+      "last",
+      "first",
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 32
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      128,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        2,
+        0,
+        3,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      64,
+      1,
+      1,
+      32
+    ],
+    "loop_orders": [
+      [
+        2,
+        0,
+        3,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      16,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      16
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        2,
+        3,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      3
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_multi_buffers": [
+      false
+    ],
+    "range_flattens": [
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "first",
+      "first",
+      "last",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 256
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      512,
+      32,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "",
+      "first",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        2,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      true
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      false
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last",
+      "",
+      "last",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 32
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last",
+      "first",
+      "last",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      512,
+      32,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "",
+      "first",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      1
+    ],
+    "range_warp_specializes": [
+      true
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "first",
+      "",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 16,
+    "maxnreg": 64
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      32,
+      32,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        2,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "first",
+      "last",
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      64
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_multi_buffers": [
+      true
+    ],
+    "range_flattens": [
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "last",
+      "last",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 8,
+    "maxnreg": 128
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      1,
+      32,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last",
+      "last",
+      "",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      1024,
+      4,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last",
+      "first",
+      "last",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      64,
+      1,
+      1,
+      64
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      1,
+      4,
+      1024
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "last",
+      "first",
+      "first",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      512,
+      32,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "first",
+      "last",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first",
+      "",
+      "first",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      1
+    ],
+    "range_warp_specializes": [
+      true
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "first",
+      "",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 16,
+    "maxnreg": 64
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      256,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      32,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "",
+      "last",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      1,
+      4,
+      4096
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "first",
+      "",
+      "last",
+      "last",
+      "last",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      512,
+      32,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first",
+      "first",
+      "",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      8,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first",
+      "first",
+      "",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      1
+    ],
+    "range_warp_specializes": [
+      true
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "first",
+      "",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 16,
+    "maxnreg": 64
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      256,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      true
+    ],
+    "range_multi_buffers": [
+      true
+    ],
+    "range_flattens": [
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "",
+      "last",
+      "first",
+      "",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 8,
+    "maxnreg": 256
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      32,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "",
+      "last",
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      1,
+      8,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last",
+      "first",
+      "",
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      512,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "last",
+      "",
+      "last",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      32,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "first",
+      "first",
+      "first",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      1
+    ],
+    "range_warp_specializes": [
+      true
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "first",
+      "",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 16,
+    "maxnreg": 64
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      512,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "first",
+      "first",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "last",
+      "last",
+      "last",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      1,
+      4,
+      512
+    ],
+    "loop_orders": [
+      [
+        3,
+        2,
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "first",
+      "first",
+      "first",
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      256,
+      32,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "",
+      "last",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "first",
+      "first",
+      "first",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      1
+    ],
+    "range_warp_specializes": [
+      true
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      false
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "first",
+      "",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 16,
+    "maxnreg": 64
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      256,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "",
+      "first",
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      32,
+      1,
+      1,
+      64
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "",
+      "last",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      1,
+      32,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      true
+    ],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      true
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first",
+      "last",
+      "last",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 8,
+    "maxnreg": 128
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      128,
+      32,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        2,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first",
+      "last",
+      "last",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      128,
+      1,
+      1,
+      64
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "",
+      "last",
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      1,
+      8,
+      256
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        2,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "first",
+      "",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      256,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "first",
+      "last",
+      "first",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      2,
+      1,
+      1,
+      8192
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [
+      null
+    ],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "",
+      "",
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  }
+}

--- a/vllm/kernels/helion/configs/static_scaled_fp8_quant/nvidia_h100.json
+++ b/vllm/kernels/helion/configs/static_scaled_fp8_quant/nvidia_h100.json
@@ -1,0 +1,6323 @@
+{
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        2,
+        3,
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first",
+      "last",
+      "first",
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "",
+      "",
+      "first",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        2,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "last",
+      "",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        2,
+        0,
+        1,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first",
+      "",
+      "first",
+      "last",
+      "",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        2,
+        3,
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "first",
+      "",
+      "first",
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        0,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        2,
+        3,
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last",
+      "",
+      "",
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      2048,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "",
+      "first",
+      "first",
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        2,
+        3,
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "first",
+      "last",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1,
+      2,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "",
+      "last",
+      "first",
+      "",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      256,
+      2,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first",
+      "",
+      "last",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      2,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        0,
+        2,
+        1,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last",
+      "",
+      "first",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "",
+      "",
+      "last",
+      "",
+      "first",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      2,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        0,
+        2,
+        3,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "first",
+      "",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1,
+      2,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last",
+      "",
+      "first",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      256,
+      2,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "first",
+      "",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      2,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        2,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "last",
+      "",
+      "first",
+      "",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "first",
+      "last",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        0,
+        2,
+        1,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first",
+      "first",
+      "",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last",
+      "first",
+      "first",
+      "last",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      128,
+      2,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last",
+      "",
+      "",
+      "first",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        2,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last",
+      "last",
+      "",
+      "last",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      2048,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "last",
+      "last",
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        3,
+        2,
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "first",
+      "last",
+      "first",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1,
+      4,
+      512
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first",
+      "last",
+      "",
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      64,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first",
+      "",
+      "last",
+      "first",
+      "first",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      8,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        2,
+        3,
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last",
+      "first",
+      "first",
+      "",
+      "first",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1,
+      2,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "last",
+      "",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "first",
+      "last",
+      "last",
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        0,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "last",
+      "last",
+      "first",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "first",
+      "",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      8,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        0,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last",
+      "first",
+      "",
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      256,
+      2,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "first",
+      "",
+      "first",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "last",
+      "first",
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last",
+      "last",
+      "",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "first",
+      "first",
+      "last",
+      "last",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        2,
+        3,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first",
+      "last",
+      "",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "",
+      "last",
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      64,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last",
+      "",
+      "first",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      2,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "first",
+      "first",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      64
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "",
+      "first",
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last",
+      "first",
+      "first",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      "last",
+      "first",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1,
+      4,
+      512
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "last",
+      "first",
+      "",
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      2048,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "last",
+      "last",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        0,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "",
+      "last",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "last",
+      "",
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      128,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first",
+      "first",
+      "first",
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "first",
+      "last",
+      "last",
+      "first",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      128
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "first",
+      "first",
+      "",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      128,
+      4,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "",
+      "last",
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      8,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "last",
+      "last",
+      "",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1,
+      32,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "last",
+      "first",
+      "first",
+      "",
+      "first",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      2,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first",
+      "",
+      "last",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1,
+      4,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first",
+      "first",
+      "",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1024,
+      2,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "last",
+      "last",
+      "first",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      8,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 2,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 2,
+    "maxnreg": 128
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last",
+      "first",
+      "",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      128,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last",
+      "",
+      "first",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "last",
+      "first",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first",
+      "first",
+      "first",
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      256,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first",
+      "last",
+      "last",
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      32,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        2,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "first",
+      "last",
+      "first",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      1,
+      64,
+      256
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last",
+      "last",
+      "last",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      256,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first",
+      "last",
+      "",
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        2,
+        1,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "",
+      "first",
+      "last",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      64,
+      32,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "first",
+      "first",
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      32,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "",
+      "last",
+      "",
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      1,
+      128,
+      128
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "first",
+      "last",
+      "last",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      128,
+      32,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      32,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      false
+    ],
+    "range_flattens": [
+      true
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 1,
+    "maxnreg": 256
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "",
+      "last",
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      4096,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "first",
+      "",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      64,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        2,
+        1,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "",
+      "first",
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      1,
+      32,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last",
+      "first",
+      "",
+      "last",
+      "first",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      256,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last",
+      "last",
+      "first",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        2,
+        1,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "",
+      "",
+      "first",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      1,
+      32,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first",
+      "last",
+      "",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      64,
+      256,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "last",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        3,
+        2,
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "first",
+      "last",
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      1,
+      4,
+      8192
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "",
+      "last",
+      "last",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      64,
+      256,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "",
+      "first",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      8,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      1
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "",
+      "last",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "persistent_blocked",
+    "num_sm_multiplier": 4,
+    "maxnreg": 256
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      1,
+      64,
+      256
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last",
+      "last",
+      "last",
+      "first",
+      "",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      256,
+      64,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last",
+      "",
+      "first",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      8,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        3,
+        2,
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "",
+      "first",
+      "first",
+      "first",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      1,
+      32,
+      256
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last",
+      "",
+      "",
+      "last",
+      "",
+      "last"
+    ],
+    "num_warps": 2,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      4096,
+      2,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first",
+      "",
+      "first",
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last",
+      "first",
+      "first",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "",
+      "",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      1024,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last",
+      "last",
+      "last",
+      "first",
+      "",
+      "first"
+    ],
+    "num_warps": 1,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      8192
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last",
+      "first",
+      "last",
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      1,
+      32,
+      128
+    ],
+    "loop_orders": [
+      [
+        0,
+        2,
+        1,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "",
+      "last",
+      "first",
+      "last",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      256,
+      64,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first",
+      "",
+      "",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      8,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "last",
+      "first",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      1,
+      2,
+      4096
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "first",
+      "first",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 1,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      4096,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "last",
+      "last",
+      "first",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      64,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last",
+      "first",
+      "last",
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 32,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      8192
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last",
+      "last",
+      "",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      256,
+      32,
+      1
+    ],
+    "loop_orders": [
+      [
+        2,
+        0,
+        3,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "first",
+      "first",
+      "last",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      1,
+      2,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last",
+      "first",
+      "first",
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      512,
+      4,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      64,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last",
+      "",
+      "last",
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      1,
+      2,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first",
+      "first",
+      "last",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      256,
+      32,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        2,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "first",
+      "last",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      2,
+      1,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        2,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "last",
+      "",
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 1,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      1,
+      8,
+      256
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last",
+      "last",
+      "",
+      "first",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 1,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      8,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last",
+      "last",
+      "last",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 1,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  }
+}

--- a/vllm/kernels/helion/configs/static_scaled_fp8_quant/nvidia_h200.json
+++ b/vllm/kernels/helion/configs/static_scaled_fp8_quant/nvidia_h200.json
@@ -1,0 +1,6320 @@
+{
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        3,
+        2,
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        2,
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first",
+      "last",
+      "first",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        2,
+        3,
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "last",
+      "last",
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "last",
+      "last",
+      "first",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "",
+      "last",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        0,
+        2,
+        1,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last",
+      "last",
+      "first",
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last",
+      "last",
+      "first",
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        2,
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "first",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_1": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        2,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "",
+      "first",
+      "first",
+      "first",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "first",
+      "first",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        2,
+        3,
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last",
+      "first",
+      "",
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "first",
+      "first",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      128,
+      2,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first",
+      "",
+      "first",
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        3,
+        2,
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "last",
+      "",
+      "",
+      "first",
+      "last"
+    ],
+    "num_warps": 4,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1,
+      2,
+      1024
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last",
+      "first",
+      "",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      256,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "last",
+      "",
+      "last",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_2": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last",
+      "first",
+      "",
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "first",
+      "last",
+      "",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      256,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first",
+      "last",
+      "last",
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "",
+      "last",
+      "",
+      "first",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "",
+      "last",
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "first",
+      "",
+      "",
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "",
+      "last",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "first",
+      "first",
+      "last",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      256,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last",
+      "last",
+      "last",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_4": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "first",
+      "last",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "",
+      "first",
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      128,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first",
+      "first",
+      "first",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "first",
+      "last",
+      "last",
+      "first",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first",
+      "first",
+      "last",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "",
+      "last",
+      "first",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "first",
+      "first",
+      "",
+      "first",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      256,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first",
+      "first",
+      "",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_8": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last",
+      "last",
+      "first",
+      "first",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        2,
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "first",
+      "last",
+      "last",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first",
+      "first",
+      "first",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "first",
+      "first",
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last",
+      "",
+      "first",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "last",
+      "first",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last",
+      "last",
+      "last",
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 7,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "last",
+      "",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_16": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last",
+      "first",
+      "first",
+      "first",
+      "first",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "",
+      "last",
+      "",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last",
+      "last",
+      "first",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "first",
+      "last",
+      "last",
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first",
+      "",
+      "first",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1024,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "",
+      "last",
+      "",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last",
+      "last",
+      "last",
+      "last",
+      "first",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last",
+      "last",
+      "",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      256,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "",
+      "last",
+      "last",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 1,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_32": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last",
+      "last",
+      "first",
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1,
+      8,
+      256
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "",
+      "first",
+      "first",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      256,
+      4,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "",
+      "last",
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      8,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first",
+      "first",
+      "",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last",
+      "first",
+      "first",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      128,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "",
+      "last",
+      "last",
+      "",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      32,
+      1,
+      1,
+      64
+    ],
+    "loop_orders": [
+      [
+        2,
+        3,
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "first",
+      "",
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      8192
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last",
+      "first",
+      "",
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      256,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        2,
+        3
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last",
+      "",
+      "first",
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_64": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      8192
+    ],
+    "loop_orders": [
+      [
+        3,
+        2,
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "",
+      "first",
+      "first",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      1,
+      16,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      512,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "",
+      "first",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      64,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        2,
+        3,
+        0,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "first",
+      "last",
+      "first",
+      "first",
+      "",
+      "last"
+    ],
+    "num_warps": 32,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      512,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "first",
+      "first",
+      "first",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        2,
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "first",
+      "first",
+      "",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      1,
+      8,
+      2048
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "last",
+      "first",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_128": {
+    "block_sizes": [
+      1,
+      4096,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "",
+      "first",
+      "last",
+      "",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_128": {
+    "block_sizes": [
+      16,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        3,
+        2,
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last",
+      "",
+      "",
+      "last",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      1,
+      32,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first",
+      "last",
+      "last",
+      "",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      64,
+      64,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "last",
+      "first",
+      "",
+      "first",
+      "first",
+      "last"
+    ],
+    "num_warps": 32,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "last",
+      "last",
+      "first",
+      "first",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "last",
+      "",
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      2048,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "",
+      "",
+      "first",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      32,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      8192
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "first",
+      "first",
+      "last",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_256": {
+    "block_sizes": [
+      1,
+      2048,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "last",
+      "last",
+      "last",
+      "last",
+      ""
+    ],
+    "num_warps": 32,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_256": {
+    "block_sizes": [
+      256,
+      1,
+      1,
+      128
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "last",
+      "last",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 32,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      1,
+      128,
+      128
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "first",
+      "last",
+      "",
+      "last",
+      "first",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      256,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "",
+      "first",
+      "first",
+      "last",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first",
+      "first",
+      "first",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first",
+      "",
+      "first",
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      2048,
+      1,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "last",
+      "last",
+      "first",
+      "",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      32,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      8192
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 32,
+    "num_stages": 8,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_512": {
+    "block_sizes": [
+      1,
+      128,
+      256,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "first",
+      "",
+      "first",
+      "first",
+      "last",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_512": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "",
+      "last",
+      "last",
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 32,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      1,
+      64,
+      256
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "last",
+      "first",
+      "last",
+      "",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      256,
+      32,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "last",
+      "last",
+      "",
+      "last",
+      "first",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      128,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "last",
+      "first",
+      "",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 32,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      2048
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "",
+      "first",
+      "last",
+      "last",
+      "first",
+      "",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      128,
+      256,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        1,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first",
+      "last",
+      "last",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "",
+      "",
+      "first",
+      "first",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      1,
+      4,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "",
+      "last",
+      "last",
+      "last",
+      "first",
+      "last"
+    ],
+    "num_warps": 1,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      512,
+      16,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "first",
+      "",
+      "last",
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 2,
+    "num_stages": 3,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_1024": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "last",
+      "",
+      "first",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 8,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      1,
+      4,
+      256
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 5,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      2048,
+      4,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "",
+      "last",
+      "first",
+      "last",
+      "",
+      ""
+    ],
+    "num_warps": 8,
+    "num_stages": 4,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      64,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "first",
+      "",
+      "last",
+      "first",
+      "last",
+      "last"
+    ],
+    "num_warps": 16,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      1,
+      32,
+      2048
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first",
+      "last",
+      "",
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 16,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      256,
+      64,
+      1
+    ],
+    "loop_orders": [
+      [
+        0,
+        3,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first",
+      "first",
+      "first",
+      "",
+      "last",
+      "last"
+    ],
+    "num_warps": 8,
+    "num_stages": 2,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      64,
+      1,
+      1,
+      256
+    ],
+    "loop_orders": [
+      [
+        2,
+        1,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "last",
+      "last",
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 4,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "last",
+      "",
+      "",
+      "",
+      "last",
+      "",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_2048": {
+    "block_sizes": [
+      1,
+      256,
+      4,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        2,
+        1
+      ]
+    ],
+    "l2_groupings": [
+      16
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "last",
+      "",
+      "first",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 2,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_2048": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        2,
+        3,
+        1,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "first",
+      "first",
+      "first",
+      "first",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 1,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      1,
+      32,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "first",
+      "",
+      "first",
+      "first",
+      "first",
+      ""
+    ],
+    "num_warps": 16,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      256,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      32
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "first",
+      "",
+      "last",
+      "first",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 3,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      64,
+      1,
+      1,
+      512
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "first",
+      "first",
+      "",
+      "",
+      "",
+      "first"
+    ],
+    "num_warps": 32,
+    "num_stages": 6,
+    "indexing": [
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      1,
+      4,
+      256
+    ],
+    "loop_orders": [
+      [
+        1,
+        3,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "first",
+      "last",
+      "last",
+      "first",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 4,
+    "indexing": [
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      512,
+      4,
+      1
+    ],
+    "loop_orders": [
+      [
+        3,
+        0,
+        1,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      4
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "",
+      "last",
+      "last",
+      "",
+      "last",
+      "",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      4,
+      1,
+      1,
+      4096
+    ],
+    "loop_orders": [
+      [
+        1,
+        2,
+        3,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      8
+    ],
+    "range_unroll_factors": [
+      2
+    ],
+    "range_warp_specializes": [],
+    "range_multi_buffers": [
+      true
+    ],
+    "range_flattens": [
+      false
+    ],
+    "load_eviction_policies": [
+      "last",
+      "last",
+      "last",
+      "",
+      "",
+      "",
+      "first",
+      "first"
+    ],
+    "num_warps": 32,
+    "num_stages": 7,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "persistent_interleaved",
+    "num_sm_multiplier": 8
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      1,
+      8,
+      2048
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        0,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      1
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "",
+      "",
+      "",
+      "",
+      "",
+      "first",
+      "last"
+    ],
+    "num_warps": 32,
+    "num_stages": 6,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_4096": {
+    "block_sizes": [
+      1,
+      512,
+      8,
+      1
+    ],
+    "loop_orders": [
+      [
+        1,
+        0,
+        3,
+        2
+      ]
+    ],
+    "l2_groupings": [
+      64
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "last",
+      "first",
+      "",
+      "first",
+      "first",
+      "last",
+      "last",
+      "first"
+    ],
+    "num_warps": 8,
+    "num_stages": 1,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "tensor_descriptor"
+    ],
+    "pid_type": "flat"
+  },
+  "hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_4096": {
+    "block_sizes": [
+      2,
+      1,
+      1,
+      1024
+    ],
+    "loop_orders": [
+      [
+        3,
+        1,
+        2,
+        0
+      ]
+    ],
+    "l2_groupings": [
+      2
+    ],
+    "range_unroll_factors": [
+      0
+    ],
+    "range_warp_specializes": [],
+    "range_num_stages": [],
+    "range_multi_buffers": [
+      null
+    ],
+    "range_flattens": [
+      null
+    ],
+    "load_eviction_policies": [
+      "first",
+      "",
+      "last",
+      "first",
+      "first",
+      "first",
+      "last",
+      "first"
+    ],
+    "num_warps": 4,
+    "num_stages": 5,
+    "indexing": [
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "tensor_descriptor",
+      "pointer",
+      "pointer",
+      "tensor_descriptor",
+      "pointer",
+      "pointer"
+    ],
+    "pid_type": "flat"
+  }
+}

--- a/vllm/kernels/helion/ops/static_scaled_fp8_quant.py
+++ b/vllm/kernels/helion/ops/static_scaled_fp8_quant.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from itertools import product
+from typing import Any
+
+import helion.language as hl
+import regex as re
+import torch
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    scaled_quantize,
+)
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_helion
+
+if not has_helion():
+    raise ImportError(
+        "Helion kernel requires helion to be installed. "
+        "Install it with: pip install helion"
+    )
+
+from vllm.kernels.helion.register import register_kernel
+
+logger = init_logger(__name__)
+
+
+def generate_inputs() -> dict[str, tuple[Any, ...]]:
+    # TODO(xiaohongchen1991): it is difficult for kernel author to cover
+    # all input property combination. Currently, dtypes are fixed. We need
+    # optimization to bucket/skip some combinations
+    num_tokens_list = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096]
+    hidden_size_list = [2048, 4096, 8192]
+    group_shape_list = [(-1, -1), (-1, 1), (1, -1)]
+    in_dtype: torch.dtype = torch.bfloat16
+    out_dtype: torch.dtype = current_platform.fp8_dtype()
+    scale_dtype: torch.dtype = torch.float32
+    inputs = {}
+
+    for hidden_size, group_shape, num_tokens in product(
+        hidden_size_list, group_shape_list, num_tokens_list
+    ):
+        input = torch.randn(num_tokens, hidden_size, device="cuda", dtype=in_dtype)
+        result = torch.empty(input.shape, device=input.device, dtype=out_dtype)
+        _, scale = scaled_quantize(
+            input,
+            group_shape,
+            out_dtype,
+            compute_dtype=scale_dtype,
+        )
+        group_shape_m, group_shape_n = group_shape
+        if scale.dim() == 0 or scale.numel() == 1:
+            group_m = num_tokens
+            group_n = hidden_size
+            scale_2d = scale.reshape(1, 1)
+        elif scale.dim() == 1:
+            group_m = num_tokens if group_shape_m == -1 else int(group_shape_m)
+            group_n = hidden_size if group_shape_n == -1 else int(group_shape_n)
+            scale_2d = scale[None, :] if group_shape_m == -1 else scale[:, None]
+        elif scale.dim() == 2:
+            scale_2d = scale
+            group_m = num_tokens if group_shape_m == -1 else int(group_shape_m)
+            group_n = hidden_size if group_shape_n == -1 else int(group_shape_n)
+
+        config_key = (
+            f"hidden_size_{hidden_size}_"
+            f"group_shape_m_{group_shape_m}_group_shape_n_{group_shape_n}_"
+            f"num_tokens_{num_tokens}"
+        )
+        inputs[config_key] = (result, input, scale_2d, group_m, group_n)
+
+    return inputs
+
+
+def pick_config(args: tuple[Any, ...], config_keys: list[str]) -> str | None:
+    """Pick the best pre-tuned config for the given input shape.
+
+    Selection strategy:
+      1. Find the closest hidden_size among available configs
+         (exact match preferred).
+      1. Find the closest (group_shape_m, group_shape_n) among available configs
+         (exact match preferred).
+      2. Among the num_tokens values tuned for that group shape, pick
+         the smallest num_tokens >= the input's num_tokens. If the input is
+         larger than all available num_tokens, fall back to the largest.
+
+    Config keys must be "default" or follow the format
+    "hidden_size_{int}_group_shape_m_{int}_group_shape_n_{int}_num_tokens_{int}".
+    """
+
+    if not config_keys:
+        return None
+
+    _, input, _, group_m, group_n = args
+    num_tokens, hidden_size = input.shape
+    group_shape_m = -1 if int(group_m) == num_tokens else int(group_m)
+    group_shape_n = -1 if int(group_n) == hidden_size else int(group_n)
+
+    configs: dict[int, dict[tuple[int, int], list[int]]] = {}
+    for key in config_keys:
+        if key == "default":
+            continue
+        match = re.fullmatch(
+            r"hidden_size_(\d+)_group_shape_m_(-?\d+)_group_shape_n_(-?\d+)_num_tokens_(\d+)",
+            key,
+        )
+        if not match:
+            raise ValueError(
+                f"Malformed config key '{key}', "
+                "expected format "
+                "'hidden_size_{int}_group_shape_m_{int}_group_shape_n_{int}_num_tokens_{int}'"
+            )
+        hidden_size_str, group_shape_m_str, group_shape_n_str, num_tokens_str = (
+            match.groups()
+        )
+        configs.setdefault(int(hidden_size_str), {}).setdefault(
+            (int(group_shape_m_str), int(group_shape_n_str)), []
+        ).append(int(num_tokens_str))
+
+    if not configs:
+        return "default" if "default" in config_keys else None
+
+    best_hidden_size = min(configs, key=lambda s: abs(s - hidden_size))
+    group_configs = configs[best_hidden_size]
+
+    if (group_shape_m, group_shape_n) in group_configs:
+        best_group_shape = (group_shape_m, group_shape_n)
+    else:
+        best_group_shape = min(
+            group_configs,
+            key=lambda g: (abs(g[0] - group_shape_m), abs(g[1] - group_shape_n)),
+        )
+    available_num_tokens = sorted(group_configs[best_group_shape])
+    best_num_tokens = next(
+        (n for n in available_num_tokens if n >= num_tokens),
+        available_num_tokens[-1],
+    )
+
+    return (
+        f"hidden_size_{best_hidden_size}_"
+        f"group_shape_m_{best_group_shape[0]}_group_shape_n_{best_group_shape[1]}_"
+        f"num_tokens_{best_num_tokens}"
+    )
+
+
+@register_kernel(
+    mutates_args=["result"],
+    config_picker=pick_config,
+    input_generator=generate_inputs,
+)  # type: ignore[misc]
+def static_scaled_fp8_quant(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    scale: torch.Tensor,
+    group_m: int,
+    group_n: int,
+) -> None:
+    assert scale.dim() == 2
+    # This code assumes batch_dim and num_tokens are flattened
+    assert input.ndim == 2
+
+    num_tokens, hidden_size = input.shape
+    num_groups_m, num_groups_n = scale.shape
+    hl.specialize(hidden_size)
+    hl.specialize(group_n)
+    hl.specialize(num_groups_n)
+
+    for tile_gm, tile_gn, tile_m, tile_n in hl.tile(
+        [num_groups_m, num_groups_n, group_m, group_n]
+    ):
+        gm_idx = tile_gm.index
+        gn_idx = tile_gn.index
+
+        # offset inside group
+        m_offset = tile_m.index
+        n_offset = tile_n.index
+
+        # Global indices
+        # m_idx: [tile_gm, tile_m]
+        # n_idx: [tile_gn, tile_n]
+        m_idx = gm_idx[:, None] * group_m + m_offset[None, :]
+        n_idx = gn_idx[:, None] * group_n + n_offset[None, :]
+
+        m_blk = m_idx[:, None, :, None]
+        n_blk = n_idx[None, :, None, :]
+
+        group_mask = (gm_idx < num_groups_m)[:, None] & (gn_idx < num_groups_n)[None, :]
+        elem_mask = (
+            (gm_idx < num_groups_m)[:, None, None, None]
+            & (gn_idx < num_groups_n)[None, :, None, None]
+            & (m_offset < group_m)[None, None, :, None]
+            & (n_offset < group_n)[None, None, None, :]
+        )
+
+        # shape: [tile_gm, tile_gn]
+        scale_blk = hl.load(
+            scale,
+            [gm_idx[:, None], gn_idx[None, :]],
+            extra_mask=group_mask,
+        )
+        inv_scale_blk = (1.0 / scale_blk).to(dtype=torch.float32)
+
+        # input tile shape:  [tile_gm, tile_gn, tile_m, tile_n]
+        x_blk = hl.load(
+            input,
+            [m_blk, n_blk],
+            extra_mask=elem_mask,
+        ).to(torch.float32)
+
+        # scale tile shape:  [tile_gm, tile_gn, 1, 1]
+        y_blk = x_blk * inv_scale_blk[:, :, None, None]
+
+        hl.store(
+            result,
+            [m_blk, n_blk],
+            y_blk.to(result.dtype),
+            extra_mask=elem_mask,
+        )
+
+
+# This is the real entrypoint for this kernel. Note that
+# 1. Helion does not support this condition dispatch logic inside @helion.kernel
+# decorator. So, the dispatch logic is implemented as a separate wrapper.
+# 2. @register_kernel decorator will apply @helion.kernel to the fn eventually,
+# so @register_kernel is applied for static_scaled_fp8_quant not this wrapper.
+def static_scaled_fp8_quant_dispatch(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    scale: torch.Tensor,
+    group_shape: tuple[int, int] | None = None,
+):
+    assert input.stride(-1) == 1
+    assert result.stride(-1) == 1
+
+    num_tokens, hidden_size = input.shape
+
+    if scale.dim() == 0 or scale.numel() == 1:
+        # per tensor
+        group_m = num_tokens
+        group_n = hidden_size
+        scale_2d = scale.reshape(1, 1)
+    elif scale.dim() == 1:
+        assert group_shape is not None
+        group_shape_m, group_shape_n = group_shape
+        assert group_shape_m == -1 or group_shape_n == -1
+        group_m = num_tokens if group_shape_m == -1 else int(group_shape_m)
+        group_n = hidden_size if group_shape_n == -1 else int(group_shape_n)
+        scale_2d = scale[None, :] if group_shape_m == -1 else scale[:, None]
+        inferred_group_m = num_tokens // scale_2d.size(0)
+        inferred_group_n = hidden_size // scale_2d.size(1)
+        assert group_m == inferred_group_m and group_n == inferred_group_n
+    elif scale.dim() == 2:
+        scale_2d = scale
+        scale_size_0, scale_size_1 = scale.shape
+        assert num_tokens % scale_size_0 == 0
+        assert hidden_size % scale_size_1 == 0
+        inferred_group_m = num_tokens // scale_size_0
+        inferred_group_n = hidden_size // scale_size_1
+
+        if group_shape is not None:
+            group_shape_m, group_shape_n = group_shape
+            group_m = num_tokens if group_shape_m == -1 else int(group_shape_m)
+            group_n = hidden_size if group_shape_n == -1 else int(group_shape_n)
+            assert group_m == inferred_group_m and group_n == inferred_group_n
+        else:
+            group_m, group_n = inferred_group_m, inferred_group_n
+
+    static_scaled_fp8_quant(result, input, scale_2d, group_m, group_n)
+
+
+def baseline(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    scale: torch.Tensor,
+    group_m: int,
+    group_n: int,
+) -> None:
+    num_tokens, hidden_size = input.shape
+    group_shape_m = -1 if int(group_m) == num_tokens else int(group_m)
+    group_shape_n = -1 if int(group_n) == hidden_size else int(group_n)
+    torch.ops._C.static_scaled_fp8_quant(
+        result, input, scale, (group_shape_m, group_shape_n)
+    )

--- a/vllm/kernels/helion/register.py
+++ b/vllm/kernels/helion/register.py
@@ -254,6 +254,7 @@ class HelionKernelWrapper:
         op_name: str,
         fake_impl: Callable,
         config_picker: Callable[[tuple[Any, ...], list[str]], str | None],
+        mutates_args: list[str] | None = None,
         helion_settings: "helion.Settings | None" = None,
         input_generator: Callable[[], dict[str, tuple[Any, ...]]] | None = None,
     ):
@@ -266,6 +267,7 @@ class HelionKernelWrapper:
         self.helion_settings = helion_settings
         self._config_picker = config_picker
         self._input_generator = input_generator
+        self._mutates_args = mutates_args
         self._configured_kernel: ConfiguredHelionKernel | None = None
         # TODO(@gmagogsfm): Remove this disable flag once integrated with vLLM IR,
         # which handles op enablement/disablement.
@@ -415,7 +417,7 @@ class HelionKernelWrapper:
         direct_register_custom_op(
             op_name=self.op_name,
             op_func=configured_kernel._decorated_kernel,
-            mutates_args=None,
+            mutates_args=self._mutates_args,
             fake_impl=self._fake_impl,
             target_lib=vllm_helion_lib,
         )
@@ -460,6 +462,8 @@ def register_kernel(
     *,
     config_picker: Callable[[tuple[Any, ...], list[str]], str | None],
     fake_impl: Callable | None = None,
+    # WARNING: mutates_args will be deprecated later when CustomOp path is removed
+    mutates_args: list[str] | None = None,
     helion_settings: "helion.Settings | None" = None,
     input_generator: Callable[[], dict[str, tuple[Any, ...]]] | None = None,
 ) -> Callable[[Callable], HelionKernelWrapper]:
@@ -521,6 +525,7 @@ def register_kernel(
             op_name=final_op_name,
             fake_impl=final_fake_impl,
             config_picker=config_picker,
+            mutates_args=mutates_args,
             helion_settings=helion_settings,
             input_generator=input_generator,
         )


### PR DESCRIPTION
## Purpose
This PR is to add Helion kernel for ```static_scaled_fp8_quant``` operation. It follows the implementation from the [vllm c version](https://github.com/vllm-project/vllm/blob/10546f925aef5d805e41f0f40c6610d08ff1a037/csrc/quantization/w8a8/fp8/common.cu#L185). 

This is a subtask for https://github.com/vllm-project/vllm/issues/32962.

Autotuning and Benchmarking in H200 and B200 were contributed by @gmagogsfm.

### Kernel level benchmark
**Environment**
Python: 3.12.13
PyTorch: 2.10.0+cu129
Cuda: 12.9
Helion: 0.3.0
Triton: 3.6.0
GPU: NVIDIA H100

**Benchmark Setup**
Latency measure: ```triton.testing.do_bench_cudagraph(rep=1000)```
Memory measure: ```torch.cuda.reset_peak_memory_stats()```
Baseline: ```torch.ops._C.static_scaled_fp8_quant```

**Results**
H100:
```
case                                                               | baseline_ms | kernel_ms | speedup(x) | baseline_peak(MB) | kernel_peak(MB) | mem_improve(x)
-------------------------------------------------------------------+-------------+-----------+------------+-------------------+-----------------+---------------
hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_1    | 0.002       | 0.001     | 1.393      | 1057.72           | 1057.72         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_2    | 0.002       | 0.001     | 1.430      | 1057.72           | 1057.72         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_4    | 0.002       | 0.001     | 1.362      | 1057.73           | 1057.73         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_8    | 0.002       | 0.001     | 1.386      | 1057.76           | 1057.76         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_16   | 0.002       | 0.001     | 1.411      | 1057.81           | 1057.81         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_32   | 0.002       | 0.001     | 1.354      | 1057.91           | 1057.91         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_64   | 0.002       | 0.001     | 1.377      | 1058.10           | 1058.10         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_128  | 0.002       | 0.001     | 1.382      | 1058.50           | 1058.50         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_256  | 0.002       | 0.002     | 1.319      | 1059.28           | 1059.28         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_512  | 0.002       | 0.002     | 1.234      | 1060.86           | 1060.86         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_1024 | 0.003       | 0.002     | 1.328      | 1064.00           | 1064.00         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_2048 | 0.004       | 0.003     | 1.202      | 1070.29           | 1070.29         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_-1_num_tokens_4096 | 0.006       | 0.006     | 0.976      | 1082.88           | 1082.88         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_1     | 0.004       | 0.001     | 3.765      | 1057.72           | 1057.72         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_2     | 0.004       | 0.001     | 3.731      | 1057.73           | 1057.73         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_4     | 0.004       | 0.001     | 3.699      | 1057.74           | 1057.74         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_8     | 0.004       | 0.001     | 3.646      | 1057.77           | 1057.77         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_16    | 0.004       | 0.001     | 3.510      | 1057.82           | 1057.82         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_32    | 0.005       | 0.001     | 3.162      | 1057.91           | 1057.91         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_64    | 0.005       | 0.001     | 3.504      | 1058.11           | 1058.11         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_128   | 0.005       | 0.001     | 3.219      | 1058.50           | 1058.50         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_256   | 0.005       | 0.002     | 3.077      | 1059.29           | 1059.29         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_512   | 0.005       | 0.002     | 2.902      | 1060.86           | 1060.86         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_1024  | 0.009       | 0.002     | 3.731      | 1064.01           | 1064.01         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_2048  | 0.015       | 0.003     | 5.320      | 1070.30           | 1070.30         | 1.000
hidden_size_2048_group_shape_m_-1_group_shape_n_1_num_tokens_4096  | 0.028       | 0.005     | 5.434      | 1082.88           | 1082.88         | 1.000
hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_1     | 0.002       | 0.001     | 1.414      | 1057.72           | 1057.72         | 1.000
hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_2     | 0.002       | 0.001     | 1.498      | 1057.72           | 1057.72         | 1.000
hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_4     | 0.002       | 0.001     | 1.332      | 1057.73           | 1057.73         | 1.000
hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_8     | 0.002       | 0.001     | 1.434      | 1057.76           | 1057.76         | 1.000
hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_16    | 0.002       | 0.001     | 1.563      | 1057.81           | 1057.81         | 1.000
hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_32    | 0.002       | 0.002     | 1.121      | 1057.91           | 1057.91         | 1.000
hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_64    | 0.002       | 0.002     | 1.267      | 1058.10           | 1058.10         | 1.000
hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_128   | 0.002       | 0.001     | 1.553      | 1058.50           | 1058.50         | 1.000
hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_256   | 0.002       | 0.002     | 1.497      | 1059.28           | 1059.28         | 1.000
hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_512   | 0.003       | 0.002     | 1.218      | 1060.86           | 1060.86         | 1.000
hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_1024  | 0.003       | 0.002     | 1.388      | 1064.01           | 1064.01         | 1.000
hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_2048  | 0.005       | 0.005     | 1.135      | 1070.30           | 1070.30         | 1.000
hidden_size_2048_group_shape_m_1_group_shape_n_-1_num_tokens_4096  | 0.009       | 0.007     | 1.157      | 1082.89           | 1082.89         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_1    | 0.002       | 0.001     | 1.508      | 1057.72           | 1057.72         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_2    | 0.002       | 0.001     | 1.520      | 1057.73           | 1057.73         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_4    | 0.002       | 0.001     | 1.502      | 1057.76           | 1057.76         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_8    | 0.002       | 0.001     | 1.489      | 1057.81           | 1057.81         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_16   | 0.002       | 0.001     | 1.385      | 1057.91           | 1057.91         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_32   | 0.002       | 0.001     | 1.411      | 1058.10           | 1058.10         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_64   | 0.002       | 0.001     | 1.389      | 1058.50           | 1058.50         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_128  | 0.002       | 0.002     | 1.310      | 1059.28           | 1059.28         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_256  | 0.002       | 0.002     | 1.250      | 1060.86           | 1060.86         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_512  | 0.003       | 0.002     | 1.186      | 1064.00           | 1064.00         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_1024 | 0.004       | 0.003     | 1.185      | 1070.29           | 1070.29         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_2048 | 0.006       | 0.006     | 0.891      | 1082.88           | 1082.88         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_-1_num_tokens_4096 | 0.018       | 0.016     | 1.106      | 1108.04           | 1108.04         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_1     | 0.008       | 0.001     | 6.399      | 1057.74           | 1057.74         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_2     | 0.008       | 0.001     | 6.359      | 1057.75           | 1057.75         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_4     | 0.008       | 0.001     | 6.028      | 1057.78           | 1057.78         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_8     | 0.008       | 0.001     | 5.994      | 1057.82           | 1057.82         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_16    | 0.008       | 0.001     | 5.806      | 1057.92           | 1057.92         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_32    | 0.008       | 0.001     | 5.452      | 1058.12           | 1058.12         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_64    | 0.008       | 0.001     | 5.634      | 1058.51           | 1058.51         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_128   | 0.008       | 0.002     | 5.032      | 1059.30           | 1059.30         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_256   | 0.008       | 0.002     | 4.858      | 1060.87           | 1060.87         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_512   | 0.009       | 0.002     | 3.771      | 1064.02           | 1064.02         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_1024  | 0.015       | 0.004     | 4.284      | 1070.31           | 1070.31         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_2048  | 0.028       | 0.009     | 2.977      | 1082.89           | 1082.89         | 1.000
hidden_size_4096_group_shape_m_-1_group_shape_n_1_num_tokens_4096  | 0.055       | 0.015     | 3.671      | 1108.06           | 1108.06         | 1.000
hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_1     | 0.002       | 0.001     | 1.519      | 1057.72           | 1057.72         | 1.000
hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_2     | 0.002       | 0.001     | 1.472      | 1057.73           | 1057.73         | 1.000
hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_4     | 0.002       | 0.001     | 1.400      | 1057.76           | 1057.76         | 1.000
hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_8     | 0.002       | 0.001     | 1.444      | 1057.81           | 1057.81         | 1.000
hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_16    | 0.002       | 0.002     | 1.163      | 1057.91           | 1057.91         | 1.000
hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_32    | 0.002       | 0.002     | 1.248      | 1058.10           | 1058.10         | 1.000
hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_64    | 0.002       | 0.002     | 1.346      | 1058.50           | 1058.50         | 1.000
hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_128   | 0.002       | 0.002     | 1.215      | 1059.28           | 1059.28         | 1.000
hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_256   | 0.003       | 0.002     | 1.194      | 1060.86           | 1060.86         | 1.000
hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_512   | 0.003       | 0.002     | 1.339      | 1064.00           | 1064.00         | 1.000
hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_1024  | 0.004       | 0.003     | 1.454      | 1070.30           | 1070.30         | 1.000
hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_2048  | 0.007       | 0.008     | 0.828      | 1082.88           | 1082.88         | 1.000
hidden_size_4096_group_shape_m_1_group_shape_n_-1_num_tokens_4096  | 0.018       | 0.017     | 1.103      | 1108.06           | 1108.06         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_1    | 0.002       | 0.001     | 1.755      | 1057.73           | 1057.73         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_2    | 0.002       | 0.001     | 1.697      | 1057.76           | 1057.76         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_4    | 0.002       | 0.001     | 1.772      | 1057.81           | 1057.81         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_8    | 0.002       | 0.001     | 1.517      | 1057.91           | 1057.91         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_16   | 0.002       | 0.001     | 1.678      | 1058.10           | 1058.10         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_32   | 0.002       | 0.002     | 1.458      | 1058.50           | 1058.50         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_64   | 0.002       | 0.002     | 1.446      | 1059.28           | 1059.28         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_128  | 0.002       | 0.002     | 1.272      | 1060.86           | 1060.86         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_256  | 0.003       | 0.002     | 1.401      | 1064.00           | 1064.00         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_512  | 0.004       | 0.003     | 1.077      | 1070.29           | 1070.29         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_1024 | 0.005       | 0.008     | 0.670      | 1082.88           | 1082.88         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_2048 | 0.017       | 0.015     | 1.126      | 1108.04           | 1108.04         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_-1_num_tokens_4096 | 0.035       | 0.035     | 1.002      | 1158.37           | 1158.37         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_1     | 0.014       | 0.001     | 11.206     | 1057.77           | 1057.77         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_2     | 0.014       | 0.001     | 11.482     | 1057.79           | 1057.79         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_4     | 0.014       | 0.001     | 10.897     | 1057.84           | 1057.84         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_8     | 0.014       | 0.001     | 10.644     | 1057.94           | 1057.94         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_16    | 0.014       | 0.001     | 10.437     | 1058.14           | 1058.14         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_32    | 0.015       | 0.001     | 10.321     | 1058.53           | 1058.53         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_64    | 0.015       | 0.002     | 8.689      | 1059.32           | 1059.32         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_128   | 0.015       | 0.002     | 8.229      | 1060.89           | 1060.89         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_256   | 0.015       | 0.003     | 5.220      | 1064.03           | 1064.03         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_512   | 0.016       | 0.003     | 5.280      | 1070.33           | 1070.33         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_1024  | 0.029       | 0.008     | 3.414      | 1082.91           | 1082.91         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_2048  | 0.060       | 0.015     | 4.019      | 1108.07           | 1108.07         | 1.000
hidden_size_8192_group_shape_m_-1_group_shape_n_1_num_tokens_4096  | 0.107       | 0.035     | 3.041      | 1158.41           | 1158.41         | 1.000
hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_1     | 0.002       | 0.001     | 1.741      | 1057.73           | 1057.73         | 1.000
hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_2     | 0.002       | 0.001     | 1.683      | 1057.76           | 1057.76         | 1.000
hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_4     | 0.002       | 0.001     | 1.756      | 1057.81           | 1057.81         | 1.000
hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_8     | 0.002       | 0.002     | 1.510      | 1057.91           | 1057.91         | 1.000
hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_16    | 0.002       | 0.002     | 1.600      | 1058.10           | 1058.10         | 1.000
hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_32    | 0.002       | 0.002     | 1.442      | 1058.50           | 1058.50         | 1.000
hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_64    | 0.003       | 0.002     | 1.515      | 1059.28           | 1059.28         | 1.000
hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_128   | 0.003       | 0.002     | 1.425      | 1060.86           | 1060.86         | 1.000
hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_256   | 0.003       | 0.002     | 1.284      | 1064.00           | 1064.00         | 1.000
hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_512   | 0.004       | 0.003     | 1.475      | 1070.29           | 1070.29         | 1.000
hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_1024  | 0.006       | 0.008     | 0.750      | 1082.88           | 1082.88         | 1.000
hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_2048  | 0.018       | 0.016     | 1.103      | 1108.05           | 1108.05         | 1.000
hidden_size_8192_group_shape_m_1_group_shape_n_-1_num_tokens_4096  | 0.036       | 0.035     | 1.032      | 1158.39           | 1158.39         | 1.000
```

Benchmarking on H200 and B200 shows similar level of speedup and results are provided here:
* H200: https://gist.github.com/gmagogsfm/9a8fbd43d39c0ebbddca3d14a8c1d0f0
* B200: https://gist.github.com/gmagogsfm/f022862cb1f9f2881b698b920fc757a1

## Test Plan

- [x] Test correctness
  - Added unit test to cover its correctness
- [x] Benchmark kernel performance 

## Test Result
### Unit test to cover correctness 
All unit test cases to cover its correctness passed. 
```
pytest tests/kernels/helion/test_static_scaled_fp8_quant.py
```

### Kernel benchmarking
See the results above.