### PR TITLE
[Quantization][Refactor] Clean up GPTQ + AWQ quantization

### DIFF
--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/MPLinearKernel.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/MPLinearKernel.py
@@ -21,6 +21,7 @@ class MPLinearLayerConfig:
     zero_points: bool
     has_g_idx: bool
     out_type: torch.dtype | None = None
+    checkpoint_format: str = ""
 
 
 class MPLinearKernel(ABC):


### PR DESCRIPTION

## Purpose
Addresses #31689. Building on `gptq_marlin.py` per @robertgshaw2-redhat's guidance to consolidate GPTQ/AWQ quantization and remove the legacy code paths.

So far: widened `GPTQMarlinConfig` to handle all GPTQ bit-widths and symmetry configs through the `MPLinearKernel` abstraction, added GPTQv2 checkpoint format support, and enabled 2/3-bit types in ExllamaLinearKernel.

Still TODO: validate all kernel backends end-to-end, remove `gptq.py`, convert `moe_wna16.py` into a modular kernel, then do the same for AWQ.

## Test Plan
Existing GPTQ tests (`test_gptq_v2.py`, `test_gptq_dynamic.py`, `test_lm_head.py`) + manual validation with 2-bit and GPTQv2 models through the new path.

## Test Result
WIP

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>