### PR TITLE
[BugFix] Skip null blocks when adding cached blocks in current step

### DIFF
--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1000,6 +1000,8 @@ class MambaManager(SingleTypeKVCacheManager):
             for block in self.req_to_blocks[request.request_id][
                 num_cached_blocks_before:num_cached_blocks_after
             ]:
+                if block.is_null:
+                    continue
                 assert block.block_hash is not None
                 self.cached_blocks_this_step.add(block.block_hash)
 


### PR DESCRIPTION
## Purpose
PR #29387 prevents Mamba layers from hitting the prefix cache within the same schedule step by recording the block hash in `MambaManager.cache_blocks()`. Currently, the logic includes an assertion `assert block.block_hash is not None` to ensure every block has a hash.

However, this does not account for Mamba cache align mode, where the `req_to_blocks` may contain null-blocks. Since null-blocks are not bound to a hash values, this causes the assertion to fail. 

This PR resolves the issue by skipping the hash check for null-blocks.

## Test Plan
```python
from vllm import LLM, SamplingParams
from vllm.distributed import cleanup_dist_env_and_memory
import time

def main():
    MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct"  # gdn
    PROMPT_MULTIPLE = 310
    sampling_params = SamplingParams(temperature=0.0, max_tokens=128)
    prefix = ( # examples/offline_inference/prefix_caching.py
        "You are an expert school principal, skilled in effectively managing "
        "faculty and staff. Draft 10-15 questions for a potential first grade "
        "Head Teacher for my K-12, all-girls', independent school that emphasizes "
        "community, joyful discovery, and life-long learning. The candidate is "
        "coming in for a first-round panel interview for a 8th grade Math "
        "teaching role. They have 5 years of previous teaching experience "
        "as an assistant teacher at a co-ed, public school with experience "
        "in middle school math teaching. ")
    prefix2 = ("Based on these information, fulfill "
                "the following paragraph: ")
    prompt = PROMPT_MULTIPLE * prefix + prefix2 + "Hello, my name is"
    print('Prompt length:', len(prompt))
    for APC in [
        True
    ]:
        engine = LLM(
            model=MODEL, enable_prefix_caching=APC, 
            max_num_batched_tokens=8192,
            block_size=64,
            tensor_parallel_size=4,
            gpu_memory_utilization=0.8, 
            disable_log_stats=False,
            mamba_cache_mode="align",
        )
        for i in range(3):
            if i == 0:
                print('Warm-up')
            if i == 1:
                print('Measuring')
                start_time = time.time()
            outputs = engine.generate(prompt, sampling_params)
            print('APC:', APC, i, f"Generated text: {outputs[0].outputs[0].text!r}")
            for m in engine.llm_engine.get_metrics():
                if 'vllm:prefix_cache_hits' in m.name:
                    print(m.name, m.value)
        print('APC:', APC, "loop took --- %s seconds ---" % (time.time() - start_time))
        del engine
        cleanup_dist_env_and_memory()


if __name__ == "__main__":
    main()
```

## Test Result

Before fix:
```
INFO 02-12 15:54:27 [llm.py:355] Supported tasks: ['generate']
Warm-up

Adding requests:   0%|          | 0/1 [00:00<?, ?it/s]
Adding requests: 100%|██████████| 1/1 [00:00<00:00, 391.00it/s]

Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s](EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008] EngineCore encountered a fatal error.
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008] Traceback (most recent call last):
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]   File "/root/huanghy/vllm_opsrc/vllm/v1/engine/core.py", line 999, in run_engine_core
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]     engine_core.run_busy_loop()
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]   File "/root/huanghy/vllm_opsrc/vllm/v1/engine/core.py", line 1026, in run_busy_loop
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]     self._process_engine_step()
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]   File "/root/huanghy/vllm_opsrc/vllm/v1/engine/core.py", line 1060, in _process_engine_step
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]     outputs, model_executed = self.step_fn()
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]                               ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]   File "/root/huanghy/vllm_opsrc/vllm/v1/engine/core.py", line 404, in step
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]     scheduler_output = self.scheduler.schedule()
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]                        ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]   File "/root/huanghy/vllm_opsrc/vllm/v1/core/sched/scheduler.py", line 715, in schedule
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]     new_blocks = self.kv_cache_manager.allocate_slots(
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]   File "/root/huanghy/vllm_opsrc/vllm/v1/core/kv_cache_manager.py", line 374, in allocate_slots
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]     self.coordinator.cache_blocks(request, num_tokens_to_cache)
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]   File "/root/huanghy/vllm_opsrc/vllm/v1/core/kv_cache_coordinator.py", line 189, in cache_blocks
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]     manager.cache_blocks(request, num_computed_tokens)
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]   File "/root/huanghy/vllm_opsrc/vllm/v1/core/single_type_kv_cache_manager.py", line 1003, in cache_blocks
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]     assert block.block_hash is not None
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=2460640) ERROR 02-12 15:54:28 [core.py:1008] AssertionError
Traceback (most recent call last):
```

After fix:
```
INFO 02-12 15:51:17 [llm.py:355] Supported tasks: ['generate']
Warm-up

Adding requests:   0%|          | 0/1 [00:00<?, ?it/s]
Adding requests: 100%|██████████| 1/1 [00:00<00:00, 323.83it/s]

Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]
Processed prompts: 100%|██████████| 1/1 [00:05<00:00,  5.69s/it, est. speed input: 5672.79 toks/s, output: 22.51 toks/s]
Processed prompts: 100%|██████████| 1/1 [00:05<00:00,  5.69s/it, est. speed input: 5672.79 toks/s, output: 22.51 toks/s]
Processed prompts: 100%|██████████| 1/1 [00:05<00:00,  5.69s/it, est. speed input: 5672.79 toks/s, output: 22.51 toks/s]
APC: True 0 Generated text: " __________, and I am the Head of School at __________. I am thrilled to welcome you to our interview today. Our school is a K-12, all-girls', independent school that emphasizes community, joyful discovery, and lifelong learning. We believe that every girl has the potential to thrive when nurtured in an environment that values curiosity, collaboration, and courage. As we consider candidates for our 8th grade Math teaching role, we are looking for educators who not only have strong content knowledge and pedagogical skills, but who also embody our core values and are excited to contribute to a vibrant, girl-centered community."
vllm:prefix_cache_hits 0
Measuring

Adding requests:   0%|          | 0/1 [00:00<?, ?it/s]
Adding requests: 100%|██████████| 1/1 [00:00<00:00, 699.40it/s]

Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]
Processed prompts: 100%|██████████| 1/1 [00:01<00:00,  1.20s/it, est. speed input: 26981.28 toks/s, output: 107.07 toks/s]
Processed prompts: 100%|██████████| 1/1 [00:01<00:00,  1.20s/it, est. speed input: 26981.28 toks/s, output: 107.07 toks/s]
Processed prompts: 100%|██████████| 1/1 [00:01<00:00,  1.20s/it, est. speed input: 26981.28 toks/s, output: 107.07 toks/s]
APC: True 1 Generated text: " __________, and I am the Head of School at __________. I am thrilled to welcome you to our interview today. Our school is a K-12, all-girls', independent school that emphasizes community, joyful discovery, and lifelong learning. We believe that every girl has the potential to thrive when nurtured in an environment that values curiosity, collaboration, and courage. As we consider candidates for our 8th grade Math teaching role, we are looking for educators who not only have strong content knowledge and pedagogical skills, but who also embody our core values and are excited to contribute to a vibrant, girl-centered community."
vllm:prefix_cache_hits 32096

Adding requests:   0%|          | 0/1 [00:00<?, ?it/s]
Adding requests: 100%|██████████| 1/1 [00:00<00:00, 731.99it/s]

Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]
Processed prompts: 100%|██████████| 1/1 [00:01<00:00,  1.23s/it, est. speed input: 26177.12 toks/s, output: 103.88 toks/s]
Processed prompts: 100%|██████████| 1/1 [00:01<00:00,  1.23s/it, est. speed input: 26177.12 toks/s, output: 103.88 toks/s]
Processed prompts: 100%|██████████| 1/1 [00:01<00:00,  1.23s/it, est. speed input: 26177.12 toks/s, output: 103.88 toks/s]
(Worker_TP3 pid=2456133) INFO 02-12 15:51:25 [multiproc_executor.py:732] Parent process exited, terminating worker
(Worker_TP2 pid=2456132) INFO 02-12 15:51:25 [multiproc_executor.py:732] Parent process exited, terminating worker
(Worker_TP0 pid=2456130) INFO 02-12 15:51:25 [multiproc_executor.py:732] Parent process exited, terminating worker
(Worker_TP1 pid=2456131) INFO 02-12 15:51:25 [multiproc_executor.py:732] Parent process exited, terminating worker
(Worker_TP2 pid=2456132) INFO 02-12 15:51:25 [multiproc_executor.py:785] WorkerProc shutting down.
(Worker_TP0 pid=2456130) INFO 02-12 15:51:25 [multiproc_executor.py:785] WorkerProc shutting down.
(Worker_TP1 pid=2456131) INFO 02-12 15:51:25 [multiproc_executor.py:785] WorkerProc shutting down.
(Worker_TP3 pid=2456133) INFO 02-12 15:51:25 [multiproc_executor.py:785] WorkerProc shutting down.
APC: True 2 Generated text: " __________, and I am the Head of School at __________. I am thrilled to welcome you to our interview today. Our school is a K-12, all-girls', independent school that emphasizes community, joyful discovery, and lifelong learning. We believe that every girl has the potential to thrive when nurtured in an environment that values curiosity, collaboration, and courage. As we consider candidates for our 8th grade Math teaching role, we are looking for educators who not only have strong content knowledge and pedagogical skills, but who also embody our core values and are excited to contribute to a vibrant, girl-centered community."
vllm:prefix_cache_hits 64192
APC: True loop took --- 2.5559322834014893 seconds ---
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

