### PR TITLE
fix(v1-worker): improve dcp assertion with backend fallback hint (#28407)

### DIFF
--- a/tests/v1/worker/test_cp_utils.py
+++ b/tests/v1/worker/test_cp_utils.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.v1.worker import cp_utils
+
+
+class _DummyImpl:
+    need_to_return_lse_for_decode = False
+    supports_pcp = True
+    supports_mtp_with_cp_non_trivial_interleave_size = True
+
+
+class _DummyLayer:
+    impl = _DummyImpl()
+
+
+def test_dcp_error_includes_attention_backend_hint(monkeypatch: pytest.MonkeyPatch):
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=1,
+            decode_context_parallel_size=2,
+            cp_kv_cache_interleave_size=1,
+        ),
+        speculative_config=None,
+    )
+    monkeypatch.setattr(
+        cp_utils,
+        "get_layers_from_vllm_config",
+        lambda *_: {"layer.0": _DummyLayer()},
+    )
+
+    with pytest.raises(AssertionError, match="VLLM_ATTENTION_BACKEND") as exc:
+        cp_utils.check_attention_cp_compatibility(vllm_config)
+    assert "_DummyImpl" in str(exc.value)

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -32,7 +32,9 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "DCP requires attention impls to return"
                     " the softmax lse for decode, but the impl "
                     f"{layer_impl.__class__.__name__} "
-                    "does not return the softmax lse for decode."
+                    "does not return the softmax lse for decode. "
+                    "Try another attention backend via "
+                    "`--attention-backend` or `VLLM_ATTENTION_BACKEND`."
                 )
 
             if pcp_size > 1:


### PR DESCRIPTION
## Problem
The current DCP compatibility assertion does not provide actionable recovery guidance when an attention backend does not return decode LSE.

## Reproduction
Configure DCP (`decode_context_parallel_size > 1`) with a backend implementation that has `need_to_return_lse_for_decode=False`.

## Solution
- Extended the assertion message in `check_attention_cp_compatibility` with explicit fallback guidance:
  - try another backend using `--attention-backend` or `VLLM_ATTENTION_BACKEND`.
- Added a focused unit test to ensure the message includes both backend hint and implementation name.

## Tests
- Added `tests/v1/worker/test_cp_utils.py`.
- Local smoke validation script executed for `check_attention_cp_compatibility` message path.

## Backward Compatibility
No behavior changes besides clearer diagnostics.

Closes #28407