### PR TITLE
[Bugfix] Remove assert that's no longer valid

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
@@ -37,7 +37,6 @@ class FusedMoEModularMethod(FusedMoEMethodBase, CustomOp):
             not self.moe_mk.supports_expert_map(),
         )
         self.old_quant_method = old_quant_method
-        assert not self.old_quant_method.is_monolithic
         logger.debug("Swapping out %s", self.old_quant_method.__class__.__name__)
 
     @staticmethod


### PR DESCRIPTION

## Purpose

This assert was causing some tests to fail, including `tests/lora/test_gptoss_tp.py`.  It's no longer valid due to other MoE refactoring work.

## Test Plan

Ran `tests/lora/test_gptoss_tp.py` on an h200 system.

## Test Result
The test no longer asserts but fails with wrong answers, although the test still fails prior to #32344

cc @robertgshaw2-redhat , @mgoin 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

