### PR TITLE
[Bugfix] Sort hf_weights_files in fastsafetensors_weights_iterator to match #33491

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -826,6 +826,7 @@ def fastsafetensors_weights_iterator(
         pg = SingleGroup()
 
     device = torch.device(f"cuda:{current_platform.current_device()}")
+    hf_weights_files = sorted(hf_weights_files, key=_natural_sort_key)
     weight_files_sub_lists = [
         hf_weights_files[i : i + pg.size()]
         for i in range(0, len(hf_weights_files), pg.size())


### PR DESCRIPTION
## Summary

PR #33491 added sorting of `hf_weights_files` in `safetensors_weights_iterator`, but the same fix was not applied to `fastsafetensors_weights_iterator`. This PR applies the identical fix to the fastsafetensors path, preventing NCCL crashes on multi-node tensor parallel deployments.

Fixes #34180

## Context

PR #33491 (already merged) sorted `hf_weights_files` using `_natural_sort_key` in `safetensors_weights_iterator` to ensure deterministic loading order. The `fastsafetensors_weights_iterator` function in the same file has the same bug — it splits `hf_weights_files` across ranks without sorting first. On multi-node setups where filesystem enumeration order differs between nodes, this causes each rank to load completely different safetensor shards, resulting in NCCL collective size mismatches and SIGABRT.

## Change

Added `hf_weights_files = sorted(hf_weights_files, key=_natural_sort_key)` immediately before the `weight_files_sub_lists` comprehension in `fastsafetensors_weights_iterator`, matching the exact style used in `safetensors_weights_iterator`.

## Testing

Tested on a 2-node DGX Spark cluster (GB10, aarch64) with `openai/gpt-oss-120b`, TP=2 across nodes via InfiniBand. Without the sort, NCCL crashes with collective size mismatches. With the sort, loading succeeds and inference is stable.

## Why This Matters

Each node constructs `hf_weights_files` from its local filesystem. Directory enumeration order depends on filesystem internals. When two nodes have different drives or filesystem history, the file list order differs. The sub-list splitting then assigns different shards to each rank. Each rank broadcasts different tensors via NCCL at the same time, causing mismatched collective sizes and a crash.

This has been reproduced across multiple hardware configurations (NVIDIA DGX Spark, ASUS GD10, MSI Spark variants) and is documented in fastsafetensors issue #36.