### PR TITLE
[BugFix] [Build] fix string literals comparison in indexer_k_quant_and_cache calling site

### DIFF
--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -1305,7 +1305,8 @@ void indexer_k_quant_and_cache(
   const at::cuda::OptionalCUDAGuard device_guard(device_of(k));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  DISPATCH_BY_KV_CACHE_DTYPE(k.dtype(), "fp8_e4m3",
+  const std::string kv_cache_dtype = "fp8_e4m3";
+  DISPATCH_BY_KV_CACHE_DTYPE(k.dtype(), kv_cache_dtype,
                              CALL_INDEXER_K_QUANT_AND_CACHE);
 }
 

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -1305,7 +1305,7 @@ void indexer_k_quant_and_cache(
   const at::cuda::OptionalCUDAGuard device_guard(device_of(k));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  const std::string kv_cache_dtype = "fp8_e4m3";
+  static const std::string kv_cache_dtype = "fp8_e4m3";
   DISPATCH_BY_KV_CACHE_DTYPE(k.dtype(), kv_cache_dtype,
                              CALL_INDEXER_K_QUANT_AND_CACHE);
 }


### PR DESCRIPTION
## Purpose
Fix https://github.com/vllm-project/vllm/issues/34132 caused by two pointer compariton.

Related to string literals comparison using == with clang20+ 

```
   DISPATCH_BY_KV_CACHE_DTYPE(k.dtype(), "fp8_e4m3",
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
csrc/quantization/w8a8/fp8/amd/quant_utils.cuh:643:18: note: expanded from macro 'DISPATCH_BY_KV_CACHE_DTYPE'
    if (KV_DTYPE == "auto") {
        ~~~~~~~~ ^  ~~~~~~
```

Instead of passing a C style "fp8_e4m3" pointer, we declare a static const std::string so that == will work.

## Test Plan

CI should pass

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

