### PR TITLE
Add support for LoRA with NVFP4 MoE models

### DIFF
--- a/vllm/lora/layers/fused_moe.py
+++ b/vllm/lora/layers/fused_moe.py
@@ -149,7 +149,10 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
                 m_fused_moe_fn.fused_experts, (MarlinExperts, UnfusedOAITritonExperts)
             )
         else:
-            assert isinstance(m_fused_moe_fn.fused_experts, TritonExperts)
+            # MarlinExperts used for NVFP4 (see select_nvfp4_moe_backend)
+            assert isinstance(
+                m_fused_moe_fn.fused_experts, (TritonExperts, MarlinExperts)
+            )
 
         def fwd_decorator(layer, func):
             def wrapper(*args, **kwargs):

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -113,6 +113,9 @@ def select_nvfp4_moe_backend(
     Note: Shape-specific fallbacks may still occur at runtime.
     """
 
+    if config.is_lora_enabled:
+        return NvFp4MoeBackend.MARLIN, backend_to_kernel_cls(NvFp4MoeBackend.MARLIN)
+
     # NOTE: the kernels are selected in the following order.
     AVAILABLE_BACKENDS = [
         NvFp4MoeBackend.FLASHINFER_TRTLLM,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

In current vLLM main there is not support for LoRA with NVFP4 MoE models.

This PR enables LoRA support by using the existing MarlinExperts backend.

Requires this fix:
https://github.com/vllm-project/vllm/pull/34575

## Test Plan

Test support for LoRA adapters with Nemotron Nano NVFP4:
https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4

LoRA adapters for testing can be found here:
https://huggingface.co/models?other=base_model:adapter:nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16

## Test Result

Tested on B200 (requires env-var `VLLM_LORA_DISABLE_PDL=1`).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

