### PR TITLE
[Kernel] [Helion] [8/N] Remove fake_impl usage and inference

### DIFF
--- a/tests/kernels/helion/test_pattern_matching.py
+++ b/tests/kernels/helion/test_pattern_matching.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test make_fx tracing and inductor pattern matching with HelionKernelWrapper."""
+
+import contextlib
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from vllm.utils.import_utils import has_helion
+
+if not has_helion():
+    pytest.skip(
+        "Helion is not installed. Install with: pip install vllm[helion]",
+        allow_module_level=True,
+    )
+
+import helion
+import helion.language as hl
+from helion._compiler._dynamo.higher_order_ops import (
+    helion_kernel_side_table,
+    helion_kernel_wrapper_mutation,
+)
+from torch._inductor.pattern_matcher import (
+    PatternMatcherPass,
+    fwd_only,
+    register_replacement,
+    select_decomp_table,
+)
+from torch.fx.experimental.proxy_tensor import make_fx
+
+from vllm.kernels.helion.config_manager import ConfigManager
+from vllm.kernels.helion.register import HelionKernelWrapper
+
+
+@contextlib.contextmanager
+def _helion_mock_context():
+    configs = {
+        "default": helion.Config(block_sizes=[64], num_warps=2, num_stages=2),
+    }
+    mock_config_manager = Mock(spec=ConfigManager)
+    mock_config_manager.get_platform_configs = Mock(return_value=configs)
+
+    with (
+        patch(
+            "vllm.kernels.helion.config_manager.ConfigManager.get_instance",
+            return_value=mock_config_manager,
+        ),
+        patch(
+            "vllm.kernels.helion.utils.get_canonical_gpu_name",
+            return_value="nvidia_h200",
+        ),
+    ):
+        yield
+
+
+class TestMakeFxHop:
+    def setup_method(self):
+        helion_kernel_side_table.reset_table()
+
+    def test_make_fx_symbolic(self):
+        def raw_add_scale(
+            x: torch.Tensor, y: torch.Tensor, scale: float
+        ) -> tuple[torch.Tensor, int, torch.Tensor]:
+            out_x = torch.empty_like(x)
+            out_y = torch.empty_like(x)
+            for tile in hl.tile(x.size()):
+                out_x[tile] = x[tile] + y[tile] * scale
+                out_y[tile] = out_x[tile] * 2.0
+            return out_x, 42, out_y
+
+        input_x = torch.randn(7, 13)
+        input_y = torch.randn(7, 13)
+        scale = 0.5
+
+        with _helion_mock_context():
+            wrapper = HelionKernelWrapper(
+                raw_kernel_func=raw_add_scale,
+                op_name="test_make_fx",
+                fake_impl=lambda *a, **kw: None,
+            )
+            wrapper.register_config_picker(lambda args, keys: "default")
+
+            def fn(x, y):
+                return wrapper(x, y, scale)
+
+            gm = make_fx(fn, tracing_mode="symbolic")(input_x, input_y)
+
+        hop_nodes = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target is helion_kernel_wrapper_mutation
+        ]
+        assert len(hop_nodes) == 1
+        node = hop_nodes[0]
+
+        assert node.kwargs["constant_args"]["scale"] == scale
+        assert set(node.kwargs["tensor_args"]) == {"x", "y"}
+
+        specs = node.kwargs["output_spec"]["leaf_specs"]
+        tensor_specs = [s for s in specs if s["type"] == "tensor"]
+        scalar_specs = [s for s in specs if s["type"] == "scalar"]
+        assert len(tensor_specs) == 2
+        assert len(scalar_specs) == 1
+
+        for spec in tensor_specs:
+            assert spec["dtype"] == input_x.dtype
+
+        assert scalar_specs[0]["scalar_value"] == 42
+
+        for val in node.meta["val"]:
+            assert all(isinstance(s, torch.SymInt) for s in val.shape)
+
+        # Both out_x and out_y are empty_like(x), so output shapes == input shape
+        input_node = next(n for n in gm.graph.nodes if n.op == "placeholder")
+        input_shape = input_node.meta["val"].shape
+        for val in node.meta["val"]:
+            assert len(val.shape) == len(input_shape)
+            for out_s, in_s in zip(val.shape, input_shape):
+                assert out_s == in_s
+
+    def test_pattern_matcher_replaces_with_helion_hop(self):
+        def raw_silu_mul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            M, N = x.size()
+            out = torch.empty_like(x)
+            for tile_m, tile_n in hl.tile([M, N]):
+                out[tile_m, tile_n] = (
+                    torch.nn.functional.silu(x[tile_m, tile_n]) * y[tile_m, tile_n]
+                )
+            return out
+
+        with _helion_mock_context():
+            wrapper = HelionKernelWrapper(
+                raw_kernel_func=raw_silu_mul,
+                op_name="test_pm_silu_mul",
+                fake_impl=lambda *a, **kw: None,
+            )
+            wrapper.register_config_picker(lambda args, keys: "default")
+
+            def pattern(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+                return torch.nn.functional.silu(x) * y
+
+            def replacement(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+                return wrapper(x, y)
+
+            inputs = [torch.randn(8, 16), torch.randn(8, 16)]
+
+            pm_pass = PatternMatcherPass(pass_name="test_helion_replacement")
+            register_replacement(pattern, replacement, inputs, fwd_only, pm_pass)
+
+            def model(x, y):
+                return torch.nn.functional.silu(x) * y
+
+            decompositions = select_decomp_table()
+            input_x = torch.randn(8, 16)
+            input_y = torch.randn(8, 16)
+            gm = make_fx(model, decompositions, tracing_mode="symbolic")(
+                input_x, input_y
+            )
+
+            def count_hop_nodes(graph):
+                return sum(
+                    1
+                    for n in graph.nodes
+                    if n.op == "call_function"
+                    and n.target is helion_kernel_wrapper_mutation
+                )
+
+            assert count_hop_nodes(gm.graph) == 0
+
+            match_count = pm_pass.apply(gm.graph)
+            gm.graph.lint()
+            gm.recompile()
+
+            assert match_count == 1
+            assert count_hop_nodes(gm.graph) == 1
+
+            hop_node = next(
+                n
+                for n in gm.graph.nodes
+                if n.op == "call_function"
+                and n.target is helion_kernel_wrapper_mutation
+            )
+
+            # raw_silu_mul returns empty_like(x), so output shape == input shape
+            for val in hop_node.meta["val"]:
+                assert all(isinstance(s, torch.SymInt) for s in val.shape)
+
+            input_node = next(n for n in gm.graph.nodes if n.op == "placeholder")
+            input_shape = input_node.meta["val"].shape
+            output_shape = hop_node.meta["val"][0].shape
+            assert len(output_shape) == len(input_shape)
+            for out_s, in_s in zip(output_shape, input_shape):
+                assert out_s == in_s

--- a/tests/kernels/helion/test_pattern_matching.py
+++ b/tests/kernels/helion/test_pattern_matching.py
@@ -76,9 +76,7 @@ class TestMakeFxHop:
 
         with _helion_mock_context():
             wrapper = HelionKernelWrapper(
-                raw_kernel_func=raw_add_scale,
-                op_name="test_make_fx",
-                fake_impl=lambda *a, **kw: None,
+                raw_kernel_func=raw_add_scale, op_name="test_make_fx"
             )
             wrapper.register_config_picker(lambda args, keys: "default")
 
@@ -132,9 +130,7 @@ class TestMakeFxHop:
 
         with _helion_mock_context():
             wrapper = HelionKernelWrapper(
-                raw_kernel_func=raw_silu_mul,
-                op_name="test_pm_silu_mul",
-                fake_impl=lambda *a, **kw: None,
+                raw_kernel_func=raw_silu_mul, op_name="test_pm_silu_mul"
             )
             wrapper.register_config_picker(lambda args, keys: "default")
 

--- a/tests/kernels/helion/test_silu_mul_fp8.py
+++ b/tests/kernels/helion/test_silu_mul_fp8.py
@@ -376,20 +376,3 @@ class TestSiluMulFp8Integration:
         kernel_wrapper = registered_kernels["silu_mul_fp8"]
         assert kernel_wrapper.op_name == "silu_mul_fp8"
         assert kernel_wrapper._config_picker is not None
-
-    def test_fake_impl_functionality(self):
-        skip_if_platform_unsupported()
-        from vllm.kernels.helion.register import get_registered_kernels
-
-        input_tensor = torch.randn(32, 4096, dtype=torch.bfloat16, device="cuda")
-        scale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
-        registered_kernels = get_registered_kernels()
-        kernel_wrapper = registered_kernels["silu_mul_fp8"]
-        fake_impl = kernel_wrapper._fake_impl
-
-        fake_output = fake_impl(input_tensor, scale)
-
-        expected_shape = (32, 2048)
-        assert fake_output.shape == expected_shape
-        assert fake_output.dtype == torch.float8_e4m3fn
-        assert fake_output.device == input_tensor.device

--- a/vllm/kernels/helion/__init__.py
+++ b/vllm/kernels/helion/__init__.py
@@ -13,7 +13,6 @@ from vllm.kernels.helion.register import (
     get_kernel_by_name,
     get_registered_kernels,
     register_kernel,
-    vllm_helion_lib,
 )
 from vllm.kernels.helion.utils import canonicalize_gpu_name, get_canonical_gpu_name
 
@@ -27,7 +26,6 @@ __all__ = [
     "get_kernel_by_name",
     "get_registered_kernels",
     "register_kernel",
-    "vllm_helion_lib",
     # Utilities
     "canonicalize_gpu_name",
     "get_canonical_gpu_name",

--- a/vllm/kernels/helion/register.py
+++ b/vllm/kernels/helion/register.py
@@ -245,15 +245,12 @@ class HelionKernelWrapper:
         self,
         raw_kernel_func: Callable,
         op_name: str,
-        fake_impl: Callable,
         helion_settings: "helion.Settings | None" = None,
     ):
-        # Validate helion_settings doesn't conflict with our custom autotuner
         validate_helion_settings(helion_settings, op_name)
 
         self.raw_kernel_func = raw_kernel_func
         self.op_name = op_name
-        self._fake_impl = fake_impl
         self.helion_settings = helion_settings
         self._config_picker: (
             Callable[[tuple[Any, ...], list[str]], str | None] | None
@@ -413,38 +410,10 @@ def get_kernel_by_name(kernel_name: str) -> HelionKernelWrapper | None:
     return _REGISTERED_KERNELS.get(kernel_name)
 
 
-def infer_fake_impl(
-    kernel_func: Callable,
-    helion_settings: "helion.Settings | None" = None,
-) -> Callable:
-    def helion_fake_kernel(*args, **kwargs):
-        kernel_kwargs = {}
-        if helion_settings:
-            kernel_kwargs.update(helion_settings.to_dict())
-
-        temp_decorated_kernel = helion.kernel(**kernel_kwargs)(kernel_func)
-
-        # Bind with args to get config_spec, then get a valid default config
-        bound = temp_decorated_kernel.bind(args)
-        default_config = bound.config_spec.default_config()
-        compiled_runner = bound.compile_config(default_config)
-
-        return compiled_runner(*args, **kwargs, _launcher=lambda *a, **kw: None)
-
-    return helion_fake_kernel
-
-
-# Overloads are necessary for proper mypy type inference.
-# Without overloads, the union return type HelionKernelWrapper | Callable[...]
-# causes mypy to complain about missing attributes when tests do:
-#   wrapper = register_kernel(func)  # Should return HelionKernelWrapper
-#   wrapper._fake_impl  # mypy error: "Callable has no attribute _fake_impl"
-# The overloads tell mypy the exact return type based on the argument pattern.
 @overload
 def register_kernel(
     op_name_or_func: Callable,
     *,
-    fake_impl: Callable | None = None,
     helion_settings: "helion.Settings | None" = None,
 ) -> HelionKernelWrapper: ...
 
@@ -453,7 +422,6 @@ def register_kernel(
 def register_kernel(
     op_name_or_func: str | None = None,
     *,
-    fake_impl: Callable | None = None,
     helion_settings: "helion.Settings | None" = None,
 ) -> Callable[[Callable], HelionKernelWrapper]: ...
 
@@ -461,15 +429,9 @@ def register_kernel(
 def register_kernel(
     op_name_or_func: str | Callable | None = None,
     *,
-    fake_impl: Callable | None = None,
     helion_settings: "helion.Settings | None" = None,
 ) -> HelionKernelWrapper | Callable[[Callable], HelionKernelWrapper]:
-    """
-    Decorator to register a Helion kernel function as a HelionKernelWrapper.
-
-    Wraps the raw kernel function in a HelionKernelWrapper and registers it
-    in the global kernel registry. Auto-generates fake_impl if not provided.
-    """
+    """Decorator to register a Helion kernel function as a HelionKernelWrapper."""
 
     def decorator(kernel_func: Callable) -> HelionKernelWrapper:
         op_name = op_name_or_func if isinstance(op_name_or_func, str) else None
@@ -481,18 +443,9 @@ def register_kernel(
                 f"Use a different op_name or check for duplicate registrations."
             )
 
-        final_fake_impl = fake_impl
-        if final_fake_impl is None:
-            final_fake_impl = infer_fake_impl(kernel_func, helion_settings)
-            logger.debug(
-                "Auto-generated fake_impl for Helion kernel '%s'",
-                kernel_func.__name__,
-            )
-
         kernel_wrapper = HelionKernelWrapper(
             raw_kernel_func=kernel_func,
             op_name=final_op_name,
-            fake_impl=final_fake_impl,
             helion_settings=helion_settings,
         )
 


### PR DESCRIPTION
NOTE: this is a manually stacked PR, each commit is reviewed separately. For this PR, please only review the top commit: Replace fake_impl with helion's infer_output_spec in HelionKernelWrapper 


Since we uses HOP to represent Helion kernel calls now, and Helion has internal support to compute output tensor shape, we no longer need to infer `fake_impl`. This PR removes all relevant logic to `fake_impl`