### PR TITLE
Make has_triton_kernels() handle import failures gracefully

### DIFF
--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -423,7 +423,10 @@ def has_triton_kernels() -> bool:
         "vllm.third_party.triton_kernels"
     )
     if is_available:
-        import_triton_kernels()
+        try:
+            import_triton_kernels()
+        except (ImportError, ModuleNotFoundError):
+            return False
     return is_available
 
 


### PR DESCRIPTION
Summary:
`has_triton_kernels()` uses `find_spec()` to check if the `triton_kernels` package exists, then eagerly calls `import_triton_kernels()`. On MTIA, the package is findable (it exists in the build) but fails to import because it depends on GPU-specific Triton modules like `triton.language.target_info` that don't exist in MTIA Triton. This causes a crash instead of the function returning `False`.

The fix wraps the `import_triton_kernels()` call in a try/except so the function correctly reports unavailability when the import fails.

This is required because MTIA-specific code imports `fused_moe`, which calls `has_triton_kernels()` at module scope in `fused_moe/config.py`:

```
platform.pre_register_and_update()
  → mtia_fp8_config.py: from vllm.model_executor.layers.fused_moe import FusedMoE
    → fused_moe/__init__.py
      → fused_moe/config.py line 28: if has_triton_kernels():
        → import_triton_kernels() → import triton_kernels → 💥
```

Applied to both trunk and media branches.

**Verification:** After this fix, the MTIA offline inference log shows no `triton_kernels` import errors. The `has_triton_kernels()` call in `fused_moe/config.py` returns `False` gracefully, and inference proceeds through model loading and execution without issues.

Test Plan: Ran MTIA inference and confirmed no import errors from `has_triton_kernels()`. The function correctly returns `False` on MTIA, and `fused_moe/config.py` skips the `triton_kernels` code path.

Differential Revision: D92963383


