### PR TITLE
[Anthropic API] Fix 6 protocol compliance bugs in Messages endpoint

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_protocol.py
+++ b/tests/entrypoints/anthropic/test_anthropic_protocol.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for Anthropic API protocol compliance fixes."""
+
+import json
+
+import pytest
+
+from vllm.entrypoints.anthropic.protocol import (
+    AnthropicMessagesResponse,
+    AnthropicUsage,
+    generate_tool_call_id,
+)
+from vllm.entrypoints.anthropic.serving import _extract_tool_result_text
+
+
+class TestMessageIdFormat:
+    """Message IDs must use the ``msg_`` prefix per the Anthropic API spec."""
+
+    def test_auto_generated_id_has_msg_prefix(self):
+        resp = AnthropicMessagesResponse(
+            id="",
+            content=[],
+            model="test",
+            usage=AnthropicUsage(input_tokens=0, output_tokens=0),
+        )
+        assert resp.id.startswith("msg_")
+
+    def test_openai_style_id_is_replaced(self):
+        resp = AnthropicMessagesResponse(
+            id="chatcmpl-abc123",
+            content=[],
+            model="test",
+            usage=AnthropicUsage(input_tokens=0, output_tokens=0),
+        )
+        assert resp.id.startswith("msg_")
+        assert "chatcmpl" not in resp.id
+
+    def test_valid_msg_id_preserved(self):
+        resp = AnthropicMessagesResponse(
+            id="msg_existing123",
+            content=[],
+            model="test",
+            usage=AnthropicUsage(input_tokens=0, output_tokens=0),
+        )
+        assert resp.id == "msg_existing123"
+
+    def test_unique_ids(self):
+        ids = set()
+        for _ in range(100):
+            resp = AnthropicMessagesResponse(
+                id="",
+                content=[],
+                model="test",
+                usage=AnthropicUsage(input_tokens=0, output_tokens=0),
+            )
+            ids.add(resp.id)
+        assert len(ids) == 100
+
+
+class TestToolCallIdFormat:
+    """Tool call IDs must use the ``toolu_`` prefix."""
+
+    def test_has_toolu_prefix(self):
+        tid = generate_tool_call_id()
+        assert tid.startswith("toolu_")
+
+    def test_unique(self):
+        ids = {generate_tool_call_id() for _ in range(100)}
+        assert len(ids) == 100
+
+
+class TestExtractToolResultText:
+    """tool_result content can be a string or a list of content blocks."""
+
+    def test_none(self):
+        assert _extract_tool_result_text(None) == ""
+
+    def test_plain_string(self):
+        assert _extract_tool_result_text("hello") == "hello"
+
+    def test_single_text_block(self):
+        content = [{"type": "text", "text": "result"}]
+        assert _extract_tool_result_text(content) == "result"
+
+    def test_multiple_text_blocks(self):
+        content = [
+            {"type": "text", "text": "line1"},
+            {"type": "text", "text": "line2"},
+        ]
+        assert _extract_tool_result_text(content) == "line1\nline2"
+
+    def test_image_block(self):
+        content = [{"type": "image", "source": {"data": "base64..."}}]
+        assert _extract_tool_result_text(content) == "[image]"
+
+    def test_unknown_block_preserved_as_json(self):
+        content = [{"type": "custom", "data": 42}]
+        result = _extract_tool_result_text(content)
+        parsed = json.loads(result)
+        assert parsed == {"type": "custom", "data": 42}
+
+    def test_does_not_produce_python_repr(self):
+        """Regression: str([{"type": "text", "text": "hi"}]) produces
+        "[{'type': 'text', 'text': 'hi'}]" which is wrong."""
+        content = [{"type": "text", "text": "hi"}]
+        result = _extract_tool_result_text(content)
+        assert result == "hi"
+        assert "[{" not in result

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -2,10 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Pydantic models for Anthropic API protocol"""
 
-import time
+import uuid
 from typing import Any, Literal
 
 from pydantic import BaseModel, field_validator
+
+
+def generate_tool_call_id() -> str:
+    """Generate a unique tool call ID with the Anthropic ``toolu_`` prefix."""
+    return f"toolu_{uuid.uuid4().hex[:24]}"
 
 
 class AnthropicError(BaseModel):
@@ -158,5 +163,5 @@ class AnthropicMessagesResponse(BaseModel):
     usage: AnthropicUsage | None = None
 
     def model_post_init(self, __context):
-        if not self.id:
-            self.id = f"msg_{int(time.time() * 1000)}"
+        if not self.id or not self.id.startswith("msg_"):
+            self.id = f"msg_{uuid.uuid4().hex[:24]}"

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -168,16 +168,12 @@ class AnthropicServingMessages(OpenAIServingChat):
                                 {
                                     "role": "tool",
                                     "tool_call_id": block.id or "",
-                                    "content": _extract_tool_result_text(
-                                        block.content
-                                    ),
+                                    "content": _extract_tool_result_text(block.content),
                                 }
                             )
                         else:
                             # Assistant tool result becomes regular text
-                            tool_result_text = _extract_tool_result_text(
-                                block.content
-                            )
+                            tool_result_text = _extract_tool_result_text(block.content)
                             content_parts.append(
                                 {
                                     "type": "text",
@@ -465,10 +461,7 @@ class AnthropicServingMessages(OpenAIServingChat):
                                 # The first chunk may carry arguments alongside
                                 # the tool call id.  Emit them as a delta so
                                 # they are not silently dropped.
-                                if (
-                                    tool_call.function
-                                    and tool_call.function.arguments
-                                ):
+                                if tool_call.function and tool_call.function.arguments:
                                     args_chunk = AnthropicStreamEvent(
                                         index=content_block_index,
                                         type="content_block_delta",

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -7,7 +7,6 @@
 
 import json
 import logging
-import time
 from collections.abc import AsyncGenerator
 from typing import Any
 
@@ -22,6 +21,7 @@ from vllm.entrypoints.anthropic.protocol import (
     AnthropicMessagesResponse,
     AnthropicStreamEvent,
     AnthropicUsage,
+    generate_tool_call_id,
 )
 from vllm.entrypoints.chat_utils import ChatTemplateContentFormatOption
 from vllm.entrypoints.logger import RequestLogger
@@ -40,6 +40,34 @@ from vllm.entrypoints.openai.engine.protocol import (
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_tool_result_text(content: str | list[dict[str, Any]] | None) -> str:
+    """Extract plain text from an Anthropic tool_result content field.
+
+    The Anthropic API allows tool_result content as either a plain string or
+    a list of content blocks (e.g. ``[{"type": "text", "text": "..."}]``).
+    Using ``str()`` on the list form produces a Python repr rather than the
+    actual text.  This helper normalises both forms to a plain string.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+                elif block.get("type") == "image":
+                    parts.append("[image]")
+                else:
+                    parts.append(json.dumps(block))
+            else:
+                parts.append(str(block))
+        return "\n".join(parts)
+    return str(content)
 
 
 def wrap_data_with_event(data: str, event: str):
@@ -126,7 +154,7 @@ class AnthropicServingMessages(OpenAIServingChat):
                     elif block.type == "tool_use":
                         # Convert tool use to function call format
                         tool_call = {
-                            "id": block.id or f"call_{int(time.time())}",
+                            "id": block.id or generate_tool_call_id(),
                             "type": "function",
                             "function": {
                                 "name": block.name or "",
@@ -140,15 +168,15 @@ class AnthropicServingMessages(OpenAIServingChat):
                                 {
                                     "role": "tool",
                                     "tool_call_id": block.id or "",
-                                    "content": str(block.content)
-                                    if block.content
-                                    else "",
+                                    "content": _extract_tool_result_text(
+                                        block.content
+                                    ),
                                 }
                             )
                         else:
                             # Assistant tool result becomes regular text
-                            tool_result_text = (
-                                str(block.content) if block.content else ""
+                            tool_result_text = _extract_tool_result_text(
+                                block.content
                             )
                             content_parts.append(
                                 {
@@ -270,23 +298,24 @@ class AnthropicServingMessages(OpenAIServingChat):
         elif generator.choices[0].finish_reason == "tool_calls":
             result.stop_reason = "tool_use"
 
-        content: list[AnthropicContentBlock] = [
-            AnthropicContentBlock(
-                type="text",
-                text=generator.choices[0].message.content
-                if generator.choices[0].message.content
-                else "",
-            )
-        ]
+        content: list[AnthropicContentBlock] = []
+
+        # Only include a text block when there is actual text content.
+        # Anthropic clients (e.g. Claude Code) do not expect an empty text
+        # block alongside tool_use blocks.
+        msg_content = generator.choices[0].message.content
+        if msg_content:
+            content.append(AnthropicContentBlock(type="text", text=msg_content))
 
         for tool_call in generator.choices[0].message.tool_calls:
-            anthropic_tool_call = AnthropicContentBlock(
-                type="tool_use",
-                id=tool_call.id,
-                name=tool_call.function.name,
-                input=json.loads(tool_call.function.arguments),
+            content.append(
+                AnthropicContentBlock(
+                    type="tool_use",
+                    id=tool_call.id,
+                    name=tool_call.function.name,
+                    input=json.loads(tool_call.function.arguments),
+                )
             )
-            content += [anthropic_tool_call]
 
         result.content = content
 
@@ -432,6 +461,28 @@ class AnthropicServingMessages(OpenAIServingChat):
                                 data = chunk.model_dump_json(exclude_unset=True)
                                 yield wrap_data_with_event(data, "content_block_start")
                                 content_block_started = True
+
+                                # The first chunk may carry arguments alongside
+                                # the tool call id.  Emit them as a delta so
+                                # they are not silently dropped.
+                                if (
+                                    tool_call.function
+                                    and tool_call.function.arguments
+                                ):
+                                    args_chunk = AnthropicStreamEvent(
+                                        index=content_block_index,
+                                        type="content_block_delta",
+                                        delta=AnthropicDelta(
+                                            type="input_json_delta",
+                                            partial_json=tool_call.function.arguments,
+                                        ),
+                                    )
+                                    data = args_chunk.model_dump_json(
+                                        exclude_unset=True
+                                    )
+                                    yield wrap_data_with_event(
+                                        data, "content_block_delta"
+                                    )
 
                             else:
                                 chunk = AnthropicStreamEvent(


### PR DESCRIPTION
## Summary

The Anthropic Messages API adapter (`/v1/messages`) has several protocol violations that break compatibility with Anthropic API clients, most notably **Claude Code**. This PR fixes all six issues:

- **Message ID prefix**: Response IDs now use the `msg_` prefix (UUID-based) instead of passing through OpenAI-style `chatcmpl-*` IDs. Applies to both streaming and non-streaming responses.
- **Tool call ID format**: Generated tool call IDs now use `toolu_` prefix with UUID instead of `call_` + timestamp, matching the Anthropic API spec and avoiding collision risk.
- **tool_result content extraction**: `tool_result` content can be a string or a list of content blocks (`[{"type": "text", "text": "..."}]`). Previously `str()` was called on the list form, producing a Python repr instead of actual text.
- **Empty text block suppression**: Non-streaming tool_use responses no longer include a spurious empty `{"type": "text", "text": ""}` block alongside tool_use blocks.
- **Streaming tool call first-chunk arguments**: When the first streaming chunk carries both the tool ID and initial arguments, the arguments are now emitted as an `input_json_delta` event instead of being silently dropped (root cause of "missing parameters" errors in Claude Code).
- **Unused import cleanup**: Removed `import time` (replaced by `uuid`).

## Test plan

- [x] Added unit tests in `tests/entrypoints/anthropic/test_anthropic_protocol.py` covering:
  - Message ID format (`msg_` prefix, uniqueness, OpenAI-style ID replacement)
  - Tool call ID format (`toolu_` prefix, uniqueness)
  - `_extract_tool_result_text()` for all content forms (string, list of blocks, None, image blocks)
  - Regression test: list content blocks no longer produce Python repr
- [ ] Verified with Claude Code 2.1.x against vLLM serving Qwen3-Coder-Next-FP8 on NVIDIA DGX Spark (GB10)
- [ ] Manual testing of streaming + non-streaming tool use round-trips

## Context

These bugs were discovered while integrating vLLM's Anthropic endpoint with Claude Code. The Anthropic Messages API is a thin adapter over the OpenAI chat completions backend, and these fixes address format translation issues in the response conversion layer.

Related: #22627 (original Anthropic API PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)