### PR TITLE
[Kernel][Perf] Fuse gather_block_tables + compute_slot_mappings into single kernel

### DIFF
--- a/benchmarks/bench_block_table_kernels.py
+++ b/benchmarks/bench_block_table_kernels.py
@@ -1,0 +1,252 @@
+"""Benchmark block table kernel launch overhead.
+
+Measures:
+1. apply_staged_writes() time (N kernel launches for N groups)
+2. gather_block_tables() time (1 kernel launch)
+3. compute_slot_mappings() time (1 kernel launch)
+4. gather + compute_slot_mappings combined (2 kernel launches)
+5. fused gather+slot_mappings (1 kernel launch)
+6. Total scheduling overhead per step
+"""
+import json
+import sys
+import time
+
+import torch
+
+sys.path.insert(0, '/workspace/h200-block-table-kernel-fusion')
+
+from vllm.v1.worker.gpu.block_table import BlockTables
+
+
+def benchmark_block_table_ops(
+    num_kv_cache_groups: int = 1,
+    block_size: int = 16,
+    max_num_reqs: int = 256,
+    max_num_batched_tokens: int = 8192,
+    max_model_len: int = 4096,
+    num_reqs: int = 128,
+    num_tokens: int = 2048,
+    num_warmup: int = 50,
+    num_iters: int = 200,
+):
+    device = torch.device("cuda:0")
+    block_sizes = [block_size] * num_kv_cache_groups
+
+    bt = BlockTables(
+        block_sizes=block_sizes,
+        max_num_reqs=max_num_reqs,
+        max_num_batched_tokens=max_num_batched_tokens,
+        max_model_len=max_model_len,
+        device=device,
+    )
+
+    # Setup: populate block tables with realistic data
+    max_blocks = max_model_len // block_size
+    for req_idx in range(num_reqs):
+        num_blocks = min(req_idx + 1, max_blocks)
+        block_ids = tuple(
+            list(range(req_idx * max_blocks, req_idx * max_blocks + num_blocks))
+            for _ in range(num_kv_cache_groups)
+        )
+        bt.append_block_ids(req_idx, block_ids, overwrite=True)
+    bt.apply_staged_writes()
+
+    # Create idx_mapping (identity for simplicity)
+    idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=device)
+
+    # Create query_start_loc (uniform distribution)
+    tokens_per_req = num_tokens // num_reqs
+    query_start_loc = torch.arange(
+        0, num_reqs * tokens_per_req + 1, tokens_per_req,
+        dtype=torch.int32, device=device
+    )[:num_reqs + 1]
+    query_start_loc[-1] = num_tokens
+
+    # Create positions (ensure non-negative)
+    positions = torch.zeros(num_tokens, dtype=torch.long, device=device)
+    for i in range(num_reqs):
+        start = query_start_loc[i].item()
+        end = query_start_loc[i + 1].item()
+        n_tok = end - start
+        seq_len = max(n_tok, (i + 1) * (max_model_len // num_reqs))
+        positions[start:end] = torch.arange(seq_len - n_tok, seq_len)
+
+    results = {}
+
+    # Benchmark apply_staged_writes
+    # First stage some writes
+    for req_idx in range(min(num_reqs, 32)):
+        new_blocks = tuple(
+            [req_idx * max_blocks + max_blocks - 1]
+            for _ in range(num_kv_cache_groups)
+        )
+        bt.append_block_ids(req_idx, new_blocks, overwrite=False)
+
+    # Warmup
+    for _ in range(num_warmup):
+        bt.apply_staged_writes()
+        # Re-stage writes for next iteration
+        for req_idx in range(min(num_reqs, 32)):
+            new_blocks = tuple(
+                [req_idx * max_blocks + max_blocks - 1]
+                for _ in range(num_kv_cache_groups)
+            )
+            bt.append_block_ids(req_idx, new_blocks, overwrite=False)
+
+    torch.cuda.synchronize()
+    start_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iters)]
+    end_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iters)]
+
+    for i in range(num_iters):
+        start_events[i].record()
+        bt.apply_staged_writes()
+        end_events[i].record()
+        # Re-stage
+        for req_idx in range(min(num_reqs, 32)):
+            new_blocks = tuple(
+                [req_idx * max_blocks + max_blocks - 1]
+                for _ in range(num_kv_cache_groups)
+            )
+            bt.append_block_ids(req_idx, new_blocks, overwrite=False)
+
+    torch.cuda.synchronize()
+    times = [s.elapsed_time(e) for s, e in zip(start_events, end_events)]
+    results['apply_staged_writes_ms'] = sum(times) / len(times)
+
+    # Ensure writes are applied before gather/slot tests
+    bt.apply_staged_writes()
+
+    # Benchmark gather_block_tables
+    for _ in range(num_warmup):
+        bt.gather_block_tables(idx_mapping)
+
+    torch.cuda.synchronize()
+    start_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iters)]
+    end_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iters)]
+
+    for i in range(num_iters):
+        start_events[i].record()
+        bt.gather_block_tables(idx_mapping)
+        end_events[i].record()
+
+    torch.cuda.synchronize()
+    times = [s.elapsed_time(e) for s, e in zip(start_events, end_events)]
+    results['gather_block_tables_ms'] = sum(times) / len(times)
+
+    # Benchmark compute_slot_mappings
+    for _ in range(num_warmup):
+        bt.compute_slot_mappings(idx_mapping, query_start_loc, positions)
+
+    torch.cuda.synchronize()
+    start_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iters)]
+    end_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iters)]
+
+    for i in range(num_iters):
+        start_events[i].record()
+        bt.compute_slot_mappings(idx_mapping, query_start_loc, positions)
+        end_events[i].record()
+
+    torch.cuda.synchronize()
+    times = [s.elapsed_time(e) for s, e in zip(start_events, end_events)]
+    results['compute_slot_mappings_ms'] = sum(times) / len(times)
+
+    # Benchmark gather + compute_slot_mappings combined (separate kernels)
+    for _ in range(num_warmup):
+        bt.gather_block_tables(idx_mapping)
+        bt.compute_slot_mappings(idx_mapping, query_start_loc, positions)
+
+    torch.cuda.synchronize()
+    start_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iters)]
+    end_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iters)]
+
+    for i in range(num_iters):
+        start_events[i].record()
+        bt.gather_block_tables(idx_mapping)
+        bt.compute_slot_mappings(idx_mapping, query_start_loc, positions)
+        end_events[i].record()
+
+    torch.cuda.synchronize()
+    times = [s.elapsed_time(e) for s, e in zip(start_events, end_events)]
+    results['gather_plus_slots_ms'] = sum(times) / len(times)
+
+    # Benchmark fused gather+slot_mappings (single kernel)
+    for _ in range(num_warmup):
+        bt.gather_and_compute_slot_mappings(idx_mapping, query_start_loc,
+                                            positions)
+
+    torch.cuda.synchronize()
+    start_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iters)]
+    end_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iters)]
+
+    for i in range(num_iters):
+        start_events[i].record()
+        bt.gather_and_compute_slot_mappings(idx_mapping, query_start_loc,
+                                            positions)
+        end_events[i].record()
+
+    torch.cuda.synchronize()
+    times = [s.elapsed_time(e) for s, e in zip(start_events, end_events)]
+    results['fused_gather_slots_ms'] = sum(times) / len(times)
+
+    results['savings_ms'] = (results['gather_plus_slots_ms']
+                             - results['fused_gather_slots_ms'])
+    results['savings_pct'] = (results['savings_ms']
+                              / results['gather_plus_slots_ms'] * 100
+                              if results['gather_plus_slots_ms'] > 0 else 0)
+
+    results['total_separate_ms'] = (results['apply_staged_writes_ms']
+                                    + results['gather_plus_slots_ms'])
+    results['total_fused_ms'] = (results['apply_staged_writes_ms']
+                                 + results['fused_gather_slots_ms'])
+
+    return results
+
+
+if __name__ == "__main__":
+    print("Block Table Kernel Benchmark")
+    print("=" * 60)
+
+    configs = [
+        {"num_kv_cache_groups": 1, "num_reqs": 32, "num_tokens": 512,
+         "label": "small_batch_1grp"},
+        {"num_kv_cache_groups": 1, "num_reqs": 128, "num_tokens": 2048,
+         "label": "medium_batch_1grp"},
+        {"num_kv_cache_groups": 1, "num_reqs": 256, "num_tokens": 8192,
+         "label": "large_batch_1grp"},
+        {"num_kv_cache_groups": 2, "num_reqs": 128, "num_tokens": 2048,
+         "label": "medium_batch_2grp"},
+        {"num_kv_cache_groups": 4, "num_reqs": 128, "num_tokens": 2048,
+         "label": "medium_batch_4grp"},
+    ]
+
+    all_results = {}
+
+    for cfg in configs:
+        label = cfg.pop("label")
+        print(f"\n--- {label} ---")
+        print(f"  Config: {cfg}")
+        results = benchmark_block_table_ops(**cfg)
+        all_results[label] = {**results, **cfg}
+        for k, v in results.items():
+            print(f"  {k}: {v:.4f} ms" if isinstance(v, float) else
+                  f"  {k}: {v}")
+
+    # Save results
+    out_path = '/workspace/h200-block-table-kernel-fusion/results/08-benchmark-comparison/comparison.json'
+    with open(out_path, 'w') as f:
+        json.dump(all_results, f, indent=2)
+    print(f"\nResults saved to {out_path}")
+
+    # Print comparison table
+    print("\n" + "=" * 80)
+    print("| Config | Separate (ms) | Fused (ms) | Savings (us) | Savings (%) |")
+    print("|--------|--------------|------------|-------------|-------------|")
+    for key in sorted(all_results.keys()):
+        r = all_results[key]
+        sep = r['gather_plus_slots_ms']
+        fused = r['fused_gather_slots_ms']
+        savings_us = r['savings_ms'] * 1000
+        savings_pct = r['savings_pct']
+        print(f"| {key:25s} | {sep:.4f} | {fused:.4f} "
+              f"| {savings_us:>8.1f} | {savings_pct:>8.1f}% |")

--- a/benchmarks/bench_block_table_kernels.py
+++ b/benchmarks/bench_block_table_kernels.py
@@ -8,13 +8,15 @@ Measures:
 5. fused gather+slot_mappings (1 kernel launch)
 6. Total scheduling overhead per step
 """
+import argparse
 import json
+import os
 import sys
 import time
 
 import torch
 
-sys.path.insert(0, '/workspace/h200-block-table-kernel-fusion')
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from vllm.v1.worker.gpu.block_table import BlockTables
 
@@ -204,6 +206,11 @@ def benchmark_block_table_ops(
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Benchmark block table kernels")
+    parser.add_argument("--output", type=str, default=None,
+                        help="Path to save JSON results")
+    args = parser.parse_args()
+
     print("Block Table Kernel Benchmark")
     print("=" * 60)
 
@@ -232,11 +239,11 @@ if __name__ == "__main__":
             print(f"  {k}: {v:.4f} ms" if isinstance(v, float) else
                   f"  {k}: {v}")
 
-    # Save results
-    out_path = '/workspace/h200-block-table-kernel-fusion/results/08-benchmark-comparison/comparison.json'
-    with open(out_path, 'w') as f:
-        json.dump(all_results, f, indent=2)
-    print(f"\nResults saved to {out_path}")
+    if args.output:
+        os.makedirs(os.path.dirname(args.output), exist_ok=True)
+        with open(args.output, 'w') as f:
+            json.dump(all_results, f, indent=2)
+        print(f"\nResults saved to {args.output}")
 
     # Print comparison table
     print("\n" + "=" * 80)

--- a/benchmarks/bench_block_table_kernels.py
+++ b/benchmarks/bench_block_table_kernels.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Benchmark block table kernel launch overhead.
 
 Measures:

--- a/tests/v1/worker/test_block_table_kernels.py
+++ b/tests/v1/worker/test_block_table_kernels.py
@@ -1,0 +1,170 @@
+"""Tests for fused block table kernels."""
+import pytest
+import torch
+
+from vllm.v1.worker.gpu.block_table import BlockTables
+
+
+@pytest.fixture
+def device():
+    return torch.device("cuda:0")
+
+
+def _setup_block_tables(device, num_kv_cache_groups=1, block_size=16,
+                         max_num_reqs=32, max_model_len=512,
+                         max_num_batched_tokens=1024):
+    block_sizes = [block_size] * num_kv_cache_groups
+    bt = BlockTables(
+        block_sizes=block_sizes,
+        max_num_reqs=max_num_reqs,
+        max_num_batched_tokens=max_num_batched_tokens,
+        max_model_len=max_model_len,
+        device=device,
+    )
+    return bt
+
+
+def _populate_block_tables(bt, num_reqs, block_size, max_model_len):
+    max_blocks = max_model_len // block_size
+    for req_idx in range(num_reqs):
+        num_blocks = min(req_idx + 1, max_blocks)
+        block_ids = tuple(
+            list(range(req_idx * 100, req_idx * 100 + num_blocks))
+            for _ in range(bt.num_kv_cache_groups)
+        )
+        bt.append_block_ids(req_idx, block_ids, overwrite=True)
+    bt.apply_staged_writes()
+
+
+@pytest.mark.parametrize("num_kv_cache_groups", [1, 2, 4])
+@pytest.mark.parametrize("num_reqs", [1, 16, 64])
+def test_fused_gather_and_slots_matches_separate(device, num_kv_cache_groups,
+                                                  num_reqs):
+    """Verify fused kernel produces identical results to separate kernels."""
+    block_size = 16
+    max_model_len = 512
+    max_num_batched_tokens = 2048
+
+    bt = _setup_block_tables(
+        device, num_kv_cache_groups, block_size,
+        max_num_reqs=64, max_model_len=max_model_len,
+        max_num_batched_tokens=max_num_batched_tokens,
+    )
+    _populate_block_tables(bt, num_reqs, block_size, max_model_len)
+
+    # Create test inputs
+    idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=device)
+    tokens_per_req = max(1, max_num_batched_tokens // max(num_reqs, 1))
+    tokens_per_req = min(tokens_per_req, 32)  # Cap for test
+    num_tokens = num_reqs * tokens_per_req
+
+    query_start_loc = torch.arange(
+        0, num_tokens + 1, tokens_per_req,
+        dtype=torch.int32, device=device
+    )[:num_reqs + 1]
+    query_start_loc[-1] = num_tokens
+
+    positions = torch.zeros(num_tokens, dtype=torch.long, device=device)
+    for i in range(num_reqs):
+        start = query_start_loc[i].item()
+        end = query_start_loc[i + 1].item()
+        positions[start:end] = torch.arange(end - start, dtype=torch.long,
+                                            device=device)
+
+    # Run SEPARATE kernels (reference)
+    ref_block_tables = bt.gather_block_tables(idx_mapping)
+    ref_slot_mappings = bt.compute_slot_mappings(idx_mapping, query_start_loc,
+                                                  positions)
+
+    # Save reference results
+    ref_bt_list = [t.clone() for t in ref_block_tables]
+    ref_sm = ref_slot_mappings.clone()
+
+    # Reset input_block_tables to zeros
+    for ibt in bt.input_block_tables:
+        ibt.zero_()
+    bt.slot_mappings.zero_()
+
+    # Run FUSED kernel
+    fused_block_tables, fused_slot_mappings = \
+        bt.gather_and_compute_slot_mappings(
+            idx_mapping, query_start_loc, positions
+        )
+
+    # Compare block tables
+    for i, (ref, fused) in enumerate(zip(ref_bt_list, fused_block_tables)):
+        assert torch.equal(ref, fused), (
+            f"Block table mismatch for group {i}:\n"
+            f"  ref:   {ref[:3, :10]}\n"
+            f"  fused: {fused[:3, :10]}"
+        )
+
+    # Compare slot mappings
+    assert torch.equal(ref_sm, fused_slot_mappings), (
+        f"Slot mapping mismatch:\n"
+        f"  ref:   {ref_sm[0, :20]}\n"
+        f"  fused: {fused_slot_mappings[0, :20]}"
+    )
+
+    print(f"PASSED: groups={num_kv_cache_groups}, reqs={num_reqs}")
+
+
+@pytest.mark.parametrize("num_kv_cache_groups", [1, 2])
+def test_fused_with_shuffled_idx_mapping(device, num_kv_cache_groups):
+    """Test with non-identity idx_mapping (requests not in order)."""
+    num_reqs = 16
+    block_size = 16
+    max_model_len = 256
+
+    bt = _setup_block_tables(
+        device, num_kv_cache_groups, block_size,
+        max_num_reqs=32, max_model_len=max_model_len,
+        max_num_batched_tokens=1024,
+    )
+    _populate_block_tables(bt, 32, block_size, max_model_len)
+
+    # Shuffled mapping: batch_idx 0 -> req 5, batch_idx 1 -> req 2, etc.
+    perm = torch.randperm(32, device=device)[:num_reqs].to(torch.int32)
+    idx_mapping = perm
+
+    tokens_per_req = 8
+    num_tokens = num_reqs * tokens_per_req
+    query_start_loc = torch.arange(0, num_tokens + 1, tokens_per_req,
+                                    dtype=torch.int32,
+                                    device=device)[:num_reqs + 1]
+
+    positions = torch.zeros(num_tokens, dtype=torch.long, device=device)
+    for i in range(num_reqs):
+        start = query_start_loc[i].item()
+        end = query_start_loc[i + 1].item()
+        positions[start:end] = torch.arange(end - start, dtype=torch.long,
+                                            device=device)
+
+    # Reference
+    ref_block_tables = bt.gather_block_tables(idx_mapping)
+    ref_slot_mappings = bt.compute_slot_mappings(idx_mapping, query_start_loc,
+                                                  positions)
+    ref_bt_list = [t.clone() for t in ref_block_tables]
+    ref_sm = ref_slot_mappings.clone()
+
+    # Reset and run fused
+    for ibt in bt.input_block_tables:
+        ibt.zero_()
+    bt.slot_mappings.zero_()
+
+    fused_block_tables, fused_slot_mappings = \
+        bt.gather_and_compute_slot_mappings(
+            idx_mapping, query_start_loc, positions
+        )
+
+    for i, (ref, fused) in enumerate(zip(ref_bt_list, fused_block_tables)):
+        assert torch.equal(ref, fused), \
+            f"Block table mismatch for group {i} with shuffled mapping"
+
+    assert torch.equal(ref_sm, fused_slot_mappings), \
+        "Slot mapping mismatch with shuffled mapping"
+    print(f"PASSED: shuffled idx_mapping, groups={num_kv_cache_groups}")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-x"])

--- a/tests/v1/worker/test_block_table_kernels.py
+++ b/tests/v1/worker/test_block_table_kernels.py
@@ -1,4 +1,5 @@
 """Tests for fused block table kernels."""
+
 import pytest
 import torch
 
@@ -10,9 +11,14 @@ def device():
     return torch.device("cuda:0")
 
 
-def _setup_block_tables(device, num_kv_cache_groups=1, block_size=16,
-                         max_num_reqs=32, max_model_len=512,
-                         max_num_batched_tokens=1024):
+def _setup_block_tables(
+    device,
+    num_kv_cache_groups=1,
+    block_size=16,
+    max_num_reqs=32,
+    max_model_len=512,
+    max_num_batched_tokens=1024,
+):
     block_sizes = [block_size] * num_kv_cache_groups
     bt = BlockTables(
         block_sizes=block_sizes,
@@ -38,16 +44,18 @@ def _populate_block_tables(bt, num_reqs, block_size, max_model_len):
 
 @pytest.mark.parametrize("num_kv_cache_groups", [1, 2, 4])
 @pytest.mark.parametrize("num_reqs", [1, 16, 64])
-def test_fused_gather_and_slots_matches_separate(device, num_kv_cache_groups,
-                                                  num_reqs):
+def test_fused_gather_and_slots_matches_separate(device, num_kv_cache_groups, num_reqs):
     """Verify fused kernel produces identical results to separate kernels."""
     block_size = 16
     max_model_len = 512
     max_num_batched_tokens = 2048
 
     bt = _setup_block_tables(
-        device, num_kv_cache_groups, block_size,
-        max_num_reqs=64, max_model_len=max_model_len,
+        device,
+        num_kv_cache_groups,
+        block_size,
+        max_num_reqs=64,
+        max_model_len=max_model_len,
         max_num_batched_tokens=max_num_batched_tokens,
     )
     _populate_block_tables(bt, num_reqs, block_size, max_model_len)
@@ -59,22 +67,23 @@ def test_fused_gather_and_slots_matches_separate(device, num_kv_cache_groups,
     num_tokens = num_reqs * tokens_per_req
 
     query_start_loc = torch.arange(
-        0, num_tokens + 1, tokens_per_req,
-        dtype=torch.int32, device=device
-    )[:num_reqs + 1]
+        0, num_tokens + 1, tokens_per_req, dtype=torch.int32, device=device
+    )[: num_reqs + 1]
     query_start_loc[-1] = num_tokens
 
     positions = torch.zeros(num_tokens, dtype=torch.long, device=device)
     for i in range(num_reqs):
         start = query_start_loc[i].item()
         end = query_start_loc[i + 1].item()
-        positions[start:end] = torch.arange(end - start, dtype=torch.long,
-                                            device=device)
+        positions[start:end] = torch.arange(
+            end - start, dtype=torch.long, device=device
+        )
 
     # Run SEPARATE kernels (reference)
     ref_block_tables = bt.gather_block_tables(idx_mapping)
-    ref_slot_mappings = bt.compute_slot_mappings(idx_mapping, query_start_loc,
-                                                  positions)
+    ref_slot_mappings = bt.compute_slot_mappings(
+        idx_mapping, query_start_loc, positions
+    )
 
     # Save reference results
     ref_bt_list = [t.clone() for t in ref_block_tables]
@@ -86,10 +95,9 @@ def test_fused_gather_and_slots_matches_separate(device, num_kv_cache_groups,
     bt.slot_mappings.zero_()
 
     # Run FUSED kernel
-    fused_block_tables, fused_slot_mappings = \
-        bt.gather_and_compute_slot_mappings(
-            idx_mapping, query_start_loc, positions
-        )
+    fused_block_tables, fused_slot_mappings = bt.gather_and_compute_slot_mappings(
+        idx_mapping, query_start_loc, positions
+    )
 
     # Compare block tables
     for i, (ref, fused) in enumerate(zip(ref_bt_list, fused_block_tables)):
@@ -117,8 +125,11 @@ def test_fused_with_shuffled_idx_mapping(device, num_kv_cache_groups):
     max_model_len = 256
 
     bt = _setup_block_tables(
-        device, num_kv_cache_groups, block_size,
-        max_num_reqs=32, max_model_len=max_model_len,
+        device,
+        num_kv_cache_groups,
+        block_size,
+        max_num_reqs=32,
+        max_model_len=max_model_len,
         max_num_batched_tokens=1024,
     )
     _populate_block_tables(bt, 32, block_size, max_model_len)
@@ -129,21 +140,23 @@ def test_fused_with_shuffled_idx_mapping(device, num_kv_cache_groups):
 
     tokens_per_req = 8
     num_tokens = num_reqs * tokens_per_req
-    query_start_loc = torch.arange(0, num_tokens + 1, tokens_per_req,
-                                    dtype=torch.int32,
-                                    device=device)[:num_reqs + 1]
+    query_start_loc = torch.arange(
+        0, num_tokens + 1, tokens_per_req, dtype=torch.int32, device=device
+    )[: num_reqs + 1]
 
     positions = torch.zeros(num_tokens, dtype=torch.long, device=device)
     for i in range(num_reqs):
         start = query_start_loc[i].item()
         end = query_start_loc[i + 1].item()
-        positions[start:end] = torch.arange(end - start, dtype=torch.long,
-                                            device=device)
+        positions[start:end] = torch.arange(
+            end - start, dtype=torch.long, device=device
+        )
 
     # Reference
     ref_block_tables = bt.gather_block_tables(idx_mapping)
-    ref_slot_mappings = bt.compute_slot_mappings(idx_mapping, query_start_loc,
-                                                  positions)
+    ref_slot_mappings = bt.compute_slot_mappings(
+        idx_mapping, query_start_loc, positions
+    )
     ref_bt_list = [t.clone() for t in ref_block_tables]
     ref_sm = ref_slot_mappings.clone()
 
@@ -152,17 +165,18 @@ def test_fused_with_shuffled_idx_mapping(device, num_kv_cache_groups):
         ibt.zero_()
     bt.slot_mappings.zero_()
 
-    fused_block_tables, fused_slot_mappings = \
-        bt.gather_and_compute_slot_mappings(
-            idx_mapping, query_start_loc, positions
-        )
+    fused_block_tables, fused_slot_mappings = bt.gather_and_compute_slot_mappings(
+        idx_mapping, query_start_loc, positions
+    )
 
     for i, (ref, fused) in enumerate(zip(ref_bt_list, fused_block_tables)):
-        assert torch.equal(ref, fused), \
+        assert torch.equal(ref, fused), (
             f"Block table mismatch for group {i} with shuffled mapping"
+        )
 
-    assert torch.equal(ref_sm, fused_slot_mappings), \
+    assert torch.equal(ref_sm, fused_slot_mappings), (
         "Slot mapping mismatch with shuffled mapping"
+    )
     print(f"PASSED: shuffled idx_mapping, groups={num_kv_cache_groups}")
 
 

--- a/tests/v1/worker/test_block_table_kernels.py
+++ b/tests/v1/worker/test_block_table_kernels.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Tests for fused block table kernels."""
 
 import pytest

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -87,11 +87,8 @@ class BlockTables:
             self.num_blocks.np[i, req_index] = start + len(block_ids)
 
     def apply_staged_writes(self) -> None:
-        # NOTE: Each block_table.apply_write() already batches all writes for
-        # that group into a single kernel launch. The loop here launches one
-        # kernel per KV cache group. For most models (num_kv_cache_groups == 1),
-        # this is a single launch. For hybrid attention models with multiple
-        # groups, this could be further optimized by batching across groups.
+        # TODO(woosuk): This can be inefficient since it launches one kernel per
+        # block table. Implement a kernel to handle all block tables at once.
         for block_table in self.block_tables:
             block_table.apply_write()
         self.num_blocks.copy_to_uva()

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -87,8 +87,11 @@ class BlockTables:
             self.num_blocks.np[i, req_index] = start + len(block_ids)
 
     def apply_staged_writes(self) -> None:
-        # TODO(woosuk): This can be inefficient since it launches one kernel per
-        # block table. Implement a kernel to handle all block tables at once.
+        # NOTE: Each block_table.apply_write() already batches all writes for
+        # that group into a single kernel launch. The loop here launches one
+        # kernel per KV cache group. For most models (num_kv_cache_groups == 1),
+        # this is a single launch. For hybrid attention models with multiple
+        # groups, this could be further optimized by batching across groups.
         for block_table in self.block_tables:
             block_table.apply_write()
         self.num_blocks.copy_to_uva()
@@ -136,9 +139,113 @@ class BlockTables:
         )
         return self.slot_mappings[:, :num_tokens]
 
+    def gather_and_compute_slot_mappings(
+        self,
+        idx_mapping: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        """Fused gather_block_tables + compute_slot_mappings in one kernel."""
+        num_reqs = idx_mapping.shape[0]
+        num_tokens = positions.shape[0]
+        num_groups = self.num_kv_cache_groups
+        _fused_gather_and_slot_mappings_kernel[(num_groups, num_reqs + 1)](
+            idx_mapping,
+            self.block_table_ptrs,
+            self.input_block_table_ptrs,
+            self.block_table_strides,
+            self.num_blocks.gpu,
+            self.num_blocks.gpu.stride(0),
+            num_tokens,
+            self.max_num_batched_tokens,
+            query_start_loc,
+            positions,
+            self.block_sizes_tensor,
+            self.slot_mappings,
+            self.slot_mappings.stride(0),
+            PAD_ID=PAD_SLOT_ID,
+            GATHER_BLOCK_SIZE=1024,  # type: ignore
+            SLOT_BLOCK_SIZE=1024,  # type: ignore
+        )
+        block_tables = tuple(
+            bt[:num_reqs] for bt in self.input_block_tables
+        )
+        slot_mappings = self.slot_mappings[:, :num_tokens]
+        return block_tables, slot_mappings
+
     def get_dummy_slot_mappings(self, num_tokens: int) -> torch.Tensor:
         self.slot_mappings.fill_(PAD_SLOT_ID)
         return self.slot_mappings[:, :num_tokens]
+
+
+@triton.jit
+def _fused_gather_and_slot_mappings_kernel(
+    # Gather parameters
+    batch_idx_to_req_idx,     # [batch_size]
+    src_block_table_ptrs,     # [num_kv_cache_groups]
+    dst_block_table_ptrs,     # [num_kv_cache_groups]
+    block_table_strides,      # [num_kv_cache_groups]
+    num_blocks_ptr,           # [num_kv_cache_groups, max_num_reqs]
+    num_blocks_stride,
+    # Slot mapping parameters
+    num_tokens,
+    max_num_tokens,
+    query_start_loc,          # [num_reqs + 1]
+    pos,                      # [num_tokens]
+    block_sizes,              # [num_kv_cache_groups]
+    slot_mappings_ptr,        # [num_kv_cache_groups, max_num_tokens]
+    slot_mappings_stride,
+    # Constants
+    PAD_ID: tl.constexpr,
+    GATHER_BLOCK_SIZE: tl.constexpr,
+    SLOT_BLOCK_SIZE: tl.constexpr,
+):
+    group_id = tl.program_id(0)
+    batch_idx = tl.program_id(1)
+
+    slot_mapping_ptr = slot_mappings_ptr + group_id * slot_mappings_stride
+
+    # Last program handles padding (same as original _compute_slot_mappings)
+    if batch_idx == tl.num_programs(1) - 1:
+        for i in range(num_tokens, max_num_tokens, SLOT_BLOCK_SIZE):
+            offset = i + tl.arange(0, SLOT_BLOCK_SIZE)
+            tl.store(slot_mapping_ptr + offset, PAD_ID,
+                     mask=offset < max_num_tokens)
+        return
+
+    req_idx = tl.load(batch_idx_to_req_idx + batch_idx)
+    stride = tl.load(block_table_strides + group_id)
+    src_block_table_ptr = _load_ptr(src_block_table_ptrs + group_id, tl.int32)
+
+    # --- Phase A: Gather block table row ---
+    group_num_blocks_ptr = num_blocks_ptr + group_id * num_blocks_stride
+    num_blocks = tl.load(group_num_blocks_ptr + req_idx)
+
+    src_row_ptr = src_block_table_ptr + req_idx * stride
+    dst_block_table_ptr = _load_ptr(dst_block_table_ptrs + group_id, tl.int32)
+    dst_row_ptr = dst_block_table_ptr + batch_idx * stride
+
+    for i in tl.range(0, num_blocks, GATHER_BLOCK_SIZE):
+        offset = i + tl.arange(0, GATHER_BLOCK_SIZE)
+        block_ids = tl.load(src_row_ptr + offset, mask=offset < num_blocks)
+        tl.store(dst_row_ptr + offset, block_ids, mask=offset < num_blocks)
+
+    # --- Phase B: Compute slot mappings ---
+    block_size = tl.load(block_sizes + group_id)
+
+    start_idx = tl.load(query_start_loc + batch_idx)
+    end_idx = tl.load(query_start_loc + batch_idx + 1)
+
+    # Read from SOURCE block table directly (avoids dependency on gather)
+    for i in range(start_idx, end_idx, SLOT_BLOCK_SIZE):
+        offset = i + tl.arange(0, SLOT_BLOCK_SIZE)
+        positions = tl.load(pos + offset, mask=offset < end_idx, other=0)
+        block_indices = positions // block_size
+        block_numbers = tl.load(
+            src_block_table_ptr + req_idx * stride + block_indices
+        )
+        slot_ids = block_numbers * block_size + positions % block_size
+        tl.store(slot_mapping_ptr + offset, slot_ids, mask=offset < end_idx)
 
 
 @triton.jit

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -608,12 +608,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # Fused gather block tables + compute slot mappings (single kernel).
         # Block tables: num_kv_cache_groups x [num_reqs, max_num_blocks]
         # Slot mappings: [num_kv_cache_groups, num_tokens]
-        block_tables, slot_mappings = \
+        block_tables, slot_mappings = (
             self.block_tables.gather_and_compute_slot_mappings(
                 idx_mapping,
                 query_start_loc,
                 self.input_buffers.positions[:num_tokens],
             )
+        )
         # Layer name -> slot mapping.
         slot_mappings_by_layer = build_slot_mappings_by_layer(
             slot_mappings, self.kv_cache_config


### PR DESCRIPTION
## Purpose

Fuse `gather_block_tables()` and `compute_slot_mappings()` into a single Triton kernel launch, reducing per-step kernel launch overhead by ~18-99us (27-63%) on H200.

Currently in `BlockTables`, `gather_block_tables` and `compute_slot_mappings` are two separate kernel launches called sequentially in `GPUModelRunner.prepare_inputs()`. The slot mapping computation reads from the **source** block table (not the gathered output), so both operations can safely execute within a single kernel with no data dependency.

Related TODO at `vllm/v1/worker/gpu/block_table.py:90-94` (fusing `apply_staged_writes` across groups) remains for future work.

### Changes
- **New kernel:** `_fused_gather_and_slot_mappings_kernel` — combines block table gathering and slot mapping computation in one Triton kernel with grid `[num_kv_cache_groups, num_reqs + 1]`
- **New method:** `BlockTables.gather_and_compute_slot_mappings()` replaces sequential calls
- **Updated caller:** `GPUModelRunner.prepare_inputs()` uses the fused method
- **Original methods preserved** for backward compatibility (used by speculative decoding in `eagle.py`)

## Test Plan

```bash
# Unit tests (11 parametrized cases)
python3 -m pytest tests/v1/worker/test_block_table_kernels.py -v --noconftest

# Benchmark
python3 benchmarks/bench_block_table_kernels.py

# End-to-end model correctness (Qwen3-VL-2B-Instruct)
# Verified coherent text generation through full vLLM inference pipeline
```

### Unit test coverage:
- `num_kv_cache_groups` = {1, 2, 4} (standard + hybrid attention models)
- `num_reqs` = {1, 16, 64}
- Identity and shuffled `idx_mapping` (non-trivial batch ordering)
- Exact `torch.equal()` comparison against separate kernel outputs (bit-identical)

## Test Result

All 11 unit tests pass. Fused kernel produces **bit-identical** results to separate kernels.

### Benchmark (H200, CUDA_LAUNCH_BLOCKING=1)

| Config | Separate (ms) | Fused (ms) | Savings (us) | Savings (%) |
|--------|:---:|:---:|:---:|:---:|
| 32 reqs, 1 group | 0.077 | 0.052 | 25.3 | **32.8%** |
| 128 reqs, 1 group | 0.156 | 0.057 | 98.8 | **63.4%** |
| 256 reqs, 1 group | 0.078 | 0.055 | 23.6 | **30.2%** |
| 128 reqs, 2 groups | 0.120 | 0.087 | 32.2 | **27.0%** |
| 128 reqs, 4 groups | 0.085 | 0.062 | 23.4 | **27.5%** |

### E2E model correctness
Qwen3-VL-2B-Instruct generates coherent, correct text output through the full inference pipeline with the fused kernel active.

## Technical Details

The fused kernel uses a 2D grid `[num_kv_cache_groups, num_reqs + 1]`:
- Each program handles one `(group_id, batch_idx)` pair
- **Phase A:** copies block table row from source to destination (gather)
- **Phase B:** computes slot mappings from source block table directly
- **Last program** per group handles padding `[num_tokens, max_num_tokens)` with `PAD_SLOT_ID` for CUDA graph compatibility

Key insight: slot mappings read from the **source** block table using `req_idx` (from `idx_mapping`), not from the gathered destination. This means no dependency between Phase A and Phase B — they can execute within the same kernel without ordering constraints.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update, such as updating supported_models.md and examples for a new model.
- [ ] (Optional) Release notes update.

</details>