### PR TITLE
[Attn,KV-cache] Use per-head scales in the attention selector

### DIFF
--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -291,3 +291,56 @@ def test_invalid_backend():
     ):
         # Invalid backend name should raise ValueError when creating enum
         AttentionConfig(backend=AttentionBackendEnum["INVALID"])
+
+
+@pytest.mark.parametrize(
+    "backend_name,supports_per_head,should_succeed",
+    [
+        ("FLASH_ATTN", True, True),  # FA3 supports per-head quant scales
+        ("FLASH_ATTN", False, False),  # FA2 does not support per-head quant scales
+        ("FLASHINFER", False, False),  # FlashInfer does not support
+        ("FLEX_ATTENTION", False, False),  # Flex does not support
+    ],
+)
+def test_per_head_quant_scales_backend_selection(
+    backend_name: str, supports_per_head: bool, should_succeed: bool
+):
+    """Test backend selection when use_per_head_quant_scales=True."""
+    # Clear cache to ensure fresh backend selection
+    _cached_get_attn_backend.cache_clear()
+
+    attention_config = AttentionConfig(backend=AttentionBackendEnum[backend_name])
+    vllm_config = VllmConfig(attention_config=attention_config)
+
+    # Get the backend class to patch
+    backend_module = {
+        "FLASH_ATTN": "vllm.v1.attention.backends.flash_attn.FlashAttentionBackend",
+        "FLASHINFER": "vllm.v1.attention.backends.flashinfer.FlashInferBackend",
+        "FLEX_ATTENTION": "vllm.v1.attention.backends.flex_attention.FlexAttentionBackend",
+    }[backend_name]
+
+    with set_current_vllm_config(vllm_config):
+        with patch("vllm.platforms.current_platform", CudaPlatform()):
+            with patch(
+                f"{backend_module}.supports_per_head_quant_scales",
+                return_value=supports_per_head,
+            ):
+                if should_succeed:
+                    backend = get_attn_backend(
+                        head_size=128,
+                        dtype=torch.float16,
+                        kv_cache_dtype="fp8",
+                        block_size=64,
+                        use_per_head_quant_scales=True,
+                    )
+                    assert backend.get_name() == backend_name
+                else:
+                    with pytest.raises(ValueError) as exc_info:
+                        get_attn_backend(
+                            head_size=128,
+                            dtype=torch.float16,
+                            kv_cache_dtype="fp8",
+                            block_size=64,
+                            use_per_head_quant_scales=True,
+                        )
+                    assert backend_name in str(exc_info.value)

--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -294,53 +294,54 @@ def test_invalid_backend():
 
 
 @pytest.mark.parametrize(
-    "backend_name,supports_per_head,should_succeed",
+    "backend_name,flash_attn_version,should_succeed",
     [
-        ("FLASH_ATTN", True, True),  # FA3 supports per-head quant scales
-        ("FLASH_ATTN", False, False),  # FA2 does not support per-head quant scales
-        ("FLASHINFER", False, False),  # FlashInfer does not support
-        ("FLEX_ATTENTION", False, False),  # Flex does not support
+        ("FLASH_ATTN", 3, True),  # FA3 supports per-head quant scales
+        ("FLASH_ATTN", 2, False),  # FA2 does not support per-head quant scales
+        ("FLASHINFER", None, False),  # FlashInfer does not support
+        ("FLEX_ATTENTION", None, False),  # Flex does not support
     ],
 )
 def test_per_head_quant_scales_backend_selection(
-    backend_name: str, supports_per_head: bool, should_succeed: bool
+    backend_name: str, flash_attn_version: int | None, should_succeed: bool
 ):
     """Test backend selection when use_per_head_quant_scales=True."""
     # Clear cache to ensure fresh backend selection
     _cached_get_attn_backend.cache_clear()
 
-    attention_config = AttentionConfig(backend=AttentionBackendEnum[backend_name])
+    attention_config = AttentionConfig(
+        backend=AttentionBackendEnum[backend_name],
+        flash_attn_version=flash_attn_version,
+    )
     vllm_config = VllmConfig(attention_config=attention_config)
 
-    # Get the backend class to patch
-    backend_module = {
-        "FLASH_ATTN": "vllm.v1.attention.backends.flash_attn.FlashAttentionBackend",
-        "FLASHINFER": "vllm.v1.attention.backends.flashinfer.FlashInferBackend",
-        "FLEX_ATTENTION": "vllm.v1.attention.backends.flex_attention.FlexAttentionBackend",
-    }[backend_name]
+    with (
+        set_current_vllm_config(vllm_config),
+        patch("vllm.platforms.current_platform", CudaPlatform()),
+    ):
+        if backend_name == "FLASH_ATTN" and flash_attn_version == 3:
+            if not torch.cuda.is_available():
+                pytest.skip("FA3 requires CUDA")
+            capability = torch.cuda.get_device_capability()
+            if capability[0] != 9:
+                pytest.skip("FA3 is only supported on Hopper (SM 9.x) GPUs")
 
-    with set_current_vllm_config(vllm_config):
-        with patch("vllm.platforms.current_platform", CudaPlatform()):
-            with patch(
-                f"{backend_module}.supports_per_head_quant_scales",
-                return_value=supports_per_head,
-            ):
-                if should_succeed:
-                    backend = get_attn_backend(
-                        head_size=128,
-                        dtype=torch.float16,
-                        kv_cache_dtype="fp8",
-                        block_size=64,
-                        use_per_head_quant_scales=True,
-                    )
-                    assert backend.get_name() == backend_name
-                else:
-                    with pytest.raises(ValueError) as exc_info:
-                        get_attn_backend(
-                            head_size=128,
-                            dtype=torch.float16,
-                            kv_cache_dtype="fp8",
-                            block_size=64,
-                            use_per_head_quant_scales=True,
-                        )
-                    assert backend_name in str(exc_info.value)
+        if should_succeed:
+            backend = get_attn_backend(
+                head_size=128,
+                dtype=torch.float16,
+                kv_cache_dtype="fp8",
+                block_size=64,
+                use_per_head_quant_scales=True,
+            )
+            assert backend.get_name() == backend_name
+        else:
+            with pytest.raises(ValueError) as exc_info:
+                get_attn_backend(
+                    head_size=128,
+                    dtype=torch.float16,
+                    kv_cache_dtype="fp8",
+                    block_size=64,
+                    use_per_head_quant_scales=True,
+                )
+            assert backend_name in str(exc_info.value)

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -238,7 +238,7 @@ class Attention(nn.Module, AttentionLayerBase):
                 cache_config.calculate_kv_scales = False
 
         # Check if per-head quant scales are required based on kv_cache_scheme
-        requires_per_head_quant_scales = (
+        use_per_head_quant_scales = (
             kv_cache_scheme is not None
             and kv_cache_scheme.get("strategy") == "attn_head"
         )
@@ -279,7 +279,7 @@ class Attention(nn.Module, AttentionLayerBase):
                 use_mla=False,
                 has_sink=self.has_sink,
                 use_mm_prefix=self.use_mm_prefix,
-                requires_per_head_quant_scales=requires_per_head_quant_scales,
+                use_per_head_quant_scales=use_per_head_quant_scales,
                 attn_type=attn_type,
             )
         else:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -985,11 +985,9 @@ class CompressedTensorsKVCacheMethod(BaseKVCacheMethod):
                 self.quant_config.kv_cache_scheme["strategy"]
             )
 
-        if strategy == QuantizationStrategy.ATTN_HEAD:
-            assert layer.impl.supports_per_head_quant_scales, (
-                f"Layer {layer.__class__.__name__} with implementation "
-                f"{layer.impl.__class__.__name__} does not support per-head scales."
-            )
+        if strategy == "attn_head":
+            # Backend selection ensures a compatible backend is chosen when
+            # per-head quant scales are required (via requires_per_head_quant_scales).
             n_scales = int(layer.num_kv_heads)
         else:
             n_scales = 1

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -985,12 +985,7 @@ class CompressedTensorsKVCacheMethod(BaseKVCacheMethod):
                 self.quant_config.kv_cache_scheme["strategy"]
             )
 
-        if strategy == "attn_head":
-            # Backend selection ensures a compatible backend is chosen when
-            # per-head quant scales are required (via requires_per_head_quant_scales).
-            n_scales = int(layer.num_kv_heads)
-        else:
-            n_scales = 1
+        n_scales = int(layer.num_kv_heads) if strategy == "attn_head" else 1
 
         layer.k_scale = torch.nn.Parameter(
             torch.ones(n_scales, requires_grad=False, dtype=torch.float32)

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -229,7 +229,7 @@ class AttentionBackend(ABC):
         has_sink: bool,
         use_sparse: bool,
         use_mm_prefix: bool,
-        requires_per_head_quant_scales: bool,
+        use_per_head_quant_scales: bool,
         device_capability: "DeviceCapability",
         attn_type: str,
     ) -> list[str]:
@@ -258,7 +258,7 @@ class AttentionBackend(ABC):
                 invalid_reasons.append("sparse not supported")
             else:
                 invalid_reasons.append("non-sparse not supported")
-        if requires_per_head_quant_scales and not cls.supports_per_head_quant_scales():
+        if use_per_head_quant_scales and not cls.supports_per_head_quant_scales():
             invalid_reasons.append("per-head quant scales not supported")
         if not cls.supports_compute_capability(device_capability):
             invalid_reasons.append("compute capability not supported")

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -188,6 +188,10 @@ class AttentionBackend(ABC):
         return False
 
     @classmethod
+    def supports_per_head_quant_scales(cls) -> bool:
+        return False
+
+    @classmethod
     def supports_attn_type(cls, attn_type: str) -> bool:
         """Check if backend supports a given attention type.
 
@@ -225,6 +229,7 @@ class AttentionBackend(ABC):
         has_sink: bool,
         use_sparse: bool,
         use_mm_prefix: bool,
+        requires_per_head_quant_scales: bool,
         device_capability: "DeviceCapability",
         attn_type: str,
     ) -> list[str]:
@@ -253,6 +258,8 @@ class AttentionBackend(ABC):
                 invalid_reasons.append("sparse not supported")
             else:
                 invalid_reasons.append("non-sparse not supported")
+        if requires_per_head_quant_scales and not cls.supports_per_head_quant_scales():
+            invalid_reasons.append("per-head quant scales not supported")
         if not cls.supports_compute_capability(device_capability):
             invalid_reasons.append("compute capability not supported")
         if not cls.supports_attn_type(attn_type):
@@ -635,7 +642,6 @@ class AttentionImplBase(ABC, Generic[T]):
     # TODO add support to more backends:
     # https://github.com/vllm-project/vllm/issues/25584
     supports_quant_query_input: bool = False
-    supports_per_head_quant_scales: bool = False
 
     dcp_world_size: int
     dcp_rank: int

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -95,6 +95,11 @@ class FlashAttentionBackend(AttentionBackend):
             AttentionType.ENCODER_DECODER,
         )
 
+    @classmethod
+    def supports_per_head_quant_scales(cls) -> bool:
+        fa_version = get_flash_attn_version()
+        return fa_version is not None and fa_version >= 3
+
     @staticmethod
     def get_impl_cls() -> type["FlashAttentionImpl"]:
         return FlashAttentionImpl
@@ -595,11 +600,6 @@ class FlashAttentionImpl(AttentionImpl):
             )
 
         self.supports_quant_query_input = True
-        self.supports_per_head_quant_scales = (
-            self.vllm_flash_attn_version >= 3
-            if self.vllm_flash_attn_version is not None
-            else False
-        )
 
     def forward(
         self,

--- a/vllm/v1/attention/selector.py
+++ b/vllm/v1/attention/selector.py
@@ -27,6 +27,7 @@ class AttentionSelectorConfig(NamedTuple):
     has_sink: bool = False
     use_sparse: bool = False
     use_mm_prefix: bool = False
+    requires_per_head_quant_scales: bool = False
     attn_type: str = AttentionType.DECODER
 
     def __repr__(self):
@@ -39,6 +40,7 @@ class AttentionSelectorConfig(NamedTuple):
             f"has_sink={self.has_sink}, "
             f"use_sparse={self.use_sparse}, "
             f"use_mm_prefix={self.use_mm_prefix}, "
+            f"requires_per_head_quant_scales={self.requires_per_head_quant_scales}, "
             f"attn_type={self.attn_type})"
         )
 
@@ -52,6 +54,7 @@ def get_attn_backend(
     has_sink: bool = False,
     use_sparse: bool = False,
     use_mm_prefix: bool = False,
+    requires_per_head_quant_scales: bool = False,
     attn_type: str | None = None,
     num_heads: int | None = None,
 ) -> type[AttentionBackend]:
@@ -77,6 +80,7 @@ def get_attn_backend(
         has_sink=has_sink,
         use_sparse=use_sparse,
         use_mm_prefix=use_mm_prefix,
+        requires_per_head_quant_scales=requires_per_head_quant_scales,
         attn_type=attn_type or AttentionType.DECODER,
     )
 

--- a/vllm/v1/attention/selector.py
+++ b/vllm/v1/attention/selector.py
@@ -27,7 +27,7 @@ class AttentionSelectorConfig(NamedTuple):
     has_sink: bool = False
     use_sparse: bool = False
     use_mm_prefix: bool = False
-    requires_per_head_quant_scales: bool = False
+    use_per_head_quant_scales: bool = False
     attn_type: str = AttentionType.DECODER
 
     def __repr__(self):
@@ -40,7 +40,7 @@ class AttentionSelectorConfig(NamedTuple):
             f"has_sink={self.has_sink}, "
             f"use_sparse={self.use_sparse}, "
             f"use_mm_prefix={self.use_mm_prefix}, "
-            f"requires_per_head_quant_scales={self.requires_per_head_quant_scales}, "
+            f"use_per_head_quant_scales={self.use_per_head_quant_scales}, "
             f"attn_type={self.attn_type})"
         )
 
@@ -54,7 +54,7 @@ def get_attn_backend(
     has_sink: bool = False,
     use_sparse: bool = False,
     use_mm_prefix: bool = False,
-    requires_per_head_quant_scales: bool = False,
+    use_per_head_quant_scales: bool = False,
     attn_type: str | None = None,
     num_heads: int | None = None,
 ) -> type[AttentionBackend]:
@@ -80,7 +80,7 @@ def get_attn_backend(
         has_sink=has_sink,
         use_sparse=use_sparse,
         use_mm_prefix=use_mm_prefix,
-        requires_per_head_quant_scales=requires_per_head_quant_scales,
+        use_per_head_quant_scales=use_per_head_quant_scales,
         attn_type=attn_type or AttentionType.DECODER,
     )
 


### PR DESCRIPTION
As requested by @MatthewBonanni and @LucasWilkinson in https://github.com/vllm-project/vllm/pull/30141 attention backends should be filtered during backend selection based on whether they support per-head attention quantization scales.

This enables early failure when a user attempts to load a model that requires per-head scales but no compatible attention backend is available.