### PR TITLE
[Bugfix] Fix no attribute error of SharedFusedMoE (DeepSeek-V3.1 as test model)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -335,6 +335,7 @@ class FusedMoE(CustomOp):
         expert_mapping: list[tuple[str, str, int, str]] | None = None,
         n_shared_experts: int | None = None,
         router_logits_dtype: torch.dtype | None = None,
+        has_shared_experts: bool = False,
     ):
         super().__init__()
 
@@ -564,7 +565,7 @@ class FusedMoE(CustomOp):
             device=vllm_config.device_config.device,
             routing_method=self.routing_method_type,
             # TODO: in_dtype == out_dtype?
-            disable_inplace=disable_inplace() or self.shared_experts is not None,
+            disable_inplace=disable_inplace() or has_shared_experts,
         )
         if self.use_mori_kernels:
             assert self.rocm_aiter_fmoe_enabled, (

--- a/vllm/model_executor/layers/fused_moe/shared_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/shared_fused_moe.py
@@ -26,6 +26,10 @@ class SharedFusedMoE(FusedMoE):
         routed_input_transform: torch.nn.Module | None = None,
         **kwargs,
     ):
+        # Pass has_shared_experts so FusedMoE.__init__ can set disable_inplace
+        # without accessing self.shared_experts (submodules cannot be set before
+        # Module.__init__()).
+        kwargs["has_shared_experts"] = shared_experts is not None
         super().__init__(**kwargs)
         self._shared_experts = shared_experts
         self._routed_input_transform = routed_input_transform


### PR DESCRIPTION
## Purpose

Model: deepseek-ai/DeepSeek-V3.1
This PR aims to fix an error:
```
Traceback (most recent call last):
  File "/workspace/xuebwang/vllm/vllm/v1/executor/multiproc_executor.py", line 754, in worker_main
    worker = WorkerProc(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xuebwang/vllm/vllm/v1/executor/multiproc_executor.py", line 580, in __init__
    self.worker.load_model()
  File "/workspace/xuebwang/vllm/vllm/v1/worker/gpu_worker.py", line 292, in load_model
    self.model_runner.load_model(eep_scale_up=eep_scale_up)
  File "/workspace/xuebwang/vllm/vllm/v1/worker/gpu_model_runner.py", line 4140, in load_model
    self.model = model_loader.load_model(
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xuebwang/vllm/vllm/model_executor/model_loader/base_loader.py", line 54, in load_model
    model = initialize_model(
            ^^^^^^^^^^^^^^^^^
  File "/workspace/xuebwang/vllm/vllm/model_executor/model_loader/utils.py", line 54, in initialize_model
    model = model_class(vllm_config=vllm_config, prefix=prefix)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xuebwang/vllm/vllm/model_executor/models/deepseek_v2.py", line 1210, in __init__
    self.model = self.model_cls(
                 ^^^^^^^^^^^^^^^
  File "/workspace/xuebwang/vllm/vllm/compilation/decorators.py", line 305, in __init__
    old_init(self, **kwargs)
  File "/workspace/xuebwang/vllm/vllm/model_executor/models/deepseek_v2.py", line 1067, in __init__
    self.start_layer, self.end_layer, self.layers = make_layers(
                                                    ^^^^^^^^^^^^
  File "/workspace/xuebwang/vllm/vllm/model_executor/models/utils.py", line 707, in make_layers
    maybe_offload_to_cpu(layer_fn(prefix=f"{prefix}.{idx}"))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xuebwang/vllm/vllm/model_executor/models/deepseek_v2.py", line 1069, in <lambda>
    lambda prefix: DeepseekV2DecoderLayer(
                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/xuebwang/vllm/vllm/model_executor/models/deepseek_v2.py", line 963, in __init__
    self.mlp = DeepseekV2MoE(
               ^^^^^^^^^^^^^^
  File "/workspace/xuebwang/vllm/vllm/model_executor/models/deepseek_v2.py", line 298, in __init__
    self.experts = SharedFusedMoE(
                   ^^^^^^^^^^^^^^^
  File "/workspace/xuebwang/vllm/vllm/model_executor/layers/fused_moe/shared_fused_moe.py", line 29, in __init__
    super().__init__(**kwargs)
  File "/workspace/xuebwang/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 567, in __init__
    disable_inplace=disable_inplace() or self.shared_experts is not None,
                                         ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1964, in __getattr__
    raise AttributeError(
AttributeError: 'SharedFusedMoE' object has no attribute 'shared_experts'
```

## Test Plan
- Model: deepseek-ai/DeepSeek-V3.1
- Script: 
```bash
export AITER_ENABLE_VSKIP=0
export VLLM_USE_V1=1
export VLLM_ROCM_USE_AITER=1

lm_eval \
  --model vllm \
  --model_args pretrained=deepseek-ai/DeepSeek-V3.1,tensor_parallel_size=8,dtype=auto,gpu_memory_utilization=0.9,block_size=1 \
  --tasks gsm8k_platinum \
  --num_fewshot 5 \
  --batch_size auto
```


## Test Result
```
|    Tasks     |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|--------------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_platinum|      3|flexible-extract|     5|exact_match|↑  |0.9777|±  |0.0043|
|              |       |strict-match    |     5|exact_match|↑  |0.9760|±  |0.0044|
```


