### PR TITLE
[Misc] Add backward-compatible import aliases for renamed translations module

### DIFF
--- a/vllm/entrypoints/openai/translations/__init__.py
+++ b/vllm/entrypoints/openai/translations/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import warnings
+
+warnings.warn(
+    "The 'vllm.entrypoints.openai.translations' module has been renamed to "
+    "'vllm.entrypoints.openai.speech_to_text'. Please update your imports. "
+    "This backward-compatible alias will be removed in version 0.17+.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/vllm/entrypoints/openai/translations/api_router.py
+++ b/vllm/entrypoints/openai/translations/api_router.py
@@ -12,12 +12,3 @@ warnings.warn(
 )
 
 from vllm.entrypoints.openai.speech_to_text.api_router import *  # noqa: F401,F403,E402
-from vllm.entrypoints.openai.speech_to_text.api_router import (  # noqa: E402
-    attach_router,
-    create_transcriptions,
-    create_translations,
-    init_transcription_state,
-    router,
-    transcription,
-    translation,
-)

--- a/vllm/entrypoints/openai/translations/api_router.py
+++ b/vllm/entrypoints/openai/translations/api_router.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import warnings
+
+warnings.warn(
+    "'vllm.entrypoints.openai.translations.api_router' has been moved to "
+    "'vllm.entrypoints.openai.speech_to_text.api_router'. Please update your "
+    "imports. This backward-compatible alias will be removed in version 0.17+.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from vllm.entrypoints.openai.speech_to_text.api_router import *  # noqa: F401,F403,E402
+from vllm.entrypoints.openai.speech_to_text.api_router import (  # noqa: E402
+    attach_router,
+    create_transcriptions,
+    create_translations,
+    init_transcription_state,
+    router,
+    transcription,
+    translation,
+)

--- a/vllm/entrypoints/openai/translations/protocol.py
+++ b/vllm/entrypoints/openai/translations/protocol.py
@@ -12,23 +12,3 @@ warnings.warn(
 )
 
 from vllm.entrypoints.openai.speech_to_text.protocol import *  # noqa: F401,F403,E402
-from vllm.entrypoints.openai.speech_to_text.protocol import (  # noqa: E402
-    AudioResponseFormat,
-    TranscriptionRequest,
-    TranscriptionResponse,
-    TranscriptionResponseStreamChoice,
-    TranscriptionResponseVariant,
-    TranscriptionResponseVerbose,
-    TranscriptionSegment,
-    TranscriptionStreamResponse,
-    TranscriptionUsageAudio,
-    TranscriptionWord,
-    TranslationRequest,
-    TranslationResponse,
-    TranslationResponseStreamChoice,
-    TranslationResponseVariant,
-    TranslationResponseVerbose,
-    TranslationSegment,
-    TranslationStreamResponse,
-    TranslationWord,
-)

--- a/vllm/entrypoints/openai/translations/protocol.py
+++ b/vllm/entrypoints/openai/translations/protocol.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import warnings
+
+warnings.warn(
+    "'vllm.entrypoints.openai.translations.protocol' has been moved to "
+    "'vllm.entrypoints.openai.speech_to_text.protocol'. Please update your "
+    "imports. This backward-compatible alias will be removed in version 0.17+.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from vllm.entrypoints.openai.speech_to_text.protocol import *  # noqa: F401,F403,E402
+from vllm.entrypoints.openai.speech_to_text.protocol import (  # noqa: E402
+    AudioResponseFormat,
+    TranscriptionRequest,
+    TranscriptionResponse,
+    TranscriptionResponseStreamChoice,
+    TranscriptionResponseVariant,
+    TranscriptionResponseVerbose,
+    TranscriptionSegment,
+    TranscriptionStreamResponse,
+    TranscriptionUsageAudio,
+    TranscriptionWord,
+    TranslationRequest,
+    TranslationResponse,
+    TranslationResponseStreamChoice,
+    TranslationResponseVariant,
+    TranslationResponseVerbose,
+    TranslationSegment,
+    TranslationStreamResponse,
+    TranslationWord,
+)

--- a/vllm/entrypoints/openai/translations/serving.py
+++ b/vllm/entrypoints/openai/translations/serving.py
@@ -12,7 +12,3 @@ warnings.warn(
 )
 
 from vllm.entrypoints.openai.speech_to_text.serving import *  # noqa: F401,F403,E402
-from vllm.entrypoints.openai.speech_to_text.serving import (  # noqa: E402
-    OpenAIServingTranscription,
-    OpenAIServingTranslation,
-)

--- a/vllm/entrypoints/openai/translations/serving.py
+++ b/vllm/entrypoints/openai/translations/serving.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import warnings
+
+warnings.warn(
+    "'vllm.entrypoints.openai.translations.serving' has been moved to "
+    "'vllm.entrypoints.openai.speech_to_text.serving'. Please update your "
+    "imports. This backward-compatible alias will be removed in version 0.17+.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from vllm.entrypoints.openai.speech_to_text.serving import *  # noqa: F401,F403,E402
+from vllm.entrypoints.openai.speech_to_text.serving import (  # noqa: E402
+    OpenAIServingTranscription,
+    OpenAIServingTranslation,
+)

--- a/vllm/entrypoints/openai/translations/speech_to_text.py
+++ b/vllm/entrypoints/openai/translations/speech_to_text.py
@@ -13,6 +13,3 @@ warnings.warn(
 )
 
 from vllm.entrypoints.openai.speech_to_text.speech_to_text import *  # noqa: F401,F403,E402
-from vllm.entrypoints.openai.speech_to_text.speech_to_text import (  # noqa: E402
-    OpenAISpeechToText,
-)

--- a/vllm/entrypoints/openai/translations/speech_to_text.py
+++ b/vllm/entrypoints/openai/translations/speech_to_text.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import warnings
+
+warnings.warn(
+    "'vllm.entrypoints.openai.translations.speech_to_text' has been moved to "
+    "'vllm.entrypoints.openai.speech_to_text.speech_to_text'. Please update "
+    "your imports. This backward-compatible alias will be removed in version "
+    "0.17+.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from vllm.entrypoints.openai.speech_to_text.speech_to_text import *  # noqa: F401,F403,E402
+from vllm.entrypoints.openai.speech_to_text.speech_to_text import (  # noqa: E402
+    OpenAISpeechToText,
+)


### PR DESCRIPTION
## Summary

- PR #33904 renamed `vllm.entrypoints.openai.translations` to `vllm.entrypoints.openai.speech_to_text`, which breaks any downstream code importing from the old path.
- This PR restores the old `vllm.entrypoints.openai.translations` package as thin backward-compatible stubs that re-export everything from the new `speech_to_text` location while emitting a `DeprecationWarning` on import.
- The deprecation warnings instruct users to update their imports and are scheduled for removal in version **0.17+**.

### Files added
| File | Re-exports from |
|------|----------------|
| `translations/__init__.py` | (warns on package import) |
| `translations/protocol.py` | `speech_to_text.protocol` |
| `translations/api_router.py` | `speech_to_text.api_router` |
| `translations/serving.py` | `speech_to_text.serving` |
| `translations/speech_to_text.py` | `speech_to_text.speech_to_text` |

## Test plan
- Verified that `from vllm.entrypoints.openai.translations.protocol import TranscriptionRequest` works and emits `DeprecationWarning`.
- Verified that the imported symbols are identical to those from the new `speech_to_text` path.


Made with [Cursor](https://cursor.com)