### PR TITLE
[Misc] vLLM's --enforce-eager should turn off compile and cudagraphs only

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -728,13 +728,13 @@ class VllmConfig:
                 "precision for chunked prefill triton kernels."
             )
 
-        if (
-            self.optimization_level > OptimizationLevel.O0
-            and self.model_config is not None
-            and self.model_config.enforce_eager
-        ):
-            logger.warning("Enforce eager set, overriding optimization level to -O0")
-            self.optimization_level = OptimizationLevel.O0
+        if self.model_config is not None and self.model_config.enforce_eager:
+            logger.warning(
+                "Enforce eager set, disabling torch.compile and CUDAGraphs. "
+                "This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none"
+            )
+            self.compilation_config.mode = CompilationMode.NONE
+            self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 
         if self.compilation_config.backend == "eager" or (
             self.compilation_config.mode is not None


### PR DESCRIPTION
## Purpose

Previously, --enforce-eager sets -O0. -O0 turns off compile and cudagraphs but also disables misc things that are present in the default -O2, like the flashinfer autotuning settings.

--enforce-eager is primarily used as a debugging tool. If a model doesn't support compile, then it will individually turn off compile (via the lack of a support_torch_compile decorator). As a debugging tool, it should just be "turn off these compile-mode related features".

There's some more context over at https://vllm-dev.slack.com/archives/C08K1FAHFPH/p1770993366543279

## Test Plan & Test Result

Ran `vllm serve --enforce-eager` and verified that compile and cudagraphs are off.
