### PR TITLE
[CI/Build] Add .deps to .dockerignore to prevent state from being pulled into ROCm build image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 /build
 dist
 vllm/*.so
+.deps/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
Fixes a build issue with `docker/Dockerfile.rocm`, where users may run into issues due to state in `.deps`. 

In my case I ran into this on a machine with H100s and CUDA dependencies, which were getting copied into the build image:
```
Bash(ls -d /home/tlrmchlsmth/vllm/build /home/tlrmchlsmth/vllm/.deps /home/tlrmchlsmth/vllm/cmake-build-* /home/tlrmchlsmth/vllm/CMakeUserPresets.json 2>&1; echo "--…)
  ⎿  Error: Exit code 2
     ls: cannot access '/home/tlrmchlsmth/vllm/build': No such file or directory
     ls: cannot access '/home/tlrmchlsmth/vllm/cmake-build-*': No such file or directory
     ls: cannot access '/home/tlrmchlsmth/vllm/CMakeUserPresets.json': No such file or directory
     /home/tlrmchlsmth/vllm/.deps
     ---
     ls: cannot access '/home/tlrmchlsmth/vllm/*.so': No such file or directory
     /home/tlrmchlsmth/vllm/vllm/_C.abi3.so
     /home/tlrmchlsmth/vllm/vllm/_flashmla_C.abi3.so
     /home/tlrmchlsmth/vllm/vllm/_flashmla_extension_C.abi3.so
 ``` 