### PR TITLE
[Misc] allow specify is_mm_prefix_lm in hf_config

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1119,6 +1119,9 @@ class ModelConfig:
     @cached_property
     def is_mm_prefix_lm(self) -> bool:
         """Whether to use bidirectional attention for mm positions."""
+        if hasattr(self.hf_config, "is_mm_prefix_lm"):
+            return bool(self.hf_config.is_mm_prefix_lm)
+        # fallback to list of known models
         MM_PREFIX_LM_MODELS = (
             "gemma3",
             "molmo2",


### PR DESCRIPTION


<!-- markdownlint-disable -->
## Purpose
Currently whether to use PrefixLM is hardcoded into a list MM_PREFIX_LM_MODELS. This PR enables model's hf_config to also specify this behaviour with a flag of the same name. If no flag is given, fallbacks to the hardcoded list.

## Test Plan
Locally extends some models `config.json` with a field `is_mm_prefix_lm` and print the `image_doc_range` in `gpu_model_runner.py` to confirm prefixLM is turned on and off correctly.

```python
        if self.is_mm_prefix_lm:
            req_doc_ranges = {}
            for req_id in self.input_batch.req_ids:
                image_doc_ranges = []
                req_state = self.requests[req_id]
                for mm_feature in req_state.mm_features:
                    pos_info = mm_feature.mm_position
                    img_doc_range = pos_info.extract_embeds_range()
                    image_doc_ranges.extend(img_doc_range)
                req_idx = self.input_batch.req_id_to_index[req_id]
                req_doc_ranges[req_idx] = image_doc_ranges
                # __AUTO_GENERATED_PRINT_VAR_START__
                print(f"GPUModelRunner#_build_attention_metadata image_doc_ranges: {str(image_doc_ranges)}") # __AUTO_GENERATED_PRINT_VAR_END__
```
## Test Result
Work as expected. `(Worker pid=3833285) GPUModelRunner#_build_attention_metadata image_doc_ranges: [(0, 1349)]`

## More context on why not extending the hardcoded list
I'm integrating a not-yet-released model in vllm-omni. Currently there is no mechanism to turn on prefixLM without integrating the model into vllm first, but our model will only works within vllm-omni due to some new architecture choices that vllm-omni affords us.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

