### PR TITLE
[Misc] Update Qwen3-VL models dummy image size calculation

### DIFF
--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -375,8 +375,10 @@ class Qwen2_5OmniThinkerDummyInputsBuilder(
             * feature_extractor.sampling_rate
         )
 
+        image_processor = self.info.get_image_processor(**mm_processor_kwargs)
+        image_max_pixels = image_processor.size["longest_edge"]
         target_width, target_height = self.info.get_image_size_with_most_features(
-            max_pixels=mm_processor_kwargs.get("max_pixels", None),
+            max_pixels=image_max_pixels,
         )
         target_num_frames = self.info.get_num_frames_with_most_features(
             seq_len, mm_counts

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -1022,8 +1022,10 @@ class Qwen2VLDummyInputsBuilder(BaseDummyInputsBuilder[Qwen2VLProcessingInfo]):
         num_videos = mm_counts.get("video", 0)
 
         mm_processor_kwargs = mm_processor_kwargs or {}
+        image_processor = self.info.get_image_processor(**mm_processor_kwargs)
+        image_max_pixels = image_processor.size["longest_edge"]
         target_width, target_height = self.info.get_image_size_with_most_features(
-            max_pixels=mm_processor_kwargs.get("max_pixels", None)
+            max_pixels=image_max_pixels,
         )
         target_num_frames = self.info.get_num_frames_with_most_features(
             seq_len, mm_counts

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -804,9 +804,11 @@ class Qwen3VLDummyInputsBuilder(BaseDummyInputsBuilder[Qwen3VLProcessingInfo]):
         video_overrides = mm_options.get("video") if mm_options else None
 
         mm_processor_kwargs = mm_processor_kwargs or {}
+        image_processor = self.info.get_image_processor(**(mm_processor_kwargs or {}))
+        image_max_pixels = image_processor.size["longest_edge"]
         target_image_width, target_image_height = (
             self.info.get_image_size_with_most_features(
-                max_pixels=mm_processor_kwargs.get("max_pixels", None),
+                max_pixels=image_max_pixels,
             )
         )
 

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -804,7 +804,7 @@ class Qwen3VLDummyInputsBuilder(BaseDummyInputsBuilder[Qwen3VLProcessingInfo]):
         video_overrides = mm_options.get("video") if mm_options else None
 
         mm_processor_kwargs = mm_processor_kwargs or {}
-        image_processor = self.info.get_image_processor(**(mm_processor_kwargs or {}))
+        image_processor = self.info.get_image_processor(**mm_processor_kwargs)
         image_max_pixels = image_processor.size["longest_edge"]
         target_image_width, target_image_height = (
             self.info.get_image_size_with_most_features(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Actually, `--mm-processor-kwargs '{"size": {"longest_edge": 234881024, "shortest_edge": 4096}}'` will also update Qwen3-VL image processor's max_pixels.
- So `mm_processor_kwargs.get("max_pixels", None)` is not robust enough for this case.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

