### PR TITLE
[Bugfix] Fix P2pNcclConnector NCCL send/recv key mismatch in disaggregated prefill XpYd

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
@@ -258,9 +258,7 @@ class P2pNcclConnector(KVConnectorBase_V1):
                     logger.warning("🚧kv_cache is None, %s", transfer_id)
                     continue
 
-                inject_kv_into_layer(
-                    layer, kv_cache, request.block_ids, transfer_id
-                )
+                inject_kv_into_layer(layer, kv_cache, request.block_ids, transfer_id)
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         """Blocking until the KV for a specific layer is loaded into vLLM's

--- a/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/p2p/p2p_nccl_connector.py
@@ -52,8 +52,9 @@ def _strip_internal_id_suffix(request_id: str) -> str:
     NCCL send/recv key ensures both sides agree on the same key.
     """
     if (
-        len(request_id) > _INTERNAL_ID_SUFFIX_LEN
+        len(request_id) >= _INTERNAL_ID_SUFFIX_LEN
         and request_id[-_INTERNAL_ID_SUFFIX_LEN] == "-"
+        and all(c in "0123456789abcdef" for c in request_id[-8:])
     ):
         return request_id[:-_INTERNAL_ID_SUFFIX_LEN]
     # Fallback: if the format doesn't match, return as-is.


### PR DESCRIPTION
## Purpose

Fix NCCL send/recv key mismatch in `P2pNcclConnector` that causes disaggregated prefill P2P NCCL XpYd KV cache transfer to hang indefinitely.

In the disaggregated prefill XpYd architecture, the proxy generates a single `request_id` (containing both prefill and decode addresses) and sends it to both vLLM instances. However, `InputProcessor.assign_request_id()` inside each vLLM instance independently appends a different random 8-char hex suffix to this ID:

```python
# vllm/v1/engine/input_processor.py
request.request_id = f"{request.external_req_id}-{random_uuid():.8}"
```

This causes the Prefill producer and Decode consumer to use **different** keys for `send_tensor()` / `recv_tensor()`, so the NCCL transfer never matches:

```
Prefill sends: "___prefill_addr_...___decode_addr_..._<uuid>-AAAA#layer.0"
Decode  recvs: "___prefill_addr_...___decode_addr_..._<uuid>-BBBB#layer.0"
                                                             ^^^^ MISMATCH
```

**Fix:** Since the suffix format is deterministic (`-` + 8 hex chars = 9 characters), we add a helper `_strip_internal_id_suffix()` that recovers the original proxy-generated ID by stripping the last 9 characters. A new `transfer_id` field on `ReqMeta` stores this stripped ID, and the worker-side methods (`start_load_kv`, `save_kv_layer`) use `transfer_id` instead of `request_id` for NCCL key matching and address parsing.

The fix is entirely scoped to `p2p_nccl_connector.py` — no changes to any other files.

**Changes summary:**
1. Added `_strip_internal_id_suffix()` helper function to recover the original proxy ID.
2. Added `transfer_id` field to `ReqMeta` dataclass, computed automatically in `make_meta()`.
3. Updated `start_load_kv()` and `save_kv_layer()` to use `request.transfer_id` for NCCL send/recv keys and `parse_request_id()` address parsing.

## Test Plan

1. Launch the disaggregated prefill XpYd example with ≥ 2 GPUs:
   ```bash
   cd examples/online_serving/disaggregated_serving_p2p_nccl_xpyd/
   export HF_TOKEN=<your_token>
   bash disagg_example_p2p_nccl_xpyd.sh
   ```

2. Verify the benchmark completes successfully instead of hanging.

3. Verify via logs that Prefill and Decode sides now use the same transfer key (the original proxy-generated ID without the random suffix).

4. Unit test: confirm `_strip_internal_id_suffix()` correctly handles:
   - Normal case: `"prefix-a1b2c3d4"` → `"prefix"`
   - Edge case (no suffix): `"short"` → `"short"` (unchanged)
   - Edge case (no dash at expected position): returns as-is

## Test Result

**Before fix:** Benchmark hangs indefinitely — Prefill completes and sends KV data, but Decode waits forever because the recv key never matches the send key.

**After fix:** KV transfer completes successfully. Both Prefill and Decode recover the same original proxy ID and agree on the NCCL transfer key:

```
Prefill sends: "___prefill_addr_...___decode_addr_..._<uuid>#layer.0"
Decode  recvs: "___prefill_addr_...___decode_addr_..._<uuid>#layer.0"
                                                              ✅ MATCH
```

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).

</details>

