### PR TITLE
Support MP backend for elastic EP scale-down

### DIFF
--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -478,6 +478,7 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
             num_qps_per_rank=num_qps_per_rank,
             allow_nvlink_for_low_latency_mode=True,
             allow_mnnvl=envs.VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL,
+            enable_shrink=True,
         )
 
     def get_handle(self, kwargs):

--- a/vllm/distributed/device_communicators/base_device_communicator.py
+++ b/vllm/distributed/device_communicators/base_device_communicator.py
@@ -23,6 +23,10 @@ class Cache:
                 instance = func(**kwargs)
                 self._cache[key] = instance
             return instance
+        
+    def clear(self):
+        with self._lock:
+            self._cache.clear()
 
 
 class All2AllManagerBase:
@@ -278,9 +282,16 @@ class DeviceCommunicatorBase:
     def destroy(self):
         pass
 
-    def prepare_communication_buffer_for_model(self, model: torch.nn.Module) -> None:
+    def prepare_communication_buffer_for_model(
+        self, model: torch.nn.Module, force: bool = False
+    ) -> None:
         """
         Prepare the communication buffer for the model.
+
+        Args:
+            model: The model to prepare buffers for.
+            force: If True, force reinitialization of modular kernels even
+                   if they already exist. Used during elastic EP scale-down.
         """
         if not self.is_ep_communicator:
             return
@@ -296,7 +307,7 @@ class DeviceCommunicatorBase:
             )
         ]
         for module in moe_modules:
-            module.maybe_init_modular_kernel()
+            module.maybe_init_modular_kernel(force=force)
 
     def dispatch_router_logits(
         self,

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -528,6 +528,7 @@ class EplbState:
         self.model_states[model_config.compute_hash()] = model_state
 
     def reinitialize_model_states(self, num_replicas: int):
+        assert not self.is_async
         for eplb_model_state in self.model_states.values():
             model = eplb_model_state.model
             model.num_physical_experts = num_replicas

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -996,9 +996,15 @@ class GroupCoordinator:
         if self.mq_broadcaster is not None:
             self.mq_broadcaster = None
 
-    def prepare_communication_buffer_for_model(self, model: torch.nn.Module):
+    def prepare_communication_buffer_for_model(
+        self, model: torch.nn.Module, force: bool = False
+    ):
+        debug(f"Preparing communication buffer, {self.unique_name}")
         if self.device_communicator is not None:
-            self.device_communicator.prepare_communication_buffer_for_model(model)
+            debug(f"calling device communicator to prepare communication buffer, {self.unique_name}")
+            self.device_communicator.prepare_communication_buffer_for_model(
+                model, force=force
+            )
 
     def dispatch_router_logits(
         self,
@@ -1497,23 +1503,30 @@ def ensure_model_parallel_initialized(
     )
 
 
-def prepare_communication_buffer_for_model(model: torch.nn.Module):
+def prepare_communication_buffer_for_model(
+    model: torch.nn.Module, force: bool = False
+):
     """Prepare the communication buffer for the model.
     Traditional communication libraries like NCCL are almost
     model agnostic. However, emerging new communication libraries like
     MoE all2all (DeepEP) usually allocate the communication buffer
     based on the model shape for optimal performance.
+
+    Args:
+        model: The model to prepare buffers for.
+        force: If True, force reinitialization of modular kernels even
+               if they already exist. Used during elastic EP scale-down.
     """
     if _TP is not None:
-        _TP.prepare_communication_buffer_for_model(model)
+        _TP.prepare_communication_buffer_for_model(model, force=force)
     if _PCP is not None:
-        _PCP.prepare_communication_buffer_for_model(model)
+        _PCP.prepare_communication_buffer_for_model(model, force=force)
     if _PP is not None:
-        _PP.prepare_communication_buffer_for_model(model)
+        _PP.prepare_communication_buffer_for_model(model, force=force)
     if _DP is not None:
-        _DP.prepare_communication_buffer_for_model(model)
+        _DP.prepare_communication_buffer_for_model(model, force=force)
     if _EP is not None:
-        _EP.prepare_communication_buffer_for_model(model)
+        _EP.prepare_communication_buffer_for_model(model, force=force)
 
 
 def model_parallel_is_initialized():

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -251,6 +251,7 @@ def run_multi_api_server(args: argparse.Namespace):
         # Construct common args for the APIServerProcessManager up-front.
         api_server_manager_kwargs = dict(
             target_server_fn=run_api_server_worker_proc,
+            engine_registry_address=addresses.engine_registry_address,
             listen_address=listen_address,
             sock=sock,
             args=args,

--- a/vllm/entrypoints/serve/elastic_ep/api_router.py
+++ b/vllm/entrypoints/serve/elastic_ep/api_router.py
@@ -81,7 +81,7 @@ async def scale_elastic_ep(raw_request: Request):
             f"after {drain_timeout} seconds",
         ) from e
     except Exception as e:
-        logger.error("Scale failed: %s", e)
+        logger.exception("Scale failed: %s", e)
         raise HTTPException(status_code=500, detail="Scale failed") from e
     finally:
         set_scaling_elastic_ep(False)

--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -189,6 +189,7 @@ def maybe_make_prepare_finalize(
             num_global_experts=moe.num_experts,
             num_local_experts=moe.num_experts // all2all_manager.world_size,
         )
+        debug(f"all_to_all_args for DeepEP LL: {all_to_all_args}")
         handle = all2all_manager.get_handle(all_to_all_args)
 
         # Note: We may want to use FP8 dispatch just to reduce
@@ -251,4 +252,5 @@ def maybe_make_prepare_finalize(
             num_dispatchers=all2all_manager.world_size,
         )
 
+    debug(f"Created prepare_finalize: {type(prepare_finalize).__name__} for moe config")
     return prepare_finalize

--- a/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
@@ -296,11 +296,12 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
 
         # Dispatch
         dispatch_topk_ids = self._map_global_to_physical_ids(topk_ids)
+        debug(f"before low_latency_dispatch {num_experts=}")
         expert_x, expert_num_tokens, handle, _, hook = self.buffer.low_latency_dispatch(
             a1,
             dispatch_topk_ids,
             self.max_tokens_per_rank,
-            num_experts,
+            256,
             use_fp8=self.use_fp8_dispatch,
             round_scale=self.use_ue8m0_dispatch,
             use_ue8m0=self.use_ue8m0_dispatch,

--- a/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
@@ -57,6 +57,25 @@ class FusedMoEModularMethod(FusedMoEMethodBase, CustomOp):
             ),
         )
 
+    def reinit(
+        self,
+        moe_layer: torch.nn.Module,
+        prepare_finalize: FusedMoEPrepareAndFinalize,
+    ) -> None:
+        """Reinitialize the modular kernel with new prepare_finalize.
+
+        Called during elastic EP scale-down to update the MK with new
+        communication buffers and configuration.
+        """
+        self.moe_mk = FusedMoEModularKernel(
+            prepare_finalize,
+            self.old_quant_method.select_gemm_impl(prepare_finalize, moe_layer),
+            self.moe_mk.shared_experts,
+            moe_parallel_config=moe_layer.moe_parallel_config,
+        )
+        # Update disable_expert_map based on new MK
+        self.disable_expert_map = not self.moe_mk.supports_expert_map()
+
     @property
     def supports_eplb(self) -> bool:
         return self.old_quant_method.supports_eplb

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -632,10 +632,13 @@ class FusedMoE(CustomOp):
     # prepare_communication_buffer_for_model.
     # This is called after all weight loading and post-processing, so it
     # should be safe to swap out the quant_method.
-    def maybe_init_modular_kernel(self) -> None:
+    def maybe_init_modular_kernel(self, force: bool = False) -> None:
         # NOTE(rob): WIP refactor. For quant methods that own the MK
         # we create the MK during process_weights_after_loading.
-        if self.quant_method.supports_internal_mk or self.quant_method.is_monolithic:
+        debug(f"{self.quant_method.supports_internal_mk=} {self.quant_method.is_monolithic=} {force=}")
+        if not force and (
+            self.quant_method.supports_internal_mk or self.quant_method.is_monolithic
+        ):
             return None
 
         self.ensure_moe_quant_config_init()
@@ -649,9 +652,14 @@ class FusedMoE(CustomOp):
             logger.debug(
                 "%s for %s(%s)", prepare_finalize.__class__.__name__, self, id(self)
             )
-            self.quant_method = FusedMoEModularMethod.make(
-                self, self.quant_method, prepare_finalize, self.shared_experts
-            )
+            if force and hasattr(self.quant_method, "reinit"):
+                # Reinitialize existing FusedMoEModularMethod
+                self.quant_method.reinit(self, prepare_finalize)
+            else:
+                # Create new FusedMoEModularMethod
+                self.quant_method = FusedMoEModularMethod.make(
+                    self, self.quant_method, prepare_finalize, self.shared_experts
+                )
 
     @property
     def shared_experts(self) -> torch.nn.Module | None:
@@ -776,6 +784,7 @@ class FusedMoE(CustomOp):
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
         # Currently routing_tables only needed for round-robin expert placement
         # with DeepEP-ll all2all backend.
+        # TODO(zsj): 支持 EPLB 么？
         if (
             self.expert_placement_strategy != "round_robin"
             or not self.use_deepep_ll_kernels

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1140,6 +1140,7 @@ class FusedMoEModularKernel(torch.nn.Module):
         apply_router_weight_on_input: bool,
         expert_tokens_meta: ExpertTokensMetadata | None,
     ) -> torch.Tensor:
+        debug(f"{a1q.size()=} {w1.size()=} {w2.size()=} {topk_ids.size()=}")
         _, M_full, N, K, top_k = self.fused_experts.moe_problem_size(
             a1q, w1, w2, topk_ids
         )

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1424,7 +1424,6 @@ class DPEngineCoreProc(EngineCoreProc):
         self, reconfig_request: ReconfigureDistributedRequest
     ) -> None:
         stateless_destroy_torch_distributed_process_group(self.dp_group)
-        self.shutdown()
 
         parallel_config = self.vllm_config.parallel_config
         old_dp_size = parallel_config.data_parallel_size
@@ -1442,7 +1441,10 @@ class DPEngineCoreProc(EngineCoreProc):
         parallel_config.data_parallel_master_port = (
             reconfig_request.new_data_parallel_master_port
         )
-        if reconfig_request.new_data_parallel_rank != -2:
+        if (
+            reconfig_request.new_data_parallel_rank
+            != ReconfigureRankType.SHUTDOWN_CURRENT_RANK
+        ):
             self.dp_rank = parallel_config.data_parallel_rank
             self.dp_group = parallel_config.stateless_init_dp_group()
         reconfig_request.new_data_parallel_master_port = (

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -204,12 +204,14 @@ class CoreEngineProcManager:
     def join_first(self):
         """Wait for any process to exit."""
         while True:
-            died = connection.wait(proc.sentinel for proc in self.processes)
+            exited_sentinals = connection.wait(proc.sentinel for proc in self.processes)
             # Scale down may remove processes from self.processes, so verify
             # that the exited process is still in the current list.
             sentinel_to_proc = {proc.sentinel: proc for proc in self.processes}
             # Return if all processes have exited or an active process died
-            if not self.processes or died[0] in sentinel_to_proc:
+            if not self.processes or any(
+                sentinel in sentinel_to_proc for sentinel in exited_sentinals
+            ):
                 return
             # Otherwise, continue waiting (scale down removed the process)
 

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -53,6 +53,7 @@ from vllm.utils.system_utils import (
     set_process_title,
 )
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
+from vllm.v1.engine import ReconfigureDistributedRequest
 from vllm.v1.executor.abstract import Executor, FailureCallback
 from vllm.v1.outputs import AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
 from vllm.v1.worker.worker_base import WorkerWrapperBase
@@ -265,6 +266,13 @@ class MultiprocExecutor(Executor):
             callback()
         else:
             self.failure_callback = callback
+
+    def reinitialize_distributed(
+        self, reconfig_request: ReconfigureDistributedRequest
+    ) -> None:
+        if self.rpc_broadcast_mq is None:
+            return
+        self.collective_rpc("reinitialize_distributed", args=(reconfig_request,))
 
     def execute_model(  # type: ignore[override]
         self, scheduler_output: SchedulerOutput, non_block: bool = False

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -14,7 +14,7 @@ import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.utils.network_utils import get_distributed_init_method, get_ip, get_open_port
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
-from vllm.v1.engine import ReconfigureDistributedRequest, ReconfigureRankType
+from vllm.v1.engine import ReconfigureDistributedRequest
 from vllm.v1.executor.abstract import Executor
 from vllm.v1.outputs import AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
 from vllm.v1.serial_utils import run_method
@@ -126,11 +126,6 @@ class UniProcExecutor(Executor):
         self, reconfig_request: ReconfigureDistributedRequest
     ) -> None:
         self.driver_worker.reinitialize_distributed(reconfig_request)
-        if (
-            reconfig_request.new_data_parallel_rank
-            == ReconfigureRankType.SHUTDOWN_CURRENT_RANK
-        ):
-            self.shutdown()
 
     def shutdown(self) -> None:
         if worker := self.driver_worker:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -802,6 +802,7 @@ class Worker(WorkerBase):
             ), "All MoE modules must have the same number of experts"
             for module in moe_modules:
                 module.moe_config.num_experts = num_local_experts * new_ep_size
+                # 这里做了修改，但是 DeepEP 的 EP 没变，导致出现问题
                 module.global_num_experts = module.moe_config.num_experts
                 module.moe_parallel_config = FusedMoEParallelConfig.make(
                     tp_size_=get_tp_group().world_size,
@@ -859,9 +860,22 @@ class Worker(WorkerBase):
             parallel_config.eplb_config.num_redundant_experts = (
                 new_physical_experts - global_expert_loads[0].shape[1]
             )
-        prepare_communication_buffer_for_model(self.model_runner.model)
+        debug(f"calling prepare_communication_buffer_for_model with force=False")
+        prepare_communication_buffer_for_model(self.model_runner.model, force=False)
         if drafter_model is not None:
-            prepare_communication_buffer_for_model(drafter_model)
+            prepare_communication_buffer_for_model(drafter_model, force=False)
+
+        for name, module in self.model_runner.model.named_modules():
+            if hasattr(module, "prepare_finalize"):
+                pf = getattr(module, "prepare_finalize", None)
+                if pf is None or not hasattr(pf, "buffer"):
+                    continue
+                buf = getattr(pf, "buffer", None)
+                assert buf is not None
+                debug(f"Updating low latency buffer for module {name} with new_ep_size {new_ep_size}, {old_ep_size=}")
+                for ep_rank in range(new_ep_size, old_ep_size):
+                    buf.low_latency_update_mask_buffer(ep_rank, True)
+
         self.model_runner.model.update_physical_experts_metadata(
             num_physical_experts=new_physical_experts,
             num_local_physical_experts=num_local_physical_experts,


### PR DESCRIPTION
## Purpose

Previously, elastic expert parallel (EEP) was only compatible with the Ray backend, which prevented the MP backend from scaling. This update introduces MP backend support for EEP scale-down.

**Design**

<img width="2490" height="752" alt="image" src="https://github.com/user-attachments/assets/9af19e68-26d0-4d3c-8255-e6f343b4029f" />

Unlike RFC #28243, this PR maintains consistency with the Ray backend's EEP implementation. The engine client receives external scale-down requests and orchestrates the entire scaling-down process.

The original Ray backend EEP implementation already included the ability to signal all engine procs to execute reinitialize_distributed. However, engine procs never actually terminated because their lifecycle is managed by the engine process manager—they cannot self-terminate. Therefore, the engine process manager must also consume scaling events to initiate shutdown for procs that need to be taken offline.

To avoid introducing additional configuration and maintain compatibility with the existing engine proc startup flow, we repurposed the handshake socket. Instead of being destroyed after startup completes, the handshake process now runs as a persistent busy loop—the EngineRegistry thread—which supports both the original handshake for engine proc startup (needed during scale-up) and propagation of scaling events.

**Scale-Down Flow**
1. The API server instructs the engine client to scale down
2. The engine client signals all engine procs to execute reinitialize_distributed
3. The engine client sends the scaling event to engine process managers via the EngineRegistry
4. Engine process managers corresponding to procs that need to be removed initiate shutdown, terminating the affected engine procs

**Key Changes**

- Add EngineRegistry to unify engine handshake and proc-manager registration.
- Reuse handshake socket as a busy loop to deliver scale-down events to MP proc managers, enabling controlled engine exit.
- Update MP client/manager scale-down flow to notify via registry and ignore expected exits.
- Prepare handshake path for future scale-up, while keeping ray-only scale-up guard.

## Test Plan

End-to-end tests conducted on Qwen3-30B-A3B with configurations: Internal DP mode

| Num API Server | Num vLLM Instance | DP Size          | TP Size | Verified |
| -------------: | ----------------: | ---------------- | ------: | -------: |
|              1 |                 1 | 8 -> 6 -> 5 -> 4 |       1 |       ✅ |
|              1 |                 2 | 8 -> 6 -> 5 -> 4 |       1 |       ✅ |
|              1 |                 2 | 4 -> 2           |       2 |       ✅ |
|              2 |                 1 | 8 -> 6 -> 5 -> 4 |       1 |       ✅ |

## Future Work

- DeepEP backend support: The current scale-down implementation has been verified with the standard MoE backend. DeepEP backend requires additional work through DeepEP Mask, which will be addressed in a follow-up PR.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>