### PR TITLE
[CI Failure] Disable Qwen3-30B-A3B-MXFP4A16.yaml due to model deletion

### DIFF
--- a/tests/evals/gsm8k/configs/Qwen3-30B-A3B-MXFP4A16.yaml
+++ b/tests/evals/gsm8k/configs/Qwen3-30B-A3B-MXFP4A16.yaml
@@ -1,5 +1,0 @@
-model_name: nm-testing/Qwen3-30B-A3B-MXFP4A16
-accuracy_threshold: 0.88
-num_questions: 1319
-num_fewshot: 5
-server_args: "--enforce-eager --max-model-len 4096"

--- a/tests/evals/gsm8k/configs/models-small.txt
+++ b/tests/evals/gsm8k/configs/models-small.txt
@@ -4,4 +4,3 @@ Llama-3-8B-Instruct-nonuniform-CT.yaml
 Qwen2.5-VL-3B-Instruct-FP8-dynamic.yaml
 Qwen1.5-MoE-W4A16-CT.yaml
 DeepSeek-V2-Lite-Instruct-FP8.yaml
-Qwen3-30B-A3B-MXFP4A16.yaml

--- a/tests/evals/gsm8k/test_gsm8k_correctness.py
+++ b/tests/evals/gsm8k/test_gsm8k_correctness.py
@@ -55,15 +55,6 @@ def test_gsm8k_correctness(config_filename):
     """Test GSM8K correctness for a given model configuration."""
     eval_config = yaml.safe_load(config_filename.read_text(encoding="utf-8"))
 
-    if (
-        not current_platform.is_cuda()
-        and "Qwen3-30B-A3B-MXFP4A16" in eval_config["model_name"]
-    ):
-        pytest.skip(
-            "Skipping Qwen3-30B-A3B-MXFP4A16 on non-CUDA platforms. "
-            "Marlin kernels are not supported."
-        )
-
     # Parse server arguments from config (use shlex to handle quoted strings)
     server_args_str = eval_config.get("server_args", "")
     server_args = shlex.split(server_args_str) if server_args_str else []


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Someone deleted this model and CI is failing https://huggingface.co/nm-testing/Qwen3-30B-A3B-MXFP4A16
https://buildkite.com/vllm/ci/builds/51785/steps/canvas?jid=019c6794-f3c2-4b21-9f70-cc1d4b991e80&tab=output#019c6794-f3c2-4b21-9f70-cc1d4b991e80/L1847
```
[2026-02-16T18:18:58Z] FAILED evals/gsm8k/test_gsm8k_correctness.py::test_gsm8k_correctness[Qwen3-30B-A3B-MXFP4A16] - OSError: nm-testing/Qwen3-30B-A3B-MXFP4A16 is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

