### PR TITLE
[ROCm][CI] Pinning lm-eval version to resolve multi-modal small eval bug

### DIFF
--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -58,7 +58,7 @@ schemathesis==3.39.15
     # OpenAI schema test
 
 # Evaluation and benchmarking
-lm-eval[api]>=0.4.9.2
+lm-eval[api]==0.4.9.2
 jiwer==4.0.0
 
 # Required for multiprocessed tests that use spawn method, Datasets and Evaluate Test


### PR DESCRIPTION
Pins `lm-eval[api]` to `==0.4.9.2` in test requirements to fix a breaking incompatibility with the vLLM VLM evaluation backend.

## Problem

The `lm-eval-harness` CI test for `Qwen2.5-VL-7B-Instruct` (and potentially other VLM configs) fails with:

```
TypeError: vllm.sampling_params.SamplingParams() argument after ** must be a mapping, not tuple
```

This occurs in `lm_eval/models/vllm_vlms.py:299` inside `_multimodal_model_generate`. A newer version of `lm-eval` changed the return signature of `modify_gen_kwargs` to return a `(kwargs_dict, stop_list, max_gen_toks)` tuple, but the VLM backend still attempts to unpack the result as `**kwargs` into `SamplingParams(...)`.