### PR TITLE
[Bugfix] Remove broken raw url GGUF model loading support

### DIFF
--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -115,25 +115,6 @@ class TestGGUFModelLoader:
 
     @patch("vllm.model_executor.model_loader.gguf_loader.hf_hub_download")
     @patch("os.path.isfile", return_value=False)
-    def test_prepare_weights_https_url(self, mock_isfile, mock_hf_download):
-        """Test _prepare_weights with HTTPS URL."""
-        load_config = LoadConfig(load_format="gguf")
-        loader = GGUFModelLoader(load_config)
-
-        mock_hf_download.return_value = "/downloaded/model.gguf"
-
-        # Create a simple mock ModelConfig with only the model attribute
-        model_config = MagicMock()
-        model_config.model = "https://huggingface.co/model.gguf"
-
-        result = loader._prepare_weights(model_config)
-        assert result == "/downloaded/model.gguf"
-        mock_hf_download.assert_called_once_with(
-            url="https://huggingface.co/model.gguf"
-        )
-
-    @patch("vllm.model_executor.model_loader.gguf_loader.hf_hub_download")
-    @patch("os.path.isfile", return_value=False)
     def test_prepare_weights_repo_filename(self, mock_isfile, mock_hf_download):
         """Test _prepare_weights with repo_id/filename.gguf format."""
         load_config = LoadConfig(load_format="gguf")

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -49,11 +49,6 @@ class GGUFModelLoader(BaseModelLoader):
         model_name_or_path = model_config.model
         if os.path.isfile(model_name_or_path):
             return model_name_or_path
-        # for raw HTTPS link
-        if model_name_or_path.startswith(
-            ("http://", "https://")
-        ) and model_name_or_path.endswith(".gguf"):
-            return hf_hub_download(url=model_name_or_path)
         # repo id/filename.gguf
         if "/" in model_name_or_path and model_name_or_path.endswith(".gguf"):
             repo_id, filename = model_name_or_path.rsplit("/", 1)
@@ -71,7 +66,7 @@ class GGUFModelLoader(BaseModelLoader):
 
         raise ValueError(
             f"Unrecognised GGUF reference: {model_name_or_path} "
-            "(expected local file, raw URL, <repo_id>/<filename>.gguf, "
+            "(expected local file, <repo_id>/<filename>.gguf, "
             "or <repo_id>:<quant_type>)"
         )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Raw url GGUF model loading support has been broken for a while.
- Given that it's seldom used and can easily cause security risk from url redirection, I decide to remove it instead of reviving it.
```
$ vllm serve https://www.modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q2_K.gguf
ERROR 02-12 21:36:16 [gpt_oss_triton_kernels_moe.py:60] Failed to import Triton kernels. Please make sure your triton version is compatible. Error: cannot import name 'SparseMatrix' from 'triton_kernels.tensor' (/home/mozf/develop-projects/vllm/vllm/third_party/triton_kernels/tensor.py)
(APIServer pid=1812520) INFO 02-12 21:36:17 [utils.py:287] 
(APIServer pid=1812520) INFO 02-12 21:36:17 [utils.py:287]        █     █     █▄   ▄█
(APIServer pid=1812520) INFO 02-12 21:36:17 [utils.py:287]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.15.0rc2.dev86+gc6e7404cc.d20260129
(APIServer pid=1812520) INFO 02-12 21:36:17 [utils.py:287]   █▄█▀ █     █     █     █  model   https://www.modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q2_K.gguf
(APIServer pid=1812520) INFO 02-12 21:36:17 [utils.py:287]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=1812520) INFO 02-12 21:36:17 [utils.py:287] 
(APIServer pid=1812520) INFO 02-12 21:36:17 [utils.py:223] non-default args: {'model_tag': 'https://www.modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q2_K.gguf', 'model': 'https://www.modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q2_K.gguf'}
(APIServer pid=1812520) /home/mozf/develop-projects/vllm/.venv/lib/python3.12/site-packages/transformers/utils/hub.py:610: FutureWarning: Using `from_pretrained` with the url of a file (here https://www.modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q2_K.gguf) is deprecated and won't be possible anymore in v5 of Transformers. You should host your file on the Hub (hf.co) instead and use the repository ID. Note that this is not compatible with the caching system (your file will be downloaded at each execution) or multiple processes (each process will download the file in a different temporary file).
(APIServer pid=1812520)   warnings.warn(
(…)GGUF/resolve/master/Qwen3-0.6B-Q2_K.gguf: 100%|███████████████████████████████████████████████████████████████████████████████████████| 296M/296M [02:06<00:00, 2.35MB/s]
(APIServer pid=1812520) Traceback (most recent call last):
(APIServer pid=1812520)   File "/home/mozf/develop-projects/vllm/.venv/lib/python3.12/site-packages/transformers/configuration_utils.py", line 756, in _get_config_dict
(APIServer pid=1812520)     config_dict = cls._dict_from_json_file(resolved_config_file)
(APIServer pid=1812520)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1812520)   File "/home/mozf/develop-projects/vllm/.venv/lib/python3.12/site-packages/transformers/configuration_utils.py", line 866, in _dict_from_json_file
(APIServer pid=1812520)     text = reader.read()
(APIServer pid=1812520)            ^^^^^^^^^^^^^
(APIServer pid=1812520)   File "<frozen codecs>", line 322, in decode
(APIServer pid=1812520) UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 415: invalid start byte
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

