### PR TITLE
feat(metrics): add configurable Prometheus histogram buckets via CLI flags

### DIFF
--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -76,6 +76,21 @@ class ObservabilityConfig:
     This includes number of context/generation requests and tokens
     and the elapsed cpu time for the iteration."""
 
+    histogram_buckets_ttft: list[float] | None = None
+    """Custom Prometheus histogram buckets for time-to-first-token (TTFT)
+    metrics. Specify as a list of float boundaries in seconds.
+    If None, uses the default buckets."""
+
+    histogram_buckets_itl: list[float] | None = None
+    """Custom Prometheus histogram buckets for inter-token latency (ITL)
+    metrics. Specify as a list of float boundaries in seconds.
+    If None, uses the default buckets."""
+
+    histogram_buckets_request_latency: list[float] | None = None
+    """Custom Prometheus histogram buckets for request latency metrics
+    (e2e, queue, inference, prefill, decode). Specify as a list of float
+    boundaries in seconds. If None, uses the default buckets."""
+
     @cached_property
     def collect_model_forward_time(self) -> bool:
         """Whether to collect model forward time for the request."""

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -531,6 +531,15 @@ class EngineArgs:
         ObservabilityConfig.enable_logging_iteration_details
     )
     enable_mm_processor_stats: bool = ObservabilityConfig.enable_mm_processor_stats
+    histogram_buckets_ttft: list[float] | None = (
+        ObservabilityConfig.histogram_buckets_ttft
+    )
+    histogram_buckets_itl: list[float] | None = (
+        ObservabilityConfig.histogram_buckets_itl
+    )
+    histogram_buckets_request_latency: list[float] | None = (
+        ObservabilityConfig.histogram_buckets_request_latency
+    )
     scheduling_policy: SchedulerPolicy = SchedulerConfig.policy
     scheduler_cls: str | type[object] | None = SchedulerConfig.scheduler_cls
 
@@ -1099,6 +1108,36 @@ class EngineArgs:
         observability_group.add_argument(
             "--enable-logging-iteration-details",
             **observability_kwargs["enable_logging_iteration_details"],
+        )
+        observability_group.add_argument(
+            "--histogram-buckets-ttft",
+            nargs="+",
+            type=float,
+            default=None,
+            help="Custom Prometheus histogram buckets for time-to-first-token "
+            "(TTFT) metrics. Specify as space-separated float boundaries "
+            "in seconds. Example: --histogram-buckets-ttft 0.01 0.05 0.1 "
+            "0.5 1.0 5.0",
+        )
+        observability_group.add_argument(
+            "--histogram-buckets-itl",
+            nargs="+",
+            type=float,
+            default=None,
+            help="Custom Prometheus histogram buckets for inter-token latency "
+            "(ITL) metrics. Specify as space-separated float boundaries "
+            "in seconds. Example: --histogram-buckets-itl 0.01 0.05 0.1 "
+            "0.5 1.0",
+        )
+        observability_group.add_argument(
+            "--histogram-buckets-request-latency",
+            nargs="+",
+            type=float,
+            default=None,
+            help="Custom Prometheus histogram buckets for request latency "
+            "metrics (e2e, queue, inference, prefill, decode). Specify as "
+            "space-separated float boundaries in seconds. Example: "
+            "--histogram-buckets-request-latency 0.5 1.0 5.0 10.0 30.0 60.0",
         )
 
         # Scheduler arguments
@@ -1785,6 +1824,9 @@ class EngineArgs:
             enable_mfu_metrics=self.enable_mfu_metrics,
             enable_mm_processor_stats=self.enable_mm_processor_stats,
             enable_logging_iteration_details=self.enable_logging_iteration_details,
+            histogram_buckets_ttft=self.histogram_buckets_ttft,
+            histogram_buckets_itl=self.histogram_buckets_itl,
+            histogram_buckets_request_latency=self.histogram_buckets_request_latency,
         )
 
         # Compilation config overrides

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -410,6 +410,14 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             vllm_config.observability_config.kv_cache_metrics
         )
 
+        # Custom histogram bucket configurations
+        obs_config = vllm_config.observability_config
+        custom_ttft_buckets = obs_config.histogram_buckets_ttft
+        custom_itl_buckets = obs_config.histogram_buckets_itl
+        custom_request_latency_buckets = (
+            obs_config.histogram_buckets_request_latency
+        )
+
         labelnames = ["model_name", "engine"]
         model_name = vllm_config.model_config.served_model_name
         max_model_len = vllm_config.model_config.max_model_len
@@ -719,63 +727,65 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         #
         # Histogram of timing intervals
         #
+        default_ttft_buckets = [
+            0.001,
+            0.005,
+            0.01,
+            0.02,
+            0.04,
+            0.06,
+            0.08,
+            0.1,
+            0.25,
+            0.5,
+            0.75,
+            1.0,
+            2.5,
+            5.0,
+            7.5,
+            10.0,
+            20.0,
+            40.0,
+            80.0,
+            160.0,
+            640.0,
+            2560.0,
+        ]
         histogram_time_to_first_token = self._histogram_cls(
             name="vllm:time_to_first_token_seconds",
             documentation="Histogram of time to first token in seconds.",
-            buckets=[
-                0.001,
-                0.005,
-                0.01,
-                0.02,
-                0.04,
-                0.06,
-                0.08,
-                0.1,
-                0.25,
-                0.5,
-                0.75,
-                1.0,
-                2.5,
-                5.0,
-                7.5,
-                10.0,
-                20.0,
-                40.0,
-                80.0,
-                160.0,
-                640.0,
-                2560.0,
-            ],
+            buckets=custom_ttft_buckets or default_ttft_buckets,
             labelnames=labelnames,
         )
         self.histogram_time_to_first_token = make_per_engine(
             histogram_time_to_first_token, engine_indexes, model_name
         )
 
+        default_itl_buckets = [
+            0.01,
+            0.025,
+            0.05,
+            0.075,
+            0.1,
+            0.15,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.75,
+            1.0,
+            2.5,
+            5.0,
+            7.5,
+            10.0,
+            20.0,
+            40.0,
+            80.0,
+        ]
         histogram_inter_token_latency = self._histogram_cls(
             name="vllm:inter_token_latency_seconds",
             documentation="Histogram of inter-token latency in seconds.",
-            buckets=[
-                0.01,
-                0.025,
-                0.05,
-                0.075,
-                0.1,
-                0.15,
-                0.2,
-                0.3,
-                0.4,
-                0.5,
-                0.75,
-                1.0,
-                2.5,
-                5.0,
-                7.5,
-                10.0,
-                20.0,
-                40.0,
-                80.0,
-            ],
+            buckets=custom_itl_buckets or default_itl_buckets,
             labelnames=labelnames,
         )
         self.histogram_inter_token_latency = make_per_engine(
@@ -785,34 +795,14 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         histogram_request_time_per_output_token = self._histogram_cls(
             name="vllm:request_time_per_output_token_seconds",
             documentation="Histogram of time_per_output_token_seconds per request.",
-            buckets=[
-                0.01,
-                0.025,
-                0.05,
-                0.075,
-                0.1,
-                0.15,
-                0.2,
-                0.3,
-                0.4,
-                0.5,
-                0.75,
-                1.0,
-                2.5,
-                5.0,
-                7.5,
-                10.0,
-                20.0,
-                40.0,
-                80.0,
-            ],
+            buckets=custom_itl_buckets or default_itl_buckets,
             labelnames=labelnames,
         )
         self.histogram_request_time_per_output_token = make_per_engine(
             histogram_request_time_per_output_token, engine_indexes, model_name
         )
 
-        request_latency_buckets = [
+        default_request_latency_buckets = [
             0.3,
             0.5,
             0.8,
@@ -835,6 +825,9 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             1920.0,
             7680.0,
         ]
+        request_latency_buckets = (
+            custom_request_latency_buckets or default_request_latency_buckets
+        )
         histogram_e2e_time_request = self._histogram_cls(
             name="vllm:e2e_request_latency_seconds",
             documentation="Histogram of e2e request latency in seconds.",

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -414,9 +414,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         obs_config = vllm_config.observability_config
         custom_ttft_buckets = obs_config.histogram_buckets_ttft
         custom_itl_buckets = obs_config.histogram_buckets_itl
-        custom_request_latency_buckets = (
-            obs_config.histogram_buckets_request_latency
-        )
+        custom_request_latency_buckets = obs_config.histogram_buckets_request_latency
 
         labelnames = ["model_name", "engine"]
         model_name = vllm_config.model_config.served_model_name


### PR DESCRIPTION
Fixes #34370

Adds three new CLI flags to configure Prometheus histogram buckets:

- `--histogram-buckets-ttft` - Custom buckets for time-to-first-token metrics
- `--histogram-buckets-itl` - Custom buckets for inter-token latency metrics
- `--histogram-buckets-request-latency` - Custom buckets for request latency metrics (e2e, queue, inference, prefill, decode)

When not specified, the existing default buckets are used. This allows operators to customize histogram resolution for their specific SLO definitions and workload profiles without patching source code.

Changes:
- `vllm/config/observability.py` - Added 3 new optional config fields
- `vllm/engine/arg_utils.py` - Wired config fields to EngineArgs and CLI argument parser
- `vllm/v1/metrics/loggers.py` - Updated histogram instantiation to use custom buckets when provided