### PR TITLE
[ROCm] [CI] Reduce Resource of two test groups

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -753,7 +753,7 @@ steps:
 
 - label: Benchmarks # 11min
   timeout_in_minutes: 20
-  mirror_hardwares: [amdexperimental, amdproduction]
+  mirror_hardwares: [amdexperimental, amdproduction, tj]
   agent_pool: mi325_1
   # grade: Blocking
   working_dir: "/vllm-workspace/.buildkite"
@@ -764,7 +764,7 @@ steps:
 
 - label: Benchmarks CLI Test # 7min
   timeout_in_minutes: 20
-  mirror_hardwares: [amdexperimental, amdproduction]
+  mirror_hardwares: [amdexperimental, amdproduction, tj]
   agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -753,7 +753,7 @@ steps:
 
 - label: Benchmarks # 11min
   timeout_in_minutes: 20
-  mirror_hardwares: [amdexperimental, amdproduction, tj]
+  mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
   # grade: Blocking
   working_dir: "/vllm-workspace/.buildkite"
@@ -764,7 +764,7 @@ steps:
 
 - label: Benchmarks CLI Test # 7min
   timeout_in_minutes: 20
-  mirror_hardwares: [amdexperimental, amdproduction, tj]
+  mirror_hardwares: [amdexperimental, amdproduction]
   agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:

--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -754,7 +754,7 @@ steps:
 - label: Benchmarks # 11min
   timeout_in_minutes: 20
   mirror_hardwares: [amdexperimental, amdproduction]
-  agent_pool: mi325_8
+  agent_pool: mi325_1
   # grade: Blocking
   working_dir: "/vllm-workspace/.buildkite"
   source_file_dependencies:
@@ -765,7 +765,7 @@ steps:
 - label: Benchmarks CLI Test # 7min
   timeout_in_minutes: 20
   mirror_hardwares: [amdexperimental, amdproduction]
-  agent_pool: mi325_8
+  agent_pool: mi325_1
   # grade: Blocking
   source_file_dependencies:
   - vllm/


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This is to reduce the number of resources use for two test groups to free up 14 more GPUs for `amd_mi325_1` jobs.

- Benchmarks
- Benchmarks CLI Test

## Test Plan

Run CI.

## Test Result

Passed CI https://buildkite.com/vllm/amd-ci/builds/4373/steps/canvas .

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

