### PR TITLE
[Bugfix] Fix ResponseCreatedEvent ValidationError for json_schema format in streaming

### DIFF
--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -2490,7 +2490,7 @@ class OpenAIServingResponses(OpenAIServing):
                 output=[],
                 status="in_progress",
                 usage=None,
-            ).model_dump()
+            )
             yield _increment_sequence_number_and_return(
                 ResponseCreatedEvent(
                     type="response.created",


### PR DESCRIPTION
## Summary
- Remove `.model_dump()` from `ResponsesResponse` before passing to `ResponseCreatedEvent`/`ResponseInProgressEvent` during streaming
- `.model_dump()` serialized using Python attribute names (e.g. `schema_`) but Pydantic re-validation expected JSON alias names (e.g. `schema`), causing a `ValidationError` when `text.format.type: json_schema` was used with `stream=True`
- This makes event construction consistent with `ResponseCompletedEvent`, which already passes the `ResponsesResponse` object directly

## Test plan
- [ ] Existing structured output tests pass: `pytest tests/v1/entrypoints/openai/serving_responses/test_structured_output.py -v`
- [ ] Existing streaming tests pass: `pytest tests/v1/entrypoints/openai/serving_responses/test_basic.py -v`
- [ ] New `test_structured_output_streaming` covers the exact failing code path (json_schema + streaming)
- [ ] Unit tests pass: `pytest tests/entrypoints/openai/test_serving_responses.py -v`