### PR TITLE
[Bugfix] Fix fused MoE IMA (sans chunking) by using int64 for strides

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -95,19 +95,19 @@ def fused_moe_kernel_gptq_awq(
     # moving by 1 element in a particular dimension. E.g. `stride_am` is
     # how much to increase `a_ptr` by to get the element one row down
     # (A has M rows).
-    stride_am,
-    stride_ak,
-    stride_be,
-    stride_bk,
-    stride_bn,
-    stride_cm,
-    stride_cn,
-    stride_bse,
-    stride_bsk,
-    stride_bsn,
-    stride_bze,
-    stride_bzk,
-    stride_bzn,
+    stride_am: tl.int64,
+    stride_ak: tl.int64,
+    stride_be: tl.int64,
+    stride_bk: tl.int64,
+    stride_bn: tl.int64,
+    stride_cm: tl.int64,
+    stride_cn: tl.int64,
+    stride_bse: tl.int64,
+    stride_bsk: tl.int64,
+    stride_bsn: tl.int64,
+    stride_bze: tl.int64,
+    stride_bzk: tl.int64,
+    stride_bzn: tl.int64,
     block_k_diviable: tl.constexpr,
     group_size: tl.constexpr,
     # Meta-parameters
@@ -329,20 +329,20 @@ def fused_moe_kernel(
     # moving by 1 element in a particular dimension. E.g. `stride_am` is
     # how much to increase `a_ptr` by to get the element one row down
     # (A has M rows).
-    stride_am,
-    stride_ak,
-    stride_be,
-    stride_bk,
-    stride_bn,
-    stride_cm,
-    stride_cn,
-    stride_asm,
-    stride_ask,
-    stride_bse,
-    stride_bsk,
-    stride_bsn,
-    stride_bbe,  # bias expert stride
-    stride_bbn,  # bias N stride
+    stride_am: tl.int64,
+    stride_ak: tl.int64,
+    stride_be: tl.int64,
+    stride_bk: tl.int64,
+    stride_bn: tl.int64,
+    stride_cm: tl.int64,
+    stride_cn: tl.int64,
+    stride_asm: tl.int64,
+    stride_ask: tl.int64,
+    stride_bse: tl.int64,
+    stride_bsk: tl.int64,
+    stride_bsn: tl.int64,
+    stride_bbe: tl.int64,  # bias expert stride
+    stride_bbn: tl.int64,  # bias N stride
     # Block size for block-wise quantization
     group_n: tl.constexpr,
     group_k: tl.constexpr,


### PR DESCRIPTION
## Summary

- Annotate all stride parameters in `fused_moe_kernel` and `fused_moe_kernel_gptq_awq` as `tl.int64` to prevent int32 overflow in pointer arithmetic for large tensors
- This follows the same pattern already used in `fused_batched_moe.py`
- Without this fix, large problem sizes cause `illegal memory access` crashes when chunking is disabled, because the C tensor offset exceeds int32 max (~2.1 billion)
- This is a prerequisite for removing the chunking workaround (`VLLM_FUSED_MOE_CHUNK_SIZE`) entirely

Allows simplification of https://github.com/vllm-project/vllm/pull/34086

## Reproduction

<details>
<summary>Repro script</summary>

```python
"""
Reproduce the triton fused MOE int32 overflow crash.
"""
import os
import torch

# Disable chunking by setting a very large chunk size
os.environ["VLLM_FUSED_MOE_CHUNK_SIZE"] = "10000000"

from vllm.config import VllmConfig, set_current_vllm_config
from vllm.model_executor.layers.fused_moe import fused_topk
from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts


def repro(m: int, n: int, k: int, e: int, topk: int, dtype=torch.bfloat16):
    print(f"\nTesting m={m}, n={n}, k={k}, e={e}, topk={topk}")

    stride_cm = topk * n
    max_offs_token = m * topk
    max_c_offset = stride_cm * max_offs_token
    stride_am = k
    max_a_offset = m * stride_am
    print(f"  stride_cm={stride_cm}, max_offs_token={max_offs_token}, "
          f"max_c_offset={max_c_offset}, int32_max={2**31-1}")
    print(f"  stride_am={stride_am}, max_a_offset={max_a_offset}")
    if max_c_offset > 2**31 - 1:
        print(f"  ** C OFFSET WILL OVERFLOW INT32 **")
    if max_a_offset > 2**31 - 1:
        print(f"  ** A OFFSET WILL OVERFLOW INT32 **")

    a = torch.randn((m, k), device="cuda", dtype=dtype) / 10
    w1 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) / 10
    w2 = torch.randn((e, k, n), device="cuda", dtype=dtype) / 10
    score = torch.randn((m, e), device="cuda", dtype=dtype)
    topk_weights, topk_ids, _ = fused_topk(a, score.float(), topk, False)

    try:
        with set_current_vllm_config(VllmConfig()):
            out = fused_experts(a, w1, w2, topk_weights, topk_ids)
        print(f"  SUCCESS - output shape: {out.shape}")
        nan_count = torch.isnan(out).sum().item()
        if nan_count > 0:
            print(f"  WARNING: {nan_count} NaN values in output "
                  f"({nan_count*100/out.numel():.1f}%)!")
        return True
    except Exception as ex:
        print(f"  CRASH: {type(ex).__name__}: {ex}")
        return False


if __name__ == "__main__":
    repro(m=1000, n=1024, k=1024, e=8, topk=2)
    repro(m=40000, n=1024, k=1024, e=8, topk=6)
    repro(m=100000, n=2048, k=1024, e=8, topk=6)
```

</details>

<details>
<summary>Before fix (crashes on the int32-overflowing case)</summary>

```
Testing m=1000, n=1024, k=1024, e=8, topk=2
  stride_cm=2048, max_offs_token=2000, max_c_offset=4096000, int32_max=2147483647
  stride_am=1024, max_a_offset=1024000
  SUCCESS - output shape: torch.Size([1000, 1024])

Testing m=40000, n=1024, k=1024, e=8, topk=6
  stride_cm=6144, max_offs_token=240000, max_c_offset=1474560000, int32_max=2147483647
  stride_am=1024, max_a_offset=40960000
  SUCCESS - output shape: torch.Size([40000, 1024])

Testing m=100000, n=2048, k=1024, e=8, topk=6
  stride_cm=12288, max_offs_token=600000, max_c_offset=7372800000, int32_max=2147483647
  stride_am=1024, max_a_offset=102400000
  ** C OFFSET WILL OVERFLOW INT32 **
  CRASH: RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
```

</details>

<details>
<summary>After fix (all pass)</summary>

```
Testing m=1000, n=1024, k=1024, e=8, topk=2
  stride_cm=2048, max_offs_token=2000, max_c_offset=4096000, int32_max=2147483647
  stride_am=1024, max_a_offset=1024000
  SUCCESS - output shape: torch.Size([1000, 1024])

Testing m=40000, n=1024, k=1024, e=8, topk=6
  stride_cm=6144, max_offs_token=240000, max_c_offset=1474560000, int32_max=2147483647
  stride_am=1024, max_a_offset=40960000
  SUCCESS - output shape: torch.Size([40000, 1024])

Testing m=100000, n=2048, k=1024, e=8, topk=6
  stride_cm=12288, max_offs_token=600000, max_c_offset=7372800000, int32_max=2147483647
  stride_am=1024, max_a_offset=102400000
  ** C OFFSET WILL OVERFLOW INT32 **
  SUCCESS - output shape: torch.Size([100000, 1024])
```

</details>

Unchunked results are bit-identical to chunked results (verified separately).

## Test plan

- [x] Reproduced the crash before the fix with chunking disabled
- [x] Verified the fix eliminates the crash
- [x] Verified unchunked results are bit-identical to chunked results
- [x] All 120 existing `test_fused_moe` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)