### PR TITLE
fix: return HTTP 413 when request exceeds max context length

### DIFF
--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -652,8 +652,12 @@ class OpenAIServing:
             from vllm.exceptions import VLLMValidationError
 
             if isinstance(exc, VLLMValidationError):
-                err_type = "BadRequestError"
-                status_code = HTTPStatus.BAD_REQUEST
+                status_code = exc.http_status or HTTPStatus.BAD_REQUEST
+                err_type = (
+                    "PayloadTooLarge"
+                    if status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+                    else "BadRequestError"
+                )
                 param = exc.parameter
             elif isinstance(exc, (ValueError, TypeError, RuntimeError, OverflowError)):
                 # Common validation errors from user input
@@ -878,6 +882,7 @@ class OpenAIServing:
                     f"Please reduce the length of the input.",
                     parameter="input_tokens",
                     value=token_num,
+                    http_status=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
                 )
             return TokensPrompt(prompt=input_text, prompt_token_ids=input_ids)
 
@@ -906,6 +911,7 @@ class OpenAIServing:
                 "the input messages.",
                 parameter="input_tokens",
                 value=token_num,
+                http_status=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
             )
 
         if max_tokens is not None and token_num + max_tokens > self.max_model_len:
@@ -917,6 +923,7 @@ class OpenAIServing:
                 f" - {token_num}).",
                 parameter="max_tokens",
                 value=max_tokens,
+                http_status=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
             )
 
         return TokensPrompt(prompt=input_text, prompt_token_ids=input_ids)

--- a/vllm/exceptions.py
+++ b/vllm/exceptions.py
@@ -3,6 +3,7 @@
 
 """Custom exceptions for vLLM."""
 
+from http import HTTPStatus
 from typing import Any
 
 
@@ -13,6 +14,7 @@ class VLLMValidationError(ValueError):
         message: The error message describing the validation failure.
         parameter: Optional parameter name that failed validation.
         value: Optional value that was rejected during validation.
+        http_status: Optional HTTP status code to return (default: 400).
     """
 
     def __init__(
@@ -21,10 +23,12 @@ class VLLMValidationError(ValueError):
         *,
         parameter: str | None = None,
         value: Any = None,
+        http_status: HTTPStatus | None = None,
     ) -> None:
         super().__init__(message)
         self.parameter = parameter
         self.value = value
+        self.http_status = http_status
 
     def __str__(self):
         base = super().__str__()

--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from dataclasses import dataclass, field
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from vllm.entrypoints.chat_utils import ChatTemplateContentFormatOption
@@ -147,6 +148,7 @@ class TokenizeParams:
                 f"Please request fewer output tokens.",
                 parameter=self.max_output_tokens_param,
                 value=max_output_tokens,
+                http_status=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
             )
 
         if (
@@ -161,6 +163,7 @@ class TokenizeParams:
                 f"Please request a smaller truncation size.",
                 parameter=self.truncate_prompt_tokens_param,
                 value=truncate_prompt_tokens,
+                http_status=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
             )
 
     def with_kwargs(self, tokenization_kwargs: dict[str, Any] | None):
@@ -262,6 +265,7 @@ class TokenizeParams:
                     f"Please reduce the length of the input prompt.",
                     parameter="input_text",
                     value=len(text),
+                    http_status=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
                 )
 
         return text
@@ -343,6 +347,7 @@ class TokenizeParams:
                 f"Please reduce the length of the input prompt.",
                 parameter="input_tokens",
                 value=len(tokens),
+                http_status=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
             )
 
         return tokens

--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -148,7 +148,6 @@ class TokenizeParams:
                 f"Please request fewer output tokens.",
                 parameter=self.max_output_tokens_param,
                 value=max_output_tokens,
-                http_status=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
             )
 
         if (
@@ -163,7 +162,6 @@ class TokenizeParams:
                 f"Please request a smaller truncation size.",
                 parameter=self.truncate_prompt_tokens_param,
                 value=truncate_prompt_tokens,
-                http_status=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
             )
 
     def with_kwargs(self, tokenization_kwargs: dict[str, Any] | None):


### PR DESCRIPTION
## Summary

Fixes #34340

Returns HTTP 413 (Request Entity Too Large) instead of 400 (Bad Request) when a request exceeds the model's maximum context length.

## Changes

- Add optional `http_status` field to `VLLMValidationError` exception class
- Return 413 when input tokens exceed `max_model_len`  
- Return 413 when `max_tokens + input_tokens` exceed `max_model_len`
- Update error type to `PayloadTooLarge` for 413 responses

## Rationale

According to [HTTP standards](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/413):
- **400 Bad Request**: Indicates malformed request syntax, invalid framing, or deceptive routing
- **413 Request Entity Too Large**: Indicates the request payload exceeds server-defined limits

Since exceeding `max_tokens` is about payload size limits rather than malformed syntax, 413 is the semantically correct status code.

## Testing

The change is backward-compatible:
- `VLLMValidationError` defaults to 400 if `http_status` is not specified
- Only the two specific "too large" validation errors return 413