### PR TITLE
[Bugfix] Fix ARC touch KeyError for non-ready T1 blocks in kv offload

### DIFF
--- a/vllm/v1/kv_offload/arc_manager.py
+++ b/vllm/v1/kv_offload/arc_manager.py
@@ -87,11 +87,12 @@ class ARCOffloadingManager(OffloadingManager):
     def touch(self, block_hashes: Iterable[BlockHash]):
         for block_hash in reversed(list(block_hashes)):
             if block_hash in self.t1:
-                block = self.t1[block_hash]
+                block = self.t1.pop(block_hash)
                 if not block.is_ready:
-                    self.t1.move_to_end(block_hash)
+                    # block was just prepared to be stored, not really touched twice
+                    # keep it in T1 and mark as most recently used
+                    self.t1[block_hash] = block
                 else:
-                    del self.t1[block_hash]
                     self.t2[block_hash] = block
 
             elif block_hash in self.t2:

--- a/vllm/v1/kv_offload/arc_manager.py
+++ b/vllm/v1/kv_offload/arc_manager.py
@@ -87,11 +87,11 @@ class ARCOffloadingManager(OffloadingManager):
     def touch(self, block_hashes: Iterable[BlockHash]):
         for block_hash in reversed(list(block_hashes)):
             if block_hash in self.t1:
-                block = self.t1.pop(block_hash)
+                block = self.t1[block_hash]
                 if not block.is_ready:
-                    # block was just prepared to be stored, not really touched twice
                     self.t1.move_to_end(block_hash)
                 else:
+                    del self.t1[block_hash]
                     self.t2[block_hash] = block
 
             elif block_hash in self.t2:


### PR DESCRIPTION
## Purpose
- Fix a bug in `ARCOffloadingManager.touch()` where a T1 block was popped before readiness check.
- For `is_ready=False`, keep the block in `t1` and move it to MRU directly.
- For `is_ready=True`, explicitly remove from `t1` and promote to `t2`.

## Root cause
`touch()` previously did `block = self.t1.pop(block_hash)` and then, in the non-ready path, called `self.t1.move_to_end(block_hash)`.  
Since the key had already been removed, this could raise `KeyError`.

## Impact
- Prevents runtime `KeyError` in deferred/offloaded async-store paths.
- Keeps ARC behavior intact: non-ready blocks stay in `T1`, ready blocks are promoted to `T2`.

## Test plan


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

