### PR TITLE
Fix RoutingMethodType logic

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -582,7 +582,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # This is ~1.1GB and only changes when FlashInfer version bumps
 # https://docs.flashinfer.ai/installation.html
 # From versions.json: .flashinfer.version
-ARG FLASHINFER_VERSION=0.6.2
+ARG FLASHINFER_VERSION=0.6.3
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system flashinfer-cubin==${FLASHINFER_VERSION} \
     && uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \

--- a/docker/Dockerfile.nightly_torch
+++ b/docker/Dockerfile.nightly_torch
@@ -217,13 +217,13 @@ RUN pip install setuptools==75.6.0 packaging==23.2 ninja==1.11.1.3 build==1.2.2.
 
 
 # build flashinfer for torch nightly from source around 10 mins
-# release version: v0.6.2
+# release version: v0.6.3
 # todo(elainewy): cache flashinfer build result for faster build
 ENV CCACHE_DIR=/root/.cache/ccache
 RUN --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=cache,target=/root/.cache/uv \
     echo "git clone flashinfer..." \
-    && git clone --depth 1 --branch v0.6.2 --recursive https://github.com/flashinfer-ai/flashinfer.git \
+    && git clone --depth 1 --branch v0.6.3 --recursive https://github.com/flashinfer-ai/flashinfer.git \
     && cd flashinfer \
     && git submodule update --init --recursive \
     && echo "finish git clone flashinfer..." \

--- a/docker/versions.json
+++ b/docker/versions.json
@@ -68,7 +68,7 @@
       "default": "true"
     },
     "FLASHINFER_VERSION": {
-      "default": "0.6.2"
+      "default": "0.6.3"
     },
     "GDRCOPY_CUDA_VERSION": {
       "default": "12.8"

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -10,4 +10,4 @@ torchaudio==2.9.1
 # These must be updated alongside torch
 torchvision==0.24.1 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # FlashInfer should be updated together with the Dockerfile
-flashinfer-python==0.6.2
+flashinfer-python==0.6.3

--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -124,6 +124,23 @@ class RoutingMethodType(IntEnum):
     Unspecified = 8.0
 
 
+def get_routing_method_type(
+    scoring_func: str, top_k: int, renormalize: bool
+) -> RoutingMethodType:
+    if scoring_func == "sigmoid":
+        if top_k == 1:
+            return RoutingMethodType.Llama4
+        else:
+            return RoutingMethodType.DeepSeekV3
+    elif scoring_func == "softmax":
+        if renormalize:
+            return RoutingMethodType.Renormalize
+        else:
+            return RoutingMethodType.Default
+    else:
+        return RoutingMethodType.Unspecified
+
+
 @dataclass
 class FusedMoEQuantDesc:
     """

--- a/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
@@ -61,6 +61,8 @@ def _supports_routing_method(
     routing_method: RoutingMethodType,
 ) -> bool:
     """Monolithic kernels need to express router support."""
+    # NOTE(dbari): TopK routing could also be enabled, but need to validate models
+    # NOTE(dbari): Default is not implemented and should not be enabled until it is
     if (weight_key, activation_key) == (kFp8Static128BlockSym, kFp8Dynamic128Sym):
         # NOTE(rob): potentially allow others here. This is a conservative list.
         return routing_method in [
@@ -72,10 +74,8 @@ def _supports_routing_method(
         # NOTE(dbari): as above, potentially allow others here.
         return routing_method in [
             RoutingMethodType.Llama4,
-            # NOTE(mgoin): Disabled to investigate accuracy issues.
-            # See https://github.com/vllm-project/vllm/issues/33532
-            # RoutingMethodType.Renormalize,
-            # RoutingMethodType.RenormalizeNaive,
+            RoutingMethodType.Renormalize,
+            RoutingMethodType.RenormalizeNaive,
         ]
     else:
         raise ValueError("Unsupported quantization scheme.")

--- a/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
@@ -302,6 +302,8 @@ def fi_trtllm_fp8_per_tensor_moe(
         per_act_token_quant=False,
     )
 
+    from flashinfer.fused_moe.core import ActivationType
+
     from vllm.utils.flashinfer import flashinfer_trtllm_fp8_per_tensor_scale_moe
 
     return flashinfer_trtllm_fp8_per_tensor_scale_moe(
@@ -323,6 +325,9 @@ def fi_trtllm_fp8_per_tensor_moe(
         routed_scaling_factor=routed_scaling_factor,
         use_routing_scales_on_input=use_routing_scales_on_input,
         routing_method_type=routing_method_type,
+        # TODO: Required for flashinfer==0.6.3, remove with update
+        # https://github.com/flashinfer-ai/flashinfer/pull/2508
+        activation_type=ActivationType.Swiglu,
     )
 
 

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
@@ -10,7 +10,10 @@ from vllm.distributed.eplb.eplb_state import EplbLayerState
 from vllm.model_executor.layers.batch_invariant import (
     vllm_is_batch_invariant,
 )
-from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
+from vllm.model_executor.layers.fused_moe.config import (
+    RoutingMethodType,
+    get_routing_method_type,
+)
 from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
 
 
@@ -158,18 +161,11 @@ class FusedTopKBiasRouter(BaseRouter):
 
     @property
     def routing_method_type(self) -> RoutingMethodType:
-        if self.scoring_func == "sigmoid":
-            if self.top_k == 1:
-                return RoutingMethodType.Llama4
-            else:
-                return RoutingMethodType.DeepSeekV3
-        elif self.scoring_func == "softmax":
-            if self.renormalize:
-                return RoutingMethodType.Renormalize
-            else:
-                return RoutingMethodType.Default
-        else:
-            return RoutingMethodType.Unspecified
+        return get_routing_method_type(
+            scoring_func=self.scoring_func,
+            top_k=self.top_k,
+            renormalize=self.renormalize,
+        )
 
     def _compute_routing(
         self,

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_bias_router.py
@@ -158,11 +158,18 @@ class FusedTopKBiasRouter(BaseRouter):
 
     @property
     def routing_method_type(self) -> RoutingMethodType:
-        return (
-            RoutingMethodType.Renormalize
-            if not self.renormalize
-            else RoutingMethodType.RenormalizeNaive
-        )
+        if self.scoring_func == "sigmoid":
+            if self.top_k == 1:
+                return RoutingMethodType.Llama4
+            else:
+                return RoutingMethodType.DeepSeekV3
+        elif self.scoring_func == "softmax":
+            if self.renormalize:
+                return RoutingMethodType.Renormalize
+            else:
+                return RoutingMethodType.Default
+        else:
+            return RoutingMethodType.Unspecified
 
     def _compute_routing(
         self,

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -7,7 +7,10 @@ import torch
 import vllm._custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.distributed.eplb.eplb_state import EplbLayerState
-from vllm.model_executor.layers.fused_moe.config import RoutingMethodType
+from vllm.model_executor.layers.fused_moe.config import (
+    RoutingMethodType,
+    get_routing_method_type,
+)
 from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
 
 
@@ -135,18 +138,11 @@ class FusedTopKRouter(BaseRouter):
 
     @property
     def routing_method_type(self) -> RoutingMethodType:
-        if self.scoring_func == "sigmoid":
-            if self.top_k == 1:
-                return RoutingMethodType.Llama4
-            else:
-                return RoutingMethodType.DeepSeekV3
-        elif self.scoring_func == "softmax":
-            if self.renormalize:
-                return RoutingMethodType.Renormalize
-            else:
-                return RoutingMethodType.Default
-        else:
-            return RoutingMethodType.Unspecified
+        return get_routing_method_type(
+            scoring_func=self.scoring_func,
+            top_k=self.top_k,
+            renormalize=self.renormalize,
+        )
 
     def _compute_routing(
         self,

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -135,11 +135,18 @@ class FusedTopKRouter(BaseRouter):
 
     @property
     def routing_method_type(self) -> RoutingMethodType:
-        return (
-            RoutingMethodType.Renormalize
-            if not self.renormalize
-            else RoutingMethodType.RenormalizeNaive
-        )
+        if self.scoring_func == "sigmoid":
+            if self.top_k == 1:
+                return RoutingMethodType.Llama4
+            else:
+                return RoutingMethodType.DeepSeekV3
+        elif self.scoring_func == "softmax":
+            if self.renormalize:
+                return RoutingMethodType.Renormalize
+            else:
+                return RoutingMethodType.Default
+        else:
+            return RoutingMethodType.Unspecified
 
     def _compute_routing(
         self,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR contains two fixes for #33792:
- Fix the selection logic for `RoutingMethodType` in `fused_topk_bias_router.py` and `fused_topk_router.py`
- When `use_grouped_topk=True`, the `GroupedTopKRouter` did not find any valid routing methods and there is only one group, fall back to the non-grouped routers

The latter point covers Mistral Large 3, which has `n_group=1` and `topk_group=1` but uses `Renormalize` instead of `DeepSeekV3` routing, handled by the `FusedTopKRouter`.

After #33858 was merged, Mistral Large 3 is broken. This PR fixes the vLLM part, however [Flashinfer PR#2502](https://github.com/flashinfer-ai/flashinfer/pull/2502) is also needed [edit: has been merged and added to 0.6.3].

## Test Plan

Will test the accuracy of the models affected by recent relevant PRs: Mistral Large 3, Kimi-K2 and Deepseek V2-Lite.

## Test Result

Results for `RedHatAI/DeepSeek-Coder-V2-Lite-Instruct-FP8`, using the default MoE backend (FLASHINFER_CUTLASS):
```
GSM8K Results for RedHatAI/DeepSeek-Coder-V2-Lite-Instruct-FP8:
  Measured metric: 0.7832
  Expected metric: 0.7200
  Tolerance: 0.0800
  Questions: 1319
  Invalid rate: 0.001
  Latency: 95.6s
  QPS: 13.8
✅ GSM8K test passed for RedHatAI/DeepSeek-Coder-V2-Lite-Instruct-FP8
```

Results for `mistralai/Mistral-Large-3-675B-Instruct-2512`, using the default MoE backend (FLASHINFER_TRTLLM):
```
local-completions (base_url=http://localhost:3825,model=mistralai/Mistral-Large-3-675B-Instruct-2512,tokenized_requests=False,,tokenizer_backend=None,num_concurrent=8,timeout=240,max_retries=3,stream=False), gen_kwargs: (temperature=0.01,top_p=0.9999999,max_gen_toks=8192), limit: 1000.0, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.942|±  |0.0074|
|     |       |strict-match    |     5|exact_match|↑  |0.909|±  |0.0091|
```

Results for `moonshotai/Kimi-K2-Instruct`, using the default MoE backend (FLASHINFER_TRTLLM):
```
local-completions (base_url=http://localhost:3825,model=/models/Kimi-K2-Instruct,tokenized_requests=False,,tokenizer_backend=None,num_concurrent=8,timeout=240,max_retries=3,stream=False), gen_kwargs: (temperature=0.01,top_p=0.9999999,max_gen_toks=8192), limit: 1000.0, num_fewshot: None, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.947|±  |0.0071|
|     |       |strict-match    |     5|exact_match|↑  |0.946|±  |0.0072|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

