### PR TITLE
[Bugfix] Avoid duplicate k-proj weight emission in helper

### DIFF
--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -958,8 +958,8 @@ def _create_fake_bias_for_k_proj(
     So that the bias for k_proj in qkv_proj can be initialized with zeros.
     """
     for name, weight in weights:
+        yield name, weight
         if name.endswith(fake_bias_key_name):
             bias = torch.zeros(weight.size(0))
             bias_name = name.replace("weight", "bias")
-            yield from [(name, weight), (bias_name, bias)]
-        yield name, weight
+            yield bias_name, bias


### PR DESCRIPTION

## Purpose
Fix duplicate emission in `_create_fake_bias_for_k_proj` so matching `k_proj.weight` entries are yielded exactly once, with one synthetic `k_proj.bias` companion.

## Test Plan
- `python3 -m py_compile vllm/model_executor/models/whisper.py`
-
```bash
.venv/bin/python - <<'PY'
import torch
from vllm.model_executor.models.whisper import _create_fake_bias_for_k_proj

weights = [
    ("layer.k_proj.weight", torch.ones(4, 3)),
    ("layer.q_proj.weight", torch.ones(4, 3)),
]
out = list(_create_fake_bias_for_k_proj(weights, ".k_proj.weight"))
assert sum(1 for n, _ in out if n == "layer.k_proj.weight") == 1
assert any(n == "layer.k_proj.bias" for n, _ in out)
PY
```

## Test Result
- `python3 -m py_compile vllm/model_executor/models/whisper.py` passed.
- Focused runtime sanity script passed (single original `k_proj.weight` + synthetic `k_proj.bias`).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

