### PR TITLE
[UX nit] Fix non-default api_server_count message

### DIFF
--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -108,6 +108,7 @@ class ServeSubcommand(CLISubcommand):
             run_multi_api_server(args)
         else:
             # Single API server (this process).
+            args.api_server_count = None
             uvloop.run(run_server(args))
 
     def validate(self, args: argparse.Namespace) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Since https://github.com/vllm-project/vllm/pull/32525 landed, we would see api_server_count always in the startup message for non-default args, even when not specified from the user: `(APIServer pid=2847065) INFO 02-09 15:29:34 [utils.py:223] non-default args: {'model_tag': 'openai/gpt-oss-20b', 'api_server_count': 1, 'model': 'openai/gpt-oss-20b'}`

This PR just fixes that by reseting the default if only using one server

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

