### PR TITLE
[Bugfix] Add missing runtime dependencies for Nemotron Parse 1.1

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -37,6 +37,8 @@ pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=77.0.3,<81.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
+timm >= 1.0.17 # Required for Nemotron Parse.
+albumentations >= 1.4.6 # Required for Nemotron Parse.
 compressed-tensors == 0.13.0 # required for compressed-tensors
 depyf==0.20.0 # required for profiling and debugging with compilation config
 cloudpickle # allows pickling lambda functions in model_executor/models/registry.py


### PR DESCRIPTION
The commit ee21291 (Nemotron Parse 1.1 Support) added timm and albumentations imports in nemotron_parse.py but only included them in test requirements. This causes an ImportError at server startup when running the NVIDIA Nemotron-Parse-v1.1 model.

So this PR adds timm and albumentations to requirements/common.txt so they are installed as runtime dependencies.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

