### PR TITLE
fix(cpu): fix mla_decode compilation on x86 without AVX512

### DIFF
--- a/csrc/cpu/mla_decode.cpp
+++ b/csrc/cpu/mla_decode.cpp
@@ -38,16 +38,7 @@ struct KernelVecType<c10::BFloat16> {
   using qk_vec_type = vec_op::BF16Vec32;
   using v_load_vec_type = vec_op::BF16Vec16;
 };
-
-#elif defined(__s390x__)
-template <>
-struct KernelVecType<c10::BFloat16> {
-  using qk_load_vec_type = vec_op::BF16Vec16;
-  using qk_vec_type = vec_op::FP32Vec16;
-  using v_load_vec_type = vec_op::BF16Vec16;
-};
-
-#elif defined(__aarch64__)
+#else
 template <>
 struct KernelVecType<c10::BFloat16> {
   using qk_load_vec_type = vec_op::BF16Vec16;


### PR DESCRIPTION
## Purpose

Fixes #33991.

This PR addresses a compilation failure in `mla_decode.cpp` when building on x86_64 CPUs without AVX512 support (or when explicitly disabling it via `VLLM_CPU_DISABLE_AVX512=true`).

## Test Plan

## Test Result

* **Before:** The build failed during the compilation of `mla_decode.cpp.o` with `error: incomplete type ‘qk_vec_type’`.
* **After:** The build completes successfully.