### PR TITLE
[Frontend] Add automatic language detection for Whisper transcription

### DIFF
--- a/tests/entrypoints/openai/test_transcription_validation_whisper.py
+++ b/tests/entrypoints/openai/test_transcription_validation_whisper.py
@@ -15,7 +15,7 @@ import soundfile as sf
 
 from ...utils import RemoteOpenAIServer
 
-MODEL_NAME = "openai/whisper-large-v3"
+MODEL_NAME = "openai/whisper-large-v3-turbo"
 
 
 @pytest.fixture(scope="module")
@@ -297,6 +297,6 @@ async def test_language_auto_detect(
     )
     assert transcription.language == expected_lang
     text_lower = transcription.text.lower()
-    assert any(word in text_lower for word in expected_text), (
+    assert any(word.lower() in text_lower for word in expected_text), (
         f"Expected {expected_lang} text but got: {transcription.text}"
     )

--- a/tests/entrypoints/openai/test_transcription_validation_whisper.py
+++ b/tests/entrypoints/openai/test_transcription_validation_whisper.py
@@ -273,3 +273,33 @@ async def test_audio_with_max_tokens(whisper_client, mary_had_lamb):
     out_text = out["text"]
     out_tokens = tok(out_text, add_special_tokens=False)["input_ids"]
     assert len(out_tokens) < 450  # ~Whisper max output len
+
+
+@pytest.mark.asyncio
+async def test_language_auto_detect_english(whisper_client, mary_had_lamb):
+    """Auto-detect language as English when no language param is provided."""
+    transcription = await whisper_client.audio.transcriptions.create(
+        model=MODEL_NAME,
+        file=mary_had_lamb,
+        response_format="verbose_json",
+        temperature=0.0,
+    )
+    assert transcription.language == "en"
+    assert "Mary had a little lamb" in transcription.text
+
+
+@pytest.mark.asyncio
+async def test_language_auto_detect_italian(whisper_client, foscolo):
+    """Auto-detect language as Italian for the Foscolo poem audio."""
+    transcription = await whisper_client.audio.transcriptions.create(
+        model=MODEL_NAME,
+        file=foscolo,
+        response_format="verbose_json",
+        temperature=0.0,
+    )
+    assert transcription.language == "it"
+    # Verify the text is actually Italian (from "A Zacinto" by Foscolo)
+    text_lower = transcription.text.lower()
+    assert any(word in text_lower for word in ["zacinto", "sacre"]), (
+        f"Expected Italian text but got: {transcription.text}"
+    )

--- a/tests/entrypoints/openai/test_transcription_validation_whisper.py
+++ b/tests/entrypoints/openai/test_transcription_validation_whisper.py
@@ -15,7 +15,7 @@ import soundfile as sf
 
 from ...utils import RemoteOpenAIServer
 
-MODEL_NAME = "openai/whisper-large-v3-turbo"
+MODEL_NAME = "openai/whisper-large-v3"
 
 
 @pytest.fixture(scope="module")

--- a/tests/models/multimodal/generation/test_whisper.py
+++ b/tests/models/multimodal/generation/test_whisper.py
@@ -140,15 +140,16 @@ def test_parse_language_detection_output():
     )
 
     # Unsupported language code
-    assert (
-        cls.parse_language_detection_output([99999], make_tokenizer("<|xx|>")) is None
-    )
+    with pytest.raises(AssertionError):
+        cls.parse_language_detection_output([99999], make_tokenizer("<|xx|>"))
 
     # No special token format
-    assert cls.parse_language_detection_output([1], make_tokenizer("hello")) is None
+    with pytest.raises(AssertionError):
+        cls.parse_language_detection_output([1], make_tokenizer("hello"))
 
     # Empty token_ids
-    assert cls.parse_language_detection_output([], make_tokenizer("anything")) is None
+    with pytest.raises((AssertionError, IndexError)):
+        cls.parse_language_detection_output([], make_tokenizer("anything"))
 
 
 @pytest.mark.core_model

--- a/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
@@ -241,6 +241,67 @@ class OpenAISpeechToText(OpenAIServing):
 
         model_cls = get_model_cls(self.model_config)
         return cast(type[SupportsTranscription], model_cls)
+    
+    async def _detect_language(
+        self,
+        audio_chunk: np.ndarray,
+        request_id: str = "lang-detect",
+    ) -> str:
+        """Auto-detect the spoken language from an audio chunk.
+
+        Delegates prompt construction and output parsing to the model class
+        via ``get_language_detection_prompt`` and
+        ``parse_language_detection_output``.  Falls back to ``"en"`` on any
+        failure.
+        """
+        try:
+            from vllm.sampling_params import SamplingParams
+
+            prompt = self.model_cls.get_language_detection_prompt(
+                audio_chunk,
+                self.asr_config,
+            )
+            sampling_params = SamplingParams(
+                max_tokens=1,
+                temperature=0.0,
+            )
+
+            result_generator = self.engine_client.generate(
+                prompt,
+                sampling_params,
+                request_id,
+            )
+
+            final_output: RequestOutput | None = None
+            async for output in result_generator:
+                final_output = output
+
+            if (
+                final_output is None
+                or not final_output.outputs
+                or not final_output.outputs[0].token_ids
+            ):
+                logger.warning(
+                    "Language detection produced no output, defaulting to 'en'"
+                )
+                return "en"
+
+            token_ids = list(final_output.outputs[0].token_ids)
+            lang = self.model_cls.parse_language_detection_output(
+                token_ids,
+                self.tokenizer,
+            )
+            if lang is not None:
+                logger.info("Auto-detected language: '%s'", lang)
+                return lang
+
+            logger.warning(
+                "Could not determine language from model output, defaulting to 'en'"
+            )
+            return "en"
+        except Exception:
+            logger.exception("Language detection failed, defaulting to 'en'")
+            return "en"
 
     async def _preprocess_speech_to_text(
         self,
@@ -274,6 +335,13 @@ class OpenAISpeechToText(OpenAIServing):
             and duration > self.asr_config.max_audio_clip_s
         )
         chunks = [y] if not do_split_audio else self._split_audio(y, int(sr))
+
+        if language is None and hasattr(
+            self.model_cls, "get_language_detection_prompt"
+        ):
+            language = await self._detect_language(chunks[0])
+            request.language = language
+
         parsed_prompts: list[DictPrompt] = []
         for chunk in chunks:
             # The model has control over the construction, as long as it

--- a/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
@@ -264,9 +264,13 @@ class OpenAISpeechToText(OpenAIServing):
                 audio_chunk,
                 self.asr_config,
             )
+            allowed_token_ids = self.model_cls.get_language_token_ids(
+                self.tokenizer,
+            )
             sampling_params = SamplingParams(
                 max_tokens=1,
                 temperature=0.0,
+                allowed_token_ids=allowed_token_ids,
             )
 
             result_generator = self.engine_client.generate(

--- a/vllm/model_executor/models/__init__.py
+++ b/vllm/model_executor/models/__init__.py
@@ -3,6 +3,7 @@
 
 from .interfaces import (
     HasInnerState,
+    SupportsExplicitLanguageDetection,
     SupportsLoRA,
     SupportsMRoPE,
     SupportsMultiModal,
@@ -40,5 +41,6 @@ __all__ = [
     "SupportsPP",
     "supports_pp",
     "SupportsTranscription",
+    "SupportsExplicitLanguageDetection",
     "supports_transcription",
 ]

--- a/vllm/model_executor/models/__init__.py
+++ b/vllm/model_executor/models/__init__.py
@@ -3,7 +3,6 @@
 
 from .interfaces import (
     HasInnerState,
-    SupportsExplicitLanguageDetection,
     SupportsLoRA,
     SupportsMRoPE,
     SupportsMultiModal,
@@ -41,6 +40,5 @@ __all__ = [
     "SupportsPP",
     "supports_pp",
     "SupportsTranscription",
-    "SupportsExplicitLanguageDetection",
     "supports_transcription",
 ]

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1230,7 +1230,7 @@ class SupportsTranscription(Protocol):
         cls,
         token_ids: list[int],
         tokenizer: object,
-    ) -> str | None:
+    ) -> str:
         """Parse the detected language from model output token IDs.
 
         Only needs to be implemented when

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1113,7 +1113,8 @@ class SupportsTranscription(Protocol):
     (e.g. Whisper needs a separate forward pass to predict the language
     token) should set this to ``True`` and implement
     :meth:`get_language_detection_prompt` and
-    :meth:`parse_language_detection_output`.
+    :meth:`parse_language_detection_output` and
+    :meth:`get_language_token_ids`.
     """
 
     def __init_subclass__(cls, **kwargs):
@@ -1231,6 +1232,20 @@ class SupportsTranscription(Protocol):
         tokenizer: object,
     ) -> str | None:
         """Parse the detected language from model output token IDs.
+
+        Only needs to be implemented when
+        ``supports_explicit_language_detection`` is ``True``.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def get_language_token_ids(
+        cls,
+        tokenizer: object,
+    ) -> list[int] | None:
+        """Return token IDs that represent valid language tokens.
+
+        Used to constrain language detection to only produce valid language tokens.
 
         Only needs to be implemented when
         ``supports_explicit_language_detection`` is ``True``.

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1203,6 +1203,27 @@ class SupportsTranscription(Protocol):
         return text
 
 
+@runtime_checkable
+class SupportsExplicitLanguageDetection(Protocol):
+    """Optional capability for transcription models that require an explicit
+    language detection step (e.g. Whisper needs a separate forward pass to
+    predict the language token)."""
+
+    @classmethod
+    def get_language_detection_prompt(
+        cls,
+        audio: np.ndarray,
+        stt_config: SpeechToTextConfig,
+    ) -> PromptType: ...
+
+    @classmethod
+    def parse_language_detection_output(
+        cls,
+        token_ids: list[int],
+        tokenizer: object,
+    ) -> str | None: ...
+
+
 @overload
 def supports_transcription(
     model: type[object],

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -814,7 +814,7 @@ class WhisperForConditionalGeneration(
     @classmethod
     def validate_language(cls, language: str | None) -> str | None:
         if language is None:
-            logger.info(
+            logger.debug(
                 "No language specified. Language will be auto-detected "
                 "from audio. To skip detection, pass the `language` field "
                 "in the TranscriptionRequest."

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -894,28 +894,18 @@ class WhisperForConditionalGeneration(
         """Parse the language token predicted by Whisper.
 
         Decodes the first token ID and extracts the language code from the
-        ``<|xx|>`` format.  Returns ``None`` if the token cannot be parsed
-        or the language is not in :attr:`supported_languages`.
+        ``<|xx|>`` format. Expects a valid language token from constrained generation.
         """
-        if not token_ids:
-            return None
 
         decoded = tokenizer.decode(
             [token_ids[0]],
             skip_special_tokens=False,
         )
         # Whisper language tokens have the form <|xx|>
-        if decoded.startswith("<|") and decoded.endswith("|>"):
-            lang_code = decoded[2:-2]
-            if lang_code in cls.supported_languages:
-                return lang_code
-            logger.warning(
-                "Detected language token '%s' not in supported languages", decoded
-            )
-            return None
-
-        logger.warning("Unexpected language token format: '%s'", decoded)
-        return None
+        assert decoded.startswith("<|") and decoded.endswith("|>")
+        lang_code = decoded[2:-2]
+        assert lang_code in cls.supported_languages
+        return lang_code
 
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -66,7 +66,6 @@ from vllm.v1.attention.backend import (
 
 from .interfaces import (
     MultiModalEmbeddings,
-    SupportsExplicitLanguageDetection,
     SupportsMultiModal,
     SupportsTranscription,
 )
@@ -792,7 +791,6 @@ class WhisperForConditionalGeneration(
     nn.Module,
     SupportsTranscription,
     SupportsMultiModal,
-    SupportsExplicitLanguageDetection,
 ):
     packed_modules_mapping = {
         "self_attn.qkv_proj": [
@@ -810,6 +808,7 @@ class WhisperForConditionalGeneration(
     # Whisper only supports audio-conditioned generation.
     supports_transcription_only = True
     supports_segment_timestamp = True
+    supports_explicit_language_detection = True
     supported_languages = ISO639_1_SUPPORTED_LANGS
 
     @classmethod

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -64,7 +64,12 @@ from vllm.v1.attention.backend import (
     AttentionType,
 )
 
-from .interfaces import MultiModalEmbeddings, SupportsMultiModal, SupportsTranscription
+from .interfaces import (
+    MultiModalEmbeddings,
+    SupportsExplicitLanguageDetection,
+    SupportsMultiModal,
+    SupportsTranscription,
+)
 from .utils import (
     AutoWeightsLoader,
     WeightsMapper,
@@ -784,7 +789,10 @@ class WhisperMultiModalProcessor(EncDecMultiModalProcessor[WhisperProcessingInfo
     dummy_inputs=WhisperDummyInputsBuilder,
 )
 class WhisperForConditionalGeneration(
-    nn.Module, SupportsTranscription, SupportsMultiModal
+    nn.Module,
+    SupportsTranscription,
+    SupportsMultiModal,
+    SupportsExplicitLanguageDetection,
 ):
     packed_modules_mapping = {
         "self_attn.qkv_proj": [

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -851,6 +851,22 @@ class WhisperForConditionalGeneration(
         )
 
     @classmethod
+    def get_language_token_ids(
+        cls,
+        tokenizer: object,
+    ) -> list[int]:
+        """Return token IDs for all supported language tokens.
+
+        Used with ``SamplingParams.allowed_token_ids`` to constrain
+        language detection to only produce valid language tokens.
+        """
+        token_ids = [
+            tokenizer.convert_tokens_to_ids(f"<|{lang_code}|>")
+            for lang_code in cls.supported_languages
+        ]
+        return token_ids
+
+    @classmethod
     def get_language_detection_prompt(
         cls,
         audio: np.ndarray,


### PR DESCRIPTION
adds feature from #14174, #25750

## Purpose
Add automatic language detection for Whisper transcription when no `language` parameter is specified.                                                                                                                                       
                                                            
  - Whisper auto-detects the spoken language by running a single-token generation with `<|startoftranscript|>` as the decoder prompt and parsing the predicted language token (e.g. `<|de|>`)                                                 
  - Falls back to `"en"` if detection fails or produces an unrecognized token
  - To implement the functionality a new class `SupportsExplicitLanguageDetection` is addet, which is implemented by whisper to get the language detection prompt and parse it                                                                                                                                                               
  - The entrypoint orchestrator (`_detect_language`) is model-agnostic and is only called `if language is None and isinstance(self.model_cls, SupportsExplicitLanguageDetection)` and delegates prompt construction + output parsing to the model class, so other STT models (e.g. Voxtral) are unaffected and future models can implement their own explicit detection strategy if needed
  - Language detection adds only ~30ms overhead regardless of audio length (only the first 30s chunk is used), measured on an RTX 4090
## Test Plan
 ```bash
  # Unit test (no GPU)
  pytest tests/models/multimodal/generation/test_whisper.py::test_parse_language_detection_output -v

  # Integration tests (GPU)
  pytest tests/entrypoints/openai/test_transcription_validation_whisper.py -v
```
## Test Result
I ran the three tests and all passed:
~~~
tests/models/multimodal/generation/test_whisper.py::test_parse_language_detection_output PASSED

tests/entrypoints/openai/test_transcription_validation_whisper.py::test_basic_audio PASSED                                                                                                                                                          [  7%]
tests/entrypoints/openai/test_transcription_validation_whisper.py::test_basic_audio_batched PASSED                                                                                                                                                  [ 15%]
tests/entrypoints/openai/test_transcription_validation_whisper.py::test_bad_requests PASSED                                                                                                                                                         [ 23%]
tests/entrypoints/openai/test_transcription_validation_whisper.py::test_long_audio_request PASSED                                                                                                                                                   [ 30%]
tests/entrypoints/openai/test_transcription_validation_whisper.py::test_completion_endpoints PASSED                                                                                                                                                 [ 38%]
tests/entrypoints/openai/test_transcription_validation_whisper.py::test_streaming_response PASSED                                                                                                                                                   [ 46%]
tests/entrypoints/openai/test_transcription_validation_whisper.py::test_stream_options PASSED                                                                                                                                                       [ 53%]
tests/entrypoints/openai/test_transcription_validation_whisper.py::test_sampling_params PASSED                                                                                                                                                      [ 61%]
tests/entrypoints/openai/test_transcription_validation_whisper.py::test_audio_prompt PASSED                                                                                                                                                         [ 69%]
tests/entrypoints/openai/test_transcription_validation_whisper.py::test_audio_with_timestamp PASSED                                                                                                                                                 [ 76%]
tests/entrypoints/openai/test_transcription_validation_whisper.py::test_audio_with_max_tokens PASSED                                                                                                                                                [ 84%]
tests/entrypoints/openai/test_transcription_validation_whisper.py::test_language_auto_detect_english PASSED                                                                                                                                         [ 92%]
tests/entrypoints/openai/test_transcription_validation_whisper.py::test_language_auto_detect_italian PASSED                                                                                                                                         [100%]
~~~

In regards to language detection duration I build vlllm and ran each command 5 times with my own audio files and took the difference of the averages:
~~~
time curl http://localhost:8000/v1/audio/transcriptions -F "file=@rec.wav" -F "language=de"
time curl http://localhost:8000/v1/audio/transcriptions -F "file=@rec.wav"
~~~
With a 16 second German audio file this results in 325ms-294ms=31ms of difference for language detection (on my 4090).