### PR TITLE
[Docs] Spec decoding docs warning removal

### DIFF
--- a/docs/features/spec_decode/README.md
+++ b/docs/features/spec_decode/README.md
@@ -1,11 +1,6 @@
 # Speculative Decoding
 
 !!! warning
-    Please note that speculative decoding in vLLM is not yet optimized and does
-    not usually yield inter-token latency reductions for all prompt datasets or sampling parameters.
-    The work to optimize it is ongoing and can be followed here: <https://github.com/vllm-project/vllm/issues/4630>
-
-!!! warning
     Currently, speculative decoding in vLLM is not compatible with pipeline parallelism.
 
 This document shows how to use [Speculative Decoding](https://x.com/karpathy/status/1697318534555336961) with vLLM.


### PR DESCRIPTION
I believe this warning may have actually been carried over from v0..
