### PR TITLE
[Bugfix] Fix more multimodal tests for transformers V5

### DIFF
--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -314,7 +314,7 @@ def _test_processing_correctness(
     input_to_hit = {
         "image": Image.new("RGB", size=(128, 128)),
         "video": np.zeros((4, 128, 128, 3), dtype=np.uint8),
-        "audio": (np.ones((512 * 16000,)), 16000),
+        "audio": (np.zeros((512,)), 16000),
         "vision_chunk": {"type": "image", "image": Image.new("RGB", size=(128, 128))},
     }
     input_factory = {
@@ -322,9 +322,7 @@ def _test_processing_correctness(
         "video": partial(
             random_video, rng, min_frames=2, max_frames=16, min_wh=128, max_wh=256
         ),
-        "audio": partial(
-            random_audio, rng, min_len=512 * 16000, max_len=1024 * 16000, sr=16000
-        ),
+        "audio": partial(random_audio, rng, min_len=512, max_len=1024, sr=16000),
         "vision_chunk": partial(
             random_vision_chunk, rng, min_wh=128, max_wh=256, min_frames=1, max_frames=1
         ),

--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -108,6 +108,7 @@ _ADD_SPECIAL_TOKENS_OVERRIDES = {
     "paligemma": False,
     "ultravox": False,
     "whisper": False,
+    "lfm2_vl": False,
 }
 
 _IGNORE_MM_KEYS = {
@@ -313,7 +314,7 @@ def _test_processing_correctness(
     input_to_hit = {
         "image": Image.new("RGB", size=(128, 128)),
         "video": np.zeros((4, 128, 128, 3), dtype=np.uint8),
-        "audio": (np.zeros((512,)), 16000),
+        "audio": (np.ones((512 * 16000,)), 16000),
         "vision_chunk": {"type": "image", "image": Image.new("RGB", size=(128, 128))},
     }
     input_factory = {
@@ -321,7 +322,9 @@ def _test_processing_correctness(
         "video": partial(
             random_video, rng, min_frames=2, max_frames=16, min_wh=128, max_wh=256
         ),
-        "audio": partial(random_audio, rng, min_len=512, max_len=1024, sr=16000),
+        "audio": partial(
+            random_audio, rng, min_len=512 * 16000, max_len=1024 * 16000, sr=16000
+        ),
         "vision_chunk": partial(
             random_vision_chunk, rng, min_wh=128, max_wh=256, min_frames=1, max_frames=1
         ),

--- a/vllm/model_executor/models/glmasr.py
+++ b/vllm/model_executor/models/glmasr.py
@@ -807,9 +807,9 @@ class GlmAsrMultiModalProcessor(BaseMultiModalProcessor["GlmAsrProcessingInfo"])
 
         # Postprocess: rename mask and add chunk counts
         # Handle different key names from different transformers versions
-        if "input_feature_mask" in outputs:
-            outputs["feature_attention_mask"] = outputs.pop("input_feature_mask")
-        elif "feature_attention_mask" not in outputs and "input_features" in outputs:
+        if "input_features_mask" in outputs:
+            outputs["feature_attention_mask"] = outputs.pop("input_features_mask")
+        elif "input_features_mask" not in outputs and "input_features" in outputs:
             # If no mask is provided, create one from input_features
             input_features = outputs["input_features"]
             if isinstance(input_features, torch.Tensor):

--- a/vllm/model_executor/models/glmasr_utils.py
+++ b/vllm/model_executor/models/glmasr_utils.py
@@ -18,8 +18,8 @@ def _calculate_conv_output_length(
     input_length: torch.Tensor, padding: int, kernel_size: int, stride: int
 ) -> torch.Tensor:
     """Calculate Conv1d output length using standard formula."""
-    # Standard formula: floor((input + 2*padding - kernel_size) / stride) + 1
-    return (input_length + 2 * padding - kernel_size) // stride + 1
+    # in sync with `hf_processor._get_audio_token_length`
+    return (input_length + 2 * padding - (kernel_size - 1) - 1) // stride + 1
 
 
 def _as_list_chunk_counts(

--- a/vllm/model_executor/models/lfm2_vl.py
+++ b/vllm/model_executor/models/lfm2_vl.py
@@ -346,7 +346,9 @@ class Lfm2VLMultiModalProcessor(BaseMultiModalProcessor[Lfm2VLProcessingInfo]):
     ) -> BatchFeature:
         # Text-only input not supported in composite processor
         if not (images := mm_data.get("images", [])):
-            prompt_ids = self.info.get_tokenizer().encode(prompt)
+            prompt_ids = self.info.get_tokenizer().encode(
+                prompt, add_special_tokens=False
+            )
             prompt_ids = self._apply_hf_processor_tokens_only(prompt_ids)
             return BatchFeature(dict(input_ids=[prompt_ids]), tensor_type="pt")
 

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -1463,15 +1463,15 @@ class Tarsier2ImageProcessor(Qwen2VLImageProcessor):
 class Tarsier2Processor(Qwen2VLProcessor):
     def __init__(
         self,
-        vision_config: dict,
+        image_processor: Tarsier2ImageProcessor,
         tokenizer: TokenizerLike,
+        video_processor: Qwen2VLVideoProcessor,
         **kwargs,
     ):
-        self.image_processor = Tarsier2ImageProcessor(**vision_config)
         super().__init__(
-            image_processor=self.image_processor,
+            image_processor=image_processor,
             tokenizer=tokenizer,
-            video_processor=Qwen2VLVideoProcessor(**vision_config),
+            video_processor=video_processor,
             chat_template=None,
             **kwargs,
         )
@@ -1485,8 +1485,12 @@ class Tarsier2ProcessingInfo(Qwen2VLProcessingInfo):
         return correct_config
 
     def get_hf_processor(self, **kwargs: object) -> Tarsier2Processor:
+        vision_config = self.ctx.get_hf_image_processor_config()
+        image_processor = Tarsier2ImageProcessor(**vision_config)
+        video_processor = Qwen2VLVideoProcessor(**vision_config)
         return Tarsier2Processor(
-            vision_config=self.ctx.get_hf_image_processor_config(),
+            image_processor=image_processor,
+            video_processor=video_processor,
             tokenizer=self.get_tokenizer(),
             **kwargs,
         )


### PR DESCRIPTION
There's also idefics test failing `tests/models/multimodal/processing/test_idefics3.py::test_processor_override[False-1-mm_processor_kwargs1-845-HuggingFaceM4/Idefics3-8B-Llama3]`

I see the root issue in `Idefics3Processor._get_prompt_updates` which creates a processor but doesn't use provided `kwargs`.  The kwargs get filtered out due to `cached_get_processor_without_dynamic_kwargs` and the number of placeholder is calculated incorrectly. It can be fixed by reverting https://github.com/vllm-project/vllm/pull/26483 but I don't think it's the right way. Please let me know how this is better fixed