### PR TITLE
Feat/silu and mul out variant

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -147,7 +147,13 @@ void rotary_embedding(torch::Tensor& positions, torch::Tensor& query,
                       std::optional<torch::Tensor> key, int64_t head_size,
                       torch::Tensor& cos_sin_cache, bool is_neox);
 
-void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
+void silu_and_mul(torch::Tensor& out, const torch::Tensor& input);
+
+// Functional variant of silu_and_mul (allocates output)
+torch::Tensor silu_and_mul_func(const torch::Tensor& input);
+
+// Out variant with PyTorch standard signature: (input, *, out) -> Tensor
+torch::Tensor silu_and_mul_out(const torch::Tensor& input, torch::Tensor& out);
 
 void silu_and_mul_quant(torch::Tensor& out, torch::Tensor& input,
                         torch::Tensor& scale);

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -102,8 +102,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   // Activation ops
   // Activation function used in SwiGLU.
-  ops.def("silu_and_mul(Tensor! result, Tensor input) -> ()");
-  ops.impl("silu_and_mul", torch::kCUDA, &silu_and_mul);
+  // Functional variant (default overload) - enables torch.compile decompose
+  // pass
+  ops.def("silu_and_mul(Tensor input) -> Tensor");
+  ops.impl("silu_and_mul", torch::kCUDA, &silu_and_mul_func);
+
+  // Out variant with kwarg-only out arg (PyTorch standard convention)
+  ops.def("silu_and_mul.out(Tensor input, *, Tensor! out) -> Tensor");
+  ops.impl("silu_and_mul.out", torch::kCUDA, &silu_and_mul_out);
 
   ops.def(
       "silu_and_mul_quant(Tensor! result, Tensor input, Tensor scale) -> ()");

--- a/tests/kernels/moe/test_pplx_moe.py
+++ b/tests/kernels/moe/test_pplx_moe.py
@@ -164,8 +164,8 @@ def torch_batched_moe(
     for expert in range(num_experts):
         num = tokens_per_expert[expert]
         if num > 0:
-            torch.ops._C.silu_and_mul(
-                tmp[:num], b_a[expert, :num, :] @ w1[expert].transpose(0, 1)
+            tmp[:num] = torch.ops._C.silu_and_mul(
+                b_a[expert, :num, :] @ w1[expert].transpose(0, 1)
             )
             out[expert, :num, :] = tmp[:num] @ w2[expert].transpose(0, 1)
 

--- a/vllm/compilation/passes/fusion/matcher_utils.py
+++ b/vllm/compilation/passes/fusion/matcher_utils.py
@@ -446,11 +446,8 @@ class MatcherSiluAndMul(MatcherCustomOp):
         self,
         x: torch.Tensor,
     ) -> torch.Tensor:
-        d = x.shape[-1] // 2
-        output_shape = x.shape[:-1] + (d,)
-        out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-        result = auto_functionalized(SILU_MUL_OP, result=out, input=x)
-        return result[1]
+        # Use functional variant directly (returns result)
+        return SILU_MUL_OP(x)
 
     def forward_native(
         self,

--- a/vllm/compilation/passes/utility/fix_functionalization.py
+++ b/vllm/compilation/passes/utility/fix_functionalization.py
@@ -116,14 +116,11 @@ class FixFunctionalizationPass(VllmInductorPass):
                     5: "scale_out",
                 }
                 self.defunctionalize(graph, node, mutated_args)
-            # For some reason we need to specify the args for both
-            # silu_and_mul and silu_and_mul_quant. The kwargs
-            # pathway gets the wrong answer.
-            elif at_target == torch.ops._C.silu_and_mul.default:
-                mutated_args = {1: "result"}
-                self.defunctionalize(
-                    graph, node, mutated_args, args=("result", "input")
-                )
+            # silu_and_mul.default is now functional (returns Tensor),
+            # silu_and_mul.out is the out variant with kwarg-only out
+            elif at_target == torch.ops._C.silu_and_mul.out:
+                mutated_args = {1: "out"}
+                self.defunctionalize(graph, node, mutated_args, args=("input", "out"))
             elif at_target == torch.ops._C.silu_and_mul_quant.default:
                 mutated_args = {1: "result"}
                 self.defunctionalize(

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -130,6 +130,7 @@ class SiluAndMul(CustomOp):
     def __init__(self, *, compile_native: bool = True):
         super().__init__(compile_native=compile_native)
         if current_platform.is_cuda_alike() or current_platform.is_xpu():
+            # Use functional variant (allocates output internally)
             self.op = torch.ops._C.silu_and_mul
         elif current_platform.is_cpu():
             self._forward_method = self.forward_native
@@ -141,11 +142,8 @@ class SiluAndMul(CustomOp):
         return F.silu(x[..., :d]) * x[..., d:]
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
-        d = x.shape[-1] // 2
-        output_shape = x.shape[:-1] + (d,)
-        out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-        self.op(out, x)
-        return out
+        # Functional variant: op allocates and returns output
+        return self.op(x)
 
     def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
         return self.forward_cuda(x)

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -376,7 +376,7 @@ def apply_moe_activation(
 
     # Activations with gated multiplication (gate × activation(up))
     if activation == "silu":
-        torch.ops._C.silu_and_mul(output, input)
+        torch.ops._C.silu_and_mul.out(input, out=output)
     elif activation == "gelu":
         torch.ops._C.gelu_and_mul(output, input)
     elif activation == "swigluoai":

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -247,16 +247,16 @@ def _fused_moe_gguf(
     activation: str,
 ) -> torch.Tensor:
     def act(x: torch.Tensor):
-        d = x.shape[-1] // 2
-        output_shape = x.shape[:-1] + (d,)
-        out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
         if activation == "silu":
-            torch.ops._C.silu_and_mul(out, x)
+            return torch.ops._C.silu_and_mul(x)
         elif activation == "gelu":
+            d = x.shape[-1] // 2
+            output_shape = x.shape[:-1] + (d,)
+            out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
             torch.ops._C.gelu_and_mul(out, x)
+            return out
         else:
             raise ValueError(f"Unsupported activation: {activation}")
-        return out
 
     # lazy import to avoid triggering triton import in CPU backend
     from vllm.model_executor.layers.fused_moe.fused_moe import moe_align_block_size


### PR DESCRIPTION
# [Custom Ops] Add functional + out variant for silu_and_mul

## Purpose

Add PyTorch-standard functional and out-variant overloads for `silu_and_mul` to
enable PyTorch Inductor's out-variant lowering optimization pass. This is the
vLLM-side change that makes `_C::silu_and_mul` compatible with the new
`lower_custom_ops_to_out_variant` config in PyTorch Inductor.

## Changes

### C++ Layer (`csrc/`)
- `silu_and_mul_func(input) -> Tensor` — functional variant that allocates output
- `silu_and_mul_out(input, *, out) -> Tensor` — out variant with kwarg-only `out` arg
- Updated schema to PyTorch standard convention

### Python Layer (`vllm/`)
- FakeTensor implementations for both variants
- Updated all call sites to use new API:
  - `SiluAndMul.forward_cuda()` → functional variant
  - `fused_moe/utils.py` → `.out()` variant for pre-allocated buffers
  - `gguf.py` → functional variant

## Breaking Change

Old API `silu_and_mul(out, input) -> ()` is replaced with:
- `silu_and_mul(input) -> Tensor` (default overload)
- `silu_and_mul.out(input, *, out=out) -> Tensor` (out variant)

All call sites within vLLM have been updated.

## Demo: Inductor Out-Variant Lowering

With the corresponding PyTorch PR ([#174739](https://github.com/pytorch/pytorch/pull/174739)),
Inductor can lower `silu_and_mul` from `ExternKernelAlloc` (opaque, no buffer reuse)
to `ExternKernelOut` (participates in `AllocateLine.plan()` buffer reuse).


### Single call: `silu_and_mul(x)`
With both overloads registered:

```python
ops.def("silu_and_mul(Tensor input) -> Tensor");
ops.def("silu_and_mul.out(Tensor input, *, Tensor! out) -> Tensor");
```
and inductor_config.lower_custom_ops_to_out_variant = True

**WITH** out-variant lowering (`lower_custom_ops_to_out_variant=True`):
```python
buf0 = empty_strided_cuda((4, 2048), (2048, 1), torch.float32)
torch.ops._C.silu_and_mul.out(arg0_1, out=buf0)       # .out() call
del arg0_1
```

**WITHOUT** (default):
```python
buf0 = torch.ops._C.silu_and_mul.default(arg0_1)       # .default() call
del arg0_1
buf1 = buf0
del buf0
```

### Chained calls with buffer reuse

```python
def f(x):
    y = silu_and_mul(x)          # x(4, 4096) -> y(4, 2048)
    y2 = torch.cat([y, y], -1)   # y2(4, 4096)
    z = silu_and_mul(y2)          # z(4, 2048) — can reuse y's dead buffer
    return z
```

**WITH** out-variant lowering:
```python
buf0 = empty_strided_cuda((4, 2048), (2048, 1), torch.float32)
torch.ops._C.silu_and_mul.out(arg0_1, out=buf0)
del arg0_1
buf1 = empty_strided_cuda((4, 4096), (4096, 1), torch.float32)
triton_poi_fused_cat_silu_and_mul_0.run(buf0, buf1, 16384, stream=stream0)
buf2 = buf0; del buf0  # reuse         ← y's dead buffer reused for z!
torch.ops._C.silu_and_mul.out(buf1, out=buf2)
del buf1
```

**WITHOUT**:
```python
buf0 = torch.ops._C.silu_and_mul.default(arg0_1)
del arg0_1
buf1 = buf0
del buf0
buf2 = empty_strided_cuda((4, 4096), (4096, 1), torch.float32)
triton_poi_fused_cat_silu_and_mul_0.run(buf1, buf2, 16384, stream=stream0)
del buf1
buf3 = torch.ops._C.silu_and_mul.default(buf2)          # no reuse
del buf2
buf4 = buf3
del buf3
```

### Analysis

|                    | WITH | WITHOUT |
|--------------------|------|---------|
| `.out()` calls     | 2    | 0       |
| `.default()` calls | 0    | 2       |
| `# reuse` comments | 1    | 0       |

**1 MORE buffer reuse** with out-variant lowering. Correctness verified: `allclose=True, max_diff=0.00e+00` for all cases.

## Test Plan

```bash
# Activation tests
pytest tests/kernels/core/test_activation.py -v

# MOE tests
pytest tests/kernels/moe/test_pplx_moe.py -v

# Compile tests
pytest tests/compile/test_functionalization.py -v
```

## Related PRs

- **PyTorch Inductor out-variant lowering**: https://github.com/pytorch/pytorch/pull/174739
  — Adds `lower_custom_ops_to_out_variant` config that lowers functional custom ops to
  `ExternKernelOut` for buffer reuse. This vLLM PR provides the op-level support.

