### PR TITLE
[vLLM IR] 3/N fused_add_rms_norm and maybe_inplace

### DIFF
--- a/tests/compile/backend.py
+++ b/tests/compile/backend.py
@@ -109,3 +109,9 @@ class TestBackend:
     def op_count(self, op: OpOverload, before=False) -> int:
         graph = self.graph_pre_pass if before else self.graph_post_pass
         return len(list(find_op_nodes(op, graph)))
+
+    def print_graphs(self):
+        print("=== Graph before custom passes ===")
+        print(self.graph_pre_pass.python_code(root_module="self").src)
+        print("=== Graph after custom passes ===")
+        print(self.graph_post_pass.python_code(root_module="self").src)

--- a/tests/compile/backend.py
+++ b/tests/compile/backend.py
@@ -112,6 +112,6 @@ class TestBackend:
 
     def print_graphs(self):
         print("=== Graph before custom passes ===")
-        print(self.graph_pre_pass.python_code(root_module="self").src)
+        print(self.graph_pre_pass.python_code(root_module="self", verbose=True).src)
         print("=== Graph after custom passes ===")
-        print(self.graph_post_pass.python_code(root_module="self").src)
+        print(self.graph_post_pass.python_code(root_module="self", verbose=True).src)

--- a/tests/compile/fusions_e2e/test_tp1_quant.py
+++ b/tests/compile/fusions_e2e/test_tp1_quant.py
@@ -66,6 +66,7 @@ def test_tp1_fp8_fusions(
     model_kwargs["hf_overrides"] = hf_overrides(n_layers)
     model_kwargs["load_format"] = "dummy"
     model_kwargs["max_model_len"] = 1024
+    model_kwargs["kernel_config"] = {"enable_flashinfer_autotune": False}
 
     compilation_config = dict(
         use_inductor_graph_partition=inductor_graph_partition,
@@ -122,6 +123,7 @@ def test_tp1_fp4_fusions(
     model_kwargs["hf_overrides"] = hf_overrides(n_layers)
     model_kwargs["load_format"] = "dummy"
     model_kwargs["max_model_len"] = 1024
+    model_kwargs["kernel_config"] = {"enable_flashinfer_autotune": False}
 
     compilation_config = dict(
         use_inductor_graph_partition=inductor_graph_partition,

--- a/tests/compile/fusions_e2e/test_tp2_ar_rms.py
+++ b/tests/compile/fusions_e2e/test_tp2_ar_rms.py
@@ -59,6 +59,7 @@ def test_tp2_ar_rms_fp8_fusions(
     model_kwargs["hf_overrides"] = hf_overrides(n_layers)
     model_kwargs["load_format"] = "dummy"
     model_kwargs["max_model_len"] = 1024
+    model_kwargs["kernel_config"] = {"enable_flashinfer_autotune": False}
 
     compilation_config = dict(
         use_inductor_graph_partition=inductor_graph_partition,
@@ -119,6 +120,7 @@ def test_tp2_ar_rms_fp4_fusions(
     model_kwargs["hf_overrides"] = hf_overrides(n_layers)
     model_kwargs["load_format"] = "dummy"
     model_kwargs["max_model_len"] = 1024
+    model_kwargs["kernel_config"] = {"enable_flashinfer_autotune": False}
 
     compilation_config = dict(
         use_inductor_graph_partition=inductor_graph_partition,
@@ -173,6 +175,7 @@ def test_tp2_ar_rms_fusions(
     model_kwargs["hf_overrides"] = hf_overrides(n_layers)
     model_kwargs["load_format"] = "dummy"
     model_kwargs["max_model_len"] = 1024
+    model_kwargs["kernel_config"] = {"enable_flashinfer_autotune": False}
 
     compilation_config = dict(
         use_inductor_graph_partition=inductor_graph_partition,

--- a/tests/compile/fusions_e2e/test_tp2_async_tp.py
+++ b/tests/compile/fusions_e2e/test_tp2_async_tp.py
@@ -55,6 +55,7 @@ def test_tp2_async_tp_fp8_fusions(
     model_kwargs["hf_overrides"] = hf_overrides(n_layers)
     model_kwargs["load_format"] = "dummy"
     model_kwargs["max_model_len"] = 1024
+    model_kwargs["kernel_config"] = {"enable_flashinfer_autotune": False}
 
     compilation_config = dict(
         use_inductor_graph_partition=inductor_graph_partition,
@@ -115,6 +116,7 @@ def test_tp2_async_tp_fusions(
     model_kwargs["hf_overrides"] = hf_overrides(n_layers)
     model_kwargs["load_format"] = "dummy"
     model_kwargs["max_model_len"] = 1024
+    model_kwargs["kernel_config"] = {"enable_flashinfer_autotune": False}
 
     compilation_config = dict(
         use_inductor_graph_partition=inductor_graph_partition,

--- a/tests/compile/passes/ir/test_lowering.py
+++ b/tests/compile/passes/ir/test_lowering.py
@@ -4,12 +4,12 @@ import pytest
 import torch
 from torch import nn
 
-import vllm.ir.ops
 import vllm.kernels  # noqa: F401 to register kernels
 from vllm.compilation.passes.ir.lowering_pass import (
     VllmIRLoweringPass,
 )
 from vllm.config import get_current_vllm_config
+from vllm.ir import ops
 
 from ...backend import TestBackend
 
@@ -17,31 +17,41 @@ from ...backend import TestBackend
 class Model(nn.Module):
     def __init__(self, hidden_size=16, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.weight = torch.ones(hidden_size)
+        self.hidden_size = hidden_size
+        self.weight = torch.ones(hidden_size, dtype=torch.bfloat16)
 
     def forward(self, x):
         y = x + 2.0
-        z = vllm.ir.ops.rms_norm(y, self.weight, 1e-5, variance_size=4)
-        return z + 3.0
+        z = ops.rms_norm(y, self.weight, 1e-5)
+        w = ops.rms_norm(z, self.weight, 1e-5)
+        return w + 3.0
 
 
-@pytest.mark.parametrize("rms_provider", vllm.ir.ops.rms_norm.supported_providers())
+@pytest.mark.parametrize("rms_provider", ops.rms_norm.supported_providers())
 def test_lowering_rms_norm(rms_provider, default_vllm_config):
     torch.set_default_device("cuda")
 
     lowering_pass = VllmIRLoweringPass(get_current_vllm_config())
     backend = TestBackend(lowering_pass)
+    backend_unlowered = TestBackend()
 
     model = Model()
-    x = torch.randn(8, 16)
-    with vllm.ir.ops.rms_norm.set_priority([rms_provider, "native"]):
-        output_eager = model(x)
+    x = torch.randn(8, 16, dtype=torch.bfloat16)
+    with ops.rms_norm.set_priority([rms_provider, "native"]):
         compiled_model = torch.compile(model, backend=backend, fullgraph=True)
-        output_compiled = compiled_model(x)
+        compiled_unlowered_model = torch.compile(
+            model, backend=backend_unlowered, fullgraph=True
+        )
+        output = compiled_model(x)
+        output_unlowered = compiled_unlowered_model(x)
+
+    selected = lowering_pass.selected_impls["rms_norm"]
+    assert len(selected) == 2
+    assert all(p == rms_provider for p in selected.values()), selected
 
     # TODO remove print
     backend.print_graphs()
 
-    output_compiled2 = compiled_model(x)
-    torch.testing.assert_close(output_eager, output_compiled)
-    torch.testing.assert_close(output_eager, output_compiled2)
+    output2 = compiled_model(x)
+    torch.testing.assert_close(output_unlowered, output)
+    torch.testing.assert_close(output_unlowered, output2)

--- a/tests/compile/passes/ir/test_lowering.py
+++ b/tests/compile/passes/ir/test_lowering.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+from torch import nn
+
+import vllm.ir.ops
+import vllm.kernels  # noqa: F401 to register kernels
+from vllm.compilation.passes.ir.lowering_pass import (
+    VllmIRLoweringPass,
+)
+from vllm.config import get_current_vllm_config
+
+from ...backend import TestBackend
+
+
+class Model(nn.Module):
+    def __init__(self, hidden_size=16, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.weight = torch.ones(hidden_size)
+
+    def forward(self, x):
+        y = x + 2.0
+        z = vllm.ir.ops.rms_norm(y, self.weight, 1e-5, variance_size=4)
+        return z + 3.0
+
+
+@pytest.mark.parametrize("rms_provider", vllm.ir.ops.rms_norm.supported_providers())
+def test_lowering_rms_norm(rms_provider, default_vllm_config):
+    torch.set_default_device("cuda")
+
+    lowering_pass = VllmIRLoweringPass(get_current_vllm_config())
+    backend = TestBackend(lowering_pass)
+
+    model = Model()
+    x = torch.randn(8, 16)
+    with vllm.ir.ops.rms_norm.set_priority([rms_provider, "native"]):
+        output_eager = model(x)
+        compiled_model = torch.compile(model, backend=backend, fullgraph=True)
+        output_compiled = compiled_model(x)
+
+    # TODO remove print
+    backend.print_graphs()
+
+    output_compiled2 = compiled_model(x)
+    torch.testing.assert_close(output_eager, output_compiled)
+    torch.testing.assert_close(output_eager, output_compiled2)

--- a/tests/compile/passes/ir/test_lowering.py
+++ b/tests/compile/passes/ir/test_lowering.py
@@ -21,12 +21,12 @@ class Model(nn.Module):
         self.weight = torch.ones(hidden_size, dtype=torch.bfloat16)
 
     def forward(self, x):
-        x1 = x + 2.0
+        x1 = x + 4.0
         x2 = ops.rms_norm(x1, self.weight, 1e-5)
         x3 = x2 * 5.0
         # no weight
         x4 = ops.rms_norm(x3, None, 1e-5)
-        x5 = x4 - 1.0
+        x5 = x4 / 2.0
         # dispatch to native due to variance_size parameter
         x6 = ops.rms_norm(x5, self.weight, 1e-5, self.hidden_size // 2)
         return x6 + 3.0
@@ -55,9 +55,6 @@ def test_lowering_rms_norm(rms_provider, default_vllm_config):
     assert selected["rms_norm"] == rms_provider
     assert selected["rms_norm_1"] == rms_provider
     assert selected["rms_norm_2"] == "native"
-
-    # TODO remove print
-    backend.print_graphs()
 
     output2 = compiled_model(x)
     torch.testing.assert_close(output_unlowered, output)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1550,3 +1550,26 @@ def use_fresh_inductor_cache():
 def enable_pickle(monkeypatch):
     """`LLM.apply_model` requires pickling a function."""
     monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+
+
+@pytest.fixture(scope="function")
+def disable_log_dedup(monkeypatch):
+    """
+    Disable log deduplication such that warning_once and info_once always print.
+    """
+
+    # Patch logger._print_warning_once to remove the lru_cache decorator
+    from vllm import logger
+
+    original_print_warning_once = logger._print_warning_once
+    original_print_info_once = logger._print_info_once
+    original_print_debug_once = logger._print_debug_once
+
+    logger._print_warning_once = original_print_warning_once.__wrapped__
+    logger._print_info_once = original_print_info_once.__wrapped__
+    logger._print_debug_once = original_print_debug_once.__wrapped__
+
+    yield
+    logger._print_warning_once = original_print_warning_once
+    logger._print_info_once = original_print_info_once
+    logger._print_debug_once = original_print_debug_once

--- a/tests/ir/test_inplace_op.py
+++ b/tests/ir/test_inplace_op.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+from torch import Tensor
+from torch.fx.experimental.proxy_tensor import make_fx
+
+import vllm.ir.op
+from vllm.ir.op import IrOp, IrOpImpl, IrOpInplaceOverload
+
+
+@vllm.ir.register_op(allow_inplace=True)
+def _custom_mm2(x: Tensor, w: Tensor) -> Tensor:
+    return x @ w
+
+
+@_custom_mm2.register_impl("regular")
+def _custom_mm2_regular(x: Tensor, w: Tensor) -> Tensor:
+    return x @ w + 1
+
+
+@_custom_mm2.register_impl("inplace", inplace=True)
+def _custom_mm2_inplace(x: Tensor, w: Tensor) -> Tensor:
+    x.copy_(x @ w + 2)
+    return x
+
+
+class TestInplaceOp:
+    def test_registration(self):
+        # Test that the inplace op is registered correctly.
+        assert "_custom_mm2" in IrOp.registry
+        assert IrOp.registry["_custom_mm2"] is _custom_mm2
+        assert _custom_mm2.torch_op is torch.ops.vllm_ir._custom_mm2.default
+        assert isinstance(_custom_mm2.maybe_inplace, IrOpInplaceOverload)
+        assert (
+            _custom_mm2.maybe_inplace.torch_op
+            is torch.ops.vllm_ir._custom_mm2.maybe_inplace
+        )
+
+    def test_inplace_dispatching(self):
+        # check that the correct implementation is dispatched based on priority,
+        # and inplace semantics hold
+        w = torch.randn(3, 3)
+        x = torch.randn(2, 3)
+        x1 = x.clone()
+
+        with _custom_mm2.set_priority(["regular"]):
+            result_regular = _custom_mm2.maybe_inplace(x, w)
+
+        # check that the regular op does not modify x
+        torch.testing.assert_close(x, x1)
+
+        with _custom_mm2.set_priority(["inplace"]):
+            result_inplace: Tensor = _custom_mm2.maybe_inplace(x, w)
+
+        # check that the inplace op returns x directly
+        assert result_inplace.data_ptr() == x.data_ptr()
+
+        torch.testing.assert_close(result_inplace, x1 @ w + 2)
+        torch.testing.assert_close(result_regular, x1 @ w + 1)
+
+    def test_default_dispatching(self):
+        # check that the correct implementation is dispatched when no priority is set,
+        # and ops do not modify inputs
+        w = torch.randn(3, 3)
+        x = torch.randn(2, 3)
+        x1 = x.clone()
+
+        with _custom_mm2.set_priority(["regular"]):
+            result_regular = _custom_mm2(x, w)
+
+        with _custom_mm2.set_priority(["inplace"]):
+            result_inplace = _custom_mm2(x, w)
+
+        # check that x was not modified by either impl
+        torch.testing.assert_close(x, x1)
+
+        torch.testing.assert_close(result_inplace, x1 @ w + 2)
+        torch.testing.assert_close(result_regular, x1 @ w + 1)
+
+    @pytest.mark.xfail
+    def test_trace(self):
+        # Test that the inplace op can be used in a graph.
+        def func(x: Tensor, y: Tensor) -> Tensor:
+            return _custom_mm2(x, y)
+
+        x = torch.randn(2, 3)
+        y = torch.randn(3, 4)
+        graph = make_fx(func)(x, y)
+        assert any(node.target == "custom_mm2" for node in graph.graph.nodes)
+
+        # Test that the inplace op can be used in an IrOpImpl.
+        class CustomMM2Impl(IrOpImpl):
+            def __init__(self):
+                super().__init__("custom_mm2")
+
+            def forward(self, x: Tensor, y: Tensor) -> Tensor:
+                return _custom_mm2(x, y)
+
+        impl = CustomMM2Impl()
+        result = impl.forward(x, y)
+        assert torch.allclose(result, x @ y)

--- a/tests/ir/test_op.py
+++ b/tests/ir/test_op.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+from torch.fx.experimental.proxy_tensor import make_fx
+
+import vllm.ir.op
+from vllm.ir.op import IrOp
+
+# This should not exist
+assert "_custom_add" not in IrOp.registry
+
+
+@vllm.ir.register_op
+def _custom_add(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    return x + y
+
+
+def test_registration_overloads():
+    # Calling with decorator
+    @vllm.ir.register_op()
+    def _custom_sub(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return x - y
+
+    assert _custom_sub.name == "_custom_sub"
+    assert _custom_sub is IrOp.registry["_custom_sub"]
+
+    # Custom name
+    @vllm.ir.register_op(name="_custom_mul")
+    def custom_mul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return x * y
+
+    assert custom_mul.name == "_custom_mul"
+    assert custom_mul is IrOp.registry["_custom_mul"]
+
+    # Direct construction is equivalent
+    def _custom_div(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return x / y
+
+    custom_div = IrOp("_custom_div", _custom_div)
+    assert custom_div.name == "_custom_div"
+    assert custom_div is IrOp.registry["_custom_div"]
+
+
+class TestIrOpCustomAdd:
+    # Registration invariants
+    def test_decorated_object(self):
+        """Make sure that referring directly to an op is correct"""
+        assert isinstance(_custom_add, IrOp)
+        assert "_custom_add" in IrOp.registry
+        assert _custom_add is IrOp.registry["_custom_add"]
+
+    def test_torch_op_is_registered(self):
+        assert hasattr(torch.ops.vllm_ir, "_custom_add")
+        assert callable(torch.ops.vllm_ir._custom_add.default)
+
+    # Semantic correctness
+    def test_semantics_match_native(self):
+        x = torch.randn(4, 5)
+        y = torch.randn(4, 5)
+
+        out = _custom_add(x, y)
+        ref = x + y
+
+        torch.testing.assert_close(out, ref)
+
+    # -------------------------
+    # Implementation registration
+    # -------------------------
+
+    def test_register_impl_is_non_intrusive(self):
+        @_custom_add.register_impl("dummy_provider")
+        def dummy_impl(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return x + y + 123
+
+        assert "dummy_provider" in _custom_add._impls
+        assert callable(_custom_add._impls["dummy_provider"])
+
+        x = torch.ones(2, 2)
+        y = torch.ones(2, 2)
+
+        # Native semantics must still hold
+        torch.testing.assert_close(_custom_add(x, y), x + y)
+
+    def test_schema_contains_tensor_signature(self):
+        schema = _custom_add._schema_str
+
+        assert "Tensor" in schema
+        assert "-> Tensor" in schema
+
+    # -------------------------
+    # FX visibility
+    # -------------------------
+
+    def test_fx_sees_single_custom_op(self):
+        def fn(x, y):
+            return _custom_add(x, y)
+
+        gm = torch.fx.symbolic_trace(fn)
+
+        assert any(
+            "vllm_ir._custom_add" in str(n.target)
+            for n in gm.graph.nodes
+            if n.op == "call_function"
+        )
+
+    def test_dynamo_sees_single_custom_op(self):
+        def fn(x, y):
+            return _custom_add(x, y)
+
+        fx_gm = make_fx(fn)(torch.randn(2, 2), torch.randn(2, 2))
+
+        assert any(
+            "vllm_ir._custom_add" in str(n.target)
+            for n in fx_gm.graph.nodes
+            if n.op == "call_function"
+        )

--- a/tests/kernels/ir/test_layernorm.py
+++ b/tests/kernels/ir/test_layernorm.py
@@ -100,6 +100,16 @@ class TestRMSNorm:
         assert not impl.supports_args(x, weight, epsilon, 4)
         assert not impl.supports_args(x, weight, epsilon, variance_size=4)
 
+        # test weight=None behavior
+        out_impl_no_weight = impl.impl_fn(x, None, epsilon)
+        out_impl_unit_weight = impl.impl_fn(x, torch.ones_like(weight), epsilon)
+        torch.testing.assert_close(
+            out_impl_no_weight,
+            out_impl_unit_weight,
+            rtol=get_default_rtol(out_impl_no_weight),
+            atol=2e-4,
+        )
+
     @pytest.mark.parametrize("provider", ["vllm_c", "aiter", "native"])
     def test_torch_opcheck(self, dtype, n_tokens, hidden_size, epsilon, provider):
         if not ir.ops.rms_norm.impls[provider].supported:

--- a/tests/kernels/ir/test_layernorm.py
+++ b/tests/kernels/ir/test_layernorm.py
@@ -86,7 +86,7 @@ class TestRMSNorm:
         out_native = rms_norm_native(*args)
 
         torch.testing.assert_close(
-            out_impl, out_native, rtol=get_default_rtol(out_impl), atol=1e-4
+            out_impl, out_native, rtol=get_default_rtol(out_impl), atol=2e-4
         )
 
         # check that dispatched call matches direct call

--- a/tests/kernels/ir/test_layernorm.py
+++ b/tests/kernels/ir/test_layernorm.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+
+# This registers op implementations
+import vllm.kernels  # noqa: F401
+from tests.kernels.allclose_default import get_default_rtol
+from vllm import ir
+from vllm.platforms import current_platform
+
+
+def rms_norm_inputs(n_tokens: int, hidden_size: int, dtype: torch.dtype):
+    x = torch.randn(n_tokens, hidden_size, dtype=dtype)
+    weight = torch.rand(hidden_size, dtype=dtype)
+    return x, weight
+
+
+rms_norm_native = ir.ops.rms_norm.impls["native"].impl_fn
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Currently only kernels on CUDA and ROCm",
+)
+def test_rms_norm_registration():
+    expected = {"native": True, "vllm_c": True, "aiter": current_platform.is_rocm()}
+
+    actual = {
+        provider: impl.supported for provider, impl in ir.ops.rms_norm.impls.items()
+    }
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("n_tokens", [1, 8, 17])
+@pytest.mark.parametrize("hidden_size", [16, 4096, 8192])
+@pytest.mark.parametrize("epsilon", [1e-6, 1e-5])
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Currently only kernels on CUDA and ROCm",
+)
+class TestRMSNorm:
+    @classmethod
+    def setup_class(cls, **kwargs):
+        torch.set_default_device("cuda")
+
+    def test_native_semantics(self, dtype, n_tokens, hidden_size, epsilon):
+        x, weight = rms_norm_inputs(4, 8, dtype)
+        out = rms_norm_native(x, weight, epsilon=epsilon)
+
+        # Check shape, dtype, device
+        assert out.shape == x.shape
+        assert out.dtype == x.dtype
+        assert out.device == x.device
+
+        # Check the scaling property of rms norm
+        out2 = rms_norm_native(x * 2.0, weight, epsilon=epsilon)
+        torch.testing.assert_close(out2, out, rtol=get_default_rtol(out), atol=1e-4)
+
+        # Check behavior with and without weight
+        weight1 = torch.ones_like(weight)
+        out3 = rms_norm_native(x, weight1, epsilon=epsilon)
+        out4 = rms_norm_native(x, None, epsilon=epsilon)
+        torch.testing.assert_close(out3, out4)
+
+    @pytest.mark.parametrize("provider", ["vllm_c", "aiter"])
+    def test_impls(self, dtype, n_tokens, hidden_size, epsilon, provider):
+        if provider == "aiter" and not current_platform.is_rocm():
+            pytest.skip("aiter impl not supported on this platform")
+
+        x, weight = rms_norm_inputs(n_tokens, hidden_size, dtype)
+        impl = ir.ops.rms_norm.impls[provider]
+        args = (x, weight, epsilon, None)
+
+        assert impl.supported
+
+        if provider == "aiter" and dtype not in [torch.float16, torch.bfloat16]:
+            assert not impl.supports_args(*args)
+            return
+
+        assert impl.supports_args(*args)
+
+        out_impl = impl.impl_fn(*args)
+        out_native = rms_norm_native(*args)
+
+        torch.testing.assert_close(
+            out_impl, out_native, rtol=get_default_rtol(out_impl), atol=1e-4
+        )

--- a/tests/kernels/ir/test_layernorm.py
+++ b/tests/kernels/ir/test_layernorm.py
@@ -57,7 +57,7 @@ class TestRMSNorm:
 
         # Check the scaling property of rms norm
         out2 = rms_norm_native(x * 2.0, weight, epsilon=epsilon)
-        torch.testing.assert_close(out2, out, rtol=get_default_rtol(out), atol=1e-4)
+        torch.testing.assert_close(out2, out, rtol=get_default_rtol(out), atol=1e-3)
 
         # Check behavior with and without weight
         weight1 = torch.ones_like(weight)

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -44,6 +44,7 @@ from .partition_rules import (
     should_split,
 )
 from .passes.inductor_pass import InductorPass, pass_context
+from .passes.ir.inplace_raising import VllmIRInplaceRaisingPass
 from .passes.pass_manager import PostGradPassManager
 
 logger = init_logger(__name__)
@@ -780,6 +781,14 @@ class VllmBackend:
         return standalone_compile_artifacts, sym_shape_indices_map, returns_tuple_map
 
     def configure_post_pass(self) -> None:
+        # TODO proper PassManager?
+        pre_grad_pass_key = "pre_grad_custom_pass"
+        assert self.pass_key != pre_grad_pass_key
+        assert self.pass_key not in self.inductor_config
+        self.inductor_config[pre_grad_pass_key] = VllmIRInplaceRaisingPass(
+            self.vllm_config
+        )
+
         self.pass_manager.configure(self.vllm_config)
 
         # Post-grad custom passes are run using the post_grad_custom_post_pass

--- a/vllm/compilation/passes/ir/inplace_raising.py
+++ b/vllm/compilation/passes/ir/inplace_raising.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections import defaultdict
+
+from torch import fx
+from torch._inductor.pattern_matcher import (
+    PatternMatcherPass,
+)
+
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+
+from ..vllm_inductor_pass import VllmInductorPass
+from .lowering_pass import get_ir_op, overload_or_default
+
+logger = init_logger(__name__)
+
+
+# TODO for pickling
+def f():
+    return 0
+
+
+# TODO avoid pickling pre_grad_pass
+class VllmIRInplaceRaisingPass(VllmInductorPass):
+    """
+    This pass raises maybe_inplace vLLM IR ops to their functional equivalents.
+    The maybe_inplace overloads have the same signature as the default overload
+    so the pass simply replaces the called overload.
+    That makes the graph properly functional.
+    """
+
+    def __init__(self, vllm_config: VllmConfig) -> None:
+        super().__init__(vllm_config)
+        self.patterns = PatternMatcherPass(self.pass_name)
+        self.raised_ops: dict[str, int] = defaultdict(f)
+
+    @VllmInductorPass.time_and_log
+    def __call__(self, graph: fx.Graph) -> None:
+        # clear at the beginning instead of end, so that tests can inspect
+        self.raised_ops.clear()
+
+        for node in graph.nodes:
+            if (ir_op := get_ir_op(node)) is None:
+                continue
+
+            op_overload = overload_or_default(node.target)
+            overload_name = op_overload._overloadname
+            if overload_name != "maybe_inplace":
+                assert overload_name == "default", (
+                    f"Found overload {overload_name} for op {ir_op.name}, "
+                    f"expected maybe_inplace or default"
+                )
+                continue
+
+            # must have maybe_inplace overload and allow_inplace
+            assert ir_op.allow_inplace and ir_op.maybe_inplace is not None
+
+            # Same signature, just replace the overload that's called.
+            node.target = ir_op.torch_op
+            self.raised_ops[ir_op.name] += 1
+
+        count = sum(self.raised_ops.values())
+        ops = ",".join(self.raised_ops.keys())
+        logger.debug(
+            "VllmIRLoweringPass raised %d vLLM IR nodes for op(s) %s", count, ops
+        )

--- a/vllm/compilation/passes/ir/lowering_pass.py
+++ b/vllm/compilation/passes/ir/lowering_pass.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import inspect
+from collections import defaultdict
+from collections.abc import Iterable
+
+from torch import fx
+from torch._inductor.pattern_matcher import (
+    CallFunctionVarArgs,
+    Match,
+    PatternMatcherPass,
+    register_graph_pattern,
+)
+from torch._ops import OpOverload, OpOverloadPacket
+
+from vllm.config import VllmConfig
+from vllm.ir.op import IrOp
+from vllm.logger import init_logger
+from vllm.logging_utils import lazy
+
+from ..vllm_inductor_pass import VllmInductorPass
+
+logger = init_logger(__name__)
+
+
+def get_default_overload(op: OpOverload | OpOverloadPacket) -> OpOverload:
+    if isinstance(op, OpOverloadPacket):
+        return op.default
+    assert isinstance(op, OpOverload), "Expected an OpOverload or OpOverloadPacket"
+    return op
+
+
+def get_ir_op(node: fx.Node) -> IrOp | None:
+    if node.op != "call_function":
+        return None
+
+    if not isinstance(node.target, (OpOverload, OpOverloadPacket)):
+        return None
+
+    op_overload = get_default_overload(node.target)
+    if op_overload.namespace != "vllm_ir":
+        return None
+
+    op_name = op_overload._opname
+    if op_name not in IrOp.registry:
+        logger.warning(
+            "Unknown vLLM IR op %s, there's likely an issue with torch registration, "
+            "or a torch custom op was registered in the vllm_ir namespace by mistake.",
+            op_name,
+        )
+        return None
+
+    ir_op = IrOp.registry[op_name]
+    return ir_op
+
+
+class VllmIRLoweringPass(VllmInductorPass):
+    """
+    This pass lowers vLLM IR ops to their implementations the priority list.
+    """
+
+    def __init__(self, vllm_config: VllmConfig) -> None:
+        super().__init__(vllm_config)
+        self.patterns = PatternMatcherPass(self.pass_name)
+        self.selected_impls: dict[str, dict[str, str]] = defaultdict(lambda: {})
+        self.ops = [ir_op.torch_op for ir_op in IrOp.registry.values()]
+
+        # Look for any call_function node where the target is a vLLM IR op.
+        # Then, lower_matched_op will select, trace, and insert the implementation.
+        register_graph_pattern(
+            CallFunctionVarArgs(self.ops),
+            pass_dict=self.patterns,
+        )(self.lower_matched_op)
+
+    def lower_matched_op(self, match: Match, *args, **kwargs):
+        # TODO(luka) I think args and kwargs are for the match, but just use the node?
+
+        assert len(match.nodes) == 1, "Expected single node match"
+        node = match.nodes[0]
+        ir_op = get_ir_op(node)
+        assert ir_op is not None, "Expected vLLM IR op"
+
+        # TODO(luka): is there a better way to handle defaults here?
+        impl_sig = inspect.signature(ir_op.native_fn)
+        bound_args = impl_sig.bind(*node.args, **node.kwargs)
+        bound_args.apply_defaults()
+        assert not bound_args.kwargs  # I think there should never be kwargs here
+
+        # Select and record the implementation, using fake args
+        fake_args = fx.map_arg(bound_args.args, lambda arg: arg.meta["val"])
+        ir_op_impl = ir_op.dispatch(*fake_args)
+        self.selected_impls[ir_op.name][node.name] = ir_op_impl.provider
+
+        # replace_by_example wants node args, not the fake tensors
+        # TODO(luka): Use aot_export_module to get functionalized graph
+        # TODO(luka): Cache the fx_replacement to avoid re-tracing the same impl
+        match.replace_by_example(ir_op_impl.impl_fn, bound_args.args)
+
+    @VllmInductorPass.time_and_log
+    def __call__(self, graph: fx.Graph) -> None:
+        count = self.patterns.apply(graph)
+        logger.debug("VllmIRLoweringPass lowered %d vLLM IR nodes", count)
+
+        # TODO write self.selected_impls to depyf/tlparse dir
+        def count_items(impls: Iterable[str]) -> dict[str, int]:
+            counts: dict[str, int] = defaultdict(lambda: 0)
+            for impl in impls:
+                counts[impl] += 1
+            return counts
+
+        def print_count(counts: dict[str, int]) -> str:
+            # e.g., "impl1*3,impl2"
+            impl_count = lambda i, c: f"{i}" if c == 1 else f"{i}*{c}"
+            return ",".join(impl_count(impl, count) for impl, count in counts.items())
+
+        logger.debug(
+            "Selected implementations: %s",
+            lazy(
+                lambda: ", ".join(
+                    f"{op}={print_count(count_items(impls_by_node.values()))}"
+                    for op, impls_by_node in self.selected_impls.items()
+                )
+            ),
+        )
+
+        failed_nodes: list[fx.Node] = []
+        failed_ops: set[str] = set()
+        # Check no vllm_ir nodes were left in the graph
+        for node in graph.nodes:
+            if (ir_op := get_ir_op(node)) is None:
+                continue
+
+            failed_nodes.append(node)
+            failed_ops.add(ir_op.name)
+
+        if failed_nodes or failed_ops:
+            logger.warning("Failed to lower vLLM IR ops: %s", ",".join(failed_ops))
+            logger.warning("Full node list: %s", failed_nodes)

--- a/vllm/compilation/passes/ir/lowering_pass.py
+++ b/vllm/compilation/passes/ir/lowering_pass.py
@@ -132,3 +132,5 @@ class VllmIRLoweringPass(VllmInductorPass):
         if failed_nodes or failed_ops:
             logger.warning("Failed to lower vLLM IR ops: %s", ",".join(failed_ops))
             logger.warning("Full node list: %s", failed_nodes)
+
+        self.selected_impls.clear()

--- a/vllm/compilation/passes/ir/lowering_pass.py
+++ b/vllm/compilation/passes/ir/lowering_pass.py
@@ -94,6 +94,9 @@ class VllmIRLoweringPass(VllmInductorPass):
 
     @VllmInductorPass.time_and_log
     def __call__(self, graph: fx.Graph) -> None:
+        # clear at the beginning instead of end, so that tests can inspect
+        self.selected_impls.clear()
+
         count = self.patterns.apply(graph)
         logger.debug("VllmIRLoweringPass lowered %d vLLM IR nodes", count)
 
@@ -132,5 +135,3 @@ class VllmIRLoweringPass(VllmInductorPass):
         if failed_nodes or failed_ops:
             logger.warning("Failed to lower vLLM IR ops: %s", ",".join(failed_ops))
             logger.warning("Full node list: %s", failed_nodes)
-
-        self.selected_impls.clear()

--- a/vllm/compilation/passes/vllm_inductor_pass.py
+++ b/vllm/compilation/passes/vllm_inductor_pass.py
@@ -137,6 +137,7 @@ class VllmPatternMatcherPass(VllmInductorPass):
                 f"auto_functionalized as auto_functionalized\n"
                 f"from torch._inductor.pattern_matcher import *\n"
                 f"vllm = torch.ops.vllm",
+                "vllm_ir = torch.ops.vllm_ir",
                 file=f,
             )
 

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -110,7 +110,7 @@ class KernelConfig:
         from vllm.platforms import current_platform
 
         platform_op_priority = current_platform.get_default_ir_op_priority(vllm_config)
-        logger.info(
+        logger.debug(
             "Setting platform-specific IR op priority defaults: %s",
             platform_op_priority,
         )
@@ -126,3 +126,8 @@ class KernelConfig:
                     op for op in op_priority if op not in current_op_priority
                 ]
                 current_op_priority.extend(unique_op_priority)
+
+        logger.info(
+            "Final IR op priority after setting platform defaults: %s",
+            self.ir_op_priority,
+        )

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -31,6 +31,9 @@ class IrOpPriorityConfig:
     rms_norm: list[str] = Field(default_factory=list)
     """Priority list for vllm.ir.ops.rms_norm"""
 
+    fused_add_rms_norm: list[str] = Field(default_factory=list)
+    """Priority list for vllm.ir.ops.fused_add_rms_norm"""
+
     def compute_hash(self) -> str:
         """
         Produces a hash unique to the pass configuration.

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -1,39 +1,101 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-
+import contextlib
 from collections.abc import Callable
-from typing import Any
+from dataclasses import fields
+from typing import TYPE_CHECKING, Any
 
+from datasets.utils.py_utils import asdict
 from pydantic import Field, field_validator
 
-from vllm.config.utils import config
-from vllm.utils.hashing import safe_hash
+from vllm.config.utils import config, get_hash_factors, hash_factors
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+logger = init_logger(__name__)
+
+
+@config
+class IrOpPriorityConfig:
+    """
+    Configuration for vLLM IR op priority for dispatching/lowering during the
+    forward pass. Each member is a list of strings, which will be passed to
+    vllm.ir.ops.<op_name>.set_priority() for the duration of the forward pass.
+
+    If specified manually, platform defaults will be appended to the lists.
+    See KernelConfig.set_platform_defaults().
+    """
+
+    rms_norm: list[str] = Field(default_factory=list)
+    """Priority list for vllm.ir.ops.rms_norm"""
+
+    def compute_hash(self) -> str:
+        """
+        Produces a hash unique to the pass configuration.
+        Any new fields that affect compilation should be added to the hash.
+        Any future fields that don't affect compilation should be excluded.
+        """
+
+        return hash_factors(get_hash_factors(self, set()))
+
+    @contextlib.contextmanager
+    def set_priority(self):
+        """
+        Context manager to set the IR op priority for all op members.
+        It also imports vllm.kernels to ensure all implementations are made available.
+        """
+        import vllm.kernels  # noqa: F401, registers IR op implementations
+        from vllm.ir.op import IrOp
+
+        with contextlib.ExitStack() as stack:
+            for field in fields(self):
+                op_priority = getattr(self, field.name)
+                assert op_priority is not None, (
+                    f"IR op priority for {field.name} must be set"
+                )
+                logger.debug(
+                    "Setting IR op priority for %s to %s", field.name, op_priority
+                )
+                ir_op = IrOp.registry[field.name]
+                stack.enter_context(ir_op.set_priority(op_priority))
+
+            yield
+
+    @classmethod
+    def with_default(
+        cls, default: list[str], /, **kwargs: list[str]
+    ) -> "IrOpPriorityConfig":
+        """
+        A helper to create an IrOpPriorityConfig where fields not specified in kwargs
+        use the given default list.
+        """
+        for field in fields(cls):
+            if field not in kwargs:
+                kwargs[field.name] = default
+
+        return cls(**kwargs)
 
 
 @config
 class KernelConfig:
     """Configuration for kernel selection and warmup behavior."""
 
+    ir_op_priority: IrOpPriorityConfig = Field(default_factory=IrOpPriorityConfig)
+    """vLLM IR op priority for dispatching/lowering during the forward pass."""
+
     enable_flashinfer_autotune: bool = Field(default=None)
     """If True, run FlashInfer autotuning during kernel warmup."""
 
     def compute_hash(self) -> str:
         """
-        WARNING: Whenever a new field is added to this config,
-        ensure that it is included in the factors list if
-        it affects the computation graph.
-
-        Provide a hash that uniquely identifies all the configs
-        that affect the structure of the computation
-        graph from input ids/embeddings to the final hidden states,
-        excluding anything before input ids/embeddings and after
-        the final hidden states.
+        Produces a hash unique to the pass configuration.
+        Any new fields that affect compilation should be added to the hash.
+        Any future fields that don't affect compilation should be excluded.
         """
-        # no factors to consider.
-        # this config will not affect the computation graph.
-        factors: list[Any] = []
-        hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
-        return hash_str
+
+        return hash_factors(get_hash_factors(self, set("enable_flashinfer_autotune")))
 
     @field_validator("enable_flashinfer_autotune", mode="wrap")
     @classmethod
@@ -42,3 +104,25 @@ class KernelConfig:
         if value is None:
             return value
         return handler(value)
+
+    def set_platform_defaults(self, vllm_config: "VllmConfig") -> None:
+        """Set platform-specific defaults for the kernel config."""
+        from vllm.platforms import current_platform
+
+        platform_op_priority = current_platform.get_default_ir_op_priority(vllm_config)
+        logger.info(
+            "Setting platform-specific IR op priority defaults: %s",
+            platform_op_priority,
+        )
+        for op_name, op_priority in asdict(platform_op_priority).items():
+            current_op_priority: list[str] = getattr(self.ir_op_priority, op_name)
+            if current_op_priority is None:
+                setattr(self.ir_op_priority, op_name, op_priority)
+            else:
+                # Append platform-specific priorities
+                # Must be idempotent because vllm_config.set_platform_defaults() may be
+                # called multiple times (due to VllmConfig.__post_init__ manual call).
+                unique_op_priority = [
+                    op for op in op_priority if op not in current_op_priority
+                ]
+                current_op_priority.extend(unique_op_priority)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -806,6 +806,12 @@ class VllmConfig:
             else:
                 self.compilation_config.custom_ops.append("+rms_norm")
 
+        # This populates IR op priorities,
+        # needs to happen after compilation mode and backend are decided.
+        # TODO(luka): it's hard to figure out where to put this because it shouldn't
+        #  affect any of the passes or anything else - a great problem to have :)
+        self.kernel_config.set_platform_defaults(self)
+
         if self.compilation_config.fast_moe_cold_start is None:
             # resolve default behavior: try to be as safe as possible
             # this config is unsafe if any spec decoding draft model has a MOE.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -101,7 +101,6 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_PAGED_ATTN: bool = False
     VLLM_ROCM_USE_AITER_LINEAR: bool = True
     VLLM_ROCM_USE_AITER_MOE: bool = True
-    VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
     VLLM_ROCM_USE_AITER_MHA: bool = True
     VLLM_ROCM_USE_AITER_FP4_ASM_GEMM: bool = False
@@ -900,10 +899,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_MOE": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_MOE", "True").lower() in ("true", "1")
-    ),
-    # use aiter rms norm op if aiter ops are enabled.
-    "VLLM_ROCM_USE_AITER_RMSNORM": lambda: (
-        os.getenv("VLLM_ROCM_USE_AITER_RMSNORM", "True").lower() in ("true", "1")
     ),
     # Whether to use aiter mla ops.
     # By default is enabled.

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -398,7 +398,10 @@ def set_forward_context(
     )
 
     try:
-        with override_forward_context(forward_context):
+        with (
+            override_forward_context(forward_context),
+            vllm_config.kernel_config.ir_op_priority.set_priority(),
+        ):
             yield
     finally:
         global last_logging_time, batchsize_logging_interval

--- a/vllm/ir/__init__.py
+++ b/vllm/ir/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from .op import register_op
+
+__all__ = ["register_op"]

--- a/vllm/ir/__init__.py
+++ b/vllm/ir/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from . import ops
 from .op import register_op
 
-__all__ = ["register_op"]
+__all__ = ["register_op", "ops"]

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -177,6 +177,15 @@ class IrOp:
             if impl.supports_args is None or impl.supports_args(*args, **kwargs):
                 return impl
 
+            logger.debug(
+                "Skipping provider %s because it does not support "
+                "%s with args=%s kwargs=%s",
+                impl.provider,
+                self.name,
+                args,
+                kwargs,
+            )
+
         raise RuntimeError(
             "Priority set incorrectly: the last implementation must "
             "support all args (can be native). This is likely an internal bug"

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Callable
+from typing import Any
+
+import torch
+from torch.library import Library, infer_schema
+
+vllm_ir_lib = Library("vllm_ir", "FRAGMENT")
+
+
+def register_op(
+    f: Callable | None = None,
+    *,
+    name: str | None = None,
+    tags: tuple[torch.Tag, ...] = (),
+) -> "IrOp | Callable[[Callable], IrOp]":
+    def decorator(_f: Callable):
+        op_name = _f.__name__ if name is None else name
+        return IrOp(op_name, _f, tags)
+
+    if f is not None:
+        return decorator(f)
+
+    return decorator
+
+
+class IrOp:
+    registry: dict[str, "IrOp"] = {}
+
+    def __init__(
+        self, name: str, native_impl: Callable, tags: tuple[torch.Tag, ...] = ()
+    ):
+        self.name = name
+        self._impls: dict[str, object] = {}
+        self._native_impl = native_impl
+        self._schema_str = infer_schema(native_impl, mutates_args=[])
+
+        # torch registration
+        dispatch_key = "CPU"  # TODO
+        vllm_ir_lib.define(self.name + self._schema_str, tags=tags)
+        vllm_ir_lib.impl(self.name, self._inner_call, dispatch_key=dispatch_key)
+        assert hasattr(torch.ops.vllm_ir, name)
+
+        self._torch_op_call = getattr(torch.ops.vllm_ir, name).default
+
+        assert name not in self.registry
+        self.registry[name] = self
+
+    def register_fake(self):
+        """
+        Register a fake impl for the torch custom op. If this method is not called,
+        the native implementation is used directly for the fake implementation.
+        """
+        pass  # TODO(luka)
+
+    def register_impl(self, provider: str):
+        def decorator(f: Callable):
+            print(f"Registering {provider} for op {self.name}")
+            assert provider not in self._impls
+            self._impls[provider] = f
+            return
+
+        return decorator
+
+    #
+    # def register_impl(provider: str, enable_if):
+    #     """Register an implementation for this custom op"""
+    #     def decorator(f):
+    #         from vllm.ir import IrOpImpl
+    #         return IrOpImpl(self, provider, f, enable_if)
+
+    def _inner_call(self, *args, **kwargs) -> Any:
+        """Direct call to torch op, could also skip the torch layer if eager?"""
+        print(f"Direct call to {self.name} with args {args} with kwargs {kwargs}")
+        return self._native_impl(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs) -> Any:
+        return self._torch_op_call(*args, **kwargs)

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -85,9 +85,9 @@ class IrOp:
         self._fake_fn = native_impl
 
         # torch registration
-        dispatch_key = "CPU"  # TODO
         vllm_ir_lib.define(self.name + self._schema_str, tags=tags)
-        vllm_ir_lib.impl(self.name, self._inner_call, dispatch_key=dispatch_key)
+        vllm_ir_lib.impl(self.name, self._inner_call, dispatch_key="CUDA")
+        vllm_ir_lib.impl(self.name, self._inner_call, dispatch_key="CPU")
         vllm_ir_lib._register_fake(self.name, self._fake_call)
         assert hasattr(torch.ops.vllm_ir, name)
         self._torch_op_call = getattr(torch.ops.vllm_ir, name).default

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -8,6 +8,7 @@ import torch
 from torch.library import Library, infer_schema
 
 from vllm.logger import init_logger
+from vllm.logging_utils import lazy, tensors_str_no_data
 
 vllm_ir_lib = Library("vllm_ir", "FRAGMENT")
 
@@ -182,8 +183,8 @@ class IrOp:
                 "%s with args=%s kwargs=%s",
                 impl.provider,
                 self.name,
-                args,
-                kwargs,
+                lazy(lambda: tensors_str_no_data(args)),
+                lazy(lambda: tensors_str_no_data(kwargs)),
             )
 
         raise RuntimeError(

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -1,12 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import contextlib
 from collections.abc import Callable
 from typing import Any
 
 import torch
 from torch.library import Library, infer_schema
 
+from vllm.logger import init_logger
+
 vllm_ir_lib = Library("vllm_ir", "FRAGMENT")
+
+logger = init_logger(__name__)
+
+RESERVED_PROVIDERS = ["native", "unfused"]
+"""Providers that are reserved and cannot be used for custom implementations."""
 
 
 def register_op(
@@ -15,6 +23,25 @@ def register_op(
     name: str | None = None,
     tags: tuple[torch.Tag, ...] = (),
 ) -> "IrOp | Callable[[Callable], IrOp]":
+    """
+    Register a new vLLM IR op.
+
+    :param f: the native implementation of the op
+    :param name: the name of the op, defaults to the function name
+    :param tags: any additional torch tags for the op
+    :return: the IrOp object if f is provided, otherwise a decorator
+
+    Example usage:
+    ```python
+    @vllm.ir.register_op
+    def my_op(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return x + y
+
+
+    @vllm.ir.register_op(name="custom_mul")
+    def multiply(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return x * y"""
+
     def decorator(_f: Callable):
         op_name = _f.__name__ if name is None else name
         return IrOp(op_name, _f, tags)
@@ -32,48 +59,177 @@ class IrOp:
         self, name: str, native_impl: Callable, tags: tuple[torch.Tag, ...] = ()
     ):
         self.name = name
-        self._impls: dict[str, object] = {}
-        self._native_impl = native_impl
+        self.impls: dict[str, IrOpImpl] = {}
+        self._priority_impls: list[IrOpImpl] = []
         self._schema_str = infer_schema(native_impl, mutates_args=[])
+
+        # native implementation, constructor also registers into impls
+        self._native_impl = IrOpImpl(
+            self, "native", native_impl, supported=True, supports_args=None
+        )
+
+        self._fake_fn = native_impl
 
         # torch registration
         dispatch_key = "CPU"  # TODO
         vllm_ir_lib.define(self.name + self._schema_str, tags=tags)
         vllm_ir_lib.impl(self.name, self._inner_call, dispatch_key=dispatch_key)
+        vllm_ir_lib._register_fake(self.name, self._fake_call)
         assert hasattr(torch.ops.vllm_ir, name)
-
         self._torch_op_call = getattr(torch.ops.vllm_ir, name).default
 
         assert name not in self.registry
         self.registry[name] = self
 
-    def register_fake(self):
+    def register_fake(self, fn: Callable) -> Callable:
         """
         Register a fake impl for the torch custom op. If this method is not called,
         the native implementation is used directly for the fake implementation.
         """
-        pass  # TODO(luka)
+        self._fake_fn = fn
+        return fn
 
-    def register_impl(self, provider: str):
-        def decorator(f: Callable):
-            print(f"Registering {provider} for op {self.name}")
-            assert provider not in self._impls
-            self._impls[provider] = f
-            return
+    def _fake_call(self, *args, **kwargs) -> Any:
+        """
+        Call to the fake implementation of the op. We use indirection because we want
+        users to be able to register fake later but also want it to fall back to native
+        directly by default, instead of going through the dispatching mechanism.
+        """
+        return self._fake_fn(*args, **kwargs)
 
-        return decorator
+    def register_impl(
+        self,
+        provider: str,
+        *,
+        supported: bool = True,
+        supports_args: Callable[..., bool] | None = None,
+    ):
+        """
+        Register an implementation for this custom op.
+        :param provider: The name of the provider, must be unique.
+        :param supported: Static support check, use this to check platform support.
+        :param supports_args: Dynamic arg support check.
+        :return: A decorator that registers the implementation.
 
-    #
-    # def register_impl(provider: str, enable_if):
-    #     """Register an implementation for this custom op"""
-    #     def decorator(f):
-    #         from vllm.ir import IrOpImpl
-    #         return IrOpImpl(self, provider, f, enable_if)
+        The provider name must be unique and not one of the RESERVED_PROVIDERS.
+        The supported and supports_args parameters should not be used to implement
+        custom enablement logic based on global state (e.g. environment variables).
+        Instead, supported param should only be used to check for platform support
+        (e.g. whether a specific hardware or library is available).
+        supports_args should be used to check whether the provided arguments are
+        compatible with the implementation.
+        For custom enablement logic, set op impl priority.
+
+        Example:
+        ```python
+        @my_op.register_impl("my_provider", supported=torch.cuda.is_available())
+        def my_provider_impl(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor: ...
+        ```
+
+        """
+        assert provider not in RESERVED_PROVIDERS, (
+            f"Provider name {provider} is reserved."
+        )
+
+        def _register_impl(f: Callable):
+            return IrOpImpl(self, provider, f, supported, supports_args)
+
+        return _register_impl
 
     def _inner_call(self, *args, **kwargs) -> Any:
         """Direct call to torch op, could also skip the torch layer if eager?"""
-        print(f"Direct call to {self.name} with args {args} with kwargs {kwargs}")
-        return self._native_impl(*args, **kwargs)
+        if not self._priority_impls:
+            logger.warning_once(
+                "Priority not set for op %s, using native implementation.", self.name
+            )
+            return self.impls["native"].impl_fn(*args, **kwargs)
+
+        for impl in self._priority_impls:
+            assert impl.supported, (
+                "All implementations in priority list must be supported."
+            )
+            if impl.supports_args is None or impl.supports_args(*args, **kwargs):
+                return impl.impl_fn(*args, **kwargs)
+
+        raise RuntimeError(
+            "Priority set incorrectly: the last implementation must "
+            "support all args (can be native). This is likely an internal bug"
+        )
 
     def __call__(self, *args, **kwargs) -> Any:
         return self._torch_op_call(*args, **kwargs)
+
+    def get_priority(self) -> list[str]:
+        """Get the current dispatch priority for implementations for this op."""
+        return [p.provider for p in self._priority_impls]
+
+    @contextlib.contextmanager
+    def set_priority(self, priority: list[str]):
+        """
+        Context manager to set the dispatch priority for implementations for this op.
+        """
+        assert all(p in self.impls for p in priority), (
+            "All providers in priority must be registered implementations."
+        )
+
+        def filter_priority_impls(p_list: list[str]) -> list[IrOpImpl]:
+            filtered_impls = []
+            for p in p_list:
+                impl = self.impls[p]
+                if not impl.supported:
+                    continue
+
+                # Skip unsupported implementations
+                filtered_impls.append(impl)
+
+                # If all args are supported, skip other implementations
+                if impl.supports_args is None:
+                    return filtered_impls
+
+            logger.warning_once(
+                "Op %s: No implementation in priority list supports all args, "
+                "execution fallback to native is possible. To silence this warning, "
+                "explicitly add 'native' to the end of the priority list",
+                self.name,
+            )
+            filtered_impls.append(self.impls["native"])
+            return filtered_impls
+
+        # Temporarily set priority
+        old_priority_impls = self._priority_impls
+        try:
+            self._priority_impls = filter_priority_impls(priority)
+            yield
+        finally:
+            self._priority_impls = old_priority_impls
+
+
+class IrOpImpl:
+    def __init__(
+        self,
+        op: IrOp,
+        provider: str,
+        impl_fn: Callable,
+        supported: bool,
+        supports_args: Callable[..., bool] | None,
+    ):
+        assert provider not in op.impls, (
+            f"Implementation for provider {provider} already registered."
+        )
+        # Native also uses this path, so we allow it here.
+        assert provider == "native" or provider not in RESERVED_PROVIDERS
+
+        self.op = op
+        self.provider = provider
+        self.impl_fn = impl_fn
+        self.supported = supported
+        self.supports_args = supports_args
+
+        op.impls[provider] = self
+
+        if op.get_priority():
+            logger.warning(
+                "Warning: registering new impl %s for op %s while priority is set.",
+                provider,
+                op.name,
+            )

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -77,6 +77,8 @@ def register_op(
 class IrOp:
     registry: ClassVar[dict[str, "IrOp"]] = {}
 
+    maybe_inplace: "IrOpInplaceOverload | None"
+
     def __init__(
         self,
         name: str,
@@ -132,6 +134,8 @@ class IrOp:
 
         if self.allow_inplace:
             self.maybe_inplace = IrOpInplaceOverload(self)
+        else:
+            self.maybe_inplace = None
 
         assert name not in self.registry
         self.registry[name] = self

--- a/vllm/ir/ops/__init__.py
+++ b/vllm/ir/ops/__init__.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Kernel implementations for vLLM."""
+from .layernorm import rms_norm
 
-from . import aiter_ops, vllm_c
-
-__all__ = ["vllm_c", "aiter_ops"]
+__all__ = ["rms_norm"]

--- a/vllm/ir/ops/__init__.py
+++ b/vllm/ir/ops/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from .layernorm import rms_norm
+from .layernorm import fused_add_rms_norm, rms_norm
 
-__all__ = ["rms_norm"]
+__all__ = ["rms_norm", "fused_add_rms_norm"]

--- a/vllm/ir/ops/layernorm.py
+++ b/vllm/ir/ops/layernorm.py
@@ -20,3 +20,27 @@ def rms_norm(
     if weight is not None:
         x = x * weight
     return x
+
+
+@register_op(allow_inplace=True)
+def fused_add_rms_norm(
+    x: Tensor,
+    x_residual: Tensor,
+    weight: Tensor | None,
+    epsilon: float,
+    variance_size: int | None = None,
+) -> tuple[Tensor, Tensor]:
+    """Fused add and weighted root-mean-square layer normalization"""
+    orig_dtype = x.dtype
+    x = x.to(torch.float32)
+    x = x + x_residual.to(torch.float32)
+    x_residual = x.to(orig_dtype)
+
+    x_var = x if variance_size is None else x[..., :variance_size]
+    variance = x_var.pow(2).mean(dim=-1, keepdim=True)
+    x = x * torch.rsqrt(variance + epsilon)
+    x = x.to(orig_dtype)
+    if weight is not None:
+        x = x * weight
+
+    return x, x_residual

--- a/vllm/ir/ops/layernorm.py
+++ b/vllm/ir/ops/layernorm.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+from torch import Tensor
+
+from ..op import register_op
+
+
+@register_op
+def rms_norm(
+    x: Tensor, weight: Tensor | None, epsilon: float, variance_size: int | None = None
+) -> Tensor:
+    """Weighted root-mean-square layer normalization"""
+    orig_dtype = x.dtype
+    x = x.to(torch.float32)
+    x_var = x if variance_size is None else x[..., :variance_size]
+    variance = x_var.pow(2).mean(dim=-1, keepdim=True)
+    x = x * torch.rsqrt(variance + epsilon)
+    x = x.to(orig_dtype)
+    if weight is not None:
+        x = x * weight
+    return x

--- a/vllm/kernels/aiter_ops.py
+++ b/vllm/kernels/aiter_ops.py
@@ -34,7 +34,7 @@ direct_register_aiter_op = functools.partial(
 AITER_SUPPORTED = is_aiter_found()
 """Most kernels in this file are supported if AITER is installed."""
 
-rms_no_var_16bit_only = lambda x, w, e, v: v is None and x.dtype in (
+rms_no_var_16bit_only = lambda x, w, e, v=None: v is None and x.dtype in (
     torch.float16,
     torch.bfloat16,
 )

--- a/vllm/kernels/aiter_ops.py
+++ b/vllm/kernels/aiter_ops.py
@@ -49,6 +49,8 @@ def rms_norm(
 ) -> Tensor:
     assert variance_size is None
     assert x.dtype in (torch.float16, torch.bfloat16)
+    if weight is None:
+        weight = torch.ones(x.shape[-1], device=x.device, dtype=x.dtype)
     return torch.ops.vllm_aiter.rms_norm(x, weight, epsilon)
 
 

--- a/vllm/kernels/aiter_ops.py
+++ b/vllm/kernels/aiter_ops.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import functools
+
+import torch
+from torch import Tensor
+from torch.library import Library
+
+from vllm import ir
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import direct_register_custom_op
+
+current_platform.import_kernels()
+
+
+def is_aiter_found() -> bool:
+    from importlib.util import find_spec
+
+    return find_spec("aiter") is not None
+
+
+aiter_lib = Library("vllm_aiter", "FRAGMENT")
+"""
+This library holds torch custom ops for wrapped AITER ops.
+Many AITER ops want to remain invisible to torch.compile even after lowering.
+They are thus wrapped into torch custom ops inside the IR op implementations.
+"""
+
+direct_register_aiter_op = functools.partial(
+    direct_register_custom_op, target_lib=aiter_lib
+)
+"""Syntactic sugar for registering AITER custom ops."""
+
+AITER_SUPPORTED = is_aiter_found()
+"""Most kernels in this file are supported if AITER is installed."""
+
+rms_no_var_16bit_only = lambda x, w, e, v: v is None and x.dtype in (
+    torch.float16,
+    torch.bfloat16,
+)
+"""AITER rms_norm only supports float16 and bfloat16 acts and no var_size override."""
+
+
+@ir.ops.rms_norm.register_impl(
+    "aiter", supports_args=rms_no_var_16bit_only, supported=AITER_SUPPORTED
+)
+def rms_norm(
+    x: Tensor, weight: Tensor | None, epsilon: float, variance_size: int | None = None
+) -> Tensor:
+    assert variance_size is None
+    assert x.dtype in (torch.float16, torch.bfloat16)
+    return torch.ops.vllm_aiter.rms_norm(x, weight, epsilon)
+
+
+def _rms_norm_impl(x: Tensor, weight: Tensor, variance_epsilon: float) -> Tensor:
+    from aiter import rms_norm
+
+    if x.dim() > 2:
+        x_original_shape = x.shape
+        x = x.reshape(-1, x_original_shape[-1])
+        x = rms_norm(x, weight, variance_epsilon)
+        return x.reshape(x_original_shape)
+
+    return rms_norm(x, weight, variance_epsilon)
+
+
+def _rms_norm_fake(x: Tensor, weight: Tensor, variance_epsilon: float) -> Tensor:
+    return torch.empty_like(x)
+
+
+direct_register_aiter_op(
+    op_name="rms_norm", op_func=_rms_norm_impl, fake_impl=_rms_norm_fake
+)

--- a/vllm/kernels/vllm_c.py
+++ b/vllm/kernels/vllm_c.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+from torch import Tensor
+
+from vllm import ir
+from vllm.platforms import current_platform
+
+current_platform.import_kernels()
+
+CUDA_ALIKE = current_platform.is_cuda_alike()
+"""Most kernels in this file are supported on all CUDA-alike platforms."""
+
+rms_no_var_size = lambda x, w, e, variance_size: variance_size is None
+"""vLLM Kernel does not support variance_size parameter."""
+
+
+@ir.ops.rms_norm.register_impl(
+    "vllm_c", supports_args=rms_no_var_size, supported=CUDA_ALIKE
+)
+def rms_norm(
+    x: Tensor, weight: Tensor | None, epsilon: float, variance_size: int | None = None
+) -> Tensor:
+    assert variance_size is None
+    output = torch.empty(x.shape, device=x.device, dtype=x.dtype)
+    torch.ops._C.rms_norm(output, x, weight, epsilon)
+    return output

--- a/vllm/kernels/vllm_c.py
+++ b/vllm/kernels/vllm_c.py
@@ -11,7 +11,7 @@ current_platform.import_kernels()
 CUDA_ALIKE = current_platform.is_cuda_alike()
 """Most kernels in this file are supported on all CUDA-alike platforms."""
 
-rms_no_var_size = lambda x, w, e, variance_size: variance_size is None
+rms_no_var_size = lambda x, w, e, variance_size=None: variance_size is None
 """vLLM Kernel does not support variance_size parameter."""
 
 

--- a/vllm/kernels/vllm_c.py
+++ b/vllm/kernels/vllm_c.py
@@ -21,6 +21,9 @@ rms_no_var_size = lambda x, w, e, variance_size=None: variance_size is None
 def rms_norm(
     x: Tensor, weight: Tensor | None, epsilon: float, variance_size: int | None = None
 ) -> Tensor:
+    if weight is None:
+        # Kernel requires weight tensor, pass ones
+        weight = torch.ones(x.shape[-1], device=x.device, dtype=x.dtype)
     assert variance_size is None
     output = torch.empty(x.shape, device=x.device, dtype=x.dtype)
     torch.ops._C.rms_norm(output, x, weight, epsilon)

--- a/vllm/kernels/vllm_c.py
+++ b/vllm/kernels/vllm_c.py
@@ -11,7 +11,7 @@ current_platform.import_kernels()
 CUDA_ALIKE = current_platform.is_cuda_alike()
 """Most kernels in this file are supported on all CUDA-alike platforms."""
 
-rms_no_var_size = lambda x, w, e, variance_size=None: variance_size is None
+rms_no_var_size = lambda x, w, e, var_size=None: var_size is None
 """vLLM Kernel does not support variance_size parameter."""
 
 

--- a/vllm/logging_utils/__init__.py
+++ b/vllm/logging_utils/__init__.py
@@ -8,6 +8,7 @@ from vllm.logging_utils.access_log_filter import (
 from vllm.logging_utils.formatter import ColoredFormatter, NewLineFormatter
 from vllm.logging_utils.lazy import lazy
 from vllm.logging_utils.log_time import logtime
+from vllm.logging_utils.torch_tensor import tensors_str_no_data
 
 __all__ = [
     "NewLineFormatter",
@@ -16,4 +17,5 @@ __all__ = [
     "create_uvicorn_log_config",
     "lazy",
     "logtime",
+    "tensors_str_no_data",
 ]

--- a/vllm/logging_utils/torch_tensor.py
+++ b/vllm/logging_utils/torch_tensor.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Any
+
+
+def tensors_str_no_data(arg: Any):
+    from torch._tensor_str import printoptions
+
+    with printoptions(threshold=1, edgeitems=0):
+        return str(arg)

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from torch.distributed import PrefixStore, ProcessGroup
 
     from vllm.config import VllmConfig
+    from vllm.config.kernel import IrOpPriorityConfig
     from vllm.inputs import ProcessorInputs, PromptType
     from vllm.pooling_params import PoolingParams
     from vllm.renderers.inputs import DictPrompt, TokPrompt
@@ -690,6 +691,16 @@ class Platform:
         Set some additional forward context for the current platform if needs.
         """
         return {}
+
+    @classmethod
+    def get_default_ir_op_priority(
+        cls, vllm_config: "VllmConfig"
+    ) -> "IrOpPriorityConfig":
+        """Get the default IR op priority for the current platform."""
+        from vllm.config.kernel import IrOpPriorityConfig
+
+        # Native always used by default. Platforms can override this behavior.
+        return IrOpPriorityConfig.with_default(["native"])
 
 
 class UnspecifiedPlatform(Platform):

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -16,6 +16,7 @@ from .interface import DeviceCapability, Platform, PlatformEnum
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.config.kernel import IrOpPriorityConfig
     from vllm.v1.attention.selector import AttentionSelectorConfig
 
 logger = init_logger(__name__)
@@ -674,3 +675,12 @@ class RocmPlatform(Platform):
     @classmethod
     def support_static_graph_mode(cls) -> bool:
         return True
+
+    @classmethod
+    def get_default_ir_op_priority(
+        cls, vllm_config: "VllmConfig"
+    ) -> "IrOpPriorityConfig":
+        from vllm.config.kernel import IrOpPriorityConfig
+
+        # On ROCm, we use custom ops by default even when compiling
+        return IrOpPriorityConfig.with_default(["aiter", "vllm_c", "native"])


### PR DESCRIPTION
This is part two of RMSNorm to vLLM IR conversion, after #33825. Includes adding a maybe_inplace overload and proper handling.

TODO: remove clones, properly pickle `custom_pre_grad_pass`

Dispatching overhead seems to be around 20% for now, which is not great.

UPDATE: got the dispatching overhead down to negligible!

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

