### PR TITLE
[Bugfix] Fix the issue where tool calling does not work when using fast detokenization with dsv32

### DIFF
--- a/vllm/tool_parsers/deepseekv32_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv32_tool_parser.py
@@ -110,6 +110,16 @@ class DeepSeekV32ToolParser(ToolParser):
         """Generate a unique tool call ID."""
         return f"call_{uuid.uuid4().hex[:24]}"
 
+    def adjust_request(self, request):
+        request = super().adjust_request(request)
+        if request.tools and request.tool_choice != "none":
+            # Ensure tool call tokens (<tool_call>, </tool_call>) are not skipped
+            # during decoding. Even though they are not marked as special tokens,
+            # setting skip_special_tokens=False ensures proper handling in
+            # transformers 5.x where decoding behavior may have changed.
+            request.skip_special_tokens = False
+        return request
+
     def _reset_streaming_state(self):
         """Reset all streaming state."""
         self.current_tool_index = 0

--- a/vllm/tool_parsers/deepseekv32_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv32_tool_parser.py
@@ -113,8 +113,10 @@ class DeepSeekV32ToolParser(ToolParser):
     def adjust_request(self, request):
         request = super().adjust_request(request)
         if request.tools and request.tool_choice != "none":
-            # Ensure tool call tokens (<tool_call>, </tool_call>) are not skipped
-            # during decoding. Even though they are not marked as special tokens,
+            # Ensure tool call tokens 
+            # (<｜DSML｜function_calls>, </｜DSML｜function_calls>)
+            # are not skippedduring decoding. 
+            # Even though they are not marked as special tokens,
             # setting skip_special_tokens=False ensures proper handling in
             # transformers 5.x where decoding behavior may have changed.
             request.skip_special_tokens = False

--- a/vllm/tool_parsers/deepseekv32_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv32_tool_parser.py
@@ -113,9 +113,9 @@ class DeepSeekV32ToolParser(ToolParser):
     def adjust_request(self, request):
         request = super().adjust_request(request)
         if request.tools and request.tool_choice != "none":
-            # Ensure tool call tokens 
+            # Ensure tool call tokens
             # (<｜DSML｜function_calls>, </｜DSML｜function_calls>)
-            # are not skippedduring decoding. 
+            # are not skippedduring decoding.
             # Even though they are not marked as special tokens,
             # setting skip_special_tokens=False ensures proper handling in
             # transformers 5.x where decoding behavior may have changed.


### PR DESCRIPTION
## Purpose
```
    <｜DSML｜function_calls>
    <｜DSML｜invoke name="get_weather">
    <｜DSML｜parameter name="location" string="true">杭州</｜DSML｜parameter>
    <｜DSML｜parameter name="date" string="true">2024-01-16</｜DSML｜parameter>
    </｜DSML｜invoke>

```

Fix the issue where tool calling does not work when using fast detokenization with dsv32
dsv32 uses special tokens like `｜DSML｜function_calls>`, which are skipped by default during decoding.


This PR is compatible with both fast and slow detokenization.



## Test Plan

using the sample code [here](https://docs.vllm.ai/projects/recipes/en/latest/DeepSeek/DeepSeek-V3_2.html#tool-calling-example),

```
Turn 1.1
reasoning_content="I need to get the weather for Hangzhou tomorrow. First, I should get the current date to determine tomorrow's date, then call get_weather for Hangzhou with tomorrow's date. Let me start by getting the current date."
content=None
tool_calls=[ChatCompletionMessageFunctionToolCall(id='chatcmpl-tool-937d8afd42ed266c', function=Function(arguments='{}', name='get_date'), type='function')]
tool result for get_date: 2025-12-01

Turn 1.2
reasoning_content='Today is December 1, 2025. Tomorrow would be December 2, 2025. Now I can get the weather for Hangzhou for that date. Let me call get_weather with location "Hangzhou" and date "2025-12-02".'
content=None
tool_calls=[ChatCompletionMessageFunctionToolCall(id='chatcmpl-tool-a1e8b5b84d974797', function=Function(arguments='{"location": "Hangzhou", "date": "2025-12-02"}', name='get_weather'), type='function')]
tool result for get_weather: Cloudy 7~13°C

Turn 1.3
reasoning_content="The weather for Hangzhou tomorrow is cloudy with temperatures between 7°C and 13°C. I should present this information to the user. Let me also mention that tomorrow is December 2, 2025, to be clear. I'll give a friendly response."
content='Tomorrow (December 2, 2025) in Hangzhou will be **cloudy** with temperatures ranging from **7°C to 13°C**. It might be a bit chilly, so you may want to dress warmly.'
tool_calls=[]
Turn 2.1
reasoning_content="The user is asking again about Hangzhou weather tomorrow. I already gave them the weather for December 2, 2025. Today is December 1, 2025, so tomorrow is December 2. I already provided the answer: cloudy 7~13°C. I should just give the same information again, maybe rephrased. Let me confirm the date again? Actually, I have the get_date function result showing 2025-12-01. So tomorrow is indeed 2025-12-02. I already have the weather data. I'll just provide it again."
content='Tomorrow (December 2, 2025) in Hangzhou will be **cloudy** with temperatures between **7°C and 13°C**. It will be cool, so you might want to wear a jacket or sweater.'
tool_calls=[]


```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

