### PR TITLE
[KV Connector] Add temporary, off-by-default `VLLM_DISABLE_REQUEST_ID_RANDOMIZATION` workaround

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -169,6 +169,7 @@ if TYPE_CHECKING:
     VLLM_XGRAMMAR_CACHE_MB: int = 0
     VLLM_MSGPACK_ZERO_COPY_THRESHOLD: int = 256
     VLLM_ALLOW_INSECURE_SERIALIZATION: bool = False
+    VLLM_DISABLE_REQUEST_ID_RANDOMIZATION: bool = False
     VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5600
     VLLM_MOONCAKE_BOOTSTRAP_PORT: int = 8998
@@ -1233,6 +1234,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # insecure method and it is needed for some reason.
     "VLLM_ALLOW_INSECURE_SERIALIZATION": lambda: bool(
         int(os.getenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "0"))
+    ),
+    # Temporary: skip adding random suffix to internal request IDs. May be
+    # needed for KV connectors that match request IDs across instances.
+    "VLLM_DISABLE_REQUEST_ID_RANDOMIZATION": lambda: bool(
+        int(os.getenv("VLLM_DISABLE_REQUEST_ID_RANDOMIZATION", "0"))
     ),
     # IP address used for NIXL handshake between remote agents.
     "VLLM_NIXL_SIDE_CHANNEL_HOST": lambda: os.getenv(

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -5,6 +5,7 @@ import time
 from collections.abc import Mapping
 from typing import Any, Literal, cast
 
+import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.inputs.data import (
     ProcessorInputs,
@@ -300,7 +301,8 @@ class InputProcessor:
                 " passed to vLLM; use the request_id field."
             )
         request.external_req_id = request.request_id
-        request.request_id = f"{request.external_req_id}-{random_uuid():.8}"
+        if not envs.VLLM_DISABLE_REQUEST_ID_RANDOMIZATION:
+            request.request_id = f"{request.external_req_id}-{random_uuid():.8}"
 
     def process_inputs(
         self,

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -304,7 +304,7 @@ class InputProcessor:
         if envs.VLLM_DISABLE_REQUEST_ID_RANDOMIZATION:
             logger.warning_once(
                 "VLLM_DISABLE_REQUEST_ID_RANDOMIZATION is set and will be "
-                "deprecated in a future release. Duplicate externally-provided "
+                "removed in a future release. Duplicate externally-provided "
                 "request IDs may cause failures and/or subtle correctness errors."
             )
         else:

--- a/vllm/v1/engine/input_processor.py
+++ b/vllm/v1/engine/input_processor.py
@@ -301,7 +301,13 @@ class InputProcessor:
                 " passed to vLLM; use the request_id field."
             )
         request.external_req_id = request.request_id
-        if not envs.VLLM_DISABLE_REQUEST_ID_RANDOMIZATION:
+        if envs.VLLM_DISABLE_REQUEST_ID_RANDOMIZATION:
+            logger.warning_once(
+                "VLLM_DISABLE_REQUEST_ID_RANDOMIZATION is set and will be "
+                "deprecated in a future release. Duplicate externally-provided "
+                "request IDs may cause failures and/or subtle correctness errors."
+            )
+        else:
             request.request_id = f"{request.external_req_id}-{random_uuid():.8}"
 
     def process_inputs(


### PR DESCRIPTION
`v0.14.0` and later adds a random suffix to frontend-provided request IDs - #27987

This change broke several in-tree KV connectors that do not have CI coverage. See:

- #33947 - P2P NCCL connector
- #32630 and #32937 - MoRIIO connector
- #31034 - Mooncake (fixed?)

As a temporary measure, add a `VLLM_DISABLE_REQUEST_ID_RANDOMIZATION=1` env var that will restore the pre-`v0.14.0` behavior so that users of these connectors can work around the breakage.

This env var will be removed again in a forthcoming release.

## Manual testing
```bash
pip install quart aiohttp pyzmq msgpack

# Terminal 1: Proxy
python examples/online_serving/disaggregated_serving_p2p_nccl_xpyd/disagg_proxy_p2p_nccl_xpyd.py

# Terminal 2: Prefill (GPU 0), add VLLM_DISABLE_REQUEST_ID_RANDOMIZATION=1 for fix
CUDA_VISIBLE_DEVICES=0 vllm serve facebook/opt-125m \
    --enforce-eager --host 0.0.0.0 --port 20003 \
    --dtype float16 --max-model-len 2048 --gpu-memory-utilization 0.5 \
    --kv-transfer-config \
    '{"kv_connector":"P2pNcclConnector","kv_role":"kv_producer","kv_port":"21001","kv_connector_extra_config":{"proxy_ip":"0.0.0.0","proxy_port":"30001","http_port":"20003","send_type":"PUT_ASYNC"}}'

# Terminal 3: Decode (GPU 1), add VLLM_DISABLE_REQUEST_ID_RANDOMIZATION for fix
CUDA_VISIBLE_DEVICES=1 vllm serve facebook/opt-125m \
    --enforce-eager --host 0.0.0.0 --port 20005 \
    --dtype float16 --max-model-len 2048 --gpu-memory-utilization 0.5 \
    --kv-transfer-config \
    '{"kv_connector":"P2pNcclConnector","kv_role":"kv_consumer","kv_buffer_size":"5e9","kv_port":"22001","kv_connector_extra_config":{"proxy_ip":"0.0.0.0","proxy_port":"30001","http_port":"20005","send_type":"PUT_ASYNC"}}'

# Terminal 4: Test
curl -s http://localhost:11001/v1/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"facebook/opt-125m","prompt":"The capital of France is","max_tokens":20}' \
  | python -m json.tool
```

## Without fix
<img width="2032" height="1167" alt="Screenshot 2026-02-12 at 9 46 29 AM" src="https://github.com/user-attachments/assets/39092d0d-28ab-4ab0-9ad9-8cfbb5fcd1af" />


## With `VLLM_DISABLE_REQUEST_ID_RANDOMIZATION=1`, the warning is visible and fires only once

<img width="2032" height="1167" alt="Screenshot 2026-02-12 at 9 51 12 AM" src="https://github.com/user-attachments/assets/0194a132-508f-4a9c-a6af-47a50f1f9968" />
