### PR TITLE
[Frontend] Realtime API uses Renderer

### DIFF
--- a/tests/v1/e2e/test_streaming_input.py
+++ b/tests/v1/e2e/test_streaming_input.py
@@ -19,12 +19,11 @@ import pytest
 import pytest_asyncio
 
 from vllm import SamplingParams
-from vllm.inputs import StreamingInput
 from vllm.outputs import RequestOutput
 from vllm.platforms import current_platform
 from vllm.sampling_params import RequestOutputKind
 from vllm.utils.torch_utils import set_default_torch_num_threads
-from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.engine.async_llm import AsyncLLM, StreamingInput
 
 if not current_platform.is_cuda():
     pytest.skip(reason="V1 currently only supported on CUDA.", allow_module_level=True)

--- a/tests/v1/streaming_input/test_async_llm_streaming.py
+++ b/tests/v1/streaming_input/test_async_llm_streaming.py
@@ -180,8 +180,10 @@ async def test_generate_with_async_generator():
     llm = MagicMock(spec=AsyncLLM)
     llm.vllm_config = MagicMock()
     llm.vllm_config.cache_config.kv_sharing_fast_prefill = False
-    llm.model_config = MagicMock()
-    llm.model_config.max_model_len = 2048
+    llm.model_config = MockModelConfig()
+    llm.input_processor = MagicMock()
+    llm.io_processor = MagicMock()
+    llm.renderer = _build_renderer(llm.model_config)
     llm.log_requests = False
     llm.errored = False
     llm._pause_cond = asyncio.Condition()

--- a/tests/v1/streaming_input/test_async_llm_streaming.py
+++ b/tests/v1/streaming_input/test_async_llm_streaming.py
@@ -7,10 +7,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from vllm.inputs import StreamingInput
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind, SamplingParams
-from vllm.v1.engine.async_llm import AsyncLLM
+from vllm.v1.engine.async_llm import AsyncLLM, StreamingInput
 from vllm.v1.engine.output_processor import RequestOutputCollector
 
 

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -3,6 +3,7 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator, Iterable, Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from vllm.config import ModelConfig, VllmConfig
@@ -10,7 +11,7 @@ from vllm.distributed.weight_transfer.base import (
     WeightTransferInitRequest,
     WeightTransferUpdateRequest,
 )
-from vllm.inputs.data import PromptType, StreamingInput
+from vllm.inputs.data import PromptType
 from vllm.lora.request import LoRARequest
 from vllm.outputs import PoolingRequestOutput, RequestOutput
 from vllm.plugins.io_processors import IOProcessor
@@ -24,6 +25,18 @@ from vllm.v1.engine.input_processor import InputProcessor
 
 if TYPE_CHECKING:
     from vllm.v1.engine import PauseMode
+
+
+@dataclass
+class StreamingInput:
+    """Input data for a streaming generation request.
+
+    This is used with generate() to support multi-turn streaming sessions
+    where inputs are provided via an async generator.
+    """
+
+    prompt: TokPrompt
+    sampling_params: SamplingParams | None = None
 
 
 class EngineClient(ABC):

--- a/vllm/inputs/__init__.py
+++ b/vllm/inputs/__init__.py
@@ -12,7 +12,6 @@ from .data import (
     PromptType,
     SingletonInputs,
     SingletonPrompt,
-    StreamingInput,
     TextPrompt,
     TokenInputs,
     TokensPrompt,
@@ -36,5 +35,4 @@ __all__ = [
     "EncoderDecoderInputs",
     "ProcessorInputs",
     "SingletonInputs",
-    "StreamingInput",
 ]

--- a/vllm/inputs/data.py
+++ b/vllm/inputs/data.py
@@ -1,12 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 import torch
 from typing_extensions import NotRequired, TypedDict
-
-from vllm.sampling_params import SamplingParams
 
 if TYPE_CHECKING:
     from vllm.multimodal.inputs import (
@@ -298,15 +295,3 @@ which can be passed to
 
 
 SingletonInputs: TypeAlias = DecoderOnlyInputs | MultiModalEncDecInputs
-
-
-@dataclass
-class StreamingInput:
-    """Input data for a streaming generation request.
-
-    This is used with generate() to support multi-turn streaming sessions
-    where inputs are provided via an async generator.
-    """
-
-    prompt: PromptType
-    sampling_params: SamplingParams | None = None

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -19,8 +19,8 @@ from vllm.distributed.weight_transfer.base import (
     WeightTransferUpdateRequest,
 )
 from vllm.engine.arg_utils import AsyncEngineArgs
-from vllm.engine.protocol import EngineClient
-from vllm.inputs import PromptType, StreamingInput
+from vllm.engine.protocol import EngineClient, StreamingInput
+from vllm.inputs import PromptType
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry


### PR DESCRIPTION

## Purpose

- Update Realtime API to use Renderer before passing inputs to engine client
- Factor out common code for constructing default `TokenizeParams` into Renderer
- Move `StreamingInputs` into `EngineClient` protocol file since it's only used by the protocol and its subclasses

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

