### PR TITLE
[Bug Fix] Re-add the DCP/PCP compatibility check for CUDA platform

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -248,6 +248,27 @@ class CudaPlatformBase(Platform):
                 logger.info(
                     "Forcing kv cache block size to 64 for FlashMLASparse backend."
                 )
+        # lazy import to avoid circular import
+        from vllm.config import CUDAGraphMode
+
+        compilation_config = vllm_config.compilation_config
+        if compilation_config.cudagraph_mode.has_full_cudagraphs():
+            # decode context parallel does not support full cudagraphs
+            if parallel_config.decode_context_parallel_size > 1:
+                logger.warning_once(
+                    "Decode context parallel (DCP) is enabled, which is "
+                    "incompatible with full CUDA graphs. "
+                    "Overriding cudagraph_mode to PIECEWISE."
+                )
+                compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+            # prefill context parallel do not support full cudagraphs
+            elif parallel_config.prefill_context_parallel_size > 1:
+                logger.warning_once(
+                    "Prefill context parallel (PCP) is enabled, which is "
+                    "incompatible with full CUDA graphs. "
+                    "Overriding cudagraph_mode to PIECEWISE."
+                )
+                compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
         scheduler_config = vllm_config.scheduler_config
         # Note: model_config may be None during testing


### PR DESCRIPTION
<!-- markdownlint-disable -->
**Background:**
- PR #29952 moved DCP/PCP + full CUDA graphs compatibility check to platform layer
- PR #29558 inadvertently removed this check during conflict resolution (see [commit diff](https://github.com/vllm-project/vllm/pull/29558/changes/BASE..41ffce7282d6d1bc50ef0ab4b2dec5af8cdb85a9#diff-d581ab6d21c1976b023a339524ef19a850e2997ff09430df53c9e047af6e6fd0))
- ROCm platform still has the check, but CUDA is missing it
- **Impact:** Users with DCP/PCP enabled crash during full CUDA graph capture

**Note:** PR #34179 is adding V2 runner support for DCP with full CUDA graphs. Once merged, this check may become unnecessary, but it's critical for current users.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

