### PR TITLE
[Bug Fix] Fix MambaManager.cache_blocks() crash on null blocks in align mode

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -742,6 +742,12 @@ def _make_hybrid_kv_cache_config(
             shapes=(1, 1),
             dtypes=(torch.float32,),
         ),
+        "mamba_align": lambda: MambaSpec(
+            block_size=block_size,
+            shapes=(1, 1),
+            dtypes=(torch.float32,),
+            mamba_cache_mode="align",
+        ),
     }
 
     kv_cache_groups = [
@@ -958,6 +964,46 @@ def test_prefill_hybrid_model_combinations_eagle(
 
     manager.free(req0)
     manager.free(req1)
+
+
+def test_prefill_hybrid_model_mamba_align():
+    """Test that MambaManager.cache_blocks() handles null blocks in align mode.
+
+    Regression test for https://github.com/vllm-project/vllm/issues/34361.
+    In mamba_cache_mode="align", allocate_new_blocks() pads req_to_blocks with
+    null blocks. cache_full_blocks() correctly skips them, but
+    MambaManager.cache_blocks() must also skip null blocks when tracking
+    cached_blocks_this_step.
+    """
+    block_size = 16
+    num_blocks = 30
+
+    kv_cache_config = _make_hybrid_kv_cache_config(
+        block_size, num_blocks, ["full", "mamba_align"]
+    )
+    manager = KVCacheManager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    hash_fn = sha256
+
+    # 3 full blocks (48 tokens) + 7 partial tokens = 55 tokens total
+    all_token_ids = [i for i in range(3) for _ in range(block_size)] + [3] * 7
+
+    # First request: allocate_slots should not crash with the assertion error
+    # in MambaManager.cache_blocks() when null blocks are present.
+    req0 = make_request("0", all_token_ids, block_size, hash_fn)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+
+    blocks = manager.allocate_slots(req0, 55, num_computed_tokens, computed_blocks)
+    assert blocks is not None
+    assert len(blocks.get_block_ids()) == 2  # full_attn + mamba groups
+
+    manager.free(req0)
 
 
 def test_prefill_plp():

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1000,6 +1000,8 @@ class MambaManager(SingleTypeKVCacheManager):
             for block in self.req_to_blocks[request.request_id][
                 num_cached_blocks_before:num_cached_blocks_after
             ]:
+                if block.is_null:
+                    continue
                 assert block.block_hash is not None
                 self.cached_blocks_this_step.add(block.block_hash)
 


### PR DESCRIPTION
## Purpose

Fixes #34361

In mamba_cache_mode="align", MambaManager.allocate_new_blocks() pads req_to_blocks with null blocks. cache_full_blocks() correctly skips them, but MambaManager.cache_blocks() iterated the same range without skipping null blocks, hitting `assert block.block_hash is not None`.

Skip null blocks in MambaManager.cache_blocks(), consistent with the handling in cache_full_blocks().

## Test Plan

Add test in tests/v1/core/test_prefix_caching.py

Add a new "mamba_align" spec type to `_make_hybrid_kv_cache_config` and new test cases to `_HYBRID_MODEL_TEST_CASES` covering align mode.

And then run the tests to verify it is fixed
```
python -m pytest tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations -xvs -k "mamba_align"
python -m pytest tests/v1/core/test_prefix_caching.py -xvs -k "hybrid"
python -m pytest tests/v1/core/test_prefix_caching.py -xvs -k "mamba"
python -m pytest tests/v1/core/test_prefix_caching.py -x
```

## Test Result

The relevant test cases have passed.

```
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_eagle PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[2g-full+sw] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[2g-full+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[2g-sw+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[2g-sw+sw_large] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-full+2sw] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-full+2mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-full+sw+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-full+sw+sw_large] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-2full+sw] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-2full+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[4g-interleaved-full+sw+sw_large] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[4g-interleaved-full+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[4g-interleaved-full+sw_mixed] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[4g-sw+mamba+sw_large+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[4g-2full+sw+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations_eagle[2g-full+sw] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_mamba_align PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[2g-full+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[2g-sw+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-full+2mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-full+sw+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[3g-2full+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[4g-interleaved-full+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[4g-sw+mamba+sw_large+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_combinations[4g-2full+sw+mamba] PASSED
tests/v1/core/test_prefix_caching.py::test_prefill_hybrid_model_mamba_align PASSED
tests/v1/core/test_prefix_caching.py .................................................                                                                                                                                                 [100%]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

