### PR TITLE
[Frontend] Add --disable-uvicorn-metrics-access-log shorthand flag

### DIFF
--- a/examples/others/logging_configuration.md
+++ b/examples/others/logging_configuration.md
@@ -181,9 +181,23 @@ vllm serve mistralai/Mistral-7B-v0.1 --max-model-len 2048 \
 | `/ping`    | SageMaker health check | SageMaker infrastructure                             |
 | `/load`    | Server load metrics    | Custom monitoring                                    |
 
+**Quick shorthand for `/health` and `/metrics`:**
+
+If you only need to suppress the most common monitoring endpoints, use the
+`--disable-uvicorn-metrics-access-log` flag instead of listing them explicitly:
+
+```bash
+vllm serve mistralai/Mistral-7B-v0.1 --max-model-len 2048 \
+    --disable-uvicorn-metrics-access-log
+```
+
+This is equivalent to `--disable-access-log-for-endpoints /health,/metrics`.
+Both options can be combined -- paths from each are merged with duplicates
+removed.
+
 **Notes:**
 
-- This option only affects uvicorn access logs, not vLLM application logs
+- These options only affect uvicorn access logs, not vLLM application logs
 - Specify multiple endpoints by separating them with commas (no spaces)
 - The filter uses exact path matching, query parameters are ignored (e.g., `/health?verbose=true` matches `/health`)
 - If you need to completely disable all access logs, use `--disable-uvicorn-access-log` instead

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -228,6 +228,11 @@ class FrontendArgs(BaseFrontendArgs):
     """Log level for uvicorn."""
     disable_uvicorn_access_log: bool = False
     """Disable uvicorn access log."""
+    disable_uvicorn_metrics_access_log: bool = False
+    """Shorthand to suppress uvicorn access logs for /health and /metrics
+    endpoints. Equivalent to --disable-access-log-for-endpoints
+    '/health,/metrics'. If --disable-access-log-for-endpoints is also set,
+    the paths from both options are merged."""
     disable_access_log_for_endpoints: str | None = None
     """Comma-separated list of endpoint paths to exclude from uvicorn access
     logs. This is useful to reduce log noise from high-frequency endpoints

--- a/vllm/entrypoints/openai/server_utils.py
+++ b/vllm/entrypoints/openai/server_utils.py
@@ -127,14 +127,41 @@ def load_log_config(log_config_file: str | None) -> dict | None:
         return None
 
 
+_METRICS_EXCLUDED_PATHS = ["/health", "/metrics"]
+
+
+def _get_excluded_paths(args: Namespace) -> list[str]:
+    """Collect endpoint paths that should be excluded from access logs.
+
+    Merges paths from ``--disable-uvicorn-metrics-access-log`` (which
+    implies ``/health`` and ``/metrics``) with any paths listed in
+    ``--disable-access-log-for-endpoints``, removing duplicates while
+    preserving order.
+    """
+    paths: list[str] = []
+
+    if getattr(args, "disable_uvicorn_metrics_access_log", False):
+        paths.extend(_METRICS_EXCLUDED_PATHS)
+
+    if args.disable_access_log_for_endpoints:
+        for p in args.disable_access_log_for_endpoints.split(","):
+            p = p.strip()
+            if p and p not in paths:
+                paths.append(p)
+
+    return paths
+
+
 def get_uvicorn_log_config(args: Namespace) -> dict | None:
     """
     Get the uvicorn log config based on the provided arguments.
 
     Priority:
     1. If log_config_file is specified, use it
-    2. If disable_access_log_for_endpoints is specified, create a config with
-       the access log filter
+    2. If endpoints to exclude are specified (via
+       --disable-uvicorn-metrics-access-log or
+       --disable-access-log-for-endpoints), create a config with the
+       access log filter
     3. Otherwise, return None (use uvicorn defaults)
     """
     # First, try to load from file if specified
@@ -142,16 +169,11 @@ def get_uvicorn_log_config(args: Namespace) -> dict | None:
     if log_config is not None:
         return log_config
 
-    # If endpoints to filter are specified, create a config with the filter
-    if args.disable_access_log_for_endpoints:
+    # Collect excluded paths from both options
+    excluded_paths = _get_excluded_paths(args)
+    if excluded_paths:
         from vllm.logging_utils import create_uvicorn_log_config
 
-        # Parse comma-separated string into list
-        excluded_paths = [
-            p.strip()
-            for p in args.disable_access_log_for_endpoints.split(",")
-            if p.strip()
-        ]
         return create_uvicorn_log_config(
             excluded_paths=excluded_paths,
             log_level=args.uvicorn_log_level,


### PR DESCRIPTION
## Summary

Adds a convenience boolean CLI flag `--disable-uvicorn-metrics-access-log` that suppresses uvicorn access logs for `/health` and `/metrics` endpoints. This is the flag originally requested in #29023.

- **New CLI argument**: `--disable-uvicorn-metrics-access-log` (boolean, default `False`)
- **Reuses existing infrastructure**: Builds on the `UvicornAccessLogFilter` and `--disable-access-log-for-endpoints` machinery from #30011 -- no new filter classes or duplicate logic
- **Composable**: When used alongside `--disable-access-log-for-endpoints`, paths from both options are merged with duplicates removed

### Why a new flag?

Issue #29023 specifically requested a simple boolean toggle. While `--disable-access-log-for-endpoints /health,/metrics` already achieves the same result, a dedicated flag provides:
- A simpler command line for the most common use case (monitoring endpoints flooding logs)
- Better discoverability via `--help` for users searching for metrics/health log suppression

## Usage

```bash
# Simple: suppress /health and /metrics access logs
vllm serve model --disable-uvicorn-metrics-access-log

# Composable: also suppress /ping
vllm serve model --disable-uvicorn-metrics-access-log \
    --disable-access-log-for-endpoints /ping
```

## Changes

| File | Change |
|------|--------|
| `vllm/entrypoints/openai/cli_args.py` | Add `disable_uvicorn_metrics_access_log` field to `FrontendArgs` |
| `vllm/entrypoints/openai/server_utils.py` | Extract `_get_excluded_paths()` helper that merges paths from both flags; update `get_uvicorn_log_config()` to use it |
| `tests/test_access_log_filter.py` | Add `TestGetExcludedPaths` and `TestGetUvicornLogConfigWithMetricsFlag` test classes |
| `examples/others/logging_configuration.md` | Document the new shorthand flag |

## Test Plan

- [x] New unit tests for `_get_excluded_paths` (no flags, metrics-only, endpoints-only, both merged, whitespace handling)
- [x] New unit tests for `get_uvicorn_log_config` with the metrics flag (returns `None` when unused, returns config when set, merges correctly)
- [x] All existing `TestUvicornAccessLogFilter`, `TestCreateUvicornLogConfig`, and `TestIntegration` tests remain unchanged and unaffected

Fixes #29023