### PR TITLE
[Ray] Propagate third-party env vars to Ray workers via prefix matching

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -123,6 +123,7 @@ steps:
   - tests/test_inputs.py
   - tests/test_outputs.py
   - tests/test_pooling_params.py
+  - tests/test_ray_env.py
   - tests/multimodal
   - tests/renderers
   - tests/standalone_tests/lazy_imports.py
@@ -136,6 +137,7 @@ steps:
   - pytest -v -s test_inputs.py
   - pytest -v -s test_outputs.py
   - pytest -v -s test_pooling_params.py
+  - pytest -v -s test_ray_env.py
   - pytest -v -s -m 'cpu_test' multimodal
   - pytest -v -s renderers
   - pytest -v -s tokenizers_

--- a/tests/test_ray_env.py
+++ b/tests/test_ray_env.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for vllm.ray.ray_env — env var propagation to Ray workers."""
+
+import os
+from unittest.mock import patch
+
+from vllm.ray.ray_env import (
+    RAY_NON_CARRY_OVER_ENV_VARS,
+    get_env_vars_to_copy,
+)
+
+# ---------------------------------------------------------------------------
+# Default prefix matching
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultPrefixes:
+    """Built-in prefixes (VLLM_, LMCACHE_, NCCL_, UCX_, HF_, HUGGING_FACE_)
+    should be forwarded without any extra configuration."""
+
+    @patch.dict(os.environ, {"LMCACHE_LOCAL_CPU": "True"}, clear=False)
+    def test_lmcache_prefix(self):
+        result = get_env_vars_to_copy()
+        assert "LMCACHE_LOCAL_CPU" in result
+
+    @patch.dict(os.environ, {"NCCL_DEBUG": "INFO"}, clear=False)
+    def test_nccl_prefix(self):
+        result = get_env_vars_to_copy()
+        assert "NCCL_DEBUG" in result
+
+    @patch.dict(os.environ, {"UCX_TLS": "rc"}, clear=False)
+    def test_ucx_prefix(self):
+        result = get_env_vars_to_copy()
+        assert "UCX_TLS" in result
+
+    @patch.dict(os.environ, {"HF_TOKEN": "secret"}, clear=False)
+    def test_hf_token_via_prefix(self):
+        result = get_env_vars_to_copy()
+        assert "HF_TOKEN" in result
+
+    @patch.dict(os.environ, {"HUGGING_FACE_HUB_TOKEN": "secret"}, clear=False)
+    def test_hugging_face_prefix(self):
+        result = get_env_vars_to_copy()
+        assert "HUGGING_FACE_HUB_TOKEN" in result
+
+
+# ---------------------------------------------------------------------------
+# Default extra vars
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultExtraVars:
+    """Individual vars listed in VLLM_RAY_EXTRA_ENV_VARS_TO_COPY's default."""
+
+    def test_pythonhashseed_in_result(self):
+        """PYTHONHASHSEED should always be in the result set (as a name to
+        copy) regardless of whether it is actually set in os.environ."""
+        result = get_env_vars_to_copy()
+        assert "PYTHONHASHSEED" in result
+
+
+# ---------------------------------------------------------------------------
+# User-supplied extensions
+# ---------------------------------------------------------------------------
+
+
+class TestUserExtensions:
+    """Users can add prefixes and extra vars at deploy time."""
+
+    @patch.dict(
+        os.environ,
+        {
+            "VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY": "MYLIB_",
+            "MYLIB_FOO": "bar",
+        },
+        clear=False,
+    )
+    def test_user_prefix(self):
+        """User-supplied prefixes are additive — built-in defaults are kept."""
+        result = get_env_vars_to_copy()
+        assert "MYLIB_FOO" in result
+
+    @patch.dict(
+        os.environ,
+        {
+            "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY": "MY_SECRET",
+            "MY_SECRET": "val",
+        },
+        clear=False,
+    )
+    def test_user_extra_var(self):
+        """User-supplied extras are additive — PYTHONHASHSEED still included."""
+        result = get_env_vars_to_copy()
+        assert "MY_SECRET" in result
+        assert "PYTHONHASHSEED" in result
+
+
+# ---------------------------------------------------------------------------
+# Exclusion
+# ---------------------------------------------------------------------------
+
+
+class TestExclusion:
+    """exclude_vars and RAY_NON_CARRY_OVER_ENV_VARS take precedence."""
+
+    @patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"}, clear=False)
+    def test_exclude_vars(self):
+        result = get_env_vars_to_copy(exclude_vars={"CUDA_VISIBLE_DEVICES"})
+        assert "CUDA_VISIBLE_DEVICES" not in result
+
+    @patch.dict(os.environ, {"LMCACHE_LOCAL_CPU": "True"}, clear=False)
+    def test_non_carry_over_blacklist(self):
+        saved = set(RAY_NON_CARRY_OVER_ENV_VARS)
+        try:
+            RAY_NON_CARRY_OVER_ENV_VARS.add("LMCACHE_LOCAL_CPU")
+            result = get_env_vars_to_copy()
+            assert "LMCACHE_LOCAL_CPU" not in result
+        finally:
+            RAY_NON_CARRY_OVER_ENV_VARS.clear()
+            RAY_NON_CARRY_OVER_ENV_VARS.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# additional_vars (platform extension point)
+# ---------------------------------------------------------------------------
+
+
+class TestAdditionalVars:
+    """The additional_vars parameter supports platform-specific vars."""
+
+    @patch.dict(os.environ, {"CUSTOM_PLATFORM_VAR": "1"}, clear=False)
+    def test_additional_vars_passthrough(self):
+        result = get_env_vars_to_copy(additional_vars={"CUSTOM_PLATFORM_VAR"})
+        assert "CUSTOM_PLATFORM_VAR" in result
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Prefix matching should be strict (startswith, not contains)."""
+
+    @patch.dict(os.environ, {"LMCACH_TYPO": "1"}, clear=False)
+    def test_prefix_no_partial_match(self):
+        """'LMCACH_' does not match the 'LMCACHE_' prefix."""
+        result = get_env_vars_to_copy()
+        assert "LMCACH_TYPO" not in result
+
+    @patch.dict(
+        os.environ,
+        {
+            "VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY": " MYLIB_ , OTHER_ ",
+        },
+        clear=False,
+    )
+    def test_csv_whitespace_handling(self):
+        """Whitespace around commas and tokens should be stripped."""
+        result = get_env_vars_to_copy()
+        # MYLIB_ and OTHER_ should be parsed as valid prefixes — no crash
+        assert isinstance(result, set)
+
+    @patch.dict(
+        os.environ,
+        {
+            "VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY": "MYLIB_",
+            "LMCACHE_BACKEND": "cpu",
+            "NCCL_DEBUG": "INFO",
+            "MYLIB_FOO": "bar",
+        },
+        clear=False,
+    )
+    def test_user_prefix_additive(self):
+        """Setting VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY does NOT drop defaults."""
+        result = get_env_vars_to_copy()
+        # Built-in defaults still present
+        assert "LMCACHE_BACKEND" in result
+        assert "NCCL_DEBUG" in result
+        # User addition also present
+        assert "MYLIB_FOO" in result
+
+    @patch.dict(
+        os.environ,
+        {
+            "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY": "MY_FLAG",
+            "PYTHONHASHSEED": "42",
+            "MY_FLAG": "1",
+        },
+        clear=False,
+    )
+    def test_user_extra_additive(self):
+        """Setting VLLM_RAY_EXTRA_ENV_VARS_TO_COPY does NOT drop defaults."""
+        result = get_env_vars_to_copy()
+        # Built-in default still present
+        assert "PYTHONHASHSEED" in result
+        # User addition also present
+        assert "MY_FLAG" in result

--- a/tests/test_ray_env.py
+++ b/tests/test_ray_env.py
@@ -5,10 +5,7 @@
 import os
 from unittest.mock import patch
 
-from vllm.ray.ray_env import (
-    RAY_NON_CARRY_OVER_ENV_VARS,
-    get_env_vars_to_copy,
-)
+from vllm.ray.ray_env import get_env_vars_to_copy
 
 # ---------------------------------------------------------------------------
 # Default prefix matching
@@ -110,15 +107,13 @@ class TestExclusion:
         assert "CUDA_VISIBLE_DEVICES" not in result
 
     @patch.dict(os.environ, {"LMCACHE_LOCAL_CPU": "True"}, clear=False)
+    @patch(
+        "vllm.ray.ray_env.RAY_NON_CARRY_OVER_ENV_VARS",
+        {"LMCACHE_LOCAL_CPU"},
+    )
     def test_non_carry_over_blacklist(self):
-        saved = set(RAY_NON_CARRY_OVER_ENV_VARS)
-        try:
-            RAY_NON_CARRY_OVER_ENV_VARS.add("LMCACHE_LOCAL_CPU")
-            result = get_env_vars_to_copy()
-            assert "LMCACHE_LOCAL_CPU" not in result
-        finally:
-            RAY_NON_CARRY_OVER_ENV_VARS.clear()
-            RAY_NON_CARRY_OVER_ENV_VARS.update(saved)
+        result = get_env_vars_to_copy()
+        assert "LMCACHE_LOCAL_CPU" not in result
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -139,6 +139,8 @@ if TYPE_CHECKING:
     VLLM_ENABLE_MOE_DP_CHUNK: bool = True
     VLLM_RANDOMIZE_DP_DUMMY_INPUTS: bool = False
     VLLM_RAY_DP_PACK_STRATEGY: Literal["strict", "fill", "span"] = "strict"
+    VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY: str = ""
+    VLLM_RAY_EXTRA_ENV_VARS_TO_COPY: str = ""
     VLLM_MARLIN_USE_ATOMIC_ADD: bool = False
     VLLM_MARLIN_INPUT_DTYPE: Literal["int8", "fp8"] | None = None
     VLLM_MXFP4_USE_MARLIN: bool | None = None
@@ -1086,6 +1088,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # This environment variable is ignored if data-parallel-backend is not Ray.
     "VLLM_RAY_DP_PACK_STRATEGY": lambda: os.getenv(
         "VLLM_RAY_DP_PACK_STRATEGY", "strict"
+    ),
+    # Comma-separated prefixes of env vars to copy from the driver to Ray
+    # workers. Merged with the built-in defaults (VLLM_, LMCACHE_, NCCL_,
+    # UCX_). Example: "MYLIB_,ANOTHER_"
+    "VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY": lambda: os.getenv(
+        "VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY", ""
+    ),
+    # Comma-separated individual env var names to copy from the driver to
+    # Ray workers. Merged with the built-in defaults (HF_TOKEN,
+    # HUGGING_FACE_HUB_TOKEN, PYTHONHASHSEED). Example: "MY_SECRET,MY_FLAG"
+    "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY": lambda: os.getenv(
+        "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY", ""
     ),
     # Whether to use S3 path for model loading in CI via RunAI Streamer
     "VLLM_CI_USE_S3": lambda: os.environ.get("VLLM_CI_USE_S3", "0") == "1",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1090,16 +1090,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "VLLM_RAY_DP_PACK_STRATEGY", "strict"
     ),
     # Comma-separated prefixes of env vars to copy from the driver to Ray
-    # workers. Merged with the built-in defaults (VLLM_, LMCACHE_, NCCL_,
-    # UCX_). Example: "MYLIB_,ANOTHER_"
+    # workers. Any env var whose name starts with one of these prefixes is
+    # forwarded.  Override to replace the defaults entirely.
+    # Default: "VLLM_,LMCACHE_,NCCL_,UCX_,HF_,HUGGING_FACE_"
     "VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY": lambda: os.getenv(
-        "VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY", ""
+        "VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY",
+        "VLLM_,LMCACHE_,NCCL_,UCX_,HF_,HUGGING_FACE_",
     ),
-    # Comma-separated individual env var names to copy from the driver to
-    # Ray workers. Merged with the built-in defaults (HF_TOKEN,
-    # HUGGING_FACE_HUB_TOKEN, PYTHONHASHSEED). Example: "MY_SECRET,MY_FLAG"
+    # Comma-separated individual env var names (without a common prefix)
+    # to copy from the driver to Ray workers.
+    # Default: "PYTHONHASHSEED"
     "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY": lambda: os.getenv(
-        "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY", ""
+        "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY", "PYTHONHASHSEED"
     ),
     # Whether to use S3 path for model loading in CI via RunAI Streamer
     "VLLM_CI_USE_S3": lambda: os.environ.get("VLLM_CI_USE_S3", "0") == "1",

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -139,7 +139,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_MOE_DP_CHUNK: bool = True
     VLLM_RANDOMIZE_DP_DUMMY_INPUTS: bool = False
     VLLM_RAY_DP_PACK_STRATEGY: Literal["strict", "fill", "span"] = "strict"
-    VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY: str = ""
+    VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY: str = ""
     VLLM_RAY_EXTRA_ENV_VARS_TO_COPY: str = ""
     VLLM_MARLIN_USE_ATOMIC_ADD: bool = False
     VLLM_MARLIN_INPUT_DTYPE: Literal["int8", "fp8"] | None = None
@@ -1089,19 +1089,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_RAY_DP_PACK_STRATEGY": lambda: os.getenv(
         "VLLM_RAY_DP_PACK_STRATEGY", "strict"
     ),
-    # Comma-separated prefixes of env vars to copy from the driver to Ray
-    # workers. Any env var whose name starts with one of these prefixes is
-    # forwarded.  Override to replace the defaults entirely.
-    # Default: "VLLM_,LMCACHE_,NCCL_,UCX_,HF_,HUGGING_FACE_"
-    "VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY": lambda: os.getenv(
-        "VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY",
-        "VLLM_,LMCACHE_,NCCL_,UCX_,HF_,HUGGING_FACE_",
+    # Comma-separated *additional* prefixes of env vars to copy from the
+    # driver to Ray workers.  These are merged with the built-in defaults
+    # defined in ``vllm.ray.ray_env`` (VLLM_, etc.).  Example: "MYLIB_,OTHER_"
+    "VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY": lambda: os.getenv(
+        "VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY", ""
     ),
-    # Comma-separated individual env var names (without a common prefix)
-    # to copy from the driver to Ray workers.
-    # Default: "PYTHONHASHSEED"
+    # Comma-separated *additional* individual env var names to copy from
+    # the driver to Ray workers.  Merged with the built-in defaults
+    # defined in ``vllm.ray.ray_env`` (PYTHONHASHSEED).
+    # Example: "MY_SECRET,MY_FLAG"
     "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY": lambda: os.getenv(
-        "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY", "PYTHONHASHSEED"
+        "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY", ""
     ),
     # Whether to use S3 path for model loading in CI via RunAI Streamer
     "VLLM_CI_USE_S3": lambda: os.environ.get("VLLM_CI_USE_S3", "0") == "1",

--- a/vllm/ray/ray_env.py
+++ b/vllm/ray/ray_env.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import json
 import os
-import warnings
 
 import vllm.envs as envs
 from vllm.logger import init_logger
@@ -11,8 +10,7 @@ logger = init_logger(__name__)
 
 CONFIG_HOME = envs.VLLM_CONFIG_ROOT
 
-# This file contains a list of env vars that should not be copied
-# from the driver to the Ray workers.
+# Env vars that should NOT be copied from the driver to Ray workers.
 RAY_NON_CARRY_OVER_ENV_VARS_FILE = os.path.join(
     CONFIG_HOME, "ray_non_carry_over_env_vars.json"
 )
@@ -30,74 +28,10 @@ except json.JSONDecodeError:
     )
     RAY_NON_CARRY_OVER_ENV_VARS = set()
 
-# ---------------------------------------------------------------------------
-# Prefix-based env var propagation
-# ---------------------------------------------------------------------------
-# In addition to env vars registered in ``envs.environment_variables``
-# (VLLM_* vars), we also copy any env var whose name starts with one of
-# these prefixes.  This ensures third-party integrations (KV connectors,
-# NCCL tuning knobs, etc.) propagate from the driver to Ray workers
-# without requiring each integration to be hard-coded here.
-#
-# Users can extend this at deploy time by setting
-# ``VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY`` (comma-separated) on the driver.
-DEFAULT_ENV_VAR_PREFIXES_TO_COPY: set[str] = {
-    "VLLM_",
-    "LMCACHE_",
-    "NCCL_",
-    "UCX_",
-    "HF_",
-    "HUGGING_FACE_",
-}
 
-# Individual env vars (without a common prefix) that should always be
-# copied.  Users can extend via ``VLLM_RAY_EXTRA_ENV_VARS_TO_COPY``.
-DEFAULT_EXTRA_ENV_VARS_TO_COPY: set[str] = {
-    "PYTHONHASHSEED",
-}
-
-
-def _get_env_var_prefixes() -> set[str]:
-    """Return the merged set of env var prefixes to copy.
-
-    Combines ``DEFAULT_ENV_VAR_PREFIXES_TO_COPY`` with any user-supplied
-    prefixes in ``VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY`` (comma-separated).
-    """
-    prefixes = set(DEFAULT_ENV_VAR_PREFIXES_TO_COPY)
-    extra = envs.VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY
-    if extra:
-        for p in extra.split(","):
-            p = p.strip()
-            if p:
-                prefixes.add(p)
-    return prefixes
-
-
-def _get_extra_env_vars() -> set[str]:
-    """Return the merged set of individual env var names to copy.
-
-    Combines ``DEFAULT_EXTRA_ENV_VARS_TO_COPY`` with any user-supplied
-    names in ``VLLM_RAY_EXTRA_ENV_VARS_TO_COPY`` (comma-separated).
-    """
-    extra_vars = set(DEFAULT_EXTRA_ENV_VARS_TO_COPY)
-    extra = envs.VLLM_RAY_EXTRA_ENV_VARS_TO_COPY
-    if extra:
-        for v in extra.split(","):
-            v = v.strip()
-            if v:
-                extra_vars.add(v)
-    return extra_vars
-
-
-def _collect_prefix_matched_vars(prefixes: set[str]) -> set[str]:
-    """Scan ``os.environ`` and return var names matching *prefixes*."""
-    matched: set[str] = set()
-    for name in os.environ:
-        for prefix in prefixes:
-            if name.startswith(prefix):
-                matched.add(name)
-                break
-    return matched
+def _parse_csv(value: str) -> set[str]:
+    """Split a comma-separated string into a set of stripped, non-empty tokens."""
+    return {tok.strip() for tok in value.split(",") if tok.strip()}
 
 
 def get_env_vars_to_copy(
@@ -105,80 +39,59 @@ def get_env_vars_to_copy(
     additional_vars: set[str] | None = None,
     destination: str | None = None,
 ) -> set[str]:
-    """
-    Get the environment variables to copy to downstream Ray actors.
+    """Return the env var names to copy from the driver to Ray actors.
 
     The result is the union of:
+
     1. Env vars registered in ``vllm.envs.environment_variables``.
-    2. Env vars in ``os.environ`` whose name matches a prefix in
-       ``DEFAULT_ENV_VAR_PREFIXES_TO_COPY`` (or user-configured via
-       ``VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY``).
-    3. Individual vars listed in ``DEFAULT_EXTRA_ENV_VARS_TO_COPY``.
+    2. Env vars in ``os.environ`` matching a prefix in
+       ``VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY``.
+    3. Individual names in ``VLLM_RAY_EXTRA_ENV_VARS_TO_COPY``.
 
-    Minus any vars in *exclude_vars* or ``RAY_NON_CARRY_OVER_ENV_VARS``.
-
-    Example use cases:
-    - Copy environment variables from RayDistributedExecutor to Ray workers.
-    - Copy environment variables from RayDPClient to Ray DPEngineCoreActor.
+    Minus any names in *exclude_vars* or ``RAY_NON_CARRY_OVER_ENV_VARS``.
 
     Args:
-        exclude_vars: A set of environment variables to exclude from copying.
-        additional_vars: **Deprecated.** Previously used to specify extra
-            env vars to copy.  All non-VLLM env vars should now be covered
-            by ``DEFAULT_ENV_VAR_PREFIXES_TO_COPY``,
-            ``DEFAULT_EXTRA_ENV_VARS_TO_COPY``, or the
-            ``VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY`` /
-            ``VLLM_RAY_EXTRA_ENV_VARS_TO_COPY`` env vars.  This parameter
-            is ignored and will be removed in a future release.
-        destination: The destination of the environment variables (for
-            logging purposes only).
-    Returns:
-        A set of environment variable names to copy.
+        exclude_vars: Env vars to exclude (e.g. worker-specific ones).
+        additional_vars: Extra individual env var names to copy.  Useful
+            for caller-specific vars (e.g. platform env vars).
+        destination: Label used in log messages only.
     """
-    if additional_vars:
-        warnings.warn(
-            "The 'additional_vars' parameter of get_env_vars_to_copy() is "
-            "deprecated and ignored. Add prefixes to "
-            "DEFAULT_ENV_VAR_PREFIXES_TO_COPY in vllm/ray/ray_env.py or set "
-            "VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY / "
-            "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY on the driver. "
-            "This parameter will be removed in a future release.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+    exclude = (exclude_vars or set()) | RAY_NON_CARRY_OVER_ENV_VARS
 
-    exclude_vars = exclude_vars or set()
+    # -- prefixes (from envs.py, user-overridable) --------------------------
+    prefixes = _parse_csv(envs.VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY)
 
-    # 1. vLLM's own registered env vars
-    env_vars_to_copy = set(envs.environment_variables)
+    # -- collect env var names ----------------------------------------------
+    # 1. vLLM's registered env vars
+    result = set(envs.environment_variables)
+    # 2. Prefix-matched vars present in the current environment
+    result |= {
+        name for name in os.environ
+        if any(name.startswith(p) for p in prefixes)
+    }
+    # 3. Individual extra vars (from envs.py, user-overridable)
+    result |= _parse_csv(envs.VLLM_RAY_EXTRA_ENV_VARS_TO_COPY)
+    # 4. Caller-supplied extra vars (e.g. platform-specific)
+    result |= additional_vars or set()
+    # 5. Exclude worker-specific and user-blacklisted vars
+    result -= exclude
 
-    # 2. Prefix-matched vars from os.environ
-    prefixes = _get_env_var_prefixes()
-    env_vars_to_copy |= _collect_prefix_matched_vars(prefixes)
-
-    # 3. Individual extra vars
-    env_vars_to_copy |= _get_extra_env_vars()
-
-    # 4. Exclude worker-specific and user-blacklisted vars
-    env_vars_to_copy -= exclude_vars
-    env_vars_to_copy -= RAY_NON_CARRY_OVER_ENV_VARS
-
-    to_destination = " to " + destination if destination is not None else ""
-
-    logger.info(
-        "RAY_NON_CARRY_OVER_ENV_VARS from config: %s", RAY_NON_CARRY_OVER_ENV_VARS
-    )
-    logger.info(
-        "Env var prefixes to copy: %s", prefixes,
-    )
+    # -- logging ------------------------------------------------------------
+    dest = f" to {destination}" if destination else ""
+    logger.info("Env var prefixes to copy: %s", sorted(prefixes))
     logger.info(
         "Copying the following environment variables%s: %s",
-        to_destination,
-        sorted(v for v in env_vars_to_copy if v in os.environ),
+        dest,
+        sorted(v for v in result if v in os.environ),
     )
+    if RAY_NON_CARRY_OVER_ENV_VARS:
+        logger.info(
+            "RAY_NON_CARRY_OVER_ENV_VARS from config: %s",
+            RAY_NON_CARRY_OVER_ENV_VARS,
+        )
     logger.info(
-        "If certain env vars should NOT be copied, add them to %s file",
+        "To exclude env vars from copying, add them to %s",
         RAY_NON_CARRY_OVER_ENV_VARS_FILE,
     )
 
-    return env_vars_to_copy
+    return result

--- a/vllm/ray/ray_env.py
+++ b/vllm/ray/ray_env.py
@@ -65,10 +65,7 @@ def get_env_vars_to_copy(
     # 1. vLLM's registered env vars
     result = set(envs.environment_variables)
     # 2. Prefix-matched vars present in the current environment
-    result |= {
-        name for name in os.environ
-        if any(name.startswith(p) for p in prefixes)
-    }
+    result |= {name for name in os.environ if any(name.startswith(p) for p in prefixes)}
     # 3. Individual extra vars (from envs.py, user-overridable)
     result |= _parse_csv(envs.VLLM_RAY_EXTRA_ENV_VARS_TO_COPY)
     # 4. Caller-supplied extra vars (e.g. platform-specific)

--- a/vllm/ray/ray_env.py
+++ b/vllm/ray/ray_env.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import json
 import os
+import warnings
 
 import vllm.envs as envs
 from vllm.logger import init_logger
@@ -29,6 +30,75 @@ except json.JSONDecodeError:
     )
     RAY_NON_CARRY_OVER_ENV_VARS = set()
 
+# ---------------------------------------------------------------------------
+# Prefix-based env var propagation
+# ---------------------------------------------------------------------------
+# In addition to env vars registered in ``envs.environment_variables``
+# (VLLM_* vars), we also copy any env var whose name starts with one of
+# these prefixes.  This ensures third-party integrations (KV connectors,
+# NCCL tuning knobs, etc.) propagate from the driver to Ray workers
+# without requiring each integration to be hard-coded here.
+#
+# Users can extend this at deploy time by setting
+# ``VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY`` (comma-separated) on the driver.
+DEFAULT_ENV_VAR_PREFIXES_TO_COPY: set[str] = {
+    "VLLM_",
+    "LMCACHE_",
+    "NCCL_",
+    "UCX_",
+    "HF_",
+    "HUGGING_FACE_",
+}
+
+# Individual env vars (without a common prefix) that should always be
+# copied.  Users can extend via ``VLLM_RAY_EXTRA_ENV_VARS_TO_COPY``.
+DEFAULT_EXTRA_ENV_VARS_TO_COPY: set[str] = {
+    "PYTHONHASHSEED",
+}
+
+
+def _get_env_var_prefixes() -> set[str]:
+    """Return the merged set of env var prefixes to copy.
+
+    Combines ``DEFAULT_ENV_VAR_PREFIXES_TO_COPY`` with any user-supplied
+    prefixes in ``VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY`` (comma-separated).
+    """
+    prefixes = set(DEFAULT_ENV_VAR_PREFIXES_TO_COPY)
+    extra = envs.VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY
+    if extra:
+        for p in extra.split(","):
+            p = p.strip()
+            if p:
+                prefixes.add(p)
+    return prefixes
+
+
+def _get_extra_env_vars() -> set[str]:
+    """Return the merged set of individual env var names to copy.
+
+    Combines ``DEFAULT_EXTRA_ENV_VARS_TO_COPY`` with any user-supplied
+    names in ``VLLM_RAY_EXTRA_ENV_VARS_TO_COPY`` (comma-separated).
+    """
+    extra_vars = set(DEFAULT_EXTRA_ENV_VARS_TO_COPY)
+    extra = envs.VLLM_RAY_EXTRA_ENV_VARS_TO_COPY
+    if extra:
+        for v in extra.split(","):
+            v = v.strip()
+            if v:
+                extra_vars.add(v)
+    return extra_vars
+
+
+def _collect_prefix_matched_vars(prefixes: set[str]) -> set[str]:
+    """Scan ``os.environ`` and return var names matching *prefixes*."""
+    matched: set[str] = set()
+    for name in os.environ:
+        for prefix in prefixes:
+            if name.startswith(prefix):
+                matched.add(name)
+                break
+    return matched
+
 
 def get_env_vars_to_copy(
     exclude_vars: set[str] | None = None,
@@ -38,28 +108,60 @@ def get_env_vars_to_copy(
     """
     Get the environment variables to copy to downstream Ray actors.
 
+    The result is the union of:
+    1. Env vars registered in ``vllm.envs.environment_variables``.
+    2. Env vars in ``os.environ`` whose name matches a prefix in
+       ``DEFAULT_ENV_VAR_PREFIXES_TO_COPY`` (or user-configured via
+       ``VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY``).
+    3. Individual vars listed in ``DEFAULT_EXTRA_ENV_VARS_TO_COPY``.
+
+    Minus any vars in *exclude_vars* or ``RAY_NON_CARRY_OVER_ENV_VARS``.
+
     Example use cases:
     - Copy environment variables from RayDistributedExecutor to Ray workers.
     - Copy environment variables from RayDPClient to Ray DPEngineCoreActor.
 
     Args:
-        exclude_vars: A set of vllm defined environment variables to exclude
-            from copying.
-        additional_vars: A set of additional environment variables to copy.
-            If a variable is in both exclude_vars and additional_vars, it will
-            be excluded.
-        destination: The destination of the environment variables.
+        exclude_vars: A set of environment variables to exclude from copying.
+        additional_vars: **Deprecated.** Previously used to specify extra
+            env vars to copy.  All non-VLLM env vars should now be covered
+            by ``DEFAULT_ENV_VAR_PREFIXES_TO_COPY``,
+            ``DEFAULT_EXTRA_ENV_VARS_TO_COPY``, or the
+            ``VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY`` /
+            ``VLLM_RAY_EXTRA_ENV_VARS_TO_COPY`` env vars.  This parameter
+            is ignored and will be removed in a future release.
+        destination: The destination of the environment variables (for
+            logging purposes only).
     Returns:
-        A set of environment variables to copy.
+        A set of environment variable names to copy.
     """
-    exclude_vars = exclude_vars or set()
-    additional_vars = additional_vars or set()
+    if additional_vars:
+        warnings.warn(
+            "The 'additional_vars' parameter of get_env_vars_to_copy() is "
+            "deprecated and ignored. Add prefixes to "
+            "DEFAULT_ENV_VAR_PREFIXES_TO_COPY in vllm/ray/ray_env.py or set "
+            "VLLM_RAY_ENV_VAR_PREFIXES_TO_COPY / "
+            "VLLM_RAY_EXTRA_ENV_VARS_TO_COPY on the driver. "
+            "This parameter will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
-    env_vars_to_copy = {
-        v
-        for v in set(envs.environment_variables).union(additional_vars)
-        if v not in exclude_vars and v not in RAY_NON_CARRY_OVER_ENV_VARS
-    }
+    exclude_vars = exclude_vars or set()
+
+    # 1. vLLM's own registered env vars
+    env_vars_to_copy = set(envs.environment_variables)
+
+    # 2. Prefix-matched vars from os.environ
+    prefixes = _get_env_var_prefixes()
+    env_vars_to_copy |= _collect_prefix_matched_vars(prefixes)
+
+    # 3. Individual extra vars
+    env_vars_to_copy |= _get_extra_env_vars()
+
+    # 4. Exclude worker-specific and user-blacklisted vars
+    env_vars_to_copy -= exclude_vars
+    env_vars_to_copy -= RAY_NON_CARRY_OVER_ENV_VARS
 
     to_destination = " to " + destination if destination is not None else ""
 
@@ -67,9 +169,12 @@ def get_env_vars_to_copy(
         "RAY_NON_CARRY_OVER_ENV_VARS from config: %s", RAY_NON_CARRY_OVER_ENV_VARS
     )
     logger.info(
+        "Env var prefixes to copy: %s", prefixes,
+    )
+    logger.info(
         "Copying the following environment variables%s: %s",
         to_destination,
-        [v for v in env_vars_to_copy if v in os.environ],
+        sorted(v for v in env_vars_to_copy if v in os.environ),
     )
     logger.info(
         "If certain env vars should NOT be copied, add them to %s file",

--- a/vllm/v1/executor/ray_executor.py
+++ b/vllm/v1/executor/ray_executor.py
@@ -336,6 +336,7 @@ class RayDistributedExecutor(Executor):
         # Environment variables to copy from driver to workers
         env_vars_to_copy = get_env_vars_to_copy(
             exclude_vars=self.WORKER_SPECIFIC_ENV_VARS,
+            additional_vars=set(current_platform.additional_env_vars),
             destination="workers",
         )
 

--- a/vllm/v1/executor/ray_executor.py
+++ b/vllm/v1/executor/ray_executor.py
@@ -73,9 +73,6 @@ class RayDistributedExecutor(Executor):
         "ROCR_VISIBLE_DEVICES",
     }
 
-    # These non-vLLM env vars are copied from the driver to workers
-    ADDITIONAL_ENV_VARS = {"HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"}
-
     uses_ray: bool = True
     supports_pp: bool = True
 
@@ -339,9 +336,6 @@ class RayDistributedExecutor(Executor):
         # Environment variables to copy from driver to workers
         env_vars_to_copy = get_env_vars_to_copy(
             exclude_vars=self.WORKER_SPECIFIC_ENV_VARS,
-            additional_vars=set(current_platform.additional_env_vars).union(
-                self.ADDITIONAL_ENV_VARS
-            ),
             destination="workers",
         )
 


### PR DESCRIPTION
## Problem

`get_env_vars_to_copy()` only forwarded env vars registered in `vllm.envs.environment_variables` (VLLM_* vars) plus a small hardcoded set (`HF_TOKEN`, `HUGGING_FACE_HUB_TOKEN`). Third-party env vars needed by KV connector integrations (`LMCACHE_*`, `NCCL_*`, `UCX_*`) and `PYTHONHASHSEED` were silently dropped when propagating from the EngineCore to Ray GPU workers.

This caused subtle failures — e.g., LMCache workers using a different hash algorithm than the scheduler, resulting in 0 cache hits for CPU KV offloading.

## Solution

Introduce prefix-based env var matching with built-in defaults and two user-extensible env vars:

### Built-in defaults (in `ray_env.py`)
- **Prefixes**: `VLLM_`, `LMCACHE_`, `NCCL_`, `UCX_`, `HF_`, `HUGGING_FACE_`
- **Individual vars**: `PYTHONHASHSEED`

### User-extensible env vars (in `envs.py`)
- **`VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY`** — comma-separated additional prefixes (default: empty). Merged with built-in defaults. Example: `VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY=MYLIB_,OTHER_`
- **`VLLM_RAY_EXTRA_ENV_VARS_TO_COPY`** — comma-separated additional individual var names (default: empty). Merged with built-in defaults. Example: `VLLM_RAY_EXTRA_ENV_VARS_TO_COPY=MY_SECRET,MY_FLAG`

Both are **additive** — setting them extends the defaults rather than replacing them. This is critical for deploy-time extensibility: if a released vLLM version doesn't yet include a new integration's prefix, users can add it without code changes.

## Changes

- **`vllm/envs.py`** — register `VLLM_RAY_EXTRA_ENV_VAR_PREFIXES_TO_COPY` and `VLLM_RAY_EXTRA_ENV_VARS_TO_COPY` (both default to empty string, additive with built-in defaults).
- **`vllm/ray/ray_env.py`** — define built-in defaults (`DEFAULT_ENV_VAR_PREFIXES`, `DEFAULT_EXTRA_ENV_VARS`) and rewrite `get_env_vars_to_copy()` to collect env vars from:
  1. `envs.environment_variables` (all registered vLLM vars)
  2. prefix-matched vars in `os.environ` (built-in + user-supplied prefixes)
  3. individual extra vars (built-in + user-supplied)
  4. caller-supplied `additional_vars` (e.g. `current_platform.additional_env_vars`)
  minus exclusions from `exclude_vars` and `RAY_NON_CARRY_OVER_ENV_VARS`.
- **`vllm/v1/executor/ray_executor.py`** — remove `ADDITIONAL_ENV_VARS` (now covered by `HF_` and `HUGGING_FACE_` prefix matching) and simplify the `get_env_vars_to_copy()` call.
- **`tests/test_ray_env.py`** — comprehensive unit tests covering default prefixes, default extra vars, user extensions, exclusion logic, `additional_vars` passthrough, strict prefix matching, CSV whitespace handling, and additive behavior verification.

## Test plan

- [x] Unit tests for all prefix-matching and extra-var logic (`tests/test_ray_env.py`)
