### PR TITLE
[bug] Make sure get_modality_with_max_tokens is deterministic

### DIFF
--- a/vllm/multimodal/encoder_budget.py
+++ b/vllm/multimodal/encoder_budget.py
@@ -181,7 +181,7 @@ class MultiModalBudget:
 
     def get_modality_with_max_tokens(self) -> str:
         mm_max_toks_per_item = self.mm_max_toks_per_item
-        modality, _ = max(mm_max_toks_per_item.items(), key=lambda x: x[1])
+        modality, _ = max(mm_max_toks_per_item.items(), key=lambda x: (x[1], x[0]))
 
         return modality
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

During __init__, we use set `tower_modalities` to stored modality strings and then iterate over it. This result in indeterministic insertion order for `self.mm_max_toks_per_item`. When we have two modalities whose max_toks_per_item is the same, during profiling run using dummy data, different ranks might be profiling different modality. If encoders are loaded with TP, this could result in problems like nccl hanging etc.

This PR changes get_modality_with_max_tokens() logic by comparing both the value and the key.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

