### PR TITLE
[Bugfix][Hardware][AMD] Fix string literal comparison in DISPATCH_BY_KV_CACHE_DTYPE macro

### DIFF
--- a/csrc/quantization/w8a8/fp8/amd/quant_utils.cuh
+++ b/csrc/quantization/w8a8/fp8/amd/quant_utils.cuh
@@ -5,6 +5,8 @@
 #include <hip/hip_bf16.h>
 #include <hip/hip_bfloat16.h>
 
+#include <string>
+
 #include "../../../../attention/attention_dtypes.h"
 
 namespace vllm {
@@ -639,7 +641,7 @@ __inline__ __device__ Tout scaled_convert(const Tin& x, const float scale) {
   // function with template<typename scalar_t, typename cache_t,
   // Fp8KVCacheDataType kv_dt>.
   #define DISPATCH_BY_KV_CACHE_DTYPE(SRC_DTYPE, KV_DTYPE, FN)                  \
-    if (KV_DTYPE == "auto") {                                                  \
+    if (std::string(KV_DTYPE) == "auto") {                                     \
       if (SRC_DTYPE == at::ScalarType::Float) {                                \
         FN(float, float, vllm::Fp8KVCacheDataType::kAuto);                     \
       } else if (SRC_DTYPE == at::ScalarType::Half) {                          \
@@ -650,7 +652,8 @@ __inline__ __device__ Tout scaled_convert(const Tin& x, const float scale) {
         TORCH_CHECK(false, "Unsupported input type of kv cache: ", SRC_DTYPE); \
       }                                                                        \
     } else {                                                                   \
-      if (KV_DTYPE == "fp8" || KV_DTYPE == "fp8_e4m3") {                       \
+      if (std::string(KV_DTYPE) == "fp8" ||                                    \
+          std::string(KV_DTYPE) == "fp8_e4m3") {                               \
         if (SRC_DTYPE == at::ScalarType::Float) {                              \
           FN(float, uint8_t, vllm::Fp8KVCacheDataType::kFp8E4M3);              \
         } else if (SRC_DTYPE == at::ScalarType::Half) {                        \


### PR DESCRIPTION
## Summary

Fix build failure with Clang 22+ (ROCm 6.3+) caused by string literal comparisons in the `DISPATCH_BY_KV_CACHE_DTYPE` macro in `csrc/quantization/w8a8/fp8/amd/quant_utils.cuh`.

The macro compares `KV_DTYPE` using `==`, which performs array address comparison (not value comparison) when `KV_DTYPE` is a string literal. This is deprecated in C++20 and treated as an error by Clang 22+:

```
warning: comparison between two arrays compare their addresses
         and will be deprecated in c++20 [-Warray-compare]
```

Wrap comparisons in `std::string()` to perform proper value comparison regardless of whether `KV_DTYPE` is a `const std::string&` or a string literal.

Fixes #34132

## Test plan

- Build vLLM with Clang 22+ / ROCm 6.3+ (previously failed at `csrc/cache_kernels.hip:1298`)
- Verify existing AMD CI tests continue to pass (the fix is semantically identical for `std::string` arguments)