### PR TITLE
[CPU] Enable FP16 (Half dtype) support for s390x

### DIFF
--- a/csrc/cpu/cpu_attn_impl.hpp
+++ b/csrc/cpu/cpu_attn_impl.hpp
@@ -821,7 +821,7 @@ struct VecTypeTrait<c10::BFloat16> {
   using vec_t = vec_op::BF16Vec16;
 };
 
-#if !defined(__powerpc__) && !defined(__s390x__)
+#if !defined(__powerpc__)
 template <>
 struct VecTypeTrait<c10::Half> {
   using vec_t = vec_op::FP16Vec16;

--- a/csrc/cpu/mla_decode.cpp
+++ b/csrc/cpu/mla_decode.cpp
@@ -18,8 +18,8 @@ struct KernelVecType<float> {
 
 template <>
 struct KernelVecType<c10::Half> {
-#if defined(__powerpc64__) || defined(__s390x__)
-  // Power and s390x architecture-specific vector types
+#if defined(__powerpc64__)
+  // Power specific vector types
   using qk_load_vec_type = vec_op::FP32Vec16;
   using qk_vec_type = vec_op::FP32Vec16;
   using v_load_vec_type = vec_op::FP32Vec16;


### PR DESCRIPTION
## Purpose
Adds FP16 model inference support for s390x (IBM Z) architecture using vectorized Bit-manipulation. FP16 was previously disabled on s390x, limiting users to BF16 or FP32.

## Test Plan
1.  Build docker image and run the server with `dtype=half`
2. Send an inference request to the server
## Test Result

```
[root@b314lp81 vllm]# docker run --rm -p 8000:8000 local:test   ibm-granite/granite-4.0-micro   --port=8000   --dtype=half 
INFO 02-06 09:11:26 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
(APIServer pid=1) INFO 02-06 09:11:30 [utils.py:314] 
(APIServer pid=1) INFO 02-06 09:11:30 [utils.py:314]        █     █     █▄   ▄█
(APIServer pid=1) INFO 02-06 09:11:30 [utils.py:314]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.16.0rc1.dev178+gbcd2f74c0.d20260206
(APIServer pid=1) INFO 02-06 09:11:30 [utils.py:314]   █▄█▀ █     █     █     █  model   ibm-granite/granite-4.0-micro
(APIServer pid=1) INFO 02-06 09:11:30 [utils.py:314]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=1) INFO 02-06 09:11:30 [utils.py:314] 
(APIServer pid=1) INFO 02-06 09:11:30 [utils.py:250] non-default args: {'model_tag': 'ibm-granite/granite-4.0-micro', 'api_server_count': 1, 'model': 'ibm-granite/granite-4.0-micro', 'dtype': 'half'}
(APIServer pid=1) INFO 02-06 09:11:41 [model.py:530] Resolved architecture: GraniteMoeHybridForCausalLM
(APIServer pid=1) WARNING 02-06 09:11:41 [model.py:1865] Casting torch.bfloat16 to torch.float16.
(APIServer pid=1) INFO 02-06 09:11:41 [model.py:1540] Using max model len 131072
(APIServer pid=1) INFO 02-06 09:11:41 [arg_utils.py:1948] Chunked prefill is not supported for POWER, S390X and RISC-V CPUs; disabling it for V1 backend.
(APIServer pid=1) INFO 02-06 09:11:41 [arg_utils.py:1954] Prefix caching is not supported for POWER, S390X and RISC-V CPUs; disabling it for V1 backend.
(APIServer pid=1) WARNING 02-06 09:11:41 [cpu.py:158] VLLM_CPU_KVCACHE_SPACE not set. Using 171.88 GiB for KV cache.
(APIServer pid=1) INFO 02-06 09:11:41 [vllm.py:666] Asynchronous scheduling is enabled.
INFO 02-06 09:11:50 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
(EngineCore_DP0 pid=90) INFO 02-06 09:11:54 [core.py:96] Initializing a V1 LLM engine (v0.16.0rc1.dev178+gbcd2f74c0.d20260206) with config: model='ibm-granite/granite-4.0-micro', speculative_config=None, tokenizer='ibm-granite/granite-4.0-micro', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=131072, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=True, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cpu, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=ibm-granite/granite-4.0-micro, enable_prefix_caching=False, enable_chunked_prefill=False, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.DYNAMO_TRACE_ONCE: 2>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': [], 'compile_mm_encoder': False, 'compile_sizes': None, 'compile_ranges_split_points': [131072], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'dce': True, 'size_asserts': False, 'nan_asserts': False, 'epilogue_fusion': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': None, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:183] auto thread-binding list (id, physical core): [(0, 0), (1, 0), (2, 1), (3, 1), (8, 4), (9, 4), (10, 5), (11, 5), (16, 8), (17, 8), (18, 9), (19, 9), (24, 12), (25, 12), (26, 13), (27, 13), (32, 16), (33, 16), (34, 17), (35, 17), (40, 20), (41, 20), (42, 21), (43, 21), (48, 24), (49, 24)]
get_mempolicy: Operation not permitted
[W206 09:11:55.125523377 utils.cpp:76] Warning: numa_migrate_pages failed. errno: 1 (function init_cpu_threads_env)
set_mempolicy: Operation not permitted
[W206 09:11:55.125537137 utils.cpp:100] Warning: numa_set_membind failed. errno: 1 (function init_cpu_threads_env)
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89] OMP threads binding of Process 90:
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 90, core 0
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 150, core 1
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 151, core 2
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 152, core 3
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 153, core 8
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 154, core 9
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 155, core 10
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 156, core 11
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 157, core 16
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 158, core 17
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 159, core 18
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 160, core 19
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 161, core 24
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 162, core 25
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 163, core 26
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 164, core 27
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 165, core 32
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 166, core 33
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 167, core 34
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 168, core 35
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 169, core 40
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 170, core 41
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 171, core 42
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 172, core 43
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 173, core 48
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89]  OMP tid: 174, core 49
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_worker.py:89] 
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.17.0.2:39507 backend=gloo
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A
(EngineCore_DP0 pid=90) INFO 02-06 09:11:55 [cpu_model_runner.py:55] Starting to load model ibm-granite/granite-4.0-micro...
(EngineCore_DP0 pid=90) INFO 02-06 09:14:04 [weight_utils.py:527] Time spent downloading weights for ibm-granite/granite-4.0-micro: 128.008319 seconds
Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:01<00:01,  1.74s/it]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:06<00:00,  3.40s/it]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:06<00:00,  3.15s/it]
(EngineCore_DP0 pid=90) 
(EngineCore_DP0 pid=90) INFO 02-06 09:14:10 [default_loader.py:291] Loading weights took 6.30 seconds
(EngineCore_DP0 pid=90) INFO 02-06 09:14:10 [kv_cache_utils.py:1307] GPU KV cache size: 2,252,800 tokens
(EngineCore_DP0 pid=90) INFO 02-06 09:14:10 [kv_cache_utils.py:1312] Maximum concurrency for 131,072 tokens per request: 17.19x
(EngineCore_DP0 pid=90) INFO 02-06 09:14:14 [cpu_model_runner.py:65] Warming up model for the compilation...
(EngineCore_DP0 pid=90) INFO 02-06 09:17:16 [cpu_model_runner.py:75] Warming up done.
(EngineCore_DP0 pid=90) INFO 02-06 09:17:16 [core.py:272] init engine (profile, create kv cache, warmup model) took 186.02 seconds
(EngineCore_DP0 pid=90) INFO 02-06 09:17:18 [vllm.py:666] Asynchronous scheduling is disabled.
(EngineCore_DP0 pid=90) WARNING 02-06 09:17:18 [vllm.py:711] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore_DP0 pid=90) WARNING 02-06 09:17:18 [cpu.py:158] VLLM_CPU_KVCACHE_SPACE not set. Using 171.88 GiB for KV cache.
(APIServer pid=1) INFO 02-06 09:17:18 [api_server.py:455] Supported tasks: ['generate']
(APIServer pid=1) INFO 02-06 09:17:18 [serving.py:186] Warming up chat template processing...
(APIServer pid=1) INFO 02-06 09:17:20 [hf.py:317] Detected the chat template content format to be 'openai'. You can set `--chat-template-content-format` to override this.
(APIServer pid=1) INFO 02-06 09:17:20 [serving.py:211] Chat template warmup completed in 1413.4ms
(APIServer pid=1) INFO 02-06 09:17:20 [api_server.py:460] Starting vLLM API server 0 on http://0.0.0.0:8000
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:38] Available routes are:
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /docs, Methods: GET, HEAD
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /redoc, Methods: GET, HEAD
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /load, Methods: GET
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /version, Methods: GET
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /tokenize, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /detokenize, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /inference/v1/generate, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /pause, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /resume, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /is_paused, Methods: GET
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /metrics, Methods: GET
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /health, Methods: GET
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /v1/models, Methods: GET
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /ping, Methods: GET
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /ping, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /invocations, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /v1/chat/completions, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /v1/responses, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /v1/completions, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /v1/completions/render, Methods: POST
(APIServer pid=1) INFO 02-06 09:17:20 [launcher.py:47] Route: /v1/messages, Methods: POST
(APIServer pid=1) INFO:     Started server process [1]
(APIServer pid=1) INFO:     Waiting for application startup.
(APIServer pid=1) INFO:     Application startup complete.
(APIServer pid=1) INFO 02-06 09:17:50 [loggers.py:259] Engine 000: Avg prompt throughput: 0.6 tokens/s, Avg generation throughput: 0.3 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 02-06 09:18:00 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 02-06 09:18:10 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 02-06 09:18:20 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 02-06 09:18:30 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 02-06 09:18:40 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 02-06 09:18:50 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 02-06 09:19:00 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.6 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 02-06 09:19:10 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO:     172.17.0.1:49676 - "POST /v1/completions HTTP/1.1" 200 OK
(APIServer pid=1) INFO 02-06 09:19:20 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=1) INFO 02-06 09:19:30 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
```

Curl request

```
[root@b314lp81 ~]#  curl -X POST http://localhost:8000/v1/completions   -H "Content-Type: application/json"   -d '{
    "model": "ibm-granite/granite-4.0-micro",
    "prompt": "Explain what is kubernetes",
    "max_tokens": 64,
    "temperature": 0.2
  }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   919  100   779  100   140      7      1  0:02:20  0:01:42  0:00:38   185
{
  "id": "cmpl-aa88b21c640a4aeb",
  "object": "text_completion",
  "created": 1770369458,
  "model": "ibm-granite/granite-4.0-micro",
  "choices": [
    {
      "index": 0,
      "text": " and how it works\n\nKubernetes, often abbreviated as \"K8s,\" is an open-source container orchestration platform that automates the deployment, scaling, and management of containerized applications. It was originally developed by Google and is now maintained by the Cloud Native Computing Foundation (CNCF).\n\nHere's an overview of",
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "token_ids": null,
      "prompt_logprobs": null,
      "prompt_token_ids": null
    }
  ],
  "service_tier": null,
  "system_fingerprint": null,
  "usage": {
    "prompt_tokens": 6,
    "total_tokens": 70,
    "completion_tokens": 64,
    "prompt_tokens_details": null
  },
  "kv_transfer_params": null
}
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

