### PR TITLE
fix: use `__annotations__` instead of `get_type_hints()` for dynamic `kwargs` detection

### DIFF
--- a/vllm/transformers_utils/processor.py
+++ b/vllm/transformers_utils/processor.py
@@ -18,9 +18,12 @@ from transformers.processing_utils import ProcessorMixin
 from transformers.video_processing_utils import BaseVideoProcessor
 from typing_extensions import TypeVar
 
+from vllm.logger import init_logger
 from vllm.transformers_utils.gguf_utils import is_gguf
 from vllm.transformers_utils.utils import convert_model_repo_to_path
 from vllm.utils.func_utils import get_allowed_kwarg_only_overrides
+
+logger = init_logger(__name__)
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig
@@ -200,7 +203,8 @@ def get_processor_kwargs_from_processor(processor: _P) -> set[str]:
                         | _collect_dynamic_keys_from_processing_kwargs(obj)
                     )
             return processor_kwargs
-    except Exception:
+    except Exception as exc:
+        logger.warning_once("Failed to collect processor kwargs: %s", exc)
         return set()
 
 

--- a/vllm/transformers_utils/processor.py
+++ b/vllm/transformers_utils/processor.py
@@ -203,8 +203,8 @@ def get_processor_kwargs_from_processor(processor: _P) -> set[str]:
                         | _collect_dynamic_keys_from_processing_kwargs(obj)
                     )
             return processor_kwargs
-    except Exception as exc:
-        logger.warning_once("Failed to collect processor kwargs", exc_info=True)
+    except Exception:
+        logger.exception("Failed to collect processor kwargs")
         return set()
 
 

--- a/vllm/transformers_utils/processor.py
+++ b/vllm/transformers_utils/processor.py
@@ -204,7 +204,7 @@ def get_processor_kwargs_from_processor(processor: _P) -> set[str]:
                     )
             return processor_kwargs
     except Exception as exc:
-        logger.warning_once("Failed to collect processor kwargs: %s", exc)
+        logger.warning_once("Failed to collect processor kwargs", exc_info=True)
         return set()
 
 

--- a/vllm/transformers_utils/processor.py
+++ b/vllm/transformers_utils/processor.py
@@ -74,7 +74,7 @@ def _collect_dynamic_keys_from_processing_kwargs(kwargs_cls: type) -> set[str]:
             kw_cls = kwargs_type_annotations[kw_type]
             kw_annotations = {}
             for base in reversed(kw_cls.__mro__):
-                kw_annotations.update(getattr(base, '__annotations__', {}))
+                kw_annotations.update(getattr(base, "__annotations__", {}))
             for kw_name in kw_annotations:
                 dynamic_kwargs.add(kw_name)
     dynamic_kwargs |= {"text_kwargs", "images_kwargs", "videos_kwargs", "audio_kwargs"}

--- a/vllm/transformers_utils/processor.py
+++ b/vllm/transformers_utils/processor.py
@@ -72,7 +72,7 @@ def _collect_dynamic_keys_from_processing_kwargs(kwargs_cls: type) -> set[str]:
             # NameError from unresolved forward references (e.g.
             # PILImageResampling). We only need key names, not types.
             kw_cls = kwargs_type_annotations[kw_type]
-            kw_annotations = {}
+            kw_annotations: dict[str, Any] = {}
             for base in reversed(kw_cls.__mro__):
                 kw_annotations.update(getattr(base, "__annotations__", {}))
             for kw_name in kw_annotations:


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose

Fix broken LRU cache in `cached_get_processor_without_dynamic_kwargs` caused by `get_type_hints()` raising `NameError` on unresolved forward references.

`_collect_dynamic_keys_from_processing_kwargs` calls `get_type_hints()` on inner kwargs classes (`ImagesKwargs`, `VideosKwargs`, etc.) to discover dynamic key names. This fails with `NameError: name 'PILImageResampling' is not defined` because `PILImageResampling` appears as a forward-reference string annotation in `ImagesKwargs.resample` and is not imported in the module namespace where `get_type_hints()` attempts resolution.

The exception is silently swallowed by the caller (`get_processor_kwargs_from_processor`, bare `except Exception: return set()`), so `dynamic_keys` is always empty. As a result, per-request kwargs like `size`, `fps`, and `do_sample_frames` are never filtered from the LRU cache key, causing `cached_get_processor` to miss on every call and re-run `from_pretrained`.

For multimodal models (e.g. Qwen2-VL, Qwen3-VL) where `get_hf_processor` is called 6 times per request, **this adds ~24s of redundant processor loading** per request.

**Fix:** Replace `get_type_hints(kw_cls)` with `__annotations__` traversal through the class MRO. Since only key names are needed (not resolved types), this avoids forward reference resolution entirely.

## Test Plan

- Verify `dynamic_keys` is populated (not empty) for Qwen2-VL / Qwen3-VL   processors
- Verify `cached_get_processor` reports cache hits after first call
- Run existing multimodal tests

## Test Result

Before fix (per video request, Qwen3-VL-Embedding-8B):
- `dynamic_keys=[]` (empty, all calls miss cache)
- `get_hf_processor` called 6 times × ~4s each = **~28s preprocessing**
- `cached_get_processor` cache: 0 hits, all misses

After fix:
- `dynamic_keys` correctly populated with 47 keys (`size`, `fps`, `do_sample_frames`, `resample`, etc.)
- `filtered_kwargs_keys=['tokenizer', 'use_fast']` (dynamic keys filtered out)
- First `get_hf_processor` call: ~6s (cold start), all subsequent: **0.000s** (cache hit)
- `cached_get_processor` cache: 10 hits, 3 misses (cold start only)
- Total preprocessing: **~6.3s** (first request), **<0.5s** (subsequent)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

