### PR TITLE
feat(spec_decode): add Qwen3-VL Eagle3 multimodal prefill support

### DIFF
--- a/vllm/model_executor/models/qwen3_vl_eagle3.py
+++ b/vllm/model_executor/models/qwen3_vl_eagle3.py
@@ -24,6 +24,8 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.model_executor.models.qwen3 import (
     Qwen3DecoderLayer as BaseQwen3DecoderLayer,
+)
+from vllm.model_executor.models.qwen3 import (
     Qwen3ForCausalLM,
 )
 from vllm.multimodal.inputs import NestedTensors

--- a/vllm/model_executor/models/qwen3_vl_eagle3.py
+++ b/vllm/model_executor/models/qwen3_vl_eagle3.py
@@ -1,0 +1,439 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Iterable
+
+import torch
+import torch.nn as nn
+from transformers import Qwen3Config
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.logger import init_logger
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import QKVParallelLinear, ReplicatedLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import (
+    default_weight_loader,
+    maybe_remap_kv_scale_name,
+)
+from vllm.model_executor.models.qwen3 import (
+    Qwen3DecoderLayer as BaseQwen3DecoderLayer,
+    Qwen3ForCausalLM,
+)
+from vllm.multimodal.inputs import NestedTensors
+
+from .interfaces import _require_is_multimodal
+from .utils import (
+    AutoWeightsLoader,
+    _merge_multimodal_embeddings,
+    get_draft_quant_config,
+    maybe_prefix,
+    process_eagle_weight,
+)
+
+logger = init_logger(__name__)
+
+
+class Qwen3DecoderLayer(BaseQwen3DecoderLayer):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        config: Qwen3Config | None = None,
+        layer_idx: int = 0,
+    ) -> None:
+        config = config or vllm_config.model_config.hf_config
+        quant_config = self.get_quant_config(vllm_config)
+        super().__init__(
+            config=config,
+            cache_config=vllm_config.cache_config,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+
+        # First layer uses 2*hidden_size (embeds + hidden_states concatenated)
+        # Subsequent layers use hidden_size (only hidden_states, no embeds)
+        qkv_input_size = 2 * self.hidden_size if layer_idx == 0 else self.hidden_size
+
+        # Parallel drafting checkpoints may have attention bias enabled
+        qkv_bias = getattr(config, "attention_bias", False)
+
+        # Override qkv_proj with correct input size and bias setting
+        self.self_attn.qkv_proj = QKVParallelLinear(
+            qkv_input_size,
+            self.self_attn.head_dim,
+            self.self_attn.total_num_heads,
+            self.self_attn.total_num_kv_heads,
+            bias=qkv_bias,
+            quant_config=quant_config,
+            # Keep Qwen3 naming layout so weight loading stays aligned.
+            prefix=maybe_prefix(prefix, "self_attn.qkv_proj"),
+        )
+
+        self.hidden_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.layer_idx = layer_idx
+
+        if getattr(config, "norm_before_residual", False):
+            self._residual_norm = self._norm_before_residual
+        else:
+            self._residual_norm = self._norm_after_residual
+
+    def get_quant_config(self, vllm_config: VllmConfig) -> QuantizationConfig | None:
+        """Use drafter's quantization config instead of verifier's."""
+        return get_draft_quant_config(vllm_config)
+
+    def _norm_before_residual(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states = self.hidden_norm(hidden_states)
+        residual = hidden_states
+        return hidden_states, residual
+
+    def _norm_after_residual(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        residual = hidden_states
+        hidden_states = self.hidden_norm(hidden_states)
+        return hidden_states, residual
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        embeds: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.layer_idx == 0:
+            # First layer: concatenate embeds with hidden_states
+            embeds = self.input_layernorm(embeds)
+            hidden_states, residual = self._residual_norm(hidden_states=hidden_states)
+            hidden_states = torch.cat([embeds, hidden_states], dim=-1)
+        else:
+            # Subsequent layers: process hidden_states and residuals only
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        # Self Attention
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+        )
+
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+
+        # Fully Connected
+        hidden_states = self.mlp(hidden_states)
+
+        return hidden_states, residual
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "hidden_states": 0,
+        "input_embeds": 0,
+    }
+)
+class Eagle3Qwen3Model(nn.Module):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        start_layer_id: int = 0,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        self.vocab_size = self.config.vocab_size
+
+        # Get drafter's quantization config
+        self.quant_config = get_draft_quant_config(vllm_config)
+
+        eagle_config = getattr(self.config, "eagle_config", None)
+        if eagle_config is not None and "use_aux_hidden_state" in eagle_config:
+            self.use_aux_hidden_state = eagle_config["use_aux_hidden_state"]
+        else:
+            self.use_aux_hidden_state = True
+
+        current_vllm_config = get_current_vllm_config()
+
+        self.embed_tokens = VocabParallelEmbedding(
+            self.config.vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
+        )
+
+        self.layers = nn.ModuleList(
+            [
+                Qwen3DecoderLayer(
+                    current_vllm_config,
+                    prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
+                    config=self.config,
+                    layer_idx=layer_idx,
+                )
+                for layer_idx in range(self.config.num_hidden_layers)
+            ]
+        )
+        if self.use_aux_hidden_state:
+            if hasattr(self.config, "target_hidden_size"):
+                fc_input_size = self.config.target_hidden_size * 3
+            else:
+                fc_input_size = self.config.hidden_size * 3
+            self.fc = ReplicatedLinear(
+                input_size=fc_input_size,
+                output_size=self.config.hidden_size,
+                bias=False,
+                params_dtype=vllm_config.model_config.dtype,
+                quant_config=self.quant_config,
+                prefix=maybe_prefix(prefix, "fc"),
+                return_bias=False,
+            )
+        self.norm = RMSNorm(
+            self.config.hidden_size,
+            eps=self.config.rms_norm_eps,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        input_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if input_embeds is None:
+            input_embeds = self.embed_input_ids(input_ids)
+        assert hidden_states.shape[-1] == input_embeds.shape[-1]
+
+        residual = None
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions=positions,
+                embeds=input_embeds,
+                hidden_states=hidden_states,
+                residual=residual,
+            )
+        hidden_states, hidden_prenorm = self.norm(hidden_states, residual)
+        return hidden_states, hidden_prenorm
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if "midlayer." in name:
+                name = name.replace("midlayer.", "layers.0.")
+            # Handle kv cache quantization scales
+            if self.quant_config is not None and (
+                scale_name := self.quant_config.get_cache_scale(name)
+            ):
+                # Loading kv cache quantization scales
+                param = params_dict[scale_name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                loaded_weight = (
+                    loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
+                )
+                weight_loader(param, loaded_weight)
+                loaded_params.add(scale_name)
+                continue
+            # Remapping the name FP8 kv-scale or zero point.
+            if "scale" in name or "zero_point" in name:
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+class Eagle3Qwen3vlForCausalLM(Qwen3ForCausalLM):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        nn.Module.__init__(self)
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        # Ensure draft_vocab_size is set
+        # default to the base vocab size when absent
+        if getattr(self.config, "draft_vocab_size", None) is None:
+            base_vocab_size = getattr(self.config, "vocab_size", None)
+            self.config.draft_vocab_size = base_vocab_size
+        target_layer_num = vllm_config.model_config.get_num_layers(
+            vllm_config.parallel_config
+        )
+
+        # Store target layer count in draft config for
+        # proper layer_types indexing in draft models
+        self.config.target_layer_count = target_layer_num
+        self.model = Eagle3Qwen3Model(
+            vllm_config=vllm_config, prefix="model", start_layer_id=target_layer_num
+        )
+
+        logit_scale = getattr(self.config, "logit_scale", 1.0)
+        self.lm_head = ParallelLMHead(
+            self.config.draft_vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(
+            self.config.draft_vocab_size, scale=logit_scale
+        )
+        self.draft_id_to_target_id = nn.Parameter(
+            torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
+            requires_grad=False,
+        )
+
+        self.use_parallel_drafting = vllm_config.speculative_config.parallel_drafting
+
+        if self.use_parallel_drafting:
+            self.register_buffer(
+                "mask_hidden",
+                torch.zeros(
+                    1,
+                    (3 if self.model.use_aux_hidden_state else 1)
+                    * self.config.hidden_size,
+                ),
+                persistent=False,
+            )
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: NestedTensors | None = None,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Start from text embeddings so text-only behavior remains unchanged.
+        inputs_embeds = self.model.embed_input_ids(input_ids)
+        if multimodal_embeddings is None:
+            return inputs_embeds
+
+        # Treat empty multimodal inputs as a no-op for compatibility.
+        if (
+            hasattr(multimodal_embeddings, "__len__")
+            and len(multimodal_embeddings) == 0
+        ):
+            return inputs_embeds
+
+        # Merge multimodal embeddings using the same semantics as other
+        # multimodal models.
+        return _merge_multimodal_embeddings(
+            inputs_embeds=inputs_embeds,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=_require_is_multimodal(is_multimodal),
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.model(input_ids, positions, hidden_states, inputs_embeds)
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor | None:
+        logits = self.logits_processor(self.lm_head, hidden_states)
+        if self.draft_id_to_target_id is None:
+            assert logits.shape[1] == self.config.vocab_size, (
+                "Expected logits to have shape "
+                f"(*, {self.config.vocab_size}), but got {logits.shape}"
+            )
+            return logits
+
+        base = torch.arange(self.config.draft_vocab_size, device=logits.device)
+        targets = base + self.draft_id_to_target_id
+        logits_new = logits.new_full(
+            (
+                logits.shape[0],
+                self.config.vocab_size,
+            ),
+            float("-inf"),
+        )
+        logits_new[:, targets] = logits
+        return logits_new
+
+    def combine_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        if not self.model.use_aux_hidden_state:
+            return hidden_states
+        # combine multiple auxiliary hidden states returned by eagle3
+        return self.model.fc(hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        model_weights = {}
+        includes_draft_id_mapping = False
+        includes_embed_tokens = False
+        includes_mask_hidden = False
+        for name, loaded_weight in weights:
+            if "t2d" in name:
+                continue
+            if "d2t" in name:
+                name = name.replace("d2t", "draft_id_to_target_id")
+                includes_draft_id_mapping = True
+            elif "mask_hidden" in name:
+                # Load mask_hidden directly into buffer
+                if not self.use_parallel_drafting:
+                    logger.warning(
+                        "mask_hidden found in weights but "
+                        "model is not configured for parallel drafting. "
+                        "Skipping loading mask_hidden."
+                    )
+                    continue
+                self.mask_hidden.copy_(loaded_weight.view(1, -1))
+                includes_mask_hidden = True
+                continue
+            elif "lm_head" not in name:
+                name = "model." + name
+            if "embed_tokens" in name:
+                includes_embed_tokens = True
+            model_weights[name] = loaded_weight
+            process_eagle_weight(self, name)
+
+        if not includes_mask_hidden and self.use_parallel_drafting:
+            raise ValueError(
+                "mask_hidden not found in weights but "
+                "model is configured for parallel drafting. "
+                "Please provide mask_hidden in the weights."
+            )
+
+        skip_substrs = ["mask_hidden"]
+        if not includes_draft_id_mapping:
+            skip_substrs.append("draft_id_to_target_id")
+        if not includes_embed_tokens:
+            skip_substrs.append("embed_tokens")
+        if not self.model.use_aux_hidden_state:
+            skip_substrs.append("fc.")
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=None,
+            skip_substrs=skip_substrs,
+        )
+        loader.load_weights(model_weights.items())

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -501,7 +501,7 @@ _SPECULATIVE_DECODING_MODELS = {
     "Eagle3LlamaForCausalLM": ("llama_eagle3", "Eagle3LlamaForCausalLM"),
     "LlamaForCausalLMEagle3": ("llama_eagle3", "Eagle3LlamaForCausalLM"),
     "Eagle3Qwen2_5vlForCausalLM": ("llama_eagle3", "Eagle3LlamaForCausalLM"),
-    "Eagle3Qwen3vlForCausalLM": ("llama_eagle3", "Eagle3LlamaForCausalLM"),
+    "Eagle3Qwen3vlForCausalLM": ("qwen3_vl_eagle3", "Eagle3Qwen3vlForCausalLM"),
     "EagleMistralLarge3ForCausalLM": (
         "mistral_large_3_eagle",
         "EagleMistralLarge3ForCausalLM",

--- a/vllm/transformers_utils/configs/speculators/algos.py
+++ b/vllm/transformers_utils/configs/speculators/algos.py
@@ -2,14 +2,52 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 SUPPORTED_SPECULATORS_TYPES = {}
+_EAGLE3_DEFAULT_ARCHITECTURE = "Eagle3LlamaForCausalLM"
 
 
 def register_speculator(name):
+    """Register a config transformer for a speculator type."""
+
     def decorator(fn):
         SUPPORTED_SPECULATORS_TYPES[name] = fn
         return fn
 
     return decorator
+
+
+def _select_eagle3_architecture(config_dict: dict, pre_trained_config: dict) -> str:
+    """Select the Eagle3 wrapper architecture from model/verifier metadata."""
+
+    def normalize(value: str) -> str:
+        return value.lower().replace("_", "").replace("-", "")
+
+    def add_hints(hints: set[str], value) -> None:
+        if isinstance(value, str):
+            hints.add(normalize(value))
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, str):
+                    hints.add(normalize(item))
+
+    model_hints: set[str] = set()
+    for key in ("model_type", "text_model_type", "architectures"):
+        add_hints(model_hints, pre_trained_config.get(key) or config_dict.get(key))
+
+    if any("qwen3vl" in hint for hint in model_hints):
+        return "Eagle3Qwen3vlForCausalLM"
+    if any("llama" in hint for hint in model_hints):
+        return _EAGLE3_DEFAULT_ARCHITECTURE
+
+    verifier_hints: set[str] = set()
+    spec_cfg = config_dict.get("speculators_config")
+    if isinstance(spec_cfg, dict):
+        verifier_cfg = spec_cfg.get("verifier")
+        if isinstance(verifier_cfg, dict):
+            add_hints(verifier_hints, verifier_cfg.get("architectures"))
+
+    if not model_hints and any("qwen3vl" in hint for hint in verifier_hints):
+        return "Eagle3Qwen3vlForCausalLM"
+    return _EAGLE3_DEFAULT_ARCHITECTURE
 
 
 @register_speculator("eagle3")
@@ -34,7 +72,10 @@ def update_eagle3(config_dict: dict, pre_trained_config: dict) -> None:
     pre_trained_config["norm_before_residual"] = config_dict.get(
         "norm_before_residual", True
     )
-    pre_trained_config["architectures"] = ["Eagle3LlamaForCausalLM"]
+    # Route checkpoints to the correct wrapper implementation.
+    pre_trained_config["architectures"] = [
+        _select_eagle3_architecture(config_dict, pre_trained_config)
+    ]
     if config_dict.get("eagle_aux_hidden_state_layer_ids"):
         pre_trained_config["eagle_aux_hidden_state_layer_ids"] = config_dict[
             "eagle_aux_hidden_state_layer_ids"

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -23,6 +23,7 @@ from vllm.model_executor.models import supports_multimodal
 from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
 from vllm.model_executor.models.interfaces import SupportsMultiModal
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
+from vllm.model_executor.models.qwen3_vl_eagle3 import Eagle3Qwen3vlForCausalLM
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.platforms import current_platform
 from vllm.triton_utils import triton
@@ -394,7 +395,10 @@ class SpecDecodeBaseProposer:
         batch_size = common_attn_metadata.batch_size()
 
         if self.method == "eagle3":
-            assert isinstance(self.model, Eagle3LlamaForCausalLM)
+            # Accept both Llama-based and Qwen3-VL-specific Eagle3 wrappers.
+            assert isinstance(
+                self.model, (Eagle3LlamaForCausalLM, Eagle3Qwen3vlForCausalLM)
+            )
             target_hidden_states = self.model.combine_hidden_states(
                 target_hidden_states
             )
@@ -1341,7 +1345,7 @@ class SpecDecodeBaseProposer:
             try:
                 dummy_input_ids = torch.tensor([[1]], device=self.input_ids.device)
                 self.model.embed_input_ids(dummy_input_ids, multimodal_embeddings=None)
-            except (NotImplementedError, AttributeError, TypeError):
+            except (NotImplementedError, AttributeError, TypeError, ValueError):
                 logger.warning(
                     "Draft model does not support multimodal inputs, "
                     "falling back to text-only mode"

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4091,22 +4091,7 @@ class GPUModelRunner(
                 # inputs and falls back to text-only mode on inconsistency
                 # to avoid silent corruption.
                 mm_embeds, is_mm_embed = mm_embed_inputs
-                if is_mm_embed is None:
-                    # Disable multimodal draft path when mask construction fails.
-                    logger.warning_once(
-                        "mm_embed_inputs returned None mask; "
-                        "using text-only draft path."
-                    )
-                    mm_embed_inputs = None
-                elif mm_embeds is None:
-                    # Disable multimodal draft path when embeddings are
-                    # missing unexpectedly.
-                    logger.warning_once(
-                        "mm_embed_inputs returned None embeddings; "
-                        "using text-only draft path."
-                    )
-                    mm_embed_inputs = None
-                elif (
+                if (
                     hasattr(mm_embeds, "__len__")
                     and len(mm_embeds) == 0
                     and bool(is_mm_embed.any().item())

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4081,14 +4081,43 @@ class GPUModelRunner(
                     else:
                         target_hidden_states = hidden_states[:total_num_tokens]
 
+            mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None
             if self.supports_mm_inputs and self.drafter.supports_mm_inputs:
                 mm_embed_inputs = self._gather_mm_embeddings(
                     scheduler_output,
                     shift_computed_tokens=1,
                 )
-            else:
-                mm_embed_inputs = None
-
+                # IMPORTANT WARNING: this guard validates multimodal draft
+                # inputs and falls back to text-only mode on inconsistency
+                # to avoid silent corruption.
+                mm_embeds, is_mm_embed = mm_embed_inputs
+                if is_mm_embed is None:
+                    # Disable multimodal draft path when mask construction fails.
+                    logger.warning_once(
+                        "mm_embed_inputs returned None mask; "
+                        "using text-only draft path."
+                    )
+                    mm_embed_inputs = None
+                elif mm_embeds is None:
+                    # Disable multimodal draft path when embeddings are
+                    # missing unexpectedly.
+                    logger.warning_once(
+                        "mm_embed_inputs returned None embeddings; "
+                        "using text-only draft path."
+                    )
+                    mm_embed_inputs = None
+                elif (
+                    hasattr(mm_embeds, "__len__")
+                    and len(mm_embeds) == 0
+                    and bool(is_mm_embed.any().item())
+                ):
+                    # Disable multimodal draft path when placeholder mask and
+                    # embeds disagree.
+                    logger.warning_once(
+                        "mm_embed_inputs has placeholder mask but empty embeddings; "
+                        "using text-only draft path."
+                    )
+                    mm_embed_inputs = None
             draft_token_ids = self.drafter.propose(
                 target_token_ids=target_token_ids,
                 target_positions=target_positions,


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
Enable single image-text pair support in speculative decoding for Eagle3 (Qwen3-VL), so VL draft models can correctly consume multimodal prefill embeddings.

Example usage:

CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}" \
```
vllm serve "${BASE_MODEL:-/path/to/qwen3-vl}" \
  --tensor-parallel-size "${TENSOR_PARALLEL_SIZE:-1}" \
  --max-model-len "${MAX_MODEL_LEN:-8192}" \
  --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION:-0.9}" \
  --trust-remote-code \
  --speculative-config "{\"model\":\"${SPEC_CKPT}\",\"method\":\"${SPEC_METHOD:-eagle3}\",\"num_speculative_tokens\":${NUM_SPEC_TOKENS:-3}}" \
  --port "${VLLM_PORT:-8000}" \
  --host "${VLLM_HOST:-127.0.0.1}" \
  --allowed-local-media-path "${ALLOWED_LOCAL_MEDIA_PATH:-/path/to/test/image}"

```


This PR mainly:
- adds a dedicated `Eagle3Qwen3vlForCausalLM` wrapper for VL Eagle3 drafting,
- routes `Eagle3Qwen3vlForCausalLM` to the correct model implementation in registry,

## Test Plan
We re-annotated 4K high-quality image-text samples from `LLaVA-CoT-100K `and trained a compact draft model with `vllm-speculators`, using` Qwen3-VL-8B-Instruct `as the verifier backbone.




## Test Result
On a single H800 PCIe
| Metric | Baseline | Speculative (Eagle3) | Delta |
|---|---:|---:|---:|
| Throughput (token/s) | 149 | 151 | +2 (+1.3%) |


### Speculative Decoding Acceptance (Spec run)

| Metric | Value |
|---|---:|
| Total samples | 22 |
| Total drafted tokens | 60,729 |
| Average drafted tokens | 2,760.41 |
| Weighted per-position acceptance | [0.43, 0.146, 0.04] |
| Conditional acceptance | [0.43, 0.339, 0.277] |

The throughput gain is limited because the draft model was trained on only 4K re-annotated high-quality image-text samples.  
Still, the end-to-end run and acceptance statistics confirm that the VL speculative decoding code path is working correctly.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

