### PR TITLE
Dependency compatibility: require transformers>=5.0.0 for vLLM

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 4.56.0, < 5
+transformers >= 4.56.0
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 5.0.0, < 6
+transformers >= 5.0.0
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 4.56.0
+transformers >= 5.0.0, < 6
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -78,19 +78,6 @@ def _get_backend_priorities(
                 AttentionBackendEnum.FLASHMLA_SPARSE,
             ]
     else:
-        # NOTE:
-        # On some newer consumer GPUs (e.g. sm_120), FLASH_ATTN can stall
-        # during default V1 startup graph-capture ("decode, FULL"), causing
-        # API startup to never complete. Prefer Triton first on these devices
-        # for functional defaults; users can still force another backend via
-        # --attention-backend.
-        if device_capability.major >= 12:
-            return [
-                AttentionBackendEnum.TRITON_ATTN,
-                AttentionBackendEnum.FLASH_ATTN,
-                AttentionBackendEnum.FLASHINFER,
-                AttentionBackendEnum.FLEX_ATTENTION,
-            ]
         if device_capability.major == 10:
             return [
                 AttentionBackendEnum.FLASHINFER,

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -78,6 +78,19 @@ def _get_backend_priorities(
                 AttentionBackendEnum.FLASHMLA_SPARSE,
             ]
     else:
+        # NOTE:
+        # On some newer consumer GPUs (e.g. sm_120), FLASH_ATTN can stall
+        # during default V1 startup graph-capture ("decode, FULL"), causing
+        # API startup to never complete. Prefer Triton first on these devices
+        # for functional defaults; users can still force another backend via
+        # --attention-backend.
+        if device_capability.major >= 12:
+            return [
+                AttentionBackendEnum.TRITON_ATTN,
+                AttentionBackendEnum.FLASH_ATTN,
+                AttentionBackendEnum.FLASHINFER,
+                AttentionBackendEnum.FLEX_ATTENTION,
+            ]
         if device_capability.major == 10:
             return [
                 AttentionBackendEnum.FLASHINFER,


### PR DESCRIPTION
## Summary
This PR updates vLLM runtime dependency requirement to `transformers>=5.0.0`.

## Why
- Axolotl compatibility update targets Transformers v5.
- We verified both `transformers==5.0.0` and `transformers==5.1.0` work in this compatibility workflow.
- This change ensures dependency resolution/installation can proceed cleanly in the paired setup.

## Change
- `requirements/common.txt`
  - `transformers >= 4.56.0, < 5` -> `transformers >= 5.0.0`
