### PR TITLE
(bugfix): Fixed encode in LLM entrypoint for IOProcessr plugin prompts

### DIFF
--- a/examples/pooling/plugin/prithvi_geospatial_mae_io_processor.py
+++ b/examples/pooling/plugin/prithvi_geospatial_mae_io_processor.py
@@ -20,12 +20,14 @@ def main():
     torch.set_default_dtype(torch.float16)
     image_url = "https://huggingface.co/christian-pinto/Prithvi-EO-2.0-300M-TL-VLLM/resolve/main/valencia_example_2024-10-26.tiff"  # noqa: E501
 
-    img_prompt = dict(
+    img_data = dict(
         data=image_url,
         data_format="url",
         image_format="tiff",
         out_data_format="b64_json",
     )
+
+    prompt = dict(data=img_data)
 
     llm = LLM(
         model="ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11",
@@ -41,7 +43,7 @@ def main():
         enable_mm_embeds=True,
     )
 
-    pooler_output = llm.encode(img_prompt, pooling_task="plugin")
+    pooler_output = llm.encode(prompt, pooling_task="plugin")
     output = pooler_output[0].outputs
 
     print(output)

--- a/tests/plugins_tests/test_io_processor_plugins.py
+++ b/tests/plugins_tests/test_io_processor_plugins.py
@@ -120,12 +120,14 @@ async def test_prithvi_mae_plugin_online(
 def test_prithvi_mae_plugin_offline(
     vllm_runner, model_name: str, image_url: str | dict, plugin: str, expected_hash: str
 ):
-    img_prompt = dict(
+    img_data = dict(
         data=image_url,
         data_format="url",
         image_format="tiff",
         out_data_format="b64_json",
     )
+
+    prompt = dict(data=img_data)
 
     with vllm_runner(
         model_name,
@@ -139,7 +141,7 @@ def test_prithvi_mae_plugin_offline(
         io_processor_plugin=plugin,
         default_torch_num_threads=1,
     ) as llm_runner:
-        pooler_output = llm_runner.get_llm().encode(img_prompt, pooling_task="plugin")
+        pooler_output = llm_runner.get_llm().encode(prompt, pooling_task="plugin")
     output = pooler_output[0].outputs
 
     # verify the output is formatted as expected for this plugin

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1135,7 +1135,15 @@ class LLM:
                 )
 
             # Validate the request data is valid for the loaded plugin
-            validated_prompt = self.io_processor.parse_data(prompts)
+            prompt_data = prompts.get("data")
+            if prompt_data is None:
+                raise ValueError(
+                    "The 'data' field of the prompt is expected to contain "
+                    "the prompt data and it cannot be None. "
+                    "Refer to the documentation of the IOProcessor "
+                    "in use for more details."
+                )
+            validated_prompt = self.io_processor.parse_data(prompt_data)
 
             # obtain the actual model prompts from the pre-processor
             prompts = self.io_processor.pre_process(prompt=validated_prompt)


### PR DESCRIPTION
## Purpose
This PR fixes a bug in encode in the LLM entrypoint when using IO Processor plugins. 

Previously in `encode` we would verify that the request is meant to use an IO Processor plugin, and then pass the full prompt to the `parse_data` of the IO Processor plugin. While we should only pass the `prompt.data` field to the plugin, similarly to what is done in the online serving mode.

This came out of a discussion in #34214 

@DarkLight1337 @staugust 

## Test Plan
Modified test to pass a properly formatted prompt to vllm when performing the inference in offline mode.
## Test Result
