### PR TITLE
Add validation to reject non-text content in system messages

### DIFF
--- a/tests/entrypoints/openai/test_chat_error.py
+++ b/tests/entrypoints/openai/test_chat_error.py
@@ -236,7 +236,14 @@ async def test_chat_error_stream():
     assert chunks[-1] == "data: [DONE]\n\n"
 
 
-def test_system_message_rejects_image():
+@pytest.mark.parametrize(
+    "image_content",
+    [
+        [{"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}],
+        [{"image_url": {"url": "https://example.com/image.jpg"}}],
+    ],
+)
+def test_system_message_rejects_image(image_content):
     """Test that system messages cannot contain image content."""
     with pytest.raises(VLLMValidationError) as exc_info:
         ChatCompletionRequest(
@@ -244,12 +251,7 @@ def test_system_message_rejects_image():
             messages=[
                 {
                     "role": "system",
-                    "content": [
-                        {
-                            "type": "image_url",
-                            "image_url": {"url": "https://example.com/image.jpg"},
-                        }
-                    ],
+                    "content": image_content,
                 }
             ],
         )
@@ -306,7 +308,14 @@ def test_user_message_accepts_image():
     assert request.messages[0]["role"] == "user"
 
 
-def test_system_message_rejects_audio():
+@pytest.mark.parametrize(
+    "audio_content",
+    [
+        [{"type": "input_audio", "input_audio": {"data": "base64data", "format": "wav"}}],
+        [{"input_audio": {"data": "base64data", "format": "wav"}}],
+    ],
+)
+def test_system_message_rejects_audio(audio_content):
     """Test that system messages cannot contain audio content."""
     with pytest.raises(VLLMValidationError) as exc_info:
         ChatCompletionRequest(
@@ -314,12 +323,7 @@ def test_system_message_rejects_audio():
             messages=[
                 {
                     "role": "system",
-                    "content": [
-                        {
-                            "type": "input_audio",
-                            "input_audio": {"data": "base64data", "format": "wav"},
-                        }
-                    ],
+                    "content": audio_content,
                 }
             ],
         )
@@ -328,7 +332,14 @@ def test_system_message_rejects_audio():
     assert "input_audio" in str(exc_info.value)
 
 
-def test_system_message_rejects_video():
+@pytest.mark.parametrize(
+    "video_content",
+    [
+        [{"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}],
+        [{"video_url": {"url": "https://example.com/video.mp4"}}],
+    ],
+)
+def test_system_message_rejects_video(video_content):
     """Test that system messages cannot contain video content."""
     with pytest.raises(VLLMValidationError) as exc_info:
         ChatCompletionRequest(
@@ -336,12 +347,7 @@ def test_system_message_rejects_video():
             messages=[
                 {
                     "role": "system",
-                    "content": [
-                        {
-                            "type": "video_url",
-                            "video_url": {"url": "https://example.com/video.mp4"},
-                        }
-                    ],
+                    "content": video_content,
                 }
             ],
         )

--- a/tests/entrypoints/openai/test_chat_error.py
+++ b/tests/entrypoints/openai/test_chat_error.py
@@ -311,7 +311,12 @@ def test_user_message_accepts_image():
 @pytest.mark.parametrize(
     "audio_content",
     [
-        [{"type": "input_audio", "input_audio": {"data": "base64data", "format": "wav"}}],
+        [
+            {
+                "type": "input_audio",
+                "input_audio": {"data": "base64data", "format": "wav"},
+            }
+        ],
         [{"input_audio": {"data": "base64data", "format": "wav"}}],
     ],
 )

--- a/tests/entrypoints/openai/test_chat_error.py
+++ b/tests/entrypoints/openai/test_chat_error.py
@@ -245,7 +245,10 @@ def test_system_message_rejects_image():
                 {
                     "role": "system",
                     "content": [
-                        {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/image.jpg"},
+                        }
                     ],
                 }
             ],
@@ -292,7 +295,10 @@ def test_user_message_accepts_image():
                 "role": "user",
                 "content": [
                     {"type": "text", "text": "What's in this image?"},
-                    {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.jpg"},
+                    },
                 ],
             },
         ],
@@ -309,7 +315,10 @@ def test_system_message_rejects_audio():
                 {
                     "role": "system",
                     "content": [
-                        {"type": "input_audio", "input_audio": {"data": "base64data", "format": "wav"}}
+                        {
+                            "type": "input_audio",
+                            "input_audio": {"data": "base64data", "format": "wav"},
+                        }
                     ],
                 }
             ],
@@ -328,7 +337,10 @@ def test_system_message_rejects_video():
                 {
                     "role": "system",
                     "content": [
-                        {"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}
+                        {
+                            "type": "video_url",
+                            "video_url": {"url": "https://example.com/video.mp4"},
+                        }
                     ],
                 }
             ],

--- a/tests/entrypoints/openai/test_chat_error.py
+++ b/tests/entrypoints/openai/test_chat_error.py
@@ -15,6 +15,7 @@ from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.logger import _print_warning_once
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.renderers.hf import HfRenderer
 from vllm.tokenizers.registry import tokenizer_args_from_config
@@ -234,6 +235,14 @@ async def test_chat_error_stream():
         f"Expected error message in chunks: {chunks}"
     )
     assert chunks[-1] == "data: [DONE]\n\n"
+
+
+@pytest.fixture(autouse=True)
+def _clear_warning_once_cache():
+    """Clear the warning_once lru_cache so each test gets a fresh state."""
+    _print_warning_once.cache_clear()
+    yield
+    _print_warning_once.cache_clear()
 
 
 @pytest.mark.parametrize(

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -694,7 +694,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                     for part in content:
                         if isinstance(part, dict):
                             part_type = part.get("type")
-                            # Infer type for content parts without an explicit 'type' field
+                            # Infer type when 'type' field is not explicit
                             if part_type is None:
                                 if "image_url" in part or "image_pil" in part:
                                     part_type = "image_url"

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -685,6 +685,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
         users who intentionally send multimodal system messages.
         See: https://platform.openai.com/docs/api-reference/chat/create#chat_create-messages-system_message
         """
+        if not isinstance(data, dict):
+            return data
         messages = data.get("messages", [])
         for msg in messages:
             # Check if this is a system message

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -713,7 +713,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
                             # Warn about non-text content in system messages
                             if part_type and part_type != "text":
-                                logger.warning(
+                                logger.warning_once(
                                     "System messages should only contain text "
                                     "content according to the OpenAI API spec. "
                                     "Found content type: '%s'.",

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -694,6 +694,21 @@ class ChatCompletionRequest(OpenAIBaseModel):
                     for part in content:
                         if isinstance(part, dict):
                             part_type = part.get("type")
+                            # Infer type for content parts without an explicit 'type' field
+                            if part_type is None:
+                                if "image_url" in part or "image_pil" in part:
+                                    part_type = "image_url"
+                                elif "image_embeds" in part:
+                                    part_type = "image_embeds"
+                                elif "audio_url" in part:
+                                    part_type = "audio_url"
+                                elif "input_audio" in part:
+                                    part_type = "input_audio"
+                                elif "audio_embeds" in part:
+                                    part_type = "audio_embeds"
+                                elif "video_url" in part:
+                                    part_type = "video_url"
+
                             # Reject any content type that is not text
                             if part_type and part_type != "text":
                                 raise VLLMValidationError(


### PR DESCRIPTION
## Summary
Fixes #33925

According to OpenAI API specification, system messages can only contain text content. This PR adds validation to warn on non-text content types (images, audio, video) in system messages.

## Problem
vLLM was accepting images and other multimodal content in system messages without any indication, which deviates from the [OpenAI API specification](https://platform.openai.com/docs/api-reference/chat/create#chat_create-messages-system_message). System messages should only support text content.

## Changes
- Added `check_system_message_content_type` model validator in `ChatCompletionRequest`
- Validator checks if system messages contain non-text content types
- Logs a `warning_once` with clear message indicating the non-text content type (avoids log spam)
- Handles both explicit `type` field and inferred types from content keys
- User messages and other roles still accept multimodal content

## Test Plan
Added comprehensive tests in `tests/entrypoints/openai/test_chat_error.py`:
- `test_system_message_warns_on_image` - Validates that image_url triggers warning (parametrized: explicit and inferred type)
- `test_system_message_warns_on_audio` - Validates that input_audio triggers warning (parametrized: explicit and inferred type)
- `test_system_message_warns_on_video` - Validates that video_url triggers warning (parametrized: explicit and inferred type)
- `test_system_message_accepts_text` - Validates that text content is accepted
- `test_system_message_accepts_text_array` - Validates that text array format is accepted
- `test_user_message_accepts_image` - Confirms user messages still accept images