### PR TITLE
[Bugfix] Fix KeyError in parse_response_input for reasoning items with optional content

### DIFF
--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1108,7 +1108,7 @@ class OpenAIServingResponses(OpenAIServing):
                 prev_outputs = []
             for response_msg in request.input:
                 new_msg = response_input_to_harmony(response_msg, prev_outputs)
-                if new_msg.author.role != "system":
+                if new_msg is not None and new_msg.author.role != "system":
                     messages.append(new_msg)
 
                 # User passes in a tool call request and its output. We need


### PR DESCRIPTION
## Purpose

Fix `KeyError: 'content'` crash in `parse_response_input()` when a reasoning input item omits the optional `content` field during multi-turn Responses API conversations.

Per the [OpenAI spec](https://platform.openai.com/docs/api-reference/responses/create), `ResponseReasoningItem.content` is `Optional[List[Content]] = None`. Clients like `langchain-openai` omit this field when constructing multi-turn input from previous responses, causing:

```python
# harmony_utils.py:224-227 (before)
content = response_msg["content"]    # KeyError if key is absent
assert len(content) == 1             # AssertionError if content is None or []
```

This fix uses `.get("content")` with fallback to `summary` text, matching the existing defensive pattern already used in `utils.py:190-201`.

Fixes #34496
Related: #33089

## Test Plan

```bash
pytest tests/entrypoints/openai/parser/test_harmony_utils.py::TestParseResponseInputReasoningItem -v
```

4 unit tests added:
| Test | Scenario |
|---|---|
| `test_reasoning_with_content` | content present (existing behavior preserved) |
| `test_reasoning_without_content_uses_summary` | content key omitted, fallback to summary |
| `test_reasoning_with_none_content_uses_summary` | content=None, fallback to summary |
| `test_reasoning_without_content_or_summary` | neither content nor summary, empty string fallback |

## Test Result

| Input format | Before | After |
|---|---|---|
| `content` key omitted | **500** KeyError | OK (uses summary) |
| `"content": null` | **500** TypeError | OK (uses summary) |
| `"content": [{"type": "reasoning_text", "text": "..."}]` | OK | OK (unchanged) |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
