### PR TITLE
Fix MoE for the Transformers modelling backend

### DIFF
--- a/vllm/model_executor/models/transformers/moe.py
+++ b/vllm/model_executor/models/transformers/moe.py
@@ -94,7 +94,7 @@ def transformers_moe_forward(
     self = forward_context.no_compile_layers[layer_name]
     self._topk_ids = topk_ids
     # Clone hidden_states because it will be mutated in-place in FusedMoE
-    return self.forward_impl(hidden_states.clone(), topk_weights)
+    return self.runner.forward(hidden_states.clone(), topk_weights)
 
 
 def transformers_moe_forward_fake(

--- a/vllm/model_executor/models/transformers/moe.py
+++ b/vllm/model_executor/models/transformers/moe.py
@@ -45,7 +45,6 @@ class TransformersFusedMoE(FusedMoE):
     # --8<-- [end:transformers_fused_moe]
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
         self._topk_ids: torch.Tensor = None
 
         def custom_routing_function(hidden_states, gating_output, topk, renormalize):
@@ -63,7 +62,8 @@ class TransformersFusedMoE(FusedMoE):
                 (topk_ids,) = dist_group.all_gatherv([topk_ids], 0, sizes)
             return topk_weights, topk_ids
 
-        self.custom_routing_function = custom_routing_function
+        kwargs["custom_routing_function"] = custom_routing_function
+        super().__init__(*args, **kwargs)
 
     def forward(
         self,


### PR DESCRIPTION
`FusedMoE` has been being refactor in recent months and the Transformers modelling backend support has not been updated with it.

This is understandable because the test (`tests/models/test_transformers.py::test_models[allenai/OLMoE-1B-7B-0924-transformers]`) will not run in vLLM CI until we update to Transformers v5.

This PR fixes the integration so that users installing Transformers v5 early may benefit from the MoE support.
