### PR TITLE
[bugfix] refactor FunASR's _get_data_parser 

### DIFF
--- a/vllm/model_executor/models/funasr.py
+++ b/vllm/model_executor/models/funasr.py
@@ -714,6 +714,13 @@ class FunASRProcessingInfo(BaseProcessingInfo):
     def get_hf_config(self) -> Qwen3Config:
         return self.ctx.get_hf_config(Qwen3Config)
 
+    def get_data_parser(self) -> MultiModalDataParser:
+        feature_extractor = self.get_feature_extractor()
+        return MultiModalDataParser(
+            target_sr=feature_extractor.sampling_rate,
+            target_channels=self.get_target_channels(),
+        )
+
     @property
     def skip_prompt_length_check(self) -> bool:
         return True  # Because the encoder prompt is padded
@@ -765,13 +772,6 @@ class FunASRDummyInputsBuilder(BaseDummyInputsBuilder[FunASRProcessingInfo]):
 
 
 class FunASRMultiModalProcessor(BaseMultiModalProcessor[FunASRProcessingInfo]):
-    def _get_data_parser(self) -> MultiModalDataParser:
-        feature_extractor = self.info.get_feature_extractor()
-        return MultiModalDataParser(
-            target_sr=feature_extractor.sampling_rate,
-            target_channels=self.info.get_target_channels(),
-        )
-
     def _call_hf_processor(
         self,
         prompt: str,

--- a/vllm/model_executor/models/funasr.py
+++ b/vllm/model_executor/models/funasr.py
@@ -714,17 +714,6 @@ class FunASRProcessingInfo(BaseProcessingInfo):
     def get_hf_config(self) -> Qwen3Config:
         return self.ctx.get_hf_config(Qwen3Config)
 
-    def get_data_parser(self) -> MultiModalDataParser:
-        feature_extractor = self.get_feature_extractor()
-        return MultiModalDataParser(
-            target_sr=feature_extractor.sampling_rate,
-            target_channels=self.get_target_channels(),
-        )
-
-    @property
-    def skip_prompt_length_check(self) -> bool:
-        return True  # Because the encoder prompt is padded
-
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
         return {"audio": 1}
 
@@ -733,6 +722,13 @@ class FunASRProcessingInfo(BaseProcessingInfo):
         feature_extractor = hf_processor.feature_extractor  # type: ignore
         assert isinstance(feature_extractor, FunASRFeatureExtractor)
         return feature_extractor
+
+    def get_data_parser(self) -> MultiModalDataParser:
+        feature_extractor = self.get_feature_extractor()
+        return MultiModalDataParser(
+            target_sr=feature_extractor.sampling_rate,
+            target_channels=self.get_target_channels(),
+        )
 
     def get_target_channels(self) -> int:
         return 1


### PR DESCRIPTION
1. refactor _get_data_parser, move it from FunASRMultiModalProcessor to FunASRProcessingInfo because "BaseMultiModalProcessor._get_data_parser has been moved to `BaseProcessingInfo.build_data_parser` in v0.16. " 
2. and It's better to check prompt_len, so I delete skip_prompt_length_check(return True)
@DarkLight1337 please take a look, thanks.

Related PR https://github.com/vllm-project/vllm/pull/33247