### PR TITLE
fix(modelopt): average divergent w13 scale factors for NVFP4 MoE

### DIFF
--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -1396,10 +1396,10 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
             layer.w13_weight_scale_2[:, 0], layer.w13_weight_scale_2[:, 1]
         ):
             logger.warning_once(
-                "w1_weight_scale_2 must match w3_weight_scale_2. "
-                "Accuracy may be affected."
+                "w1_weight_scale_2 != w3_weight_scale_2; averaging both scales "
+                "for w13. This avoids dropping one branch scale entirely."
             )
-        w13_weight_scale_2 = layer.w13_weight_scale_2[:, 0].contiguous()
+        w13_weight_scale_2 = layer.w13_weight_scale_2.mean(dim=1).contiguous()
 
         (
             w13,


### PR DESCRIPTION
## Summary
- average `w13_weight_scale_2` across both branches when `w1` and `w3` scales differ instead of always taking column 0
- update warning text to reflect the fallback behavior

## Why
For GLM-4.7 Flash NVFP4 MoE, we observed cases where `w1_weight_scale_2` and `w3_weight_scale_2` differ. Taking only one branch scale can degrade output quality. Averaging preserves both branch scales and avoids dropping one branch entirely.

## Validation
- built and served with this patch in our local `vllm-glm:nightly-glm-scalefix` runtime
- verified coherent text responses on the quantized GLM-4.7 Flash deployment path
