### PR TITLE
[ROCm][CI] Fix test_sequence_parallel.py location in AMD CI pipeline

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -1334,7 +1334,7 @@ steps:
   - pytest -v -s ./compile/test_wrapper.py
   - VLLM_TEST_SAME_HOST=1 torchrun --nproc-per-node=4 distributed/test_same_node.py | grep 'Same node test passed'
   - VLLM_TEST_SAME_HOST=1 VLLM_TEST_WITH_DEFAULT_DEVICE_SET=1 torchrun --nproc-per-node=4 distributed/test_same_node.py | grep 'Same node test passed'
-  - pytest -v -s distributed/test_sequence_parallel.py
+  - pytest -v -s compile/correctness_e2e/test_sequence_parallel.py
   - CUDA_VISIBLE_DEVICES=0,1 pytest -v -s v1/shutdown
   - pytest -v -s v1/worker/test_worker_memory_snapshot.py
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
https://github.com/vllm-project/vllm/pull/33731 moved `tests/distributed/test_sequence_parallel.py` to `tests/compile/correctness_e2e/test_sequence_parallel.py` and updated the associated locations in the CI pipelines, but missed one spot in AMD CI for `Distributed Tests (2 GPUs)`. This PR fixes that.
