### PR TITLE
[Bugfix] Fix MXFP4 weight loading for individual expert tensors

### DIFF
--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.fused_moe import (
     FusedMoE,
     FusedMoEConfig,
     FusedMoEMethodBase,
+    FusedMoeWeightScaleSupported,
     MoEActivation,
 )
 from vllm.model_executor.layers.fused_moe import modular_kernel as mk
@@ -357,7 +358,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             requires_grad=False,
         )
         layer.register_parameter("w13_weight_scale", w13_weight_scale)
-        set_weight_attrs(w13_weight_scale, extra_weight_attrs)
+        # Add the quantization method to ensure the weight scales are loaded in properly
+        set_weight_attrs(
+            w13_weight_scale,
+            {
+                **extra_weight_attrs,
+                "quant_method": FusedMoeWeightScaleSupported.BLOCK.value,
+            },
+        )
 
         w13_bias = torch.nn.Parameter(
             torch.zeros(
@@ -393,7 +401,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             requires_grad=False,
         )
         layer.register_parameter("w2_weight_scale", w2_weight_scale)
-        set_weight_attrs(w2_weight_scale, extra_weight_attrs)
+        # Add the quantization method to ensure the weight scales are loaded in properly
+        set_weight_attrs(
+            w2_weight_scale,
+            {
+                **extra_weight_attrs,
+                "quant_method": FusedMoeWeightScaleSupported.BLOCK.value,
+            },
+        )
 
         w2_bias = torch.nn.Parameter(
             torch.zeros(


### PR DESCRIPTION
## Purpose
Fix MXFP4 weight loading for models other than gpt-oss

The MXFP4 code path in `FusedMoE.weight_loader` (added in #22339) only handled 3D pre-stacked tensors (GPT-OSS style). Models that store experts as individual 2D tensors (e.g., MiniMax-M2.5) crash during weight loading:
```bash                                                                            
  (EngineCore_DP0 pid=1106)     loaded_params = module_load_weights(weights)                                                                                                                                                                        
  (EngineCore_DP0 pid=1106)                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                        
  (EngineCore_DP0 pid=1106)   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/minimax_m2.py", line 458, in load_weights                                                                                                    
  (EngineCore_DP0 pid=1106)     weight_loader(                                                                                                                                                                                                      
  (EngineCore_DP0 pid=1106)   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/layer.py", line 1125, in weight_loader                                                                                             
  (EngineCore_DP0 pid=1106)     dim2 = loaded_weight.shape[2]                                                                                                                                                                                       
  (EngineCore_DP0 pid=1106)            ~~~~~~~~~~~~~~~~~~~^^^                                                                                                                                                                                       
  (EngineCore_DP0 pid=1106) IndexError: tuple index out of range
```

This PR isolates gpt-oss execution path and sets quant_method to “block” (similarly to fp8) to re-use generic execution path for mxfp4 quants

Resolves the `FIXME` noted in #22339 for non-GPT-OSS models.

## Test Plan
Test gpt-oss, mxfp4 and fp8 models to ensure no execution path is broken

## Test Result
End-to-end verification with MiniMax-M2.5 (229B MoE) quantized to MXFP4, serving on 2x DGX Spark:

gsm8k result (--limit 250):
|Tasks|Version|     Filter     |n-shot|  Metric   |   Value  |Stderr|
|-----|------:|----------------|-----:|-----------|---|-------:|
|gsm8k|      3|flexible-extract|     5|exact_match|0.948|±  0.0141|
|     |       |strict-match    |     5|exact_match|0.932|±  0.0160|
| WikiText-2    |       |   |     |perplexity |9.222||
|    |       |    |     |mean NLL  |2.221||


*WikiText-2 perplexity measured with max_len=2048, stride=512, 550 windows, 283K tokens scored.*

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>




