### PR TITLE
Flashinfer cuDNN backend for Qwen3 VL ViT attention

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -589,7 +589,7 @@ nvidia-cuda-nvrtc-cu12==12.9.86
     # via torch
 nvidia-cuda-runtime-cu12==12.9.79
     # via torch
-nvidia-cudnn-cu12==9.10.2.21
+nvidia-cudnn-cu12==9.11.0.98
     # via torch
 nvidia-cufft-cu12==11.4.1.4
     # via torch

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -589,7 +589,7 @@ nvidia-cuda-nvrtc-cu12==12.9.86
     # via torch
 nvidia-cuda-runtime-cu12==12.9.79
     # via torch
-nvidia-cudnn-cu12==9.11.0.98
+nvidia-cudnn-cu12==9.10.2.21
     # via torch
 nvidia-cufft-cu12==11.4.1.4
     # via torch

--- a/tests/kernels/attention/test_mha_attn.py
+++ b/tests/kernels/attention/test_mha_attn.py
@@ -282,12 +282,8 @@ def test_mha_attn_varlen_forward_flashinfer(
         hidden_size = num_heads * head_size
         tp_size = 1
 
-        sequence_lengths_np = cu_seqlens_np[1:] - cu_seqlens_np[:-1]
-        sequence_lengths_np = MMEncoderAttention.maybe_add_padding_to_seqlens(
-            AttentionBackendEnum.FLASHINFER,
-            sequence_lengths_np,
-            len(sequence_lengths_np),
-            0,
+        sequence_lengths_np = MMEncoderAttention.maybe_compute_sequence_lengths(
+            AttentionBackendEnum.FLASHINFER, cu_seqlens_np
         )
         sequence_lengths = torch.from_numpy(sequence_lengths_np).to(
             device, dtype=torch.int32, non_blocking=True

--- a/tests/kernels/attention/test_mha_attn.py
+++ b/tests/kernels/attention/test_mha_attn.py
@@ -244,8 +244,8 @@ def test_mha_attn_varlen_forward_flashinfer(
     """Test MMEncoderAttention varlen forward with FLASHINFER backend (head_size=72).
 
     Exercises the path that uses --mm-encoder-attn-backend=FLASHINFER with
-    workspace_buffer, recomputed cu_seqlens, max_seqlen, and sequence_lengths
-    as in qwen3_vl vision encoder.
+    recomputed cu_seqlens, max_seqlen, and sequence_lengths as in qwen3_vl
+    vision encoder.
     """
     pytest.importorskip("flashinfer")
 
@@ -310,18 +310,12 @@ def test_mha_attn_varlen_forward_flashinfer(
             device, dtype=torch.int32, non_blocking=True
         )
 
-        workspace_buffer = torch.zeros(
-            128 * 1024 * 1024,
-            dtype=torch.uint8,
-            device=device,
-        )
         scale = 1.0 / head_size**0.5
         attn = MMEncoderAttention(
             num_heads,
             head_size,
             scale=scale,
             num_kv_heads=num_heads,
-            workspace_buffer=workspace_buffer,
         )
         assert attn.attn_backend == AttentionBackendEnum.FLASHINFER
 

--- a/tests/kernels/attention/test_mha_attn.py
+++ b/tests/kernels/attention/test_mha_attn.py
@@ -9,9 +9,12 @@ Test:
 import itertools
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 import torch
 
+from vllm.config import get_current_vllm_config
+from vllm.config.multimodal import MultiModalConfig
 from vllm.model_executor.layers.attention import MMEncoderAttention
 from vllm.platforms import current_platform
 from vllm.platforms.cpu import CpuPlatform
@@ -224,3 +227,122 @@ def test_mha_attn_varlen_forward(
         ref_output.append(output_i)
     ref_output = torch.cat(ref_output, dim=1)
     torch.testing.assert_close(output, ref_output, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("var_seq_len", VAR_SEQ_LENS)
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.half],
+)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_mha_attn_varlen_forward_flashinfer(
+    default_vllm_config,
+    var_seq_len: list[int],
+    dtype: torch.dtype,
+    device: str,
+):
+    """Test MMEncoderAttention varlen forward with FLASHINFER backend (head_size=72).
+
+    Exercises the path that uses --mm-encoder-attn-backend=FLASHINFER with
+    workspace_buffer, recomputed cu_seqlens, max_seqlen, and sequence_lengths
+    as in qwen3_vl vision encoder.
+    """
+    pytest.importorskip("flashinfer")
+
+    num_heads = 16
+    head_size = 72
+    set_random_seed(0)
+    torch.set_default_device(device)
+    torch.set_default_dtype(dtype)
+
+    # Override vllm config so get_vit_attn_backend returns FLASHINFER (simulates
+    # --mm-encoder-attn-backend=FLASHINFER).
+    vllm_config = get_current_vllm_config()
+    old_model_config = getattr(vllm_config, "model_config", None)
+    minimal_model_config = type(
+        "MinimalModelConfig",
+        (),
+        {
+            "multimodal_config": MultiModalConfig(
+                mm_encoder_attn_backend=AttentionBackendEnum.FLASHINFER
+            ),
+        },
+    )()
+    vllm_config.model_config = minimal_model_config
+    try:
+        total_len = sum(var_seq_len)
+        # Stride of second dim = 3 * num_heads * head_size (same as qwen2_5_vl
+        # after qkv rearrange and unbind: qkv shape (b, s, 3, head, head_dim)).
+        qkv = torch.randn(1, total_len, 3, num_heads, head_size)
+        q, k, v = qkv.unbind(dim=2)
+
+        cu_seqlens_np = np.array(
+            [0] + list(itertools.accumulate(var_seq_len)), dtype=np.int32
+        )
+        hidden_size = num_heads * head_size
+        tp_size = 1
+
+        sequence_lengths_np = cu_seqlens_np[1:] - cu_seqlens_np[:-1]
+        sequence_lengths_np = MMEncoderAttention.maybe_add_padding_to_seqlens(
+            AttentionBackendEnum.FLASHINFER,
+            sequence_lengths_np,
+            len(sequence_lengths_np),
+            0,
+        )
+        sequence_lengths = torch.from_numpy(sequence_lengths_np).to(
+            device, dtype=torch.int32, non_blocking=True
+        )
+
+        max_seqlen_val = MMEncoderAttention.compute_max_seqlen(
+            AttentionBackendEnum.FLASHINFER, cu_seqlens_np
+        )
+        max_seqlen = torch.tensor(max_seqlen_val, device=device, dtype=torch.int32)
+
+        cu_seqlens_np = MMEncoderAttention.maybe_recompute_cu_seqlens(
+            AttentionBackendEnum.FLASHINFER,
+            cu_seqlens_np,
+            hidden_size,
+            tp_size,
+            rotary_pos_emb_cos=None,
+            rotary_pos_emb_sin=None,
+        )
+        cu_seqlens = torch.from_numpy(cu_seqlens_np).to(
+            device, dtype=torch.int32, non_blocking=True
+        )
+
+        workspace_buffer = torch.zeros(
+            128 * 1024 * 1024,
+            dtype=torch.uint8,
+            device=device,
+        )
+        scale = 1.0 / head_size**0.5
+        attn = MMEncoderAttention(
+            num_heads,
+            head_size,
+            scale=scale,
+            num_kv_heads=num_heads,
+            workspace_buffer=workspace_buffer,
+        )
+        assert attn.attn_backend == AttentionBackendEnum.FLASHINFER
+
+        output = attn(
+            q,
+            k,
+            v,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            sequence_lengths=sequence_lengths,
+        )
+
+        ref_output = []
+        for q_i, k_i, v_i in zip(
+            torch.split(q, var_seq_len, dim=1),
+            torch.split(k, var_seq_len, dim=1),
+            torch.split(v, var_seq_len, dim=1),
+        ):
+            output_i = ref_attention(q_i, k_i, v_i, scale=scale)
+            ref_output.append(output_i)
+        ref_output = torch.cat(ref_output, dim=1)
+        torch.testing.assert_close(output, ref_output, atol=1e-2, rtol=1e-2)
+    finally:
+        vllm_config.model_config = old_model_config

--- a/tests/kernels/attention/test_mha_attn.py
+++ b/tests/kernels/attention/test_mha_attn.py
@@ -299,8 +299,6 @@ def test_mha_attn_varlen_forward_flashinfer(
             cu_seqlens_np,
             hidden_size,
             tp_size,
-            rotary_pos_emb_cos=None,
-            rotary_pos_emb_sin=None,
         )
         cu_seqlens = torch.from_numpy(cu_seqlens_np).to(
             device, dtype=torch.int32, non_blocking=True

--- a/vllm/model_executor/layers/attention/mm_encoder_attention.py
+++ b/vllm/model_executor/layers/attention/mm_encoder_attention.py
@@ -44,7 +44,7 @@ FLASHINFER_MAX_SEQLEN_BUCKETS = [
     128 * 1024,
 ]
 
-# Shared workspace for FlashInfer CuDNN backend
+# Workspace buffer for FlashInfer CuDNN backend
 FLASHINFER_CUDNN_WORKSPACE_SIZE_BYTES = 128 * 1024 * 1024
 _flashinfer_workspace_buffer: torch.Tensor | None = None
 

--- a/vllm/model_executor/layers/attention/mm_encoder_attention.py
+++ b/vllm/model_executor/layers/attention/mm_encoder_attention.py
@@ -11,6 +11,7 @@ from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.ops.vit_attn_wrappers import (
     vit_flash_attn_wrapper,
+    vit_flashinfer_wrapper,
     vit_torch_sdpa_wrapper,
     vit_triton_attn_wrapper,
 )
@@ -32,6 +33,7 @@ class MMEncoderAttention(CustomOp):
         scale: float | None = None,
         num_kv_heads: int | None = None,
         prefix: str = "",
+        workspace_buffer: torch.Tensor | None = None,  # Only used for FlashInfer
     ) -> None:
         """
         Args:
@@ -46,10 +48,10 @@ class MMEncoderAttention(CustomOp):
 
         self.num_heads = num_heads
         self.head_size = head_size
-        self.scale = scale
+        self.scale = 1.0 / (head_size**0.5) if scale is None else scale
         self.num_kv_heads = num_heads if num_kv_heads is None else num_kv_heads
         self.layer_name = prefix
-
+        self.workspace_buffer = workspace_buffer
         assert self.num_heads % self.num_kv_heads == 0, (
             f"num_heads ({self.num_heads}) is not "
             f"divisible by num_kv_heads ({self.num_kv_heads})"
@@ -201,6 +203,27 @@ class MMEncoderAttention(CustomOp):
             output = output.reshape(bsz, q_len, -1)
         return output
 
+    def _forward_flashinfer(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,
+        sequence_lengths: torch.Tensor
+        | None = None,  # Only used for FlashInfer CuDNN backend
+    ) -> torch.Tensor:
+        return vit_flashinfer_wrapper(
+            q=query,
+            k=key,
+            v=value,
+            scale=self.scale,
+            workspace_buffer=self.workspace_buffer,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            sequence_lengths=sequence_lengths,
+        )
+
     def forward_native(
         self,
         query: torch.Tensor,
@@ -208,6 +231,8 @@ class MMEncoderAttention(CustomOp):
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
         max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        sequence_lengths: torch.Tensor
+        | None = None,  # Only used for FlashInfer CuDNN backend
     ) -> torch.Tensor:
         return self._forward_sdpa(query, key, value, cu_seqlens)
 
@@ -218,11 +243,17 @@ class MMEncoderAttention(CustomOp):
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
         max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        sequence_lengths: torch.Tensor
+        | None = None,  # Only used for FlashInfer CuDNN backend
     ) -> torch.Tensor:
         if self.is_flash_attn_backend:
             return self._forward_fa(query, key, value, cu_seqlens, max_seqlen)
         elif self.attn_backend == AttentionBackendEnum.TRITON_ATTN:
             return self._forward_triton(query, key, value, cu_seqlens, max_seqlen)
+        elif self.attn_backend == AttentionBackendEnum.FLASHINFER:
+            return self._forward_flashinfer(
+                query, key, value, cu_seqlens, max_seqlen, sequence_lengths
+            )
         elif self.attn_backend == AttentionBackendEnum.TORCH_SDPA:
             return self._forward_sdpa(query, key, value, cu_seqlens)
         else:
@@ -238,6 +269,8 @@ class MMEncoderAttention(CustomOp):
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
         max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        sequence_lengths: torch.Tensor
+        | None = None,  # Only used for FlashInfer CuDNN backend
     ) -> torch.Tensor:
         return self._forward_sdpa(query, key, value, cu_seqlens)
 
@@ -248,6 +281,8 @@ class MMEncoderAttention(CustomOp):
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
         max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        sequence_lengths: torch.Tensor
+        | None = None,  # Only used for FlashInfer CuDNN backend
     ) -> torch.Tensor:
         if self.attn_backend == AttentionBackendEnum.FLASH_ATTN:
             return self._forward_fa(query, key, value, cu_seqlens, max_seqlen)

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -460,7 +460,6 @@ class Qwen2_5_VisionBlock(nn.Module):
         rotary_pos_emb_cos: torch.Tensor,
         rotary_pos_emb_sin: torch.Tensor,
         max_seqlen: torch.Tensor,  # Only used for Flash Attention
-        sequence_lengths: torch.Tensor,  # Only used for FlashInfer CuDNN backend
     ) -> torch.Tensor:
         x_attn = self.attn(
             self.norm1(x),
@@ -468,7 +467,7 @@ class Qwen2_5_VisionBlock(nn.Module):
             rotary_pos_emb_cos=rotary_pos_emb_cos,
             rotary_pos_emb_sin=rotary_pos_emb_sin,
             max_seqlen=max_seqlen,
-            sequence_lengths=sequence_lengths,
+            sequence_lengths=None,
         )
         x_fused_norm, residual = self.norm2(x, residual=x_attn)
         x = residual + self.mlp(x_fused_norm)
@@ -823,11 +822,7 @@ class Qwen2_5_VisionTransformer(nn.Module):
         cu_seqlens = torch.cat(cu_seqlens)
         cu_seqlens = torch.cumsum(cu_seqlens, dim=0, dtype=torch.int32)
         cu_seqlens = F.pad(cu_seqlens, (1, 0), "constant", 0)
-        # sequence_lengths is only a placeholder for the now
-        # unsupported FlashInfer CuDNN backend, will need to
-        # revisit this computation when FlashInfer CuDNN backend is supported.
-        sequence_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-        sequence_lengths = sequence_lengths.to(device=self.device, non_blocking=True)
+
         # transformers
         # pre-compute seqlens for window/full attn to reduce cuMemcpy operations
         max_seqlen_full = self.compute_attn_mask_seqlen(cu_seqlens)
@@ -868,7 +863,6 @@ class Qwen2_5_VisionTransformer(nn.Module):
                 rotary_pos_emb_cos=rotary_pos_emb_cos,
                 rotary_pos_emb_sin=rotary_pos_emb_sin,
                 max_seqlen=max_seqlen_now,
-                sequence_lengths=sequence_lengths,
             )
 
         # For Qwen2.5-VL-3B, float16 will overflow at last block

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -305,7 +305,6 @@ class Qwen2_5_VisionAttention(nn.Module):
         projection_size: int,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        workspace_buffer: torch.Tensor | None = None,  # Only used for FlashInfer
     ) -> None:
         super().__init__()
         # Per attention head and per partition values.
@@ -347,7 +346,6 @@ class Qwen2_5_VisionAttention(nn.Module):
             head_size=self.hidden_size_per_attention_head,
             scale=self.hidden_size_per_attention_head**-0.5,
             prefix=f"{prefix}.attn",
-            workspace_buffer=workspace_buffer,
         )
 
         self.apply_rotary_emb = ApplyRotaryEmb(enforce_enable=True)

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -564,8 +564,6 @@ class Qwen3_VisionTransformer(nn.Module):
             cu_seqlens,
             self.hidden_size,
             self.tp_size,
-            rotary_pos_emb_cos,
-            rotary_pos_emb_sin,
         )
         cu_seqlens = torch.from_numpy(cu_seqlens).to(self.device, non_blocking=True)
         hidden_states = hidden_states.unsqueeze(1)

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -54,6 +54,9 @@ from vllm.config.multimodal import BaseDummyOptions, VideoDummyOptions
 from vllm.distributed import get_pp_group, parallel_state
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import _ACTIVATION_REGISTRY
+from vllm.model_executor.layers.attention.mm_encoder_attention import (
+    MMEncoderAttention,
+)
 from vllm.model_executor.layers.conv import Conv3dLayer
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -138,37 +141,6 @@ logger = init_logger(__name__)
 # of the maximum size.
 DUMMY_VIDEO_NUM_FRAMES = 2048
 
-# Batch buckets for cuDNN graph caching.
-# Graphs use batch size and max sequence length as cache key.
-# This avoids creating a new graph for each unique set of
-# batch size and max sequence length at runtime.
-# From the cuDNN team's performance measurements, there
-# is no significant kernel performance difference between padding
-# to a smaller batch size/seq length and padding to larger
-# ones. The bucketing here is solely used to avoid memory
-# operation overhead, which won't be needed if we have CUDA
-# graph support in the future.
-# TODO: In cuDNN 9.19 and cudnn-frontend 1.18,
-# we will have the graph recompilation optimization
-# where real batch size and max sequence length can
-# be used and no graph recompilation will happen.
-# We will need to remove the padding. But this optimization
-# won't be compatible with CUDA graph.
-# TODO: When we have full CUDA graph support on
-# the mm encoder, we can remove these buckets
-# and only use a large enough padding size to
-# capture one large CUDA graph.
-FLASHINFER_BATCH_BUCKETS = [8, 16, 32, 64]
-FLASHINFER_MAX_SEQLEN_BUCKETS = [
-    1 * 1024,
-    2 * 1024,
-    4 * 1024,
-    8 * 1024,
-    16 * 1024,
-    32 * 1024,
-    64 * 1024,
-    128 * 1024,
-]
 FLASHINFER_CUDNN_WORKSPACE_SIZE_BYTES = 128 * 1024 * 1024
 
 
@@ -568,85 +540,6 @@ class Qwen3_VisionTransformer(nn.Module):
 
         return torch.cat(outputs, dim=0)
 
-    def compute_attn_mask_seqlen(
-        self,
-        cu_seqlens: torch.Tensor,
-    ) -> torch.Tensor:
-        max_seqlen = torch.zeros([], device=cu_seqlens.device)
-        if self.attn_backend in (
-            AttentionBackendEnum.FLASH_ATTN,
-            AttentionBackendEnum.ROCM_AITER_FA,
-            AttentionBackendEnum.TRITON_ATTN,
-            AttentionBackendEnum.FLASHINFER,
-        ):
-            max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()
-        return max_seqlen
-
-    def add_padding_to_fi_seqlens(
-        self, seq: np.ndarray, batch_size: int, padding_value: int
-    ) -> np.ndarray:
-        batch_size_padded = next(
-            (b for b in FLASHINFER_BATCH_BUCKETS if b >= batch_size),
-            # For large batches (> max bucket), round up to a multiple of
-            # the base bucket size to avoid negative pad length.
-            round_up(batch_size, FLASHINFER_BATCH_BUCKETS[0]),
-        )
-        if batch_size_padded == batch_size:
-            return seq
-        return np.concatenate(
-            [
-                seq,
-                np.full(
-                    (batch_size_padded - batch_size,), padding_value, dtype=seq.dtype
-                ),
-            ]
-        )
-
-    def compute_flashinfer_cu_seqlens(
-        self,
-        cu_seqlens: np.ndarray,
-        rotary_pos_emb_cos: torch.Tensor | None = None,
-        rotary_pos_emb_sin: torch.Tensor | None = None,
-    ) -> np.ndarray:
-        batch_size = len(cu_seqlens) - 1
-
-        # Currently FI cudnn api needs to compute the batch_offsets_*
-        # by scaling from cu_seqlens
-        # TODO: remove this computation when FI cudnn api
-        # supports computing batch offsets from q, k, v tensor
-        scale = self.hidden_size // self.tp_size
-        cu_seqlens = cu_seqlens * scale
-        if rotary_pos_emb_cos is not None and rotary_pos_emb_sin is not None:
-            # batch_offsets_* = cu_seqlens * scale * 1 if q, k is contiguous
-            cu_seqlens_qk = cu_seqlens
-        else:
-            # batch_offsets_* = cu_seqlens * scale * 3
-            # if q, k is directly unbinded from qkv
-            cu_seqlens_qk = cu_seqlens * 3
-        cu_seqlens_v = cu_seqlens * 3
-        cu_seqlens_o = cu_seqlens
-
-        cu_seqlens_qk = self.add_padding_to_fi_seqlens(
-            cu_seqlens_qk, batch_size, cu_seqlens_qk[-1]
-        )
-        cu_seqlens_v = self.add_padding_to_fi_seqlens(
-            cu_seqlens_v, batch_size, cu_seqlens_v[-1]
-        )
-        cu_seqlens_o = self.add_padding_to_fi_seqlens(
-            cu_seqlens_o, batch_size, cu_seqlens_o[-1]
-        )
-        return np.concatenate([cu_seqlens_qk, cu_seqlens_v, cu_seqlens_o])
-
-    def bucket_flashinfer_max_seqlen(self, real_max_seqlen: int) -> int:
-        if real_max_seqlen <= 0:
-            return FLASHINFER_MAX_SEQLEN_BUCKETS[0]
-        return next(
-            (s for s in FLASHINFER_MAX_SEQLEN_BUCKETS if s >= real_max_seqlen),
-            # For large sequences (> max bucket), round up to a multiple of
-            # the largest bucket to avoid under-estimation.
-            round_up(real_max_seqlen, FLASHINFER_MAX_SEQLEN_BUCKETS[-1]),
-        )
-
     def forward(
         self,
         x: torch.Tensor,
@@ -671,30 +564,26 @@ class Qwen3_VisionTransformer(nn.Module):
         )
         cu_seqlens = np.concatenate([np.zeros(1, dtype=np.int32), cu_seqlens])
         sequence_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-        flashinfer_max_seqlen = 0
-        if self.attn_backend == AttentionBackendEnum.FLASHINFER:
-            flashinfer_max_seqlen = self.bucket_flashinfer_max_seqlen(
-                int(sequence_lengths.max()) if sequence_lengths.size > 0 else 0
-            )
-            sequence_lengths = self.add_padding_to_fi_seqlens(
-                sequence_lengths, len(sequence_lengths), 0
-            )
-            cu_seqlens = self.compute_flashinfer_cu_seqlens(
-                cu_seqlens, rotary_pos_emb_cos, rotary_pos_emb_sin
-            )
-        cu_seqlens = torch.from_numpy(cu_seqlens)
+        sequence_lengths = MMEncoderAttention.maybe_add_padding_to_seqlens(
+            self.attn_backend, sequence_lengths, len(sequence_lengths), 0
+        )
         sequence_lengths = torch.from_numpy(sequence_lengths).to(
             self.device, non_blocking=True
         )
-        hidden_states = hidden_states.unsqueeze(1)
-        max_seqlen = (
-            torch.tensor(flashinfer_max_seqlen, device=self.device)
-            # setting to a bucket to avoid cudnn recompilation
-            # TODO: use the real max_seqlen once cudnn compilation is optimized
-            if self.attn_backend == AttentionBackendEnum.FLASHINFER
-            else self.compute_attn_mask_seqlen(cu_seqlens)
+        max_seqlen = torch.tensor(
+            MMEncoderAttention.compute_max_seqlen(self.attn_backend, cu_seqlens),
+            device=self.device,
         )
-        cu_seqlens = cu_seqlens.to(self.device, non_blocking=True)
+        cu_seqlens = MMEncoderAttention.maybe_recompute_cu_seqlens(
+            self.attn_backend,
+            cu_seqlens,
+            self.hidden_size,
+            self.tp_size,
+            rotary_pos_emb_cos,
+            rotary_pos_emb_sin,
+        )
+        cu_seqlens = torch.from_numpy(cu_seqlens).to(self.device, non_blocking=True)
+        hidden_states = hidden_states.unsqueeze(1)
 
         deepstack_feature_lists = []
         for layer_num, blk in enumerate(self.blocks):

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -689,7 +689,7 @@ class Qwen3_VisionTransformer(nn.Module):
         hidden_states = hidden_states.unsqueeze(1)
         max_seqlen = (
             torch.tensor(flashinfer_max_seqlen, device=self.device)
-            # setting to 128k to avoid cudnn recompilation
+            # setting to a bucket to avoid cudnn recompilation
             # TODO: use the real max_seqlen once cudnn compilation is optimized
             if self.attn_backend == AttentionBackendEnum.FLASHINFER
             else self.compute_attn_mask_seqlen(cu_seqlens)

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -414,6 +414,7 @@ class CudaPlatformBase(Platform):
             AttentionBackendEnum.FLASH_ATTN,
             AttentionBackendEnum.TRITON_ATTN,
             AttentionBackendEnum.TORCH_SDPA,
+            AttentionBackendEnum.FLASHINFER,
         ]
 
     @classmethod

--- a/vllm/v1/attention/ops/vit_attn_wrappers.py
+++ b/vllm/v1/attention/ops/vit_attn_wrappers.py
@@ -288,7 +288,7 @@ def flashinfer_wrapper(
         reshape_batch_size = q.shape[0]
         q, k, v = (einops.rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
     # cuDNN <= 9.10.2.21 requires q, k to be contiguous
-    # this comes with no cost for ViT's with RoPE because
+    # this comes with no cost for ViTs with RoPE because
     # RoPE has already made q and k contiguous.
     q, k = q.contiguous(), k.contiguous()
 

--- a/vllm/v1/attention/ops/vit_attn_wrappers.py
+++ b/vllm/v1/attention/ops/vit_attn_wrappers.py
@@ -268,3 +268,88 @@ def vit_torch_sdpa_wrapper(
     return torch.ops.vllm.torch_sdpa_wrapper(
         q, k, v, scale, cu_seqlens, enable_gqa=enable_gqa
     )
+
+
+def flashinfer_wrapper(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float,
+    workspace_buffer: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
+    max_seqlen: torch.Tensor | None = None,
+    sequence_lengths: torch.Tensor | None = None,
+) -> torch.Tensor:
+    from flashinfer.prefill import cudnn_batch_prefill_with_kv_cache
+
+    is_reshaped = q.dim() == 4
+
+    if is_reshaped:
+        reshape_batch_size = q.shape[0]
+        q, k, v = (einops.rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
+
+    assert len(cu_seqlens) % 3 == 0, "cu_seqlens must be divisible by 3"
+    cu_seqlength = len(cu_seqlens) // 3
+    batch_offsets_qk = cu_seqlens[:cu_seqlength].view(-1, 1, 1, 1)
+    batch_offsets_v = cu_seqlens[cu_seqlength : cu_seqlength * 2].view(-1, 1, 1, 1)
+    batch_offsets_o = cu_seqlens[cu_seqlength * 2 :].view(-1, 1, 1, 1)
+    sequence_lengths = sequence_lengths.view(-1, 1, 1, 1)
+    max_seqlen = max_seqlen.item()
+
+    output, _ = cudnn_batch_prefill_with_kv_cache(
+        q,
+        k,
+        v,
+        scale,
+        workspace_buffer,
+        max_token_per_sequence=max_seqlen,
+        max_sequence_kv=max_seqlen,
+        actual_seq_lens_q=sequence_lengths,
+        actual_seq_lens_kv=sequence_lengths,
+        causal=False,
+        return_lse=False,
+        batch_offsets_q=batch_offsets_qk,
+        batch_offsets_k=batch_offsets_qk,
+        batch_offsets_v=batch_offsets_v,
+        batch_offsets_o=batch_offsets_o,
+    )
+
+    if is_reshaped:
+        output = einops.rearrange(output, "(b s) h d -> b s h d", b=reshape_batch_size)
+
+    return output
+
+
+def vit_flashinfer_wrapper_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float,
+    workspace_buffer: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
+    max_seqlen: torch.Tensor | None = None,
+    sequence_lengths: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return torch.empty_like(q)
+
+
+direct_register_custom_op(
+    op_name="flashinfer_wrapper",
+    op_func=flashinfer_wrapper,
+    fake_impl=vit_flashinfer_wrapper_fake,
+)
+
+
+def vit_flashinfer_wrapper(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: float,
+    workspace_buffer: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
+    max_seqlen: torch.Tensor | None = None,
+    sequence_lengths: torch.Tensor | None = None,
+) -> torch.Tensor:
+    return torch.ops.vllm.flashinfer_wrapper(
+        q, k, v, scale, workspace_buffer, cu_seqlens, max_seqlen, sequence_lengths
+    )


### PR DESCRIPTION
## Purpose
Enable by `--mm-encoder-attn-backend=FLASHINFER`

### Details
- Add `FLASHINFER` as a backend for `MMEncoderAttention`
- Add computation for `cu_seqlens` and `sequence_lengths` before calling vision blocks. This is due to cuDNN backend's requirement to pass batch offsets and actual sequence lengths
- Pad `cu_seqlens`, `sequence_lengths` and `max_seqlen` to avoid cuDNN frontend graph recompilation
- Only support Qwen3 VL ViT, Qwen2.5 VL ViT is not supported

## Credit

NVIDIA's MLPerf Qwen3 VL MoE Submission Team @Anerudhan @b-mu @zhandaz @vedaanta @wangshangsam

## Test Plan
```
vllm bench mm-processor --mm-encoder-attn-backend=FLASHINFER --model Qwen/Qwen3-VL-8B-Instruct

tests/kernels/attention/test_mha_attn.py:test_mha_attn_varlen_forward_flashinfer
```

## Test Result
```
vllm bench mm-processor --mm-encoder-attn-backend=FLASHINFER/FLASH_ATTN --num-prompt 1000 --model Qwen/Qwen3-VL-30B-A3B-Instruct
```

#### mm request distribution:
1024 text tokens + 1 image (50% 256×256, 50% 720×1280), then generate 128 tokens.

#### Performance improvement (GB200):
***FLASH_ATTN***
```                                                                                                                                
MM Processor Metrics:
                     Stage  Mean Median   Std P99.0
          get_mm_hashes_ms  0.52   0.88  0.39  0.93
get_cache_missing_items_ms  0.01   0.01  0.00  0.02
     apply_hf_processor_ms 14.56  25.10 12.13 28.46
        merge_mm_kwargs_ms  0.05   0.05  0.02  0.10
   apply_prompt_updates_ms  1.71   2.67  1.07  2.93
     preprocessor_total_ms 16.85  28.79 13.60 32.21
        encoder_forward_ms  7.16   6.47  3.18 16.61
         num_encoder_calls  1.00   1.00  0.00  1.00

Summary: 1000 total encoder calls across 1000 requests.

End-to-End Latency (ms):
Metric Value (ms)
  Mean   25937.46
Median   27018.73
   Std   10737.60
 P99.0   40904.64
```
***FLASHINFER***
```
MM Processor Metrics:                                                              
                     Stage  Mean Median   Std P99.0                                
          get_mm_hashes_ms  0.53   0.88  0.39  0.93                                
get_cache_missing_items_ms  0.01   0.01  0.00  0.02                                
     apply_hf_processor_ms 14.68  25.78 12.24 28.17                                
        merge_mm_kwargs_ms  0.05   0.04  0.02  0.09                                
   apply_prompt_updates_ms  1.72   2.68  1.08  2.96                                
     preprocessor_total_ms 16.99  29.45 13.72 31.97                                
        encoder_forward_ms  5.78   5.16  3.32 13.00                                
         num_encoder_calls  1.00   1.00  0.00  1.00                                

Summary: 1000 total encoder calls across 1000 requests.                                                                                                                

End-to-End Latency (ms):                                                           
Metric Value (ms)                                                                  
  Mean   24701.19                                                                  
Median   25512.37                                                                  
   Std   10516.90                                                                  
 P99.0   40645.69   
```
***mm encoder performance gain = 19.3%***

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>