### PR TITLE
[Online Quantization] Support memory-efficient online quantization via layerwise loading

### DIFF
--- a/vllm/model_executor/model_loader/reload/types.py
+++ b/vllm/model_executor/model_loader/reload/types.py
@@ -17,7 +17,7 @@ class LayerReloadingInfo:
     restore_metadata: LayerTensors = field(default_factory=lambda: ({}, {}))
 
     # kernel format (device)
-    kernel_tensors: LayerTensors = field(default_factory=lambda: ({}, {}))
+    kernel_tensors: LayerTensors | None = None
 
     # track how many restored elements are ready for loading
     load_numel: int = 0


### PR DESCRIPTION
## Purpose ##
* Support online quantization in a more maintainable way by integrating with existing layerwise processing functionality

## Changes ##
* Change layerwise logic to only copy and re-place into kernel tensors if reloading

## Weights with initialized values ##
Handling weights which require values placed at init time is a little tricky. One example are rotary embeddings, whose values are created at init time, and are not loaded from disk. In order to avoid overwriting these values with materialized empty tensors, we explicitly exclude these modules from our restore/materialize process. However, handling a weight which initializes some values and loads values would be more complex, although not at all impossible to handle. One way of doing this would be to load values directly into weights, and count those, rather than using `get_numel_loaded`.

## TODO ##
* Rename "reload" utilities to just "layerwise"
* Break out attention processing into a separate for loop
* Check that there are no side effects from loading and processing the model in device context

## Testing ##
* Quantized reloading regression tests pass (`test_reload.py`)
* Smoke tested online quantization
```python
from vllm import LLM; llm = LLM("Qwen/Qwen3-0.6B", quantization="fp8", tensor_parallel_size=2)
llm.generate("Hello there")
```