### PR TITLE
[torch.compile] Disable ar-rms fusion for ds3-fp4 & DP, fix CI test

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1681,6 +1681,19 @@ class ModelConfig:
     def is_quantized(self) -> bool:
         return getattr(self.hf_config, "quantization_config", None) is not None
 
+    def is_nvfp4_quantized(self) -> bool:
+        # ModelOpt NVFP4 checkpoints resolve to modelopt_fp4 quantization method
+        if self.quantization in ("modelopt_fp4",):
+            return True
+
+        # For Compressed Tensors we look for `"format": "nvfp4-pack-quantized"`
+        # in the quantization config
+        return (
+            self.quantization == "compressed-tensors"
+            and "nvfp4"
+            in self.model_arch_config.quantization_config.get("format", "").lower()
+        )
+
 
 def get_served_model_name(model: str, served_model_name: str | list[str] | None):
     """

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1683,7 +1683,7 @@ class ModelConfig:
 
     def is_nvfp4_quantized(self) -> bool:
         # ModelOpt NVFP4 checkpoints resolve to modelopt_fp4 quantization method
-        if self.quantization in ("modelopt_fp4", ):
+        if self.quantization in ("modelopt_fp4",):
             return True
 
         # For Compressed Tensors we look for `"format": "nvfp4-pack-quantized"`
@@ -1692,7 +1692,8 @@ class ModelConfig:
         return (
             self.quantization == "compressed-tensors"
             and quant_config is not None
-            and "nvfp4" in quant_config.get("format", "").lower())
+            and "nvfp4" in quant_config.get("format", "").lower()
+        )
 
 
 def get_served_model_name(model: str, served_model_name: str | list[str] | None):

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1683,16 +1683,16 @@ class ModelConfig:
 
     def is_nvfp4_quantized(self) -> bool:
         # ModelOpt NVFP4 checkpoints resolve to modelopt_fp4 quantization method
-        if self.quantization in ("modelopt_fp4",):
+        if self.quantization in ("modelopt_fp4", ):
             return True
 
         # For Compressed Tensors we look for `"format": "nvfp4-pack-quantized"`
         # in the quantization config
+        quant_config = self.model_arch_config.quantization_config
         return (
             self.quantization == "compressed-tensors"
-            and "nvfp4"
-            in self.model_arch_config.quantization_config.get("format", "").lower()
-        )
+            and quant_config is not None
+            and "nvfp4" in quant_config.get("format", "").lower())
 
 
 def get_served_model_name(model: str, served_model_name: str | list[str] | None):

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -115,6 +115,9 @@ def enable_allreduce_rms_fusion(cfg: "VllmConfig") -> bool:
             current_platform.is_device_capability(100)
             or current_platform.is_device_capability(90)
         )
+        # tp-dp combination broken:
+        # https://github.com/vllm-project/vllm/issues/34458
+        and cfg.parallel_config.data_parallel_size == 1
     )
 
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -103,7 +103,7 @@ def enable_act_fusion(cfg: "VllmConfig") -> bool:
 
 
 def enable_allreduce_rms_fusion(cfg: "VllmConfig") -> bool:
-"""Enable if TP > 1 and Hopper/Blackwell and flashinfer installed."""
+    """Enable if TP > 1 and Hopper/Blackwell and flashinfer installed."""
     from vllm.platforms import current_platform
     from vllm.utils.flashinfer import has_flashinfer
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -103,8 +103,7 @@ def enable_act_fusion(cfg: "VllmConfig") -> bool:
 
 
 def enable_allreduce_rms_fusion(cfg: "VllmConfig") -> bool:
-    """Enable if TP > 1 and Hopper+ and flashinfer installed."""
-    # TODO:
+"""Enable if TP > 1 and Hopper/Blackwell and flashinfer installed."""
     from vllm.platforms import current_platform
     from vllm.utils.flashinfer import has_flashinfer
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -104,14 +104,18 @@ def enable_act_fusion(cfg: "VllmConfig") -> bool:
 
 def enable_allreduce_rms_fusion(cfg: "VllmConfig") -> bool:
     """Enable if TP > 1 and Hopper+ and flashinfer installed."""
+    # TODO:
     from vllm.platforms import current_platform
     from vllm.utils.flashinfer import has_flashinfer
 
     return (
         cfg.parallel_config.tensor_parallel_size > 1
         and current_platform.is_cuda()
-        and current_platform.has_device_capability(90)
         and has_flashinfer()
+        and (
+            current_platform.is_device_capability(100)
+            or current_platform.is_device_capability(90)
+        )
     )
 
 

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -544,6 +544,7 @@ class DeepseekV3ForCausalLM(VerifyAndUpdateConfig):
     @classmethod
     def verify_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         """Disable AR-RMS-Quant fusion for DeepSeekV3 in NVFP4"""
+        # TODO: https://github.com/vllm-project/vllm/issues/34395
 
         # disable AR-rms-fp4 fusion for DSv3+
         ar_rms_enabled = vllm_config.compilation_config.pass_config.fuse_allreduce_rms

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -550,13 +550,14 @@ class DeepseekV3ForCausalLM(VerifyAndUpdateConfig):
         ar_rms_enabled = vllm_config.compilation_config.pass_config.fuse_allreduce_rms
         nvfp4 = vllm_config.model_config.is_nvfp4_quantized()
 
-        # Also handle None case
-        if ar_rms_enabled is not False and nvfp4:
+        # Disable by default, warn if manually enabled:
+        if ar_rms_enabled is None and nvfp4:
             vllm_config.compilation_config.pass_config.fuse_allreduce_rms = False
-            if ar_rms_enabled is True:
-                logger.warning(
-                    "Disabling allreduce-rms fusion for DeepSeekV3 with NVFP4 quant"
-                )
+        if ar_rms_enabled and nvfp4:
+            logger.warning(
+                "Allreduce-rms fusion broken for DeepSeekV3 with NVFP4 quant,"
+                "see https://github.com/vllm-project/vllm/issues/34395."
+            )
 
 
 class DeepseekV32ForCausalLM(DeepseekV3ForCausalLM):


### PR DESCRIPTION
## Purpose
#34299 enabled AR+rms fusion by default, which is causing accuracy issues on DS3-fp4. Other fp4 and non-fp4 deepseek models appear unaffected. There also seems to be a problem when running with DP. Do not enable the fusion by default for those cases.

## Test Plan
CI, tested locally

## Test Result
Good

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

