### PR TITLE
[Bugfix] Fix TorchAO bugs and add `--torchao-config` CLI

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -577,3 +577,19 @@ def test_torchao_config_merges_with_existing_hf_overrides():
     assert "some_key" in engine_args.hf_overrides
     assert engine_args.hf_overrides["some_key"] == "some_value"
     assert "quantization_config_dict_json" in engine_args.hf_overrides
+
+
+def test_torchao_config_invalid_path_treated_as_file():
+    """Test that invalid file path (not valid JSON) is treated as file path.
+
+    This ensures users get a clear FileNotFoundError instead of JSONDecodeError
+    when they have a typo in the file path.
+    """
+    invalid_path = "/nonexistent/path/to/config.json"
+    engine_args = EngineArgs(model="test-model", torchao_config=invalid_path)
+
+    assert engine_args.hf_overrides is not None
+    # Should be treated as file path, not JSON string
+    assert "quantization_config_file" in engine_args.hf_overrides
+    assert engine_args.hf_overrides["quantization_config_file"] == invalid_path
+    assert "quantization_config_dict_json" not in engine_args.hf_overrides

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -660,8 +660,14 @@ class EngineArgs:
         if os.path.isfile(self.torchao_config):
             self.hf_overrides["quantization_config_file"] = self.torchao_config
         else:
-            # Assume it's a JSON string
-            self.hf_overrides["quantization_config_dict_json"] = self.torchao_config
+            # Try to parse as JSON string first
+            try:
+                json.loads(self.torchao_config)
+                self.hf_overrides["quantization_config_dict_json"] = self.torchao_config
+            except json.JSONDecodeError:
+                # Not valid JSON, treat as file path
+                # (will raise FileNotFoundError later with clear message)
+                self.hf_overrides["quantization_config_file"] = self.torchao_config
 
     @staticmethod
     def add_cli_args(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -458,8 +458,10 @@ class VocabParallelEmbedding(CustomOp):
 
         # Copy the data. Select chunk corresponding to current shard.
         loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
-        param[: loaded_weight.shape[0]].data.copy_(loaded_weight)
-        param[loaded_weight.shape[0] :].data.fill_(0)
+        # Do not use .data accessor to preserve TorchAO tensor subclass attributes
+        # (e.g., tensor_data_names) that are essential for quantization.
+        param[: loaded_weight.shape[0]].copy_(loaded_weight)
+        param[loaded_weight.shape[0] :].fill_(0)
 
     def forward_native(self, input_):
         if self.tp_size > 1:

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -13,7 +13,7 @@ from torch.func import functional_call
 from torch.nn.modules.module import register_module_module_registration_hook
 from transformers import PretrainedConfig
 
-from vllm.config import VllmConfig
+from vllm.config import LoadConfig, VllmConfig
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -789,7 +789,8 @@ def get_draft_quant_config(
         The draft model's config if available, None otherwise.
     """
     draft_model_config = vllm_config.speculative_config.draft_model_config
-    draft_load_config = vllm_config.load_config
+    # Use LoadConfig() if load_config is None to prevent AttributeError
+    draft_load_config = vllm_config.load_config or LoadConfig()
 
     return (
         VllmConfig.get_quantization_config(draft_model_config, draft_load_config)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR implements TorchAO quantization bug fixes and CLI support for vLLM v1 engine, based on the closed PR #31815.
## Changes
1. Add `--torchao-config` CLI argument: Accepts JSON string or file path, which is merged into hf_overrides for TorchAO quantization initialization.
2. Preserve tensor metadata in weight_loader: Remove .data accessor in `vocab_parallel_embedding.weight_loader` to preserve TorchAO tensor subclass attributes (e.g., tensor_data_names) essential for quantization.
3. Fix LoadConfig initialization: Pass LoadConfig() instead of None in `get_draft_quant_config` to prevent AttributeError.

Resolves #31668

## Test Plan
```
pytest tests/engine/test_arg_utils.py
```

## Test Result


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

