### PR TITLE
[Feature]: Implement get_kv_cache_stride_order for all classes

### DIFF
--- a/benchmarks/attention_benchmarks/runner.py
+++ b/benchmarks/attention_benchmarks/runner.py
@@ -333,11 +333,8 @@ def _create_kv_cache(
     )
 
     # Get the stride order for custom memory layout
-    try:
-        stride_order = backend_class.get_kv_cache_stride_order()
-        assert len(stride_order) == len(cache_shape)
-    except (AttributeError, NotImplementedError):
-        stride_order = tuple(range(len(cache_shape)))
+    stride_order = backend_class.get_kv_cache_stride_order()
+    assert len(stride_order) == len(cache_shape)
 
     # Permute shape to physical layout order
     physical_shape = tuple(cache_shape[i] for i in stride_order)

--- a/tests/compile/passes/test_fusion_attn.py
+++ b/tests/compile/passes/test_fusion_attn.py
@@ -108,10 +108,8 @@ class AttentionQuantPatternModel(torch.nn.Module):
         kv_cache_shape = attn_backend.get_kv_cache_shape(
             num_blocks, self.block_size, self.num_kv_heads, self.head_size
         )
-        try:
-            kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
-        except (AttributeError, NotImplementedError):
-            kv_cache_stride_order = tuple(range(len(kv_cache_shape)))
+        kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
+        assert len(kv_cache_stride_order) == len(kv_cache_shape)
 
         kv_cache_shape = tuple(kv_cache_shape[i] for i in kv_cache_stride_order)
         inv_order = [

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -342,12 +342,10 @@ class TpKVTopology:
             # prepend layers dimension
             _MOCK_NUM_LAYERS = 80
             kv_cache_shape = (_MOCK_NUM_LAYERS,) + kv_cache_shape
-            try:
-                kv_cache_stride_order = self.attn_backend.get_kv_cache_stride_order(
-                    include_num_layers_dimension=self._cross_layers_blocks
-                )
-            except (AttributeError, NotImplementedError):
-                kv_cache_stride_order = tuple(range(len(self.tensor_shape)))
+            kv_cache_stride_order = self.attn_backend.get_kv_cache_stride_order(
+                include_num_layers_dimension=self._cross_layers_blocks
+            )
+            assert len(kv_cache_stride_order) == len(kv_cache_shape)
 
             # In case of cross layers permute kv_cache_shape according to
             # stride_order to retrieve physical position of block_size

--- a/vllm/v1/kv_offload/worker/cpu_gpu.py
+++ b/vllm/v1/kv_offload/worker/cpu_gpu.py
@@ -259,13 +259,10 @@ class CpuGpuOffloadingHandlers:
                 assert gpu_shape[0] == 2
                 split_k_and_v = True
 
-            try:
-                kv_cache_stride_order = attn_backend.get_kv_cache_stride_order(
-                    include_num_layers_dimension=has_layers_dim
-                )
-                assert len(kv_cache_stride_order) == len(gpu_shape)
-            except (AttributeError, NotImplementedError):
-                kv_cache_stride_order = tuple(range(len(gpu_shape)))
+            kv_cache_stride_order = attn_backend.get_kv_cache_stride_order(
+                include_num_layers_dimension=has_layers_dim
+            )
+            assert len(kv_cache_stride_order) == len(gpu_shape)
 
             # permute test_shape according to stride_order
             test_shape = tuple(test_shape[i] for i in kv_cache_stride_order)

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -99,12 +99,8 @@ def _reshape_kv_cache(
                 kv_cache_spec.head_size,
             )
 
-            # FIXME(woosuk): Add kv_cache_stride_order to all attention backends.
-            try:
-                kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
-                assert len(kv_cache_stride_order) == len(kv_cache_shape)
-            except (AttributeError, NotImplementedError):
-                kv_cache_stride_order = tuple(range(len(kv_cache_shape)))
+            kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
+            assert len(kv_cache_stride_order) == len(kv_cache_shape)
 
             kv_cache_shape = tuple(kv_cache_shape[i] for i in kv_cache_stride_order)
             inv_order = [

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5877,11 +5877,8 @@ class GPUModelRunner(
                         cache_dtype_str=self.cache_config.cache_dtype,
                     )
                     dtype = kv_cache_spec.dtype
-                    try:
-                        kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
-                        assert len(kv_cache_stride_order) == len(kv_cache_shape)
-                    except (AttributeError, NotImplementedError):
-                        kv_cache_stride_order = tuple(range(len(kv_cache_shape)))
+                    kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
+                    assert len(kv_cache_stride_order) == len(kv_cache_shape)
                     # The allocation respects the backend-defined stride order
                     # to ensure the semantic remains consistent for each
                     # backend. We first obtain the generic kv cache shape and

--- a/vllm/v1/worker/kv_connector_model_runner_mixin.py
+++ b/vllm/v1/worker/kv_connector_model_runner_mixin.py
@@ -127,7 +127,7 @@ class KVConnectorModelRunnerMixin:
             have the same page size.
         2. A KV connector is configured, and the KV connector instance prefers
             to use this layout (prefer_cross_layer_blocks() returns True)
-        2. The flash attention backend supports this layout
+        3. The attention backend supports this layout
             (get_kv_cache_stride_order(True) includes a placement for a
             num_layers dimension)
 
@@ -166,12 +166,9 @@ class KVConnectorModelRunnerMixin:
             cache_dtype_str=cache_dtype,
         )
 
-        try:
-            kv_cache_stride_order = attn_backend.get_kv_cache_stride_order(
-                include_num_layers_dimension=True
-            )
-        except (AttributeError, NotImplementedError):
-            return False
+        kv_cache_stride_order = attn_backend.get_kv_cache_stride_order(
+            include_num_layers_dimension=True
+        )
 
         # check that attention backend include a layers dimension
         return len(kv_cache_stride_order) == len(kv_cache_shape) + 1
@@ -236,13 +233,10 @@ class KVConnectorModelRunnerMixin:
         # prepend a num_layers dimension into the shape
         kv_cache_shape = (num_layers,) + kv_cache_shape
 
-        try:
-            kv_cache_stride_order = attn_backend.get_kv_cache_stride_order(
-                include_num_layers_dimension=True
-            )
-            assert len(kv_cache_stride_order) == len(kv_cache_shape)
-        except (AttributeError, NotImplementedError):
-            kv_cache_stride_order = tuple(range(len(kv_cache_shape)))
+        kv_cache_stride_order = attn_backend.get_kv_cache_stride_order(
+            include_num_layers_dimension=True
+        )
+        assert len(kv_cache_stride_order) == len(kv_cache_shape)
 
         kv_cache_shape = tuple(kv_cache_shape[i] for i in kv_cache_stride_order)
 


### PR DESCRIPTION
## Purpose
This PR implements a default `get_kv_cache_stride_order` in `AttentionBackend` and removes fallback `try/except` usage patterns at call sites.

Previously, the base method raised `NotImplementedError`, which forced call sites to handle fallback manually (usually `tuple(range(len(kv_cache_shape)))`).  
Now the default behavior lives in the backend base class, so call sites can use a single code path.

Related Issue: https://github.com/vllm-project/vllm/issues/33951
## Test Plan
```shell
pytest -q tests/v1/worker/test_gpu_model_runner.py::test_kv_cache_stride_order
pytest -q tests/v1/kv_offload/test_cpu_gpu.py::test_transfer
pytest -q tests/v1/kv_connector/unit/test_nixl_connector.py::test_register_kv_caches
```
## Test Result
```shell
pytest -q tests/v1/worker/test_gpu_model_runner.py::test_kv_cache_stride_order
.                                                                                                      [100%]
pytest -q tests/v1/kv_offload/test_cpu_gpu.py::test_transfer
........                                                                                                 [100%]
pytest -q tests/v1/kv_connector/unit/test_nixl_connector.py::test_register_kv_caches
..ss..                                                                                                   [100%]
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

