### PR TITLE
[ROCm][CI] Fix plugins test group; updating terratorch and dependencies

### DIFF
--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -67,8 +67,6 @@ multiprocess==0.70.16
 # Required for v1/metrics/test_engine_logger_apis.py
 ray[cgraph,default]>=2.48.0
 
-# Plugins test
-terratorch @ git+https://github.com/IBM/terratorch.git@07184fcf91a1324f831ff521dd238d97fe350e3e
 torchgeo==0.7.0
     # via terratorch
 # MTEB Benchmark Test
@@ -98,3 +96,9 @@ transformers==4.57.3
 huggingface-hub==0.36.2
 # Pin Mistral Common
 mistral-common[image,audio]==1.9.1
+# Required for Prithvi tests
+terratorch==1.2.2
+# Required for Prithvi tests
+segmentation-models-pytorch==0.5.0
+# Required for Prithvi tests
+imagehash==4.3.2

--- a/vllm/model_executor/models/terratorch.py
+++ b/vllm/model_executor/models/terratorch.py
@@ -208,10 +208,7 @@ class TerratorchMultiModalProcessor(BaseMultiModalProcessor[TerratorchProcessing
 
         _, passthrough_data = self._get_hf_mm_data(mm_items)
         mm_processed_data = BatchFeature(
-            {
-                k: torch.as_tensor(v).detach().clone().unsqueeze(0)
-                for k, v in passthrough_data.items()
-            },
+            {k: torch.as_tensor(v).unsqueeze(0) for k, v in passthrough_data.items()},
             tensor_type="pt",
         )
         mm_placeholders = {"image": [PlaceholderRange(offset=0, length=0)]}

--- a/vllm/model_executor/models/terratorch.py
+++ b/vllm/model_executor/models/terratorch.py
@@ -209,7 +209,7 @@ class TerratorchMultiModalProcessor(BaseMultiModalProcessor[TerratorchProcessing
         _, passthrough_data = self._get_hf_mm_data(mm_items)
         mm_processed_data = BatchFeature(
             {
-                k: torch.as_tensor(v).clone().unsqueeze(0)
+                k: torch.as_tensor(v).detach().clone().unsqueeze(0)
                 for k, v in passthrough_data.items()
             },
             tensor_type="pt",

--- a/vllm/model_executor/models/terratorch.py
+++ b/vllm/model_executor/models/terratorch.py
@@ -208,7 +208,10 @@ class TerratorchMultiModalProcessor(BaseMultiModalProcessor[TerratorchProcessing
 
         _, passthrough_data = self._get_hf_mm_data(mm_items)
         mm_processed_data = BatchFeature(
-            {k: torch.tensor(v).unsqueeze(0) for k, v in passthrough_data.items()},
+            {
+                k: torch.as_tensor(v).clone().unsqueeze(0)
+                for k, v in passthrough_data.items()
+            },
             tensor_type="pt",
         )
         mm_placeholders = {"image": [PlaceholderRange(offset=0, length=0)]}


### PR DESCRIPTION
Follow up to: #34416 
This PR stabilizes the TerraTorch test dependencies and fixes a minor runtime warning.

**Dependency changes:**

- Replace the git commit pin for `terratorch` (`@07184fc...`) with the stable release `terratorch==1.2.2`, matching `test.txt` requirement versions.
- Pin `segmentation-models-pytorch==0.5.0` to ensure compatibility with `terratorch==1.2.2`. Previous unpinned versions of smp renamed the `use_batchnorm` parameter to `use_norm` in `UnetDecoder`, causing a `TypeError` at model initialization.
- Pin `imagehash==4.3.2`, required by the Prithvi plugin tests.

**Code minor patch:**

- In `vllm/model_executor/models/terratorch.py`, replace `torch.tensor(v)` with `torch.as_tensor(v).clone()` when constructing the `BatchFeature` in `TerratorchMultiModalProcessor.apply()`. This avoids the `UserWarning` triggered when copying from an existing tensor.

**Testing:**

- `plugins_tests/test_platform_plugins.py`
- `plugins_tests/test_io_processor_plugins.py`
- `plugins_tests/test_stats_logger_plugins.py`
- `plugins_tests/test_scheduler_plugins.py`
- `distributed/test_distributed_oot.py`
- `entrypoints/openai/test_oot_registration.py`
- `models/test_oot_registration.py`
- `plugins/lora_resolvers`
