### PR TITLE
[ROCm] [CI] fix test_unrecognized_env

### DIFF
--- a/tests/config/test_config_generation.py
+++ b/tests/config/test_config_generation.py
@@ -81,8 +81,14 @@ def test_ray_runtime_env(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_unrecognized_env(monkeypatch):
-    # Remove any existing VLLM env vars that might interfere
-    monkeypatch.delenv("VLLM_TEST_GROUP_NAME", raising=False)
+    import os
+
+    from vllm.envs import environment_variables
+
+    # Remove any existing unrecognized VLLM env vars that might interfere
+    for env in list(os.environ):
+        if env.startswith("VLLM_") and env not in environment_variables:
+            monkeypatch.delenv(env, raising=False)
 
     # Test that if fail_on_environ_validation is True, then an error
     # is raised when an unrecognized vLLM environment variable is set

--- a/tests/config/test_config_generation.py
+++ b/tests/config/test_config_generation.py
@@ -80,12 +80,13 @@ def test_ray_runtime_env(monkeypatch: pytest.MonkeyPatch):
     ray.shutdown()
 
 
-def test_unrecognized_env():
-    import os
+def test_unrecognized_env(monkeypatch):
+    # Remove any existing VLLM env vars that might interfere
+    monkeypatch.delenv("VLLM_TEST_GROUP_NAME", raising=False)
 
     # Test that if fail_on_environ_validation is True, then an error
     # is raised when an unrecognized vLLM environment variable is set
-    os.environ["VLLM_UNRECOGNIZED_ENV_VAR"] = "some_value"
+    monkeypatch.setenv("VLLM_UNRECOGNIZED_ENV_VAR", "some_value")
     engine_args = EngineArgs(
         fail_on_environ_validation=True,
     )
@@ -97,7 +98,7 @@ def test_unrecognized_env():
     engine_args.create_engine_config()
 
     # Test that when the unrecognized env var is removed, no error is raised
-    os.environ.pop("VLLM_UNRECOGNIZED_ENV_VAR", None)
+    monkeypatch.delenv("VLLM_UNRECOGNIZED_ENV_VAR")
     engine_args = EngineArgs(
         fail_on_environ_validation=True,
     )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix https://buildkite.com/vllm/amd-ci/builds/4609/steps/canvas?sid=019c4d1a-4084-4c15-b40f-c0ef00b0ffd7&tab=output

```
<html>
<body>
<!--StartFragment-->
def validate_environ(hard_fail: bool) -> None:
--
for env in os.environ:
if env.startswith("VLLM_") and env not in environment_variables:
if hard_fail:
>                   raise ValueError(f"Unknown vLLM environment variable detected: {env}")
E                   ValueError: Unknown vLLM environment variable detected: VLLM_TEST_GROUP_NAME
 
/usr/local/lib/python3.12/dist-packages/vllm/envs.py:1623: ValueError
=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
<frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
 
<frozen importlib._bootstrap>:488
<frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
 
../../usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305
/usr/local/lib/python3.12/dist-packages/schemathesis/generation/coverage.py:305: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
ref_error: type[Exception] = jsonschema.RefResolutionError,
 
tests/config/test_config_generation.py::test_ray_runtime_env
/usr/local/lib/python3.12/dist-packages/ray/_private/worker.py:2046: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
warnings.warn(
 
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED config/test_config_generation.py::test_unrecognized_env - ValueError: ...
============= 1 failed, 48 passed, 4 warnings in 189.02s (0:03:09) =============
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

<!--EndFragment-->
</body>
</html>
```

This is introduced by the `VLLM_TEST_GROUP_NAME=mi325_1-async-engine--inputs--utils--worker--config-test-cpu` env in AMD CI.

```
BUILDKITE_COMMAND="bash .buildkite/scripts/hardware_ci/run-amd-test.sh \"(command rocm-smi || true) && export VLLM_TEST_GROUP_NAME=mi325_1-async-engine--inputs--utils--worker--config-test-cpu && export VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1 && cd /vllm-workspace/tests ; python3 standalone_tests/lazy_imports.py && pytest -v -s test_inputs.py && pytest -v -s test_outputs.py && pytest -v -s test_pooling_params.py && pytest -v -s -m 'cpu_test' multimodal && pytest -v -s renderers && pytest -v -s tokenizers_ && pytest -v -s tool_parsers && pytest -v -s transformers_utils && pytest -v -s config\""
```

## Test Plan

`VLLM_TEST_GROUP_NAME=mi325_1-async-engine--inputs--utils--worker--config-test-cpu pytest -s -v tests/config/test_config_generation.py::test_unrecognized_env`

## Test Result

```
# VLLM_TEST_GROUP_NAME=12312 pytest -s -v tests/config/test_config_generation.py::test_unrecognized_env
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /app/reviewpr3/fusionpasscionly
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.12.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                                                                            

tests/config/test_config_generation.py::test_unrecognized_env WARNING 02-11 15:40:34 [envs.py:1625] Unknown vLLM environment variable detected: VLLM_UNRECOGNIZED_ENV_VAR
WARNING 02-11 15:40:42 [gpt_oss_triton_kernels_moe.py:54] Using legacy triton_kernels on ROCm
INFO 02-11 15:40:42 [model.py:531] Resolved architecture: Qwen3ForCausalLM
INFO 02-11 15:40:42 [model.py:1555] Using max model len 40960
INFO 02-11 15:40:43 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 02-11 15:40:43 [vllm.py:698] Asynchronous scheduling is enabled.
INFO 02-11 15:40:43 [model.py:531] Resolved architecture: Qwen3ForCausalLM
INFO 02-11 15:40:43 [model.py:1555] Using max model len 40960
INFO 02-11 15:40:44 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=2048.
PASSED

===================================================================================== warnings summary ======================================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================== 1 passed, 2 warnings in 9.82s ===============================================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

