### PR TITLE
[Frontend, grpc] add support for Embed RPC in grpc_server 

### DIFF
--- a/vllm/grpc/vllm_engine.proto
+++ b/vllm/grpc/vllm_engine.proto
@@ -143,7 +143,12 @@ message GenerateComplete {
 
 message EmbedRequest {
   string request_id = 1;
-  TokenizedInput tokenized = 2;
+
+  // Prompt input
+  oneof input {
+    TokenizedInput tokenized = 2;
+    string text = 3;
+  }
 }
 
 message EmbedResponse {


### PR DESCRIPTION
## Purpose
gRPC server support was added recently to vLLM in #30190 but it is missing functionality compared to the HTTP/REST server. In particular, embedding model inference that relies on `AsyncLLM.encode()` does not work, since the `Embed` RPC was stubbed out as `UNIMPLEMENTED`. This PR implements the `Embed` RPC, enabling embedding models to be served via gRPC.

### Changes

**Proto (`vllm/grpc/vllm_engine.proto`):**
- Added `text` field to `EmbedRequest` as a `oneof input` alongside the existing `tokenized` field, allowing clients to send either raw text or pre-tokenized input

**Server (`vllm/entrypoints/grpc_server.py`):**
- Replaced the `UNIMPLEMENTED` stub with a working `Embed()` method that:
  - Accepts both `TokenizedInput` (pre-tokenized) and plain `text` input
  - Calls `AsyncLLM.encode()` with `PoolingParams(task="embed")`
  - Returns the embedding vector, prompt token count, and embedding dimension
  - Uses gRPC-native error handling (`INVALID_ARGUMENT` / `INTERNAL`) matching the `Generate` pattern

**Tests (`tests/entrypoints/test_grpc_server.py`):**
- Added embedding-specific server fixture using `intfloat/multilingual-e5-small`
- Added tests for tokenized input, text input, and concurrent requests

## Test Plan
```bash
pytest tests/entrypoints/test_grpc_server.py -v -k embed
```

## Test Result
All embedding tests pass:

```
test_embed_basic         - PASSED (tokenized input, verifies 384-dim embedding)
test_embed_text_input    - PASSED (raw text input)
test_embed_multiple_requests - PASSED (3 concurrent requests)
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
