### PR TITLE
[kv cache quantisation]TRITION_ATTN  backend  support int8 kvcache dtype

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -173,7 +173,7 @@ Priority is **1 = highest** (tried first).
 | `ROCM_AITER_UNIFIED_ATTN` |  | fp16, bf16 | `auto` | Any | Any | ❌ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_ATTN` |  | fp16, bf16, fp32 | `auto` | 16, 32, 544 | 32, 64, 96, 128, 160, 192, 224, 256 | ❌ | ❌ | ❌ | Decoder | N/A |
 | `TREE_ATTN` |  | fp16, bf16 | `auto` | %16 | 32, 64, 96, 128, 160, 192, 224, 256 | ❌ | ❌ | ❌ | Decoder | Any |
-| `TRITON_ATTN` |  | fp16, bf16, fp32 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | Any | ✅ | ✅ | ❌ | All | Any |
+| `TRITON_ATTN` |  | fp16, bf16, fp32 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2`, `int8` | %16 | Any | ✅ | ✅ | ❌ | All | Any |
 
 > **†** FlashInfer uses TRTLLM attention on Blackwell (SM100), which supports sinks. Disable via `--attention-config.use_trtllm_attention=0`.
 >

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -211,12 +211,28 @@ class CacheConfig:
     @field_validator("cache_dtype", mode="after")
     @classmethod
     def _validate_cache_dtype(cls, cache_dtype: CacheDType) -> CacheDType:
+        warn_info = (
+            "Using %s data type to store kv cache. It reduces the GPU "
+            "memory footprint and boosts the performance. "
+            "Meanwhile, it may cause accuracy drop without a proper "
+            "scaling factor"
+        )
         if cache_dtype.startswith("fp8"):
             logger.info(
-                "Using fp8 data type to store kv cache. It reduces the GPU "
-                "memory footprint and boosts the performance. "
-                "Meanwhile, it may cause accuracy drop without a proper "
-                "scaling factor."
+                warn_info,
+                str(cache_dtype),
+            )
+        elif cache_dtype.startswith("int8"):
+            int8_warn_info = "Int8 quantization is very sensitive to scale factor. "
+            "Make sure --calculate_kv_scales argument is set and "
+            "K_SCALE_CONSTANT/V_SCALE_CONSTANT environment variables are set. "
+            "Normally 127 for INT8."
+            logger.info(
+                warn_info,
+                str(cache_dtype),
+            )
+            logger.info(
+                int8_warn_info,
             )
         return cache_dtype
 

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -28,6 +28,7 @@ CacheDType = Literal[
     "fp8_e5m2",
     "fp8_inc",
     "fp8_ds_mla",
+    "int8",
 ]
 MambaDType = Literal["auto", "float32", "float16"]
 MambaCacheMode = Literal["all", "align", "none"]

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -223,10 +223,12 @@ class CacheConfig:
                 str(cache_dtype),
             )
         elif cache_dtype.startswith("int8"):
-            int8_warn_info = "Int8 quantization is very sensitive to scale factor. "
-            "Make sure --calculate_kv_scales argument is set and "
-            "K_SCALE_CONSTANT/V_SCALE_CONSTANT environment variables are set. "
-            "Normally 127 for INT8."
+            int8_warn_info = (
+                "int8 kv cache requires calibrated scaling factors. "
+                "Make sure --calculate_kv_scales argument is set and "
+                "K_SCALE_CONSTANT/V_SCALE_CONSTANT environment variables are set. "
+                "Normally 127 for INT8."
+            )
             logger.info(
                 warn_info,
                 str(cache_dtype),

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -226,8 +226,8 @@ class CacheConfig:
             int8_warn_info = (
                 "int8 kv cache requires calibrated scaling factors. "
                 "Make sure --calculate_kv_scales argument is set and "
-                "K_SCALE_CONSTANT/V_SCALE_CONSTANT environment variables are set. "
-                "Normally 127 for INT8."
+                "K_SCALE_CONSTANT/V_SCALE_CONSTANT environment variables are set, "
+                "normally set to 127 for int8."
             )
             logger.info(
                 warn_info,

--- a/vllm/model_executor/layers/quantization/kv_cache.py
+++ b/vllm/model_executor/layers/quantization/kv_cache.py
@@ -162,8 +162,8 @@ class BaseKVCacheMethod(QuantizeMethodBase):
         else:
             prob_scale = 1.0
 
-        is_singleton_float = lambda x: (
-            isinstance(x, float)
+        is_singleton_float = (
+            lambda x: isinstance(x, float)
             or isinstance(x, torch.Tensor)
             and x.numel() == 1
             and x.is_floating_point()

--- a/vllm/model_executor/layers/quantization/kv_cache.py
+++ b/vllm/model_executor/layers/quantization/kv_cache.py
@@ -66,7 +66,9 @@ class BaseKVCacheMethod(QuantizeMethodBase):
                 k_scale = layer.k_scale.to("cpu").tolist()
                 v_scale = layer.v_scale.to("cpu").tolist()
                 # Only apply FNUZ scaling for FP8, not INT8
-                if current_platform.is_fp8_fnuz() and layer.kv_cache_dtype.startswith("fp8"):
+                if current_platform.is_fp8_fnuz() and layer.kv_cache_dtype.startswith(
+                    "fp8"
+                ):
                     k_scale *= 2
                     v_scale *= 2
             elif layer.k_scale < 0.0 and layer.v_scale < 0.0:
@@ -76,11 +78,12 @@ class BaseKVCacheMethod(QuantizeMethodBase):
                     # INT8 KV cache is very sensitive to scale values
                     logger.warning_once(
                         "INT8 KV cache requires calibrated scaling factors. "
-                        "Using default scale=1.0 will likely cause severe accuracy loss. "
+                        "Using default scale=1.0 will likely cause severe accuracy "
+                        "loss. "
                         "Please either: "
-                        "(1) Use a checkpoint with calibrated k/v_scale, or "
-                        "(2) Set calculate_kv_scales=True for on-the-fly calibration, or "
-                        "(3) Use FP8 KV cache instead (recommended if hardware supports it). "
+                        "(1) Use a checkpoint with calibrated k/v_scale."
+                        "(2) Set calculate_kv_scales=True for on-the-fly calibration."
+                        "(3) Use FP8 KV cache instead."
                         "Expected: scale = absmax(tensor) / 127 for INT8."
                     )
                 k_scale = 1.0
@@ -94,7 +97,9 @@ class BaseKVCacheMethod(QuantizeMethodBase):
                 k_scale = scale_to_duplicate.to("cpu").tolist()
                 v_scale = scale_to_duplicate.to("cpu").tolist()
                 # Only apply FNUZ scaling for FP8, not INT8
-                if current_platform.is_fp8_fnuz() and layer.kv_cache_dtype.startswith("fp8"):
+                if current_platform.is_fp8_fnuz() and layer.kv_cache_dtype.startswith(
+                    "fp8"
+                ):
                     k_scale *= 2
                     v_scale *= 2
 
@@ -117,18 +122,26 @@ class BaseKVCacheMethod(QuantizeMethodBase):
             layer._v_scale.copy_(v_scale)
             layer._k_scale_float = k_scale
             layer._v_scale_float = v_scale
-            
+
             # Warn about INT8 with scale=1.0 (critical issue)
-            if layer.kv_cache_dtype.startswith("int8") and (k_scale == 1.0 or v_scale == 1.0):
+            if layer.kv_cache_dtype.startswith("int8") and (
+                k_scale == 1.0 or v_scale == 1.0
+            ):
                 logger.warning_once(
                     f"INT8 KV cache using scale k={k_scale:.6f}, v={v_scale:.6f}. "
-                    "Scale=1.0 is likely incorrect for INT8 and will cause accuracy issues. "
+                    "Scale=1.0 is likely incorrect for INT8 and "
+                    "will cause accuracy issues. "
                     "Expected: scale = absmax(tensor) / 127 for INT8. "
                     "This will result in value overflow and severe precision loss."
                 )
-            
+
             # Warn about FP8 with scale=1.0 (less critical, informational)
-            if k_scale == 1.0 and v_scale == 1.0 and layer.kv_cache_dtype.startswith("fp8") and "e5m2" not in layer.kv_cache_dtype:
+            if (
+                k_scale == 1.0
+                and v_scale == 1.0
+                and layer.kv_cache_dtype.startswith("fp8")
+                and "e5m2" not in layer.kv_cache_dtype
+            ):
                 logger.warning_once(
                     "Using KV cache scaling factor 1.0 for fp8_e4m3. "
                     "If this is unintended, verify that k/v_scale "
@@ -149,8 +162,8 @@ class BaseKVCacheMethod(QuantizeMethodBase):
         else:
             prob_scale = 1.0
 
-        is_singleton_float = (
-            lambda x: isinstance(x, float)
+        is_singleton_float = lambda x: (
+            isinstance(x, float)
             or isinstance(x, torch.Tensor)
             and x.numel() == 1
             and x.is_floating_point()

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -266,7 +266,7 @@ class TritonAttentionBackend(AttentionBackend):
         "fp8",
         "fp8_e4m3",
         "fp8_e5m2",
-        "int8"
+        "int8",
     ]
 
     @staticmethod

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -266,6 +266,7 @@ class TritonAttentionBackend(AttentionBackend):
         "fp8",
         "fp8_e4m3",
         "fp8_e5m2",
+        "int8"
     ]
 
     @staticmethod
@@ -389,6 +390,7 @@ class TritonAttentionImpl(AttentionImpl):
 
         self.attn_type = attn_type
         self.fp8_dtype = current_platform.fp8_dtype()
+        self.int8_dtype = torch.int8
 
         self.sinks = sinks
         if sinks is not None:
@@ -471,6 +473,10 @@ class TritonAttentionImpl(AttentionImpl):
             assert layer._q_scale_float == 1.0, (
                 "A non 1.0 q_scale is not currently supported."
             )
+        elif self.kv_cache_dtype.startswith("int8"):
+            if key_cache.dtype != self.int8_dtype:
+                key_cache = key_cache.view(self.int8_dtype)
+                value_cache = value_cache.view(self.int8_dtype)
 
         cu_seqlens_q = attn_metadata.query_start_loc
         seqused_k = attn_metadata.seq_lens
@@ -586,6 +592,9 @@ class TritonAttentionImpl(AttentionImpl):
             # triton kernel does not support uint8 kv_cache
             #  (because some explicit casts (e.g. float8_e4m3fnuz)
             #   are not supported)
+        elif self.kv_cache_dtype.startswith("int8"):
+            key_cache = key_cache.view(self.int8_dtype)
+            value_cache = value_cache.view(self.int8_dtype)
         triton_reshape_and_cache_flash(
             key,
             value,

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -105,7 +105,7 @@ def kernel_unified_attention_2d(
     num_seqs: tl.int32,
     BLOCK_M: tl.constexpr,  # int
     USE_FP8: tl.constexpr,  # bool
-    USE_QUANTIZED_KV: tl.constexpr,  # bool, True for fp8/int8/int4 KV cache
+    USE_QUANTIZED_KV: tl.constexpr,  # bool, True for fp8/int8 KV cache
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
 ):
@@ -451,7 +451,7 @@ def kernel_unified_attention_3d(
     num_seqs: tl.int32,
     BLOCK_M: tl.constexpr,  # int
     NUM_SEGMENTS_PER_SEQ: tl.constexpr,  # int
-    USE_QUANTIZED_KV: tl.constexpr,  # bool, True for fp8/int8/int4 KV cache
+    USE_QUANTIZED_KV: tl.constexpr,  # bool, True for fp8/int8 KV cache
     USE_MM_PREFIX: tl.constexpr,  # bool
     MAX_MM_RANGES: tl.constexpr,  # int
     mm_prefix_range_ptr,  # [num_seqs] - prefix length for each sequence
@@ -933,7 +933,7 @@ def unified_attention(
 
     use_alibi_slopes = alibi_slopes is not None
     use_qq_bias = qq_bias is not None
-    # True when KV cache is quantized (fp8/int8/int4); kernel dequantizes with scale
+    # True when KV cache is quantized (fp8/int8); kernel dequantizes with scale
     use_quantized_kv = k_descale is not None
 
     block_size = v.shape[1]


### PR DESCRIPTION
## Purpose
as title describe

## Test Plan

A100-PCIE-40G
Qwen3-4B

vllm bench latency  --model ../Qwen3-4B/ --batch-size BATCH_SIZE --input-len 512 --output-len OUT_LEN --max_model_len 2000  --num-iters 1 --gpu-memory-utilization 0.90 --num-iters-warmup 1 --at
tention-backend TRITON_ATTN   --kv-cache-dtype  KV_CACHE_TYEP

BATCH_SIZE : [1,10,100,300 ]      
OUT_LEN : [1000,2000,3000]
KV_CACHE_TYEP [auto, int8]
## Test Result


### Time cost for  different BATCH_SIZE 
|        BATCH_SIZE \ time cost(s)        |  int8 | auto |
|---------|---------|---------|
|   1           |  8.1 |  8.1 |
|  10 |        9.85 |       9.95 |
|  100|   21.4 | 23.4 |
|  300 |  57.9 | 73.5 |

A batchsize of 300 caused the kvcache usage for auto precision to reach 100%, while the kvcache usage for int8 precision was not fully utilized.




### This test verifies that int8 precision delivers performance almost identical to auto precision when no queuing is involved.

BATCH_SIZE = 1, OUT_LEN changes

|       output len (decode len) \ time cost(s)    |  int8 | auto |
|---------|---------|---------|
|   1000           |  8.1 |  8.1 |
|   2000 |        16.5 |       16.4 |
|   3000|   25 | 25 |


### kvcache volume
as expected :
int8:
(EngineCore_DP0 pid=38913) INFO 02-11 13:39:45 [kv_cache_utils.py:1307] GPU KV cache size: 384,816 tokens
auto:
(EngineCore_DP0 pid=40031) INFO 02-11 13:43:18 [kv_cache_utils.py:1307] GPU KV cache size: 192,400 tokens



### accuracy test
test using mmlu ,hellaswag,  number varies for different datasets
|       datasets \ acc    |  int8 | auto |
|---------|---------|---------|
|   mmlu(50000+)         |  0.58 | 0.69  |
|   hellaswag(3000)|  0.53  |  0.59 |

In term of accuracy,  per attn-head, even per token scale would be required.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

