### PR TITLE
Don't try and run GLM-ASR with remote code

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -725,7 +725,6 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     "Gemma3nForConditionalGeneration": _HfExamplesInfo("google/gemma-3n-E2B-it"),
     "GlmAsrForConditionalGeneration": _HfExamplesInfo(
         "zai-org/GLM-ASR-Nano-2512",
-        trust_remote_code=True,
         min_transformers_version="5.0.0",
     ),
     "GraniteVision": _HfExamplesInfo("ibm-granite/granite-vision-3.3-2b"),


### PR DESCRIPTION
GLM-ASR has been upstreamed to Transformers in https://github.com/huggingface/transformers/commit/a7f29523361b2cc12e51c1f5133d95f122f6f45c which was first released in `v5.0.0rc2`.

Therefore we should remove this kwarg from our test. (The test will not actually run in this PR because it's still gated on Transformesr v5)