### PR TITLE
[CPU Offloading] Add offloading connector scheduler load delay metric

### DIFF
--- a/tests/v1/kv_connector/unit/test_offloading_connector.py
+++ b/tests/v1/kv_connector/unit/test_offloading_connector.py
@@ -17,6 +17,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading_connector import (
     OffloadingConnector,
     OffloadingConnectorMetadata,
     OffloadingConnectorStats,
+    OffloadingOperationMetrics,
 )
 from vllm.forward_context import ForwardContext
 from vllm.utils.hashing import sha256
@@ -355,7 +356,7 @@ class RequestRunner:
             self.scheduler.update_from_output(scheduler_output, model_runner_output)
 
             if (
-                prev_token_id == EOS_TOKEN_ID
+                prev_token_id is EOS_TOKEN_ID
                 and prev_token_id != token_id
                 and self.scheduler.requests
             ):
@@ -781,6 +782,64 @@ def test_abort_loading_requests(request_runner):
     assert req_id not in runner.scheduler.requests
 
 
+def test_request_load_time_tracking(request_runner):
+    """Test that per-request load times are tracked during CPU offloading."""
+    offloaded_block_size = 12
+    gpu_block_size = 4
+    num_gpu_blocks = 100
+
+    runner = request_runner(
+        offloaded_block_size=offloaded_block_size,
+        gpu_block_size=gpu_block_size,
+        num_gpu_blocks=num_gpu_blocks,
+    )
+
+    # Store 2 blocks to CPU
+    runner.new_request(token_ids=[0] * offloaded_block_size * 2)
+    runner.manager.prepare_store.side_effect = (
+        lambda block_hashes: generate_store_output(block_hashes)
+    )
+    runner.run(
+        decoded_tokens=[EOS_TOKEN_ID],
+        expected_stored_gpu_block_indexes=(0, 1, 2, 3, 4, 5),
+    )
+
+    # Reset prefix cache to force a reload from CPU
+    runner.scheduler.reset_prefix_cache()
+    runner.new_request(token_ids=[0] * offloaded_block_size * 2)
+    runner.manager.lookup.return_value = 2
+    runner.manager.prepare_store.side_effect = (
+        lambda block_hashes: generate_store_output([])
+    )
+
+    # Clear any previous stats before the load test
+    runner.scheduler_connector.get_kv_connector_stats()
+
+    # Run and trigger CPU→GPU load
+    runner.run(
+        decoded_tokens=[EOS_TOKEN_ID],
+        expected_loaded_gpu_block_indexes=(0, 1, 2, 3, 4, 5),
+    )
+
+    # Get stats and verify request load time was recorded
+    stats = runner.scheduler_connector.get_kv_connector_stats()
+    assert stats is not None
+    assert isinstance(stats, OffloadingConnectorStats)
+    assert "request_load_time" in stats.data
+
+    # Verify we have at least one load time recorded
+    request_load_times = stats.data["request_load_time"]
+    assert len(request_load_times) > 0
+
+    # Verify each load time entry has the expected structure
+    for load_time_entry in request_load_times:
+        assert isinstance(load_time_entry, OffloadingOperationMetrics)
+        # op_time should be >= 0 (recorded time in seconds)
+        assert load_time_entry.op_time >= 0
+        # op_size is 0 for request load times (not block-level)
+        assert load_time_entry.op_size == 0
+
+
 class TestOffloadingConnectorStats:
     """Tests for OffloadingConnector stats reconstruction and operations."""
 
@@ -920,3 +979,60 @@ class TestOffloadingConnectorStats:
         # After reset, stats should be empty
         assert offload_connector_stats.is_empty()
         assert len(offload_connector_stats.data) == 0
+
+    def test_request_load_time_reduce(self):
+        """Test that request_load_time stats are properly reduced."""
+        stats = OffloadingConnectorStats(
+            data={
+                "request_load_time": [
+                    {"op_size": 0, "op_time": 0.025},
+                    {"op_size": 0, "op_time": 0.030},
+                    {"op_size": 0, "op_time": 0.050},
+                ],
+            }
+        )
+
+        reduced = stats.reduce()
+
+        assert isinstance(reduced, dict)
+        # Check that request load time stats were reduced
+        assert "request_load_time_total_bytes" in reduced
+        assert "request_load_time_total_time" in reduced
+        assert reduced["request_load_time_total_bytes"] == 0  # op_size is 0 for request metrics
+        assert abs(reduced["request_load_time_total_time"] - 0.105) < 1e-9
+
+    def test_request_load_time_aggregation_with_other_stats(self):
+        """Test that request_load_time aggregates properly with other transfer stats."""
+        stats1 = OffloadingConnectorStats(
+            data={
+                "CPU_to_GPU": [
+                    {"op_size": 16, "op_time": 1.0},
+                ],
+                "request_load_time": [
+                    {"op_size": 0, "op_time": 0.025},
+                    {"op_size": 0, "op_time": 0.030},
+                ],
+            }
+        )
+
+        stats2 = OffloadingConnectorStats(
+            data={
+                "CPU_to_GPU": [
+                    {"op_size": 8, "op_time": 0.5},
+                ],
+                "request_load_time": [
+                    {"op_size": 0, "op_time": 0.040},
+                ],
+            }
+        )
+
+        result = stats1.aggregate(stats2)
+
+        assert result is stats1  # Should return self
+        # Verify both block-level and request-level stats are aggregated
+        assert len(result.data["CPU_to_GPU"]) == 2
+        assert len(result.data["request_load_time"]) == 3
+
+        # Verify the values
+        load_times = [op["op_time"] for op in result.data["request_load_time"]]
+        assert load_times == [0.025, 0.030, 0.040]

--- a/tests/v1/kv_connector/unit/test_offloading_connector.py
+++ b/tests/v1/kv_connector/unit/test_offloading_connector.py
@@ -356,7 +356,7 @@ class RequestRunner:
             self.scheduler.update_from_output(scheduler_output, model_runner_output)
 
             if (
-                prev_token_id is EOS_TOKEN_ID
+                prev_token_id == EOS_TOKEN_ID
                 and prev_token_id != token_id
                 and self.scheduler.requests
             ):


### PR DESCRIPTION
## Purpose

We currently have an offloading connector worker metric to measure the latency incurred from the block copies themselves from CPU to GPU, but this can in some situations represent only a small section of the broader "per request CPU onloading latency segment".

The purpose of this PR is to provide the metric for the latency segment capturing the effective delay experienced as a result of loading blocks which takes into account offloading connector scheduler <-> worker delays.

This will help in measuring the effectiveness of CPU onloading in high concurrency scenarios.

## Test Plan

Tested on an Nvidia L4 with Qwen/Qweb2.5-7B-Instruct model.

```
VLLM_SERVER_DEV_MODE=1 python -m vllm.entrypoints.openai.api_server 
--model Qwen/Qwen2.5-7B-Instruct 
--gpu-memory-utilization 0.8 
--kv_offloading_backend native 
--kv_offloading_size 1 
--disable-hybrid-kv-cache-manager
```
Small load test configuration:
- 10 prompts of 6K ISL to prewarm CPU cache
- Prefix cache reset
- Resend same 10 prompts concurrently to see all their blocks loaded.

```
(base) thomas_pougetabadie_gmail_com@instance-20260112-035650:~/vllm$ ./load_test_cpu_only.sh -p 1 -P 10 -i 6000 -n 10 -o 50
[*] Reading 10 prompts starting from 1 from prompts_isl_6000.txt...
    Prompt 1 length: 37924 characters
    Prompt 2 length: 37877 characters
    Prompt 3 length: 37735 characters
    Prompt 4 length: 37816 characters
    Prompt 5 length: 37553 characters
    Prompt 6 length: 38054 characters
    Prompt 7 length: 37847 characters
    Prompt 8 length: 37881 characters
    Prompt 9 length: 37962 characters
    Prompt 10 length: 37659 characters
[*] Checking server connectivity...
    Server is reachable

================================================================================
CPU CACHE WARMING TEST
================================================================================
Server: http://localhost:8000
Model: Qwen/Qwen2.5-7B-Instruct
Prompts: #1-10 from ISL 6000 (10 prompts)
Output tokens: 50
Total requests: 10
Requests per prompt: 1 (sent in batches of 10)

[1] WARMUP: Sending initial request(s) to populate GPU cache...
    Prompt 1 warmup completed in 4.543s
    Prompt 2 warmup completed in 2.976s
    Prompt 3 warmup completed in 4.555s
    Prompt 4 warmup completed in 4.568s
    Prompt 5 warmup completed in 4.424s
    Prompt 6 warmup completed in 2.980s
    Prompt 7 warmup completed in 4.610s
    Prompt 8 warmup completed in 4.610s
    Prompt 9 warmup completed in 4.630s
    Prompt 10 warmup completed in 4.623s
    All warmup requests completed (avg: 4.252s)
    Waiting 3s for potential CPU offloading...

[2] RESET: Resetting prefix cache to offload blocks to CPU...
    Cache reset successful
    Waiting 2s for offloading to complete...

[3] TEST: Sending 1 batches of 10 requests (10 total)...

Batch 1/1:
  [09:40:44] Batch completed in 22.959s (running avg per request: 18.445s)
```


## Test Result:

```
================================================================================
RESULTS
================================================================================
Request timing statistics (10 requests):
  Warmup time:  4.623s
  Average time: 18.445s
  Min time:     12.813s
  Max time:     22.906s
  Total time:   184.451s

Per-request CPU load metrics:
  Count:        6.0 requests
  Total time:   3.0567467169998963s
  Avg load time: 0.509s/req

Block-level CPU→GPU transfer metrics:
  Operations:   6.0 ops
  Total bytes:  1112.12 MB
  Avg time:     16.485 ms/op

Block-level GPU→CPU transfer metrics:
  Operations:   114.0 ops
  Total bytes:  12649.00 MB
  Avg time:     9.171 ms/op
```

Results show a significant difference between the scheduler-side request delay metric and the block level CPU->GPU transfer latency.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

