### PR TITLE
Fix call to moe_mk in modelopt MoE modules (required for LoRA)

### DIFF
--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -977,11 +977,11 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
 
         assert self.moe_mk is not None
         return self.moe_mk(
-            x,
-            layer.w13_weight,
-            layer.w2_weight,
-            topk_weights,
-            topk_ids,
+            hidden_states=x,
+            w1=layer.w13_weight,
+            w2=layer.w2_weight,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
             activation=layer.activation,
             global_num_experts=layer.global_num_experts,
             expert_map=layer.expert_map,
@@ -1549,11 +1549,11 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         else:
             assert self.moe_mk is not None
             return self.moe_mk(
-                x,
-                layer.w13_weight,
-                layer.w2_weight,
-                topk_weights,
-                topk_ids,
+                hidden_states=x,
+                w1=layer.w13_weight,
+                w2=layer.w2_weight,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
                 activation=layer.activation,
                 global_num_experts=layer.global_num_experts,
                 expert_map=layer.expert_map,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Model:
https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8

When running Nemotron Nano with LoRA adapters the following error is raised:
```
(EngineCore_DP0 pid=1568002)   File "/my_home/workspace/my_vllm/vllm/model_executor/layers/fused_moe/runner/default_moe_runner.py", line 91, in _moe_forward_shared
(EngineCore_DP0 pid=1568002)     return layer.runner.forward_impl(
(EngineCore_DP0 pid=1568002)            ^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1568002)   File "/my_home/workspace/my_vllm/vllm/model_executor/layers/fused_moe/runner/default_moe_runner.py", line 709, in forward_impl
(EngineCore_DP0 pid=1568002)     final_hidden_states = self.quant_method.apply(
(EngineCore_DP0 pid=1568002)                           ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1568002)   File "/my_home/workspace/my_vllm/vllm/model_executor/layers/quantization/modelopt.py", line 979, in apply
(EngineCore_DP0 pid=1568002)     return self.moe_mk(
(EngineCore_DP0 pid=1568002)            ^^^^^^^^^^^^
(EngineCore_DP0 pid=1568002)   File "/my_home/workspace/venv_cuda128/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=1568002)     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=1568002)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1568002)   File "/my_home/workspace/venv_cuda128/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=1568002)     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=1568002)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1568002)   File "/my_home/workspace/my_vllm/vllm/lora/layers/fused_moe.py", line 156, in wrapper
(EngineCore_DP0 pid=1568002)     moe_state_dict["hidden_states"] = kwargs["hidden_states"]
(EngineCore_DP0 pid=1568002)                                       ~~~~~~^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=1568002) KeyError: 'hidden_states'
```

It seems like the function `FusedMoEWithLoRA._inject_lora_into_fused_moe.fwd_decorator` expects keyword arguments and fails if positional arguments are used.

The arguments will later be passed to `FusedMoEModularKernel.forward`.

This PR adds positional arguments to modelopt's MoE methods classes.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

