### PR TITLE
[CI/Build] Add opentelemetry libs in default vllm build (requirements/common.txt)

### DIFF
--- a/examples/online_serving/opentelemetry/README.md
+++ b/examples/online_serving/opentelemetry/README.md
@@ -1,14 +1,6 @@
 # Setup OpenTelemetry POC
 
-1. Install OpenTelemetry packages:
-
-    ```bash
-    pip install \
-      'opentelemetry-sdk>=1.26.0,<1.27.0' \
-      'opentelemetry-api>=1.26.0,<1.27.0' \
-      'opentelemetry-exporter-otlp>=1.26.0,<1.27.0' \
-      'opentelemetry-semantic-conventions-ai>=0.4.1,<0.5.0'
-    ```
+> **Note:** The core OpenTelemetry packages (`opentelemetry-sdk`, `opentelemetry-api`, `opentelemetry-exporter-otlp`, `opentelemetry-semantic-conventions-ai`) are bundled with vLLM. Manual installation is not required.
 
 1. Start Jaeger in a docker container:
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -53,3 +53,7 @@ model-hosting-container-standards >= 0.1.13, < 1.0.0
 mcp
 grpcio
 grpcio-reflection
+opentelemetry-sdk >= 1.27.0
+opentelemetry-api >= 1.27.0
+opentelemetry-exporter-otlp >= 1.27.0
+opentelemetry-semantic-conventions-ai >= 0.4.1


### PR DESCRIPTION
<!-- markdownlint-disable -->
[CI/Build] Add opentelemetry libs in default vllm build (requirements/common.txt)

## Purpose
Opentelemetry libs are essential for a production environment. We have been patching opentelemetry libs on top of :nightly for a while and we would like to upstream this change to avoid patching. 

Multiple times we have seen that users omit to do this and they end up asking how to get metrics on their tiers. 
There are also users which add --otlp-traces-endpoint which can't even start the job because it will have an import failure (because by mistake they run an image that does not have the otel libs). 
This PR will reduce the churn.

The libs take ~1 minutes to fetch so the vllm build will not be affected.

```
w/o Otel libs (20.5GB):
"Size": 20479755533,

w/ Otel libs (20.5GB):
"Size": 20484875369,
```


## Test Plan
```
FROM vllm/vllm-openai:nightly

RUN pip install --upgrade pip && pip install \
    "opentelemetry-sdk>=1.27.0" \
    "opentelemetry-api>=1.27.0" \
    "opentelemetry-exporter-otlp>=1.27.0" \
    "opentelemetry-semantic-conventions-ai>=0.4.1" 
```

podman build --network=host -t vllm/vllm-openai:nightly-otel .

This podman build takes only ~5 minutes total.

## Test Result

Works in production and otel traces + metrics are exported as expected.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

