### PR TITLE
[AMD][CI] Skip test new_weight_syncing/rlhf.py

### DIFF
--- a/examples/offline_inference/new_weight_syncing/rlhf.py
+++ b/examples/offline_inference/new_weight_syncing/rlhf.py
@@ -27,6 +27,7 @@ causes unexpected behavior.
 """
 
 import os
+import sys
 
 import ray
 from ray.util.placement_group import placement_group
@@ -38,7 +39,13 @@ from vllm.config import WeightTransferConfig
 from vllm.distributed.weight_transfer.nccl_engine import (
     NCCLWeightTransferEngine,
 )
+from vllm.platforms import current_platform
 from vllm.utils.network_utils import get_ip, get_open_port
+
+if current_platform.is_rocm():
+    print("Skipping for ROCm: Ray with quantization is unsupported.")
+    sys.exit(0)
+
 
 MODEL_NAME = "facebook/opt-125m"
 # MODEL_NAME = "inference-optimization/Qwen3-0.6B-W4A16-G128"

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -441,6 +441,7 @@ class RocmPlatform(Platform):
         torch.cuda.set_device(device)
 
     @classmethod
+    @with_amdsmi_context
     @lru_cache(maxsize=8)
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
         arch_to_capability = {

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -5,7 +5,6 @@ import os
 from functools import cache, lru_cache, wraps
 from typing import TYPE_CHECKING
 
-import regex as re
 import torch
 
 import vllm.envs as envs
@@ -442,16 +441,9 @@ class RocmPlatform(Platform):
         torch.cuda.set_device(device)
 
     @classmethod
-    @with_amdsmi_context
     @lru_cache(maxsize=8)
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
-        h = amdsmi_get_processor_handles()[device_id]
-        gfx = amdsmi_get_gpu_asic_info(h)["target_graphics_version"]
-        m = re.match(r"gfx(\d)(\d)", gfx)
-        if not m:
-            raise RuntimeError(f"Unexpected gfx format: {gfx}")
-        major = int(m.group(1))
-        minor = int(m.group(2))
+        major, minor = torch.cuda.get_device_capability(device_id)
         return DeviceCapability(major=major, minor=minor)
 
     @classmethod

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -441,7 +441,6 @@ class RocmPlatform(Platform):
         torch.cuda.set_device(device)
 
     @classmethod
-    @with_amdsmi_context
     @lru_cache(maxsize=8)
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
         arch_to_capability = {

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -5,7 +5,6 @@ import os
 from functools import cache, lru_cache, wraps
 from typing import TYPE_CHECKING
 
-import regex as re
 import torch
 
 import vllm.envs as envs
@@ -445,13 +444,14 @@ class RocmPlatform(Platform):
     @with_amdsmi_context
     @lru_cache(maxsize=8)
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
-        h = amdsmi_get_processor_handles()[device_id]
-        gfx = amdsmi_get_gpu_asic_info(h)["target_graphics_version"]
-        m = re.match(r"gfx(\d)(\d)", gfx)
-        if not m:
-            raise RuntimeError(f"Unexpected gfx format: {gfx}")
-        major = int(m.group(1))
-        minor = int(m.group(2))
+        arch_to_capability = {
+            "gfx90a": (9, 0),
+            "gfx942": (9, 4),
+            "gfx950": (9, 5),
+            "gfx11": (11, 0),
+            "gfx12": (12, 0),
+        }
+        major, minor = arch_to_capability[_GCN_ARCH]
         return DeviceCapability(major=major, minor=minor)
 
     @classmethod


### PR DESCRIPTION
## Purpose
Skip the test [new_weight_syncing/rlhf.py in the Distributed Tests (4 GPUs) testgroup](https://github.com/vllm-project/vllm/blob/3b30e6150777de549b11f67dde3ecc0d3b1f3f50/.buildkite/test-amd.yaml#L1944-L1945).

The test fails because `torch.cuda.get_device_capability(device_id)` is called before vLLM initializes `CUDA_VISIBLE_DEVICES`. `amdsmi` doesn't expose a way to get the major, minor compute versions, so there is not a straightforward stateless solution.

The traceback for the failing test is below.

<details>
<summary>Full traceback</summary>

```text
  File "/usr/local/lib/python3.12/dist-packages/ray/_private/function_manager.py", line 693, in actor_method_executor
    return method(__ray_actor, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/ray/util/tracing/tracing_helper.py", line 461, in _resume_span
    return method(self, *_args, **_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/vllm/examples/offline_inference/new_weight_syncing/rlhf.py", line 52, in __init__
    super().__init__(*args, **kwargs)
  File "/workspace/vllm/vllm/entrypoints/llm.py", line 346, in __init__
    self.llm_engine = LLMEngine.from_engine_args(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/vllm/vllm/v1/engine/llm_engine.py", line 169, in from_engine_args
    vllm_config = engine_args.create_engine_config(usage_context)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/vllm/vllm/engine/arg_utils.py", line 1828, in create_engine_config
    config = VllmConfig(
             ^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
  File "/workspace/vllm/vllm/config/vllm.py", line 622, in __post_init__
    self.quant_config = VllmConfig._get_quantization_config(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/vllm/vllm/config/vllm.py", line 449, in _get_quantization_config
    capability_tuple = current_platform.get_device_capability()
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/vllm/vllm/platforms/rocm.py", line 447, in get_device_capability
    major, minor = torch.cuda.get_device_capability(device_id)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py", line 598, in get_device_capability
    prop = get_device_properties(device)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py", line 614, in get_device_properties
    _lazy_init()  # will define _get_device_properties
    ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py", line 410, in _lazy_init
    torch._C._cuda_init()
RuntimeError: No HIP GPUs are available
```

</details>

## Test Plan
```bash
cd examples/offline_inference/new_weight_syncing
python rlhf.py
```

## Test Result
Skip

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
