### PR TITLE
Remove dead bitsandbytes CxB code from 8-bit inference path

### DIFF
--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -336,16 +336,6 @@ class BitsAndBytesLinearMethod(LinearMethodBase):
 
             current_index += output_size
 
-            # only update the matmul_states if it is not profile_run
-            if (
-                generation > 0
-                and not self.quant_config.llm_int8_has_fp16_weight
-                and matmul_states[i].CB is not None
-                and matmul_states[i].CxB is not None
-            ):
-                del matmul_states[i].CB
-                qweight[offsets[i] : offsets[i + 1]] = matmul_states[i].CxB
-
         out = out.to(original_type)
 
         if reshape_after_matmul:


### PR DESCRIPTION
## Summary

- Remove dead code in `BitsAndBytesLinearMethod._apply_8bit_weight()` that accesses `MatmulLtState.CxB` — an attribute that has been always `None` since bitsandbytes v0.45.0 (December 2024)
- This is a no-op change: the removed branch has never executed since `CxB` was part of the old col32/ColAmpere tensor layout system that was removed over a year ago

## Context

bitsandbytes is cleaning up its deprecated API surface. In the current release, `CxB` will still exist as a deprecated stub that emits a `FutureWarning` and returns `None` (see [bitsandbytes#1871](https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1871)), so there is no immediate breakage. However, the attribute will be fully removed in the next bitsandbytes release.

This PR removes the dead code proactively so vLLM is ready for both the current and next bitsandbytes versions.

## Test plan

- [ ] Existing 8-bit inference tests pass (no behavioral change — the removed code paths were unreachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)