### PR TITLE
[Docs] Fix format error in KV load failure recovery doc

### DIFF
--- a/examples/offline_inference/kv_load_failure_recovery/README.md
+++ b/examples/offline_inference/kv_load_failure_recovery/README.md
@@ -28,3 +28,4 @@ It demonstrates vLLM's ability to recover from KV load failures in both synchron
 
 ```bash
 ./run.sh
+```


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

In `KV Load Failure Recovery Test` document, there was a missing code fence closing backticks.
Fixed it by adding the closing one.

https://docs.vllm.ai/en/latest/examples/offline_inference/kv_load_failure_recovery/#files

<img width="500" alt="image" src="https://github.com/user-attachments/assets/cf5c70e8-1d0b-4ce1-ae76-6972e2acca3f" />

## Test Plan

```bash
$ API_AUTONAV_EXCLUDE=vllm mkdocs serve
```

Ran the command, and checked it rendered well.

## Test Result

<img width="500" alt="image" src="https://github.com/user-attachments/assets/e0b42bda-baa6-4faf-ad28-bd5be2f40376" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

