### PR TITLE
[Kernels] Fix Helion GPU utils to use platform-agnostic device name API

### DIFF
--- a/vllm/kernels/helion/utils.py
+++ b/vllm/kernels/helion/utils.py
@@ -2,11 +2,19 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Utility functions for Helion kernel management."""
 
+import logging
+
 from vllm.platforms import current_platform
+
+logger = logging.getLogger(__name__)
 
 
 def get_gpu_name(device_id: int | None = None) -> str:
     if device_id is None:
+        logger.warning(
+            "get_gpu_name() called without device_id, defaulting to 0. "
+            "This may return the wrong device name in multi-node setups."
+        )
         device_id = 0
     return current_platform.get_device_name(device_id)
 

--- a/vllm/kernels/helion/utils.py
+++ b/vllm/kernels/helion/utils.py
@@ -2,14 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Utility functions for Helion kernel management."""
 
-import torch
+from vllm.platforms import current_platform
 
 
 def get_gpu_name(device_id: int | None = None) -> str:
     if device_id is None:
-        device_id = torch.cuda.current_device()
-    props = torch.cuda.get_device_properties(device_id)
-    return props.name
+        device_id = 0
+    return current_platform.get_device_name(device_id)
 
 
 def canonicalize_gpu_name(name: str) -> str:
@@ -18,6 +17,7 @@ def canonicalize_gpu_name(name: str) -> str:
 
     Converts to lowercase and replaces spaces and hyphens with underscores.
     e.g., "NVIDIA A100-SXM4-80GB" -> "nvidia_a100_sxm4_80gb"
+          "AMD_Instinct_MI300X"   -> "amd_instinct_mi300x"
 
     Raises ValueError if name is empty.
     """


### PR DESCRIPTION
This PR fixes `vllm/kernels/helion/utils.py` to use vLLM's existing platform abstraction instead of hardcoded `torch.cuda` calls.

## Problem

The current implementation calls `torch.cuda.get_device_properties()` and `torch.cuda.current_device()` directly, which:

- **Breaks on AMD/ROCm** --- ROCm uses `amdsmi` for device queries and has its own device ID-to-name mapping.
- **Prematurely initializes CUDA context** --- vLLM intentionally defers CUDA init (e.g. so Ray workers can set `CUDA_VISIBLE_DEVICES` after import).
- **Ignores existing abstractions** --- `current_platform.get_device_name()` already handles CUDA (via NVML), ROCm (via amdsmi), and CPU correctly.

## Changes

- Replace `torch.cuda.get_device_properties()` with `current_platform.get_device_name()`
- Replace `torch.cuda.current_device()` fallback with a default `device_id=0`

## Testing

`pip install helion; pytest -v -s tests/kernels/helion/`