### PR TITLE
fix(exaone4): pad MLP intermediate size for group quant TP alignment

### DIFF
--- a/vllm/model_executor/models/exaone4.py
+++ b/vllm/model_executor/models/exaone4.py
@@ -21,6 +21,7 @@
 # limitations under the License.
 """Inference-only Exaone model compatible with HuggingFace weights."""
 
+import math
 from collections.abc import Iterable
 from itertools import islice
 
@@ -63,6 +64,47 @@ from .utils import (
     make_layers,
     maybe_prefix,
 )
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _padded_intermediate_size(
+    intermediate_size: int,
+    quant_config: QuantizationConfig | None,
+    tp_size: int,
+) -> int:
+    if quant_config is None:
+        return intermediate_size
+    weight_block_size = getattr(quant_config, "weight_block_size", None)
+    if not weight_block_size or len(weight_block_size) < 2:
+        return intermediate_size
+    block_n, block_k = weight_block_size[0], weight_block_size[1]
+    if block_n <= 0 or block_k <= 0:
+        return intermediate_size
+    alignment = tp_size * math.lcm(block_n, block_k)
+    return _ceil_div(intermediate_size, alignment) * alignment
+
+
+def _pad_tensor_along_dim(
+    tensor: torch.Tensor,
+    target: int,
+    dim: int,
+    fill_value: float,
+) -> torch.Tensor:
+    if dim >= tensor.ndim:
+        return tensor
+    current = tensor.size(dim)
+    if target <= current:
+        return tensor
+    new_shape = list(tensor.shape)
+    new_shape[dim] = target
+    padded = tensor.new_full(new_shape, fill_value)
+    index = [slice(None)] * tensor.ndim
+    index[dim] = slice(0, current)
+    padded[tuple(index)] = tensor
+    return padded
 
 
 class Exaone4GatedMLP(nn.Module):
@@ -221,6 +263,7 @@ class Exaone4DecoderLayer(nn.Module):
         config: Exaone4Config,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
+        intermediate_size: int | None = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -245,9 +288,11 @@ class Exaone4DecoderLayer(nn.Module):
             cache_config=cache_config,
             prefix=f"{prefix}.self_attn",
         )
+        if intermediate_size is None:
+            intermediate_size = config.intermediate_size
         self.mlp = Exaone4GatedMLP(
             hidden_size=self.hidden_size,
-            intermediate_size=config.intermediate_size,
+            intermediate_size=intermediate_size,
             hidden_act=config.hidden_act,
             quant_config=quant_config,
             bias=getattr(config, "mlp_bias", False),
@@ -302,6 +347,14 @@ class Exaone4Model(nn.Module):
         self.config = config
         self.quant_config = quant_config
 
+        tp_size = get_tensor_model_parallel_world_size()
+        self._orig_intermediate_size = config.intermediate_size
+        self._padded_intermediate_size = _padded_intermediate_size(
+            self._orig_intermediate_size, quant_config, tp_size
+        )
+        if self._padded_intermediate_size != self._orig_intermediate_size:
+            config.intermediate_size = self._padded_intermediate_size
+
         self.vocab_size = config.vocab_size
         if get_pp_group().is_first_rank or (
             config.tie_word_embeddings and get_pp_group().is_last_rank
@@ -319,6 +372,7 @@ class Exaone4Model(nn.Module):
                 config=config,
                 cache_config=cache_config,
                 quant_config=quant_config,
+                intermediate_size=self._padded_intermediate_size,
                 prefix=prefix,
             ),
             prefix=f"{prefix}.layers",
@@ -378,6 +432,26 @@ class Exaone4Model(nn.Module):
             (".gate_up_proj", ".up_proj", 1),
         ]
         params_dict = dict(self.named_parameters())
+        orig_intermediate_size = getattr(
+            self, "_orig_intermediate_size", self.config.intermediate_size
+        )
+        padded_intermediate_size = getattr(
+            self, "_padded_intermediate_size", self.config.intermediate_size
+        )
+        should_pad = padded_intermediate_size != orig_intermediate_size
+        weight_block_size = (
+            getattr(self.quant_config, "weight_block_size", None)
+            if self.quant_config is not None
+            else None
+        )
+        block_n = block_k = None
+        if should_pad and weight_block_size:
+            block_n, block_k = weight_block_size[0], weight_block_size[1]
+            padded_scale_out = _ceil_div(padded_intermediate_size, block_n)
+            padded_scale_in = _ceil_div(padded_intermediate_size, block_k)
+        else:
+            padded_scale_out = padded_scale_in = None
+
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
@@ -386,6 +460,38 @@ class Exaone4Model(nn.Module):
                 # Models trained using ColossalAI may include these tensors in
                 # the checkpoint. Skip them.
                 continue
+            if should_pad:
+                if (
+                    name.endswith(".gate_proj.weight")
+                    or name.endswith(".up_proj.weight")
+                    or name.endswith(".gate_proj.bias")
+                    or name.endswith(".up_proj.bias")
+                ):
+                    loaded_weight = _pad_tensor_along_dim(
+                        loaded_weight, padded_intermediate_size, 0, 0.0
+                    )
+                elif name.endswith(".down_proj.weight"):
+                    loaded_weight = _pad_tensor_along_dim(
+                        loaded_weight, padded_intermediate_size, 1, 0.0
+                    )
+                if weight_block_size is not None:
+                    if (
+                        name.endswith(".gate_proj.weight_scale_inv")
+                        or name.endswith(".up_proj.weight_scale_inv")
+                        or name.endswith(".gate_proj.weight_scale")
+                        or name.endswith(".up_proj.weight_scale")
+                    ):
+                        if padded_scale_out is not None:
+                            loaded_weight = _pad_tensor_along_dim(
+                                loaded_weight, padded_scale_out, 0, 1.0
+                            )
+                    elif (
+                        name.endswith(".down_proj.weight_scale_inv")
+                        or name.endswith(".down_proj.weight_scale")
+                    ) and padded_scale_in is not None:
+                        loaded_weight = _pad_tensor_along_dim(
+                            loaded_weight, padded_scale_in, 1, 1.0
+                        )
             if self.quant_config is not None and (
                 scale_name := self.quant_config.get_cache_scale(name)
             ):

--- a/vllm/model_executor/models/exaone4.py
+++ b/vllm/model_executor/models/exaone4.py
@@ -21,7 +21,6 @@
 # limitations under the License.
 """Inference-only Exaone model compatible with HuggingFace weights."""
 
-import math
 from collections.abc import Iterable
 from itertools import islice
 
@@ -83,7 +82,13 @@ def _padded_intermediate_size(
     block_n, block_k = weight_block_size[0], weight_block_size[1]
     if block_n <= 0 or block_k <= 0:
         return intermediate_size
-    alignment = tp_size * math.lcm(block_n, block_k)
+
+    def gcd(a: int, b: int) -> int:
+        while b:
+            a, b = b, a % b
+        return a
+
+    alignment = tp_size * (block_n * block_k // gcd(block_n, block_k))
     return _ceil_div(intermediate_size, alignment) * alignment
 
 


### PR DESCRIPTION
## Purpose

Some EXAONE4 FP8 group-quantized checkpoints cannot be loaded under tensor parallelism because the MLP intermediate size is not aligned with `TP x quant_block_size`.

For example, in `LGAI-EXAONE/EXAONE-4.0-32B-FP8`:

- intermediate size = 27392
- quant block size = 128
- TP = 4

For the down projection MLP:
```
27392 / (4 x 128) = 53.5 -> not divisible
```

This causes group scales to be unevenly partitioned across TP ranks, which breaks vLLM's internal assumptions and results in shape mismatch errors during model loading.

The fused gate-up projection has size `2 x intermediate_size`, which is divisible by `(4 x 128)`.
However, its group scale tensor still does not align cleanly with TP partitioning at block granularity, leading to incorrect scale application and silent correctness issues.

This PR addresses the problem **without modifying core vLLM quant logic** by:
- padding the intermediate size at model load time to the required alignment
- padding affected weights and group scale tensors accordingly

This ensures safe TP partitioning while preserving numerical correctness.

Some minor changes in the diff are formatting fixes introduced by pre-commit.

## Test Plan

1. Load FP8 model with TP=4:
```sh
vllm serve LGAI-EXAONE/EXAONE-4.0-32B-FP8 --tensor
```

2. Run generation sanity check:
```
vllm bench latench --model LGAI-EXAONE/EXAONE-4.0-32B-FP8
```

3. Compare behavior
- before patch -> load failure
```
ValueError: Weight input_size_per_partition = 6848 is not divisible by weight quantization block_k = 128.
```
- after patch -> successful load + stable generation

## Test Result

- Model loads successfully under TP=4
- No shape mismatch errors
- Generation works normally
- No regression observed for:
  - non-FP8 EXAONE4
  - non-quantized EXAONE4
  - TP=1 cases

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

