### PR TITLE
Add explicit validation error for tool calls.

### DIFF
--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -65,20 +65,16 @@ def maybe_serialize_tool_calls(request: "MistralChatCompletionRequest"):
     # TODO: remove when pydantic v2.11 is released
     for i, message in enumerate(request.messages):
         if message.get("role") == "assistant":
-            tool_calls_validator = message.get("tool_calls", None)
-            validated_tool_calls = []
-            iterating_tool_calls = tool_calls_validator is not None
-            while iterating_tool_calls:
+            if (tool_calls_validator := message.get("tool_calls", None)) is not None:
                 try:
-                    tool_call = next(tool_calls_validator)  # type: ignore
-                    validated_tool_calls.append(tool_call)
+                    validated_tool_calls = list(tool_calls_validator)
                 except ValidationError as e:
                     raise ValueError(
                         "Validating messages' `tool_calls` raised an error. "
                         "Please ensure `tool_calls` are iterable of tool calls."
                     ) from e
-                except StopIteration:
-                    iterating_tool_calls = False
+            else:
+                validated_tool_calls = []
 
             request.messages[i]["tool_calls"] = validated_tool_calls
 


### PR DESCRIPTION
## Purpose

Add explicit validation error for tool calls.

Fix https://github.com/vllm-project/vllm/issues/34225

## Test Plan

Checked with these messages in the request:

```messages = [
    {
        "role": "user",
        "content": [
            {
                "type": "text",
                "text": "Hey call a tool",
            },
        ],
    },
    {
      "role":"assistant",
      "content":"...",
      "tool_calls":"should_be_serialized_object_but_its_str"
    },
    {
        "role": "user",
        "content": [
            {
                "type": "text",
                "text": "What is the weather in Paris?",
            },
        ],
    },
]
```

## Test Result

Raised correctly:
```
(APIServer pid=106559) ERROR 02-12 14:55:36 [serving.py:310]   File "/mnt/vast/home/julien.denize/workspace/vllm/vllm/tokenizers/mistral.py", line 77, in maybe_serialize_tool_calls
(APIServer pid=106559) ERROR 02-12 14:55:36 [serving.py:310]     raise ValueError(
(APIServer pid=106559) ERROR 02-12 14:55:36 [serving.py:310]     ...<2 lines>...
(APIServer pid=106559) ERROR 02-12 14:55:36 [serving.py:310]     ) from e
(APIServer pid=106559) ERROR 02-12 14:55:36 [serving.py:310] ValueError: Validating messages' `tool_calls` raised an error. Please ensure `tool_calls` are iterable of tool calls.
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results