### PR TITLE
[Bugfix] Fix ROCm UVA CPU weight offloading broken by #32993

### DIFF
--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -683,7 +683,7 @@ def get_accelerator_view_from_cpu_tensor(cpu_tensor: torch.Tensor) -> torch.Tens
     if current_platform.is_xpu():
         assert cpu_tensor.is_pinned(), "CPU tensor must be pinned"
         return torch.ops._C.get_xpu_view_from_cpu_tensor(cpu_tensor)
-    elif current_platform.is_cuda():
+    elif current_platform.is_cuda() or current_platform.is_rocm():
         return torch.ops._C.get_cuda_view_from_cpu_tensor(cpu_tensor)
     else:
         raise ValueError(


### PR DESCRIPTION
- PR #32993 added UVA (Unified Virtual Addressing) support for CPU weight offloading but only included platform checks for CUDA and XPU in `get_accelerator_view_from_cpu_tensor`, causing a `ValueError` on ROCm.
- The C++ layer already works on ROCm since `cuda_view.cu` is hipified automatically and the op registration is not ROCm-guarded. Only the Python-level platform check was missing.
- Fix: add `current_platform.is_rocm()` to the existing CUDA branch, since ROCm shares the same device type and dispatch key.

## Test plan
- [x] `tests/kernels/core/test_uva.py`
- [x] `tests/basic_correctness/test_cpu_offload.py`
- [x] `tests/quantization/test_cpu_offload.py`