### PR TITLE
[Bugfix][ROCm] Fix WNA16 MoE quant config init and Qwen3-VL tie_word_embeddings

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -1979,6 +1979,12 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         from vllm.model_executor.layers.fused_moe import fused_experts
 
+        # Lazy init: moe_quant_config may not yet be set if
+        # ensure_moe_quant_config_init() hasn't run (e.g. during the first
+        # compiled forward pass with piecewise backends).
+        if self.moe_quant_config is None:
+            self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+
         return fused_experts(
             x,
             layer.w13_weight_packed,

--- a/vllm/model_executor/layers/quantization/moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/moe_wna16.py
@@ -376,6 +376,12 @@ class MoeWNA16Method(FusedMoEMethodBase):
             f"Only SiLU activation is supported, not {layer.activation}."
         )
 
+        # Lazy init: moe_quant_config may not yet be set if
+        # ensure_moe_quant_config_init() hasn't run (e.g. during the first
+        # compiled forward pass with piecewise backends).
+        if self.moe_quant_config is None:
+            self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+
         return fused_experts(
             x,
             layer.w13_qweight,

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -341,7 +341,7 @@ class Qwen3MoeLLMForCausalLM(Qwen3MoeForCausalLM):
             quant_config=self.quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
-        if self.config.tie_word_embeddings:
+        if getattr(self.config, "tie_word_embeddings", False):
             self.lm_head.weight = self.model.embed_tokens.weight
         self.logits_processor = LogitsProcessor(self.config.vocab_size)
         self.make_empty_intermediate_tensors = (


### PR DESCRIPTION
## Summary

Two small bug fixes found while testing on ROCm/RDNA4:

- **WNA16 MoE quant config not initialized before first `apply()`**: The `FusedMoEQuantConfig` was not being set up before the first forward pass in the WNA16 quantization path, causing failures on first inference.
- **Qwen3MoeLLMForCausalLM `tie_word_embeddings` AttributeError**: Some Qwen3-VL MoE checkpoint configs lack the `tie_word_embeddings` field entirely. Changed direct attribute access to `getattr(..., False)` for safety.

Both fixes are defensive and should not affect existing behavior on any platform.

## Test plan
- [ ] Verify WNA16 MoE models load and run inference without error
- [ ] Verify Qwen3-VL MoE models with and without `tie_word_embeddings` in config
- [ ] Existing CI should pass (no behavioral change for configs that have the field)