### PR TITLE
[Bugfix] Fix Qwen3 context length limited to sliding_window when use_sliding_window=False

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -534,12 +534,13 @@ def _maybe_remap_hf_config_attrs(config: PretrainedConfig) -> PretrainedConfig:
                 config.update({new_attr: getattr(config, old_attr)})
             logger.debug("Remapped config attribute '%s' to '%s'", old_attr, new_attr)
 
-    # For Qwen3 models, ensure sliding_window is None when use_sliding_window is False
-    # This prevents context length being limited to sliding_window value
+    # For models that support disabling sliding window, ensure it is set to None
+    # when use_sliding_window is False to prevent incorrect context length limiting.
     if (
         hasattr(config, "use_sliding_window")
         and not config.use_sliding_window
         and hasattr(config, "sliding_window")
+        and getattr(config, "sliding_window", None) is not None
     ):
         config.sliding_window = None
         logger.debug("Set sliding_window=None for model with use_sliding_window=False")

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -533,6 +533,17 @@ def _maybe_remap_hf_config_attrs(config: PretrainedConfig) -> PretrainedConfig:
             if not hasattr(config, new_attr):
                 config.update({new_attr: getattr(config, old_attr)})
             logger.debug("Remapped config attribute '%s' to '%s'", old_attr, new_attr)
+
+    # For Qwen3 models, ensure sliding_window is None when use_sliding_window is False
+    # This prevents context length being limited to sliding_window value
+    if (
+        hasattr(config, "use_sliding_window")
+        and not config.use_sliding_window
+        and hasattr(config, "sliding_window")
+    ):
+        config.sliding_window = None
+        logger.debug("Set sliding_window=None for model with use_sliding_window=False")
+
     return config
 
 


### PR DESCRIPTION
## Summary
Fixes #33921

For Qwen3 models with `use_sliding_window=False`, this PR ensures `sliding_window` is set to `None` to prevent context length being incorrectly limited.

## Problem
Qwen3 models like `Qwen/Qwen3-4B-Instruct-2507-FP8` have:
- `max_position_embeddings: 262144` (256K native context)
- `use_sliding_window: False`
- `sliding_window: None` in config.json

However, the Qwen3Config class has a default value of `sliding_window: 4096` in the class definition. When `use_sliding_window=False`, the Qwen3Config `__init__` sets `self.sliding_window = None`, but vLLM wasn't respecting the `use_sliding_window` flag.

This caused vLLM to incorrectly limit the context length, leading to errors like:
```
This model's maximum context length is 8192 tokens. However, your request has 10031 input tokens.
```

## Root Cause
vLLM's config loading didn't check the `use_sliding_window` attribute. For models that have `use_sliding_window=False`, vLLM should ensure `sliding_window` is `None` regardless of any default values.

## Changes
Added a check in `_maybe_remap_hf_config_attrs()` to set `sliding_window=None` when `use_sliding_window=False`. This ensures:
1. Models with `use_sliding_window=False` have their full `max_position_embeddings` available
2. The fix is generic and will work for any model using this pattern (not just Qwen3)

## Test Plan
Manual testing with the affected model:
```bash
vllm serve Qwen/Qwen3-4B-Instruct-2507-FP8 --max-model-len 262144
# Should now accept inputs up to 256K tokens instead of being limited to 8K
```

The fix ensures the model correctly uses its full 256K context window.