### PR TITLE
[Bugfix] Fix tokenizer model_max_length incorrectly constraining user-specified max_model_len

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1920,8 +1920,11 @@ def _get_and_verify_max_len(
         max_len_key = "sliding_window"
         derived_max_model_len = sliding_window
 
-    # Consider model_max_length in tokenizer_config
-    if tokenizer_config:
+    # Consider model_max_length in tokenizer_config only when the user
+    # has not explicitly specified max_model_len. The tokenizer's
+    # model_max_length should serve as a default, not override explicit
+    # user configuration.
+    if tokenizer_config and (max_model_len is None or max_model_len == -1):
         tokenizer_model_max_length = tokenizer_config.get(
             "model_max_length", derived_max_model_len
         )


### PR DESCRIPTION
This fixes a bug where the tokenizer's model_max_length would override the user's explicit --max-model-len parameter, preventing users from utilizing extended context lengths even when the model supports them.

For example, with Qwen/Qwen3-4B-Instruct-2507-FP8:
- Model supports 256K tokens (max_position_embeddings = 262144)
- Tokenizer config has model_max_length = 8192
- User specifies --max-model-len 262144
- Before: Server would cap at 8192 and reject 10K token requests
- After: Server correctly uses 262144 as specified

Changes:
- Modified _get_and_verify_max_len() to only apply tokenizer's model_max_length as a default when user doesn't specify max_model_len
- Added regression test to verify explicit max_model_len overrides tokenizer limit
- Updated existing test to reflect correct behavior

Fixes issue where users cannot use extended context models despite explicit configuration.

<!-- markdownlint-disable -->

## Purpose                                                                                                                                                                                                         
   
  Fixes a bug where the tokenizer's `model_max_length` incorrectly constrains the user's explicit `--max-model-len` parameter, preventing users from utilizing extended context lengths even when the model supports 
  them.           

  **Problem**:
For models with extended context support (e.g., Qwen/Qwen3-4B-Instruct-2507-FP8 with 256K tokens), if the tokenizer config has an outdated `model_max_length` (e.g., 8192), vLLM would reject requests even when
the user explicitly specifies `--max-model-len 262144`.

  **Root Cause**:
In `_get_and_verify_max_len()`, the tokenizer's `model_max_length` was always used to constrain
`derived_max_model_len`, even when the user provided an explicit `--max-model-len` override.

  **Solution**:
Only apply the tokenizer's `model_max_length` constraint when the user has NOT specified `max_model_len` (i.e., when it should serve as a default, not a hard limit).

  ## Test Plan

  ```bash
  # Run the new regression test
  python3 -m pytest tests/test_config.py::test_explicit_max_model_len_overrides_tokenizer -v

  # Run all related config tests
  python3 -m pytest tests/test_config.py::test_get_and_verify_max_len -v
```
Test Results:
  All tests pass (7/7):

  tests/test_config.py::test_get_and_verify_max_len[BAAI/bge-reranker-base-None-512-False] PASSED
  tests/test_config.py::test_get_and_verify_max_len[BAAI/bge-reranker-base-256-256-False] PASSED
  tests/test_config.py::test_get_and_verify_max_len[BAAI/bge-reranker-base-513-513-False] PASSED
  tests/test_config.py::test_get_and_verify_max_len[BAAI/bge-reranker-base-515-514-True] PASSED
  tests/test_config.py::test_get_and_verify_max_len[deepseek-ai/DeepSeek-R1-Distill-Qwen-7B-None-131072-False] PASSED
  tests/test_config.py::test_get_and_verify_max_len[deepseek-ai/DeepSeek-R1-Distill-Qwen-7B-131073-131072-True] PASSED

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

