### PR TITLE
Fix TRTLLM decode assertion in dummy batch with full cudagraph padding

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4784,6 +4784,7 @@ class GPUModelRunner(
             pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
             attn_metadata, _ = self._build_attention_metadata(
                 num_tokens=num_tokens_unpadded,
+                num_tokens_padded=num_tokens_padded if pad_attn else None,
                 num_reqs=num_reqs_padded,
                 max_query_len=max_query_len,
                 ubatch_slices=ubatch_slices_padded if pad_attn else ubatch_slices,


### PR DESCRIPTION
Summary:
When `execute_dummy_batch()` runs `_dummy_run(1, uniform_decode=True)` with
`cudagraph_mode=FULL` on Blackwell GPUs, the batch gets padded (num_reqs_padded > 1)
but `num_tokens_padded` was not passed to `_build_attention_metadata`. This caused
`CommonAttentionMetadata.num_actual_tokens` to remain at the unpadded value (1) while
`num_reqs` was the padded value, leading to `num_decode_tokens % num_decodes != 0` in
the TRTLLM decode assertion.

Pass `num_tokens_padded` to `_build_attention_metadata` in the dummy run path,
matching the normal execution path's calling convention.

Test Plan: Run `USE_FP8=1 start_server_with_safetensors.sh` on Blackwell GPU

Reviewed By: houseroad

Differential Revision: D92582501


