### PR TITLE
[ROCm][CI] Pin TorchCodec to v0.10.0 for ROCm compatibility

### DIFF
--- a/tools/install_torchcodec_rocm.sh
+++ b/tools/install_torchcodec_rocm.sh
@@ -7,7 +7,8 @@
 set -e
 
 TORCHCODEC_REPO="${TORCHCODEC_REPO:-https://github.com/pytorch/torchcodec.git}"
-TORCHCODEC_BRANCH="${TORCHCODEC_BRANCH:-main}"
+# Pin to a specific release for reproducibility; update as needed.
+TORCHCODEC_BRANCH="${TORCHCODEC_BRANCH:-v0.10.0}"
 
 echo "=== TorchCodec Installation Script ==="
 


### PR DESCRIPTION
The `main` branch of TorchCodec introduced a dependency on PyTorch's stable ABI headers (`torch/csrc/stable/device.h`) which are not available in ROCm PyTorch builds. This causes the source build to fail with a missing header error.

Pinning to v0.10.0 (the latest release before this change) avoids the issue. The version can still be overridden via the `TORCHCODEC_BRANCH` env var.