### PR TITLE
[Core] Pipeline Parallel support for Model Runner V2

### DIFF
--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -3,7 +3,6 @@
 import gc
 import time
 from copy import deepcopy
-from typing import Any
 
 import numpy as np
 import torch
@@ -11,11 +10,14 @@ import torch.nn as nn
 
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
-from vllm.distributed.parallel_state import prepare_communication_buffer_for_model
+from vllm.distributed.parallel_state import (
+    prepare_communication_buffer_for_model,
+)
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader import get_model_loader
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.sequence import IntermediateTensors
 from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
@@ -54,6 +56,10 @@ from vllm.v1.worker.gpu.kv_connector import (
 from vllm.v1.worker.gpu.lora_utils import LoraState
 from vllm.v1.worker.gpu.mm.encoder_runner import EncoderRunner
 from vllm.v1.worker.gpu.mm.mrope_utils import MRopeState
+from vllm.v1.worker.gpu.pp_handler import (
+    PPHandler,
+    get_pp_handler,
+)
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
 from vllm.v1.worker.gpu.sample.prompt_logprob import PromptLogprobsWorker
 from vllm.v1.worker.gpu.sample.sampler import Sampler
@@ -175,6 +181,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # KV Connector if configured.
         self.kv_connector: KVConnector = NO_OP_KV_CONNECTOR
 
+        # PP Handler for pipeline parallelism.
+        # Initialize here since distributed groups are set up before model runner.
+        self.pp_handler: PPHandler = get_pp_handler(self.parallel_config)
+
     def update_max_model_len(self, max_model_len: int) -> None:
         self.max_model_len = max_model_len
         self.req_states.max_model_len = max_model_len
@@ -287,7 +297,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     @torch.inference_mode()
     def _dummy_run(
         self, num_tokens: int, *args, skip_attn: bool = True, **kwargs
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
         # Create a dummy scheduler output.
         num_reqs = min(num_tokens, self.max_num_reqs)
         num_tokens_per_request = [num_tokens // num_reqs] * num_reqs
@@ -303,13 +313,31 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Disable any use of KVConnector for dummy runs.
         self.kv_connector.set_disabled(True)
 
+        # For non-first PP ranks, create dummy intermediate_tensors.
+        intermediate_tensors = None
+        if not self.pp_handler.receives_raw_inputs:
+            intermediate_tensors = self.model.make_empty_intermediate_tensors(
+                batch_size=num_tokens,
+                dtype=self.model_config.dtype,
+                device=self.device,
+            )
+
         # Execute the model.
         self.execute_model(
-            dummy_scheduler_output, dummy_run=True, skip_attn_for_dummy_run=skip_attn
+            dummy_scheduler_output,
+            intermediate_tensors=intermediate_tensors,
+            dummy_run=True,
+            skip_attn_for_dummy_run=skip_attn,
         )
         self.kv_connector.set_disabled(False)
+
+        # Non-last PP ranks don't produce output for sampling.
+        if not self.pp_handler.produces_final_output:
+            return None, None
+
         assert self.execute_model_state is not None
         hidden_states, input_batch, _ = self.execute_model_state
+        assert hidden_states is not None  # Last PP rank always has hidden_states
         sample_hidden_states = hidden_states[input_batch.logits_indices]
         return hidden_states, sample_hidden_states
 
@@ -342,7 +370,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         hidden_states, sample_hidden_states = self._dummy_run(
             self.max_num_tokens, skip_attn=True
         )
-        self._dummy_sampler_run(sample_hidden_states)
+        # Only run sampler on last PP rank (non-last ranks return None).
+        if self.pp_handler.produces_final_output:
+            assert sample_hidden_states is not None
+            self._dummy_sampler_run(sample_hidden_states)
         if self.do_spec_decode:
             num_tokens_across_dp = make_num_tokens_across_dp(
                 self.parallel_config.data_parallel_size, self.max_num_tokens
@@ -375,6 +406,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             logger.warning(
                 "Skipping CUDA graph capture. To turn on CUDA graph capture, "
                 "ensure `cudagraph_mode` was not manually set to `NONE`"
+            )
+            return 0
+
+        # TODO (zhanqiu): support CUDA graph for PP.
+        if self.pp_handler.is_enabled:
+            logger.warning_once(
+                "Skipping CUDA graph capture because pipeline parallel is "
+                "enabled. Pipeline parallel is currently eager-only.",
             )
             return 0
 
@@ -506,7 +545,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         # Decode first, then prefill.
         # batch_idx -> req_id
-        req_ids = sorted(num_tokens_per_req, key=num_tokens_per_req.get)  # type: ignore[arg-type]
+        # NOTE: In PP mode, every rank must construct the *exact* same request
+        # ordering for the batched token dimension. Python's `sorted(..., key=...)`
+        # is stable, so ties would otherwise be broken by the input dict's
+        # insertion order, which can differ across processes. Use `req_id` as a
+        # deterministic tie-breaker to keep PP stages in sync.
+        req_ids = sorted(
+            num_tokens_per_req,
+            key=lambda req_id: (num_tokens_per_req[req_id], req_id),
+        )
         numtoks_iter = map(num_tokens_per_req.get, req_ids)
         num_scheduled_tokens = np.fromiter(numtoks_iter, dtype=np.int32, count=num_reqs)
 
@@ -796,11 +843,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     def execute_model(
         self,
         scheduler_output: SchedulerOutput,
-        intermediate_tensors: Any | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
         dummy_run: bool = False,
         skip_attn_for_dummy_run: bool = False,
-    ) -> ModelRunnerOutput | None:
-        assert intermediate_tensors is None
+    ) -> ModelRunnerOutput | IntermediateTensors | None:
         if not dummy_run:
             # Update the request states.
             self.finish_requests(scheduler_output)
@@ -846,8 +892,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 )
                 self._set_active_loras(*lora_inputs)
 
-            if self.supports_mm_inputs:
-                # Execute the multimodal encoder.
+            # Multimodal embeddings: only first PP rank prepares them.
+            should_prepare_mm_embeddings = (
+                self.supports_mm_inputs and self.pp_handler.receives_raw_inputs
+            )
+            if should_prepare_mm_embeddings:
                 mm_embeds, is_mm_embed = self.get_mm_embeddings(
                     scheduler_output.scheduled_encoder_inputs, input_batch
                 )
@@ -889,6 +938,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if self.uses_mrope:
                 assert input_batch.mrope_positions is not None
                 positions = input_batch.mrope_positions
+
+            # PP input preparation: handler centralizes all PP input logic.
+            model_inputs = self.pp_handler.prepare_model_inputs(
+                input_batch.input_ids,
+                positions,
+                input_batch.inputs_embeds,
+                intermediate_tensors,
+            )
+
             with set_forward_context(
                 input_batch.attn_metadata,
                 self.vllm_config,
@@ -899,27 +957,52 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 slot_mapping=input_batch.slot_mappings,
             ):
                 self.kv_connector.pre_forward(scheduler_output)
-                hidden_states = self.model(
-                    input_ids=input_batch.input_ids,
-                    positions=positions,
-                    inputs_embeds=input_batch.inputs_embeds,
-                )
+                hidden_states = self.model(**model_inputs)
 
+        # PP output handling: use handler so all PP output logic lives in one place.
         kv_connector_output = self.kv_connector.post_forward(scheduler_output)
-        self.execute_model_state = hidden_states, input_batch, kv_connector_output
+        output = self.pp_handler.prepare_output(hidden_states, kv_connector_output)
+
+        if isinstance(output, IntermediateTensors):
+            # Non-last rank: return intermediate tensors to worker for sending
+            self.execute_model_state = (None, input_batch, kv_connector_output)
+            return output
+
+        # Last rank: store hidden states for sampling
+        self.execute_model_state = (output, input_batch, kv_connector_output)
         return None
 
     @torch.inference_mode()
     def sample_tokens(
         self, grammar_output: GrammarOutput | None
-    ) -> AsyncOutput | ModelRunnerOutput:
+    ) -> AsyncOutput | ModelRunnerOutput | None:
         assert self.execute_model_state is not None
         hidden_states, input_batch, kv_connector_output = self.execute_model_state
         self.execute_model_state = None  # type: ignore
 
+        # Non-last PP rank: receive tokens and update state.
+        # Don't need to sample tokens here - just receive from last rank.
+        if hidden_states is None:
+            received = self.pp_handler.maybe_receive_sampled_tokens(
+                input_batch.num_reqs,
+                self.device,
+                max_sample_len=self.num_speculative_steps + 1,
+            )
+            if received is not None:
+                sampled, num_sampled, num_rejected = received
+                self.postprocess(input_batch, sampled, num_sampled, num_rejected)
+            return None
+
+        # Last rank: sample tokens
         sampler_output, num_sampled, num_rejected = self.sample(
             hidden_states, input_batch, grammar_output
         )
+
+        # Broadcast to non-last ranks (handles spec decode multi-token)
+        self.pp_handler.maybe_broadcast_sampled_tokens(
+            sampler_output, num_sampled, num_rejected
+        )
+
         prompt_logprobs_dict = self.prompt_logprobs_worker.compute_prompt_logprobs(
             self.model.compute_logits,
             hidden_states,

--- a/vllm/v1/worker/gpu/pp_handler.py
+++ b/vllm/v1/worker/gpu/pp_handler.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pipeline Parallelism handler for V2 Model Runner."""
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any
+
+import torch
+
+from vllm.sequence import IntermediateTensors
+from vllm.v1.worker.gpu.sample.output import SamplerOutput
+
+
+class PPRole(Enum):
+    """Role of this rank in pipeline parallelism."""
+
+    NO_PP = auto()  # No PP (pp_size=1), full model on one rank
+    FIRST = auto()  # First stage
+    MIDDLE = auto()  # Middle stage
+    LAST = auto()  # Last stage
+
+
+@dataclass
+class PPConfig:
+    """Pipeline parallelism configuration for this rank."""
+
+    role: PPRole
+    pp_size: int
+    pp_rank: int
+
+    @property
+    def is_first_rank(self) -> bool:
+        return self.role in (PPRole.NO_PP, PPRole.FIRST)
+
+    @property
+    def is_last_rank(self) -> bool:
+        return self.role in (PPRole.NO_PP, PPRole.LAST)
+
+    @classmethod
+    def from_parallel_config(cls, parallel_config) -> "PPConfig":
+        """Build PPConfig from vLLM parallel config."""
+        from vllm.distributed.parallel_state import get_pp_group
+
+        pp_size = parallel_config.pipeline_parallel_size
+        if pp_size <= 1:
+            return cls(role=PPRole.NO_PP, pp_size=1, pp_rank=0)
+
+        pp = get_pp_group()
+        if pp.is_first_rank:
+            role = PPRole.FIRST
+        elif pp.is_last_rank:
+            role = PPRole.LAST
+        else:
+            role = PPRole.MIDDLE
+
+        return cls(role=role, pp_size=pp_size, pp_rank=pp.rank_in_group)
+
+
+class PPHandler:
+    """Pipeline parallelism handler for Model Runner V2.
+
+    Manages sampled token synchronization between PP ranks and prepares
+    model inputs/outputs for pipeline-parallel execution.
+
+    All public methods no-op when PP is disabled or called on an
+    inapplicable rank, so callers don't need guard conditions.
+    """
+
+    def __init__(self, config: PPConfig):
+        self.config = config
+
+    @property
+    def is_enabled(self) -> bool:
+        """Is pipeline parallelism enabled (pp_size > 1)?"""
+        return self.config.pp_size > 1
+
+    @property
+    def receives_raw_inputs(self) -> bool:
+        """Does this rank receive tokens/embeddings (vs intermediate tensors)?
+
+        True for first rank or when PP is disabled.
+        """
+        return self.config.is_first_rank
+
+    @property
+    def produces_final_output(self) -> bool:
+        """Does this rank produce output for sampling?
+
+        True for last rank or when PP is disabled.
+        """
+        return self.config.is_last_rank
+
+    # === Sampled token synchronization across PP ranks ===
+
+    def maybe_broadcast_sampled_tokens(
+        self,
+        sampler_output: SamplerOutput,
+        num_sampled: torch.Tensor,
+        num_rejected: torch.Tensor,
+    ) -> None:
+        """Broadcast sampled tokens from the last PP rank to all other ranks.
+
+        No-ops if PP is disabled or if this is not the last rank.
+
+        Broadcasts sampled_token_ids [num_reqs, max_sample_len], num_sampled
+        [num_reqs], and num_rejected [num_reqs] to support both regular decode
+        and speculative decoding.
+
+        Args:
+            sampler_output: SamplerOutput from sampling.
+            num_sampled: Number of accepted tokens per request.
+            num_rejected: Number of rejected tokens per request.
+        """
+        if not self.is_enabled or not self.produces_final_output:
+            return
+
+        from vllm.distributed.parallel_state import get_pp_group
+
+        pp = get_pp_group()
+        torch.distributed.broadcast(
+            sampler_output.sampled_token_ids.contiguous(),
+            src=pp.last_rank,
+            group=pp.device_group,
+        )
+        # NOTE: num_sampled/num_rejected are only needed
+        # for speculative decoding.
+        torch.distributed.broadcast(
+            num_sampled.contiguous(),
+            src=pp.last_rank,
+            group=pp.device_group,
+        )
+        torch.distributed.broadcast(
+            num_rejected.contiguous(),
+            src=pp.last_rank,
+            group=pp.device_group,
+        )
+
+    def maybe_receive_sampled_tokens(
+        self,
+        num_reqs: int,
+        device: torch.device,
+        max_sample_len: int = 1,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+        """Receive sampled tokens broadcast by the last PP rank.
+
+        No-ops (returns None) if PP is disabled or if this is the last rank.
+
+        Args:
+            num_reqs: Number of requests in the batch.
+            device: Device to create tensors on.
+            max_sample_len: Maximum number of tokens sampled per request
+                (1 for regular decode, >1 for speculative decoding).
+
+        Returns:
+            None if PP disabled or called on last rank.
+            Otherwise, tuple of (sampled_tokens, num_sampled, num_rejected):
+            - sampled_tokens: shape [num_reqs, max_sample_len]
+            - num_sampled: shape [num_reqs]
+            - num_rejected: shape [num_reqs]
+        """
+        if not self.is_enabled or self.produces_final_output:
+            return None
+
+        from vllm.distributed.parallel_state import get_pp_group
+
+        pp = get_pp_group()
+        sampled_tokens = torch.empty(
+            num_reqs, max_sample_len, dtype=torch.int64, device=device
+        )
+        torch.distributed.broadcast(
+            sampled_tokens,
+            src=pp.last_rank,
+            group=pp.device_group,
+        )
+        # NOTE: num_sampled/num_rejected are only needed
+        # for speculative decoding.
+        num_sampled = torch.empty(num_reqs, dtype=torch.int32, device=device)
+        torch.distributed.broadcast(
+            num_sampled,
+            src=pp.last_rank,
+            group=pp.device_group,
+        )
+        num_rejected = torch.empty(num_reqs, dtype=torch.int32, device=device)
+        torch.distributed.broadcast(
+            num_rejected,
+            src=pp.last_rank,
+            group=pp.device_group,
+        )
+        return sampled_tokens, num_sampled, num_rejected
+
+    # === Model input/output preparation ===
+
+    def prepare_model_inputs(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None,
+        intermediate_tensors: IntermediateTensors | None,
+    ) -> dict[str, Any]:
+        """
+        Prepare inputs for model.forward().
+
+        Returns dict with keys: input_ids, positions, inputs_embeds,
+        and optionally intermediate_tensors.
+        """
+        if self.receives_raw_inputs:
+            return {
+                "input_ids": input_ids,
+                "positions": positions,
+                "inputs_embeds": inputs_embeds,
+            }
+        else:
+            assert intermediate_tensors is not None, (
+                "Non-first PP rank requires intermediate_tensors"
+            )
+            return {
+                "input_ids": None,
+                "positions": positions,
+                "inputs_embeds": None,
+                "intermediate_tensors": intermediate_tensors,
+            }
+
+    def prepare_output(
+        self,
+        hidden_states: torch.Tensor | IntermediateTensors,
+        kv_connector_output: Any,
+    ) -> torch.Tensor | IntermediateTensors:
+        """
+        Prepare output after model forward.
+
+        Returns:
+            - Last rank: torch.Tensor (hidden states for sampling)
+            - Non-last rank: IntermediateTensors (to send to next rank)
+        """
+        if self.produces_final_output:
+            # Last rank: extract hidden states for sampling
+            if isinstance(hidden_states, IntermediateTensors):
+                if "hidden_states" not in hidden_states.tensors:
+                    raise ValueError(
+                        "IntermediateTensors from model on the last PP rank "
+                        "must contain 'hidden_states' tensor."
+                    )
+                return hidden_states["hidden_states"]
+            return hidden_states
+        else:
+            # Non-last rank: wrap as IntermediateTensors
+            if isinstance(hidden_states, IntermediateTensors):
+                intermediate = hidden_states
+            else:
+                intermediate = IntermediateTensors({"hidden_states": hidden_states})
+            intermediate.kv_connector_output = kv_connector_output
+            return intermediate
+
+
+def get_pp_handler(parallel_config) -> PPHandler:
+    """Factory function to create PPHandler."""
+    config = PPConfig.from_parallel_config(parallel_config)
+    return PPHandler(config)
+
+
+# No-op singleton for when PP is disabled
+NO_OP_PP_HANDLER = PPHandler(PPConfig(PPRole.NO_PP, 1, 0))

--- a/vllm/v1/worker/gpu/pp_handler.py
+++ b/vllm/v1/worker/gpu/pp_handler.py
@@ -2,96 +2,18 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Pipeline Parallelism handler for V2 Model Runner."""
 
-from dataclasses import dataclass
-from enum import Enum, auto
-from typing import Any
-
 import torch
 
-from vllm.sequence import IntermediateTensors
+from vllm.distributed.parallel_state import get_pp_group
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
-
-
-class PPRole(Enum):
-    """Role of this rank in pipeline parallelism."""
-
-    NO_PP = auto()  # No PP (pp_size=1), full model on one rank
-    FIRST = auto()  # First stage
-    MIDDLE = auto()  # Middle stage
-    LAST = auto()  # Last stage
-
-
-@dataclass
-class PPConfig:
-    """Pipeline parallelism configuration for this rank."""
-
-    role: PPRole
-    pp_size: int
-    pp_rank: int
-
-    @property
-    def is_first_rank(self) -> bool:
-        return self.role in (PPRole.NO_PP, PPRole.FIRST)
-
-    @property
-    def is_last_rank(self) -> bool:
-        return self.role in (PPRole.NO_PP, PPRole.LAST)
-
-    @classmethod
-    def from_parallel_config(cls, parallel_config) -> "PPConfig":
-        """Build PPConfig from vLLM parallel config."""
-        from vllm.distributed.parallel_state import get_pp_group
-
-        pp_size = parallel_config.pipeline_parallel_size
-        if pp_size <= 1:
-            return cls(role=PPRole.NO_PP, pp_size=1, pp_rank=0)
-
-        pp = get_pp_group()
-        if pp.is_first_rank:
-            role = PPRole.FIRST
-        elif pp.is_last_rank:
-            role = PPRole.LAST
-        else:
-            role = PPRole.MIDDLE
-
-        return cls(role=role, pp_size=pp_size, pp_rank=pp.rank_in_group)
 
 
 class PPHandler:
     """Pipeline parallelism handler for Model Runner V2.
 
-    Manages sampled token synchronization between PP ranks and prepares
-    model inputs/outputs for pipeline-parallel execution.
-
-    All public methods no-op when PP is disabled or called on an
-    inapplicable rank, so callers don't need guard conditions.
+    Manages sampled token synchronization between PP ranks.
+    Only instantiated when PP is enabled (pp_size > 1).
     """
-
-    def __init__(self, config: PPConfig):
-        self.config = config
-
-    @property
-    def is_enabled(self) -> bool:
-        """Is pipeline parallelism enabled (pp_size > 1)?"""
-        return self.config.pp_size > 1
-
-    @property
-    def receives_raw_inputs(self) -> bool:
-        """Does this rank receive tokens/embeddings (vs intermediate tensors)?
-
-        True for first rank or when PP is disabled.
-        """
-        return self.config.is_first_rank
-
-    @property
-    def produces_final_output(self) -> bool:
-        """Does this rank produce output for sampling?
-
-        True for last rank or when PP is disabled.
-        """
-        return self.config.is_last_rank
-
-    # === Sampled token synchronization across PP ranks ===
 
     def maybe_broadcast_sampled_tokens(
         self,
@@ -101,7 +23,7 @@ class PPHandler:
     ) -> None:
         """Broadcast sampled tokens from the last PP rank to all other ranks.
 
-        No-ops if PP is disabled or if this is not the last rank.
+        No-ops if this is not the last rank.
 
         Broadcasts sampled_token_ids [num_reqs, max_sample_len], num_sampled
         [num_reqs], and num_rejected [num_reqs] to support both regular decode
@@ -112,12 +34,10 @@ class PPHandler:
             num_sampled: Number of accepted tokens per request.
             num_rejected: Number of rejected tokens per request.
         """
-        if not self.is_enabled or not self.produces_final_output:
+        pp = get_pp_group()
+        if not pp.is_last_rank:
             return
 
-        from vllm.distributed.parallel_state import get_pp_group
-
-        pp = get_pp_group()
         torch.distributed.broadcast(
             sampler_output.sampled_token_ids.contiguous(),
             src=pp.last_rank,
@@ -144,7 +64,7 @@ class PPHandler:
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
         """Receive sampled tokens broadcast by the last PP rank.
 
-        No-ops (returns None) if PP is disabled or if this is the last rank.
+        Returns None if this is the last rank (which samples, not receives).
 
         Args:
             num_reqs: Number of requests in the batch.
@@ -153,18 +73,16 @@ class PPHandler:
                 (1 for regular decode, >1 for speculative decoding).
 
         Returns:
-            None if PP disabled or called on last rank.
+            None if called on last rank.
             Otherwise, tuple of (sampled_tokens, num_sampled, num_rejected):
             - sampled_tokens: shape [num_reqs, max_sample_len]
             - num_sampled: shape [num_reqs]
             - num_rejected: shape [num_reqs]
         """
-        if not self.is_enabled or self.produces_final_output:
+        pp = get_pp_group()
+        if pp.is_last_rank:
             return None
 
-        from vllm.distributed.parallel_state import get_pp_group
-
-        pp = get_pp_group()
         sampled_tokens = torch.empty(
             num_reqs, max_sample_len, dtype=torch.int64, device=device
         )
@@ -189,75 +107,13 @@ class PPHandler:
         )
         return sampled_tokens, num_sampled, num_rejected
 
-    # === Model input/output preparation ===
-
-    def prepare_model_inputs(
-        self,
-        input_ids: torch.Tensor,
-        positions: torch.Tensor,
-        inputs_embeds: torch.Tensor | None,
-        intermediate_tensors: IntermediateTensors | None,
-    ) -> dict[str, Any]:
-        """
-        Prepare inputs for model.forward().
-
-        Returns dict with keys: input_ids, positions, inputs_embeds,
-        and optionally intermediate_tensors.
-        """
-        if self.receives_raw_inputs:
-            return {
-                "input_ids": input_ids,
-                "positions": positions,
-                "inputs_embeds": inputs_embeds,
-            }
-        else:
-            assert intermediate_tensors is not None, (
-                "Non-first PP rank requires intermediate_tensors"
-            )
-            return {
-                "input_ids": None,
-                "positions": positions,
-                "inputs_embeds": None,
-                "intermediate_tensors": intermediate_tensors,
-            }
-
-    def prepare_output(
-        self,
-        hidden_states: torch.Tensor | IntermediateTensors,
-        kv_connector_output: Any,
-    ) -> torch.Tensor | IntermediateTensors:
-        """
-        Prepare output after model forward.
-
-        Returns:
-            - Last rank: torch.Tensor (hidden states for sampling)
-            - Non-last rank: IntermediateTensors (to send to next rank)
-        """
-        if self.produces_final_output:
-            # Last rank: extract hidden states for sampling
-            if isinstance(hidden_states, IntermediateTensors):
-                if "hidden_states" not in hidden_states.tensors:
-                    raise ValueError(
-                        "IntermediateTensors from model on the last PP rank "
-                        "must contain 'hidden_states' tensor."
-                    )
-                return hidden_states["hidden_states"]
-            return hidden_states
-        else:
-            # Non-last rank: wrap as IntermediateTensors
-            if isinstance(hidden_states, IntermediateTensors):
-                intermediate = hidden_states
-            else:
-                intermediate = IntermediateTensors({"hidden_states": hidden_states})
-            intermediate.kv_connector_output = kv_connector_output
-            return intermediate
-
 
 def get_pp_handler(parallel_config) -> PPHandler:
-    """Factory function to create PPHandler."""
-    config = PPConfig.from_parallel_config(parallel_config)
-    return PPHandler(config)
+    """Factory function to create PPHandler.
 
-
-# No-op singleton for when PP is disabled
-NO_OP_PP_HANDLER = PPHandler(PPConfig(PPRole.NO_PP, 1, 0))
+    Must only be called when PP is enabled (pp_size > 1).
+    """
+    assert parallel_config.pipeline_parallel_size > 1, (
+        "PPHandler should not be created when pipeline parallelism is disabled."
+    )
+    return PPHandler()


### PR DESCRIPTION
## Summary

Co-authored with @yewentao256

Add Pipeline Parallel (PP) support to Model Runner V2 (`vllm/v1/worker/gpu/model_runner.py`). This introduces a modular `PPHandler` class that encapsulates all PP logic, keeping the model runner code clean. Verified correct output and competitive throughput against the V1 baseline.

Related: #32455 (Q1 2026 Roadmap) — PP is listed as a missing feature for Model Runner V2.


## Changes

### In Model Runner (`vllm/v1/worker/gpu/model_runner.py`)

- **`execute_model`**:
  - First rank: Run model forward with raw token inputs, send `IntermediateTensors` to next stage.
  - Middle ranks: Accept `IntermediateTensors` from previous stage, run model forward, send `IntermediateTensors` to next stage.
  - Last rank: Accept `IntermediateTensors` from previous stage, run model forward, store hidden states for sampling.
  - Delegates input/output preparation to `PPHandler`.

- **`sample_tokens`**:
  - Last rank: Sample tokens, broadcast `sampled_token_ids`/`num_sampled`/`num_rejected` to all other ranks, then return `ModelRunnerOutput`.
  - Non-last ranks: Receive broadcast tensors, call `postprocess` to update local state, return `None`.

- **`_dummy_run`**: Create dummy intermediate tensors for non-first ranks; skip sampler for non-last ranks.
- **`capture_model`**: Skip CUDA graph capture when PP is enabled (eager-only for now).
- **Deterministic request sorting**: Use `req_id` as tie-breaker to ensure consistent batch ordering across PP ranks.
- **Multimodal guard**: Only prepare MM embeddings on the first PP rank.

### New Class: PPHandler (`vllm/v1/worker/gpu/pp_handler.py`)

New module with a `PPHandler` class. All public methods no-op when PP is disabled or called on an inapplicable rank, so callers don't need guard conditions.

| Method | Description |
|--------|-------------|
| `maybe_broadcast_sampled_tokens` | Last rank broadcasts `sampled_token_ids`, `num_sampled`, `num_rejected` to all PP ranks. No-ops on non-last ranks. |
| `maybe_receive_sampled_tokens` | Non-last ranks receive the broadcast tensors. Returns `None` on last rank. Supports variable `max_sample_len` for future speculative decoding + PP. |
| `prepare_model_inputs` | Builds the `model.forward()` kwargs — raw inputs for first rank, intermediate tensors for others. |
| `prepare_output` | Extracts hidden states (last rank) or wraps as `IntermediateTensors` (non-last ranks). |

Helper classes: `PPConfig` (dataclass with rank role, size, index) and `PPRole` enum (`NO_PP`, `FIRST`, `MIDDLE`, `LAST`).

## Future Work

- [ ] CUDA graph support for PP (currently eager-only)
- [ ] Async (non-blocking) next-sampled-token transfer
- [ ] Async intermediate tensor send/recv
- [ ] Speculative decoding + PP integration

## Test Plan

**Accuracy** — lm_eval gsm8k (5-shot):
```bash
export MODEL="Qwen/Qwen3-30B-A3B-Thinking-2507-FP8"

# V1 baseline
vllm serve $MODEL -pp 2 --port 9256 --enable-expert-parallel --max-num-seqs 128 --enforce-eager

# V2
VLLM_USE_V2_MODEL_RUNNER=1 vllm serve $MODEL -pp 2 --port 9256 --enable-expert-parallel --max-num-seqs 128 --enforce-eager

# Evaluate
lm_eval --model local-completions \
  --model_args "base_url=http://127.0.0.1:9256/v1/completions,model=$MODEL,num_concurrent=1024" \
  --tasks gsm8k
```

**Throughput** — decode-heavy random workload:
```bash
vllm bench serve --model $MODEL --dataset-name random --host 127.0.0.1 \
  --random-input-len 2 --random-output-len 512 --num-prompts 128 \
  --port 9256 --num-warmups 16
```

## Test Results

### Accuracy (gsm8k, PP=2, Qwen3-30B-A3B MoE FP8)

| Metric | V1 | V2 |
|--------|----|----|
| flexible-extract (exact_match) | 0.6641 ± 0.0130 | 0.6641 ± 0.0130 |
| strict-match (exact_match) | 0.7801 ± 0.0114 | 0.7794 ± 0.0114 |

**V2 matches V1 accuracy.** The 0.0007 difference in strict-match is within noise (±0.0114 stderr).

### Throughput (PP=2, Qwen3-30B-A3B MoE FP8, input=2, output=512, 128 prompts)

| Metric | V1 | V2 | Diff |
|--------|----|----|------|
| Output token throughput (tok/s) | 7315.42 | 6956.99 | -4.9% |
| Total token throughput (tok/s) | 7344.00 | 6984.17 | -4.9% |
| Mean TTFT (ms) | 170.33 | 194.20 | +14.0% |
| Mean TPOT (ms) | 17.12 | 17.99 | +5.1% |
| Mean ITL (ms) | 17.12 | 17.99 | +5.1% |

---

*Note: Claude (Anthropic) was used as a coding assistant during development of this PR.*

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
