### PR TITLE
[Bugfix] Fix `tests/compile/correctness_e2e/test_sequence_parallel.py::test_tp_sp_generation`

### DIFF
--- a/tests/compile/correctness_e2e/test_sequence_parallel.py
+++ b/tests/compile/correctness_e2e/test_sequence_parallel.py
@@ -229,7 +229,7 @@ def _compare_sp(
     if chunked_prefill:
         common_args.append("--enable-chunked-prefill")
     if eager_mode:
-        common_args.append("--enforce-eager")
+        common_args.append("-cc.cudagraph_mode=none")
     if runner != "auto":
         common_args.extend(["--runner", runner])
     if trust_remote_code:


### PR DESCRIPTION
Fix `tests/compile/correctness_e2e/test_sequence_parallel.py::test_tp_sp_generation` following up on https://github.com/vllm-project/vllm/pull/34523 changes.

Interpreting original PR's intent, I am trying to address quirks of handling `--enforce-eager` + `compilation-config` in the same start command.

cc @ProExpertProg 