### PR TITLE
[perf] silu early return for 0s

### DIFF
--- a/csrc/activation_kernels.cu
+++ b/csrc/activation_kernels.cu
@@ -195,7 +195,7 @@ __global__ void act_and_mul_kernel(
   }
 }
 
-  template <typename T>
+template <typename T>
 __device__ __forceinline__ T silu_kernel(const T& x) {
   const float xf = static_cast<float>(x);
   // x * sigmoid(x)

--- a/csrc/activation_kernels.cu
+++ b/csrc/activation_kernels.cu
@@ -195,18 +195,21 @@ __global__ void act_and_mul_kernel(
   }
 }
 
-template <typename T>
+  template <typename T>
 __device__ __forceinline__ T silu_kernel(const T& x) {
+  const float xf = static_cast<float>(x);
   // x * sigmoid(x)
-  return (T)(((float)x) / (1.0f + expf((float)-x)));
+  // early return for zero
+  return static_cast<T>((xf == 0.0f) ? 0.0f : xf / (1.0f + expf(-xf)));
 }
 
 template <typename packed_t>
 __device__ __forceinline__ packed_t packed_silu_kernel(const packed_t& val) {
-  // x * sigmoid(x)
   float2 fval = cast_to_float2(val);
-  fval.x = fval.x / (1.0f + expf(-fval.x));
-  fval.y = fval.y / (1.0f + expf(-fval.y));
+  // x * sigmoid(x)
+  // early return for zero per lane
+  fval.x = (fval.x == 0.0f) ? 0.0f : fval.x / (1.0f + expf(-fval.x));
+  fval.y = (fval.y == 0.0f) ? 0.0f : fval.y / (1.0f + expf(-fval.y));
   return cast_to_packed<packed_t>(fval);
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

In the moe codepaths we allocate the full `M * topk` buffer for activations which means that in EP cases a lot of the rows will be 0 (corresponding to tokens processed by experts not on the current rank). The existing silu kernel has poor performance (like 50% slower) when many rows are 0 due to extra divisibility checks/different codepath in the generated SASS. This can be fixed by compiling with `--use_fast_math`/using `__expf` but that changes numerics so another solution is to just return 0 when the input is 0.

While it improves perf significantly, this approach has some extra overhead for non-zero cases (~5%), concrete numbers below. I suppose it is possible to compile a different kernel and let the caller choose, since in general we know when to expect a large fraction of zeros in the activation inputs (when we are doing EP > 1 and in the specific moe code path). Let me know if that approach is preferred!


## Test Plan
microbenchmark - similar to `benchmark_activation.py` except that we just benchmark the raw op since that's how it's called in the moe code path. We also add `zero_frac` which means fraction of rows which are zero, which will happen for EP case (for uniform routing, EP4 we expect `zero_frac ~= 0.75`). Numbers shown are for B200 GPU.

<details>
<summary>benchmark_activation_raw_op.py</summary>

```
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

# Benchmark raw CUDA activation op performance.
import itertools

import torch
import vllm._custom_ops  # noqa: F401
from vllm.triton_utils import triton
from vllm.utils.argparse_utils import FlexibleArgumentParser
from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE, set_random_seed

batch_size_range = [1, 16, 128]
seq_len_range = [1, 16, 64, 1024, 4096]
intermediate_size = [3072, 9728, 12288]
configs = list(itertools.product(batch_size_range, seq_len_range, intermediate_size))


def benchmark_activation_raw_op(
    batch_size: int,
    seq_len: int,
    intermediate_size: int,
    func_name: str,
    dtype: torch.dtype,
    zero_frac: float,
):
    device = "cuda"
    num_tokens = batch_size * seq_len
    d = intermediate_size
    set_random_seed(42)
    torch.set_default_device(device)

    x = torch.randn(num_tokens, 2 * d, dtype=dtype, device=device)
    num_zero_rows = int(num_tokens * zero_frac)
    if num_zero_rows > 0:
        x[-num_zero_rows:, :] = 0
    out = torch.empty(num_tokens, d, dtype=dtype, device=device)

    threshold = 0.5
    alpha = 1.702
    limit = 7.0
    if func_name == "fatrelu_and_mul":
        fn = lambda: torch.ops._C.fatrelu_and_mul(out, x, threshold)
    elif func_name == "swigluoai_and_mul":
        fn = lambda: torch.ops._C.swigluoai_and_mul(out, x, alpha, limit)
    else:
        op = getattr(torch.ops._C, func_name)
        fn = lambda: op(out, x)

    ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(
        fn, quantiles=[0.5, 0.2, 0.8]
    )
    return ms, max_ms, min_ms


if __name__ == "__main__":
    parser = FlexibleArgumentParser(
        description="Benchmark raw CUDA activation op kernels."
    )
    parser.add_argument(
        "--func-name",
        type=str,
        choices=[
            "mul_and_silu",
            "silu_and_mul",
            "gelu_and_mul",
            "gelu_tanh_and_mul",
            "fatrelu_and_mul",
            "swigluoai_and_mul",
        ],
        default="silu_and_mul",
    )
    parser.add_argument(
        "--dtype", type=str, choices=["half", "bfloat16", "float"], default="bfloat16"
    )
    parser.add_argument(
        "--zero-frac",
        type=float,
        default=0.0,
        help="Fraction of trailing rows to zero in the input tensor (0.0 to 1.0).",
    )
    args = parser.parse_args()
    assert args
    assert 0.0 <= args.zero_frac <= 1.0, "--zero-frac must be in [0.0, 1.0]"

    func_name = args.func_name
    dtype = STR_DTYPE_TO_TORCH_DTYPE[args.dtype]

    perf_report = triton.testing.perf_report(
        triton.testing.Benchmark(
            x_names=["batch_size", "seq_len", "intermediate_size"],
            x_vals=configs,
            line_arg="impl",
            line_vals=["raw_op"],
            line_names=["Raw OP"],
            styles=[("blue", "-")],
            ylabel="ms",
            plot_name=f"{func_name}-raw-op-performance",
            args={},
        )
    )

    perf_report(
        lambda batch_size, seq_len, intermediate_size, impl: benchmark_activation_raw_op(
            batch_size, seq_len, intermediate_size, func_name, dtype, args.zero_frac
        )
    ).run(print_data=True)

```

</details>

for inputs which are all non-zero this change is on average about 5% slower
<details>
<summary>before vs after, nonzero inputs</summary>

batch_size | seq_len | intermediate_size | before_ms | after_ms | pct_change
-- | -- | -- | -- | -- | --
1 | 1 | 3072 | 0.001683 | 0.001795 | 6.654780
1 | 1 | 9728 | 0.003125 | 0.003313 | 6.016000
1 | 1 | 12288 | 0.003237 | 0.003429 | 5.931420
1 | 16 | 3072 | 0.002054 | 0.002157 | 5.014610
1 | 16 | 9728 | 0.003305 | 0.003498 | 5.839640
1 | 16 | 12288 | 0.003417 | 0.003615 | 5.794560
1 | 64 | 3072 | 0.002119 | 0.002228 | 5.143940
1 | 64 | 9728 | 0.003374 | 0.003585 | 6.253710
1 | 64 | 12288 | 0.003499 | 0.003706 | 5.915980
1 | 1024 | 3072 | 0.004763 | 0.005093 | 6.928410
1 | 1024 | 9728 | 0.010413 | 0.011368 | 9.171230
1 | 1024 | 12288 | 0.012245 | 0.013330 | 8.860760
1 | 4096 | 3072 | 0.012464 | 0.013446 | 7.878690
1 | 4096 | 9728 | 0.042769 | 0.044652 | 4.402720
1 | 4096 | 12288 | 0.050600 | 0.052558 | 3.869570
16 | 1 | 3072 | 0.002125 | 0.002272 | 6.917650
16 | 1 | 9728 | 0.003308 | 0.003515 | 6.257560
16 | 1 | 12288 | 0.003428 | 0.003613 | 5.396730
16 | 16 | 3072 | 0.002847 | 0.003033 | 6.533190
16 | 16 | 9728 | 0.004271 | 0.004556 | 6.672910
16 | 16 | 12288 | 0.004869 | 0.005141 | 5.586360
16 | 64 | 3072 | 0.004756 | 0.005102 | 7.275020
16 | 64 | 9728 | 0.010429 | 0.011397 | 9.281810
16 | 64 | 12288 | 0.012293 | 0.013238 | 7.687300
16 | 1024 | 3072 | 0.047361 | 0.050945 | 7.567410
16 | 1024 | 9728 | 0.164153 | 0.171878 | 4.705980
16 | 1024 | 12288 | 0.198541 | 0.202074 | 1.779480
16 | 4096 | 3072 | 0.199160 | 0.208600 | 4.739910
16 | 4096 | 9728 | 0.669356 | 0.707548 | 5.705780
16 | 4096 | 12288 | 0.767501 | 0.802136 | 4.512700
128 | 1 | 3072 | 0.002547 | 0.002633 | 3.376520
128 | 1 | 9728 | 0.003548 | 0.003694 | 4.114990
128 | 1 | 12288 | 0.003606 | 0.003777 | 4.742100
128 | 16 | 3072 | 0.007279 | 0.007808 | 7.267480
128 | 16 | 9728 | 0.023125 | 0.024428 | 5.634600
128 | 16 | 12288 | 0.026785 | 0.028019 | 4.607060
128 | 64 | 3072 | 0.024597 | 0.026429 | 7.448060
128 | 64 | 9728 | 0.084967 | 0.089421 | 5.242030
128 | 64 | 12288 | 0.102749 | 0.106324 | 3.479350
128 | 1024 | 3072 | 0.376172 | 0.403828 | 7.351960
128 | 1024 | 9728 | 1.403800 | 1.360110 | -3.112260
128 | 1024 | 12288 | 1.476680 | 1.555690 | 5.350520
128 | 4096 | 3072 | 1.490700 | 1.604570 | 7.638070
128 | 4096 | 9728 | 4.992620 | 5.287020 | 5.896870
128 | 4096 | 12288 | 5.919110 | 6.311950 | 6.636810



</details>

for `zero_frac=0.75` on average it is ~35% faster

<details>
<summary>before vs after, zero_frac=0.75</summary>

batch_size | seq_len | intermediate_size | before_ms | after_ms | pct_change
-- | -- | -- | -- | -- | --
1 | 1 | 3072 | 0.001685 | 0.001794 | 6.468840
1 | 1 | 9728 | 0.003123 | 0.003312 | 6.051870
1 | 1 | 12288 | 0.003238 | 0.003431 | 5.960470
1 | 16 | 3072 | 0.003072 | 0.002089 | -31.998700
1 | 16 | 9728 | 0.005563 | 0.003433 | -38.288700
1 | 16 | 12288 | 0.005770 | 0.003553 | -38.422900
1 | 64 | 3072 | 0.003127 | 0.002137 | -31.659700
1 | 64 | 9728 | 0.005669 | 0.003492 | -38.401800
1 | 64 | 12288 | 0.005891 | 0.003645 | -38.126000
1 | 1024 | 3072 | 0.007891 | 0.003548 | -55.037400
1 | 1024 | 9728 | 0.019832 | 0.007515 | -62.106700
1 | 1024 | 12288 | 0.023431 | 0.008921 | -61.926500
1 | 4096 | 3072 | 0.022107 | 0.008169 | -63.047900
1 | 4096 | 9728 | 0.072411 | 0.038143 | -47.324300
1 | 4096 | 12288 | 0.084756 | 0.045517 | -46.296400
16 | 1 | 3072 | 0.003085 | 0.002119 | -31.312800
16 | 1 | 9728 | 0.005563 | 0.003445 | -38.073000
16 | 1 | 12288 | 0.005767 | 0.003569 | -38.113400
16 | 16 | 3072 | 0.004879 | 0.002914 | -40.274600
16 | 16 | 9728 | 0.007668 | 0.003484 | -54.564400
16 | 16 | 12288 | 0.008713 | 0.003771 | -56.719800
16 | 64 | 3072 | 0.007890 | 0.003546 | -55.057000
16 | 64 | 9728 | 0.019855 | 0.007516 | -62.145600
16 | 64 | 12288 | 0.023399 | 0.008835 | -62.242000
16 | 1024 | 3072 | 0.080398 | 0.044877 | -44.181400
16 | 1024 | 9728 | 0.274116 | 0.142202 | -48.123400
16 | 1024 | 12288 | 0.323705 | 0.174822 | -45.993400
16 | 4096 | 3072 | 0.307846 | 0.172935 | -43.824200
16 | 4096 | 9728 | 1.078490 | 0.558813 | -48.185600
16 | 4096 | 12288 | 1.277780 | 0.694502 | -45.647900
128 | 1 | 3072 | 0.003205 | 0.002196 | -31.482100
128 | 1 | 9728 | 0.005745 | 0.003539 | -38.398600
128 | 1 | 12288 | 0.005976 | 0.003662 | -38.721600
128 | 16 | 3072 | 0.012611 | 0.004697 | -62.754700
128 | 16 | 9728 | 0.038784 | 0.020365 | -47.491200
128 | 16 | 12288 | 0.045140 | 0.024176 | -46.442200
128 | 64 | 3072 | 0.042305 | 0.023272 | -44.990000
128 | 64 | 9728 | 0.139654 | 0.072880 | -47.813900
128 | 64 | 12288 | 0.164724 | 0.088266 | -46.415800
128 | 1024 | 3072 | 0.611244 | 0.345515 | -43.473500
128 | 1024 | 9728 | 2.151880 | 1.115360 | -48.168100
128 | 1024 | 12288 | 2.549620 | 1.387970 | -45.561600
128 | 4096 | 3072 | 2.431340 | 1.380560 | -43.218200
128 | 4096 | 9728 | 6.600080 | 4.837700 | -26.702500
128 | 4096 | 12288 | 7.250590 | 5.870380 | -19.035800

</details>

e2e benchmark using `RedHatAI/Qwen3-235B-A22B-FP8-dynamic` EP4 on B200, uniform routing, 8k prefill
```
before
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  21.44     
Total input tokens:                      819200    
Total generated tokens:                  100       
Request throughput (req/s):              4.66      
Output token throughput (tok/s):         4.66      
Peak output token throughput (tok/s):    5.00      
Peak concurrent requests:                6.00      
Total token throughput (tok/s):          38216.89  
---------------Time to First Token----------------
Mean TTFT (ms):                          214.23    
Median TTFT (ms):                        215.01    
P99 TTFT (ms):                           222.10    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P99 ITL (ms):                            0.00      
==================================================

after
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  20.69     
Total input tokens:                      819200    
Total generated tokens:                  100       
Request throughput (req/s):              4.83      
Output token throughput (tok/s):         4.83      
Peak output token throughput (tok/s):    5.00      
Peak concurrent requests:                6.00      
Total token throughput (tok/s):          39591.99  
---------------Time to First Token----------------
Mean TTFT (ms):                          206.78    
Median TTFT (ms):                        207.16    
P99 TTFT (ms):                           213.11    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P99 ITL (ms):                            0.00      
==================================================
```
about 4%

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

