### PR TITLE
[build] fix priority of cuda-compat libraries in ld loading

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -132,8 +132,8 @@ ENV UV_LINK_MODE=copy
 # Verify GCC version
 RUN gcc --version
 
-# Ensure CUDA compatibility library is loaded
-RUN echo "/usr/local/cuda-$(echo "$CUDA_VERSION" | cut -d. -f1,2)/compat/" > /etc/ld.so.conf.d/cuda-compat.conf && ldconfig
+# Ensure CUDA compatibility library is loaded at last to avoid overriding the system libraries
+RUN echo "/usr/local/cuda-$(echo "$CUDA_VERSION" | cut -d. -f1,2)/compat/" > /etc/ld.so.conf.d/zzz-cuda-compat.conf && ldconfig
 
 # ============================================================
 # SLOW-CHANGING DEPENDENCIES BELOW
@@ -560,8 +560,8 @@ ENV UV_HTTP_TIMEOUT=500
 ENV UV_INDEX_STRATEGY="unsafe-best-match"
 ENV UV_LINK_MODE=copy
 
-# Ensure CUDA compatibility library is loaded
-RUN echo "/usr/local/cuda-$(echo "$CUDA_VERSION" | cut -d. -f1,2)/compat/" > /etc/ld.so.conf.d/cuda-compat.conf && ldconfig
+# Ensure CUDA compatibility library is loaded at last to avoid overriding the system libraries
+RUN echo "/usr/local/cuda-$(echo "$CUDA_VERSION" | cut -d. -f1,2)/compat/" > /etc/ld.so.conf.d/zzz-cuda-compat.conf && ldconfig
 
 # ============================================================
 # SLOW-CHANGING DEPENDENCIES BELOW


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

People still report `Error 803: system has unsupported display driver / cuda driver combination` after https://github.com/vllm-project/vllm/pull/33116 . It is because some docker images specify the driver so file in `nvidia.conf`, which gets suppressed by `cuda-compat.conf`.

This PR adds `zzz-` to `cuda-compat.conf` so that it's ordered lastly.

<img width="970" height="594" alt="a119df1a223395c6b8d6145b8913cd2c" src="https://github.com/user-attachments/assets/306d7b6c-88b3-476d-b2f2-222bfe154b4b" />

<img width="828" height="370" alt="4e92deee226670978ce91bc8830ad978" src="https://github.com/user-attachments/assets/16195d95-581d-4093-8b75-4e50bf4fc606" />


## Test Plan

Test some simple code

`python3 -c "import torch; print(torch.cuda.is_available()); print(torch.cuda.device_count())"`

## Test Result

It can pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

