### PR TITLE
[Bugfix][Frontend] Fix IndexError in Mistral tool parser during streaming tool calls

### DIFF
--- a/tests/tool_parsers/test_mistral_tool_parser.py
+++ b/tests/tool_parsers/test_mistral_tool_parser.py
@@ -1292,3 +1292,121 @@ def test_adjust_request_tool_choice_auto_with_json_schema_uses_jinja_factory(
     assert result.structured_outputs is not None
     assert isinstance(result.structured_outputs.grammar, str)
     assert len(result.structured_outputs.grammar) > 0
+
+
+def test_streamed_args_for_tool_populated_v11(
+    mistral_tool_parser,
+    mistral_tokenizer,
+):
+    """
+    Regression test for https://github.com/vllm-project/vllm/issues/33916
+
+    Verify that streamed_args_for_tool is populated during streaming
+    for v11+ tokenizer, preventing IndexError in serving_chat.py when
+    it accesses tool_parser.streamed_args_for_tool[index].
+    """
+    tools = [("add", '{"a": 3, "b": 4}')]
+    expected_args = json.dumps({"a": 3, "b": 4})
+
+    for _ in stream_delta_message_generator(
+        mistral_tool_parser, mistral_tokenizer, None, tools
+    ):
+        pass
+
+    # After streaming completes, streamed_args_for_tool must have at
+    # least one entry so that serving_chat.py can safely index into it.
+    assert len(mistral_tool_parser.streamed_args_for_tool) >= 1, (
+        "streamed_args_for_tool should be populated after streaming tool "
+        "calls but was empty, which would cause IndexError in "
+        "serving_chat.py"
+    )
+    # The accumulated arguments string should match the expected arguments
+    assert mistral_tool_parser.streamed_args_for_tool[0] == expected_args
+
+
+def test_streamed_args_for_tool_populated_v11_multiple_tools(
+    mistral_tool_parser,
+    mistral_tokenizer,
+):
+    """
+    Regression test for https://github.com/vllm-project/vllm/issues/33916
+
+    Verify that streamed_args_for_tool is populated for multiple tool calls
+    during streaming for v11+ tokenizer.
+    """
+    tools = [
+        ("add", '{"a": 3.5, "b": 4}'),
+        (
+            "get_current_weather",
+            '{"city": "San Francisco", "state": "CA", "unit": "celsius"}',
+        ),
+    ]
+
+    for _ in stream_delta_message_generator(
+        mistral_tool_parser, mistral_tokenizer, None, tools
+    ):
+        pass
+
+    assert len(mistral_tool_parser.streamed_args_for_tool) >= 2, (
+        "streamed_args_for_tool should have entries for each tool call "
+        f"but had {len(mistral_tool_parser.streamed_args_for_tool)}"
+    )
+
+
+def test_streamed_args_for_tool_populated_pre_v11(
+    mistral_pre_v11_tool_parser,
+    mistral_pre_v11_tokenizer,
+):
+    """
+    Regression test for https://github.com/vllm-project/vllm/issues/33916
+
+    Verify that streamed_args_for_tool is populated during streaming
+    for pre-v11 tokenizer.
+    """
+    model_output = (
+        '[TOOL_CALLS] [{"name": "add", "arguments":{"a": 3, "b": 4}}]'
+    )
+
+    for _ in stream_delta_message_generator(
+        mistral_pre_v11_tool_parser,
+        mistral_pre_v11_tokenizer,
+        model_output,
+        None,
+    ):
+        pass
+
+    assert len(mistral_pre_v11_tool_parser.streamed_args_for_tool) >= 1, (
+        "streamed_args_for_tool should be populated after streaming tool "
+        "calls but was empty, which would cause IndexError in "
+        "serving_chat.py"
+    )
+
+
+def test_streamed_args_for_tool_populated_pre_v11_multiple_tools(
+    mistral_pre_v11_tool_parser,
+    mistral_pre_v11_tokenizer,
+):
+    """
+    Regression test for https://github.com/vllm-project/vllm/issues/33916
+
+    Verify that streamed_args_for_tool is populated for multiple tool calls
+    during streaming for pre-v11 tokenizer.
+    """
+    model_output = (
+        '[TOOL_CALLS] [{"name": "add", "arguments": {"a": 3.5, "b": 4}}, '
+        '{"name": "get_current_weather", "arguments":'
+        '{"city": "San Francisco", "state": "CA", "unit": "celsius"}}]'
+    )
+
+    for _ in stream_delta_message_generator(
+        mistral_pre_v11_tool_parser,
+        mistral_pre_v11_tokenizer,
+        model_output,
+        None,
+    ):
+        pass
+
+    assert len(mistral_pre_v11_tool_parser.streamed_args_for_tool) >= 2, (
+        "streamed_args_for_tool should have entries for each tool call "
+        f"but had {len(mistral_pre_v11_tool_parser.streamed_args_for_tool)}"
+    )

--- a/tests/tool_parsers/test_mistral_tool_parser.py
+++ b/tests/tool_parsers/test_mistral_tool_parser.py
@@ -1351,6 +1351,13 @@ def test_streamed_args_for_tool_populated_v11_multiple_tools(
         "streamed_args_for_tool should have entries for each tool call "
         f"but had {len(mistral_tool_parser.streamed_args_for_tool)}"
     )
+    # The accumulated arguments strings should match the expected arguments
+    expected_args_0 = json.dumps({"a": 3.5, "b": 4})
+    expected_args_1 = json.dumps(
+        {"city": "San Francisco", "state": "CA", "unit": "celsius"}
+    )
+    assert mistral_tool_parser.streamed_args_for_tool[0] == expected_args_0
+    assert mistral_tool_parser.streamed_args_for_tool[1] == expected_args_1
 
 
 def test_streamed_args_for_tool_populated_pre_v11(
@@ -1380,6 +1387,10 @@ def test_streamed_args_for_tool_populated_pre_v11(
         "calls but was empty, which would cause IndexError in "
         "serving_chat.py"
     )
+    # The accumulated arguments string should match the expected arguments
+    assert json.loads(
+        mistral_pre_v11_tool_parser.streamed_args_for_tool[0]
+    ) == {"a": 3, "b": 4}
 
 
 def test_streamed_args_for_tool_populated_pre_v11_multiple_tools(
@@ -1410,3 +1421,10 @@ def test_streamed_args_for_tool_populated_pre_v11_multiple_tools(
         "streamed_args_for_tool should have entries for each tool call "
         f"but had {len(mistral_pre_v11_tool_parser.streamed_args_for_tool)}"
     )
+    # The accumulated arguments strings should match the expected arguments
+    assert json.loads(
+        mistral_pre_v11_tool_parser.streamed_args_for_tool[0]
+    ) == {"a": 3.5, "b": 4}
+    assert json.loads(
+        mistral_pre_v11_tool_parser.streamed_args_for_tool[1]
+    ) == {"city": "San Francisco", "state": "CA", "unit": "celsius"}

--- a/tests/tool_parsers/test_mistral_tool_parser.py
+++ b/tests/tool_parsers/test_mistral_tool_parser.py
@@ -1370,9 +1370,7 @@ def test_streamed_args_for_tool_populated_pre_v11(
     Verify that streamed_args_for_tool is populated during streaming
     for pre-v11 tokenizer.
     """
-    model_output = (
-        '[TOOL_CALLS] [{"name": "add", "arguments":{"a": 3, "b": 4}}]'
-    )
+    model_output = '[TOOL_CALLS] [{"name": "add", "arguments":{"a": 3, "b": 4}}]'
 
     for _ in stream_delta_message_generator(
         mistral_pre_v11_tool_parser,
@@ -1388,9 +1386,10 @@ def test_streamed_args_for_tool_populated_pre_v11(
         "serving_chat.py"
     )
     # The accumulated arguments string should match the expected arguments
-    assert json.loads(
-        mistral_pre_v11_tool_parser.streamed_args_for_tool[0]
-    ) == {"a": 3, "b": 4}
+    assert json.loads(mistral_pre_v11_tool_parser.streamed_args_for_tool[0]) == {
+        "a": 3,
+        "b": 4,
+    }
 
 
 def test_streamed_args_for_tool_populated_pre_v11_multiple_tools(
@@ -1422,9 +1421,12 @@ def test_streamed_args_for_tool_populated_pre_v11_multiple_tools(
         f"but had {len(mistral_pre_v11_tool_parser.streamed_args_for_tool)}"
     )
     # The accumulated arguments strings should match the expected arguments
-    assert json.loads(
-        mistral_pre_v11_tool_parser.streamed_args_for_tool[0]
-    ) == {"a": 3.5, "b": 4}
-    assert json.loads(
-        mistral_pre_v11_tool_parser.streamed_args_for_tool[1]
-    ) == {"city": "San Francisco", "state": "CA", "unit": "celsius"}
+    assert json.loads(mistral_pre_v11_tool_parser.streamed_args_for_tool[0]) == {
+        "a": 3.5,
+        "b": 4,
+    }
+    assert json.loads(mistral_pre_v11_tool_parser.streamed_args_for_tool[1]) == {
+        "city": "San Francisco",
+        "state": "CA",
+        "unit": "celsius",
+    }

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1140,17 +1140,33 @@ class OpenAIServingChat(OpenAIServing):
                                 expected_call = json.dumps(args, ensure_ascii=False)
 
                             # get what we've streamed so far for arguments
-                            # for the current tool
-                            actual_call = tool_parser.streamed_args_for_tool[index]
-                            if latest_delta_len > 0:
-                                actual_call = actual_call[:-latest_delta_len]
+                            # for the current tool. Some tool parsers
+                            # (e.g. Mistral) manage their own streaming
+                            # state and may not populate
+                            # streamed_args_for_tool, so we guard against
+                            # IndexError here.
+                            if index < len(
+                                tool_parser.streamed_args_for_tool
+                            ):
+                                actual_call = (
+                                    tool_parser.streamed_args_for_tool[index]
+                                )
+                                if latest_delta_len > 0:
+                                    actual_call = actual_call[
+                                        :-latest_delta_len
+                                    ]
 
-                            # check to see if there's anything left to stream
-                            remaining_call = expected_call.replace(actual_call, "", 1)
-                            # set that as a delta message
-                            delta_message = self._create_remaining_args_delta(
-                                delta_message, remaining_call, index
-                            )
+                                # check to see if there's anything left
+                                # to stream
+                                remaining_call = expected_call.replace(
+                                    actual_call, "", 1
+                                )
+                                # set that as a delta message
+                                delta_message = (
+                                    self._create_remaining_args_delta(
+                                        delta_message, remaining_call, index
+                                    )
+                                )
 
                         # Send the finish response for each request.n only once
                         # In OpenAI's API, when a tool is called, the

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1148,13 +1148,9 @@ class OpenAIServingChat(OpenAIServing):
                             if index < len(
                                 tool_parser.streamed_args_for_tool
                             ):
-                                actual_call = (
-                                    tool_parser.streamed_args_for_tool[index]
-                                )
+                                actual_call = tool_parser.streamed_args_for_tool[index]
                                 if latest_delta_len > 0:
-                                    actual_call = actual_call[
-                                        :-latest_delta_len
-                                    ]
+                                    actual_call = actual_call[:-latest_delta_len]
 
                                 # check to see if there's anything left
                                 # to stream
@@ -1162,10 +1158,8 @@ class OpenAIServingChat(OpenAIServing):
                                     actual_call, "", 1
                                 )
                                 # set that as a delta message
-                                delta_message = (
-                                    self._create_remaining_args_delta(
-                                        delta_message, remaining_call, index
-                                    )
+                                delta_message = self._create_remaining_args_delta(
+                                    delta_message, remaining_call, index
                                 )
 
                         # Send the finish response for each request.n only once

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1145,9 +1145,7 @@ class OpenAIServingChat(OpenAIServing):
                             # state and may not populate
                             # streamed_args_for_tool, so we guard against
                             # IndexError here.
-                            if index < len(
-                                tool_parser.streamed_args_for_tool
-                            ):
+                            if index < len(tool_parser.streamed_args_for_tool):
                                 actual_call = tool_parser.streamed_args_for_tool[index]
                                 if latest_delta_len > 0:
                                     actual_call = actual_call[:-latest_delta_len]

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1106,7 +1106,13 @@ class OpenAIServingChat(OpenAIServing):
                         )
                         # only check if there are any tool calls
                         # detected by partial parsing
-                        if should_check and tool_parser and auto_tools_called:
+                        if (
+                            should_check
+                            and tool_parser
+                            and auto_tools_called
+                            and index < len(tool_parser.prev_tool_call_arr)
+                            and index < len(tool_parser.streamed_args_for_tool)
+                        ):
                             latest_delta_len = 0
                             if (
                                 isinstance(

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -502,9 +502,7 @@ class MistralToolParser(ToolParser):
                 if delta_arguments and self.current_tool_id < len(
                     self.streamed_args_for_tool
                 ):
-                    self.streamed_args_for_tool[
-                        self.current_tool_id
-                    ] += delta_arguments
+                    self.streamed_args_for_tool[self.current_tool_id] += delta_arguments
                 self.current_tool_name = None
             if next_function_text:
                 ret += self._generate_delta_tool_call(next_function_text)
@@ -680,12 +678,10 @@ class MistralToolParser(ToolParser):
                     )
                 # Track streamed arguments for serving_chat.py's
                 # autocomplete logic
-                if self.current_tool_id < len(
-                    self.streamed_args_for_tool
-                ):
-                    self.streamed_args_for_tool[
-                        self.current_tool_id
-                    ] += delta_to_be_parsed
+                if self.current_tool_id < len(self.streamed_args_for_tool):
+                    self.streamed_args_for_tool[self.current_tool_id] += (
+                        delta_to_be_parsed
+                    )
 
         if current_tool_call_modified:
             if self.current_tool_mistral_id is not None:

--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -457,6 +457,7 @@ class MistralToolParser(ToolParser):
             StreamingState.PARSING_ARGUMENTS,
         ] and delta_text.startswith(self.bot_token):
             self.current_tool_id += 1
+            self.streamed_args_for_tool.append("")
             self.streaming_state = StreamingState.PARSING_NAME
             delta_text = delta_text.replace(self.bot_token, "", 1)
         if self.streaming_state == StreamingState.PARSING_NAME:
@@ -496,6 +497,14 @@ class MistralToolParser(ToolParser):
                         ).model_dump(exclude_none=True),
                     )
                 ]
+                # Track streamed arguments for serving_chat.py's
+                # autocomplete logic
+                if delta_arguments and self.current_tool_id < len(
+                    self.streamed_args_for_tool
+                ):
+                    self.streamed_args_for_tool[
+                        self.current_tool_id
+                    ] += delta_arguments
                 self.current_tool_name = None
             if next_function_text:
                 ret += self._generate_delta_tool_call(next_function_text)
@@ -636,6 +645,7 @@ class MistralToolParser(ToolParser):
                     delta_tool_calls.append(current_tool_call)
                 current_tool_call_modified = False
                 self.current_tool_id += 1
+                self.streamed_args_for_tool.append("")
                 self.current_tool_mistral_id = MistralToolCall.generate_random_id()
                 current_tool_call = DeltaToolCall(
                     index=self.current_tool_id,
@@ -668,6 +678,14 @@ class MistralToolParser(ToolParser):
                     current_tool_call.function.arguments = (
                         current_tool_call.function.arguments.lstrip()
                     )
+                # Track streamed arguments for serving_chat.py's
+                # autocomplete logic
+                if self.current_tool_id < len(
+                    self.streamed_args_for_tool
+                ):
+                    self.streamed_args_for_tool[
+                        self.current_tool_id
+                    ] += delta_to_be_parsed
 
         if current_tool_call_modified:
             if self.current_tool_mistral_id is not None:


### PR DESCRIPTION
## Summary
- Fixes `IndexError: list index out of range` in `chat_completion_stream_generator` when using `--tool-call-parser=mistral` with streaming tool calls
- The root cause was that the Mistral tool parser never populated `streamed_args_for_tool`, but `serving.py` unconditionally accessed `tool_parser.streamed_args_for_tool[index]` at stream completion
- Adds a defensive bounds check in `serving.py` before indexing `streamed_args_for_tool` (protects all tool parsers)
- Updates both v11+ and pre-v11 Mistral streaming paths to properly track streamed arguments in `streamed_args_for_tool`, matching the pattern used by other parsers (e.g. Hermes, MiniMax M2)
- Adds 4 regression tests verifying `streamed_args_for_tool` is populated after streaming for both single and multiple tool calls, across both tokenizer versions

Fixes #33916
Related: #30554

## Test plan
- [x] Added `test_streamed_args_for_tool_populated_v11` - verifies single tool call populates `streamed_args_for_tool` for v11+ tokenizer
- [x] Added `test_streamed_args_for_tool_populated_v11_multiple_tools` - verifies multiple tool calls for v11+ tokenizer
- [x] Added `test_streamed_args_for_tool_populated_pre_v11` - verifies single tool call for pre-v11 tokenizer
- [x] Added `test_streamed_args_for_tool_populated_pre_v11_multiple_tools` - verifies multiple tool calls for pre-v11 tokenizer
- [x] Existing Mistral tool parser tests continue to pass