### PR TITLE
[torch.compile] Enable AR+rms fusion by default available for `-O2`

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -115,7 +115,7 @@ class PassConfig:
     """Fuse the custom SiluMul + quant ops."""
     fuse_attn_quant: bool = Field(default=None)
     """Fuse the custom attention + quant ops."""
-    eliminate_noops: bool = Field(default=None)
+    eliminate_noops: bool = Field(default=True)
     """Eliminate no-op ops."""
     enable_sp: bool = Field(default=None)
     """Enable sequence parallelism."""
@@ -194,7 +194,6 @@ class PassConfig:
         "fuse_norm_quant",
         "fuse_act_quant",
         "fuse_attn_quant",
-        "eliminate_noops",
         "enable_sp",
         "fuse_gemm_comms",
         "fuse_allreduce_rms",

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -105,7 +105,7 @@ def enable_act_fusion(cfg: "VllmConfig") -> bool:
 def enable_allreduce_rms_fusion(cfg: "VllmConfig") -> bool:
     """Enable if TP > 1 and Hopper+ and flashinfer installed."""
     from vllm.platforms import current_platform
-    from vllm.utils.import_utils import has_flashinfer
+    from vllm.utils.flashinfer import has_flashinfer
 
     return (
         cfg.parallel_config.tensor_parallel_size > 1


### PR DESCRIPTION
## Purpose
Turns out AR+RMS fusion and compiling for a second range only marginally increases warm/cold start compile time, and the benefits are 5-22% (see #24252). This PR enables this fusion by default.

## Test Plan
Startup, bench, eval, CI

## Test Result

### Startup
```
$ vllm bench startup --model=RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8 -tp=4
COLD STARTUP:
Avg total startup time: 94.18 seconds

WARM STARTUP:
Avg total startup time: 68.90 seconds

$ vllm bench startup --model=RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8 -tp=4 -cc.pass_nconfig.fuse_allreduce_rms
COLD STARTUP:
Avg total startup time: 108.63 seconds

WARM STARTUP:
Avg total startup time: 76.07 seconds
```

### Bench

#### llama3-70B-fp8 tp=2 B200

5-22% improvement

<img width="1862" height="1470" alt="ttft15" src="https://github.com/user-attachments/assets/c59afa45-c45c-4951-b306-d9d5cb853c47" />

<img width="2485" height="2069" alt="tpot15_1" src="https://github.com/user-attachments/assets/0692263d-38d0-42bf-b994-0fcbfd841ad0" />

#### qwen3-235B TP=4 B200

TODO

### Eval

```
$ vllm serve RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8 -tp=4

local-completions (pretrained=RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8,base_url=http://0.0.0.0:8000/v1/completions,num_concurrent=50,max_retries=3), gen_kwargs: (None), limit: 100.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.89|±  |0.0314|
|     |       |strict-match    |     5|exact_match|↑  | 0.86|±  |0.0349|

$ vllm serve nvidia/Llama-3.3-70B-Instruct-NVFP4 -tp=4
local-completions (pretrained=nvidia/Llama-3.3-70B-Instruct-NVFP4,base_url=http://0.0.0.0:8000/v1/completions,num_concurrent=50,max_retries=3), gen_kwargs: (None), limit: 100.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.91|±  |0.0288|
|     |       |strict-match    |     5|exact_match|↑  | 0.86|±  |0.0349|

$ vllm serve nvidia/Llama-4-Scout-17B-16E-Instruct-NVFP4 -tp=4
local-completions (pretrained=nvidia/Llama-4-Scout-17B-16E-Instruct-NVFP4,base_url=http://0.0.0.0:8000/v1/completions,num_concurrent=50,max_retries=3), gen_kwargs: (None), limit: 100.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.90|±  |0.0302|
|     |       |strict-match    |     5|exact_match|↑  | 0.88|±  |0.0327|
```

### CI

Looks good.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

