### PR TITLE
[Bugfix] Fix encoder cache underestimation for GLM-4V/GLM-OCR single image

### DIFF
--- a/vllm/model_executor/models/glm4_1v.py
+++ b/vllm/model_executor/models/glm4_1v.py
@@ -869,9 +869,28 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
 
         return preprocessed_size, num_vision_tokens
 
+    def _get_image_max_pixels(self) -> int:
+        """Read max_pixels from the HF image processor config.
+
+        Despite the name, ``longest_edge`` is a pixel **area** (total pixel
+        count), not an edge length.  The HF processor passes it directly to
+        ``smart_resize`` as the ``max_pixels`` argument, which constrains
+        ``t_bar * h_bar * w_bar <= max_pixels``.
+        """
+        return self.get_image_processor().size["longest_edge"]
+
     def get_image_size_with_most_features(self) -> ImageSize:
+        # Use num_frames=1 for single-image budget estimation.
+        # _get_vision_info defaults to num_frames=16 (video), which
+        # makes smart_resize constrain 16*H*W <= max_pixels, vastly
+        # underestimating the spatial budget for a single image and
+        # causing encoder cache overflow for large images
+        # (see https://github.com/vllm-project/vllm/issues/34040).
         max_image_size, _ = self._get_vision_info(
-            image_width=9999999, image_height=9999999
+            image_width=9999999,
+            image_height=9999999,
+            num_frames=1,
+            max_image_pixels=self._get_image_max_pixels(),
         )
         return max_image_size
 
@@ -884,7 +903,8 @@ class Glm4vProcessingInfo(BaseProcessingInfo):
         _, num_image_tokens = self._get_vision_info(
             image_width=image_width,
             image_height=image_height,
-            max_image_pixels=28 * 28 * 2 * 6144,
+            num_frames=1,
+            max_image_pixels=self._get_image_max_pixels(),
         )
         return num_image_tokens
 


### PR DESCRIPTION
## Purpose

Fixes #34040

`get_image_size_with_most_features()` and `get_num_image_tokens()` called `_get_vision_info()` with the default `num_frames=16` (video), causing `smart_resize` to constrain `16*H*W <= max_pixels` and vastly underestimating the spatial budget for a single image. This resulted in an encoder cache of ~3721 tokens, while large single images can produce up to ~6084 tokens, triggering "exceeds the pre-allocated encoder cache size" errors.

Fix by passing `num_frames=1` for single-image methods and reading `max_pixels` from the HF image processor config instead of hardcoding.

## Test Plan

Verify locally via

```python
"""Reproduce https://github.com/vllm-project/vllm/issues/34040

A large single image can exceed the pre-allocated encoder cache size
for zai-org/GLM-OCR because get_image_size_with_most_features() uses
num_frames=16 (video default), underestimating the max tokens a single
image can produce.
"""

import base64
import io

from PIL import Image
from vllm import LLM, SamplingParams

MODEL = "zai-org/GLM-OCR"

# A 2968x1596 image produces 6042 tokens after processing,
# which exceeds the profiled encoder cache (~3721 tokens).
# This simulates the user's scenario of merging 3 PDF pages.
WIDTH, HEIGHT = 2968, 1596
image = Image.new("RGB", (WIDTH, HEIGHT), color=(255, 255, 255))

# Encode image to base64 data URI for the OpenAI-style content format
buf = io.BytesIO()
image.save(buf, format="PNG")
b64 = base64.b64encode(buf.getvalue()).decode()
image_url = f"data:image/png;base64,{b64}"

llm = LLM(
    model=MODEL,
    max_model_len=8192,
    gpu_memory_utilization=0.8,
    enforce_eager=True,
    # Use a small max_num_batched_tokens to expose the bug.
    # The profiled max image tokens is ~3721, so any value below that
    # (or even up to ~6084) will cause failure for large images.
    # On GPUs with >=70GB, the default is 8192 which masks the bug.
    max_num_batched_tokens=2048,
)

result = llm.chat(
    messages=[{
        "role": "user",
        "content": [
            {"type": "image_url",
             "image_url": {"url": image_url}},
            {"type": "text", "text": "Describe this image."},
        ],
    }],
    chat_template_content_format="openai",
    sampling_params=SamplingParams(max_tokens=64),
)
print(result)
```

## Test Result

No error after apply this change.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

