### PR TITLE
[ROCm][Bugfix] fix act_quant_fusion module import error

### DIFF
--- a/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
+++ b/vllm/compilation/passes/fusion/rocm_aiter_fusion.py
@@ -18,9 +18,9 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.platforms import current_platform
 
-from ..activation_quant_fusion import ActivationQuantPattern
 from ..inductor_pass import enable_fake_mode
 from ..vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
+from .act_quant_fusion import ActivationQuantPattern
 from .matcher_utils import (
     MatcherFusedAddRMSNorm,
     MatcherQuantFP8,


### PR DESCRIPTION
Fixes:

```log
File "/app/vllm/vllm/compilation/passes/fusion/rocm_aiter_fusion.py", line 21, in <module>
ModuleNotFoundError: No module named 'vllm.compilation.passes.activation_quant_fusion'
```

Manifests in several cases including: `pytest -s -v tests/models/language/generation/test_common.py::test_models[False-True-5-32-meta-llama/Llama-3.2-1B-Instruct]` when executed on ROCm.