### PR TITLE
Support benchmarking of Geospatial models 

### DIFF
--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2098,13 +2098,14 @@ class CustomDataset(BenchmarkDataset):
 
             if tokenizer is None:
                 prompt_len = 1
-            # apply template
-            elif not skip_chat_template:
-                prompt = tokenizer.apply_chat_template(
-                    [{"role": "user", "content": prompt}],
-                    add_generation_prompt=True,
-                    tokenize=False,
-                )
+            else:
+                # apply template
+                if not skip_chat_template:
+                    prompt = tokenizer.apply_chat_template(
+                        [{"role": "user", "content": prompt}],
+                        add_generation_prompt=True,
+                        tokenize=False,
+                    )
 
                 prompt_len = len(tokenizer(prompt).input_ids)
             sampled_requests.append(

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2076,32 +2076,37 @@ class CustomDataset(BenchmarkDataset):
                 break
             prompt = item["prompt"]
 
-            new_output_len = output_len
-            if output_len is None or output_len == -1:
-                # check that the request has an 'output_tokens' field
-                if "output_tokens" not in item:
-                    raise ValueError(
-                        "If no output length is provided the "
-                        "custom dataset must contain an 'output_tokens' field."
-                    )
-                # Use number of output tokens from the request data
-                try:
-                    new_output_len = int(item["output_tokens"])
-                except (ValueError, TypeError) as e:
-                    raise ValueError(
-                        f"Invalid value for 'output_tokens' in custom dataset: "
-                        f"'{item['output_tokens']}'. Must be an integer."
-                    ) from e
+            if tokenizer is None:
+                new_output_len = 1
+            else:
+                new_output_len = output_len
+                if output_len is None or output_len == -1:
+                    # check that the request has an 'output_tokens' field
+                    if "output_tokens" not in item:
+                        raise ValueError(
+                            "If no output length is provided the "
+                            "custom dataset must contain an 'output_tokens' field."
+                        )
+                    # Use number of output tokens from the request data
+                    try:
+                        new_output_len = int(item["output_tokens"])
+                    except (ValueError, TypeError) as e:
+                        raise ValueError(
+                            f"Invalid value for 'output_tokens' in custom dataset: "
+                            f"'{item['output_tokens']}'. Must be an integer."
+                        ) from e
 
+            if tokenizer is None:
+                prompt_len = 1
             # apply template
-            if not skip_chat_template:
+            elif not skip_chat_template:
                 prompt = tokenizer.apply_chat_template(
                     [{"role": "user", "content": prompt}],
                     add_generation_prompt=True,
                     tokenize=False,
                 )
 
-            prompt_len = len(tokenizer(prompt).input_ids)
+                prompt_len = len(tokenizer(prompt).input_ids)
             sampled_requests.append(
                 SampleRequest(
                     prompt=prompt,

--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -746,12 +746,43 @@ async def async_request_infinity_embeddings_clip(
     )
 
 
+async def async_request_vllm_pooling(
+    request_func_input: RequestFuncInput,
+    session: aiohttp.ClientSession,
+    pbar: tqdm | None = None,
+) -> RequestFuncOutput:
+    api_url = request_func_input.api_url
+    _validate_api_url(api_url, "vLLM Pooling API", "pooling")
+
+    payload = {
+        "model": request_func_input.model_name
+        if request_func_input.model_name
+        else request_func_input.model,
+        "data": request_func_input.prompt["data"],
+        "truncate_prompt_tokens": -1,
+    }
+
+    _update_payload_common(payload, request_func_input)
+
+    headers = _get_headers("application/json")
+    _update_headers_common(headers, request_func_input)
+
+    return await _run_pooling_request(
+        session,
+        api_url,
+        payload=payload,
+        headers=headers,
+        pbar=pbar,
+    )
+
+
 # TODO: Add more request functions for different API protocols.
 ASYNC_REQUEST_FUNCS: dict[str, RequestFunc] = {
     "vllm": async_request_openai_completions,
     "openai": async_request_openai_completions,
     "openai-chat": async_request_openai_chat_completions,
     "openai-audio": async_request_openai_audio,
+    "vllm-pooling": async_request_vllm_pooling,
     "openai-embeddings": async_request_openai_embeddings,
     "openai-embeddings-chat": async_request_openai_embeddings_chat,
     "openai-embeddings-clip": async_request_openai_embeddings_clip,

--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -783,7 +783,6 @@ ASYNC_REQUEST_FUNCS: dict[str, RequestFunc] = {
     "openai": async_request_openai_completions,
     "openai-chat": async_request_openai_chat_completions,
     "openai-audio": async_request_openai_audio,
-    "vllm-pooling": async_request_vllm_pooling,
     "openai-embeddings": async_request_openai_embeddings,
     "openai-embeddings-chat": async_request_openai_embeddings_chat,
     "openai-embeddings-clip": async_request_openai_embeddings_clip,
@@ -793,6 +792,7 @@ ASYNC_REQUEST_FUNCS: dict[str, RequestFunc] = {
     "infinity-embeddings-clip": async_request_infinity_embeddings_clip,
     # (Infinity embedding server does not support vlm2vec)
     "vllm-rerank": async_request_vllm_rerank,
+    "vllm-pooling": async_request_vllm_pooling,
 }
 
 OPENAI_COMPATIBLE_BACKENDS = [

--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -758,9 +758,10 @@ async def async_request_vllm_pooling(
         "model": request_func_input.model_name
         if request_func_input.model_name
         else request_func_input.model,
-        "data": request_func_input.prompt["data"],
         "truncate_prompt_tokens": -1,
     }
+
+    payload = payload | request_func_input.prompt
 
     _update_payload_common(payload, request_func_input)
 

--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -791,8 +791,8 @@ ASYNC_REQUEST_FUNCS: dict[str, RequestFunc] = {
     "infinity-embeddings": async_request_infinity_embeddings,
     "infinity-embeddings-clip": async_request_infinity_embeddings_clip,
     # (Infinity embedding server does not support vlm2vec)
-    "vllm-rerank": async_request_vllm_rerank,
     "vllm-pooling": async_request_vllm_pooling,
+    "vllm-rerank": async_request_vllm_rerank,
 }
 
 OPENAI_COMPATIBLE_BACKENDS = [

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1588,18 +1588,15 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
     if args.skip_tokenizer_init:
         tokenizer_id = None
         tokenizer_mode = None
+        tokenizer = None
     else:
         tokenizer_id = args.tokenizer if args.tokenizer is not None else model_id
         tokenizer_mode = args.tokenizer_mode
-
-    if tokenizer_id or tokenizer_mode:
         tokenizer = get_tokenizer(
             tokenizer_id,
             tokenizer_mode=tokenizer_mode,
             trust_remote_code=args.trust_remote_code,
         )
-    else:
-        tokenizer = None
 
     if args.dataset_name is None:
         raise ValueError(

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1589,7 +1589,7 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
         tokenizer_id = None
         tokenizer_mode = None
     else:
-        tokenizer_id = args.tokenizer if args.tokenizer is not None else args.model
+        tokenizer_id = args.tokenizer if args.tokenizer is not None else model_id
         tokenizer_mode = args.tokenizer_mode
 
     if tokenizer_id or tokenizer_mode:

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -419,16 +419,19 @@ def calculate_metrics(
             output_len = outputs[i].output_tokens
 
             if not output_len:
-                # We use the tokenizer to count the number of output tokens
-                # for some serving backends instead of looking at
-                # len(outputs[i].itl) since multiple output tokens may be
-                # bundled together
-                # Note : this may inflate the output token count slightly
-                output_len = len(
-                    tokenizer(
-                        outputs[i].generated_text, add_special_tokens=False
-                    ).input_ids
-                )
+                if tokenizer is None:
+                    output_len = len(input_requests)
+                else:
+                    # We use the tokenizer to count the number of output tokens
+                    # for some serving backends instead of looking at
+                    # len(outputs[i].itl) since multiple output tokens may be
+                    # bundled together
+                    # Note : this may inflate the output token count slightly
+                    output_len = len(
+                        tokenizer(
+                            outputs[i].generated_text, add_special_tokens=False
+                        ).input_ids
+                    )
             actual_output_lens.append(output_len)
             total_input += input_requests[i].prompt_len
             tpot = 0
@@ -912,7 +915,7 @@ async def benchmark(
         print("{:<40} {:<10.2f}".format("Request rate configured (RPS):", request_rate))
     print("{:<40} {:<10.2f}".format("Benchmark duration (s):", benchmark_duration))
     print("{:<40} {:<10}".format("Total input tokens:", metrics.total_input))
-    if isinstance(metrics, BenchmarkMetrics):
+    if isinstance(metrics, BenchmarkMetrics) and tokenizer:
         print("{:<40} {:<10}".format("Total generated tokens:", metrics.total_output))
     print(
         "{:<40} {:<10.2f}".format(
@@ -926,16 +929,18 @@ async def benchmark(
             )
         )
     if isinstance(metrics, BenchmarkMetrics):
-        print(
-            "{:<40} {:<10.2f}".format(
-                "Output token throughput (tok/s):", metrics.output_throughput
+        if tokenizer:
+            print(
+                "{:<40} {:<10.2f}".format(
+                    "Output token throughput (tok/s):", metrics.output_throughput
+                )
             )
-        )
-        print(
-            "{:<40} {:<10.2f}".format(
-                "Peak output token throughput (tok/s):", metrics.max_output_tokens_per_s
+            print(
+                "{:<40} {:<10.2f}".format(
+                    "Peak output token throughput (tok/s):",
+                    metrics.max_output_tokens_per_s,
+                )
             )
-        )
         print(
             "{:<40} {:<10.2f}".format(
                 "Peak concurrent requests:", metrics.max_concurrent_requests
@@ -947,11 +952,12 @@ async def benchmark(
                     "RTFx (Inverse Real-Time Factor):", metrics.rtfx
                 )
             )
-    print(
-        "{:<40} {:<10.2f}".format(
-            "Total token throughput (tok/s):", metrics.total_token_throughput
+    if tokenizer:
+        print(
+            "{:<40} {:<10.2f}".format(
+                "Total token throughput (tok/s):", metrics.total_token_throughput
+            )
         )
-    )
 
     if isinstance(metrics, BenchmarkMetrics):
         result = {
@@ -1040,7 +1046,7 @@ async def benchmark(
             print("{:<40} {:<10.2f}".format(f"P{p_word} {metric_name} (ms):", value))
             result[f"p{p_word}_{metric_attribute_name}_ms"] = value
 
-    if task_type == TaskType.GENERATION:
+    if task_type == TaskType.GENERATION and tokenizer:
         process_one_metric("ttft", "TTFT", "Time to First Token")
         process_one_metric("tpot", "TPOT", "Time per Output Token (excl. 1st token)")
         process_one_metric("itl", "ITL", "Inter-token Latency")
@@ -1512,6 +1518,12 @@ def add_cli_args(parser: argparse.ArgumentParser):
         type=json.loads,
         default=None,
     )
+    parser.add_argument(
+        "--skip-tokenizer-init",
+        type=bool,
+        default=False,
+        help="Skip initialization of tokenizer and detokenizer",
+    )
 
 
 def main(args: argparse.Namespace) -> dict[str, Any]:
@@ -1573,14 +1585,21 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
         model_name = args.served_model_name
         model_id = args.model
 
-    tokenizer_id = args.tokenizer if args.tokenizer is not None else model_id
-    tokenizer_mode = args.tokenizer_mode
+    if args.skip_tokenizer_init:
+        tokenizer_id = None
+        tokenizer_mode = None
+    else:
+        tokenizer_id = args.tokenizer if args.tokenizer is not None else args.model
+        tokenizer_mode = args.tokenizer_mode
 
-    tokenizer = get_tokenizer(
-        tokenizer_id,
-        tokenizer_mode=tokenizer_mode,
-        trust_remote_code=args.trust_remote_code,
-    )
+    if tokenizer_id:
+        tokenizer = get_tokenizer(
+            tokenizer_id,
+            tokenizer_mode=tokenizer_mode,
+            trust_remote_code=args.trust_remote_code,
+        )
+    else:
+        tokenizer = None
 
     if args.dataset_name is None:
         raise ValueError(

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -420,7 +420,7 @@ def calculate_metrics(
 
             if not output_len:
                 if tokenizer is None:
-                    output_len = len(input_requests)
+                    output_len = 1
                 else:
                     # We use the tokenizer to count the number of output tokens
                     # for some serving backends instead of looking at

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1592,7 +1592,7 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
         tokenizer_id = args.tokenizer if args.tokenizer is not None else args.model
         tokenizer_mode = args.tokenizer_mode
 
-    if tokenizer_id:
+    if tokenizer_id or tokenizer_mode:
         tokenizer = get_tokenizer(
             tokenizer_id,
             tokenizer_mode=tokenizer_mode,

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -1520,7 +1520,7 @@ def add_cli_args(parser: argparse.ArgumentParser):
     )
     parser.add_argument(
         "--skip-tokenizer-init",
-        type=bool,
+        action="store_true",
         default=False,
         help="Skip initialization of tokenizer and detokenizer",
     )


### PR DESCRIPTION
This PR adds the following features necessary to the Geospatial models like Prithvi:
- ability to run benchmarks when the tokenizer is not initialised. This is done via a new argument `--skip-tokenizer-init`. In this case the benchmark does not print token related metrics.
- Adds new benchmark backend that supports sending requests to the /pooling endpoint.


The benchmark can be run as following:

**Step 1: start the server**

```
python -m vllm.entrypoints.openai.api_server \
--model='ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11' \
--trust-remote-code --dtype float16 --skip-tokenizer-init --enforce-eager \
--io-processor-plugin terratorch_segmentation --enable-mm-embeds
```

**Step 2: start the benchmark**

```
vllm bench serve  \
--base-url  http://127.0.0.1:8000 \
--dataset-name=custom \
--model ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11 \
--skip-tokenizer-init \
--backend  vllm-pooling \
--num-prompts 10 \
--dataset-path  ./dataset_url_input_india.jsonl \
--endpoint /pooling  \
--metric-percentiles 25,75,99  \
--percentile-metrics e2el
```

`dataset_url_input_india.jsonl` contains the following sample:
```
{"prompt":{"data": {"data": "https://huggingface.co/christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM/resolve/main/India_900498_S2Hand.tif","data_format": "url","out_data_format": "b64_json","indices": [1, 2, 3, 8, 11, 12]},"priority": 0,"softmax": false}}
```

Results will be showed as following:

```
tip: install termplotlib and gnuplot to plot the metrics
============ Serving Benchmark Result ============
Successful requests:                     10        
Failed requests:                         0         
Benchmark duration (s):                  1.59      
Total input tokens:                      10        
Request throughput (req/s):              6.30      
Peak concurrent requests:                10.00     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          1200.33   
Median E2EL (ms):                        1126.21   
P25 E2EL (ms):                           944.64    
P75 E2EL (ms):                           1449.38   
P99 E2EL (ms):                           1582.95   
```
