### PR TITLE
[Bugfix] Fix kv_load_failure_recovery example in sync mode

### DIFF
--- a/examples/offline_inference/kv_load_failure_recovery/decode_example.py
+++ b/examples/offline_inference/kv_load_failure_recovery/decode_example.py
@@ -65,6 +65,7 @@ def main():
         max_num_batched_tokens=64,
         max_num_seqs=16,
         kv_transfer_config=ktc,
+        async_scheduling=args.async_load,
     )
 
     outputs = llm.generate(prompts, sampling_params)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix the kv_load_failure_recovery example to work correctly in sync mode. When async_scheduling is not explicitly set, vLLM automatically enables async scheduling by default (unless incompatible configurations are detected). However, async scheduling is incompatible with the sync mode of kv_load_failure_recovery, causing the example to fail.

### Changes

Explicitly set async_scheduling=False in sync mode to prevent automatic async scheduling activation.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

