### PR TITLE
add extras dict to FinishedRequestStats to enable stat logger plugins…

### DIFF
--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -109,6 +109,49 @@ def test_prefill_kv_computed_edge_cases():
     assert prefill_kv_computed2 == 0  # All cached, nothing computed
 
 
+def test_extras_passed_through():
+    """Test that **kwargs in update_from_finished_request are
+    available as extras on FinishedRequestStats."""
+    iteration_stats = IterationStats()
+    req_stats = RequestStateStats(arrival_time=0.0)
+    req_stats.scheduled_ts = 0.1
+    req_stats.first_token_ts = 0.2
+    req_stats.last_token_ts = 0.5
+    req_stats.num_generation_tokens = 10
+
+    iteration_stats.update_from_finished_request(
+        finish_reason=FinishReason.STOP,
+        num_prompt_tokens=50,
+        max_tokens_param=100,
+        req_stats=req_stats,
+        request_id="test-123",
+    )
+
+    finished_req = iteration_stats.finished_requests[0]
+    assert finished_req.extras is not None
+    assert finished_req.extras["request_id"] == "test-123"
+
+
+def test_extras_default_none():
+    """Test that extras is None when no kwargs are passed."""
+    iteration_stats = IterationStats()
+    req_stats = RequestStateStats(arrival_time=0.0)
+    req_stats.scheduled_ts = 0.1
+    req_stats.first_token_ts = 0.2
+    req_stats.last_token_ts = 0.5
+    req_stats.num_generation_tokens = 10
+
+    iteration_stats.update_from_finished_request(
+        finish_reason=FinishReason.STOP,
+        num_prompt_tokens=50,
+        max_tokens_param=100,
+        req_stats=req_stats,
+    )
+
+    finished_req = iteration_stats.finished_requests[0]
+    assert finished_req.extras is None
+
+
 def test_prompt_token_stats_all_computed():
     """Test all tokens computed locally, no caching."""
     stats = PromptTokenStats()

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -229,6 +229,7 @@ class FinishedRequestStats:
     mean_time_per_output_token: float = 0.0
     is_corrupted: bool = False
     num_cached_tokens: int = 0
+    extras: dict[str, object] | None = None
 
 
 @dataclass
@@ -408,6 +409,7 @@ class IterationStats:
         max_tokens_param: int | None,
         req_stats: RequestStateStats,
         num_cached_tokens: int = 0,
+        **kwargs,
     ):
         e2e_latency = self._time_since(req_stats.arrival_time)
 
@@ -446,6 +448,7 @@ class IterationStats:
             mean_time_per_output_token=mean_time_per_output_token,
             is_corrupted=req_stats.is_corrupted,
             num_cached_tokens=num_cached_tokens,
+            extras=kwargs,
         )
         self.finished_requests.append(finished_req)
 


### PR DESCRIPTION
… to consume extra request-scoped values

## Purpose
Add an extras: dict | None field to FinishedRequestStats and accept **kwargs in IterationStats.update_from_finished_request, passing them through as extras.

  vLLM supports custom stat logger plugins via the vllm.stat_logger_plugins entry point, but plugins can only access the fixed fields on FinishedRequestStats. There's no way for callers to pass through contextual data (like `request_id` ) that plugins need but the core stats don't track.

  This is a minimal change:
  - Add `extras: dict | None = None` to FinishedRequestStats
  - Accept **kwargs in update_from_finished_request and set extras=kwargs or None
  - Pass request_id=req_state.request_id from the existing call site in the output processor

  This enables plugin authors to build per-request logging without patching vLLM internals.

 ## Test Plan
- `
python -m pytest tests/v1/metrics/test_stats.py::test_extras_passed_through tests/v1/metrics/test_stats.py::test_extras_default_none -v
`
- Existing unit tests pass (no signatures are broken, **kwargs and extras=None default are backwards compatible)
- Example stat logger plugin consuming extras:
```python
class ExampleStatLogger(StatLoggerBase):
    def __init__(self, vllm_config, engine_index=0):
        self.finished_requests = []
    def record(self, scheduler_stats, iteration_stats, mm_cache_stats=None, engine_idx=0):
        if iteration_stats:
            self.finished_requests.extend(iteration_stats.finished_requests)
    def log(self):
        for req in self.finished_requests:
            extras = req.extras or {}
            print(f"request_id={extras.get('request_id')} "
                    f"e2e={req.e2e_latency:.3f}s "
                    f"tokens={req.num_generation_tokens}")
            self.finished_requests.clear()
    def log_engine_initialized(self):
        pass

```

 Register the plugin via entry point in pyproject.toml:
 ```
  [project.entry-points."vllm.stat_logger_plugins"]
  example = "my_package:ExampleStatLogger"
```

