### PR TITLE
[Bugfix] Fix Whisper tokenization

### DIFF
--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -732,8 +732,9 @@ class WhisperMultiModalProcessor(EncDecMultiModalProcessor[WhisperProcessingInfo
         # `truncation` and `max_length` must be removed when audio data
         # is present, otherwise the feature extractor interprets
         # `max_length` as raw audio samples and truncates the audio.
-        tok_kwargs.pop("truncation", None)
-        tok_kwargs.pop("max_length", None)
+        tok_kwargs = {
+            k: v for k, v in tok_kwargs.items() if k not in ("truncation", "max_length")
+        }
         processed_outputs = super()._call_hf_processor(
             prompt=prompt,
             mm_data=mm_data,

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -727,6 +727,13 @@ class WhisperMultiModalProcessor(EncDecMultiModalProcessor[WhisperProcessingInfo
                 **mm_kwargs,
                 sampling_rate=feature_extractor.sampling_rate,
             )
+        # The HF WhisperProcessor passes **kwargs to both the tokenizer
+        # and the feature extractor. Text-tokenizer kwargs like
+        # `truncation` and `max_length` must be removed when audio data
+        # is present, otherwise the feature extractor interprets
+        # `max_length` as raw audio samples and truncates the audio.
+        tok_kwargs.pop("truncation", None)
+        tok_kwargs.pop("max_length", None)
         processed_outputs = super()._call_hf_processor(
             prompt=prompt,
             mm_data=mm_data,


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/34002.

Since HF forwards **kwargs to both tokenizer and feature extractor, WhisperFeatureExtractor truncates audio to N raw samples (~0.03s), producing empty output. Strip these kwargs when audio data is present.


cc @DarkLight1337 