### PR TITLE
[Bugfix] Fix benchmark_moe.py inplace assertion with torch >= 2.9

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -226,9 +226,10 @@ def benchmark_config(
                 x, input_gating, topk, renormalize=not use_deep_gemm
             )
 
+            inplace = not disable_inplace()
             if use_deep_gemm:
                 return deep_gemm_experts(
-                    x, w1, w2, topk_weights, topk_ids, inplace=True
+                    x, w1, w2, topk_weights, topk_ids, inplace=inplace
                 )
             return fused_experts(
                 x,
@@ -236,7 +237,7 @@ def benchmark_config(
                 w2,
                 topk_weights,
                 topk_ids,
-                inplace=True,
+                inplace=inplace,
                 quant_config=quant_config,
             )
 


### PR DESCRIPTION
## Purpose

Fix `benchmarks/kernels/benchmark_moe.py` crashing with an `AssertionError` on torch >= 2.9.

After #33375 moved the `disable_inplace()` guard from inside `fused_experts_impl` / `dispatch_fused_experts_func` to an assertion at the `fused_experts` entry point, the benchmark was not updated and still unconditionally passes `inplace=True`. This triggers:

```
assert not inplace or not disable_inplace()
AssertionError
```

The fix respects `disable_inplace()` the same way the production code does (e.g. `inplace=not moe_config.disable_inplace` in the oracle layer).

Fixes the crash for both the `fused_experts` and `deep_gemm_experts` paths in the benchmark.

## Test Plan

```bash
python benchmarks/kernels/benchmark_moe.py --model Qwen/Qwen3-30B-A3B --tp-size 1 --batch-size 1 2 4
```

## Test Result

Before (torch 2.9):
```
AssertionError
```

After:
```
Batch size: 1, config: {...}, Kernel time: 839.08 us
Batch size: 2, config: {...}, Kernel time: 1308.35 us
Batch size: 4, config: {...}, Kernel time: 2210.20 us
```
