### PR TITLE
Pass modality information in embed_multimodal

### DIFF
--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -325,6 +325,7 @@ class SupportsMultiModal(Protocol):
         *,
         is_multimodal: torch.Tensor,
         handle_oov_mm_token: bool = False,
+        modality_types: list[str] | None = None,
     ) -> Tensor: ...
 
     def _embed_text_input_ids(
@@ -354,6 +355,7 @@ class SupportsMultiModal(Protocol):
         *,
         is_multimodal: Tensor | None = None,
         handle_oov_mm_token: bool = False,
+        modality_types: list[str] | None = None,
     ) -> Tensor:
         """
         Apply token embeddings to `input_ids`.

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -386,7 +386,8 @@ class SpecDecodeBaseProposer:
         token_indices_to_sample: torch.Tensor | None,
         common_attn_metadata: CommonAttentionMetadata,
         sampling_metadata: SamplingMetadata,
-        mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor, list[str]] | None = None,
+        mm_embed_inputs: tuple[
+            list[torch.Tensor], torch.Tensor, list[str]] | None = None,
         num_rejected_tokens_gpu: torch.Tensor | None = None,
         slot_mappings: dict[str, torch.Tensor]
         | list[dict[str, torch.Tensor]]

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1260,9 +1260,6 @@ class GPUModelRunner(
         mm_budget = self.mm_budget
         assert mm_budget is not None
 
-        if not mm_budget.mm_max_toks_per_item:
-            return {}  # No tower modalities (embed-only mode)
-
         dummy_modality = mm_budget.get_modality_with_max_tokens()
         return self._get_mm_dummy_batch(dummy_modality, num_seqs)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

From [multimodal community sync docs](https://docs.google.com/document/d/1rQN5GeZZfBINksWCeDwh4fgJJNUc2p0dTKsHaK-mC8U/edit?tab=t.0)

This PR passes explicit modality labels ("image", "video", "audio") through embed_input_ids so models can distinguish embedding types without relying on fragile shape heuristics.

Context: In Qwen3-Omni, embed_input_ids needs to tell vision embeddings apart from audio embeddings for deepstack feature splitting. The existing code inferred modality by checking embedding.shape[-1] != hidden_size, which only worked incidentally because vision embeddings have a different last dimension after deepstack concatenation. This adds an optional modality_types: list[str] | None parameter threaded from the model runner, where MultiModalFeatureSpec.modality already tracks this information. The supports_kw utility gates delivery of the kwarg so existing models are unaffected.


## Test Plan

## Test Result

```
# pytest tests/model_executor/test_qwen3_omni.py -v
  1 passed

# pytest tests/multimodal/test_embedding_shape_validation_unit.py -v
  18 passed

# pytest tests/v1/worker/test_gpu_model_runner.py -v
  23 passed

# pytest tests/v1/spec_decode/test_eagle.py -v
  45 passed, 28 skipped

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

