### PR TITLE
[bug-fix] supported_tasks is breaking backward compatibility at init_app_state

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -151,7 +151,18 @@ async def build_async_engine_client_from_engine_args(
             async_llm.shutdown()
 
 
-def build_app(args: Namespace, supported_tasks: tuple["SupportedTask", ...]) -> FastAPI:
+
+def build_app(
+    args: Namespace, supported_tasks: tuple["SupportedTask", ...] | None = None
+) -> FastAPI:
+    if supported_tasks is None:
+        # If no supported tasks are provided, default to only generating tasks.
+        logger.warning(
+            "No supported tasks provided to build_app, defaulting to only "
+            "'generate' tasks."
+        )
+        supported_tasks = ("generate",)
+
     if args.disable_fastapi_docs:
         app = FastAPI(
             openapi_url=None, docs_url=None, redoc_url=None, lifespan=lifespan

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -262,9 +262,11 @@ async def init_app_state(
     engine_client: EngineClient,
     state: State,
     args: Namespace,
-    supported_tasks: tuple["SupportedTask", ...],
+    supported_tasks: tuple["SupportedTask", ...] | None = None,
 ) -> None:
     vllm_config = engine_client.vllm_config
+    if supported_tasks is None:
+        supported_tasks = await engine_client.get_supported_tasks()
 
     if args.served_model_name is not None:
         served_model_names = args.served_model_name

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -288,7 +288,7 @@ async def init_app_state(
             DeprecationWarning,
             stacklevel=2,
         )
-        supported_tasks = await engine_client.get_supported_tasks()
+        supported_tasks = _FALLBACK_SUPPORTED_TASKS
 
     if args.served_model_name is not None:
         served_model_names = args.served_model_name


### PR DESCRIPTION
init_app_state has now added supported_task as a mandatory input which breaks applications that integrate with vllm at this layer. 


engine_client is the source of truth for supported_tasks and it's already a parameter to the init_app_state helper. This PR makes supported_tasks param optional and in case of None retrieves it from engine_client. 