### PR TITLE
fix(mistral): Validate tool_calls type before iterating

### DIFF
--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -74,7 +74,10 @@ def maybe_serialize_tool_calls(request: "MistralChatCompletionRequest"):
                     f"'tool_calls' must be a list of tool call objects, "
                     f"got {type(raw_tool_calls).__name__}"
                 )
-            tool_calls_validator = raw_tool_calls
+            if isinstance(raw_tool_calls, (list, tuple)):
+                tool_calls_validator = iter(raw_tool_calls)
+            else:
+                tool_calls_validator = raw_tool_calls
             validated_tool_calls = []
             while True:
                 try:

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -64,7 +64,17 @@ def maybe_serialize_tool_calls(request: "MistralChatCompletionRequest"):
     # TODO: remove when pydantic v2.11 is released
     for i, message in enumerate(request.messages):
         if message.get("role") == "assistant":
-            tool_calls_validator = message.get("tool_calls", ().__iter__())
+            raw_tool_calls = message.get("tool_calls")
+            if raw_tool_calls is None:
+                continue
+            if not isinstance(raw_tool_calls, (list, tuple)) and not hasattr(
+                raw_tool_calls, "__next__"
+            ):
+                raise ValueError(
+                    f"'tool_calls' must be a list of tool call objects, "
+                    f"got {type(raw_tool_calls).__name__}"
+                )
+            tool_calls_validator = raw_tool_calls
             validated_tool_calls = []
             while True:
                 try:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -286,9 +286,10 @@ class Worker(WorkerBase):
     # to hijack tensor allocation.
     def load_model(self) -> None:
         eep_scale_up = os.environ.get("VLLM_ELASTIC_EP_SCALE_UP_LAUNCH") == "1"
-        with self._maybe_get_memory_pool_context(
-            tag="weights"
-        ) and set_current_vllm_config(self.vllm_config):
+        with (
+            self._maybe_get_memory_pool_context(tag="weights"),
+            set_current_vllm_config(self.vllm_config),
+        ):
             self.model_runner.load_model(eep_scale_up=eep_scale_up)
 
     def update_config(self, overrides: dict[str, Any]) -> None:


### PR DESCRIPTION
maybe_serialize_tool_calls() calls next() on the raw tool_calls value without verifying it is an iterable. When tool_calls is a string or other non-iterable type, the pydantic ValidatorIterator tries to validate each character as a dict, producing a confusing error.

Add an explicit type check before iterating: if tool_calls is not a list, tuple, or iterator, raise a clear ValueError. Also skip the message entirely when tool_calls is None instead of creating an empty tuple iterator.

<!-- markdownlint-disable -->

## Purpose
Fixes https://github.com/vllm-project/vllm/issues/34225

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

