### PR TITLE
[ModelRunner V2] Revert token rank comparison difference for now

### DIFF
--- a/vllm/v1/worker/gpu/sample/logprob.py
+++ b/vllm/v1/worker/gpu/sample/logprob.py
@@ -68,7 +68,7 @@ def _ranks_kernel(
     for i in range(0, vocab_size, BLOCK_SIZE):
         block = i + tl.arange(0, BLOCK_SIZE)
         logits = tl.load(row_ptr + block, mask=block < vocab_size, other=float("-inf"))
-        n += tl.sum((logits > x).to(tl.int32))
+        n += tl.sum((logits >= x).to(tl.int32))
     tl.store(output_ptr + req_idx, n)
 
 


### PR DESCRIPTION
We think it makes more sense to use a strict inequality for the token rank computation, but would be best to propose this in a separate PR since it involves a behavior change and is orthogonal to MRV2.

Making this consistent with V1 will help with output equivalence tests. We can subsequently change it in both places if needed (or make configurable if that's really a problem).