### PR TITLE
[CI][Frontend] Return 422 instead of 500 for invalid Anthropic tool_choice

### DIFF
--- a/tests/entrypoints/openai/test_openai_schema.py
+++ b/tests/entrypoints/openai/test_openai_schema.py
@@ -151,6 +151,7 @@ def test_openapi_stateless(case: schemathesis.Case):
         # requires a longer timeout
         ("POST", "/v1/chat/completions"): LONG_TIMEOUT_SECONDS,
         ("POST", "/v1/completions"): LONG_TIMEOUT_SECONDS,
+        ("POST", "/v1/messages"): LONG_TIMEOUT_SECONDS,
     }.get(key, DEFAULT_TIMEOUT_SECONDS)
 
     # No need to verify SSL certificate for localhost

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -5,7 +5,7 @@
 import time
 from typing import Any, Literal
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, model_validator
 
 
 class AnthropicError(BaseModel):
@@ -75,6 +75,12 @@ class AnthropicToolChoice(BaseModel):
 
     type: Literal["auto", "any", "tool"]
     name: str | None = None
+
+    @model_validator(mode="after")
+    def validate_name_required_for_tool(self) -> "AnthropicToolChoice":
+        if self.type == "tool" and not self.name:
+            raise ValueError("tool_choice.name is required when type is 'tool'")
+        return self
 
 
 class AnthropicMessagesRequest(BaseModel):


### PR DESCRIPTION
When `tool_choice` is `{"type": "tool"}` without a `name`, the `/v1/messages` endpoint crashes with a 500 Internal Server Error. This happens because `_convert_anthropic_to_openai_request` passes `name=None` to `ChatCompletionNamedToolChoiceParam`, which fails Pydantic validation as an unhandled exception.

The Anthropic API spec requires `name` when `tool_choice.type` is `"tool"`. This PR adds a `model_validator` to `AnthropicToolChoice` so the constraint is enforced at request parsing time, producing a proper 422 validation error instead of a 500.

Also adds the `/v1/messages` endpoint to the longer timeout map in the schema test, since it is a completion endpoint.

## Motivation

AMD nightly CI: https://buildkite.com/vllm/amd-ci/builds/4788/steps/canvas?sid=019c6019-8f6f-4b50-a415-c3f443c97c5e&tab=output
`schemathesis` property-based testing in `test_openapi_stateless[POST /v1/messages]`.