### PR TITLE
[Bugfix] Fix Worker.load_model context-manager composition for sleep mode

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -286,9 +286,10 @@ class Worker(WorkerBase):
     # to hijack tensor allocation.
     def load_model(self) -> None:
         eep_scale_up = os.environ.get("VLLM_ELASTIC_EP_SCALE_UP_LAUNCH") == "1"
-        with self._maybe_get_memory_pool_context(
-            tag="weights"
-        ), set_current_vllm_config(self.vllm_config):
+        with (
+            self._maybe_get_memory_pool_context(tag="weights"),
+            set_current_vllm_config(self.vllm_config),
+        ):
             self.model_runner.load_model(eep_scale_up=eep_scale_up)
 
     def update_config(self, overrides: dict[str, Any]) -> None:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -288,7 +288,7 @@ class Worker(WorkerBase):
         eep_scale_up = os.environ.get("VLLM_ELASTIC_EP_SCALE_UP_LAUNCH") == "1"
         with self._maybe_get_memory_pool_context(
             tag="weights"
-        ) and set_current_vllm_config(self.vllm_config):
+        ), set_current_vllm_config(self.vllm_config):
             self.model_runner.load_model(eep_scale_up=eep_scale_up)
 
     def update_config(self, overrides: dict[str, Any]) -> None:


### PR DESCRIPTION
## What this PR does

Fixes a context-manager composition bug in `vllm/v1/worker/gpu_worker.py`:

- Before: `with A and B:`
- After: `with A, B:`

In Python, `with A and B:` evaluates to a single context manager (`B` when `A` is truthy), so `A` is never entered. Here that means `_maybe_get_memory_pool_context(tag="weights")` is skipped, so weight allocations are not tracked by cuMem sleep mode.

## Why this matters

When sleep mode is enabled, skipping the weights memory-pool context prevents expected weight tracking/offload behavior.

## Change scope

- 1-line fix in `Worker.load_model`
- No behavior changes outside this context-manager bugfix

## Validation

- `python -m py_compile vllm/v1/worker/gpu_worker.py`