### PR TITLE
[Feature][Perf] Support Selective CPU Weight Offloading

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -101,6 +101,11 @@ class CacheConfig:
     Note that this requires fast CPU-GPU interconnect, as part of the model is
     loaded from CPU memory to GPU memory on the fly in each model forward pass.
     """
+    cpu_offload_params: set[str] = Field(default_factory=set)
+    """The parameters to offload to CPU. Default is an empty set, which means
+    all parameters will be offloaded until reaching the limit set by
+    `cpu_offload_gb`.
+    """
     calculate_kv_scales: bool = False
     """This enables dynamic calculation of `k_scale` and `v_scale` when
     kv_cache_dtype is fp8. If `False`, the scales will be loaded from the model

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -102,9 +102,15 @@ class CacheConfig:
     loaded from CPU memory to GPU memory on the fly in each model forward pass.
     """
     cpu_offload_params: set[str] = Field(default_factory=set)
-    """The parameters to offload to CPU. Default is an empty set, which means
-    all parameters will be offloaded until reaching the limit set by
-    `cpu_offload_gb`.
+    """ The set of parameter name segments to target for CPU offloading.
+    Unmatched parameters are not offloaded. If this set is empty, parameters
+    are offloaded non-selectively until the memory limit defined by
+    `cpu_offload_gb` is reached.
+    Examples:
+        - For parameter name "mlp.experts.w2_weight":
+            - "experts" or "experts.w2_weight" will match.
+            - "expert" or "w2" will NOT match (must be exact segments).
+    This allows distinguishing parameters like "w2_weight" and "w2_weight_scale".
     """
     calculate_kv_scales: bool = False
     """This enables dynamic calculation of `k_scale` and `v_scale` when

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -434,6 +434,7 @@ class EngineArgs:
     disable_cascade_attn: bool = ModelConfig.disable_cascade_attn
     swap_space: float = CacheConfig.swap_space
     cpu_offload_gb: float = CacheConfig.cpu_offload_gb
+    cpu_offload_params: set[str] = CacheConfig.cpu_offload_params
     gpu_memory_utilization: float = CacheConfig.gpu_memory_utilization
     kv_cache_memory_bytes: int | None = CacheConfig.kv_cache_memory_bytes
     max_num_batched_tokens: int | None = None
@@ -942,6 +943,9 @@ class EngineArgs:
             "--prefix-caching-hash-algo", **cache_kwargs["prefix_caching_hash_algo"]
         )
         cache_group.add_argument("--cpu-offload-gb", **cache_kwargs["cpu_offload_gb"])
+        cache_group.add_argument(
+            "--cpu-offload-params", **cache_kwargs["cpu_offload_params"]
+        )
         cache_group.add_argument(
             "--calculate-kv-scales", **cache_kwargs["calculate_kv_scales"]
         )
@@ -1453,6 +1457,7 @@ class EngineArgs:
             enable_prefix_caching=self.enable_prefix_caching,
             prefix_caching_hash_algo=self.prefix_caching_hash_algo,
             cpu_offload_gb=self.cpu_offload_gb,
+            cpu_offload_params=self.cpu_offload_params,
             calculate_kv_scales=self.calculate_kv_scales,
             kv_sharing_fast_prefill=self.kv_sharing_fast_prefill,
             mamba_cache_dtype=self.mamba_cache_dtype,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -434,7 +434,7 @@ class EngineArgs:
     disable_cascade_attn: bool = ModelConfig.disable_cascade_attn
     swap_space: float = CacheConfig.swap_space
     cpu_offload_gb: float = CacheConfig.cpu_offload_gb
-    cpu_offload_params: set[str] = CacheConfig.cpu_offload_params
+    cpu_offload_params: set[str] = get_field(CacheConfig, "cpu_offload_params")
     gpu_memory_utilization: float = CacheConfig.gpu_memory_utilization
     kv_cache_memory_bytes: int | None = CacheConfig.kv_cache_memory_bytes
     max_num_batched_tokens: int | None = None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -345,9 +345,13 @@ class GPUModelRunner(
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config
 
-        from vllm.model_executor.models.utils import set_cpu_offload_max_bytes
+        from vllm.model_executor.models.utils import (
+            set_cpu_offload_max_bytes,
+            set_cpu_offload_params,
+        )
 
         set_cpu_offload_max_bytes(int(self.cache_config.cpu_offload_gb * 1024**3))
+        set_cpu_offload_params(self.cache_config.cpu_offload_params)
 
         model_config = self.model_config
         cache_config = self.cache_config


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
This PR adds support to selectively offload parameters to CPU based on name matching. One use case is to only offload experts weights for MoE weights, which is useful for low-concurrency settings. This is turned on by passing argument `--cpu-offload-params`

## Test Plan
Tested offloading Kimi K2 NVFP4 on one GB300.
```
VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY=1 python3 -m vllm.entrypoints.openai.api_server \
	--model nvidia/Kimi-K2-Thinking-NVFP4 \
	--trust-remote-code \
        --cpu-offload-gb 350 \
        --load-format dummy \
        --cpu-offload-params w13_weight w2_weight
```

Benchmarking single-user throughput:
```
vllm bench serve \
  --backend vllm \
  --endpoint /v1/completions \
  --num-prompts 5 \
  --dataset-name random \
  --input-len 100 \
  --output-len 100 \
  --max-concurrency 1 \
  --trust-remote-code \
  --num-warmups 2
```

## Test Result
**Before: 15 tok/s**
```
============ Serving Benchmark Result ============
Successful requests:                     5         
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  32.17     
Total input tokens:                      500       
Total generated tokens:                  500       
Request throughput (req/s):              0.16      
Output token throughput (tok/s):         15.54     
Peak output token throughput (tok/s):    17.00     
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          31.08     
---------------Time to First Token----------------
Mean TTFT (ms):                          302.71    
Median TTFT (ms):                        326.77    
P99 TTFT (ms):                           327.42    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          61.94     
Median TPOT (ms):                        61.93     
P99 TPOT (ms):                           61.95     
---------------Inter-token Latency----------------
Mean ITL (ms):                           61.94     
Median ITL (ms):                         61.90     
P99 ITL (ms):                            62.72     
==================================================
```

**Offloading MoE weights only: **31 tok/s****
```
============ Serving Benchmark Result ============
Successful requests:                     5         
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  15.81     
Total input tokens:                      500       
Total generated tokens:                  500       
Request throughput (req/s):              0.32      
Output token throughput (tok/s):         31.62     
Peak output token throughput (tok/s):    34.00     
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          63.24     
---------------Time to First Token----------------
Mean TTFT (ms):                          244.12    
Median TTFT (ms):                        272.78    
P99 TTFT (ms):                           273.59    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          29.48     
Median TPOT (ms):                        29.48     
P99 TPOT (ms):                           29.49     
---------------Inter-token Latency----------------
Mean ITL (ms):                           29.48     
Median ITL (ms):                         29.47     
P99 ITL (ms):                            29.85     
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

