### PR TITLE
[CI] [Kernel] Rename Helion config key to match actual H100 SXM5 device name used in CI

### DIFF
--- a/vllm/kernels/helion/configs/silu_mul_fp8.json
+++ b/vllm/kernels/helion/configs/silu_mul_fp8.json
@@ -273,7 +273,7 @@
       "range_warp_specializes": []
     }
   },
-  "nvidia_h100_sxm5": {
+  "nvidia_h100_80gb_hbm3": {
     "intermediate_2048_batchsize_256": {
       "block_sizes": [
         1,


### PR DESCRIPTION
Rename "nvidia_h100_sxm5" to "nvidia_h100_80gb_hbm3" to match the exact device name we use in vLLM CI. Previously some tests were incorrectly skipped due to mismatching device name.