### PR TITLE
[BugFix] Fix and optimize max_num_blocks_per_req calculation for MambaSpec

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5710,14 +5710,11 @@ class GPUModelRunner(
             )
             block_sizes.append(block_size)
             if isinstance(kv_cache_group.kv_cache_spec, MambaSpec):
-                mamba_blocks_per_req = (
+                max_num_blocks_per_req = (
                     max_num_blocks_per_req
                     if self.cache_config.enable_prefix_caching
                     else 1
                 ) + kv_cache_group.kv_cache_spec.num_speculative_blocks
-                max_num_blocks_per_req = max(
-                    max_num_blocks_per_req, mamba_blocks_per_req
-                )
             max_num_blocks.append(max_num_blocks_per_req)
 
         if block_sizes != [self.cache_config.block_size] or kernel_block_sizes != [

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5705,10 +5705,10 @@ class GPUModelRunner(
             if isinstance(kv_cache_group.kv_cache_spec, EncoderOnlyAttentionSpec):
                 continue
             block_size = kv_cache_group.kv_cache_spec.block_size
+            block_sizes.append(block_size)
             max_num_blocks_per_req = cdiv(
                 max_model_len, block_size * get_total_cp_world_size()
             )
-            block_sizes.append(block_size)
             if isinstance(kv_cache_group.kv_cache_spec, MambaSpec):
                 max_num_blocks_per_req = (
                     max_num_blocks_per_req


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Main changes in this PR:

1. Fixed the calculation logic for `max_num_blocks_per_req`: Previously, the code accessed `block_sizes[i]` using an index `i` when calculating `max_num_blocks_per_req` for each `kv_cache_group`. This led to potential mismatches when `EncoderOnlyAttentionSpec` was present in `kv_cache_groups`. This PR **unifies the construction of `block_sizes` and `max_num_blocks` within a single for-loop to ensure they correspond correctly**.

2. Optimized the `max_num_blocks_per_req` calculation for Mamba models: For Mamba models with prefix-caching disabled, **each request requires at most `1 + num_speculative_blocks` blocks**. Therefore, the previous `max` logic is redundant and can be simplified.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

