### PR TITLE
fix: compute chunk start times from actual audio lengths

### DIFF
--- a/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
@@ -456,7 +456,7 @@ class OpenAISpeechToText(OpenAIServing):
 
         lora_request = self._maybe_get_adapters(request)
 
-(
+        (
             engine_prompts,
             duration_s,
             chunk_start_times,

--- a/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
@@ -4,6 +4,7 @@ import asyncio
 import io
 import math
 import time
+import warnings
 import zlib
 from collections.abc import AsyncGenerator, Callable
 from functools import cached_property
@@ -552,10 +553,12 @@ class OpenAISpeechToText(OpenAIServing):
             text = ""
             chunk_size_in_s = self.asr_config.max_audio_clip_s
             if chunk_size_in_s is None:
-                logger.warning(
+                warnings.warn(
                     "Setting max_audio_clip_s=None is deprecated and will be "
-                    "removed in a future release. Audio chunking will be enabled "
-                    "by default for long audio files."
+                    "removed in a future release. Audio chunking will be "
+                    "enabled by default for long audio files.",
+                    DeprecationWarning,
+                    stacklevel=2,
                 )
                 assert len(list_result_generator) == 1, (
                     "`max_audio_clip_s` is set to None, audio cannot be chunked"

--- a/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
@@ -550,6 +550,16 @@ class OpenAISpeechToText(OpenAIServing):
             }
             segment_class: type[SpeechToTextSegment] = segments_types[self.task_type]
             text = ""
+            chunk_size_in_s = self.asr_config.max_audio_clip_s
+            if chunk_size_in_s is None:
+                logger.warning(
+                    "Setting max_audio_clip_s=None is deprecated and will be "
+                    "removed in a future release. Audio chunking will be enabled "
+                    "by default for long audio files."
+                )
+                assert len(list_result_generator) == 1, (
+                    "`max_audio_clip_s` is set to None, audio cannot be chunked"
+                )
             for idx, result_generator in enumerate(list_result_generator):
                 start_time = chunk_start_times[idx]
                 async for op in result_generator:

--- a/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
@@ -190,7 +190,7 @@ class OpenAISpeechToText(OpenAIServing):
         request: SpeechToTextRequest,
         audio_data: bytes,
         request_id: str,
-    ) -> tuple[list[ProcessorInputs], float]:
+    ) -> tuple[list[ProcessorInputs], float, list[float]]:
         # Validate request
         language = self.model_cls.validate_language(request.language)
         # Skip to_language validation to avoid extra logging for Whisper.
@@ -266,7 +266,15 @@ class OpenAISpeechToText(OpenAIServing):
             request.language = language
 
         parsed_prompts: list[DictPrompt] = []
+        # Track the actual start time of each chunk based on its sample
+        # length. When audio is split at low-energy points the chunks may
+        # be shorter than max_audio_clip_s, so using a fixed offset would
+        # cause timestamps to drift.
+        chunk_start_times: list[float] = []
+        cumulative_samples = 0
         for chunk in chunks:
+            chunk_start_times.append(float(cumulative_samples) / float(sr))
+            cumulative_samples += chunk.shape[-1]
             # The model has control over the construction, as long as it
             # returns a valid PromptType.
             prompt = self.model_cls.get_generation_prompt(
@@ -290,7 +298,7 @@ class OpenAISpeechToText(OpenAIServing):
 
         engine_prompts = await self.renderer.render_cmpl_async(parsed_prompts)
 
-        return engine_prompts, duration
+        return engine_prompts, duration, chunk_start_times
 
     def _preprocess_verbose_prompt(self, prompt: EncoderDecoderDictPrompt):
         dec_prompt = prompt["decoder_prompt"]
@@ -447,7 +455,11 @@ class OpenAISpeechToText(OpenAIServing):
 
         lora_request = self._maybe_get_adapters(request)
 
-        engine_prompts, duration_s = await self._preprocess_speech_to_text(
+(
+            engine_prompts,
+            duration_s,
+            chunk_start_times,
+        ) = await self._preprocess_speech_to_text(
             request=request,
             audio_data=audio_data,
             request_id=request_id,
@@ -538,15 +550,8 @@ class OpenAISpeechToText(OpenAIServing):
             }
             segment_class: type[SpeechToTextSegment] = segments_types[self.task_type]
             text = ""
-            chunk_size_in_s = self.asr_config.max_audio_clip_s
-            if chunk_size_in_s is None:
-                assert len(list_result_generator) == 1, (
-                    "`max_audio_clip_s` is set to None, audio cannot be chunked"
-                )
             for idx, result_generator in enumerate(list_result_generator):
-                start_time = (
-                    float(idx * chunk_size_in_s) if chunk_size_in_s is not None else 0.0
-                )
+                start_time = chunk_start_times[idx]
                 async for op in result_generator:
                     if request.response_format == "verbose_json":
                         assert op.outputs[0].logprobs


### PR DESCRIPTION
## Summary

Fixes #32588.

When audio longer than 30s is transcribed with Whisper, the audio is split into chunks at low-energy (quiet) regions within a configurable overlap window. This means chunks are often shorter than `max_audio_clip_s`.

Previously, segment timestamps for each chunk were computed as `idx * chunk_size_in_s`, assuming fixed-size chunks. This caused an incremental ~0.5s offset per segment that accumulates over time (e.g., ~5s drift after 10 segments).

This PR fixes the issue by tracking the actual cumulative sample count as chunks are created in `_preprocess_speech_to_text`, and deriving each chunk's start time from its true position in the original audio signal. The start times are then passed through to `_create_speech_to_text` and used directly instead of the fixed-offset calculation.

### Changes
- `_preprocess_speech_to_text` now returns a list of chunk start times computed from actual chunk sample lengths
- `_create_speech_to_text` uses the actual start times instead of `idx * chunk_size_in_s`
- Removed the now-unnecessary `chunk_size_in_s` / `max_audio_clip_s is None` assertion block (this invariant is already enforced by the chunking logic in `_preprocess_speech_to_text`)

## Test plan
- [ ] Existing test `test_audio_with_timestamp` continues to pass (short audio, single chunk)
- [ ] Transcribe audio >30s with `response_format=verbose_json` and verify segment timestamps align with actual speech positions