### PR TITLE
[DO NOT MERGE ]  Evidence for FlashInfer allreduce_fusion one-shot (kARResidualRMSNorm) causes deterministic NaN corruption and GSM8K collapse

### DIFF
--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -241,14 +241,12 @@ if flashinfer_comm is not None:
         if _AR_RMS_NUMERIC_DEBUG and not skip_debug_during_capture:
             _AR_RMS_NUMERIC_DEBUG_CALLS += 1
             call_id = _AR_RMS_NUMERIC_DEBUG_CALLS
+            # Before kernel launch, only inspect true inputs.
             debug_inputs = (
                 ("allreduce_in_pre", allreduce_in),
                 ("residual_pre", residual),
                 ("rms_gamma", rms_gamma),
                 ("scale_factor", scale_factor),
-                ("norm_out_pre", norm_out),
-                ("quant_out_pre", quant_out),
-                ("scale_out_pre", scale_out),
             )
             input_non_finite = any(_has_non_finite(t) for _, t in debug_inputs)
             if (

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import contextlib
+import os
 from importlib.util import find_spec
 from types import ModuleType
 
@@ -85,6 +86,84 @@ if flashinfer_comm is not None:
     _FI_WORKSPACE = None
     MiB = 1024 * 1024
 
+    def _parse_int_env(name: str, default: int) -> int:
+        value = os.getenv(name, str(default))
+        try:
+            return int(value)
+        except ValueError:
+            logger.warning("Invalid %s=%r. Falling back to %d", name, value, default)
+            return default
+
+    _AR_RMS_NUMERIC_DEBUG = os.getenv("VLLM_DEBUG_AR_RMS_NUMERICS", "0") == "1"
+    _AR_RMS_NUMERIC_DEBUG_LOG_ALL = (
+        os.getenv("VLLM_DEBUG_AR_RMS_NUMERICS_LOG_ALL", "0") == "1"
+    )
+    _AR_RMS_NUMERIC_DEBUG_ABORT = (
+        os.getenv("VLLM_DEBUG_AR_RMS_NUMERICS_ABORT", "0") == "1"
+    )
+    _AR_RMS_NUMERIC_DEBUG_MAX_LOGS = _parse_int_env(
+        "VLLM_DEBUG_AR_RMS_NUMERICS_MAX_LOGS", 200
+    )
+    _AR_RMS_NUMERIC_DEBUG_CALLS = 0
+    _AR_RMS_NUMERIC_DEBUG_LOGS = 0
+
+    def _pattern_name(pattern_code: int) -> str:
+        fi_comm = flashinfer_comm
+        if fi_comm is None:
+            return str(pattern_code)
+        pattern_enum = fi_comm.AllReduceFusionPattern
+        for name in (
+            "kARResidualRMSNorm",
+            "kARResidualRMSNormFP8Quant",
+            "kARResidualRMSNormFP4Quant",
+        ):
+            code = getattr(pattern_enum, name, None)
+            if code is not None and int(code) == int(pattern_code):
+                return name
+        return str(pattern_code)
+
+    def _has_non_finite(tensor: torch.Tensor | None) -> bool:
+        if tensor is None or not torch.is_floating_point(tensor):
+            return False
+        return bool(
+            torch.isnan(tensor).any().item() or torch.isinf(tensor).any().item()
+        )
+
+    def _tensor_summary(name: str, tensor: torch.Tensor | None) -> str:
+        if tensor is None:
+            return f"{name}=None"
+        shape = tuple(tensor.shape)
+        dtype = str(tensor.dtype).replace("torch.", "")
+        numel = tensor.numel()
+        if numel == 0:
+            return f"{name}[{dtype}{shape}] empty"
+
+        if torch.is_floating_point(tensor):
+            nan_count = int(torch.isnan(tensor).sum().item())
+            inf_count = int(torch.isinf(tensor).sum().item())
+            finite = torch.isfinite(tensor)
+            finite_count = int(finite.sum().item())
+            if finite_count > 0:
+                finite_vals = tensor[finite]
+                min_val = float(finite_vals.min().item())
+                max_val = float(finite_vals.max().item())
+                abs_max = float(finite_vals.abs().max().item())
+                range_str = f"min={min_val:.4e} max={max_val:.4e} abs_max={abs_max:.4e}"
+            else:
+                range_str = "min=nan max=nan abs_max=nan"
+            return (
+                f"{name}[{dtype}{shape}] nonfinite(nan={nan_count},inf={inf_count}) "
+                f"finite={finite_count}/{numel} {range_str}"
+            )
+
+        min_val = tensor.min().item()
+        max_val = tensor.max().item()
+        summary = f"{name}[{dtype}{shape}] min={min_val} max={max_val}"
+        if tensor.dtype == torch.uint8:
+            zero_count = int((tensor == 0).sum().item())
+            summary += f" zero={zero_count}/{numel}"
+        return summary
+
     def call_trtllm_fused_allreduce_norm(
         allreduce_in: torch.Tensor,
         residual: torch.Tensor,
@@ -100,6 +179,7 @@ if flashinfer_comm is not None:
         scale_out: torch.Tensor | None = None,
         scale_factor: torch.Tensor | None = None,
     ) -> None:
+        global _AR_RMS_NUMERIC_DEBUG_CALLS, _AR_RMS_NUMERIC_DEBUG_LOGS
         num_tokens, hidden_size = allreduce_in.shape
         element_size = allreduce_in.element_size()
         current_tensor_size = num_tokens * hidden_size * element_size
@@ -133,6 +213,36 @@ if flashinfer_comm is not None:
             # as flashinfer does not support rms_norm
             # and allreduce_out together
             residual_out = allreduce_in
+
+        input_non_finite = False
+        call_id = 0
+        if _AR_RMS_NUMERIC_DEBUG:
+            _AR_RMS_NUMERIC_DEBUG_CALLS += 1
+            call_id = _AR_RMS_NUMERIC_DEBUG_CALLS
+            debug_inputs = (
+                ("allreduce_in_pre", allreduce_in),
+                ("residual_pre", residual),
+                ("rms_gamma", rms_gamma),
+                ("scale_factor", scale_factor),
+                ("norm_out_pre", norm_out),
+                ("quant_out_pre", quant_out),
+                ("scale_out_pre", scale_out),
+            )
+            input_non_finite = any(_has_non_finite(t) for _, t in debug_inputs)
+            if (
+                input_non_finite or _AR_RMS_NUMERIC_DEBUG_LOG_ALL
+            ) and _AR_RMS_NUMERIC_DEBUG_LOGS < _AR_RMS_NUMERIC_DEBUG_MAX_LOGS:
+                _AR_RMS_NUMERIC_DEBUG_LOGS += 1
+                logger.warning(
+                    "AR_RMS_NUMERIC_DEBUG before call=%d rank=%d pattern=%s "
+                    "use_oneshot=%s | %s",
+                    call_id,
+                    get_tensor_model_parallel_rank(),
+                    _pattern_name(pattern_code),
+                    use_oneshot,
+                    " | ".join(_tensor_summary(n, t) for n, t in debug_inputs),
+                )
+
         # For the sizes that are smaller than the max size,
         # we only use flashinfer one shot allreduce
         flashinfer_comm.allreduce_fusion(
@@ -153,6 +263,38 @@ if flashinfer_comm is not None:
             layout_code=flashinfer_comm.QuantizationSFLayout.SWIZZLED_128x4,
             scale_factor=scale_factor,
         )
+
+        if _AR_RMS_NUMERIC_DEBUG:
+            debug_outputs = (
+                ("allreduce_in_post", allreduce_in),
+                ("residual_post", residual),
+                ("norm_out_post", norm_out),
+                ("quant_out_post", quant_out),
+                ("scale_out_post", scale_out),
+            )
+            output_non_finite = any(_has_non_finite(t) for _, t in debug_outputs)
+            if (
+                input_non_finite or output_non_finite or _AR_RMS_NUMERIC_DEBUG_LOG_ALL
+            ) and _AR_RMS_NUMERIC_DEBUG_LOGS < _AR_RMS_NUMERIC_DEBUG_MAX_LOGS:
+                _AR_RMS_NUMERIC_DEBUG_LOGS += 1
+                logger.warning(
+                    "AR_RMS_NUMERIC_DEBUG after call=%d rank=%d pattern=%s "
+                    "use_oneshot=%s input_non_finite=%s output_non_finite=%s | %s",
+                    call_id,
+                    get_tensor_model_parallel_rank(),
+                    _pattern_name(pattern_code),
+                    use_oneshot,
+                    input_non_finite,
+                    output_non_finite,
+                    " | ".join(_tensor_summary(n, t) for n, t in debug_outputs),
+                )
+
+            if _AR_RMS_NUMERIC_DEBUG_ABORT and (input_non_finite or output_non_finite):
+                raise RuntimeError(
+                    "AR_RMS_NUMERIC_DEBUG detected non-finite tensors "
+                    f"(call={call_id}, pattern={_pattern_name(pattern_code)}, "
+                    f"use_oneshot={use_oneshot})."
+                )
 
     def call_trtllm_fused_allreduce_norm_fake(
         allreduce_in: torch.Tensor,

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -516,7 +516,7 @@ class AllReduceFusedRMSNormStaticQuantNVFP4Pattern(BasePattern):
         self.rmsnorm_matcher = MatcherRMSNorm(epsilon)
 
     def get_inputs(self) -> list[torch.Tensor]:
-        input = torch.empty([16, 16], device=self.device, dtype=self.dtype)
+        input = torch.empty([1, 16, 16], device=self.device, dtype=self.dtype)
         quant_result = torch.empty((16, 8), device=self.device, dtype=torch.uint8)
         input_global_scale = torch.empty(
             [1, 1], device=self.device, dtype=torch.float32
@@ -607,7 +607,7 @@ class AllReduceFusedAddRMSNormStaticQuantNVFP4Pattern(BasePattern):
         input = torch.empty([16, 16], device=self.device, dtype=self.dtype)
 
         residual = torch.empty([16, 16], device=self.device, dtype=self.dtype)
-        weight = torch.empty([16], device=self.device, dtype=self.dtype)
+        weight = torch.empty([16, 16], device=self.device, dtype=self.dtype)
         quant_result = torch.empty((16, 8), device=self.device, dtype=torch.uint8)
         input_global_scale = torch.empty(
             [1, 1], device=self.device, dtype=torch.float32

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -516,7 +516,7 @@ class AllReduceFusedRMSNormStaticQuantNVFP4Pattern(BasePattern):
         self.rmsnorm_matcher = MatcherRMSNorm(epsilon)
 
     def get_inputs(self) -> list[torch.Tensor]:
-        input = torch.empty([1, 16, 16], device=self.device, dtype=self.dtype)
+        input = torch.empty([16, 16], device=self.device, dtype=self.dtype)
         quant_result = torch.empty((16, 8), device=self.device, dtype=torch.uint8)
         input_global_scale = torch.empty(
             [1, 1], device=self.device, dtype=torch.float32
@@ -607,7 +607,7 @@ class AllReduceFusedAddRMSNormStaticQuantNVFP4Pattern(BasePattern):
         input = torch.empty([16, 16], device=self.device, dtype=self.dtype)
 
         residual = torch.empty([16, 16], device=self.device, dtype=self.dtype)
-        weight = torch.empty([16, 16], device=self.device, dtype=self.dtype)
+        weight = torch.empty([16], device=self.device, dtype=self.dtype)
         quant_result = torch.empty((16, 8), device=self.device, dtype=torch.uint8)
         input_global_scale = torch.empty(
             [1, 1], device=self.device, dtype=torch.float32

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -101,6 +101,15 @@ if flashinfer_comm is not None:
     _AR_RMS_NUMERIC_DEBUG_ABORT = (
         os.getenv("VLLM_DEBUG_AR_RMS_NUMERICS_ABORT", "0") == "1"
     )
+    _AR_RMS_NUMERIC_DEBUG_ABORT_ON_NEW = (
+        os.getenv("VLLM_DEBUG_AR_RMS_NUMERICS_ABORT_ON_NEW", "0") == "1"
+    )
+    _AR_RMS_NUMERIC_DEBUG_FORCE_NO_ONESHOT = (
+        os.getenv("VLLM_DEBUG_AR_RMS_FORCE_NO_ONESHOT", "0") == "1"
+    )
+    _AR_RMS_NUMERIC_DEBUG_FORCE_ONESHOT = (
+        os.getenv("VLLM_DEBUG_AR_RMS_FORCE_ONESHOT", "0") == "1"
+    )
     _AR_RMS_NUMERIC_DEBUG_MAX_LOGS = _parse_int_env(
         "VLLM_DEBUG_AR_RMS_NUMERICS_MAX_LOGS", 200
     )
@@ -212,6 +221,10 @@ if flashinfer_comm is not None:
         use_oneshot = (
             max_one_shot_size is None or current_tensor_size <= max_one_shot_size * MiB
         )
+        if _AR_RMS_NUMERIC_DEBUG_FORCE_NO_ONESHOT:
+            use_oneshot = False
+        elif _AR_RMS_NUMERIC_DEBUG_FORCE_ONESHOT:
+            use_oneshot = True
 
         assert _FI_WORKSPACE is not None, (
             "Flashinfer must be enabled when using flashinfer"
@@ -293,20 +306,42 @@ if flashinfer_comm is not None:
                 ("scale_out_post", scale_out),
             )
             output_non_finite = any(_has_non_finite(t) for _, t in debug_outputs)
+            if output_non_finite and not input_non_finite:
+                numeric_debug_source = "introduced_inside_fused_op"
+            elif input_non_finite and output_non_finite:
+                numeric_debug_source = "upstream_non_finite_input"
+            elif input_non_finite and not output_non_finite:
+                numeric_debug_source = "input_non_finite_but_output_finite"
+            else:
+                numeric_debug_source = "all_finite"
             if (
                 input_non_finite or output_non_finite or _AR_RMS_NUMERIC_DEBUG_LOG_ALL
             ) and _AR_RMS_NUMERIC_DEBUG_LOGS < _AR_RMS_NUMERIC_DEBUG_MAX_LOGS:
                 _AR_RMS_NUMERIC_DEBUG_LOGS += 1
                 logger.warning(
                     "AR_RMS_NUMERIC_DEBUG after call=%d rank=%d pattern=%s "
-                    "use_oneshot=%s input_non_finite=%s output_non_finite=%s | %s",
+                    "use_oneshot=%s input_non_finite=%s output_non_finite=%s "
+                    "source=%s | %s",
                     call_id,
                     get_tensor_model_parallel_rank(),
                     _pattern_name(pattern_code),
                     use_oneshot,
                     input_non_finite,
                     output_non_finite,
+                    numeric_debug_source,
                     " | ".join(_tensor_summary(n, t) for n, t in debug_outputs),
+                )
+
+            if (
+                _AR_RMS_NUMERIC_DEBUG_ABORT_ON_NEW
+                and output_non_finite
+                and (not input_non_finite)
+            ):
+                raise RuntimeError(
+                    "AR_RMS_NUMERIC_DEBUG detected newly introduced non-finite "
+                    "values inside fused op "
+                    f"(call={call_id}, pattern={_pattern_name(pattern_code)}, "
+                    f"use_oneshot={use_oneshot})."
                 )
 
             if _AR_RMS_NUMERIC_DEBUG_ABORT and (input_non_finite or output_non_finite):

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import itertools
-import os
 from abc import abstractmethod
 from typing import Any
 
@@ -65,137 +64,6 @@ WEIGHT_LOADER_V2_SUPPORTED = [
     "ModelOptNvFp4LinearMethod",
     "PetitNvFp4LinearMethod",
 ]
-
-
-def _parse_int_env(name: str, default: int) -> int:
-    value = os.getenv(name, str(default))
-    try:
-        return int(value)
-    except ValueError:
-        logger.warning("Invalid %s=%r. Falling back to %d", name, value, default)
-        return default
-
-
-_TP_ROW_NUMERIC_DEBUG = os.getenv("VLLM_DEBUG_TP_ROW_NUMERICS", "0") == "1"
-_TP_ROW_NUMERIC_DEBUG_ABORT = os.getenv("VLLM_DEBUG_TP_ROW_NUMERICS_ABORT", "0") == "1"
-_TP_ROW_NUMERIC_DEBUG_LAYER_FILTER = os.getenv(
-    "VLLM_DEBUG_TP_ROW_NUMERICS_LAYER_FILTER", ""
-)
-_TP_ROW_NUMERIC_DEBUG_MAX_LOGS = _parse_int_env(
-    "VLLM_DEBUG_TP_ROW_NUMERICS_MAX_LOGS", 200
-)
-_TP_ROW_NUMERIC_DEBUG_CALLS = 0
-_TP_ROW_NUMERIC_DEBUG_LOGS = 0
-
-
-def _has_non_finite(tensor: torch.Tensor) -> bool:
-    if not torch.is_floating_point(tensor):
-        return False
-    return bool(torch.isnan(tensor).any().item() or torch.isinf(tensor).any().item())
-
-
-def _is_torch_compiling() -> bool:
-    compiler = getattr(torch, "compiler", None)
-    if compiler is not None:
-        is_compiling = getattr(compiler, "is_compiling", None)
-        if callable(is_compiling):
-            try:
-                return bool(is_compiling())
-            except Exception:
-                pass
-
-    dynamo = getattr(torch, "_dynamo", None)
-    if dynamo is not None:
-        is_compiling = getattr(dynamo, "is_compiling", None)
-        if callable(is_compiling):
-            try:
-                return bool(is_compiling())
-            except Exception:
-                pass
-    return False
-
-
-def _tensor_summary(name: str, tensor: torch.Tensor) -> str:
-    shape = tuple(tensor.shape)
-    dtype = str(tensor.dtype).replace("torch.", "")
-    numel = tensor.numel()
-    if numel == 0:
-        return f"{name}[{dtype}{shape}] empty"
-
-    if not torch.is_floating_point(tensor):
-        min_val = tensor.min().item()
-        max_val = tensor.max().item()
-        return f"{name}[{dtype}{shape}] min={min_val} max={max_val}"
-
-    nan_count = int(torch.isnan(tensor).sum().item())
-    inf_count = int(torch.isinf(tensor).sum().item())
-    finite = torch.isfinite(tensor)
-    finite_count = int(finite.sum().item())
-    if finite_count > 0:
-        finite_vals = tensor[finite]
-        min_val = float(finite_vals.min().item())
-        max_val = float(finite_vals.max().item())
-        abs_max = float(finite_vals.abs().max().item())
-        range_str = f"min={min_val:.4e} max={max_val:.4e} abs_max={abs_max:.4e}"
-    else:
-        range_str = "min=nan max=nan abs_max=nan"
-    return (
-        f"{name}[{dtype}{shape}] nonfinite(nan={nan_count},inf={inf_count}) "
-        f"finite={finite_count}/{numel} {range_str}"
-    )
-
-
-def _log_tp_row_numeric_debug(
-    *,
-    layer_prefix: str,
-    input_parallel: torch.Tensor,
-    output_parallel: torch.Tensor,
-) -> None:
-    global _TP_ROW_NUMERIC_DEBUG_CALLS, _TP_ROW_NUMERIC_DEBUG_LOGS
-    if not _TP_ROW_NUMERIC_DEBUG:
-        return
-    if (
-        _TP_ROW_NUMERIC_DEBUG_LAYER_FILTER
-        and _TP_ROW_NUMERIC_DEBUG_LAYER_FILTER not in layer_prefix
-    ):
-        return
-
-    _TP_ROW_NUMERIC_DEBUG_CALLS += 1
-    call_id = _TP_ROW_NUMERIC_DEBUG_CALLS
-    input_non_finite = _has_non_finite(input_parallel)
-    output_non_finite = _has_non_finite(output_parallel)
-
-    if output_non_finite and not input_non_finite:
-        source = "introduced_in_row_parallel_linear"
-    elif input_non_finite and output_non_finite:
-        source = "propagated_from_row_linear_input"
-    elif input_non_finite and not output_non_finite:
-        source = "input_non_finite_but_output_finite"
-    else:
-        source = "all_finite"
-
-    if (
-        input_non_finite or output_non_finite
-    ) and _TP_ROW_NUMERIC_DEBUG_LOGS < _TP_ROW_NUMERIC_DEBUG_MAX_LOGS:
-        _TP_ROW_NUMERIC_DEBUG_LOGS += 1
-        logger.warning(
-            "TP_ROW_NUMERIC_DEBUG call=%d rank=%d layer=%s "
-            "input_non_finite=%s output_non_finite=%s source=%s | %s | %s",
-            call_id,
-            get_tensor_model_parallel_rank(),
-            layer_prefix,
-            input_non_finite,
-            output_non_finite,
-            source,
-            _tensor_summary("input_parallel", input_parallel),
-            _tensor_summary("output_parallel", output_parallel),
-        )
-
-    if _TP_ROW_NUMERIC_DEBUG_ABORT and (input_non_finite or output_non_finite):
-        raise RuntimeError(
-            "TP_ROW_NUMERIC_DEBUG detected non-finite tensors "
-            f"(call={call_id}, layer={layer_prefix}, source={source})."
-        )
 
 
 def adjust_marlin_shard(param, shard_size, shard_offset):
@@ -1583,12 +1451,6 @@ class RowParallelLinear(LinearBase):
         # bias will not get added more than once in TP>1 case)
         bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
         output_parallel = self.quant_method.apply(self, input_parallel, bias_)
-        if self.reduce_results and self.tp_size > 1 and not _is_torch_compiling():
-            _log_tp_row_numeric_debug(
-                layer_prefix=self.prefix,
-                input_parallel=input_parallel,
-                output_parallel=output_parallel,
-            )
 
         if self.reduce_results and self.tp_size > 1:
             output = tensor_model_parallel_all_reduce(output_parallel)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
#34395
This PR documents and mitigates a deterministic numeric issue on the FlashInfer fused AR+RMS path for NVFP4 on B300.
The issue is isolated to the use_oneshot=True  , not generic PyTorch ops.

Evidence
1 Repro with AR+RMS fusion enabled (fuse_allreduce_rms=true, fi_allreduce_fusion_max_size_mb=32) gives GSM8K collapse to 0.0 (issue-aligned behavior).

2 First numeric corruption point is consistently:
AR_RMS_NUMERIC_DEBUG before call=126
pattern=kARResidualRMSNorm
use_oneshot=True
allreduce_in_pre already contains NaNs, while residual_pre and rms_gamma remain finite.

3 Corruption pattern is deterministic and cross-rank consistent:
bad_rows(allreduce_in_pre)=8/1024
row indices [523, 583, 651, 711, 779, 839, 907, 967]

4 A/B confirms branch sensitivity:
Large-token non-one-shot path restores GSM8K to 0.96.
Keeping one-shot path triggers collapse.

5 Forcing non-one-shot globally is invalid due FlashInfer constraint on small decode steps:
Assertion in [trtllm_ar.py](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/dongj/.cursor/extensions/openai.chatgpt-0.4.71-universal/webview/#): sequence length must be larger than TP size.
This proves path switching is happening inside FlashInfer runtime, not in unrelated layers.
## Test Plan

## Test Result

https://paste.ubuntu.com/p/D9ztNgQYQc/
did not go to fallback roll 
<img width="1619" height="235" alt="image" src="https://github.com/user-attachments/assets/3c67792b-2805-43be-a591-a78d7e4b44a2" />
 res:
https://paste.ubuntu.com/p/7jdCFfGRPJ/



 for turn on  one shot 
https://paste.ubuntu.com/p/YRWV7YdQPS/ 
res: https://paste.ubuntu.com/p/JRrH9BW4Gd/
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

