### PR TITLE
[torch.compile] Disable recursive pre_grad_passes

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -132,6 +132,7 @@ if TYPE_CHECKING:
     VLLM_DP_RANK_LOCAL: int = -1
     VLLM_DP_SIZE: int = 1
     VLLM_USE_STANDALONE_COMPILE: bool = True
+    VLLM_ENABLE_PREGRAD_PASSES: bool = False
     VLLM_DP_MASTER_IP: str = ""
     VLLM_DP_MASTER_PORT: int = 0
     VLLM_MOE_DP_CHUNK_SIZE: int = 256
@@ -566,6 +567,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # enabled by default.
     "VLLM_USE_STANDALONE_COMPILE": lambda: os.environ.get(
         "VLLM_USE_STANDALONE_COMPILE", "1"
+    )
+    == "1",
+    # Inductor's pre-grad passes don't do anything for vLLM.
+    # The pre-grad passes get run even on cache-hit and negatively impact
+    # vllm cold compile times by O(1s)
+    # Can remove this after the following issue gets fixed
+    # https://github.com/pytorch/pytorch/issues/174502
+    "VLLM_ENABLE_PREGRAD_PASSES": lambda: os.environ.get(
+        "VLLM_ENABLE_PREGRAD_PASSES", "0"
     )
     == "1",
     # Debug pattern matching inside custom passes.


### PR DESCRIPTION
## Purpose
Inductor's pre-grad passes don't do anything for vLLM. The pre-grad passes get run even on cache-hit and negatively impact vllm cold compile times by O(1s)
Can remove this after the following issue gets fixed https://github.com/pytorch/pytorch/issues/174502

I added an envvar to toggle this so there's an easy way to turn this back on if something goes wrong or if Inductor ends up adding some useful pre-grad optimizations before the pytorch issue is fixed. It's an envvar and not a config option because I expect this to be short-lived.

## Test Plan & Test Result

This gives me ~1s back on llama-3.1-70b cold start.

I also verified that the inductor-generated output code for llama-3.1-70b was identical before and after
