### PR TITLE
[Benchmarks] Add bimodal dataset for mixed short-chat + long-RAG work…

### DIFF
--- a/tests/benchmarks/test_bimodal_dataset.py
+++ b/tests/benchmarks/test_bimodal_dataset.py
@@ -1,0 +1,418 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import random
+from typing import NamedTuple
+
+import numpy as np
+import pytest
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
+
+from vllm.benchmarks.datasets import BimodalDataset, SampleRequest
+
+
+@pytest.fixture(scope="session")
+def hf_tokenizer() -> PreTrainedTokenizerBase:
+    # Use a small, commonly available tokenizer
+    return AutoTokenizer.from_pretrained("gpt2")
+
+
+class BimodalParams(NamedTuple):
+    num_requests: int
+    short_ratio: float
+    short_input_range: tuple[int, int]
+    short_output_range: tuple[int, int]
+    long_input_range: tuple[int, int]
+    long_output_len: int
+
+
+@pytest.fixture(scope="session")
+def bimodal_params() -> BimodalParams:
+    return BimodalParams(
+        num_requests=100,
+        short_ratio=BimodalDataset.DEFAULT_SHORT_RATIO,
+        short_input_range=(
+            BimodalDataset.DEFAULT_SHORT_INPUT_MIN,
+            BimodalDataset.DEFAULT_SHORT_INPUT_MAX,
+        ),
+        short_output_range=(
+            BimodalDataset.DEFAULT_SHORT_OUTPUT_MIN,
+            BimodalDataset.DEFAULT_SHORT_OUTPUT_MAX,
+        ),
+        long_input_range=(
+            BimodalDataset.DEFAULT_LONG_INPUT_MIN,
+            BimodalDataset.DEFAULT_LONG_INPUT_MAX,
+        ),
+        long_output_len=BimodalDataset.DEFAULT_LONG_OUTPUT_LEN,
+    )
+
+
+def _fingerprint_sample(req: SampleRequest) -> tuple[str, int, int]:
+    """Project a SampleRequest into a comparable tuple."""
+    return (req.prompt, req.prompt_len, req.expected_output_len)
+
+
+def _collect_samples(
+    dataset: BimodalDataset,
+    tokenizer: PreTrainedTokenizerBase,
+    num_requests: int = 100,
+    short_ratio: float = BimodalDataset.DEFAULT_SHORT_RATIO,
+    short_input_range: tuple[int, int] = (
+        BimodalDataset.DEFAULT_SHORT_INPUT_MIN,
+        BimodalDataset.DEFAULT_SHORT_INPUT_MAX,
+    ),
+    short_output_range: tuple[int, int] = (
+        BimodalDataset.DEFAULT_SHORT_OUTPUT_MIN,
+        BimodalDataset.DEFAULT_SHORT_OUTPUT_MAX,
+    ),
+    long_input_range: tuple[int, int] = (
+        BimodalDataset.DEFAULT_LONG_INPUT_MIN,
+        BimodalDataset.DEFAULT_LONG_INPUT_MAX,
+    ),
+    long_output_len: int = BimodalDataset.DEFAULT_LONG_OUTPUT_LEN,
+) -> list[tuple[str, int, int]]:
+    samples = dataset.sample(
+        tokenizer=tokenizer,
+        num_requests=num_requests,
+        short_ratio=short_ratio,
+        short_input_range=short_input_range,
+        short_output_range=short_output_range,
+        long_input_range=long_input_range,
+        long_output_len=long_output_len,
+    )
+    return [_fingerprint_sample(s) for s in samples]
+
+
+# -------------------------------------------
+# Seed determinism
+# -------------------------------------------
+
+
+@pytest.mark.benchmark
+def test_bimodal_dataset_same_seed(
+    hf_tokenizer: PreTrainedTokenizerBase,
+    bimodal_params: BimodalParams,
+) -> None:
+    """Same seed should yield identical outputs, even if global RNGs change.
+
+    This guards against accidental reliance on Python's random or np.random
+    in BimodalDataset after moving to numpy.default_rng.
+    """
+    p = bimodal_params
+    common_seed = 123
+    dataset_a = BimodalDataset(random_seed=common_seed)
+    dataset_b = BimodalDataset(random_seed=common_seed)
+
+    a = _collect_samples(
+        dataset_a,
+        hf_tokenizer,
+        num_requests=p.num_requests,
+        short_ratio=p.short_ratio,
+        short_input_range=p.short_input_range,
+        short_output_range=p.short_output_range,
+        long_input_range=p.long_input_range,
+        long_output_len=p.long_output_len,
+    )
+
+    # Perturb global RNG state to ensure isolation.
+    random.seed(999)
+    _ = [random.random() for _ in range(100)]
+    np.random.seed(888)
+    _ = [np.random.random() for _ in range(100)]
+
+    b = _collect_samples(
+        dataset_b,
+        hf_tokenizer,
+        num_requests=p.num_requests,
+        short_ratio=p.short_ratio,
+        short_input_range=p.short_input_range,
+        short_output_range=p.short_output_range,
+        long_input_range=p.long_input_range,
+        long_output_len=p.long_output_len,
+    )
+    assert a == b
+
+
+@pytest.mark.benchmark
+def test_bimodal_dataset_different_seeds(
+    hf_tokenizer: PreTrainedTokenizerBase,
+    bimodal_params: BimodalParams,
+) -> None:
+    """Different seeds should change outputs with overwhelming likelihood."""
+    p = bimodal_params
+    dataset_a = BimodalDataset(random_seed=0)
+    a = _collect_samples(
+        dataset_a,
+        hf_tokenizer,
+        num_requests=p.num_requests,
+        short_ratio=p.short_ratio,
+        short_input_range=p.short_input_range,
+        short_output_range=p.short_output_range,
+        long_input_range=p.long_input_range,
+        long_output_len=p.long_output_len,
+    )
+
+    dataset_b = BimodalDataset(random_seed=999)
+    # Perturb global RNG with same seed as dataset_a to ensure isolation.
+    random.seed(0)
+    np.random.seed(0)
+    b = _collect_samples(
+        dataset_b,
+        hf_tokenizer,
+        num_requests=p.num_requests,
+        short_ratio=p.short_ratio,
+        short_input_range=p.short_input_range,
+        short_output_range=p.short_output_range,
+        long_input_range=p.long_input_range,
+        long_output_len=p.long_output_len,
+    )
+    assert a != b
+
+
+# -------------------------------------------
+# Distribution tests
+# -------------------------------------------
+
+
+@pytest.mark.benchmark
+def test_bimodal_dataset_default_distribution(
+    hf_tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    """Default 80/20 split should produce the expected ratio.
+
+    With a fixed seed and 500 samples, the actual split is deterministic.
+    We assert within a tighter tolerance (+/- 5%) than the statistical
+    bound to catch regressions in sampling logic.
+    """
+    dataset = BimodalDataset(random_seed=42)
+    num_requests = 500
+    requests = dataset.sample(
+        tokenizer=hf_tokenizer,
+        num_requests=num_requests,
+    )
+    assert len(requests) == num_requests
+
+    # Thresholds derived from class constants with tokenizer margin.
+    short_upper = BimodalDataset.DEFAULT_SHORT_INPUT_MAX + 50
+    long_lower = BimodalDataset.DEFAULT_LONG_INPUT_MIN - 100
+
+    short_count = sum(
+        1
+        for r in requests
+        if r.prompt_len <= short_upper
+        and BimodalDataset.DEFAULT_SHORT_OUTPUT_MIN
+        <= r.expected_output_len
+        <= BimodalDataset.DEFAULT_SHORT_OUTPUT_MAX
+    )
+    long_count = sum(
+        1
+        for r in requests
+        if r.prompt_len >= long_lower
+        and r.expected_output_len == BimodalDataset.DEFAULT_LONG_OUTPUT_LEN
+    )
+
+    # With fixed seed=42 and 500 samples, expect ~80% short, ~20% long.
+    # Use +/- 5% tolerance (75%-85% short, 15%-25% long).
+    assert short_count >= num_requests * 0.75, (
+        f"Expected ~80% short, got {short_count}/{num_requests}"
+    )
+    assert short_count <= num_requests * 0.85, (
+        f"Expected ~80% short, got {short_count}/{num_requests}"
+    )
+    assert long_count >= num_requests * 0.15, (
+        f"Expected ~20% long, got {long_count}/{num_requests}"
+    )
+    assert long_count <= num_requests * 0.25, (
+        f"Expected ~20% long, got {long_count}/{num_requests}"
+    )
+
+
+@pytest.mark.benchmark
+def test_bimodal_dataset_custom_ratio(
+    hf_tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    """Custom short_ratio=0.5 should shift the distribution."""
+    dataset = BimodalDataset(random_seed=42)
+    num_requests = 500
+    requests = dataset.sample(
+        tokenizer=hf_tokenizer,
+        num_requests=num_requests,
+        short_ratio=0.5,
+        short_input_range=(50, 100),
+        short_output_range=(10, 20),
+        long_input_range=(500, 1000),
+        long_output_len=64,
+    )
+    assert len(requests) == num_requests
+
+    short_count = sum(
+        1 for r in requests
+        if r.prompt_len <= 150 and r.expected_output_len <= 20
+    )
+    long_count = sum(
+        1 for r in requests
+        if r.prompt_len >= 400 and r.expected_output_len == 64
+    )
+    # 50/50 split with +/- 5% tolerance.
+    assert short_count >= num_requests * 0.40, (
+        f"Expected ~50% short, got {short_count}/{num_requests}"
+    )
+    assert long_count >= num_requests * 0.40, (
+        f"Expected ~50% long, got {long_count}/{num_requests}"
+    )
+
+
+# -------------------------------------------
+# Edge case: all short / all long
+# -------------------------------------------
+
+
+@pytest.mark.benchmark
+def test_bimodal_dataset_all_short(
+    hf_tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    """short_ratio=1.0 should produce only short requests."""
+    dataset = BimodalDataset(random_seed=42)
+    num_requests = 50
+    requests = dataset.sample(
+        tokenizer=hf_tokenizer,
+        num_requests=num_requests,
+        short_ratio=1.0,
+        short_input_range=(50, 100),
+        short_output_range=(10, 20),
+        long_input_range=(500, 1000),
+        long_output_len=64,
+    )
+    assert len(requests) == num_requests
+    for r in requests:
+        assert r.expected_output_len <= 20, (
+            f"Expected all short outputs, got output_len={r.expected_output_len}"
+        )
+
+
+@pytest.mark.benchmark
+def test_bimodal_dataset_all_long(
+    hf_tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    """short_ratio=0.0 should produce only long requests."""
+    dataset = BimodalDataset(random_seed=42)
+    num_requests = 50
+    requests = dataset.sample(
+        tokenizer=hf_tokenizer,
+        num_requests=num_requests,
+        short_ratio=0.0,
+        short_input_range=(50, 100),
+        short_output_range=(10, 20),
+        long_input_range=(500, 1000),
+        long_output_len=64,
+    )
+    assert len(requests) == num_requests
+    for r in requests:
+        assert r.expected_output_len == 64, (
+            f"Expected all long outputs (64), got {r.expected_output_len}"
+        )
+
+
+# -------------------------------------------
+# Input validation
+# -------------------------------------------
+
+
+@pytest.mark.benchmark
+def test_bimodal_dataset_invalid_short_ratio(
+    hf_tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    """Raise ValueError when short_ratio is outside [0, 1]."""
+    dataset = BimodalDataset(random_seed=42)
+    with pytest.raises(ValueError, match="bimodal-short-ratio"):
+        dataset.sample(
+            tokenizer=hf_tokenizer,
+            num_requests=10,
+            short_ratio=1.5,
+        )
+    with pytest.raises(ValueError, match="bimodal-short-ratio"):
+        dataset.sample(
+            tokenizer=hf_tokenizer,
+            num_requests=10,
+            short_ratio=-0.1,
+        )
+
+
+@pytest.mark.benchmark
+def test_bimodal_dataset_invalid_range(
+    hf_tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    """Raise ValueError when min > max in any range."""
+    dataset = BimodalDataset(random_seed=42)
+    with pytest.raises(ValueError, match="bimodal-short-input-min"):
+        dataset.sample(
+            tokenizer=hf_tokenizer,
+            num_requests=10,
+            short_input_range=(200, 100),
+        )
+    with pytest.raises(ValueError, match="bimodal-short-output-min"):
+        dataset.sample(
+            tokenizer=hf_tokenizer,
+            num_requests=10,
+            short_output_range=(50, 10),
+        )
+    with pytest.raises(ValueError, match="bimodal-long-input-min"):
+        dataset.sample(
+            tokenizer=hf_tokenizer,
+            num_requests=10,
+            long_input_range=(4000, 2000),
+        )
+
+
+# -------------------------------------------
+# max_model_len validation
+# -------------------------------------------
+
+
+@pytest.mark.benchmark
+def test_bimodal_dataset_max_model_len_rejects_oversized_long(
+    hf_tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    """Raise ValueError when long-arm max sequence exceeds max_model_len."""
+    dataset = BimodalDataset(random_seed=42)
+    with pytest.raises(ValueError, match="long-arm.*exceeds max_model_len"):
+        dataset.sample(
+            tokenizer=hf_tokenizer,
+            num_requests=10,
+            long_input_range=(2000, 4000),
+            long_output_len=128,
+            max_model_len=2048,
+        )
+
+
+@pytest.mark.benchmark
+def test_bimodal_dataset_max_model_len_rejects_oversized_short(
+    hf_tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    """Raise ValueError when short-arm max sequence exceeds max_model_len."""
+    dataset = BimodalDataset(random_seed=42)
+    with pytest.raises(ValueError, match="short-arm.*exceeds max_model_len"):
+        dataset.sample(
+            tokenizer=hf_tokenizer,
+            num_requests=10,
+            short_input_range=(1500, 2000),
+            short_output_range=(500, 600),
+            long_input_range=(500, 1000),
+            long_output_len=128,
+            max_model_len=2048,
+        )
+
+
+@pytest.mark.benchmark
+def test_bimodal_dataset_max_model_len_accepts_valid(
+    hf_tokenizer: PreTrainedTokenizerBase,
+) -> None:
+    """Succeed when max sequence fits within max_model_len."""
+    dataset = BimodalDataset(random_seed=42)
+    requests = dataset.sample(
+        tokenizer=hf_tokenizer,
+        num_requests=10,
+        long_input_range=(500, 1000),
+        long_output_len=128,
+        max_model_len=2048,
+    )
+    assert len(requests) == 10

--- a/tests/benchmarks/test_bimodal_dataset.py
+++ b/tests/benchmarks/test_bimodal_dataset.py
@@ -245,12 +245,10 @@ def test_bimodal_dataset_custom_ratio(
     assert len(requests) == num_requests
 
     short_count = sum(
-        1 for r in requests
-        if r.prompt_len <= 150 and r.expected_output_len <= 20
+        1 for r in requests if r.prompt_len <= 150 and r.expected_output_len <= 20
     )
     long_count = sum(
-        1 for r in requests
-        if r.prompt_len >= 400 and r.expected_output_len == 64
+        1 for r in requests if r.prompt_len >= 400 and r.expected_output_len == 64
     )
     # 50/50 split with +/- 5% tolerance.
     assert short_count >= num_requests * 0.40, (

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -720,11 +720,17 @@ class BimodalDataset(RandomDataset):
         batchsize: int = 1,
         short_ratio: float = DEFAULT_SHORT_RATIO,
         short_input_range: tuple[int, int] = (
-            DEFAULT_SHORT_INPUT_MIN, DEFAULT_SHORT_INPUT_MAX),
+            DEFAULT_SHORT_INPUT_MIN,
+            DEFAULT_SHORT_INPUT_MAX,
+        ),
         short_output_range: tuple[int, int] = (
-            DEFAULT_SHORT_OUTPUT_MIN, DEFAULT_SHORT_OUTPUT_MAX),
+            DEFAULT_SHORT_OUTPUT_MIN,
+            DEFAULT_SHORT_OUTPUT_MAX,
+        ),
         long_input_range: tuple[int, int] = (
-            DEFAULT_LONG_INPUT_MIN, DEFAULT_LONG_INPUT_MAX),
+            DEFAULT_LONG_INPUT_MIN,
+            DEFAULT_LONG_INPUT_MAX,
+        ),
         long_output_len: int = DEFAULT_LONG_OUTPUT_LEN,
         max_model_len: int | None = None,
         **kwargs,
@@ -732,8 +738,7 @@ class BimodalDataset(RandomDataset):
         # --- Validate bimodal parameters ---
         if not 0.0 <= short_ratio <= 1.0:
             raise ValueError(
-                f"--bimodal-short-ratio must be in [0.0, 1.0], "
-                f"got {short_ratio}."
+                f"--bimodal-short-ratio must be in [0.0, 1.0], got {short_ratio}."
             )
         if short_input_range[0] > short_input_range[1]:
             raise ValueError(
@@ -793,10 +798,8 @@ class BimodalDataset(RandomDataset):
             no_oversample=no_oversample,
             prefix_len=prefix_len,
             range_ratio=range_ratio,
-            input_len=(input_len if input_len is not None
-                       else long_input_range[1]),
-            output_len=(output_len if output_len is not None
-                        else long_output_len),
+            input_len=(input_len if input_len is not None else long_input_range[1]),
+            output_len=(output_len if output_len is not None else long_output_len),
             batchsize=batchsize,
             **kwargs,
         )
@@ -840,11 +843,16 @@ class BimodalDataset(RandomDataset):
             "BimodalDataset: %d short (%d%% target), %d long (%d%% target); "
             "short input [%d, %d] output [%d, %d], "
             "long input [%d, %d] output %d",
-            short_count, int(self._short_ratio * 100),
-            long_count, int((1 - self._short_ratio) * 100),
-            self._short_input_range[0], self._short_input_range[1],
-            self._short_output_range[0], self._short_output_range[1],
-            self._long_input_range[0], self._long_input_range[1],
+            short_count,
+            int(self._short_ratio * 100),
+            long_count,
+            int((1 - self._short_ratio) * 100),
+            self._short_input_range[0],
+            self._short_input_range[1],
+            self._short_output_range[0],
+            self._short_output_range[1],
+            self._long_input_range[0],
+            self._long_input_range[1],
             self._long_output_len,
         )
 
@@ -1806,15 +1814,13 @@ def add_bimodal_dataset_args(
         "--bimodal-long-input-min",
         type=int,
         default=BimodalDataset.DEFAULT_LONG_INPUT_MIN,
-        help="Min input tokens for long (RAG-style) requests. "
-        "Default: %(default)s.",
+        help="Min input tokens for long (RAG-style) requests. Default: %(default)s.",
     )
     parser_or_group.add_argument(
         "--bimodal-long-input-max",
         type=int,
         default=BimodalDataset.DEFAULT_LONG_INPUT_MAX,
-        help="Max input tokens for long (RAG-style) requests. "
-        "Default: %(default)s.",
+        help="Max input tokens for long (RAG-style) requests. Default: %(default)s.",
     )
     parser_or_group.add_argument(
         "--bimodal-long-output-len",
@@ -2895,9 +2901,11 @@ class MMVUDataset(HuggingFaceDataset):
 
     DEFAULT_OUTPUT_LEN = 128
     SUPPORTED_DATASET_PATHS = {
-        "yale-nlp/MMVU": lambda x: x["question"]
-        + " "
-        + (" ".join(f"{k}.{v}" for k, v in x["choices"].items())),
+        "yale-nlp/MMVU": lambda x: (
+            x["question"]
+            + " "
+            + (" ".join(f"{k}.{v}" for k, v in x["choices"].items()))
+        ),
     }
 
     def sample(

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -363,9 +363,7 @@ def get_requests(args, tokenizer):
         )
         random_input_len = getattr(args, "random_input_len", None)
         sample_kwargs["input_len"] = (
-            random_input_len
-            if random_input_len is not None
-            else args.input_len
+            random_input_len if random_input_len is not None else args.input_len
         )
         random_output_len = getattr(args, "random_output_len", None)
         sample_kwargs["output_len"] = (


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Add `BimodalDataset` -- a synthetic bimodal workload mixing short chat-style and long RAG-style requests for benchmarking.

**Problem:** Uniform synthetic workloads (`--dataset-name random`) hide scheduling bottlenecks present in production LLM traffic. Real-world systems serve a mix of short conversational turns and long retrieval-augmented generation (RAG) queries, which causes head-of-line blocking, KV-cache memory pressure, and P99 latency spikes -- none of which are visible under uniform benchmarks.

**Solution:** `--dataset-name bimodal` generates a configurable mix (default 80% short chat / 20% long RAG) of synthetic requests. All parameters are tunable via CLI flags (`--bimodal-short-ratio`, `--bimodal-short-input-min/max`, etc.).

Works with both `vllm bench throughput` and `vllm bench serve`.

## Test Plan

### Unit tests (11 tests covering seed determinism, distribution, edge cases, validation):
```bash
pytest tests/benchmarks/test_bimodal_dataset.py -v
```

### Serving benchmark comparison (short-only vs bimodal at 30 QPS):
```bash
# Short-only baseline (what short requests look like in isolation)
vllm bench serve --dataset-name random --num-prompts 400 \
    --model Qwen/Qwen2.5-0.5B --request-rate 30 \
    --random-input-len 100 --random-output-len 30 \
    --save-result --save-detailed --result-filename short-only-baseline.json

# Bimodal workload (80% short chat + 20% long RAG)
vllm bench serve --dataset-name bimodal --num-prompts 500 \
    --model Qwen/Qwen2.5-0.5B --request-rate 30 \
    --save-result --save-detailed --result-filename bimodal-detailed.json
```

## Test Result

### Unit tests: all 11 pass

```
tests/benchmarks/test_bimodal_dataset.py::test_bimodal_dataset_same_seed PASSED
tests/benchmarks/test_bimodal_dataset.py::test_bimodal_dataset_different_seeds PASSED
tests/benchmarks/test_bimodal_dataset.py::test_bimodal_dataset_default_distribution PASSED
tests/benchmarks/test_bimodal_dataset.py::test_bimodal_dataset_custom_ratio PASSED
tests/benchmarks/test_bimodal_dataset.py::test_bimodal_dataset_all_short PASSED
tests/benchmarks/test_bimodal_dataset.py::test_bimodal_dataset_all_long PASSED
tests/benchmarks/test_bimodal_dataset.py::test_bimodal_dataset_invalid_short_ratio PASSED
tests/benchmarks/test_bimodal_dataset.py::test_bimodal_dataset_invalid_range PASSED
tests/benchmarks/test_bimodal_dataset.py::test_bimodal_dataset_max_model_len_rejects_oversized_long PASSED
tests/benchmarks/test_bimodal_dataset.py::test_bimodal_dataset_max_model_len_rejects_oversized_short PASSED
tests/benchmarks/test_bimodal_dataset.py::test_bimodal_dataset_max_model_len_accepts_valid PASSED
```

### Benchmark: bimodal workload at 15 QPS across chunk sizes (Qwen/Qwen2.5-0.5B)

Throughput is identical across all configs (~14.84 req/s, ~21,945 tok/s). The chunk size only changes latency distribution, not total compute.

#### TTFT -- Short requests (50-150 input tokens)

| Metric | Chunk 512 | Chunk 2048 | Chunk 8192 |
|--------|-----------|------------|------------|
| Median TTFT (ms) | 14.2 | 14.5 | 14.3 |
| P90 TTFT (ms) | 50.5 | 41.3 | 34.7 |
| P99 TTFT (ms) | 99.1 | 77.7 | 66.3 |
| Max TTFT (ms) | 243.7 | 129.1 | 125.8 |
| P99/Median ratio | 7.0x | 5.3x | 4.6x |

#### TTFT -- Long requests (3000-5000 input tokens)

| Metric | Chunk 512 | Chunk 2048 | Chunk 8192 |
|--------|-----------|------------|------------|
| Median TTFT (ms) | 65.5 | 55.3 | 47.2 |
| P90 TTFT (ms) | 100.2 | 80.6 | 64.8 |
| P99 TTFT (ms) | 182.4 | 118.2 | 128.4 |

#### ITL -- Decode stalls

| Metric | Chunk 512 | Chunk 2048 | Chunk 8192 |
|--------|-----------|------------|------------|
| Short P99 ITL (ms) | 6.05 | 13.35 | 13.44 |
| Short Max ITL (ms) | 8.71 | 18.65 | 54.62 |
| Long P99 ITL (ms) | 6.34 | 13.55 | 14.13 |
| Short: % with >10ms spike | 0.0% | 26.3% | 26.6% |
| Long: % with >10ms spike | 0.0% | 81.7% | 81.1% |

### Key findings

**1. TTFT improves with larger chunks.** A 4000-token request at chunk 512 takes ~8 steps to prefill, occupying a sequence slot and consuming KV cache across all those steps -- blocking admission of short requests. At chunk 8192, the same request prefills in 1 step and frees resources immediately.

**2. ITL degrades with larger chunks -- the inverse tradeoff.** During each step, prefill and decode tokens share the same GPU forward pass. At chunk 8192, a single step may process 5000 prefill tokens alongside decode tokens, stretching step latency to 54ms -- a visible stutter in streamed output. At chunk 512, zero requests experience a >10ms ITL spike.

**3. This maps to two different user experiences:**
- **Small chunks (512):** Slow TTFT tail (7.0x P99/Median spread) but smooth streaming (max ITL 8.7ms). Best for chatbots and real-time streaming.
- **Large chunks (8192):** Fast TTFT tail (4.6x spread) but spiky streaming (max ITL 54.6ms). Best for batch/non-streaming APIs.

**4. The bimodal dataset is what makes this tradeoff measurable.** Uniform workloads produce uniform prefill sizes that don't stress the chunk boundary. The mix of 80% short (50-150 token) and 20% long (3000-5000 token) requests creates the prefill size variance that exposes how chunk size shifts latency between TTFT and ITL.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
