### PR TITLE
Fixed whisper CPU test that does not spawn properly.

### DIFF
--- a/tests/models/multimodal/generation/test_whisper.py
+++ b/tests/models/multimodal/generation/test_whisper.py
@@ -117,7 +117,6 @@ def check_model_available(model: str) -> None:
 @pytest.mark.parametrize("dtype", ["half", "float"])
 @pytest.mark.parametrize("num_logprobs", [5])
 @pytest.mark.parametrize("enforce_eager", [True, False])
-@create_new_process_for_each_test("spawn")
 def test_models(
     hf_runner,
     vllm_runner,


### PR DESCRIPTION
<!-- markdownlint-disable -->

Partially addresses #34323 

## Purpose

Fix a test that isn't being run properly. This [issue](https://github.com/vllm-project/vllm/issues/34323) describes the problem with using the annotation ```@create_new_process_for_each_test("spawn")```. This change will prevent spawning or forking of the test.

## Test Plan

Locally, checkout a known problematic commit, `a32cb49b60688fb64a6d3d7f86378b4d2fad06e6`, where the test should fail and run:
```
python -m pytest -x -v -s tests/models/multimodal/generation/test_whisper.py -m cpu_model
```
Test should pass. Apply this change and repeat: test should fail.

## Test Result

Test now fails with problematic commit. Test passes on latest code.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

