### PR TITLE
[ROCm] update triton branch to support gpt-oss models for gfx11xx devices

### DIFF
--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=rocm/dev-ubuntu-22.04:7.0-complete
-ARG TRITON_BRANCH="57c693b6"
+ARG TRITON_BRANCH="f332c49"
 ARG TRITON_REPO="https://github.com/ROCm/triton.git"
 ARG PYTORCH_BRANCH="89075173"
 ARG PYTORCH_REPO="https://github.com/ROCm/pytorch.git"

--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=rocm/dev-ubuntu-22.04:7.0-complete
-ARG TRITON_BRANCH="f332c49"
+ARG TRITON_BRANCH="f332c492a61b8f935825c736cc0fce102edf1561"
 ARG TRITON_REPO="https://github.com/ROCm/triton.git"
 ARG PYTORCH_BRANCH="89075173"
 ARG PYTORCH_REPO="https://github.com/ROCm/pytorch.git"

--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=rocm/dev-ubuntu-22.04:7.0-complete
-ARG TRITON_BRANCH="f332c492a61b8f935825c736cc0fce102edf1561"
+ARG TRITON_BRANCH="f332c492"
 ARG TRITON_REPO="https://github.com/ROCm/triton.git"
 ARG PYTORCH_BRANCH="89075173"
 ARG PYTORCH_REPO="https://github.com/ROCm/pytorch.git"


### PR DESCRIPTION

Fix https://github.com/vllm-project/vllm/issues/33906
Fix https://github.com/vllm-project/vllm/issues/33143

To add support to gfx11xx devices to serve gpt-oss (20b for example) models , we need to update triton branch in Dockerfile.rocm_base.
The needed support was in upstream triton, but not in the branch used by vllm base docker.
The patch to rocm/triton was done using this associated PR  https://github.com/ROCm/triton/pull/923.


<!-- markdownlint-disable -->

## Purpose
To add support to gfx11xx devices for gpt-oss models 

(associated PR  https://github.com/ROCm/triton/pull/923 ).

## Test Plan
Build the base docker locally, and then build vllm docker.
Verified on gfx1100 devices. 
Do online serve verification

## Test Result
Verified on gfx1100 devices on `vllm serve` using `gpt-oss-20b` model and run `curl` script which produced result successfully.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

