### PR TITLE
[Misc][Spec Decode] support different load config for draft model

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from vllm.config import LoadConfig
 import ast
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
@@ -159,6 +160,10 @@ class SpeculativeConfig:
     """The minimum token probability for suffix decoding. Will only speculate
     tokens with estimated probability (based on frequency counts) greater than
     or equal to this value."""
+
+    draft_load_config: LoadConfig | None = None
+    """Load config for the draft model. If not specified, will use the load
+    config from the target model."""
 
     def compute_hash(self) -> str:
         """

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from vllm.config import LoadConfig
 import ast
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from pydantic import Field, SkipValidation, model_validator
 from typing_extensions import Self
 
+from vllm.config import LoadConfig
 from vllm.config.model import ModelConfig
 from vllm.config.parallel import ParallelConfig
 from vllm.config.utils import config

--- a/vllm/model_executor/model_loader/__init__.py
+++ b/vllm/model_executor/model_loader/__init__.py
@@ -128,8 +128,9 @@ def get_model(
     vllm_config: VllmConfig,
     model_config: ModelConfig | None = None,
     prefix: str = "",
+    load_config: LoadConfig | None = None,
 ) -> nn.Module:
-    loader = get_model_loader(vllm_config.load_config)
+    loader = get_model_loader(load_config or vllm_config.load_config)
     if model_config is None:
         model_config = vllm_config.model_config
     return loader.load_model(

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1283,9 +1283,11 @@ class SpecDecodeBaseProposer:
         from vllm.compilation.backends import set_model_tag
 
         with set_model_tag("eagle_head"):
+            load_config = self.vllm_config.speculative_config.draft_load_config
             model = get_model(
                 vllm_config=self.vllm_config,
                 model_config=self.speculative_config.draft_model_config,
+                load_config=load_config,
             )
         return model
 

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1283,11 +1283,10 @@ class SpecDecodeBaseProposer:
         from vllm.compilation.backends import set_model_tag
 
         with set_model_tag("eagle_head"):
-            load_config = self.vllm_config.speculative_config.draft_load_config
             model = get_model(
                 vllm_config=self.vllm_config,
                 model_config=self.speculative_config.draft_model_config,
-                load_config=load_config,
+                load_config=self.speculative_config.draft_load_config,
             )
         return model
 


### PR DESCRIPTION
[Misc][Spec Decode] support different load config for draft model

Summary:

Sometime, to achieve better draft model performance, or to use different checkpoint format, we will customize those part, adding freedom to specify different load config can make our private trained draft model work. 

Test Plan:
Command:

```
CUDA_VISIBLE_DEVICES=6,7 vllm serve /home/zzhengkai/vllm_models/Llama-3.1-8B-Instruct   --disable-log-requests --port 9001   --speculative_config '{"method": "eagle3", "model": "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B", "num_speculative_tokens": 2, "draft_load_config": {"load_format": "auto"}}'
```



```
(APIServer pid=3406797) INFO:     Started server process [3406797]
(APIServer pid=3406797) INFO:     Waiting for application startup.
(APIServer pid=3406797) INFO:     Application startup complete.
```