### PR TITLE
[Fix] Fix `logprobs=0` handling for `/inference/v1/generate` endpoint

### DIFF
--- a/tests/entrypoints/openai/test_serving_tokens.py
+++ b/tests/entrypoints/openai/test_serving_tokens.py
@@ -88,7 +88,7 @@ async def test_generate_endpoint(client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("logprobs_value", [0, 1])
+@pytest.mark.parametrize("logprobs_value", [0, 1, 5])
 async def test_generate_logprobs(client, logprobs_value):
     payload = {
         "model": MODEL_NAME,

--- a/tests/entrypoints/openai/test_serving_tokens.py
+++ b/tests/entrypoints/openai/test_serving_tokens.py
@@ -109,7 +109,8 @@ async def test_generate_logprobs(client, logprobs_value):
     assert len(logprobs_content) == len(choice["token_ids"])
     for entry in logprobs_content:
         assert "logprob" in entry
-        assert len(entry["top_logprobs"]) <= logprobs_value
+        assert len(entry["top_logprobs"]) >= 1
+        assert len(entry["top_logprobs"]) <= max(logprobs_value, 1)
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/test_serving_tokens.py
+++ b/tests/entrypoints/openai/test_serving_tokens.py
@@ -110,7 +110,7 @@ async def test_generate_logprobs(client, logprobs_value):
     for entry in logprobs_content:
         assert "logprob" in entry
         assert len(entry["top_logprobs"]) >= 1
-        assert len(entry["top_logprobs"]) <= max(logprobs_value, 1)
+        assert len(entry["top_logprobs"]) == max(logprobs_value, 1)
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/test_serving_tokens.py
+++ b/tests/entrypoints/openai/test_serving_tokens.py
@@ -88,6 +88,31 @@ async def test_generate_endpoint(client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("logprobs_value", [0, 1])
+async def test_generate_logprobs(client, logprobs_value):
+    payload = {
+        "model": MODEL_NAME,
+        "token_ids": [1, 2, 3],
+        "sampling_params": {
+            "max_tokens": 5,
+            "temperature": 0.0,
+            "logprobs": logprobs_value,
+        },
+        "stream": False,
+    }
+    resp = await client.post(GEN_ENDPOINT, json=payload)
+    resp.raise_for_status()
+    data = resp.json()
+    choice = data["choices"][0]
+    assert choice["logprobs"] is not None
+    logprobs_content = choice["logprobs"]["content"]
+    assert len(logprobs_content) == len(choice["token_ids"])
+    for entry in logprobs_content:
+        assert "logprob" in entry
+        assert len(entry["top_logprobs"]) <= logprobs_value
+
+
+@pytest.mark.asyncio
 async def test_same_response_as_chat_completions(client, tokenizer, messages):
     token_ids = tokenizer.apply_chat_template(
         messages,

--- a/vllm/entrypoints/serve/disagg/serving.py
+++ b/vllm/entrypoints/serve/disagg/serving.py
@@ -284,7 +284,8 @@ class ServingTokens(OpenAIServing):
                                 logprob=max(p[1].logprob, -9999.0),
                             )
                             for i, p in enumerate(step_top_logprobs.items())
-                            if num_output_top_logprobs and i < num_output_top_logprobs
+                            if num_output_top_logprobs is not None
+                            and i < max(num_output_top_logprobs, 1)
                         ],
                     )
                 )

--- a/vllm/entrypoints/serve/disagg/serving.py
+++ b/vllm/entrypoints/serve/disagg/serving.py
@@ -184,7 +184,7 @@ class ServingTokens(OpenAIServing):
             out_logprobs = output.logprobs
 
             # This is top_logprobs in completions API
-            if sampling_params.logprobs:
+            if sampling_params.logprobs is not None:
                 assert out_logprobs is not None, "Did not output logprobs"
                 logprobs = self._create_tokens_logprobs(
                     token_ids=token_ids,


### PR DESCRIPTION

## Purpose

`/inference/v1/generate` endpoint differs from `/v1/completions` endpoint and the Engine APIs in `logprobs=0` handling: Passing `logprobs=0` returns no logprobs, while it is supposed to return chosen token logprobs (same as `logprobs=1`)

This PR ensures that the behaviour is consistent with the completions endpoint. 

## Test Plan

Added a new test for logprobs handling in the generate endpoint - with logprobs values 0, 1, 5

## Test Result

Tests pass for logprobs=0 after this PR

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

