### PR TITLE
[CI] Fix bake config artifact path for AMI rebuild pipeline

### DIFF
--- a/.buildkite/image_build/image_build.sh
+++ b/.buildkite/image_build/image_build.sh
@@ -151,7 +151,7 @@ print_bake_config() {
     docker buildx bake -f "${VLLM_BAKE_FILE_PATH}" -f "${CI_HCL_PATH}" --print "${TARGET}" | tee "${BAKE_CONFIG_FILE}" || true
     echo "Saved bake config to ${BAKE_CONFIG_FILE}"
     echo "--- :arrow_down: Uploading bake config to Buildkite"
-    buildkite-agent artifact upload "${BAKE_CONFIG_FILE}"
+    (cd "$(dirname "${BAKE_CONFIG_FILE}")" && buildkite-agent artifact upload "$(basename "${BAKE_CONFIG_FILE}")")
 }
 
 #################################


### PR DESCRIPTION
PR #34569 moved bake config writes to a temp directory to avoid polluting the Docker build context. However, `buildkite-agent artifact upload` preserves the full path, so the artifact gets stored as `tmp/tmp.XXXXX/bake-config-build-NNN.json` instead of just `bake-config-build-NNN.json`. The AMI rebuild pipeline searches by filename and fails to find it.

Fix by uploading from within the temp directory so the artifact path is just the filename.