### PR TITLE
[V1][BugFix] Fix EAGLE3 encoder cache miss with disable_chunked_mm_input

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1155,7 +1155,12 @@ class Scheduler(SchedulerInterface):
                 and (num_computed_tokens + num_new_tokens)
                 < (start_pos + num_encoder_tokens)
             ):
-                num_new_tokens = start_pos - num_computed_tokens
+                # Account for EAGLE shift when rolling back to avoid
+                # encoder cache miss. This ensures the scheduled range
+                # stops before start_pos even with the shift.
+                num_new_tokens = max(
+                    0, start_pos - (num_computed_tokens + shift_computed_tokens)
+                )
                 break
             if not self.encoder_cache_manager.can_allocate(
                 request, i, encoder_compute_budget, num_embeds_to_schedule


### PR DESCRIPTION
Fixes #32469

### Description
When using EAGLE3 speculative decoding with multimodal inputs and `disable_chunked_mm_input=True`, the scheduler's rollback calculation didn't account for `shift_computed_tokens`, causing it to schedule tokens overlapping the multimodal range without scheduling encoder inputs. This triggered "Encoder cache miss" assertions.

### Changes
- Fixed rollback calculation in `_try_schedule_encoder_inputs` to account for `shift_computed_tokens` 
- Added regression test for the boundary case

### Testing
Verified with the reproduction case from the issue and added unit test `test_eagle3_mm_encoder_cache_rollback`.