### PR TITLE
[Bugfix] Fix sleep mode wake_up memory leaks

### DIFF
--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -235,19 +235,47 @@ class CuMemAllocator:
             back to GPU memory. If None, all memory allocation will be loaded
             back to GPU memory.
         """
-        for ptr, data in self.pointer_to_data.items():
-            if tags is None or data.tag in tags:
-                handle = data.handle
-                create_and_map(handle)
-                if data.cpu_backup_tensor is not None:
-                    cpu_backup_tensor = data.cpu_backup_tensor
-                    if cpu_backup_tensor is not None:
-                        size_in_bytes = (
-                            cpu_backup_tensor.numel() * cpu_backup_tensor.element_size()
-                        )
-                        cpu_ptr = cpu_backup_tensor.data_ptr()
-                        libcudart.cudaMemcpy(ptr, cpu_ptr, size_in_bytes)
-                        data.cpu_backup_tensor = None
+        # Track successfully mapped allocations for rollback on failure
+        successfully_mapped = []
+
+        try:
+            for ptr, data in self.pointer_to_data.items():
+                if tags is None or data.tag in tags:
+                    handle = data.handle
+                    create_and_map(handle)
+                    successfully_mapped.append(ptr)
+
+                    if data.cpu_backup_tensor is not None:
+                        cpu_backup_tensor = data.cpu_backup_tensor
+                        if cpu_backup_tensor is not None:
+                            size_in_bytes = (
+                                cpu_backup_tensor.numel()
+                                * cpu_backup_tensor.element_size()
+                            )
+                            cpu_ptr = cpu_backup_tensor.data_ptr()
+                            libcudart.cudaMemcpy(ptr, cpu_ptr, size_in_bytes)
+                            data.cpu_backup_tensor = None
+        except Exception as e:
+            # Rollback all successfully mapped allocations on failure
+            logger.error(
+                "Failed to wake up allocator: %s. Rolling back %d successfully "
+                "mapped allocations.",
+                str(e),
+                len(successfully_mapped),
+            )
+            for ptr in successfully_mapped:
+                try:
+                    data = self.pointer_to_data[ptr]
+                    handle = data.handle
+                    unmap_and_release(handle)
+                except Exception as rollback_error:
+                    logger.error(
+                        "Failed to rollback allocation at ptr %s: %s",
+                        ptr,
+                        str(rollback_error),
+                    )
+            # Re-raise the original exception after cleanup
+            raise
 
     @contextmanager
     def use_memory_pool(self, tag: str | None = None):


### PR DESCRIPTION

## Purpose
Fix GPU memory leak in sleep mode when `wake_up()` fails due to OOM.                                                              
  
### Problem
When `wake_up()` encounters an out-of-memory (OOM) error during the GPU memory restoration process, it fails to clean up partially allocated GPU memory blocks. This causes a memory leak where successfully mapped allocations remain on the GPU even though the wake_up operation failed.

**Reproduction scenario:**
  1. Put model to sleep (offloads weights to CPU)
  2. Another process allocates most of the GPU memory
  3. Call `wake_up()` - OOM occurs during restoration
  4. Previously allocated GPU memory blocks are leaked and never released

### Root Cause
In `vllm/device_allocator/cumem.py`, the `wake_up()` method iterates through memory blocks and calls `create_and_map()` for each one. If an OOM error occurs mid-loop:
  - Blocks allocated before the error remain mapped on GPU
  - No rollback mechanism exists to clean up these allocations
  - The exception propagates but leaves GPU in an inconsistent state

### Solution

Added exception handling with automatic rollback to `wake_up()`:
  - Track successfully mapped allocations in a list
  - On any exception, iterate through successfully mapped blocks and call `unmap_and_release()` to free GPU memory
  - Each rollback operation is wrapped in try-except to ensure all cleanup attempts are made
  - Re-raise the original exception after cleanup completes

This ensures GPU memory is always properly released when `wake_up()` fails, preventing leaks and leaving the system in a consistent state for retry.

## Test Plan
sleep two models on one GPU, then wake up one, the rest memory is not enough for another, then wake up another, observe that there is no memory leaks
1. run model1
```bash
CUDA_VISIBLE_DEVICES=0 VLLM_SERVER_DEV_MODE=1 VLLM_WORKER_MULTIPROC_METHOD="spawn" \
uv run vllm serve \
--host 0.0.0.0 \
--port 8005 \
--model /path/to/model1/ \
--no-enable-prefix-caching \
--enable-chunked-prefill \
--gpu-memory-utilization 0.80 \
--enable-sleep-mode
```
2. run model2
```bash
CUDA_VISIBLE_DEVICES=0 VLLM_SERVER_DEV_MODE=1 VLLM_WORKER_MULTIPROC_METHOD="spawn" \
uv run vllm serve \
--host 0.0.0.0 \
--port 8006 \
--model /path/to/model2/ \
--no-enable-prefix-caching \
--enable-chunked-prefill \
--gpu-memory-utilization 0.80 \
--enable-sleep-mode
```
3. sleep model1&2
```bash
curl -v -X POST 'http://localhost:8005/sleep?level=1'
curl -v -X POST 'http://localhost:8006/sleep?level=1'
```
4. wake up model1, will success
```bash
curl -v -X POST 'http://localhost:8005/wake_up'
```
5. then wake up model2, will fail
```bash
curl -v -X POST 'http://localhost:8006/wake_up'
```

## Test Result
result before
<img width="3921" height="1599" alt="image" src="https://github.com/user-attachments/assets/31348956-9466-40b1-8d32-91f024495d4f" />
<img width="3919" height="1599" alt="image" src="https://github.com/user-attachments/assets/9b31901b-f2bf-4542-87a1-ca3c8cabda53" />

result after
<img width="3918" height="1599" alt="image" src="https://github.com/user-attachments/assets/24ad416a-9628-4660-85d9-05727982780b" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>

