### PR TITLE
[torch.compile] Remove attention layer name from unified_kv_cache_update

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -629,6 +629,13 @@ class CompilationConfig:
     static_all_moe_layers: list[str] = field(default_factory=list, init=False)
     """The names of all the MOE layers in the model
     """
+    static_all_kv_cache_update_layers: list[str] = field(
+        default_factory=list, init=False
+    )
+    """The names of all attention layers that call unified_kv_cache_update.
+    These are layers where forward_includes_kv_cache_update is False
+    and kv_sharing_target_layer_name is None.
+    """
 
     # Attention ops; used for piecewise cudagraphs
     # Use PyTorch operator format: "namespace::name"

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -250,6 +250,11 @@ class ForwardContext:
     all_moe_layers: list[str] | None = None
     moe_layer_index: int = 0
 
+    # Same approach for unified_kv_cache_update: avoid hard-coding attention
+    # layer name strings into the compiled graph.
+    all_kv_cache_update_layers: list[str] | None = None
+    kv_cache_update_index: int = 0
+
     additional_kwargs: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
@@ -299,9 +304,14 @@ def create_forward_context(
     else:
         all_moe_layers = None
 
+    all_kv_cache_update_layers = (
+        vllm_config.compilation_config.static_all_kv_cache_update_layers or None
+    )
+
     return ForwardContext(
         no_compile_layers=vllm_config.compilation_config.static_forward_context,
         all_moe_layers=all_moe_layers,
+        all_kv_cache_update_layers=all_kv_cache_update_layers,
         virtual_engine=virtual_engine,
         attn_metadata=attn_metadata,
         slot_mapping=slot_mapping or {},

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -304,9 +304,13 @@ def create_forward_context(
     else:
         all_moe_layers = None
 
-    all_kv_cache_update_layers = (
-        vllm_config.compilation_config.static_all_kv_cache_update_layers or None
-    )
+    # Similar optimization for KV cache: skip when using speculative decoding
+    if vllm_config.speculative_config is None:
+        all_kv_cache_update_layers = (
+            vllm_config.compilation_config.static_all_kv_cache_update_layers or None
+        )
+    else:
+        all_kv_cache_update_layers = None
 
     return ForwardContext(
         no_compile_layers=vllm_config.compilation_config.static_forward_context,


### PR DESCRIPTION
## Purpose

Fixes https://github.com/vllm-project/vllm/issues/33267

`unified_kv_cache_update` appears in piecewise cudagraph regions, and each layer has a different name string hard-coded into the graph. This prevents Inductor from reusing compiled graphs across layers, increasing cold start compilation time with Dynamo partition.

## Changes

Apply the same approach used for MOE layers in #32805 and #33184:

1. **`vllm/config/compilation.py`**: Add `static_all_kv_cache_update_layers` list to `CompilationConfig` to store the names of all attention layers that call `unified_kv_cache_update` (computed once at model init time).

2. **`vllm/forward_context.py`**: Add `all_kv_cache_update_layers` list and `kv_cache_update_index` counter to `ForwardContext`, mirroring the existing `all_moe_layers` / `moe_layer_index` pattern.

3. **`vllm/model_executor/layers/attention/attention.py`**:
   - Register attention layers in `static_all_kv_cache_update_layers` during `__init__` (only for layers where `forward_includes_kv_cache_update is False` and `kv_sharing_target_layer_name is None`).
   - Add `encode_kv_cache_layer_name()` helper in `forward()` that returns the sentinel string `"from_forward_context"` when the optimization is available, avoiding hard-coding the layer name into the compiled graph.
   - In `unified_kv_cache_update()`, resolve the actual layer name from the forward context when the sentinel is received.

This allows the compiled graph for the KV cache update operation to be reused across all layers, reducing cold start compilation time.

## Test Plan

- CI
- This follows the exact same proven pattern as MOE cold start optimization (#32805, #33184)