### PR TITLE
[Bugfix] Add reasoning_content backward compat to DeltaMessage for streaming

### DIFF
--- a/tests/entrypoints/openai/test_engine_protocol.py
+++ b/tests/entrypoints/openai/test_engine_protocol.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for vllm.entrypoints.openai.engine.protocol module."""
+
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+
+
+class TestDeltaMessageReasoningCompat:
+    """Test backward compatibility for reasoning_content field in DeltaMessage.
+
+    The reasoning_content field was deprecated in favor of reasoning.
+    These tests ensure both fields remain in sync for backward compatibility.
+    See: https://github.com/vllm-project/vllm/issues/27755
+    """
+
+    def test_reasoning_syncs_to_reasoning_content(self):
+        """When reasoning is set, reasoning_content should be auto-populated."""
+        msg = DeltaMessage(reasoning="thinking steps")
+        assert msg.reasoning == "thinking steps"
+        assert msg.reasoning_content == "thinking steps"
+
+    def test_reasoning_content_syncs_to_reasoning(self):
+        """When reasoning_content is set, reasoning should be auto-populated."""
+        msg = DeltaMessage(reasoning_content="thinking steps")
+        assert msg.reasoning_content == "thinking steps"
+        assert msg.reasoning == "thinking steps"
+
+    def test_both_fields_set_explicitly(self):
+        """When both fields are set, both values should be preserved."""
+        msg = DeltaMessage(reasoning="a", reasoning_content="b")
+        assert msg.reasoning == "a"
+        assert msg.reasoning_content == "b"
+
+    def test_neither_field_set(self):
+        """When neither field is set, both should remain None."""
+        msg = DeltaMessage(content="hello")
+        assert msg.reasoning is None
+        assert msg.reasoning_content is None
+
+    def test_empty_string_reasoning(self):
+        """Empty string should sync like any other value."""
+        msg = DeltaMessage(reasoning="")
+        assert msg.reasoning == ""
+        assert msg.reasoning_content == ""
+
+    def test_serialization_includes_both_fields(self):
+        """Both fields should appear in serialized output when set."""
+        msg = DeltaMessage(reasoning="thinking")
+        data = msg.model_dump(exclude_none=True)
+        assert data["reasoning"] == "thinking"
+        assert data["reasoning_content"] == "thinking"
+
+    def test_streaming_use_case(self):
+        """Simulate streaming chunks with reasoning content."""
+        chunks = [
+            DeltaMessage(role="assistant"),
+            DeltaMessage(reasoning="Let me think..."),
+            DeltaMessage(reasoning=" about this"),
+            DeltaMessage(content="The answer is 42"),
+        ]
+
+        # All chunks should have synced fields
+        assert chunks[0].reasoning is None
+        assert chunks[0].reasoning_content is None
+
+        assert chunks[1].reasoning == "Let me think..."
+        assert chunks[1].reasoning_content == "Let me think..."
+
+        assert chunks[2].reasoning == " about this"
+        assert chunks[2].reasoning_content == " about this"
+
+        assert chunks[3].reasoning is None
+        assert chunks[3].reasoning_content is None
+        assert chunks[3].content == "The answer is 42"

--- a/tests/entrypoints/openai/test_engine_protocol.py
+++ b/tests/entrypoints/openai/test_engine_protocol.py
@@ -25,11 +25,11 @@ class TestDeltaMessageReasoningCompat:
         assert msg.reasoning_content == "thinking steps"
         assert msg.reasoning == "thinking steps"
 
-    def test_both_fields_set_explicitly(self):
-        """When both fields are set, both values should be preserved."""
+    def test_both_fields_set_reasoning_takes_precedence(self):
+        """When both fields are set, reasoning takes precedence as canonical."""
         msg = DeltaMessage(reasoning="a", reasoning_content="b")
         assert msg.reasoning == "a"
-        assert msg.reasoning_content == "b"
+        assert msg.reasoning_content == "a"  # Synced from reasoning
 
     def test_neither_field_set(self):
         """When neither field is set, both should remain None."""

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -270,9 +270,9 @@ class DeltaMessage(OpenAIBaseModel):
         This validator ensures both fields stay in sync for backward
         compatibility with clients that expect reasoning_content.
         """
-        if self.reasoning is not None and self.reasoning_content is None:
+        if self.reasoning is not None:
             self.reasoning_content = self.reasoning
-        elif self.reasoning_content is not None and self.reasoning is None:
+        elif self.reasoning_content is not None:
             self.reasoning = self.reasoning_content
         return self
 

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -259,7 +259,22 @@ class DeltaMessage(OpenAIBaseModel):
     role: str | None = None
     content: str | None = None
     reasoning: str | None = None
+    reasoning_content: str | None = None  # Deprecated: use reasoning instead
     tool_calls: list[DeltaToolCall] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def sync_reasoning_fields(self) -> "DeltaMessage":
+        """Maintain backward compatibility by syncing reasoning fields.
+
+        The reasoning_content field is deprecated in favor of reasoning.
+        This validator ensures both fields stay in sync for backward
+        compatibility with clients that expect reasoning_content.
+        """
+        if self.reasoning is not None and self.reasoning_content is None:
+            self.reasoning_content = self.reasoning
+        elif self.reasoning_content is not None and self.reasoning is None:
+            self.reasoning = self.reasoning_content
+        return self
 
 
 ####### Tokens IN <> Tokens OUT #######


### PR DESCRIPTION
# PR: [Bugfix] Add reasoning_content backward compat to DeltaMessage for streaming

## Summary

Adds `reasoning_content` field to `DeltaMessage` class to maintain backward compatibility for streaming responses, completing the work started in commit bf001da.

## Context

- RFC #27755 renamed `reasoning_content` to `reasoning` to align with OpenAI API
- Commit bf001da added backward compat for **input message parsing** in `chat_utils.py`
- However, **streaming output** via `DeltaMessage` was missed
- This breaks clients like LiteLLM that expect `reasoning_content` in streaming chunks

The documentation at `docs/features/reasoning_outputs.md` states:
> `reasoning` used to be called `reasoning_content`. For now, `reasoning_content` will continue to work.

This promise is currently broken for streaming responses.

## Changes

**File:** `vllm/entrypoints/openai/engine/protocol.py`

1. Add `reasoning_content` field to `DeltaMessage` class
2. Add Pydantic `model_validator` to auto-sync `reasoning` <-> `reasoning_content`

The validator ensures:
- When `reasoning` is set, `reasoning_content` is auto-populated (for backward compat)
- When `reasoning_content` is set, `reasoning` is auto-populated (for clients using deprecated field)

## Test Plan

- [x] Added unit tests in `tests/entrypoints/openai/test_engine_protocol.py`
- [x] Verified streaming responses include both fields
- [x] Tested with LiteLLM proxy receiving `reasoning_content` correctly
- [x] Passed ruff linter checks

## Related Issues

- RFC: #27755
- Original rename commit: d9ab1ad
- Non-streaming fix commit: bf001da

---

Signed-off-by: Craig Donnelly <mail@craig.ie>
