### PR TITLE
[CI] Enable mypy import following for vllm/v1/kv_offload

### DIFF
--- a/tools/pre_commit/mypy.py
+++ b/tools/pre_commit/mypy.py
@@ -30,8 +30,6 @@ SEPARATE_GROUPS = [
     # v0 related
     "vllm/lora",
     "vllm/model_executor",
-    # v1 related
-    "vllm/v1/kv_offload",
 ]
 
 # TODO(woosuk): Include the code from Megatron and HuggingFace.


### PR DESCRIPTION
  ## Purpose

  Removes `vllm/v1/kv_offload` from `SEPARATE_GROUPS` in `tools/pre_commit/mypy.py` so that mypy runs with `follow_imports = "silent"` (main group) instead of `--follow-imports skip`.

  This enables proper import-following type checking for `vllm/v1/kv_offload`, fixing the issue where local pre-commit runs on a single file could produce false failures.

  Fixes part of https://github.com/vllm-project/vllm/issues/26533

  ## Test Plan

  1. Run mypy via the pre-commit hook script simulating CI (Python 3.10) on all 14 files in `vllm/v1/kv_offload/`:
     ```bash
     python tools/pre_commit/mypy.py 1 3.10 vllm/v1/kv_offload/*.py vllm/v1/kv_offload/**/*.py

  2. Run mypy via the pre-commit hook script simulating local pre-commit on a single file:
  python tools/pre_commit/mypy.py 0 3.10 vllm/v1/kv_offload/abstract.py
  3. Full pre-commit run:
  pre-commit run --hook-stage manual mypy-3.10 -a

  Test Result

  All 14 files pass with zero errors. No type fixes needed.

  $ python tools/pre_commit/mypy.py 1 3.10 <all kv_offload files>
  Success: no issues found in 14 source files
  $ mypy --python-version 3.10

  $ python tools/pre_commit/mypy.py 0 3.10 vllm/v1/kv_offload/abstract.py
  Success: no issues found in 1 source file
  $ mypy --python-version 3.10 --follow-imports skip

  ---- The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
  - The test plan, such as providing test command.
  - The test results, such as pasting the results comparison before and after, or e2e results
  - (Optional) The necessary documentation update, such as updating supported_models.md and examples for a new model.
  - (Optional) Release notes update. If your change is user facing, please update the release notes draft in the https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0.
