### PR TITLE
[Bugfix] - Fix Mamba prefix caching corruption with chunked prefill

### DIFF
--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1042,19 +1042,19 @@ class MambaManager(SingleTypeKVCacheManager):
             positions[block_idx] = write_pos
 
     def _get_num_cacheable_blocks(self, request_id: str, num_tokens: int) -> int:
-        """Return count of blocks with complete SSM state.
+        """Return count of blocks with complete mamba_block_size.
 
         A block is complete if write_pos == (block_idx + 1) * block_size exactly.
         """
         num_full_blocks = num_tokens // self.block_size
         num_already_cached = self.num_cached_block.get(request_id, 0)
-        positions = self.block_write_positions.get(request_id, {})
+        seq_positions = self.block_write_positions.get(request_id, {})
 
         for block_idx in range(num_already_cached, num_full_blocks):
-            expected = (block_idx + 1) * self.block_size
+            expected_block_size = (block_idx + 1) * self.block_size
 
-            if positions.get(block_idx, 0) != expected:
-                return block_idx  # First incomplete block = cacheable count
+            if seq_positions.get(block_idx, 0) != expected_block_size:
+                return block_idx  # Number of complete blocks before this one
 
         return num_full_blocks
 


### PR DESCRIPTION
## Purpose

When using Mamba models with `mamba_cache_mode="all"` and chunked prefill enabled, mamba state blocks can be cached before they contain complete state (e.g. if `mamba_block_size=2048` and chunked prefill chunks the sequence to 1800 and 1100 tokens), leading to incorrect output when subsequent requests hit the prefix cache.

Root Cause

The SSM kernel (`selective_scan_fwd`) writes state at chunk boundaries that don't necessarily align with block boundaries. When the scheduler splits a long prefill into multiple chunks:

So if sequence is 3026
  1. Chunk 1 (e.g., 1866 tokens): Kernel writes SSM state to block 0, covering positions [0, 1866)
  2. Chunk 2 (e.g., 1160 tokens, total 3026): Kernel writes to block 1 only - block 0 is untouched
  3. cache_blocks() sees `3026 // block_size` full blocks -> caches block 0
  4. Block 0's state only covers 1866 tokens, but its hash represents the full block (mamba_block_size - 2048 tokens) → corruption on cache hit

The kernel writes state based on:
- Intermediate chunks: `block_idx_first_scheduled + chunk_idx`
- Last chunk: `block_idx_last_scheduled`

This means earlier blocks may never be "completed" if subsequent scheduler calls skip over them.

Solution:

Track exactly when each block was written by the kernel via a `block_write_positions` dict. Only cache blocks where `write_position == (block_idx + 1) * block_size` exactly.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

