### PR TITLE
[Bugfix] Avoid double-sharding pre-sharded FusedMoE expert weights in TP loaders

### DIFF
--- a/tests/model_executor/test_fused_moe_weight_loader.py
+++ b/tests/model_executor/test_fused_moe_weight_loader.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+
+
+def _make_fake_fused_moe(*, is_act_and_mul: bool = True) -> FusedMoE:
+    moe = object.__new__(FusedMoE)
+    moe.moe_config = SimpleNamespace(is_act_and_mul=is_act_and_mul)
+    return moe
+
+
+def test_load_w13_with_rank_local_weight_does_not_reshard():
+    moe = _make_fake_fused_moe()
+    expert_data = torch.zeros(4096, 8)
+    loaded_weight = torch.arange(2048 * 8, dtype=torch.float32).reshape(2048, 8)
+
+    FusedMoE._load_w13(
+        moe,
+        expert_data=expert_data,
+        shard_dim=0,
+        shard_id="w3",
+        loaded_weight=loaded_weight,
+        tp_rank=1,
+        load_full=False,
+    )
+
+    assert torch.equal(expert_data[2048:], loaded_weight)
+    assert torch.count_nonzero(expert_data[:2048]) == 0
+
+
+def test_load_w13_with_global_weight_still_shards_by_tp_rank():
+    moe = _make_fake_fused_moe()
+    expert_data = torch.zeros(4096, 8)
+    loaded_weight = torch.arange(4096 * 8, dtype=torch.float32).reshape(4096, 8)
+
+    FusedMoE._load_w13(
+        moe,
+        expert_data=expert_data,
+        shard_dim=0,
+        shard_id="w1",
+        loaded_weight=loaded_weight,
+        tp_rank=1,
+        load_full=False,
+    )
+
+    assert torch.equal(expert_data[:2048], loaded_weight[2048:])
+    assert torch.count_nonzero(expert_data[2048:]) == 0
+
+
+def test_load_w2_with_rank_local_weight_does_not_reshard():
+    moe = _make_fake_fused_moe()
+    expert_data = torch.zeros(8, 2048)
+    loaded_weight = torch.arange(8 * 2048, dtype=torch.float32).reshape(8, 2048)
+
+    FusedMoE._load_w2(
+        moe,
+        expert_data=expert_data,
+        shard_dim=1,
+        loaded_weight=loaded_weight,
+        tp_rank=1,
+        load_full=False,
+    )
+
+    assert torch.equal(expert_data, loaded_weight)
+
+
+def test_load_w13_non_act_and_mul_rank_local_does_not_reshard():
+    moe = _make_fake_fused_moe(is_act_and_mul=False)
+    expert_data = torch.zeros(2048, 8)
+    loaded_weight = torch.arange(2048 * 8, dtype=torch.float32).reshape(2048, 8)
+
+    FusedMoE._load_w13(
+        moe,
+        expert_data=expert_data,
+        shard_dim=0,
+        shard_id="w1",
+        loaded_weight=loaded_weight,
+        tp_rank=3,
+        load_full=False,
+    )
+
+    assert torch.equal(expert_data, loaded_weight)
+
+
+def test_load_w2_load_full_keeps_global_tensor():
+    moe = _make_fake_fused_moe()
+    expert_data = torch.zeros(8, 4096)
+    loaded_weight = torch.arange(8 * 4096, dtype=torch.float32).reshape(8, 4096)
+
+    FusedMoE._load_w2(
+        moe,
+        expert_data=expert_data,
+        shard_dim=1,
+        loaded_weight=loaded_weight,
+        tp_rank=1,
+        load_full=True,
+    )
+
+    assert torch.equal(expert_data, loaded_weight)


### PR DESCRIPTION
## Purpose

Fixes #34257

Fix a `FusedMoE` weight-loading bug that can occur when the weight loader already returns tensor-parallel (TP) rank-local expert weights.

Reported in #34257 when serving `xai-org/grok-2` with `--tensor_parallel_size 8`, with a failure like:
- `RuntimeError: start (2048) + length (2048) exceeds dimension size (2048)`

#### Change
In the `FusedMoE` load path, only apply TP sharding (`narrow`) when the incoming tensor is global along the shard dimension; if it is already rank-local, copy directly (avoids double-sharding/out-of-bounds).

## Test Plan

- Added regression tests for global vs rank-local loader inputs (`w13` / `w2`) in `tests/model_executor/test_fused_moe_weight_loader.py`.

## Test Result
- `pytest -q tests/model_executor/test_fused_moe_weight_loader.py tests/model_executor/test_routed_experts_capture.py` → `9 passed`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

