### PR TITLE
[Bugfix][Hardware][AMD] Add ahead-of-time weight dequantization for quantization emulation

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -180,6 +180,7 @@ if TYPE_CHECKING:
     VLLM_KV_CACHE_LAYOUT: Literal["NHD", "HND"] | None = None
     VLLM_COMPUTE_NANS_IN_LOGITS: bool = False
     VLLM_USE_NVFP4_CT_EMULATIONS: bool = False
+    VLLM_EMULATION_DEQUANT_WEIGHTS_AOT: bool = False
     VLLM_ROCM_QUICK_REDUCE_QUANTIZATION: Literal[
         "FP", "INT8", "INT6", "INT4", "NONE"
     ] = "NONE"
@@ -1326,6 +1327,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # models
     "VLLM_USE_NVFP4_CT_EMULATIONS": lambda: bool(
         int(os.getenv("VLLM_USE_NVFP4_CT_EMULATIONS", "0"))
+    ),
+    # When set, dequantize weights ahead of time during model loading
+    # instead of on each forward pass during quantization emulation
+    # (OCP MX, NVFP4). Trades higher memory for faster inference.
+    "VLLM_EMULATION_DEQUANT_WEIGHTS_AOT": lambda: bool(
+        int(os.getenv("VLLM_EMULATION_DEQUANT_WEIGHTS_AOT", "0"))
     ),
     # Time (in seconds) after which the KV cache on the producer side is
     # automatically cleared if no READ notification is received from the


### PR DESCRIPTION
## Summary

When running MXFP4/MXFP6/NVFP4 models on platforms without native MX support (e.g. CDNA3: MI300X, MI325X, MI250), vLLM emulates quantization by dequantizing weights on every forward pass. This makes running large workloads (e.g. end-to-end eval) impractically slow.

This PR adds `VLLM_EMULATION_DEQUANT_WEIGHTS_AOT=1` as an opt-in env var to dequantize weights at model load time instead. This trades higher memory usage for significantly faster inference during emulation.

### Affected paths

- **Quark OCP MX dense linear** — weights dequantized in `process_weights_after_loading()`, skipped in `apply_weights()`
- **NVFP4 compressed-tensors emulation** — weights dequantized in `convert_to_nvfp4_linear_kernel_format()`, skipped in `run_nvfp4_emulations()`

MoE layers are not yet covered (requires deeper changes to the fused_experts dispatch) and can be addressed in a follow-up.

### Usage

```bash
VLLM_EMULATION_DEQUANT_WEIGHTS_AOT=1 vllm serve <model>
```

Addresses #34331

## Test plan

- Run MXFP4 model on MI300X with and without `VLLM_EMULATION_DEQUANT_WEIGHTS_AOT=1` — verify identical output and faster throughput with AOT
- Run NVFP4 model with `VLLM_USE_NVFP4_CT_EMULATIONS=1 VLLM_EMULATION_DEQUANT_WEIGHTS_AOT=1` — verify identical output
- Verify default behavior (env var unset) is unchanged

cc @fxmarty-amd @mgoin