### PR TITLE
Update `WeightTransferConfig` to be more standard like the others

### DIFF
--- a/vllm/config/weight_transfer.py
+++ b/vllm/config/weight_transfer.py
@@ -1,13 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from dataclasses import dataclass
 from typing import Literal
 
 from vllm.config.utils import config
 
 
 @config
-@dataclass
 class WeightTransferConfig:
     """Configuration for weight transfer during RL training."""
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -582,10 +582,10 @@ class EngineArgs:
     kv_offloading_backend: KVOffloadingBackend = CacheConfig.kv_offloading_backend
     tokens_only: bool = False
 
-    weight_transfer_config: WeightTransferConfig | None = None
-    """Configuration for weight transfer during RL training. 
-    Accepts a JSON string or dict with backend-specific options.
-    Example: '{"backend": "nccl"}'"""
+    weight_transfer_config: WeightTransferConfig | None = get_field(
+        VllmConfig,
+        "weight_transfer_config",
+    )
 
     def __post_init__(self):
         # support `EngineArgs(compilation_config={...})`


### PR DESCRIPTION
- `@config` is a dataclass transform now
- The default shouldn't be duplicated in `EngineArgs`