### PR TITLE
[Model] Introduce first-class DFlash speculative decoding in vLLM V1

### DIFF
--- a/docs/features/spec_decode/README.md
+++ b/docs/features/spec_decode/README.md
@@ -323,7 +323,7 @@ vLLM also supports speculative decoding with DFlash draft models via
 
 Important constraints for DFlash:
 
-1. DFlash draft models are currently intended for Qwen3-based checkpoints.
+1. DFlash draft models are currently tested with Qwen3-based checkpoints.
 2. `runtime_mode="block_drafting"` supports batched requests in vLLM V1, but
    this path is still under active hardening and should be validated for your
    workload/backends before production rollout.

--- a/docs/features/spec_decode/README.md
+++ b/docs/features/spec_decode/README.md
@@ -324,8 +324,9 @@ vLLM also supports speculative decoding with DFlash draft models via
 Important constraints for DFlash:
 
 1. DFlash draft models are currently intended for Qwen3-based checkpoints.
-2. `runtime_mode="block_drafting"` is currently BS1-only. For batch size > 1,
-   vLLM falls back to the shared EAGLE-style draft path.
+2. `runtime_mode="block_drafting"` supports batched requests in vLLM V1, but
+   this path is still under active hardening and should be validated for your
+   workload/backends before production rollout.
 3. DFlash requires an attention backend with non-causal drafting support.
    If backend validation fails, use FlashAttention or Triton attention backend.
 

--- a/examples/offline_inference/spec_decode.py
+++ b/examples/offline_inference/spec_decode.py
@@ -53,7 +53,7 @@ def parse_args():
         "--method",
         type=str,
         default="eagle",
-        choices=["ngram", "eagle", "eagle3", "mtp", "draft_model"],
+        choices=["ngram", "eagle", "eagle3", "mtp", "draft_model", "dflash"],
     )
     parser.add_argument("--backend", type=str, default="openai")
     parser.add_argument("--num-spec-tokens", type=int, default=2)
@@ -131,7 +131,7 @@ def main(args):
             "prompt_lookup_max": args.prompt_lookup_max,
             "prompt_lookup_min": args.prompt_lookup_min,
         }
-    elif args.method == "draft_model":
+    elif args.method in ("draft_model", "dflash"):
         assert args.draft_model is not None and args.draft_model != ""
         speculative_config = {
             "method": args.method,

--- a/tests/config/draft_model_arch_groundtruth.json
+++ b/tests/config/draft_model_arch_groundtruth.json
@@ -83,5 +83,22 @@
         "is_deepseek_mla": false,
         "is_multimodal_model": false,
         "dtype": "float16"
+    },
+    "z-lab/Qwen3-8B-DFlash-b16": {
+        "architectures": [
+            "DFlashDraftModel"
+        ],
+        "model_type": "qwen3",
+        "text_model_type": "qwen3",
+        "hidden_size": 4096,
+        "total_num_hidden_layers": 5,
+        "total_num_attention_heads": 32,
+        "head_size": 128,
+        "vocab_size": 151936,
+        "total_num_kv_heads": 8,
+        "num_experts": 0,
+        "is_deepseek_mla": false,
+        "is_multimodal_model": false,
+        "dtype": "torch.bfloat16"
     }
 }

--- a/tests/config/test_model_arch_config.py
+++ b/tests/config/test_model_arch_config.py
@@ -52,6 +52,7 @@ SPECULATIVE_MODELS = [
     ("eagle618/deepseek-v3-random", "eagle618/eagle-deepseek-v3-random", True),
     ("meta-llama/Meta-Llama-3-8B-Instruct", "yuhuili/EAGLE-LLaMA3-Instruct-8B", True),
     ("meta-llama/Llama-3.1-8B-Instruct", "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B", True),
+    ("Qwen/Qwen3-8B", "z-lab/Qwen3-8B-DFlash-b16", False),
 ]
 
 

--- a/tests/config/test_speculative_config.py
+++ b/tests/config/test_speculative_config.py
@@ -119,3 +119,22 @@ def test_dflash_target_model_validation():
             target_model_config=_make_target_model_config(model_type="opt"),
             target_parallel_config=ParallelConfig(),
         )
+
+
+def test_dflash_hash_differs_from_non_eagle3_method():
+    ngram_config = SpeculativeConfig(
+        method="ngram",
+        num_speculative_tokens=1,
+    )
+    with patch(
+        "vllm.config.speculative.ModelConfig",
+        new=_model_config_factory(),
+    ):
+        dflash_config = SpeculativeConfig(
+            method="dflash",
+            model="org/dflash-draft",
+            num_speculative_tokens=1,
+            target_model_config=_make_target_model_config(),
+            target_parallel_config=ParallelConfig(),
+        )
+    assert dflash_config.compute_hash() != ngram_config.compute_hash()

--- a/tests/config/test_speculative_config.py
+++ b/tests/config/test_speculative_config.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from vllm.config import ParallelConfig, SpeculativeConfig
+
+
+class _DummyDraftModelConfig:
+    def __init__(self, model: str, model_type: str, architectures: list[str]):
+        self.model = model
+        self.hf_config = SimpleNamespace(
+            model_type=model_type,
+            architectures=architectures,
+        )
+        self.hf_text_config = self.hf_config
+        self.architectures = architectures
+        self.max_model_len = 4096
+
+    def verify_with_parallel_config(self, parallel_config: ParallelConfig) -> None:
+        del parallel_config
+
+
+def _make_target_model_config(model_type: str = "qwen"):
+    return SimpleNamespace(
+        model="dummy-target",
+        tokenizer="dummy-target",
+        tokenizer_mode="auto",
+        trust_remote_code=False,
+        allowed_local_media_path=None,
+        allowed_media_domains=None,
+        dtype="float16",
+        seed=0,
+        revision=None,
+        tokenizer_revision=None,
+        max_model_len=4096,
+        quantization=None,
+        enforce_eager=False,
+        max_logprobs=20,
+        config_format="hf",
+        hf_text_config=SimpleNamespace(model_type=model_type),
+        get_vocab_size=lambda: 1000,
+    )
+
+
+def _model_config_factory(
+    model_type: str = "dummy",
+    architectures: list[str] | None = None,
+):
+    def _factory(*args, **kwargs):
+        del args
+        return _DummyDraftModelConfig(
+            model=kwargs["model"],
+            model_type=model_type,
+            architectures=architectures or ["DummyForCausalLM"],
+        )
+
+    return _factory
+
+
+def test_dflash_method_is_supported_in_speculative_config():
+    with patch(
+        "vllm.config.speculative.ModelConfig",
+        new=_model_config_factory(),
+    ):
+        config = SpeculativeConfig(
+            method="dflash",
+            model="z-lab/Qwen3-8B-DFlash-b16",
+            num_speculative_tokens=1,
+            target_model_config=_make_target_model_config(),
+            target_parallel_config=ParallelConfig(),
+        )
+    assert config.method == "dflash"
+
+
+def test_dflash_method_auto_detects_from_model_name():
+    with patch(
+        "vllm.config.speculative.ModelConfig",
+        new=_model_config_factory(),
+    ):
+        config = SpeculativeConfig(
+            model="z-lab/Qwen3-8B-DFlash-b16",
+            num_speculative_tokens=1,
+            target_model_config=_make_target_model_config(),
+            target_parallel_config=ParallelConfig(),
+        )
+    assert config.method == "dflash"
+
+
+def test_dflash_method_auto_detects_from_draft_architecture():
+    with patch(
+        "vllm.config.speculative.ModelConfig",
+        new=_model_config_factory(architectures=["DFlashDraftModel"]),
+    ):
+        config = SpeculativeConfig(
+            model="org/draft-model-without-name-hint",
+            num_speculative_tokens=1,
+            target_model_config=_make_target_model_config(),
+            target_parallel_config=ParallelConfig(),
+        )
+    assert config.method == "dflash"
+
+
+def test_dflash_target_model_validation():
+    with (
+        patch(
+            "vllm.config.speculative.ModelConfig",
+            new=_model_config_factory(),
+        ),
+        pytest.raises(ValueError, match="dflash is only supported"),
+    ):
+        SpeculativeConfig(
+            method="dflash",
+            model="z-lab/Qwen3-8B-DFlash-b16",
+            num_speculative_tokens=1,
+            target_model_config=_make_target_model_config(model_type="opt"),
+            target_parallel_config=ParallelConfig(),
+        )

--- a/tests/config/test_speculative_config.py
+++ b/tests/config/test_speculative_config.py
@@ -170,3 +170,25 @@ def test_dflash_aux_layers_from_dflash_config():
         target_layer_count=36,
     )
     assert model.get_eagle3_aux_hidden_state_layers() == (31, 33, 35)
+
+
+def test_dflash_aux_layers_fallback_to_eagle_aux_layer_ids():
+    model = DFlashQwen3ForCausalLM.__new__(DFlashQwen3ForCausalLM)
+    model.config = SimpleNamespace(
+        eagle_aux_hidden_state_layer_ids=[7, 11, 15],
+        target_layer_count=36,
+    )
+    assert model.get_eagle3_aux_hidden_state_layers() == (7, 11, 15)
+
+
+def test_dflash_aux_layers_fallback_to_target_layer_count_default():
+    model = DFlashQwen3ForCausalLM.__new__(DFlashQwen3ForCausalLM)
+    model.config = SimpleNamespace(target_layer_count=8)
+    assert model.get_eagle3_aux_hidden_state_layers() == (2, 4, 5)
+
+
+def test_set_dflash_aux_layers_updates_dflash_config():
+    model = DFlashQwen3ForCausalLM.__new__(DFlashQwen3ForCausalLM)
+    model.config = SimpleNamespace(dflash_config={})
+    model.set_aux_hidden_state_layers((1, 3, 5))
+    assert model.config.dflash_config["layer_ids"] == [1, 3, 5]

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1022,6 +1022,11 @@ _MULTIMODAL_EXAMPLE_MODELS = {
 
 
 _SPECULATIVE_DECODING_EXAMPLE_MODELS = {
+    "DFlashDraftModel": _HfExamplesInfo(
+        "Qwen/Qwen3-8B",
+        speculative_model="z-lab/Qwen3-8B-DFlash-b16",
+        speculative_method="dflash",
+    ),
     "MedusaModel": _HfExamplesInfo(
         "JackFram/llama-68m", speculative_model="abhigoyal/vllm-medusa-llama-68m-random"
     ),

--- a/tests/v1/e2e/test_async_spec_decode.py
+++ b/tests/v1/e2e/test_async_spec_decode.py
@@ -82,6 +82,13 @@ SPEC_DECODE_CONFIGS = [
         2,
         id="eagle-mla-deepseek",
     ),
+    pytest.param(
+        "Qwen/Qwen3-8B",
+        "z-lab/Qwen3-8B-DFlash-b16",
+        "dflash",
+        2,
+        id="dflash-qwen3",
+    ),
 ]
 
 

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -332,6 +332,12 @@ def test_speculators_model_integration(
             False,
             "transformers",
         ),
+        (
+            ("dflash", "Qwen/Qwen3-8B", "z-lab/Qwen3-8B-DFlash-b16", 1),
+            False,
+            False,
+            "auto",
+        ),
         pytest.param(
             (
                 "eagle3",
@@ -422,6 +428,7 @@ def test_speculators_model_integration(
     ids=[
         "qwen3_eagle3",
         "qwen3_eagle3-transformers",
+        "qwen3_dflash",
         "qwen3_vl_eagle3",
         "qwen2_5_vl_eagle3",
         "llama3_eagle",

--- a/tests/v1/spec_decode/test_dflash.py
+++ b/tests/v1/spec_decode/test_dflash.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm.v1.spec_decode.dflash import DFlashProposer
+from vllm.v1.spec_decode.eagle import EagleProposer
+
+
+def test_dflash_proposer_rejects_batch_size_gt_one():
+    proposer = DFlashProposer.__new__(DFlashProposer)
+    common_attn_metadata = SimpleNamespace(batch_size=lambda: 2)
+    with pytest.raises(NotImplementedError, match="batch size 1 only"):
+        proposer.propose(common_attn_metadata=common_attn_metadata)
+
+
+def test_dflash_proposer_delegates_to_eagle_for_bs1():
+    proposer = DFlashProposer.__new__(DFlashProposer)
+    common_attn_metadata = SimpleNamespace(batch_size=lambda: 1)
+    sentinel = torch.tensor([[1]], dtype=torch.int32)
+
+    with patch.object(EagleProposer, "propose", return_value=sentinel) as mock_propose:
+        out = proposer.propose(common_attn_metadata=common_attn_metadata)
+
+    mock_propose.assert_called_once()
+    assert torch.equal(out, sentinel)

--- a/tests/v1/spec_decode/test_eagle_config_resolution.py
+++ b/tests/v1/spec_decode/test_eagle_config_resolution.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from vllm.v1.spec_decode.eagle import EagleProposer
+
+
+def test_dflash_use_aux_hidden_state_resolution():
+    proposer = EagleProposer.__new__(EagleProposer)
+    proposer.method = "dflash"
+    proposer.draft_model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            eagle_config={"use_aux_hidden_state": True},
+            dflash_config={"use_aux_hidden_state": False},
+        )
+    )
+    assert proposer._get_eagle3_use_aux_hidden_state_from_config() is False

--- a/tests/v1/spec_decode/test_eagle_config_resolution.py
+++ b/tests/v1/spec_decode/test_eagle_config_resolution.py
@@ -3,16 +3,26 @@
 
 from types import SimpleNamespace
 
+from vllm.v1.spec_decode.dflash import DFlashProposer
 from vllm.v1.spec_decode.eagle import EagleProposer
 
 
 def test_dflash_use_aux_hidden_state_resolution():
-    proposer = EagleProposer.__new__(EagleProposer)
+    proposer = DFlashProposer.__new__(DFlashProposer)
     proposer.method = "dflash"
     proposer.draft_model_config = SimpleNamespace(
         hf_config=SimpleNamespace(
             eagle_config={"use_aux_hidden_state": True},
             dflash_config={"use_aux_hidden_state": False},
         )
+    )
+    assert proposer._get_eagle3_use_aux_hidden_state_from_config() is False
+
+
+def test_eagle3_use_aux_hidden_state_resolution():
+    proposer = EagleProposer.__new__(EagleProposer)
+    proposer.method = "eagle3"
+    proposer.draft_model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(eagle_config={"use_aux_hidden_state": False})
     )
     assert proposer._get_eagle3_use_aux_hidden_state_from_config() is False

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1225,3 +1225,15 @@ def test_get_eagle3_aux_layers_from_config_uses_eagle_field_for_eagle3():
     )
 
     assert runner._get_eagle3_aux_layers_from_config() == (2, 16, 29)
+
+
+def test_is_supported_dflash_metadata_builder():
+    assert GPUModelRunner._is_supported_dflash_metadata_builder(
+        "FlashAttentionMetadataBuilder"
+    )
+    assert GPUModelRunner._is_supported_dflash_metadata_builder(
+        "TritonAttentionMetadataBuilder"
+    )
+    assert not GPUModelRunner._is_supported_dflash_metadata_builder(
+        "GDNAttentionMetadataBuilder"
+    )

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -173,9 +173,9 @@ class SpeculativeConfig:
         the final hidden states.
         """
         factors: list[Any] = []
-        # Eagle3 affects the computation graph because it returns intermediate
-        # hidden states in addition to the final hidden state.
-        factors.append(self.method == "eagle3")
+        # Eagle3 and DFlash affect the computation graph because they return
+        # intermediate hidden states in addition to the final hidden state.
+        factors.append(self.method in ("eagle3", "dflash"))
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -735,7 +735,7 @@ class SpeculativeConfig:
                 )
 
     def use_eagle(self) -> bool:
-        return self.method in ("eagle", "eagle3", "mtp")
+        return self.method in ("eagle", "eagle3", "mtp", "dflash")
 
     def uses_draft_model(self) -> bool:
         return self.method == "draft_model"

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -719,7 +719,7 @@ class SpeculativeConfig:
 
     def verify_equal_vocab_size_if_draft_model(self):
         if (
-            self.method == "draft_model"
+            self.method in ("draft_model", "dflash")
             and self.target_model_config is not None
             and self.draft_model_config is not None
         ):

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -1,0 +1,502 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from torch import nn
+from transformers import Qwen3Config
+
+from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
+from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.logger import init_logger
+from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    maybe_remap_kv_scale_name,
+)
+from vllm.multimodal.inputs import NestedTensors
+from vllm.transformers_utils.config import set_default_rope_theta
+from vllm.v1.attention.backend import AttentionType
+
+from .qwen2 import Qwen2MLP as Qwen3MLP
+from .qwen3 import Qwen3ForCausalLM
+from .utils import (
+    AutoWeightsLoader,
+    extract_layer_index,
+    get_draft_quant_config,
+    maybe_prefix,
+    process_eagle_weight,
+)
+
+logger = init_logger(__name__)
+
+
+class DFlashQwen3Attention(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_parameters: dict,
+        max_position: int = 4096 * 32,
+        head_dim: int | None = None,
+        rms_norm_eps: float = 1e-06,
+        qkv_bias: bool = False,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        attn_type: str = AttentionType.DECODER,
+        dual_chunk_attention_config: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        tp_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = num_heads
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = num_kv_heads
+        if self.total_num_kv_heads >= tp_size:
+            assert self.total_num_kv_heads % tp_size == 0
+        else:
+            assert tp_size % self.total_num_kv_heads == 0
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.head_dim = head_dim or hidden_size // self.total_num_heads
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=qkv_bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            max_position=max_position,
+            rope_parameters=rope_parameters,
+            dual_chunk_attention_config=dual_chunk_attention_config,
+        )
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            num_kv_heads=self.num_kv_heads,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn",
+            attn_type=attn_type,
+            **{
+                "layer_idx": extract_layer_index(prefix),
+                "dual_chunk_attention_config": dual_chunk_attention_config,
+            }
+            if dual_chunk_attention_config
+            else {},
+        )
+        self.q_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+        self.k_norm = RMSNorm(self.head_dim, eps=rms_norm_eps)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        context_states: torch.Tensor,
+    ) -> torch.Tensor:
+        # DFlash attends with query tokens against the context+query KV states.
+        num_context_tokens = context_states.shape[0]
+        concat_states = torch.cat([context_states, hidden_states], dim=0)
+
+        qkv, _ = self.qkv_proj(concat_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+
+        q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
+        k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
+        q = self.q_norm(q_by_head).view(q.shape)
+        k = self.k_norm(k_by_head).view(k.shape)
+
+        q, k = self.rotary_emb(positions, q, k)
+
+        q = q[num_context_tokens:]
+        attn_output = self.attn(q, k, v)
+        output, _ = self.o_proj(attn_output)
+        return output
+
+
+class DFlashQwen3DecoderLayer(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        *,
+        config: Qwen3Config,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        layer_idx: int = 0,
+    ) -> None:
+        del layer_idx
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        set_default_rope_theta(config, default_theta=1000000)
+        dual_chunk_attention_config = getattr(
+            config, "dual_chunk_attention_config", None
+        )
+
+        self.self_attn = DFlashQwen3Attention(
+            hidden_size=self.hidden_size,
+            num_heads=config.num_attention_heads,
+            max_position=config.max_position_embeddings,
+            num_kv_heads=config.num_key_value_heads,
+            rms_norm_eps=config.rms_norm_eps,
+            qkv_bias=getattr(config, "attention_bias", False),
+            head_dim=getattr(config, "head_dim", None),
+            cache_config=cache_config,
+            quant_config=quant_config,
+            rope_parameters=config.rope_parameters,
+            prefix=f"{prefix}.self_attn",
+            attn_type=AttentionType.DECODER,
+            dual_chunk_attention_config=dual_chunk_attention_config,
+        )
+        self.mlp = Qwen3MLP(
+            hidden_size=self.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            prefix=f"{prefix}.mlp",
+        )
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        context_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+            context_states=context_states,
+        )
+
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+class DFlashQwen3Model(nn.Module):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        start_layer_id: int = 0,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.vocab_size = self.config.vocab_size
+        self.quant_config = get_draft_quant_config(vllm_config)
+
+        drafter_config: dict[str, Any] = {}
+        eagle_config = getattr(self.config, "eagle_config", None)
+        dflash_config = getattr(self.config, "dflash_config", None)
+        if isinstance(eagle_config, dict):
+            drafter_config.update(eagle_config)
+        if isinstance(dflash_config, dict):
+            drafter_config.update(dflash_config)
+
+        self.use_aux_hidden_state = drafter_config.get("use_aux_hidden_state", True)
+
+        current_vllm_config = get_current_vllm_config()
+
+        self.embed_tokens = VocabParallelEmbedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
+        )
+
+        self.layers = nn.ModuleList(
+            [
+                DFlashQwen3DecoderLayer(
+                    current_vllm_config,
+                    prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
+                    config=self.config,
+                    layer_idx=layer_idx,
+                )
+                for layer_idx in range(self.config.num_hidden_layers)
+            ]
+        )
+
+        if self.use_aux_hidden_state:
+            layer_ids = drafter_config.get("layer_ids")
+            if isinstance(layer_ids, (list, tuple)) and len(layer_ids) > 0:
+                num_features_to_use = len(layer_ids)
+            else:
+                num_features_to_use = 3
+
+            if hasattr(self.config, "target_hidden_size"):
+                fc_input_size = self.config.target_hidden_size * num_features_to_use
+            else:
+                fc_input_size = self.config.hidden_size * num_features_to_use
+
+            self.fc = ReplicatedLinear(
+                input_size=fc_input_size,
+                output_size=self.config.hidden_size,
+                bias=False,
+                params_dtype=vllm_config.model_config.dtype,
+                quant_config=self.quant_config,
+                prefix=maybe_prefix(prefix, "fc"),
+                return_bias=False,
+            )
+
+        self.hidden_norm = RMSNorm(
+            self.config.hidden_size,
+            eps=self.config.rms_norm_eps,
+        )
+        self.norm = RMSNorm(
+            self.config.hidden_size,
+            eps=self.config.rms_norm_eps,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        input_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if input_embeds is None:
+            input_embeds = self.embed_input_ids(input_ids)
+
+        assert hidden_states.shape[-1] == input_embeds.shape[-1]
+
+        context_states = hidden_states
+        hidden_states = input_embeds
+
+        residual = None
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions=positions,
+                hidden_states=hidden_states,
+                context_states=context_states,
+                residual=residual,
+            )
+
+        hidden_states, hidden_prenorm = self.norm(hidden_states, residual)
+        return hidden_states, hidden_prenorm
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if "midlayer." in name:
+                name = name.replace("midlayer.", "layers.0.")
+            if self.quant_config is not None and (
+                scale_name := self.quant_config.get_cache_scale(name)
+            ):
+                param = params_dict[scale_name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                loaded_weight = (
+                    loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
+                )
+                weight_loader(param, loaded_weight)
+                loaded_params.add(scale_name)
+                continue
+            if "scale" in name or "zero_point" in name:
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        nn.Module.__init__(self)
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+
+        if getattr(self.config, "draft_vocab_size", None) is None:
+            self.config.draft_vocab_size = getattr(self.config, "vocab_size", None)
+
+        target_layer_num = vllm_config.model_config.get_num_layers(
+            vllm_config.parallel_config
+        )
+        self.config.target_layer_count = target_layer_num
+
+        self.model = DFlashQwen3Model(
+            vllm_config=vllm_config,
+            prefix="model",
+            start_layer_id=target_layer_num,
+        )
+
+        logit_scale = getattr(self.config, "logit_scale", 1.0)
+        self.lm_head = ParallelLMHead(
+            self.config.draft_vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(
+            self.config.draft_vocab_size, scale=logit_scale
+        )
+
+        self.draft_id_to_target_id = nn.Parameter(
+            torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
+            requires_grad=False,
+        )
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        del layers
+
+    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        dflash_config = getattr(self.config, "dflash_config", None)
+        if isinstance(dflash_config, dict):
+            layer_ids = dflash_config.get("layer_ids")
+            if isinstance(layer_ids, (list, tuple)) and len(layer_ids) > 0:
+                return tuple(int(layer_id) for layer_id in layer_ids)
+
+        target_layer_count = getattr(self.config, "target_layer_count", None)
+        if isinstance(target_layer_count, int) and target_layer_count >= 3:
+            return (2, target_layer_count // 2, target_layer_count - 3)
+
+        return super().get_eagle3_aux_hidden_state_layers()
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: NestedTensors | None = None,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del multimodal_embeddings, is_multimodal
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.model(input_ids, positions, hidden_states, inputs_embeds)
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor | None:
+        logits = self.logits_processor(self.lm_head, hidden_states)
+        if self.draft_id_to_target_id is None:
+            assert logits.shape[1] == self.config.vocab_size, (
+                "Expected logits to have shape "
+                f"(*, {self.config.vocab_size}), but got {logits.shape}"
+            )
+            return logits
+
+        base = torch.arange(self.config.draft_vocab_size, device=logits.device)
+        targets = base + self.draft_id_to_target_id
+        logits_new = logits.new_full(
+            (
+                logits.shape[0],
+                self.config.vocab_size,
+            ),
+            float("-inf"),
+        )
+        logits_new[:, targets] = logits
+        return logits_new
+
+    def combine_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        if not self.model.use_aux_hidden_state:
+            return hidden_states
+        return self.model.hidden_norm(self.model.fc(hidden_states))
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        model_weights = {}
+        includes_draft_id_mapping = False
+        includes_embed_tokens = False
+
+        for name, loaded_weight in weights:
+            if "t2d" in name:
+                continue
+            if "d2t" in name:
+                name = name.replace("d2t", "draft_id_to_target_id")
+                includes_draft_id_mapping = True
+            elif "lm_head" not in name:
+                name = "model." + name
+
+            if "embed_tokens" in name:
+                includes_embed_tokens = True
+
+            model_weights[name] = loaded_weight
+            process_eagle_weight(self, name)
+
+        skip_substrs = []
+        if not includes_draft_id_mapping:
+            skip_substrs.append("draft_id_to_target_id")
+        if not includes_embed_tokens:
+            skip_substrs.append("embed_tokens")
+        if not self.model.use_aux_hidden_state:
+            skip_substrs.append("fc.")
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=None,
+            skip_substrs=skip_substrs,
+        )
+        loader.load_weights(model_weights.items())

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -485,6 +485,7 @@ _MULTIMODAL_MODELS = {
 
 _SPECULATIVE_DECODING_MODELS = {
     "MiMoMTPModel": ("mimo_mtp", "MiMoMTP"),
+    "DFlashDraftModel": ("qwen3", "Qwen3ForCausalLM"),
     "EagleLlamaForCausalLM": ("llama_eagle", "EagleLlamaForCausalLM"),
     "EagleLlama4ForCausalLM": ("llama4_eagle", "EagleLlama4ForCausalLM"),
     "EagleMiniCPMForCausalLM": ("minicpm_eagle", "EagleMiniCPMForCausalLM"),

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -485,7 +485,7 @@ _MULTIMODAL_MODELS = {
 
 _SPECULATIVE_DECODING_MODELS = {
     "MiMoMTPModel": ("mimo_mtp", "MiMoMTP"),
-    "DFlashDraftModel": ("qwen3", "Qwen3ForCausalLM"),
+    "DFlashDraftModel": ("qwen3_dflash", "DFlashQwen3ForCausalLM"),
     "EagleLlamaForCausalLM": ("llama_eagle", "EagleLlamaForCausalLM"),
     "EagleLlama4ForCausalLM": ("llama4_eagle", "EagleLlama4ForCausalLM"),
     "EagleMiniCPMForCausalLM": ("minicpm_eagle", "EagleMiniCPMForCausalLM"),

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -40,3 +40,12 @@ class DFlashProposer(EagleProposer):
             )
 
         return use_aux_hidden_state
+
+    def propose(self, *args, **kwargs) -> torch.Tensor:
+        common_attn_metadata = kwargs.get("common_attn_metadata")
+        if common_attn_metadata is not None and common_attn_metadata.batch_size() > 1:
+            raise NotImplementedError(
+                "DFlash speculative decoding currently supports batch size 1 only. "
+                "Please reduce max_num_seqs to 1 for method='dflash'."
+            )
+        return super().propose(*args, **kwargs)

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.v1.spec_decode.eagle import EagleProposer
+
+
+class DFlashProposer(EagleProposer):
+    """Dedicated proposer for method='dflash' with DFlash-specific config."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        runner=None,
+    ):
+        super().__init__(vllm_config=vllm_config, device=device, runner=runner)
+
+    def _get_eagle3_use_aux_hidden_state_from_config(self) -> bool:
+        """
+        DFlash config precedence:
+        1) dflash_config.use_aux_hidden_state
+        2) eagle_config.use_aux_hidden_state
+        3) default True
+        """
+        use_aux_hidden_state = True
+
+        eagle_config = getattr(self.draft_model_config.hf_config, "eagle_config", None)
+        if isinstance(eagle_config, dict):
+            use_aux_hidden_state = eagle_config.get("use_aux_hidden_state", True)
+
+        dflash_config = getattr(
+            self.draft_model_config.hf_config, "dflash_config", None
+        )
+        if isinstance(dflash_config, dict):
+            use_aux_hidden_state = dflash_config.get(
+                "use_aux_hidden_state", use_aux_hidden_state
+            )
+
+        return use_aux_hidden_state

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -3,8 +3,14 @@
 
 import torch
 
-from vllm.config import VllmConfig
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.forward_context import set_forward_context
+from vllm.logger import init_logger
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.eagle import EagleProposer
+
+logger = init_logger(__name__)
 
 
 class DFlashProposer(EagleProposer):
@@ -17,6 +23,49 @@ class DFlashProposer(EagleProposer):
         runner=None,
     ):
         super().__init__(vllm_config=vllm_config, device=device, runner=runner)
+        self.runtime_mode = self._get_dflash_runtime_mode_from_config()
+        self.mask_token_id = self._resolve_mask_token_id_from_config()
+
+    def _get_dflash_runtime_mode_from_config(self) -> str:
+        dflash_config = getattr(self.draft_model_config.hf_config, "dflash_config", {})
+        if not isinstance(dflash_config, dict):
+            dflash_config = {}
+
+        runtime_mode = dflash_config.get("runtime_mode", "shared_eagle")
+        if runtime_mode not in ("shared_eagle", "block_drafting"):
+            raise ValueError(
+                "Invalid dflash_config.runtime_mode. "
+                "Expected one of ['shared_eagle', 'block_drafting'], "
+                f"got {runtime_mode!r}."
+            )
+        return runtime_mode
+
+    def _resolve_mask_token_id_from_config(self) -> int | None:
+        hf_config = self.draft_model_config.hf_config
+        dflash_config = getattr(hf_config, "dflash_config", {})
+        if not isinstance(dflash_config, dict):
+            dflash_config = {}
+
+        candidates = (
+            dflash_config.get("mask_token_id"),
+            getattr(hf_config, "mask_token_id", None),
+            getattr(hf_config, "pard_token", None),
+            getattr(hf_config, "ptd_token_id", None),
+            getattr(hf_config, "pad_token_id", None),
+        )
+        for candidate in candidates:
+            if not isinstance(candidate, int):
+                continue
+            if candidate < 0:
+                continue
+            vocab_size = getattr(hf_config, "vocab_size", None)
+            if isinstance(vocab_size, int) and candidate >= vocab_size:
+                raise ValueError(
+                    "Resolved DFlash mask token id is out of vocab bounds: "
+                    f"{candidate} >= vocab_size ({vocab_size})."
+                )
+            return candidate
+        return None
 
     def _get_eagle3_use_aux_hidden_state_from_config(self) -> bool:
         """
@@ -41,11 +90,238 @@ class DFlashProposer(EagleProposer):
 
         return use_aux_hidden_state
 
-    def propose(self, *args, **kwargs) -> torch.Tensor:
-        common_attn_metadata = kwargs.get("common_attn_metadata")
-        if common_attn_metadata is not None and common_attn_metadata.batch_size() > 1:
-            raise NotImplementedError(
-                "DFlash speculative decoding currently supports batch size 1 only. "
-                "Please reduce max_num_seqs to 1 for method='dflash'."
+    def _maybe_combine_target_hidden_states(
+        self, target_hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        if not hasattr(self.model, "combine_hidden_states"):
+            return target_hidden_states
+        target_hidden_states = self.model.combine_hidden_states(target_hidden_states)
+        if target_hidden_states.shape[-1] != self.hidden_size:
+            raise RuntimeError(
+                "DFlash combined hidden size mismatch: "
+                f"expected {self.hidden_size}, got {target_hidden_states.shape[-1]}."
             )
-        return super().propose(*args, **kwargs)
+        return target_hidden_states
+
+    def _propose_shared_eagle(
+        self,
+        target_token_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        token_indices_to_sample: torch.Tensor | None,
+        common_attn_metadata: CommonAttentionMetadata,
+        sampling_metadata: SamplingMetadata,
+        mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+        num_rejected_tokens_gpu: torch.Tensor | None = None,
+        slot_mappings: dict[str, torch.Tensor]
+        | list[dict[str, torch.Tensor]]
+        | None = None,
+    ) -> torch.Tensor:
+        return super().propose(
+            target_token_ids=target_token_ids,
+            target_positions=target_positions,
+            target_hidden_states=target_hidden_states,
+            next_token_ids=next_token_ids,
+            token_indices_to_sample=token_indices_to_sample,
+            common_attn_metadata=common_attn_metadata,
+            sampling_metadata=sampling_metadata,
+            mm_embed_inputs=mm_embed_inputs,
+            num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+            slot_mappings=slot_mappings,
+        )
+
+    def _propose_block_drafting(
+        self,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        common_attn_metadata: CommonAttentionMetadata,
+    ) -> torch.Tensor:
+        if self.mask_token_id is None:
+            raise ValueError(
+                "DFlash block_drafting requires a resolved mask token id. "
+                "Set dflash_config.mask_token_id (or compatible fallback fields)."
+            )
+
+        batch_size = common_attn_metadata.batch_size()
+        if batch_size != 1:
+            raise NotImplementedError(
+                "DFlash block_drafting currently supports batch size 1 only. "
+                "Use runtime_mode='shared_eagle' for larger batches."
+            )
+        if (
+            self.uses_mrope
+            or self.uses_xdrope_dim > 0
+            or self.draft_uses_xdrope_dim > 0
+        ):
+            raise NotImplementedError(
+                "DFlash block_drafting does not support M-RoPE/XD-RoPE in this release."
+            )
+        if target_positions.dim() != 1:
+            raise NotImplementedError(
+                "DFlash block_drafting currently expects 1D position ids."
+            )
+        if self.indexer_layer_names:
+            raise NotImplementedError(
+                "DFlash block_drafting does not support indexer layers in this release."
+            )
+
+        assert self.runner is not None
+        if self.attn_metadata_builder is None:
+            attn_metadata_builder = self._get_attention_metadata_builder()
+        else:
+            attn_metadata_builder = self.attn_metadata_builder
+
+        num_context_tokens = target_hidden_states.shape[0]
+        num_query_tokens = 1 + self.num_speculative_tokens
+        num_kv_tokens = num_context_tokens + num_query_tokens
+
+        last_position = int(target_positions[-1].item())
+        query_positions = (
+            torch.arange(
+                num_query_tokens,
+                device=target_positions.device,
+                dtype=target_positions.dtype,
+            )
+            + last_position
+            + 1
+        )
+        position_ids = torch.cat([target_positions, query_positions], dim=0)
+
+        block_size = attn_metadata_builder.kv_cache_spec.block_size
+        block_numbers = query_positions // block_size
+        block_ids = common_attn_metadata.block_table_tensor.gather(
+            dim=1, index=block_numbers.view(1, -1)
+        ).view(-1)
+        slot_mapping = block_ids * block_size + (query_positions % block_size)
+
+        # Build non-causal metadata for query tokens only.
+        common_attn_metadata.slot_mapping = slot_mapping
+        common_attn_metadata.num_actual_tokens = num_query_tokens
+        common_attn_metadata.max_query_len = num_query_tokens
+        common_attn_metadata.query_start_loc = (
+            self.arange[: batch_size + 1] * num_query_tokens
+        )
+        common_attn_metadata.query_start_loc_cpu = (
+            torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone()
+            * num_query_tokens
+        )
+        common_attn_metadata.max_seq_len += num_query_tokens
+        common_attn_metadata.seq_lens += num_query_tokens
+        common_attn_metadata._seq_lens_cpu = None
+        common_attn_metadata._num_computed_tokens_cpu = None
+        common_attn_metadata.causal = False
+
+        attn_metadata = attn_metadata_builder.build_for_drafting(
+            common_attn_metadata=common_attn_metadata, draft_index=0
+        )
+        if hasattr(attn_metadata, "causal") and attn_metadata.causal:
+            raise NotImplementedError(
+                "DFlash block_drafting requires non-causal attention metadata."
+            )
+        per_layer_attn_metadata = {
+            layer_name: attn_metadata for layer_name in self.attn_layer_names
+        }
+
+        # Query input is [next_token, mask, mask, ...].
+        self.input_ids[:num_query_tokens].fill_(self.mask_token_id)
+        self.input_ids[0] = next_token_ids[0]
+        self._set_positions(num_kv_tokens, position_ids)
+        self.hidden_states[:num_context_tokens] = target_hidden_states
+
+        # NOTE: block_drafting currently runs in eager mode to avoid
+        # cudagraph/padding complexity while we stabilize correctness.
+        with set_forward_context(
+            per_layer_attn_metadata,
+            self.vllm_config,
+            num_tokens=num_query_tokens,
+            cudagraph_runtime_mode=CUDAGraphMode.NONE,
+            slot_mapping=self._get_slot_mapping(
+                num_query_tokens, common_attn_metadata.slot_mapping
+            ),
+        ):
+            ret_hidden_states = self.model(
+                input_ids=self.input_ids[:num_query_tokens],
+                positions=self._get_positions(num_kv_tokens),
+                hidden_states=self.hidden_states[:num_context_tokens],
+                inputs_embeds=None,
+            )
+            if not self.model_returns_tuple():
+                last_hidden_states = ret_hidden_states
+            else:
+                last_hidden_states, _ = ret_hidden_states
+
+        # Skip the first query token (the sampled next token), and use mask slots.
+        sample_hidden_states = last_hidden_states[1:num_query_tokens]
+        logits = self.model.compute_logits(sample_hidden_states)
+        return logits.argmax(dim=-1).view(1, self.num_speculative_tokens)
+
+    def propose(
+        self,
+        target_token_ids: torch.Tensor,
+        target_positions: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        next_token_ids: torch.Tensor,
+        token_indices_to_sample: torch.Tensor | None,
+        common_attn_metadata: CommonAttentionMetadata,
+        sampling_metadata: SamplingMetadata,
+        mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
+        num_rejected_tokens_gpu: torch.Tensor | None = None,
+        slot_mappings: dict[str, torch.Tensor]
+        | list[dict[str, torch.Tensor]]
+        | None = None,
+    ) -> torch.Tensor:
+        target_hidden_states = self._maybe_combine_target_hidden_states(
+            target_hidden_states
+        )
+
+        if self.runtime_mode == "shared_eagle":
+            draft_token_ids = self._propose_shared_eagle(
+                target_token_ids=target_token_ids,
+                target_positions=target_positions,
+                target_hidden_states=target_hidden_states,
+                next_token_ids=next_token_ids,
+                token_indices_to_sample=token_indices_to_sample,
+                common_attn_metadata=common_attn_metadata,
+                sampling_metadata=sampling_metadata,
+                mm_embed_inputs=mm_embed_inputs,
+                num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+                slot_mappings=slot_mappings,
+            )
+        else:
+            if common_attn_metadata.batch_size() > 1:
+                logger.warning_once(
+                    "DFlash block_drafting does not yet support batch_size>1; "
+                    "falling back to shared_eagle path for this batch."
+                )
+                draft_token_ids = self._propose_shared_eagle(
+                    target_token_ids=target_token_ids,
+                    target_positions=target_positions,
+                    target_hidden_states=target_hidden_states,
+                    next_token_ids=next_token_ids,
+                    token_indices_to_sample=token_indices_to_sample,
+                    common_attn_metadata=common_attn_metadata,
+                    sampling_metadata=sampling_metadata,
+                    mm_embed_inputs=mm_embed_inputs,
+                    num_rejected_tokens_gpu=num_rejected_tokens_gpu,
+                    slot_mappings=slot_mappings,
+                )
+            else:
+                draft_token_ids = self._propose_block_drafting(
+                    target_positions=target_positions,
+                    target_hidden_states=target_hidden_states,
+                    next_token_ids=next_token_ids,
+                    common_attn_metadata=common_attn_metadata,
+                )
+
+        expected_shape = (
+            common_attn_metadata.batch_size(),
+            self.num_speculative_tokens,
+        )
+        if tuple(draft_token_ids.shape) != expected_shape:
+            raise RuntimeError(
+                "DFlash proposer returned an unexpected draft token shape. "
+                f"Expected {expected_shape}, got {tuple(draft_token_ids.shape)}."
+            )
+        return draft_token_ids

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1592,28 +1592,20 @@ class SpecDecodeBaseProposer:
 
     def _get_eagle3_use_aux_hidden_state_from_config(self) -> bool:
         """
-        Some eagle3/dflash heads do not use auxiliary hidden states and
+        Some eagle3 heads do not use auxiliary hidden states and
         directly use the last layer output like eagle1.
 
         Config precedence:
-        1) dflash_config.use_aux_hidden_state (for method=dflash)
-        2) eagle_config.use_aux_hidden_state
-        3) default True
+        1) eagle_config.use_aux_hidden_state
+        2) default True
         """
-        if self.method not in ("eagle3", "dflash"):
+        if self.method != "eagle3":
             return False
 
         use_aux_hidden_state = True
         eagle_config = getattr(self.draft_model_config.hf_config, "eagle_config", None)
         if isinstance(eagle_config, dict):
             use_aux_hidden_state = eagle_config.get("use_aux_hidden_state", True)
-        dflash_config = getattr(
-            self.draft_model_config.hf_config, "dflash_config", None
-        )
-        if isinstance(dflash_config, dict):
-            use_aux_hidden_state = dflash_config.get(
-                "use_aux_hidden_state", use_aux_hidden_state
-            )
         return use_aux_hidden_state
 
     def validate_same_kv_cache_group(self, kv_cache_config: KVCacheConfig) -> None:

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1592,18 +1592,28 @@ class SpecDecodeBaseProposer:
 
     def _get_eagle3_use_aux_hidden_state_from_config(self) -> bool:
         """
-        Some eagle3 heads (e.g., nvidia/gpt-oss-120b-Eagle3-v2) do not use auxiliary
-        hidden states and directly uses the last layer output just like eagle1.
-        They might indicate this by setting "use_aux_hidden_state" to False
-        inside the "eagle_config" dict of their hf_config.
+        Some eagle3/dflash heads do not use auxiliary hidden states and
+        directly use the last layer output like eagle1.
+
+        Config precedence:
+        1) dflash_config.use_aux_hidden_state (for method=dflash)
+        2) eagle_config.use_aux_hidden_state
+        3) default True
         """
-        if self.method != "eagle3":
+        if self.method not in ("eagle3", "dflash"):
             return False
-        # Assume that eagle3 heads use aux hidden states by default
+
         use_aux_hidden_state = True
         eagle_config = getattr(self.draft_model_config.hf_config, "eagle_config", None)
-        if eagle_config is not None:
+        if isinstance(eagle_config, dict):
             use_aux_hidden_state = eagle_config.get("use_aux_hidden_state", True)
+        dflash_config = getattr(
+            self.draft_model_config.hf_config, "dflash_config", None
+        )
+        if isinstance(dflash_config, dict):
+            use_aux_hidden_state = dflash_config.get(
+                "use_aux_hidden_state", use_aux_hidden_state
+            )
         return use_aux_hidden_state
 
     def validate_same_kv_cache_group(self, kv_cache_config: KVCacheConfig) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable --> 

## Purpose
This PR **introduces first-class DFlash speculative decoding support** in vLLM V1.

This is the **initial DFlash implementation in vLLM**. Prior to this change, vLLM did not support DFlash speculative decoding. This PR establishes an explicit, config-driven DFlash execution path with correctness and maintainability guarantees.

Key changes:
- Adds explicit `method="dflash"` support and full DFlash model/config plumbing.
- Establishes a dedicated `DFlashProposer` execution path (separate from EAGLE), including:
  - `shared_eagle` runtime mode.
  - `block_drafting` runtime mode.
- Hardens DFlash correctness for both BS=1 and BS>1 workloads via:
  - per-sequence metadata handling and slot-mapping logic
  - shape and invariant validation
  - backend capability checks for non-causal drafting
- Removes hardcoded DFlash runtime assumptions in favor of config-driven behavior.
- Expands DFlash coverage across unit and end-to-end speculative decoding tests.
- Adds runtime hardening to reduce per-step allocation overhead in DFlash block drafting.

## Test Plan

Testing focuses on DFlash proposer correctness, backend compatibility, and speculative decoding invariants across batch sizes.

- Run DFlash proposer and unit tests.
- Run DFlash backend guard tests in the GPU model runner.
- Run targeted speculative decoding end-to-end coverage updates in CI.

Commands run locally:
- `python -m pytest -q tests/v1/spec_decode/test_dflash.py`
- `python -m pytest -q tests/v1/worker/test_gpu_model_runner.py -k "dflash_metadata_builder or raise_if_unsupported_dflash_backend"`

## Test Result
- `tests/v1/spec_decode/test_dflash.py`: **22 passed**
- `tests/v1/worker/test_gpu_model_runner.py -k "dflash_metadata_builder or raise_if_unsupported_dflash_backend"`: **4 passed**

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

