### PR TITLE
[Feature] Lazy import of ngram_proposer module.

### DIFF
--- a/vllm/utils/ngram_proposer.py
+++ b/vllm/utils/ngram_proposer.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Provides lazy import of the ngram_proposer module.
+"""
+from typing import TYPE_CHECKING
+
+from vllm.utils.import_utils import LazyLoader
+
+if TYPE_CHECKING:
+    # if type checking, eagerly import the module
+    import vllm.v1.spec_decode.ngram_proposer as ngp
+else:
+    ngp = LazyLoader("ngp", globals(), "vllm.v1.spec_decode.ngram_proposer")

--- a/vllm/utils/ngram_proposer.py
+++ b/vllm/utils/ngram_proposer.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Provides lazy import of the ngram_proposer module.
-"""
+"""Provides lazy import of the ngram_proposer module."""
+
 from typing import TYPE_CHECKING
 
 from vllm.utils.import_utils import LazyLoader


### PR DESCRIPTION
## Purpose

This makes the import of the `ngram_proposer` module lazy.  This is the only module that uses numba and by doing a lazy import we can make numba an optional package, if ngram_proposer is not actually used.  It should also improve startup time by not importing modules that are not needed.

## Test Plan

Run built-in test suite (i.e. "pytest tests/").


## Test Result

There are a couple of failed tests but I believe they are only because of missing other dependencies and not due to this code change (lm_eval, torchvision, pqdm).