### PR TITLE
[Docs] Speed up build environment set-up 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
     python: "3.12"
   jobs:
     post_checkout:
-      - git fetch --unshallow --no-tags --jobs=8 origin main || true
+      - git fetch origin main --unshallow --no-tags --filter=blob:none || true
     pre_create_environment:
       - pip install uv
     create_environment:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
     create_environment:
       - uv venv $READTHEDOCS_VIRTUALENV_PATH
     post_create_environment:
-      - uv pip install -r requirements/docs.txt
+      - uv pip install --python $READTHEDOCS_VIRTUALENV_PATH/bin/python --no-cache-dir -r requirements/docs.txt
 
 mkdocs:
   configuration: mkdocs.yaml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
     create_environment:
       - uv venv $READTHEDOCS_VIRTUALENV_PATH
     install:
-      - uv pip install --python $READTHEDOCS_VIRTUALENV_PATH/bin/python --exists-action=w --no-cache-dir -r requirements/docs.txt 
+      - uv pip install --python $READTHEDOCS_VIRTUALENV_PATH/bin/python --no-cache-dir -r requirements/docs.txt 
 
 mkdocs:
   configuration: mkdocs.yaml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
     create_environment:
       - uv venv $READTHEDOCS_VIRTUALENV_PATH
     install:
-      - uv pip install --exists-action=w --no-cache-dir -r requirements/docs.txt 
+      - uv pip install --python $READTHEDOCS_VIRTUALENV_PATH/bin/python --exists-action=w --no-cache-dir -r requirements/docs.txt 
 
 mkdocs:
   configuration: mkdocs.yaml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,12 +10,13 @@ build:
   jobs:
     post_checkout:
       - git fetch --unshallow || true
+    pre_create_environment:
+      - pip install uv
+    create_environment:
+      - uv venv $READTHEDOCS_VIRTUALENV_PATH
+    post_create_environment:
+      - uv pip install -r requirements/docs.txt
 
 mkdocs:
   configuration: mkdocs.yaml
   fail_on_warning: true
-
-# Optionally declare the Python requirements required to build your docs
-python:
-  install:
-    - requirements: requirements/docs.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
     python: "3.12"
   jobs:
     post_checkout:
-      - git fetch --unshallow || true
+      - git fetch --unshallow --no-tags --jobs=8 origin main || true
     pre_create_environment:
       - pip install uv
     create_environment:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
       - pip install uv
     create_environment:
       - uv venv $READTHEDOCS_VIRTUALENV_PATH
-    post_create_environment:
+    install:
       - uv pip install --python $READTHEDOCS_VIRTUALENV_PATH/bin/python --no-cache-dir -r requirements/docs.txt
 
 mkdocs:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
     create_environment:
       - uv venv $READTHEDOCS_VIRTUALENV_PATH
     install:
-      - uv pip install --python $READTHEDOCS_VIRTUALENV_PATH/bin/python --no-cache-dir -r requirements/docs.txt
+      - uv pip install --exists-action=w --no-cache-dir -r requirements/docs.txt 
 
 mkdocs:
   configuration: mkdocs.yaml


### PR DESCRIPTION
- Update `post_checkout`'s fetch command (used only by `git-revision-date-localized` to the "last updated" info) to be as fast as possible:
  - Explicitly only fetch `origin main` - other branches are not used
  - Add `--no-tags` - tags are not used
  - Add `--filter=blob:none` - defers downloading file blobs until they're actually needed (since we only care about the graph, I believe they will never be needed)
  - This reduces the fetch time from ~10-20s to ~3s
- Update Python environment management to use `uv`:
  - We did not do this before because environment setup time was dominated by `torch` download/install
  - `torch` is no longer needed to build the docs the effects of using `uv` will be more noticeable
  - This reduces the environment set-up time from 1+12+5+17=35s ([from this build](https://app.readthedocs.org/projects/vllm/builds/31350087/)) to 3+9=12s (from this PR)

---

These are small gains but saving up to 40s per build will add up.