### PR TITLE
[Frontend] Add --disable-log-prefix flag

### DIFF
--- a/tests/entrypoints/openai/test_cli_args.py
+++ b/tests/entrypoints/openai/test_cli_args.py
@@ -320,3 +320,16 @@ def test_lora_target_modules_default_none(serve_parser):
     """Test that lora-target-modules defaults to None"""
     args = serve_parser.parse_args(args=[])
     assert args.lora_target_modules is None
+
+
+### Tests for --enable-log-prefix flag
+def test_enable_log_prefix_default_true(serve_parser):
+    """Ensure --enable-log-prefix defaults to True."""
+    args = serve_parser.parse_args(args=[])
+    assert args.enable_log_prefix is True
+
+
+def test_no_enable_log_prefix_flag(serve_parser):
+    """Ensure --no-enable-log-prefix sets the attribute to False."""
+    args = serve_parser.parse_args(args=["--no-enable-log-prefix"])
+    assert args.enable_log_prefix is False

--- a/tests/utils_/test_system_utils.py
+++ b/tests/utils_/test_system_utils.py
@@ -1,11 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import io
 import os
+import sys
 import tempfile
 from pathlib import Path
+from unittest import mock
 
-from vllm.utils.system_utils import _maybe_force_spawn, unique_filepath
+from vllm.envs import disable_envs_cache
+from vllm.utils.system_utils import (
+    _add_prefix,
+    _maybe_force_spawn,
+    decorate_logs,
+    unique_filepath,
+)
 
 
 def test_unique_filepath():
@@ -25,3 +34,53 @@ def test_numa_bind_forces_spawn(monkeypatch):
     monkeypatch.setattr("sys.argv", ["vllm", "serve", "--numa-bind"])
     _maybe_force_spawn()
     assert os.environ["VLLM_WORKER_MULTIPROC_METHOD"] == "spawn"
+
+
+class TestDecorateLogsEnablePrefix:
+    """Tests for the --enable-log-prefix feature."""
+
+    def test_add_prefix_decorates_output(self):
+        """Verify _add_prefix adds the expected prefix to writes."""
+        buf = io.StringIO()
+        _add_prefix(buf, "TestProc", 9999)
+        buf.write("hello\n")
+        assert buf.getvalue() == "(TestProc pid=9999) hello\n"
+
+    def test_decorate_logs_applies_prefix_by_default(self):
+        """decorate_logs should add prefix when not disabled."""
+        fake_stdout = io.StringIO()
+        fake_stderr = io.StringIO()
+        with (
+            mock.patch.object(sys, "stdout", fake_stdout),
+            mock.patch.object(sys, "stderr", fake_stderr),
+        ):
+            decorate_logs("TestWorker")
+
+            fake_stdout.write("stdout line\n")
+            fake_stderr.write("stderr line\n")
+
+        assert "(TestWorker pid=" in fake_stdout.getvalue()
+        assert "(TestWorker pid=" in fake_stderr.getvalue()
+
+    def test_decorate_logs_skipped_when_configure_logging_off(self):
+        """decorate_logs should be a no-op when VLLM_CONFIGURE_LOGGING=0."""
+        fake_stdout = io.StringIO()
+        fake_stderr = io.StringIO()
+        with (
+            mock.patch.object(sys, "stdout", fake_stdout),
+            mock.patch.object(sys, "stderr", fake_stderr),
+            mock.patch.dict(
+                os.environ,
+                {"VLLM_CONFIGURE_LOGGING": "0"},
+                clear=False,
+            ),
+        ):
+            disable_envs_cache()
+
+            decorate_logs("TestWorker")
+
+            fake_stdout.write("stdout line\n")
+            fake_stderr.write("stderr line\n")
+
+        assert fake_stdout.getvalue() == "stdout line\n"
+        assert fake_stderr.getvalue() == "stderr line\n"

--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -70,6 +70,14 @@ class ObservabilityConfig:
     This is for internal use only (e.g., benchmarks) and is not exposed as a CLI
     argument."""
 
+    enable_log_prefix: bool = True
+    """Enable the process/thread log prefix (e.g. '(APIServer pid=12345)')
+    that vLLM adds to stdout/stderr. When set to True (the default), vLLM
+    decorates log output with process identification. Use
+    --no-enable-log-prefix to disable this when using custom logging
+    configurations or log aggregation systems that already handle process
+    identification."""
+
     enable_logging_iteration_details: bool = False
     """Enable detailed logging of iteration details.
     If set, vllm EngineCore will log iteration details

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -567,6 +567,7 @@ class EngineArgs:
     enable_layerwise_nvtx_tracing: bool = (
         ObservabilityConfig.enable_layerwise_nvtx_tracing
     )
+    enable_log_prefix: bool = ObservabilityConfig.enable_log_prefix
     enable_mfu_metrics: bool = ObservabilityConfig.enable_mfu_metrics
     enable_logging_iteration_details: bool = (
         ObservabilityConfig.enable_logging_iteration_details
@@ -1221,6 +1222,10 @@ class EngineArgs:
         observability_group.add_argument(
             "--enable-layerwise-nvtx-tracing",
             **observability_kwargs["enable_layerwise_nvtx_tracing"],
+        )
+        observability_group.add_argument(
+            "--enable-log-prefix",
+            **observability_kwargs["enable_log_prefix"],
         )
         observability_group.add_argument(
             "--enable-mfu-metrics",
@@ -1978,6 +1983,7 @@ class EngineArgs:
             kv_cache_metrics=self.kv_cache_metrics,
             kv_cache_metrics_sample=self.kv_cache_metrics_sample,
             cudagraph_metrics=self.cudagraph_metrics,
+            enable_log_prefix=self.enable_log_prefix,
             enable_layerwise_nvtx_tracing=self.enable_layerwise_nvtx_tracing,
             enable_mfu_metrics=self.enable_mfu_metrics,
             enable_mm_processor_stats=self.enable_mm_processor_stats,

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -10,7 +10,8 @@ import uvloop
 import vllm
 import vllm.envs as envs
 from vllm.entrypoints.cli.types import CLISubcommand
-from vllm.entrypoints.openai.api_server import run_server, setup_server
+from vllm.entrypoints.openai.api_server import run_server, run_server_worker, setup_server
+from vllm.utils.system_utils import decorate_logs, set_process_title
 from vllm.entrypoints.openai.cli_args import make_arg_parser, validate_parsed_serve_args
 from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG
 from vllm.logger import init_logger
@@ -333,3 +334,21 @@ def run_multi_api_server(args: argparse.Namespace):
             local_engine_manager.shutdown(timeout=to_timeout(shutdown_by))
         if coordinator:
             coordinator.shutdown(timeout=to_timeout(shutdown_by))
+
+
+
+def run_api_server_worker_proc(
+    listen_address, sock, args, client_config=None, **uvicorn_kwargs
+) -> None:
+    """Entrypoint for individual API server worker processes."""
+    client_config = client_config or {}
+    server_index = client_config.get("client_index", 0)
+
+    # Set process title and add process-specific prefix to stdout and stderr.
+    set_process_title("APIServer", str(server_index))
+    if getattr(args, "enable_log_prefix", True):
+        decorate_logs()
+
+    uvloop.run(
+        run_server_worker(listen_address, sock, args, client_config, **uvicorn_kwargs)
+    )

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -680,7 +680,8 @@ async def run_server(args, **uvicorn_kwargs) -> None:
     """Run a single-worker API server."""
 
     # Add process-specific prefix to stdout and stderr.
-    decorate_logs("APIServer")
+    if getattr(args, "enable_log_prefix", True):
+        decorate_logs("APIServer")
 
     listen_address, sock = setup_server(args)
     await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1056,7 +1056,8 @@ class EngineCoreProc(EngineCore):
                 process_title = "EngineCore"
             set_process_title(process_title)
             maybe_init_worker_tracer("vllm.engine_core", "engine_core", process_title)
-            decorate_logs()
+            if vllm_config.observability_config.enable_log_prefix:
+                decorate_logs()
             if parallel_config.numa_bind:
                 numa_utils.log_current_affinity_state(process_title)
 

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -613,14 +613,18 @@ class WorkerProc:
         self.worker = wrapper
 
         self.setup_proc_title_and_log_prefix(
-            enable_ep=vllm_config.parallel_config.enable_expert_parallel
+            enable_ep=vllm_config.parallel_config.enable_expert_parallel,
+            enable_log_prefix=vllm_config.observability_config
+            .enable_log_prefix,
         )
 
         # Load model
         self.worker.init_device()
         # Update process title now that parallel groups are initialized
         self.setup_proc_title_and_log_prefix(
-            enable_ep=vllm_config.parallel_config.enable_expert_parallel
+            enable_ep=vllm_config.parallel_config.enable_expert_parallel,
+            enable_log_prefix=vllm_config.observability_config
+            .enable_log_prefix,
         )
         if envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
             self.worker.elastic_ep_execute("load_model")
@@ -979,12 +983,15 @@ class WorkerProc:
                 self.handle_output(output)
 
     @staticmethod
-    def setup_proc_title_and_log_prefix(enable_ep: bool) -> None:
+    def setup_proc_title_and_log_prefix(
+        enable_ep: bool, enable_log_prefix: bool = True
+    ) -> None:
         # Check if parallel groups are initialized first
         if not model_parallel_is_initialized():
             # Parallel groups not yet initialized, use default process name
             set_process_title(name="Worker")
-            decorate_logs("Worker")
+            if enable_log_prefix:
+                decorate_logs("Worker")
             return
 
         dp_size = get_dp_group().world_size
@@ -1012,7 +1019,8 @@ class WorkerProc:
             ep_rank = get_ep_group().rank_in_group
             process_name += f"_EP{ep_rank}"
         set_process_title(name=process_name)
-        decorate_logs(process_name)
+        if enable_log_prefix:
+            decorate_logs(process_name)
 
 
 def set_multiprocessing_worker_envs():


### PR DESCRIPTION
## Summary
Add option to disable the process/thread log prefix (e.g. `(APIServer pid=12345)`) that vLLM adds to stdout/stderr via `decorate_logs()`.

**Motivation:** Users with custom logging configs or log aggregation systems cannot control this prefix because it's injected before Python's logging system. The `VLLM_LOGGING_CONFIG_PATH` config has no effect on it.

## Changes
- **`vllm/envs.py`**: Add `VLLM_DISABLE_LOG_PREFIX` environment variable
- **`vllm/entrypoints/openai/cli_args.py`**: Add `--disable-log-prefix` CLI flag to `FrontendArgs`
- **`vllm/utils/system_utils.py`**: Check `VLLM_DISABLE_LOG_PREFIX` in `decorate_logs()` and skip prefix when set
- **`vllm/entrypoints/cli/serve.py`** + **`api_server.py`**: Propagate CLI flag to env var for child processes

## Test plan
- [x] `test_disable_log_prefix_default_false` - flag defaults to False
- [x] `test_disable_log_prefix_flag` - flag sets attribute to True
- [x] `test_add_prefix_decorates_output` - prefix works normally
- [x] `test_decorate_logs_applies_prefix_by_default` - prefix applied when not disabled
- [x] `test_decorate_logs_skipped_when_env_var_set` - no prefix when VLLM_DISABLE_LOG_PREFIX=1
- [x] `test_decorate_logs_skipped_when_configure_logging_off` - no prefix when VLLM_CONFIGURE_LOGGING=0

Closes #29269