### PR TITLE
[ROCm][Kernel] Add GFX11 (RDNA3/4) support for wvSplitK skinny GEMM kernels

### DIFF
--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -29,6 +29,10 @@
   #define __HIP__MI3XX__
 #endif
 
+#if defined(__HIPCC__) && defined(__GFX11__)
+  #define __HIP__GFX11__
+#endif
+
 #if defined(__gfx950__)
   #define LDS_SIZE 160 * 1024
 #else
@@ -46,6 +50,16 @@ int get_lds_size() {
     is_cached = true;
   }
   return result;
+}
+
+bool is_gfx11() {
+  static int result = -1;
+  if (result == -1) {
+    auto dprops = at::cuda::getCurrentDeviceProperties();
+    std::string device_arch = dprops->gcnArchName;
+    result = (device_arch.find("gfx11") != std::string::npos) ? 1 : 0;
+  }
+  return result == 1;
 }
 
 #if defined(NDEBUG)
@@ -285,21 +299,41 @@ torch::Tensor LLMM1(at::Tensor& in_a, at::Tensor& in_b,
   return out_c;
 }
 
-#define DOT2C(V0, V2, V3)                                                     \
-  if constexpr (std::is_same_v<scalar_t, half>) {                             \
-    asm("v_dot2c_f32_f16 %0, %2, %3" : "=v"(V0) : "0"(V0), "v"(V2), "v"(V3)); \
-  } else if constexpr (std::is_same_v<scalar_t, __hip_bfloat16>) {            \
-    float2 s = __bfloat1622float2(*((__hip_bfloat162*)(&(V2)))) *             \
-               __bfloat1622float2(*((__hip_bfloat162*)(&(V3))));              \
-    V0 += (s.x + s.y);                                                        \
+// GFX11 (RDNA3) renamed v_dot2c_f32_f16 to v_dot2acc_f32_f16
+#if defined(__HIP__GFX11__)
+  #define DOT2C_FP16_INSN "v_dot2acc_f32_f16"
+#else
+  #define DOT2C_FP16_INSN "v_dot2c_f32_f16"
+#endif
+
+#define DOT2C(V0, V2, V3)                                                      \
+  if constexpr (std::is_same_v<scalar_t, half>) {                              \
+    asm(DOT2C_FP16_INSN " %0, %2, %3" : "=v"(V0) : "0"(V0), "v"(V2), "v"(V3)); \
+  } else if constexpr (std::is_same_v<scalar_t, __hip_bfloat16>) {             \
+    float2 s = __bfloat1622float2(*((__hip_bfloat162*)(&(V2)))) *              \
+               __bfloat1622float2(*((__hip_bfloat162*)(&(V3))));               \
+    V0 += (s.x + s.y);                                                         \
   }
+
+// GFX11 (RDNA, wave32) butterfly reduction: sum all 32 lanes within one
+// wavefront.  Every lane gets the result.
+#if defined(__HIP__GFX11__)
+  #define REDUCE_SUM_WAVE32(val)  \
+    do {                          \
+      val += __shfl_xor(val, 1);  \
+      val += __shfl_xor(val, 2);  \
+      val += __shfl_xor(val, 4);  \
+      val += __shfl_xor(val, 8);  \
+      val += __shfl_xor(val, 16); \
+    } while (0)
+#endif
 
 // To avoid LLVM silently upcasting to double
 __device__ inline unsigned int min__(uint32_t a, uint32_t b) {
   return min(a, b);
 }
 
-#if defined(__HIP__GFX9__)  // TODO: Add NAVI support
+#if defined(__HIP__GFX9__) || defined(__HIP__GFX11__)
 // This version targets cases where A[] fits LDS capacity
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N>
@@ -471,6 +505,28 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     // Final reduction step using shuffle
     //----------------------------------------------------
     if constexpr (!use_mfma) {
+  #if defined(__HIP__GFX11__)
+      // Wave32: butterfly reduce within the single wavefront per row
+      for (int n = 0; n < N; n++)
+        for (int y = 0; y < YTILE; y++) REDUCE_SUM_WAVE32(sum[n][y]);
+
+      // Lane 0 has the complete sum; write the result
+      if (threadIdx.x == 0) {
+        for (int n = 0; n < N; n++) {
+          for (int i = 0; i < YTILE; i++) {
+            if constexpr (std::is_same_v<scalar_t, half>) {
+              if (BIAS)
+                sum[n][i] += __half2float(BIAS[(m + i) % Bx + (n % By) * M]);
+            } else if constexpr (std::is_same_v<scalar_t, __hip_bfloat16>) {
+              if (BIAS)
+                sum[n][i] +=
+                    __bfloat162float(BIAS[(m + i) % Bx + (n % By) * M]);
+            }
+            C[m + i + n * M] = __float2s<scalar_t>(sum[n][i]);
+          }
+        }
+      }
+  #else   // GFX9 wave64 path
       for (int n = 0; n < N; n++) {
         for (int y = 0; y < YTILE; y++) {
           asm("s_nop 0\n\tv_add_f32 %0, %2, %3 row_shr:8 bound_ctrl:0 "
@@ -509,6 +565,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
           }
         }
       }
+  #endif  // defined(__HIP__GFX11__)
     } else {
   #pragma unroll
       for (int n = 0; n < N; n++) {
@@ -560,7 +617,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     m += CuCount * _WvPrGrp * YTILE;
   }
 }
-#else   // !defined(__HIP__GFX9__) TODO: Add NAVI support
+#else   // !defined(__HIP__GFX9__) && !defined(__HIP__GFX11__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N>
 __global__ void wvSplitK_hf_sml_(const int K, const int M, const int Bx,
@@ -570,9 +627,9 @@ __global__ void wvSplitK_hf_sml_(const int K, const int M, const int Bx,
                                  const int _WvPrGrp, const int CuCount) {
   UNREACHABLE_CODE
 }
-#endif  // defined(__HIP__GFX9__) TODO: Add NAVI support
+#endif  // defined(__HIP__GFX9__) || defined(__HIP__GFX11__)
 
-#if defined(__HIP__GFX9__)  // TODO: Add NAVI support
+#if defined(__HIP__GFX9__) || defined(__HIP__GFX11__)
 // This version targets cases where A[] marginally exceeds LDS capacity
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N>
@@ -771,6 +828,30 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     // Final reduction step using shuffle
     //----------------------------------------------------
     if constexpr (!use_mfma) {
+  #if defined(__HIP__GFX11__)
+      // Wave32: butterfly reduce within the single wavefront per row
+      for (int n = 0; n < N; n++)
+        for (int y = 0; y < YTILE; y++) REDUCE_SUM_WAVE32(sum[n][y]);
+
+      // Lane 0 has the complete sum; write the result
+      if (threadIdx.x == 0) {
+        for (int n = 0; n < N; n++) {
+          for (int i = 0; i < YTILE; i++) {
+            if (commitColumn[i]) {
+              if constexpr (std::is_same_v<scalar_t, half>) {
+                if (BIAS)
+                  sum[n][i] += __half2float(BIAS[(m + i) % Bx + (n % By) * M]);
+              } else if constexpr (std::is_same_v<scalar_t, __hip_bfloat16>) {
+                if (BIAS)
+                  sum[n][i] +=
+                      __bfloat162float(BIAS[(m + i) % Bx + (n % By) * M]);
+              }
+              C[m + i + n * M] = __float2s<scalar_t>(sum[n][i]);
+            }
+          }
+        }
+      }
+  #else   // GFX9 wave64 path
       for (int n = 0; n < N; n++) {
         for (int y = 0; y < YTILE; y++) {
           asm("s_nop 0\n\tv_add_f32 %0, %2, %3 row_shr:8 bound_ctrl:0 "
@@ -811,6 +892,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
           }
         }
       }
+  #endif  // defined(__HIP__GFX11__)
     } else {
   #pragma unroll
       for (int n = 0; n < N; n++) {
@@ -877,7 +959,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
   }
 }
 
-#else   // !defined(__HIP__GFX9__) TODO: Add NAVI support
+#else   // !defined(__HIP__GFX9__) && !defined(__HIP__GFX11__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N>
 __global__ void wvSplitK_hf_(const int K, const int M, const int Bx,
@@ -887,9 +969,9 @@ __global__ void wvSplitK_hf_(const int K, const int M, const int Bx,
                              const int _WvPrGrp, const int CuCount) {
   UNREACHABLE_CODE
 }
-#endif  // defined(__HIP__GFX9__) TODO: Add NAVI support
+#endif  // defined(__HIP__GFX9__) || defined(__HIP__GFX11__)
 
-#if defined(__HIP__GFX9__)  // TODO: Add NAVI support
+#if defined(__HIP__GFX9__) || defined(__HIP__GFX11__)
 // This version targets big A[] cases, where it is much larger than LDS capacity
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N>
@@ -1139,6 +1221,30 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     // Final reduction step using shuffle
     //----------------------------------------------------
     if constexpr (!use_mfma) {
+  #if defined(__HIP__GFX11__)
+      // Wave32: butterfly reduce within the single wavefront per row
+      for (int n = 0; n < N; n++)
+        for (int y = 0; y < YTILE; y++) REDUCE_SUM_WAVE32(sum[n][y]);
+
+      // Lane 0 has the complete sum; write the result
+      if (threadIdx.x == 0) {
+        for (int n = 0; n < N; n++) {
+          for (int i = 0; i < YTILE; i++) {
+            if (commitColumn[i]) {
+              if constexpr (std::is_same_v<scalar_t, half>) {
+                if (BIAS)
+                  sum[n][i] += __half2float(BIAS[(m + i) % Bx + (n % By) * M]);
+              } else if constexpr (std::is_same_v<scalar_t, __hip_bfloat16>) {
+                if (BIAS)
+                  sum[n][i] +=
+                      __bfloat162float(BIAS[(m + i) % Bx + (n % By) * M]);
+              }
+              C[m + i + n * M] = __float2s<scalar_t>(sum[n][i]);
+            }
+          }
+        }
+      }
+  #else   // GFX9 wave64 path
       for (int n = 0; n < N; n++) {
         for (int y = 0; y < YTILE; y++) {
           asm("s_nop 0\n\tv_add_f32 %0, %2, %3 row_shr:8 bound_ctrl:0 "
@@ -1179,6 +1285,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
           }
         }
       }
+  #endif  // defined(__HIP__GFX11__)
     } else {
   #pragma unroll
       for (int n = 0; n < N; n++) {
@@ -1241,7 +1348,7 @@ __global__ void __launch_bounds__(WvPrGrp* THRDS)
     }
   }
 }
-#else   // !defined(__HIP__GFX9__) TODO: Add NAVI support
+#else   // !defined(__HIP__GFX9__) && !defined(__HIP__GFX11__)
 template <typename scalar_t, int THRDS, int YTILE, int WvPrGrp, int A_CHUNK,
           int UNRL, int N>
 __global__ void wvSplitK_hf_big_(const int K, const int M, const int Bx,
@@ -1251,7 +1358,7 @@ __global__ void wvSplitK_hf_big_(const int K, const int M, const int Bx,
                                  const int _WvPrGrp, const int CuCount) {
   UNREACHABLE_CODE
 }
-#endif  // defined(__HIP__GFX9__) TODO: Add NAVI support
+#endif  // defined(__HIP__GFX9__) || defined(__HIP__GFX11__)
 
 // Find the min val of div2 that doesn't increase N/(div1*div2)
 int mindiv(int N, int div1, int div2) {
@@ -1296,23 +1403,29 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   const int max_lds_len = get_lds_size() / 2;
 
-#define WVSPLITK(_YTILE, _UNRL, _N)                                        \
+#define WVSPLITK_LAUNCH(_THRDS, _YTILE, _UNRL, _N)                         \
   {                                                                        \
-    dim3 block(64, 16);                                                    \
+    dim3 block(_THRDS, 16);                                                \
     int __wvPrGrp = mindiv(M_in, CuCount * _YTILE, 16);                    \
     if ((K_in * N_in <= max_lds_len) && (M_in % _YTILE == 0))              \
-      wvSplitK_hf_sml_<fptype, 64, _YTILE, 16, 8, _UNRL, _N>               \
+      wvSplitK_hf_sml_<fptype, _THRDS, _YTILE, 16, 8, _UNRL, _N>           \
           <<<grid, block, 0, stream>>>(K_in, M_in, Bx_in, By_in, af4, bf4, \
                                        biasf4, c, __wvPrGrp, CuCount);     \
     else if (K_in * N_in <= max_lds_len * 1.2)                             \
-      wvSplitK_hf_<fptype, 64, _YTILE, 16, 8, _UNRL, _N>                   \
+      wvSplitK_hf_<fptype, _THRDS, _YTILE, 16, 8, _UNRL, _N>               \
           <<<grid, block, 0, stream>>>(K_in, M_in, Bx_in, By_in, af4, bf4, \
                                        biasf4, c, __wvPrGrp, CuCount);     \
     else                                                                   \
-      wvSplitK_hf_big_<fptype, 64, _YTILE, 16, 8, _UNRL, _N>               \
+      wvSplitK_hf_big_<fptype, _THRDS, _YTILE, 16, 8, _UNRL, _N>           \
           <<<grid, block, 0, stream>>>(K_in, M_in, Bx_in, By_in, af4, bf4, \
                                        biasf4, c, __wvPrGrp, CuCount);     \
   }
+
+#define WVSPLITK(_YTILE, _UNRL, _N)        \
+  if (is_gfx11())                          \
+    WVSPLITK_LAUNCH(32, _YTILE, _UNRL, _N) \
+  else                                     \
+    WVSPLITK_LAUNCH(64, _YTILE, _UNRL, _N)
 
 #define WVSPLIT_TILE(_sYT, __N)                           \
   {                                                       \

--- a/tests/kernels/quantization/test_rocm_skinny_gemms.py
+++ b/tests/kernels/quantization/test_rocm_skinny_gemms.py
@@ -194,7 +194,9 @@ def test_rocm_wvsplitk_kernel(n, k, m, dtype, seed):
     ref_out = torch.nn.functional.linear(A, B)
     out = ops.wvSplitK(B, A.view(-1, A.size(-1)), cu_count)
 
-    assert torch.allclose(out, ref_out, rtol=0.01)
+    # Accumulation error in fp16 GEMM scales with sqrt(K)
+    atol = torch.finfo(dtype).eps * math.sqrt(k)
+    assert torch.allclose(out, ref_out, rtol=0.01, atol=atol)
 
 
 @pytest.mark.parametrize("n,k,m", NKM_FACTORS_WVSPLITK)

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -143,7 +143,7 @@ def use_aiter_triton_gemm(n, m, k, dtype):
 def rocm_unquantized_gemm_impl(
     x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
 ) -> torch.Tensor:
-    from vllm.platforms.rocm import on_gfx9, on_gfx950
+    from vllm.platforms.rocm import on_gfx9, on_gfx11, on_gfx950
 
     n = x.numel() // x.size(-1)
     m = weight.shape[0]
@@ -188,7 +188,7 @@ def rocm_unquantized_gemm_impl(
 
     use_skinny = (
         envs.VLLM_ROCM_USE_SKINNY_GEMM
-        and on_gfx9()
+        and (on_gfx9() or on_gfx11())
         and x.dtype in [torch.float16, torch.bfloat16]
         and k % 8 == 0
         and x.is_contiguous()

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -140,6 +140,12 @@ def on_gfx9() -> bool:
 
 
 @cache
+def on_gfx11() -> bool:
+    GPU_ARCH = _get_gcn_arch_via_amdsmi()
+    return "gfx11" in GPU_ARCH
+
+
+@cache
 def on_gfx942() -> bool:
     GPU_ARCH = _get_gcn_arch_via_amdsmi()
     return any(arch in GPU_ARCH for arch in ["gfx942"])


### PR DESCRIPTION
## Summary

Enable the wvSplitK skinny GEMM kernels on all GFX11 (RDNA3) GPUs. These kernels accelerate decode-phase GEMMs (small batch size, large K) by using wave-level split-K with butterfly reduction.

Key adaptations for RDNA's wave32 execution model:
- Use `v_dot2acc_f32_f16` (renamed from `v_dot2c_f32_f16` on GFX11)
- Wave32 butterfly reduction via `__shfl_xor` instead of GFX9's DPP `row_shr`
- Use `THRDS=32` on GFX11 (one wavefront per row); keep `THRDS=64` on GFX9
- Add `is_gfx11()` runtime helper for host-side kernel dispatch
- Add `on_gfx11()` helper and use `on_gfx9() or on_gfx11()` to gate the Python dispatch path
- Relax wvSplitK test tolerance to account for fp16 accumulation error scaling with `sqrt(K)`

## Performance

Benchmarked on AMD Strix Halo (gfx1151, LPDDR5X-8000 128 GB):

**Qwen/Qwen3-4B (bf16, unquantized) — decode TPOT ~20% faster:**

| Workload | Metric | Baseline | Optimized | Change |
|---|---|---|---|---|
| input=128, output=128 | Median TPOT | 50.03 ms | 40.18 ms | **19.7% faster** |
| input=1920, output=128 | Median TPOT | 51.39 ms | 41.37 ms | **19.5% faster** |

**hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4 — minimal impact (AWQ layers bypass skinny GEMM path):**

| Workload | Metric | Baseline | Optimized | Change |
|---|---|---|---|---|
| input=128, output=128 | Median TPOT | 172.22 ms | 169.49 ms | 1.6% faster |
| input=1920, output=128 | Median TPOT | 173.33 ms | 170.54 ms | 1.6% faster |

TTFT (prefill) is unaffected as the skinny kernels only target batch_size ≤ 4 GEMMs.

## Test plan

- [x] `test_rocm_wvsplitk_kernel` — all 22 parametrized cases pass on gfx1151
- [x] `test_rocm_wvsplitk_bias1D_kernel` — all 22 parametrized cases pass
- [x] `test_rocm_wvsplitk_bias2D_kernel` — all 22 parametrized cases pass
- [x] Sanity check: model produces correct answers to math questions in both benchmarks
