### PR TITLE
[Bugfix] Grammar ignored when reasoning ends within speculated tokens

### DIFF
--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -256,17 +256,77 @@ class StructuredOutputManager:
                 grammar = structured_output_request.grammar
                 apply_bitmask = self.should_fill_bitmask(request)
 
-                state_advancements = 0
+                # Check if reasoning ends within the scheduled spec tokens.
+                # This handles MTP/spec decode where </think> might be a draft
+                # token, and we need to constrain the bonus token that follows.
+                reasoning_ends_at_idx = -1
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
-                for token in itertools.chain(req_tokens, (-1,)):
+                if (
+                    not apply_bitmask
+                    and self.reasoner is not None
+                    and req_tokens
+                    and not structured_output_request.reasoning_ended
+                ):
+                    # Check each spec token position to find where reasoning ends
+                    for idx in range(len(req_tokens)):
+                        check_seq = list(request.all_token_ids) + list(
+                            req_tokens[: idx + 1]
+                        )
+                        if self.reasoner.is_reasoning_end(check_seq):
+                            reasoning_ends_at_idx = idx
+                            break
+
+                state_advancements = 0
+                allow_advance = True
+                apply_bitmask_from_reasoning = (
+                    not apply_bitmask and reasoning_ends_at_idx >= 0
+                )
+                if apply_bitmask:
+                    advance_from_idx = 0
+                elif reasoning_ends_at_idx >= 0:
+                    # Start advancing after reasoning ends within spec tokens.
+                    advance_from_idx = reasoning_ends_at_idx + 1
+                else:
+                    advance_from_idx = None
+                for token_idx, token in enumerate(itertools.chain(req_tokens, (-1,))):
+                    # Enable bitmask for positions after reasoning ends in spec
+                    # tokens. token_idx corresponds to spec token positions,
+                    # with -1 being the bonus token position.
+                    if (
+                        not apply_bitmask
+                        and reasoning_ends_at_idx >= 0
+                        and token_idx > reasoning_ends_at_idx
+                    ):
+                        apply_bitmask = True
+
+                    if apply_bitmask_from_reasoning and token == -1:
+                        # Don't constrain the bonus token based on draft-only
+                        # reasoning end predictions.
+                        apply_bitmask = False
+
                     self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
                     if token == -1:
                         # Stop advancing the grammar once we hit a padding token.
                         apply_bitmask = False
-                    if apply_bitmask and not grammar.is_terminated():
-                        accepted = grammar.accept_tokens(req_id, [token])
-                        assert accepted, (token, req_id, scheduled_spec_decode_tokens)
-                        state_advancements += 1
+                    if (
+                        advance_from_idx is not None
+                        and not grammar.is_terminated()
+                        and allow_advance
+                        and token_idx >= advance_from_idx
+                        and token != -1
+                    ):
+                        if grammar.validate_tokens([token]):
+                            accepted = grammar.accept_tokens(req_id, [token])
+                            assert accepted, (
+                                token,
+                                req_id,
+                                scheduled_spec_decode_tokens,
+                            )
+                            state_advancements += 1
+                        else:
+                            # Draft token is invalid; stop advancing for
+                            # subsequent speculative positions.
+                            allow_advance = False
                     cumulative_index += 1
                 if state_advancements > 0:
                     grammar.rollback(state_advancements)
@@ -319,17 +379,37 @@ class StructuredOutputManager:
 
         structured_req = request.structured_output_request
         if structured_req.reasoning_ended:
+            # Guard against speculative draft tokens that suggested reasoning
+            # ended but were not actually accepted in the output.
+            if (
+                not structured_req.reasoning_ended_by_fallback
+                and not self.reasoner.is_reasoning_end(list(request.all_token_ids))
+            ):
+                structured_req.reasoning_ended = False
+                return False
             return True
 
         # Check if reasoning ends in *this* step
         delta_from = request.num_computed_tokens - request.num_output_placeholders
-        all_token_ids = request.all_token_ids
-        if self.reasoner.is_reasoning_end_streaming(
-            all_token_ids, all_token_ids[delta_from:]
-        ):
-            # Reasoning just ended, so we shouldn't advance til
-            # next pass
+        delta_ids = list(request.all_token_ids[delta_from:])
+        if self.reasoner.is_reasoning_end_streaming(request.all_token_ids, delta_ids):
             structured_req.reasoning_ended = True
+            # Try to sync grammar with tokens after </think> that were
+            # generated in this step. Use validate_tokens to only accept
+            # tokens that are actually valid according to the grammar.
+            # This handles MTP/spec decode where tokens after </think>
+            # may have been generated without constraints.
+            content_ids = self.reasoner.extract_content_ids(delta_ids)
+            if content_ids:
+                grammar = structured_req.grammar
+                assert grammar is not None
+                # Only accept the valid prefix of content tokens
+                valid_tokens = grammar.validate_tokens(content_ids)
+                if valid_tokens:
+                    grammar.accept_tokens(request.request_id, valid_tokens)
+            # Return False so caller doesn't try to accept all delta tokens
+            # (which would include </think> and reasoning tokens).
+            return False
 
         return False
 

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -20,7 +20,6 @@ class StructuredOutputRequest:
     params: StructuredOutputsParams
     _grammar: Future[StructuredOutputGrammar] | StructuredOutputGrammar | None = None
     reasoning_ended: bool | None = None
-    reasoning_ended_by_fallback: bool = False
 
     @staticmethod
     def from_sampling_params(

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -20,6 +20,7 @@ class StructuredOutputRequest:
     params: StructuredOutputsParams
     _grammar: Future[StructuredOutputGrammar] | StructuredOutputGrammar | None = None
     reasoning_ended: bool | None = None
+    reasoning_ended_by_fallback: bool = False
 
     @staticmethod
     def from_sampling_params(


### PR DESCRIPTION
## Purpose

This PR attempts to fix a bug (#31858) when Speculative Decoding (such as MTP), Reasoning, and Structured Output / Grammar are used in combination: typically, grammar is not enabled during reasoning but only for the final answer. However, when the reasoning end token is generated, any subsequent draft tokens are not validated against the grammar, leading to an invalid final answer. 


## Test Plan

In general, the bug seems to be independent of the specific SpecDecode method; originally I had observed it with DeepSeek models and MTP, but for testing I recommend a smaller model like Qwen3-8B and using the same model as draft model. This way, we have high acceptance rates for our tests and a high likelihood that the original bug appears. 

```
vllm serve "Qwen/Qwen3-8B" \
  --max-model-len 40960 \
  --reasoning-parser qwen3 \
  --speculative-config '{"method":"draft_model","model":"Qwen/Qwen3-8B","num_speculative_tokens":5}'
```

The test request should have `response_format=json_schema` and a prompt that lurkes the model into generating not pure json, e.g.

<details>
<summary>example payload</summary>
<code>
{
  "model": "Qwen/Qwen3-8B",
  "messages": [
    {
      "role": "user",
      "content": "Imagine a Fantasy hero (10). Return valid json, wrapped in markdown fences: ```json\n[...]\n```"
    }
  ],
  "response_format": {
    "type": "json_schema",
    "json_schema": {
      "name": "hero",
      "schema": {
        "$defs": {
          "CharacterRole": {"enum": ["mage", "warrior", "healer"], "title": "CharacterRole", "type": "string"}
        },
        "properties": {
          "name": {"description": "Character name", "title": "Name", "type": "string"},
          "age": {"description": "Character age", "title": "Age", "type": "integer"},
          "role": {"allOf": [{"$ref": "#/$defs/CharacterRole"}], "description": "Character class"}
        },
        "required": ["name", "age", "role"],
        "title": "Character",
        "type": "object"
      }
    }
  }
}
</code>
</details>

## Test Result

without bugfix, the `content` field contains invalid json, e.g. because of markdown fences
```
"content": "```json\n{\n\n\"name\": \"Eldrin the Flameheart\",\n\"age\": 32,\n\"role\": \"warrior\"\n}```"
```

with the bugfix, the `content` field contains valid json that satisfies the requested grammar
```
"content": "{\n\n\"name\": \"Eldrin the Flameheart\",\n\"age\": 32,\n\"role\": \"warrior\"\n}"
```
---

I am happy to receive feedback and suggestions on how to improve the PR: the interplay of spec decode, grammar, reasoning, and async scheduling seems to be quite complex. I found the first commits with bugfix attempts in the [vllm-chutes fork](https://github.com/chutesai/vllm/commits/chutes/) but had to make a few more additions. 