### PR TITLE
[ROCm][quantization] improve OCP weight quant parser robust

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -337,6 +337,13 @@ class QuarkConfig(QuantizationConfig):
             )
             return False
 
+        if isinstance(weight_quant, list):
+            logger.debug(
+                "Quark model's weight quantization is incompatible with OCP_MX format: "
+                "weight_quant is a list (e.g. fp8_w4a8), OCP_MX requires a single dict."
+            )
+            return False
+
         # Input and weight qscheme needs to be per group.
         if weight_quant.get("qscheme") != "per_group":
             logger.debug(


### PR DESCRIPTION
## Purpose

This PR aims to fix an error:
```
 Traceback (most recent call last):
   File "/workspace/vllm/vllm/v1/executor/multiproc_executor.py", line 754, in worker_main
     worker = WorkerProc(*args, **kwargs)
   File "/workspace/vllm/vllm/v1/executor/multiproc_executor.py", line 580, in __init__
     self.worker.load_model()
   File "/workspace/vllm/vllm/v1/worker/gpu_worker.py", line 294, in load_model
     self.model_runner.load_model(eep_scale_up=eep_scale_up)
   File "/workspace/vllm/vllm/v1/worker/gpu_model_runner.py", line 4143, in load_model
     self.model = model_loader.load_model(
   File "/workspace/vllm/vllm/model_executor/model_loader/base_loader.py", line 54, in load_model
     model = initialize_model(
   File "/workspace/vllm/vllm/model_executor/model_loader/utils.py", line 54, in initialize_model
     model = model_class(vllm_config=vllm_config, prefix=prefix)
   File "/workspace/vllm/vllm/model_executor/models/deepseek_v2.py", line 1210, in __init__
     self.model = self.model_cls(
   File "/workspace/vllm/vllm/compilation/decorators.py", line 305, in __init__
     old_init(self, **kwargs)
   File "/workspace/vllm/vllm/model_executor/models/deepseek_v2.py", line 1067, in __init__
     self.start_layer, self.end_layer, self.layers = make_layers(
   File "/workspace/vllm/vllm/model_executor/models/utils.py", line 707, in make_layers
     maybe_offload_to_cpu(layer_fn(prefix=f"{prefix}.{idx}"))
   File "/workspace/vllm/vllm/model_executor/models/deepseek_v2.py", line 1069, in <lambda>
     lambda prefix: DeepseekV2DecoderLayer(
   File "/workspace/vllm/vllm/model_executor/models/deepseek_v2.py", line 963, in __init__
     self.mlp = DeepseekV2MoE(
   File "/workspace/vllm/vllm/model_executor/models/deepseek_v2.py", line 298, in __init__
     self.experts = SharedFusedMoE(
   File "/workspace/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 539, in __init__
     quant_config is not None and quant_config.is_mxfp4_quant(prefix, self)
   File "/workspace/vllm/vllm/model_executor/layers/quantization/quark/quark.py", line 396, in is_mxfp4_quant
     self._is_w_ocp_mx_a_x(weight_config, input_config)
   File "/workspace/vllm/vllm/model_executor/layers/quantization/quark/quark.py", line 348, in _is_w_ocp_mx_a_x
     if weight_quant.get("qscheme") != "per_group":
 AttributeError: 'list' object has no attribute 'get'
```
Model: amd/Kimi-K2-Thinking-W4A8

## Test Plan

## Test Result

