### PR TITLE
[CI][Bugfix] add regression test for GDN fused_recurrent kernel

### DIFF
--- a/tests/kernels/test_fused_recurrent.py
+++ b/tests/kernels/test_fused_recurrent.py
@@ -1,0 +1,366 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="fused_recurrent requires CUDA or ROCm",
+)
+
+PAD_SLOT_ID = -1
+
+BATCH_SIZES = [1, 2, 4]
+SEQ_LENS = [1, 4, 16]
+NUM_PADDINGS = [0, 1, 2, 4]
+DTYPES = [torch.float32, torch.bfloat16]
+MAX_BATCH_SIZES = [4, 8, 16]
+ACTUAL_BATCHES = [1, 2, 4]
+TP_SIZES = [1, 2, 4, 8]
+
+# Qwen3-Next-80B shapes: (H, HV, K, V) for different TP sizes
+QWEN3_NEXT_SHAPES = {
+    1: (16, 32, 128, 128),
+    2: (8, 16, 128, 128),
+    4: (4, 8, 128, 128),
+    8: (2, 4, 128, 128),
+}
+
+
+def get_fused_recurrent_fn():
+    """Import the fused_recurrent function, skip if not available."""
+    try:
+        from vllm.model_executor.layers.fla.ops.fused_recurrent import (
+            fused_recurrent_gated_delta_rule,
+        )
+
+        return fused_recurrent_gated_delta_rule
+    except ImportError:
+        pytest.skip("fused_recurrent_gated_delta_rule not available")
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seq_len", [1, 4])
+@pytest.mark.parametrize("num_padding", NUM_PADDINGS)
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
+@torch.inference_mode()
+def test_fused_recurrent_pad_slot_id(
+    batch_size: int,
+    num_padding: int,
+    seq_len: int,
+    dtype: torch.dtype,
+):
+    """Test kernel handles PAD_SLOT_ID (-1) without crashing (Issue #31186)."""
+    fused_recurrent = get_fused_recurrent_fn()
+    set_random_seed(42)
+    device = torch.device("cuda:0")
+
+    H, HV, K, V = 4, 4, 64, 64
+    total_seqs = batch_size + num_padding
+
+    valid_indices = torch.arange(batch_size, dtype=torch.int64, device=device)
+    if num_padding > 0:
+        padding_indices = torch.full(
+            (num_padding,), PAD_SLOT_ID, dtype=torch.int64, device=device
+        )
+        ssm_state_indices = torch.cat([valid_indices, padding_indices])
+    else:
+        ssm_state_indices = valid_indices
+
+    q = torch.randn(total_seqs, seq_len, H, K, dtype=dtype, device=device)
+    k = F.normalize(
+        torch.randn(total_seqs, seq_len, H, K, dtype=dtype, device=device),
+        p=2,
+        dim=-1,
+    )
+    v = torch.randn(total_seqs, seq_len, HV, V, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(total_seqs, seq_len, HV, dtype=dtype, device=device))
+    beta = torch.rand(total_seqs, seq_len, HV, dtype=dtype, device=device).sigmoid()
+    initial_state = torch.zeros(batch_size, HV, K, V, dtype=dtype, device=device)
+
+    try:
+        output, final_state = fused_recurrent(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=K**-0.5,
+            initial_state=initial_state,
+            inplace_final_state=True,
+            ssm_state_indices=ssm_state_indices,
+        )
+        assert output.shape == (total_seqs, seq_len, HV, V)
+        assert not torch.isnan(output).any()
+        assert not torch.isinf(output).any()
+    except RuntimeError as e:
+        if "illegal memory access" in str(e).lower():
+            pytest.fail(f"Kernel crashed with PAD_SLOT_ID - regression #31186: {e}")
+        raise
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 8])
+@torch.inference_mode()
+def test_fused_recurrent_all_padding(batch_size: int):
+    """Test edge case where all indices are PAD_SLOT_ID."""
+    fused_recurrent = get_fused_recurrent_fn()
+    set_random_seed(42)
+    device = torch.device("cuda:0")
+    dtype = torch.float32
+
+    H, HV, K, V = 4, 4, 64, 64
+    seq_len = 1
+
+    ssm_state_indices = torch.full(
+        (batch_size,), PAD_SLOT_ID, dtype=torch.int64, device=device
+    )
+
+    q = torch.randn(batch_size, seq_len, H, K, dtype=dtype, device=device)
+    k = F.normalize(
+        torch.randn(batch_size, seq_len, H, K, dtype=dtype, device=device),
+        p=2,
+        dim=-1,
+    )
+    v = torch.randn(batch_size, seq_len, HV, V, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(batch_size, seq_len, HV, dtype=dtype, device=device))
+    beta = torch.rand(batch_size, seq_len, HV, dtype=dtype, device=device).sigmoid()
+    initial_state = torch.zeros(1, HV, K, V, dtype=dtype, device=device)
+
+    try:
+        output, _ = fused_recurrent(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=K**-0.5,
+            initial_state=initial_state,
+            inplace_final_state=True,
+            ssm_state_indices=ssm_state_indices,
+        )
+        assert output.shape == (batch_size, seq_len, HV, V)
+    except RuntimeError as e:
+        if "illegal memory access" in str(e).lower():
+            pytest.fail(f"Kernel crashed with all PAD_SLOT_ID: {e}")
+        raise
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seq_len", SEQ_LENS)
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
+@torch.inference_mode()
+def test_fused_recurrent_basic_forward(
+    batch_size: int,
+    seq_len: int,
+    dtype: torch.dtype,
+):
+    """Test basic forward pass."""
+    fused_recurrent = get_fused_recurrent_fn()
+    set_random_seed(42)
+    device = torch.device("cuda:0")
+
+    H, HV, K, V = 4, 4, 64, 64
+
+    q = torch.randn(batch_size, seq_len, H, K, dtype=dtype, device=device) * 0.1
+    k = F.normalize(
+        torch.randn(batch_size, seq_len, H, K, dtype=dtype, device=device),
+        p=2,
+        dim=-1,
+    )
+    v = torch.randn(batch_size, seq_len, HV, V, dtype=dtype, device=device) * 0.1
+    g = F.logsigmoid(torch.randn(batch_size, seq_len, HV, dtype=dtype, device=device))
+    beta = torch.rand(batch_size, seq_len, HV, dtype=dtype, device=device).sigmoid()
+    initial_state = torch.zeros(batch_size, HV, K, V, dtype=dtype, device=device)
+
+    ssm_state_indices = torch.arange(batch_size, dtype=torch.int64, device=device)
+    ssm_state_indices = ssm_state_indices.unsqueeze(1).expand(batch_size, seq_len)
+    ssm_state_indices = ssm_state_indices.contiguous()
+
+    output, final_state = fused_recurrent(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=K**-0.5,
+        initial_state=initial_state,
+        inplace_final_state=True,
+        ssm_state_indices=ssm_state_indices,
+    )
+
+    assert output.shape == (batch_size, seq_len, HV, V)
+    assert output.dtype == dtype
+    assert not torch.isnan(output).any()
+    assert not torch.isinf(output).any()
+    assert final_state.shape == (batch_size, HV, K, V)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@torch.inference_mode()
+def test_fused_recurrent_dtype_support(dtype: torch.dtype):
+    """Test kernel supports various dtypes."""
+    fused_recurrent = get_fused_recurrent_fn()
+    set_random_seed(42)
+    device = torch.device("cuda:0")
+
+    B, T, H, HV, K, V = 2, 4, 4, 4, 64, 64
+
+    q = torch.randn(B, T, H, K, dtype=dtype, device=device)
+    k = F.normalize(torch.randn(B, T, H, K, dtype=dtype, device=device), p=2, dim=-1)
+    v = torch.randn(B, T, HV, V, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.randn(B, T, HV, dtype=dtype, device=device))
+    beta = torch.rand(B, T, HV, dtype=dtype, device=device).sigmoid()
+    initial_state = torch.zeros(B, HV, K, V, dtype=dtype, device=device)
+
+    output, _ = fused_recurrent(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=K**-0.5,
+        initial_state=initial_state,
+        ssm_state_indices=None,
+    )
+
+    assert output.dtype == dtype
+
+
+@pytest.mark.parametrize("actual_batch", ACTUAL_BATCHES)
+@pytest.mark.parametrize("max_batch_size", MAX_BATCH_SIZES)
+@torch.inference_mode()
+def test_fused_recurrent_cuda_graph_scenario(
+    max_batch_size: int,
+    actual_batch: int,
+):
+    """Test CUDA Graph scenario that caused Issue #31186."""
+    if actual_batch > max_batch_size:
+        pytest.skip("actual_batch must be <= max_batch_size")
+
+    fused_recurrent = get_fused_recurrent_fn()
+    set_random_seed(42)
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+
+    H, HV, K, V = 8, 8, 128, 128
+    seq_len = 1
+
+    initial_state = torch.zeros(max_batch_size, HV, K, V, dtype=dtype, device=device)
+
+    valid_indices = torch.arange(actual_batch, dtype=torch.int64, device=device)
+    padding_count = max_batch_size - actual_batch
+    if padding_count > 0:
+        padding_indices = torch.full(
+            (padding_count,), PAD_SLOT_ID, dtype=torch.int64, device=device
+        )
+        ssm_state_indices = torch.cat([valid_indices, padding_indices])
+    else:
+        ssm_state_indices = valid_indices
+
+    q = torch.randn(max_batch_size, seq_len, H, K, dtype=dtype, device=device)
+    k = F.normalize(
+        torch.randn(max_batch_size, seq_len, H, K, dtype=dtype, device=device),
+        p=2,
+        dim=-1,
+    )
+    v = torch.randn(max_batch_size, seq_len, HV, V, dtype=dtype, device=device)
+    g = F.logsigmoid(
+        torch.randn(max_batch_size, seq_len, HV, dtype=dtype, device=device)
+    )
+    beta = torch.rand(max_batch_size, seq_len, HV, dtype=dtype, device=device).sigmoid()
+
+    try:
+        output, final_state = fused_recurrent(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=K**-0.5,
+            initial_state=initial_state,
+            inplace_final_state=True,
+            ssm_state_indices=ssm_state_indices,
+        )
+
+        assert output.shape == (max_batch_size, seq_len, HV, V)
+        valid_output = output[:actual_batch]
+        assert not torch.isnan(valid_output).any()
+        assert not torch.isinf(valid_output).any()
+
+    except RuntimeError as e:
+        if "illegal memory access" in str(e).lower():
+            pytest.fail(f"CUDA Graph simulation crashed - regression #31186: {e}")
+        raise
+
+
+@pytest.mark.parametrize("actual_batch", [1, 4])
+@pytest.mark.parametrize("max_batch_size", [8, 16])
+@pytest.mark.parametrize("tp_size", TP_SIZES)
+@torch.inference_mode()
+def test_fused_recurrent_qwen3_next_shapes(
+    tp_size: int,
+    max_batch_size: int,
+    actual_batch: int,
+):
+    """Test with Qwen3-Next-80B shapes and PAD_SLOT_ID padding."""
+    if actual_batch > max_batch_size:
+        pytest.skip("actual_batch must be <= max_batch_size")
+
+    fused_recurrent = get_fused_recurrent_fn()
+    set_random_seed(42)
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+
+    H, HV, K, V = QWEN3_NEXT_SHAPES[tp_size]
+    seq_len = 1
+
+    valid_indices = torch.arange(actual_batch, dtype=torch.int64, device=device)
+    padding_count = max_batch_size - actual_batch
+    if padding_count > 0:
+        padding_indices = torch.full(
+            (padding_count,), PAD_SLOT_ID, dtype=torch.int64, device=device
+        )
+        ssm_state_indices = torch.cat([valid_indices, padding_indices])
+    else:
+        ssm_state_indices = valid_indices
+
+    q = torch.randn(max_batch_size, seq_len, H, K, dtype=dtype, device=device)
+    k = F.normalize(
+        torch.randn(max_batch_size, seq_len, H, K, dtype=dtype, device=device),
+        p=2,
+        dim=-1,
+    )
+    v = torch.randn(max_batch_size, seq_len, HV, V, dtype=dtype, device=device)
+    g = F.logsigmoid(
+        torch.randn(max_batch_size, seq_len, HV, dtype=dtype, device=device)
+    )
+    beta = torch.rand(max_batch_size, seq_len, HV, dtype=dtype, device=device).sigmoid()
+    initial_state = torch.zeros(max_batch_size, HV, K, V, dtype=dtype, device=device)
+
+    try:
+        output, final_state = fused_recurrent(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=K**-0.5,
+            initial_state=initial_state,
+            inplace_final_state=True,
+            ssm_state_indices=ssm_state_indices,
+        )
+
+        assert output.shape == (max_batch_size, seq_len, HV, V)
+        valid_output = output[:actual_batch]
+        assert not torch.isnan(valid_output).any()
+        assert not torch.isinf(valid_output).any()
+
+    except RuntimeError as e:
+        if "illegal memory access" in str(e).lower():
+            pytest.fail(f"Kernel crashed with Qwen3-Next shapes (TP={tp_size}): {e}")
+        raise

--- a/tests/v1/e2e/test_qwen3_next_mtp.py
+++ b/tests/v1/e2e/test_qwen3_next_mtp.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+
+import pytest
+import torch
+
+from tests.utils import large_gpu_mark
+from vllm import LLM, SamplingParams
+from vllm.distributed import cleanup_dist_env_and_memory
+from vllm.platforms import current_platform
+
+TEST_PROMPTS = [
+    [{"role": "user", "content": "What is 2 + 2?"}],
+    [{"role": "user", "content": "Say hello in Chinese."}],
+    [{"role": "user", "content": "Count from 1 to 5."}],
+    [{"role": "user", "content": "What color is the sky?"}],
+]
+
+SAMPLING_PARAMS = SamplingParams(temperature=0, max_tokens=32, ignore_eos=False)
+
+
+def _check_model_available(model_name: str) -> bool:
+    """Check if model is available."""
+    try:
+        from huggingface_hub import HfApi
+
+        api = HfApi()
+        api.model_info(model_name)
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    """Cleanup GPU memory after each test."""
+    yield
+    torch.cuda.empty_cache()
+    cleanup_dist_env_and_memory()
+
+
+@large_gpu_mark(min_gb=80)
+@pytest.mark.parametrize("num_speculative_tokens", [1, 2])
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 1
+    or torch.cuda.get_device_properties(0).total_memory < 40 * 1024**3,
+    reason="Requires at least 40GB GPU memory",
+)
+def test_qwen3_next_80b_mtp_cuda_graph(
+    num_speculative_tokens: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test Qwen3-Next-80B with MTP and CUDA Graph (Issue #31186 regression)."""
+    model_name = "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8"
+
+    if not _check_model_available(model_name):
+        pytest.skip(f"Model {model_name} not available")
+
+    monkeypatch.setenv("VLLM_ATTENTION_BACKEND", "FLASH_ATTN")
+
+    llm = LLM(
+        model=model_name,
+        max_model_len=4096,
+        gpu_memory_utilization=0.9,
+        tensor_parallel_size=1,
+        speculative_config={
+            "method": "qwen3_next_mtp",
+            "num_speculative_tokens": num_speculative_tokens,
+        },
+    )
+
+    for i in range(3):
+        try:
+            outputs = llm.chat(TEST_PROMPTS, SAMPLING_PARAMS)
+            for output in outputs:
+                assert output.outputs[0].text is not None
+                assert len(output.outputs[0].text) > 0
+        except RuntimeError as e:
+            error_msg = str(e).lower()
+            if "illegal memory access" in error_msg or "cuda error" in error_msg:
+                pytest.fail(f"CUDA error during batch {i + 1} - regression #31186: {e}")
+            raise
+
+    del llm
+
+
+@pytest.mark.skipif(
+    os.environ.get("VLLM_TEST_QWEN3_NEXT_MTP") != "1",
+    reason="Set VLLM_TEST_QWEN3_NEXT_MTP=1 to run",
+)
+@pytest.mark.parametrize("tensor_parallel_size", [1, 4])
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+def test_qwen3_next_mtp_manual(
+    tensor_parallel_size: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Manual test for Qwen3-Next MTP with various TP sizes."""
+    available_gpus = torch.cuda.device_count()
+    if available_gpus < tensor_parallel_size:
+        pytest.skip(f"Need {tensor_parallel_size} GPUs, have {available_gpus}")
+
+    model_name = "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8"
+    monkeypatch.setenv("VLLM_ATTENTION_BACKEND", "FLASH_ATTN")
+
+    llm = LLM(
+        model=model_name,
+        max_model_len=4096,
+        gpu_memory_utilization=0.8,
+        tensor_parallel_size=tensor_parallel_size,
+        speculative_config={
+            "method": "qwen3_next_mtp",
+            "num_speculative_tokens": 2,
+        },
+    )
+
+    outputs = llm.chat(TEST_PROMPTS * 5, SAMPLING_PARAMS)
+
+    assert len(outputs) == 20
+    for output in outputs:
+        assert output.outputs[0].text is not None
+
+    del llm
+
+
+@pytest.mark.parametrize(
+    "model_setup",
+    [("XiaomiMiMo/MiMo-7B-Base", "mtp", 20)],
+    ids=["mimo_7b"],
+)
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA required")
+def test_mtp_cuda_graph_stress(
+    model_setup: tuple[str, str, int],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Stress test MTP with CUDA Graph using smaller models."""
+    model_name, method, min_gpu_gb = model_setup
+
+    if torch.cuda.get_device_properties(0).total_memory < min_gpu_gb * 1024**3:
+        pytest.skip(f"Requires at least {min_gpu_gb}GB GPU memory")
+
+    monkeypatch.setenv("VLLM_ATTENTION_BACKEND", "FLASH_ATTN")
+
+    llm = LLM(
+        model=model_name,
+        max_model_len=2048,
+        trust_remote_code=True,
+        speculative_config={
+            "method": method,
+            "num_speculative_tokens": 2,
+        },
+    )
+
+    for _ in range(5):
+        outputs = llm.chat(TEST_PROMPTS, SAMPLING_PARAMS)
+        assert len(outputs) == len(TEST_PROMPTS)
+        for output in outputs:
+            assert output.outputs[0].text is not None
+
+    del llm


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix illegal memory access in `fused_recurrent` kernel when handling `PAD_SLOT_ID (-1)` for padded sequences ([Issue #31186](https://github.com/vllm-project/vllm/issues/31186)).

**Root Cause:**
The `fused_recurrent_gated_delta_rule_fwd_kernel` was not properly handling `PAD_SLOT_ID (-1)` when storing final states in continuous batching mode. When processing padded sequences in CUDA Graph scenarios (especially with Qwen3-Next MTP), the kernel would attempt to access invalid memory locations using negative state indices, causing CUDA illegal memory access errors.

**Fix:**
- Added proper check for `IS_CONTINUOUS_BATCHING` flag before using `ssm_state_indices` to access final state
- For non-continuous batching, use sequence index directly instead of state indices
- Fixed state offset calculation (changed from `i_hv * V * K + o_v[:, None] * K + o_k[None, :]` to `i_hv * K * V + o_k[:, None] * V + o_v[None, :]`)

## Test Plan

Added comprehensive regression tests to prevent this issue from recurring:

1. **Unit tests** (`tests/kernels/test_fused_recurrent.py`):
   - `test_fused_recurrent_pad_slot_id`: Tests kernel handles `PAD_SLOT_ID` without crashing
   - `test_fused_recurrent_cuda_graph_scenario`: Tests CUDA Graph scenario that caused the original issue
   - `test_fused_recurrent_qwen3_next_shapes`: Tests with Qwen3-Next-80B shapes and various TP sizes

2. **E2E tests** (`tests/v1/e2e/test_qwen3_next_mtp.py`):
   - `test_qwen3_next_80b_mtp_cuda_graph`: Tests Qwen3-Next-80B with MTP and CUDA Graph to ensure no CUDA errors occur

**Test commands:**
```bash
# Run kernel unit tests
pytest tests/kernels/test_fused_recurrent.py -v

# Run E2E tests (requires 40GB+ GPU memory)
VLLM_TEST_QWEN3_NEXT_MTP=1 pytest tests/v1/e2e/test_qwen3_next_mtp.py::test_qwen3_next_80b_mtp_cuda_graph -v
```

## Test Result

[Please paste test results here, showing that tests pass and no CUDA errors occur]

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

