### PR TITLE
[Bug Fix] Fix --served-model-name greedily consuming positional model_tag

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -694,6 +694,11 @@ class EngineArgs:
         model_group.add_argument(
             "--enable-prompt-embeds", **model_kwargs["enable_prompt_embeds"]
         )
+        # Special case: served_model_name needs append action to avoid
+        # nargs="+" greedily consuming the positional model_tag argument.
+        model_kwargs["served_model_name"]["action"] = "append"
+        if "nargs" in model_kwargs["served_model_name"]:
+            del model_kwargs["served_model_name"]["nargs"]
         model_group.add_argument(
             "--served-model-name", **model_kwargs["served_model_name"]
         )


### PR DESCRIPTION
## Purpose

Fixes #34326 

The auto-generated nargs="+" on --served-model-name caused argparse to greedily consume the positional model_tag argument when the flag was placed before it (e.g. `vllm serve --served-model-name ASR Model`), resulting in the model falling back to the default.

Switch to action="append" following the existing --middleware convention, so each name requires its own flag instance.

## Test Plan

Add new test cases 
```
test_served_model_name
test_served_model_name_does_not_consume_model_tag
```

And then run

```
python -m pytest tests/entrypoints/openai/test_cli_args.py -x -v
```

to verify

## Test Result

```
tests/entrypoints/openai/test_cli_args.py::test_served_model_name[cli_args0-expected0] PASSED                                                                                                                                          [ 87%]
tests/entrypoints/openai/test_cli_args.py::test_served_model_name[cli_args1-expected1] PASSED                                                                                                                                          [ 91%]
tests/entrypoints/openai/test_cli_args.py::test_served_model_name[cli_args2-None] PASSED                                                                                                                                               [ 95%]
tests/entrypoints/openai/test_cli_args.py::test_served_model_name_does_not_consume_model_tag PASSED                                                                                                                                    [100%]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

