### PR TITLE
[Kernel] [Helion] [5/N] Add Helion Autotuning infrastructure

### DIFF
--- a/scripts/autotune_helion_kernels.py
+++ b/scripts/autotune_helion_kernels.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Autotune registered Helion kernels for optimal configurations.
+
+Usage:
+    # Autotune all registered kernels
+    python scripts/autotune_helion_kernels.py
+
+    # Autotune specific kernel
+    python scripts/autotune_helion_kernels.py --kernels silu_mul_fp8
+
+    # Autotune multiple kernels
+    python scripts/autotune_helion_kernels.py --kernels silu_mul_fp8 rms_norm_fp8
+
+    # Force re-autotuning
+    python scripts/autotune_helion_kernels.py --force
+
+    # List available kernels
+    python scripts/autotune_helion_kernels.py --list
+"""
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass
+
+import torch
+
+try:
+    import helion
+
+    from vllm.kernels.helion import (
+        ConfigManager,
+        get_kernel_by_name,
+        get_registered_kernels,
+    )
+    from vllm.kernels.helion.utils import get_canonical_gpu_name
+    from vllm.logger import init_logger
+    from vllm.utils.import_utils import has_helion
+except ImportError as e:
+    print(f"Error importing vLLM: {e}")
+    print("Please ensure vLLM is installed and in your Python path")
+    sys.exit(1)
+
+logger = init_logger("vllm.scripts.autotune_helion_kernels")
+
+
+@dataclass
+class AutotuneResult:
+    status: str  # "success" | "partial" | "error" | "skipped"
+    successful: int
+    failed: int
+    configs: dict[str, "helion.Config"]
+    message: str = ""
+
+
+def list_kernels() -> None:
+    kernels = get_registered_kernels()
+
+    if not kernels:
+        print("No Helion kernels found in registry.")
+        return
+
+    print("Available Helion kernels:")
+    print("=" * 50)
+
+    for name in sorted(kernels.keys()):
+        print(f"  {name}")
+
+    print(f"\nTotal: {len(kernels)} kernels")
+
+
+def check_requirements() -> bool:
+    if not torch.cuda.is_available():
+        logger.error("CUDA is not available. Helion autotuning requires GPU.")
+        return False
+
+    if not has_helion():
+        logger.error("Helion is not installed. Please install Helion package.")
+        return False
+
+    return True
+
+
+def autotune_kernel(
+    kernel_name: str,
+    platform: str,
+    config_manager: ConfigManager,
+    force: bool = False,
+    autotune_effort: str = "quick",
+) -> AutotuneResult:
+    logger.debug(
+        "Starting autotune for kernel '%s' with effort='%s'",
+        kernel_name,
+        autotune_effort,
+    )
+    kernel_wrapper = get_kernel_by_name(kernel_name)
+    if kernel_wrapper is None:
+        error_msg = f"Kernel '{kernel_name}' not found in registry"
+        logger.error(error_msg)
+        return AutotuneResult(
+            status="error",
+            message=error_msg,
+            successful=0,
+            failed=0,
+            configs={},
+        )
+
+    try:
+        inputs_dict = kernel_wrapper.get_inputs()
+    except NotImplementedError:
+        error_msg = f"Kernel '{kernel_name}' has no input generator registered"
+        logger.error(error_msg)
+        return AutotuneResult(
+            status="error",
+            message=error_msg,
+            successful=0,
+            failed=0,
+            configs={},
+        )
+
+    try:
+        logger.info(
+            "Autotuning kernel '%s' for platform '%s' with %d configs",
+            kernel_name,
+            platform,
+            len(inputs_dict),
+        )
+
+        configs_to_autotune = {}
+        if not force:
+            existing_configs = config_manager.get_platform_configs(
+                kernel_name, platform
+            )
+            for config_key, inputs in inputs_dict.items():
+                if config_key in existing_configs:
+                    logger.debug(
+                        "Config '%s' already exists for platform '%s', skipping",
+                        config_key,
+                        platform,
+                    )
+                else:
+                    configs_to_autotune[config_key] = inputs
+        else:
+            logger.debug("Force mode enabled, will re-autotune all configs")
+            configs_to_autotune = inputs_dict
+
+        if not configs_to_autotune:
+            logger.info(
+                "All configs already exist for kernel '%s' on platform '%s'. "
+                "Use --force to re-autotune.",
+                kernel_name,
+                platform,
+            )
+            return AutotuneResult(
+                status="skipped",
+                message="All configs already exist",
+                successful=0,
+                failed=0,
+                configs={},
+            )
+
+        total_start_time = time.time()
+        autotuned_configs = {}
+        failed_configs = []
+
+        for config_key, inputs in configs_to_autotune.items():
+            logger.info("Autotuning config: %s", config_key)
+            logger.debug(
+                "Input shapes: %s",
+                [getattr(inp, "shape", type(inp).__name__) for inp in inputs],
+            )
+
+            try:
+                config_start_time = time.time()
+                config = kernel_wrapper.run_autotune(inputs, autotune_effort)
+                config_duration = time.time() - config_start_time
+
+                # Save immediately for checkpointing
+                config_manager.save_configs(kernel_name, platform, {config_key: config})
+
+                autotuned_configs[config_key] = config
+                logger.debug("Config details: %s", config)
+
+                logger.info(
+                    "✓ Autotuned and saved config '%s' (%.2fs)",
+                    config_key,
+                    config_duration,
+                )
+
+            except (RuntimeError, ValueError, OSError) as e:
+                logger.exception(
+                    "Failed to autotune config '%s': %s",
+                    config_key,
+                    e,
+                )
+                failed_configs.append(config_key)
+
+        total_duration = time.time() - total_start_time
+        successful = len(autotuned_configs)
+        failed = len(failed_configs)
+
+        logger.info(
+            "Completed autotuning for kernel '%s': %d successful, %d failed (%.2fs)",
+            kernel_name,
+            successful,
+            failed,
+            total_duration,
+        )
+
+        status = "success" if failed == 0 else "partial"
+        return AutotuneResult(
+            status=status,
+            successful=successful,
+            failed=failed,
+            configs=autotuned_configs,
+        )
+
+    except (KeyError, RuntimeError, ValueError, OSError) as e:
+        error_msg = f"Unexpected error: {e}"
+        logger.exception("Failed to autotune kernel '%s': %s", kernel_name, e)
+        return AutotuneResult(
+            status="error",
+            message=error_msg,
+            successful=0,
+            failed=0,
+            configs={},
+        )
+
+
+def summarize_results(results: dict[str, AutotuneResult]) -> bool:
+    logger.info("=" * 50)
+    logger.info("Autotuning Results Summary")
+    logger.info("=" * 50)
+
+    total_successful = 0
+    total_failed = 0
+    success_kernels = []
+    partial_kernels = []
+    error_kernels = []
+    skipped_kernels = []
+
+    for kernel_name, result in results.items():
+        total_successful += result.successful
+        total_failed += result.failed
+
+        if result.status == "success":
+            success_kernels.append(f"{kernel_name} ({result.successful} configs)")
+            logger.info("✓ %s: %d configs successful", kernel_name, result.successful)
+        elif result.status == "partial":
+            partial_kernels.append(
+                f"{kernel_name} ({result.successful} ok, {result.failed} failed)"
+            )
+            logger.warning(
+                "⚠ %s: %d successful, %d failed",
+                kernel_name,
+                result.successful,
+                result.failed,
+            )
+        elif result.status == "error":
+            error_kernels.append(f"{kernel_name}: {result.message or 'Unknown error'}")
+            logger.error("✗ %s: %s", kernel_name, result.message or "Unknown error")
+        elif result.status == "skipped":
+            skipped_kernels.append(f"{kernel_name}: {result.message or 'Skipped'}")
+            logger.info("- %s: %s", kernel_name, result.message or "Skipped")
+
+    logger.info("=" * 50)
+    logger.info(
+        "Summary: %d total configs (%d successful, %d failed)",
+        total_successful + total_failed,
+        total_successful,
+        total_failed,
+    )
+    logger.info(
+        "Kernels: %d success, %d partial, %d error, %d skipped",
+        len(success_kernels),
+        len(partial_kernels),
+        len(error_kernels),
+        len(skipped_kernels),
+    )
+
+    has_failures = bool(error_kernels or partial_kernels)
+
+    if not has_failures:
+        if total_successful > 0:
+            logger.info("All configs autotuned successfully!")
+        else:
+            logger.info("No new configs were generated (all may already exist)")
+
+    return not has_failures
+
+
+def get_kernels_to_autotune(requested_kernels: list[str] | None) -> list[str]:
+    all_kernels = get_registered_kernels()
+    if not all_kernels:
+        logger.error("No Helion kernels found in registry")
+        sys.exit(1)
+
+    if not requested_kernels:
+        return list(all_kernels.keys())
+
+    if len(requested_kernels) != len(set(requested_kernels)):
+        duplicates = [
+            k for k in set(requested_kernels) if requested_kernels.count(k) > 1
+        ]
+        logger.error("Duplicate kernel names in --kernels flag: %s", duplicates)
+        sys.exit(1)
+
+    kernels_to_autotune = []
+    missing_kernels = []
+
+    for kernel_name in requested_kernels:
+        if kernel_name in all_kernels:
+            kernels_to_autotune.append(kernel_name)
+        else:
+            missing_kernels.append(kernel_name)
+
+    if missing_kernels:
+        logger.error("Kernel(s) not found: %s", missing_kernels)
+        logger.error("Available kernels: %s", list(all_kernels.keys()))
+        sys.exit(1)
+
+    return kernels_to_autotune
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Autotune Helion kernels",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__.split("Usage:")[1] if "Usage:" in __doc__ else "",
+    )
+
+    parser.add_argument(
+        "--kernels",
+        nargs="+",
+        help="Kernel(s) to autotune (default: all kernels)",
+    )
+
+    parser.add_argument(
+        "--config-dir",
+        type=str,
+        help="Config directory for config files (default: vLLM helion configs dir)",
+    )
+
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available Helion kernels and exit",
+    )
+
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Force re-autotuning even if configs already exist for the "
+            "platform and config keys"
+        ),
+    )
+
+    parser.add_argument(
+        "--autotune-effort",
+        type=str,
+        default="quick",
+        help=(
+            "Helion autotune effort level: 'quick' (smaller search) or "
+            "'full' (full search budget) (default: quick)"
+        ),
+    )
+
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
+    args = parser.parse_args()
+
+    import logging
+
+    if args.verbose:
+        logging.getLogger("vllm").setLevel(logging.DEBUG)
+        logger.debug("Verbose mode enabled")
+        logger.debug("Arguments: %s", vars(args))
+    else:
+        logging.getLogger("vllm").setLevel(logging.INFO)
+
+    if args.list:
+        list_kernels()
+        return
+
+    if not check_requirements():
+        sys.exit(1)
+
+    platform = get_canonical_gpu_name()
+    logger.info("Detected GPU platform: %s", platform)
+
+    config_manager = (
+        ConfigManager(args.config_dir) if args.config_dir else ConfigManager()
+    )
+
+    try:
+        config_manager.ensure_base_dir_writable()
+    except OSError as e:
+        logger.error("Failed to access config directory: %s", e)
+        sys.exit(1)
+
+    kernels_to_autotune = get_kernels_to_autotune(args.kernels)
+
+    logger.info(
+        "Will autotune %d kernel(s) for platform '%s': %s",
+        len(kernels_to_autotune),
+        platform,
+        kernels_to_autotune,
+    )
+
+    results = {}
+    for kernel_name in kernels_to_autotune:
+        result = autotune_kernel(
+            kernel_name, platform, config_manager, args.force, args.autotune_effort
+        )
+        results[kernel_name] = result
+
+    success = summarize_results(results)
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/helion/test_register.py
+++ b/tests/kernels/helion/test_register.py
@@ -554,10 +554,18 @@ class TestKernelRegistry:
     """Test suite for kernel registry functionality."""
 
     def setup_method(self):
-        """Clear the registry before each test."""
+        """Save and clear the registry before each test."""
+        from vllm.kernels.helion.register import _REGISTERED_KERNELS
+
+        self._saved_registry = dict(_REGISTERED_KERNELS)
+        _REGISTERED_KERNELS.clear()
+
+    def teardown_method(self):
+        """Restore the registry after each test."""
         from vllm.kernels.helion.register import _REGISTERED_KERNELS
 
         _REGISTERED_KERNELS.clear()
+        _REGISTERED_KERNELS.update(self._saved_registry)
 
     def test_get_registered_kernels_returns_copy(self):
         """Test get_registered_kernels returns copy of registry."""

--- a/tests/kernels/helion/test_silu_mul_fp8.py
+++ b/tests/kernels/helion/test_silu_mul_fp8.py
@@ -1,0 +1,331 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.utils.import_utils import has_helion
+
+if not has_helion():
+    pytest.skip(
+        "Helion is not installed. Install with: pip install vllm[helion]",
+        allow_module_level=True,
+    )
+
+from vllm.kernels.helion.config_manager import ConfigManager
+from vllm.kernels.helion.ops.silu_mul_fp8 import (
+    pick_silu_mul_fp8_config,
+    silu_mul_fp8,
+    silu_mul_fp8_baseline,
+)
+
+
+def skip_if_platform_unsupported():
+    try:
+        from vllm.kernels.helion.utils import get_canonical_gpu_name
+
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        platform = get_canonical_gpu_name()
+
+        try:
+            config_manager = ConfigManager.get_instance()
+        except RuntimeError:
+            config_manager = ConfigManager()
+
+        configs = config_manager.get_platform_configs("silu_mul_fp8", platform)
+        if len(configs) == 0:
+            pytest.skip("Current GPU platform not supported for silu_mul_fp8 kernel")
+
+    except (ImportError, RuntimeError, KeyError):
+        pytest.skip("Error detecting platform support for silu_mul_fp8 kernel")
+
+
+@pytest.fixture(autouse=True)
+def reset_config_manager_singleton():
+    ConfigManager.reset_instance()
+    ConfigManager()
+    yield
+    ConfigManager.reset_instance()
+
+
+class TestSiluMulFp8ConfigPicker:
+    def test_config_picker_exact_match(self):
+        config_keys = [
+            "intermediate_2048_batchsize_256",
+            "intermediate_4096_batchsize_256",
+        ]
+
+        input_tensor = torch.randn(32, 4096, dtype=torch.bfloat16, device="cuda")
+        scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
+        args = (input_tensor, scale)
+
+        selected_key = pick_silu_mul_fp8_config(args, config_keys)
+        assert selected_key == "intermediate_2048_batchsize_256"
+
+    def test_config_picker_closest_match(self):
+        config_keys = [
+            "intermediate_2048_batchsize_256",
+            "intermediate_4096_batchsize_256",
+        ]
+        # Use 7000 (intermediate_size=3500) which is closer to 4096 than 2048
+        input_tensor = torch.randn(32, 7000, dtype=torch.bfloat16, device="cuda")
+        scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
+        args = (input_tensor, scale)
+
+        selected_key = pick_silu_mul_fp8_config(args, config_keys)
+        assert selected_key == "intermediate_4096_batchsize_256"
+
+    def test_config_picker_fallback_to_default(self):
+        config_keys = ["default", "some_other_key"]
+
+        input_tensor = torch.randn(32, 4096, dtype=torch.bfloat16, device="cuda")
+        scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
+        args = (input_tensor, scale)
+
+        selected_key = pick_silu_mul_fp8_config(args, config_keys)
+        assert selected_key == "default"
+
+    def test_config_picker_no_configs(self):
+        config_keys: list[str] = []
+
+        input_tensor = torch.randn(32, 4096, dtype=torch.bfloat16, device="cuda")
+        scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
+        args = (input_tensor, scale)
+
+        selected_key = pick_silu_mul_fp8_config(args, config_keys)
+        assert selected_key is None
+
+    @pytest.mark.parametrize("intermediate_size", [2048, 4096, 5120])
+    def test_config_picker_different_sizes(self, intermediate_size):
+        config_keys = [
+            "intermediate_2048_batchsize_256",
+            "intermediate_4096_batchsize_256",
+            "intermediate_5120_batchsize_256",
+        ]
+
+        input_tensor = torch.randn(
+            32, 2 * intermediate_size, dtype=torch.bfloat16, device="cuda"
+        )
+        scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
+        args = (input_tensor, scale)
+
+        selected_key = pick_silu_mul_fp8_config(args, config_keys)
+        expected_key = f"intermediate_{intermediate_size}_batchsize_256"
+        assert selected_key == expected_key
+
+
+class TestSiluMulFp8Correctness:
+    @pytest.mark.parametrize("batch_size", [1, 8, 32, 128])
+    @pytest.mark.parametrize("intermediate_size", [2048, 3000, 3500, 4096, 5000])
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_silu_mul_fp8_correctness(self, batch_size, intermediate_size, dtype):
+        skip_if_platform_unsupported()
+
+        input_size = 2 * intermediate_size
+        input_tensor = torch.randn(batch_size, input_size, dtype=dtype, device="cuda")
+        scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
+
+        reference_output = silu_mul_fp8_baseline(input_tensor, scale)
+        helion_output = silu_mul_fp8(input_tensor, scale)
+
+        assert helion_output.shape == reference_output.shape
+        assert helion_output.dtype == torch.float8_e4m3fn
+        assert reference_output.dtype == torch.float8_e4m3fn
+
+        ref_f32 = reference_output.to(torch.float32)
+        helion_f32 = helion_output.to(torch.float32)
+        # FP8 E4M3 has limited precision. Values near quantization boundaries
+        # can round differently due to intermediate precision differences.
+        torch.testing.assert_close(
+            helion_f32,
+            ref_f32,
+            atol=0.05,
+            rtol=0.05,
+            msg=f"Mismatch at batch={batch_size}, size={intermediate_size}",
+        )
+
+    def test_silu_mul_fp8_shape_inference(self):
+        skip_if_platform_unsupported()
+        batch_size, input_size = 32, 8192
+        intermediate_size = input_size // 2
+
+        input_tensor = torch.randn(
+            batch_size, input_size, dtype=torch.bfloat16, device="cuda"
+        )
+        scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
+
+        output = silu_mul_fp8(input_tensor, scale)
+
+        expected_shape = (batch_size, intermediate_size)
+        assert output.shape == expected_shape
+        assert output.dtype == torch.float8_e4m3fn
+
+    def test_silu_mul_fp8_scale_variations(self):
+        skip_if_platform_unsupported()
+        batch_size, input_size = 16, 4096
+
+        input_tensor = torch.randn(
+            batch_size, input_size, dtype=torch.bfloat16, device="cuda"
+        )
+
+        scales = [0.1, 0.5, 1.0, 2.0, 10.0]
+
+        for scale_val in scales:
+            scale = torch.tensor([scale_val], dtype=torch.float32, device="cuda")
+
+            reference_output = silu_mul_fp8_baseline(input_tensor, scale)
+            helion_output = silu_mul_fp8(input_tensor, scale)
+            ref_f32 = reference_output.to(torch.float32)
+            helion_f32 = helion_output.to(torch.float32)
+
+            torch.testing.assert_close(
+                helion_f32,
+                ref_f32,
+                atol=0.05,
+                rtol=0.05,
+                msg=f"Mismatch for scale={scale_val}",
+            )
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            (1, 4096),
+            (16, 4096),
+            (128, 4096),
+            (1024, 4096),
+            (1, 8192),
+            (16, 8192),
+            (128, 8192),
+        ],
+    )
+    def test_silu_mul_fp8_various_shapes(self, shape):
+        skip_if_platform_unsupported()
+
+        input_tensor = torch.randn(*shape, dtype=torch.bfloat16, device="cuda")
+        scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
+
+        reference_output = silu_mul_fp8_baseline(input_tensor, scale)
+        helion_output = silu_mul_fp8(input_tensor, scale)
+
+        assert helion_output.shape == reference_output.shape
+
+        ref_f32 = reference_output.to(torch.float32)
+        helion_f32 = helion_output.to(torch.float32)
+
+        torch.testing.assert_close(
+            helion_f32, ref_f32, atol=0.05, rtol=0.05, msg=f"Mismatch for shape={shape}"
+        )
+
+
+def silu_mul_fp8_pytorch(input: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Pure PyTorch reference using F.silu.
+
+    This matches vLLM's SiluAndMul.forward_native exactly:
+    F.silu(x[..., :d]) * x[..., d:]
+    """
+    d = input.shape[-1] // 2
+    result = F.silu(input[..., :d]) * input[..., d:]
+    return (result.to(torch.float32) / scale).to(torch.float8_e4m3fn)
+
+
+class TestSiluMulFp8PytorchReference:
+    """Tests comparing Helion kernel against pure PyTorch implementation.
+
+    Uses tighter tolerance since both use PyTorch's FP8 conversion
+    (same rounding mode), unlike the vLLM C++ baseline which uses
+    NVIDIA's hardware FP8 conversion with different rounding.
+    """
+
+    @pytest.mark.parametrize("batch_size", [1, 8, 32, 128, 256])
+    @pytest.mark.parametrize("intermediate_size", [1024, 2048, 4096])
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_silu_mul_fp8_vs_pytorch(self, batch_size, intermediate_size, dtype):
+        skip_if_platform_unsupported()
+
+        input_tensor = torch.randn(
+            batch_size, 2 * intermediate_size, dtype=dtype, device="cuda"
+        )
+        scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
+
+        pytorch_output = silu_mul_fp8_pytorch(input_tensor, scale)
+        helion_output = silu_mul_fp8(input_tensor, scale)
+
+        assert helion_output.shape == pytorch_output.shape
+        assert helion_output.dtype == torch.float8_e4m3fn
+
+        pytorch_f32 = pytorch_output.to(torch.float32)
+        helion_f32 = helion_output.to(torch.float32)
+
+        # Tolerance accounts for FP8 quantization boundary effects
+        torch.testing.assert_close(
+            helion_f32,
+            pytorch_f32,
+            atol=0.05,
+            rtol=0.05,
+            msg=(
+                f"Mismatch at batch={batch_size}, size={intermediate_size}, "
+                f"dtype={dtype}"
+            ),
+        )
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            (1, 2, 4096),  # 3D input
+            (2, 4, 2048),  # 3D input
+            (1, 1, 1, 8192),  # 4D input
+        ],
+    )
+    def test_silu_mul_fp8_multidim_vs_pytorch(self, shape):
+        skip_if_platform_unsupported()
+
+        input_tensor = torch.randn(*shape, dtype=torch.bfloat16, device="cuda")
+        scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
+
+        pytorch_output = silu_mul_fp8_pytorch(input_tensor, scale)
+        helion_output = silu_mul_fp8(input_tensor, scale)
+
+        assert helion_output.shape == pytorch_output.shape
+
+        pytorch_f32 = pytorch_output.to(torch.float32)
+        helion_f32 = helion_output.to(torch.float32)
+
+        torch.testing.assert_close(
+            helion_f32,
+            pytorch_f32,
+            atol=0.05,
+            rtol=0.05,
+            msg=f"Mismatch for shape={shape}",
+        )
+
+
+class TestSiluMulFp8Integration:
+    def test_kernel_registration_integration(self):
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        registered_kernels = get_registered_kernels()
+        assert "silu_mul_fp8" in registered_kernels
+
+        kernel_wrapper = registered_kernels["silu_mul_fp8"]
+        assert kernel_wrapper.op_name == "silu_mul_fp8"
+        assert kernel_wrapper._config_picker is not None
+
+    def test_fake_impl_functionality(self):
+        skip_if_platform_unsupported()
+        from vllm.kernels.helion.register import get_registered_kernels
+
+        input_tensor = torch.randn(32, 4096, dtype=torch.bfloat16, device="cuda")
+        scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
+        registered_kernels = get_registered_kernels()
+        kernel_wrapper = registered_kernels["silu_mul_fp8"]
+        fake_impl = kernel_wrapper._fake_impl
+
+        fake_output = fake_impl(input_tensor, scale)
+
+        expected_shape = (32, 2048)
+        assert fake_output.shape == expected_shape
+        assert fake_output.dtype == torch.float8_e4m3fn
+        assert fake_output.device == input_tensor.device

--- a/vllm/kernels/helion/__init__.py
+++ b/vllm/kernels/helion/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Helion integration for vLLM."""
 
+import vllm.kernels.helion.ops  # noqa: F401  Auto-register all Helion ops
 from vllm.kernels.helion.config_manager import (
     ConfigManager,
     ConfigSet,

--- a/vllm/kernels/helion/config_manager.py
+++ b/vllm/kernels/helion/config_manager.py
@@ -104,9 +104,6 @@ class ConfigSet:
             result[platform] = {}
 
             for config_key, config in config_keys_dict.items():
-                # Convert helion.Config to dict using to_json() + json.loads()
-                import json
-
                 result[platform][config_key] = json.loads(config.to_json())
 
         return result

--- a/vllm/kernels/helion/config_manager.py
+++ b/vllm/kernels/helion/config_manager.py
@@ -131,6 +131,27 @@ class ConfigSet:
 
         return config_set
 
+    def set_config(
+        self, platform: str, config_key: str, config: "helion.Config"
+    ) -> None:
+        platform = platform.lower()
+        if platform not in self._configs:
+            self._configs[platform] = {}
+        self._configs[platform][config_key] = config
+        logger.debug(
+            "Set config for kernel '%s': platform='%s', key='%s'",
+            self._kernel_name,
+            platform,
+            config_key,
+        )
+
+    def has_config(self, platform: str, config_key: str) -> bool:
+        platform = platform.lower()
+        platform_dict = self._configs.get(platform)
+        if platform_dict is None:
+            return False
+        return config_key in platform_dict
+
 
 class ConfigManager:
     """File-level configuration management for Helion kernels (global singleton)."""
@@ -142,7 +163,6 @@ class ConfigManager:
         resolved_base_dir = cls._resolve_base_dir(base_dir)
 
         if cls._instance is not None:
-            # Instance already exists - check for base_dir mismatch
             if cls._instance_base_dir != resolved_base_dir:
                 raise ValueError(
                     f"ConfigManager singleton already exists with base_dir "
@@ -151,14 +171,12 @@ class ConfigManager:
                 )
             return cls._instance
 
-        # Create new instance
         instance = super().__new__(cls)
         cls._instance = instance
         cls._instance_base_dir = resolved_base_dir
         return instance
 
     def __init__(self, base_dir: str | Path | None = None):
-        # Only initialize if not already initialized
         if hasattr(self, "_base_dir"):
             return
 
@@ -193,6 +211,17 @@ class ConfigManager:
         self._base_dir.mkdir(parents=True, exist_ok=True)
         return self._base_dir
 
+    def ensure_base_dir_writable(self) -> None:
+        self.ensure_base_dir_exists()
+        test_file = self._base_dir / ".write_test"
+        try:
+            test_file.write_text("test")
+            test_file.unlink()
+        except OSError as e:
+            raise OSError(
+                f"Config directory '{self._base_dir}' is not writable: {e}"
+            ) from e
+
     def load_config_set(self, kernel_name: str) -> ConfigSet:
         config_path = self.get_config_file_path(kernel_name)
         if not config_path.exists():
@@ -226,3 +255,19 @@ class ConfigManager:
 
         logger.info("Saved config to: %s", config_path)
         return config_path
+
+    def save_configs(
+        self,
+        kernel_name: str,
+        platform: str,
+        configs: dict[str, "helion.Config"],
+    ) -> Path:
+        """Save configs for a kernel/platform, merging with existing."""
+        config_set = self.load_config_set(kernel_name)
+        for config_key, config in configs.items():
+            config_set.set_config(platform, config_key, config)
+        return self.save_config_set(config_set)
+
+    def config_exists(self, kernel_name: str, platform: str, config_key: str) -> bool:
+        config_set = self.load_config_set(kernel_name)
+        return config_set.has_config(platform, config_key)

--- a/vllm/kernels/helion/configs/silu_mul_fp8.json
+++ b/vllm/kernels/helion/configs/silu_mul_fp8.json
@@ -1,0 +1,550 @@
+{
+  "nvidia_h200": {
+    "intermediate_2048_batchsize_256": {
+      "block_sizes": [
+        64,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        2
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "tensor_descriptor",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "range_warp_specializes": []
+    },
+    "intermediate_4096_batchsize_256": {
+      "block_sizes": [
+        16,
+        64
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "",
+        ""
+      ],
+      "num_warps": 2,
+      "num_stages": 1,
+      "indexing": [
+        "pointer",
+        "pointer",
+        "pointer",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "range_warp_specializes": []
+    },
+    "default": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "range_warp_specializes": []
+    }
+  },
+  "nvidia_h100_pcie": {
+    "intermediate_2048_batchsize_256": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "range_warp_specializes": []
+    },
+    "intermediate_4096_batchsize_256": {
+      "block_sizes": [
+        256,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        2
+      ],
+      "range_num_stages": [
+        3
+      ],
+      "range_multi_buffers": [
+        false
+      ],
+      "range_flattens": [
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "persistent_blocked",
+      "range_warp_specializes": []
+    },
+    "default": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "range_warp_specializes": []
+    }
+  },
+  "nvidia_h100_sxm5": {
+    "intermediate_2048_batchsize_256": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "range_warp_specializes": []
+    },
+    "intermediate_4096_batchsize_256": {
+      "block_sizes": [
+        256,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        2
+      ],
+      "range_num_stages": [
+        3
+      ],
+      "range_multi_buffers": [
+        false
+      ],
+      "range_flattens": [
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "persistent_blocked",
+      "range_warp_specializes": []
+    },
+    "default": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "range_warp_specializes": []
+    }
+  },
+  "nvidia_h100": {
+    "intermediate_2048_batchsize_256": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "range_warp_specializes": []
+    },
+    "intermediate_4096_batchsize_256": {
+      "block_sizes": [
+        256,
+        128
+      ],
+      "loop_orders": [
+        [
+          0,
+          1
+        ]
+      ],
+      "flatten_loops": [
+        true
+      ],
+      "l2_groupings": [
+        1
+      ],
+      "range_unroll_factors": [
+        2
+      ],
+      "range_num_stages": [
+        3
+      ],
+      "range_multi_buffers": [
+        false
+      ],
+      "range_flattens": [
+        true
+      ],
+      "load_eviction_policies": [
+        "last",
+        "last",
+        ""
+      ],
+      "num_warps": 32,
+      "num_stages": 3,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "persistent_blocked",
+      "range_warp_specializes": []
+    },
+    "default": {
+      "block_sizes": [
+        1,
+        512
+      ],
+      "loop_orders": [
+        [
+          1,
+          0
+        ]
+      ],
+      "flatten_loops": [
+        false
+      ],
+      "l2_groupings": [
+        4
+      ],
+      "range_unroll_factors": [
+        0
+      ],
+      "range_num_stages": [
+        0
+      ],
+      "range_multi_buffers": [
+        null
+      ],
+      "range_flattens": [
+        null
+      ],
+      "load_eviction_policies": [
+        "",
+        "first",
+        ""
+      ],
+      "num_warps": 8,
+      "num_stages": 2,
+      "indexing": [
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor",
+        "pointer"
+      ],
+      "pid_type": "flat",
+      "range_warp_specializes": []
+    }
+  }
+}

--- a/vllm/kernels/helion/ops/__init__.py
+++ b/vllm/kernels/helion/ops/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Auto-import all Helion op modules to trigger kernel registration."""
+
+import importlib
+import pkgutil
+
+# Automatically import all submodules so that @register_kernel
+# decorators execute and register ops with torch.ops.vllm_helion.
+for _module_info in pkgutil.iter_modules(__path__):
+    importlib.import_module(f"{__name__}.{_module_info.name}")

--- a/vllm/kernels/helion/ops/silu_mul_fp8.py
+++ b/vllm/kernels/helion/ops/silu_mul_fp8.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Any
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.utils.import_utils import has_helion
+
+if not has_helion():
+    raise ImportError(
+        "silu_mul_fp8 Helion kernel requires helion to be installed. "
+        "Install it with: pip install helion"
+    )
+
+import helion.language as hl
+
+from vllm.kernels.helion.register import register_kernel
+
+logger = init_logger(__name__)
+
+
+@register_kernel  # type: ignore[misc]
+def silu_mul_fp8(input: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    original_shape = input.shape
+    two_d = hl.specialize(original_shape[-1])
+    d = two_d // 2
+    output_shape = original_shape[:-1] + (d,)
+
+    input_2d = input.view(-1, original_shape[-1])
+    m = input_2d.shape[0]
+
+    # TODO(gmagogsfm): Support for more float8 subtypes (e4m3fnuz, e5m2) coming
+    out = torch.empty((m, d), device=input.device, dtype=torch.float8_e4m3fn)
+
+    input_part_a = input_2d[:, :d]
+    input_part_b = input_2d[:, d:]
+
+    assert scale.numel() == 1, "Scale must be a scalar Tensor"
+
+    for tile_m, tile_n in hl.tile([m, d]):
+        a_vals = input_part_a[tile_m, tile_n]
+        silu_result = torch.nn.functional.silu(a_vals)
+        b_vals = input_part_b[tile_m, tile_n]
+        result = silu_result * b_vals
+        result_f32 = result.to(torch.float32)
+        scale_val = hl.load(scale, [0])
+        inv_scale = 1.0 / scale_val
+        result_scaled = result_f32 * inv_scale
+        out[tile_m, tile_n] = result_scaled.to(out.dtype)
+
+    return out.view(output_shape)
+
+
+@silu_mul_fp8.register_config_picker  # type: ignore[misc]
+def pick_silu_mul_fp8_config(
+    args: tuple[Any, ...], config_keys: list[str]
+) -> str | None:
+    if not config_keys:
+        return None
+
+    input_tensor, scale = args
+    intermediate_size = input_tensor.shape[-1] // 2
+
+    # TODO(gmagosfm): Rerun autotuning to capture config for
+    # other batch sizes.
+    target_key = f"intermediate_{intermediate_size}_batchsize_256"
+    if target_key in config_keys:
+        return target_key
+
+    intermediate_sizes = []
+    for key in config_keys:
+        if key.startswith("intermediate_") and "_batchsize_256" in key:
+            try:
+                size_str = key.split("_")[1]
+                size = int(size_str)
+                intermediate_sizes.append((abs(size - intermediate_size), key))
+            except (ValueError, IndexError):
+                continue
+
+    if intermediate_sizes:
+        _, best_key = min(intermediate_sizes)
+        logger.debug(
+            "No exact config for intermediate_size=%d, using closest match: %s",
+            intermediate_size,
+            best_key,
+        )
+        return best_key
+    if "default" in config_keys:
+        return "default"
+
+    return None
+
+
+def silu_mul_fp8_baseline(input: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    output_shape = input.shape[:-1] + (input.shape[-1] // 2,)
+    out = torch.empty(output_shape, dtype=torch.float8_e4m3fn, device=input.device)
+    torch.ops._C.silu_and_mul_quant(out, input, scale)
+    return out


### PR DESCRIPTION
NOTE: this is a manually stacked PR, each commit is reviewed separately. For this PR, please only review the top commit: Add Helion autotuning infra

This PR adds autotuning support to vLLM-Helion. Each Helion kernel can register an input generator that returns a dictionary of `(helion_config_key, representative_input)` pairs. The autotuning infra would run autotuning against these inputs and generate one config per `helion_config_key`.