### PR TITLE
Fix KeyError loading GLM-4.7-NVFP4: handle k_scale/v_scale remap early

### DIFF
--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -506,6 +506,11 @@ class Glm4MoeModel(nn.Module):
             spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
             if spec_layer is not None:
                 continue
+            if ("scale" in name) or ("zero_point" in name):
+                remapped = maybe_remap_kv_scale_name(name, params_dict)
+                if remapped is None:
+                    continue
+                name = remapped
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 # Skip non-stacked layers and experts (experts handled below).
                 if weight_name not in name:

--- a/vllm/model_executor/models/glm4_moe.py
+++ b/vllm/model_executor/models/glm4_moe.py
@@ -507,10 +507,9 @@ class Glm4MoeModel(nn.Module):
             if spec_layer is not None:
                 continue
             if ("scale" in name) or ("zero_point" in name):
-                remapped = maybe_remap_kv_scale_name(name, params_dict)
-                if remapped is None:
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
                     continue
-                name = remapped
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 # Skip non-stacked layers and experts (experts handled below).
                 if weight_name not in name:


### PR DESCRIPTION
## Summary
This PR fixes a weight-loading crash in glm4_moe when using ModelOpt/NVFP4-style checkpoints that contain FP8 `k_scale / v_scale` (and related scale/zero_point) tensors.
#Problem
Some GLM4-MoE checkpoints include per-projection scale keys such as:

- layers.<n>.self_attn.k_proj.k_scale
- layers.<n>.self_attn.v_proj.v_scale

In glm4_moe.load_weights(), stacked parameter mapping can run before kv-scale remapping, rewriting keys like k_proj.k_scale into qkv_proj.k_scale. The runtime model typically does not define parameters/buffers with names like ...qkv_proj.k_scale, so loading fails with:
```
KeyError: 'layers.27.self_attn.qkv_proj.k_scale'
```
This prevents vllm serve from starting.
#Fix
Remap scale/zero_point keys before stacked parameter mapping in glm4_moe.load_weights():
Call maybe_remap_kv_scale_name() (and the same treatment for scale/zero_point) early.
If the remapped name does not exist in the model, safely skip (preserving existing warning behavior).
This mirrors the ordering used in other loaders where kv-scale remapping happens prior to stacked QKV name transformations.
