### PR TITLE
feat(whisper): add decoder prefix and custom task tokens for transcription API

### DIFF
--- a/vllm/entrypoints/openai/speech_to_text/protocol.py
+++ b/vllm/entrypoints/openai/speech_to_text/protocol.py
@@ -113,6 +113,26 @@ class TranscriptionRequest(OpenAIBaseModel):
             "numeric values, used by custom extensions."
         ),
     )
+
+    decoder_prefix: str | None = Field(
+        default=None,
+        description=(
+            "Text to seed the decoder with for continuation. Unlike 'prompt' "
+            "which uses the <|prev|> conditioning mechanism for style guidance, "
+            "this forces the decoder to continue generation from the given text. "
+            "Useful for continuous transcription of overlapping audio chunks."
+        ),
+    )
+
+    custom_task_tokens: list[str] | None = Field(
+        default=None,
+        description=(
+            "Custom special tokens to inject into the decoder task token "
+            "sequence. Inserted after the task token (e.g. <|transcribe|>) "
+            "but before <|notimestamps|>. For example, ['<|nopunctuation|>'] "
+            "for fine-tuned models that support punctuation control."
+        ),
+    )
     # --8<-- [end:transcription-extra-params]
 
     to_language: str | None = None

--- a/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
@@ -297,6 +297,10 @@ class OpenAISpeechToText(OpenAIServing):
                 task_type=self.task_type,
                 request_prompt=request.prompt,
                 to_language=to_language,
+                decoder_prefix=getattr(request, "decoder_prefix", None),
+                custom_task_tokens=getattr(
+                    request, "custom_task_tokens", None
+                ),
             )
             if request.response_format == "verbose_json":
                 prompt = self._preprocess_verbose_prompt(parse_enc_dec_prompt(prompt))

--- a/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
@@ -298,9 +298,7 @@ class OpenAISpeechToText(OpenAIServing):
                 request_prompt=request.prompt,
                 to_language=to_language,
                 decoder_prefix=getattr(request, "decoder_prefix", None),
-                custom_task_tokens=getattr(
-                    request, "custom_task_tokens", None
-                ),
+                custom_task_tokens=getattr(request, "custom_task_tokens", None),
             )
             if request.response_format == "verbose_json":
                 prompt = self._preprocess_verbose_prompt(parse_enc_dec_prompt(prompt))

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1129,6 +1129,8 @@ class SupportsTranscription(Protocol):
         task_type: Literal["transcribe", "translate"],
         request_prompt: str,
         to_language: str | None,
+        decoder_prefix: str | None = None,
+        custom_task_tokens: list[str] | None = None,
     ) -> PromptType:
         """Get the prompt for the ASR model.
         The model has control over the construction, as long as it

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -828,15 +828,31 @@ class WhisperForConditionalGeneration(
         task_type: Literal["transcribe", "translate"],
         request_prompt: str,
         to_language: str | None,
+        decoder_prefix: str | None = None,
+        custom_task_tokens: list[str] | None = None,
     ) -> PromptType:
         if language is None:
             raise ValueError(
                 "Language must be specified when creating the Whisper prompt"
             )
 
+        # Build prompt conditioning (style guidance via <|prev|>)
         decoder_text = (
             f"<|prev|>{request_prompt}" if request_prompt else ""
-        ) + f"<|startoftranscript|><|{language}|><|{task_type}|><|notimestamps|>"
+        )
+
+        # Build task token sequence
+        decoder_text += f"<|startoftranscript|><|{language}|><|{task_type}|>"
+
+        # Insert custom task tokens before <|notimestamps|>
+        if custom_task_tokens:
+            decoder_text += "".join(custom_task_tokens)
+
+        decoder_text += "<|notimestamps|>"
+
+        # Append decoder prefix (forces continuation from this text)
+        if decoder_prefix:
+            decoder_text += decoder_prefix
 
         return ExplicitEncoderDecoderPrompt(
             encoder_prompt=TextPrompt(

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -837,9 +837,7 @@ class WhisperForConditionalGeneration(
             )
 
         # Build prompt conditioning (style guidance via <|prev|>)
-        decoder_text = (
-            f"<|prev|>{request_prompt}" if request_prompt else ""
-        )
+        decoder_text = f"<|prev|>{request_prompt}" if request_prompt else ""
 
         # Build task token sequence
         decoder_text += f"<|startoftranscript|><|{language}|><|{task_type}|>"


### PR DESCRIPTION
Fixes #34518

Adds two new parameters to the `/v1/audio/transcriptions` API for Whisper models:

**1. `decoder_prefix`** - Seeds the decoder with text for continuation. Unlike `prompt` (which uses the `<|prev|>` conditioning mechanism for style guidance), this appends text after the task tokens to force the decoder to continue from that point. Essential for continuous transcription of overlapping audio chunks.

**2. `custom_task_tokens`** - Injects custom special tokens into the task token sequence between the task token (e.g. `<|transcribe|>`) and `<|notimestamps|>`. Useful for fine-tuned models that support additional control tokens like `<|nopunctuation|>`.

Changes:
- `vllm/entrypoints/openai/speech_to_text/protocol.py` - Added `decoder_prefix` and `custom_task_tokens` fields to `TranscriptionRequest`
- `vllm/model_executor/models/whisper.py` - Updated `get_generation_prompt()` to build decoder text with custom tokens and prefix
- `vllm/entrypoints/openai/speech_to_text/speech_to_text.py` - Pass new params through to model
- `vllm/model_executor/models/interfaces.py` - Updated `SupportsTranscription` interface signature

Both parameters are optional with `None` defaults, maintaining full backward compatibility.