### PR TITLE
[GGUF][Model] Add Qwen3-Coder-Next GGUF support

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -8,6 +8,7 @@ from itertools import islice
 import torch
 from einops import rearrange
 from torch import nn
+from torch.nn.parameter import UninitializedParameter
 from transformers.activations import ACT2FN
 
 from vllm.compilation.decorators import support_torch_compile
@@ -92,7 +93,6 @@ from .interfaces import (
     SupportsPP,
 )
 from .utils import (
-    AutoWeightsLoader,
     PPMissingLayer,
     extract_layer_index,
     is_pp_missing_parameter,
@@ -1108,10 +1108,12 @@ class Qwen3NextModel(nn.Module):
         self.config = config
 
         self.vocab_size = config.vocab_size
+        quant_config = vllm_config.quant_config
 
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
         )
 
         def get_layer(prefix: str):
@@ -1200,6 +1202,22 @@ class Qwen3NextModel(nn.Module):
             if name.startswith("mtp."):
                 continue
 
+            # ---- GGUF data transformations for qwen3_next ----
+            # ssm_a: GGUF stores -exp(A_log), model expects A_log
+            if "A_log" in name or "ssm_a" in name:
+                loaded_weight = torch.log(-loaded_weight.float()).to(
+                    loaded_weight.dtype
+                )
+            # Norm weights: GGUF stores weight+1, reverse: weight-1
+            # Exception: ssm_norm (linear_attn.norm) was NOT +1'd
+            elif (
+                "norm" in name
+                and name.endswith(".weight")
+                and "ssm_norm" not in name
+                and "linear_attn.norm" not in name
+            ):
+                loaded_weight = loaded_weight - 1
+
             # Remapping the name of FP8 kv-scale.
             if name.endswith("scale"):
                 name = maybe_remap_kv_scale_name(name, params_dict)
@@ -1260,14 +1278,33 @@ class Qwen3NextModel(nn.Module):
                     if is_pp_missing_parameter(name, self):
                         continue
                     if name not in params_dict:
-                        logger.warning_once(
-                            f"Parameter {name} not found in params_dict, skip loading"
+                        logger.warning(
+                            "Parameter %s not found in params_dict, skip loading",
+                            name,
                         )
                         continue
                     param = params_dict[name]
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
                     )
+                    # GGUF shape fixups (only for materialized params)
+                    if not isinstance(param, UninitializedParameter):
+                        # GGUF may provide 1D weights for 2D parameters
+                        # (e.g. shared_expert_gate [hidden] -> [1, hidden])
+                        if (
+                            loaded_weight.dim() == 1
+                            and param.dim() == 2
+                            and param.size(0) == 1
+                        ):
+                            loaded_weight = loaded_weight.unsqueeze(0)
+                        # GGUF conv1d weights are 2D [channels, kernel]
+                        # but nn.Conv1d expects 3D [channels, 1, kernel]
+                        if (
+                            loaded_weight.dim() == 2
+                            and param.dim() == 3
+                            and param.size(1) == 1
+                        ):
+                            loaded_weight = loaded_weight.unsqueeze(1)
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)
         return loaded_params
@@ -1358,6 +1395,7 @@ class Qwen3NextForCausalLM(
         self.lm_head = ParallelLMHead(
             config.vocab_size,
             config.hidden_size,
+            quant_config=self.quant_config,
             prefix=maybe_prefix(prefix, "lm_head"),
         )
         self.logits_processor = LogitsProcessor(config.vocab_size)
@@ -1429,11 +1467,41 @@ class Qwen3NextForCausalLM(
         return self.logits_processor(self.lm_head, hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        loader = AutoWeightsLoader(
-            self,
-            skip_prefixes=["mtp."],
+        # Bypass AutoWeightsLoader to avoid itertools.groupby splitting
+        # non-contiguous prefix groups from the GGUF two-pass iterator
+        # (pass 1 yields all qweight_type, then pass 2 yields all qweight,
+        #  with lm_head entries between them breaking the "model" group).
+        from vllm.model_executor.model_loader.weight_utils import (
+            default_weight_loader,
         )
-        return loader.load_weights(weights)
+
+        lm_head_weights: list[tuple[str, torch.Tensor]] = []
+
+        def _route_to_model() -> Iterable[tuple[str, torch.Tensor]]:
+            for name, w in weights:
+                if name.startswith("mtp."):
+                    continue
+                elif name.startswith("lm_head."):
+                    lm_head_weights.append((name, w))
+                elif name.startswith("model."):
+                    yield name[len("model.") :], w
+                else:
+                    # GGUF names may already lack model. prefix
+                    yield name, w
+
+        model_loaded = self.model.load_weights(_route_to_model())
+        loaded = {"model." + n for n in model_loaded}
+
+        # Load lm_head weights that were collected during iteration
+        params = dict(self.named_parameters())
+        for name, w in lm_head_weights:
+            if name in params:
+                param = params[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, w)
+                loaded.add(name)
+
+        return loaded
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()


### PR DESCRIPTION
## Summary

Enable GGUF quantized inference for **Qwen3-Coder-Next** (Qwen3NextForCausalLM) — an 80B MoE model with 3B active parameters, hybrid Gated DeltaNet + Gated Attention architecture, 512 experts with top-10 routing.

This PR adds:
- **GGUF bfloat16 activation support** with automatic fp16 kernel fallback (needed because DeltaNet recurrence requires bf16 for numerical stability, but GGML CUDA kernels only support fp16)
- **GGUF weight loading** for Qwen3Next: tensor name mappings, QKVZ merge iterator (merges `attn_qkv` + `attn_gate` → interleaved `in_proj_qkvz`), MoE expert mappings, sideload patterns
- **Model-side GGUF integration**: data transforms (A_log inversion, norm weight correction), shape fixups (1D→2D, 2D→3D), `AutoWeightsLoader` bypass for GGUF two-pass iterator compatibility

### Key technical details

**bfloat16 + GGUF (generic, benefits other models too):**
- GGML matmul/MoE kernels only support fp16 activations. When running in bf16, we cast inputs to fp16 before kernel calls and cast back after.
- The MMQ MoE kernel (`ggml_moe_a8`) produces NaN with bf16→fp16 converted data, so we skip it and use MMVQ (`ggml_moe_a8_vec`) instead.
- MMVQ has a 64-token launch config limit, so we chunk inputs into groups of 64 tokens when bf16 conversion is active.

**Qwen3Next GGUF weight loading:**
- The GGUF file stores the DeltaNet input projection as two separate tensors (`attn_qkv` for Q/K/V and `attn_gate` for Z), but the model expects a single fused `in_proj_qkvz` with interleaved layout. A custom second-pass iterator dequantizes and merges them.
- Multiple tensor name mapping fixes: MoE experts, `ssm_dt.bias`, `ssm_a` (suffix-less name bug), removal of incorrect `ssm_in` mapping.

**AutoWeightsLoader bypass:**
- GGUF's two-pass iterator (first `qweight_type` metadata, then `qweight` data) interleaves `lm_head` entries between `model.*` entries, breaking `itertools.groupby` in `AutoWeightsLoader`. Manual weight routing fixes this.

## Test plan

- [x] All 975/975 GGUF parameters load correctly
- [x] Short prompts (5-54 tokens) produce correct output
- [x] Long prompts (75-504 tokens) produce correct output (was previously garbage due to MMQ NaN bug)
- [x] PIECEWISE CUDA graphs work (~79 tok/s decode on RTX PRO 6000 Blackwell)
- [x] Claude Code CLI end-to-end via vLLM's native Anthropic Messages API
- [x] `ruff check` and `ruff format` pass

## Hardware tested

- NVIDIA RTX PRO 6000 Blackwell (96GB GDDR7, compute capability 12.0)
- WSL2 Ubuntu 24.04, CUDA 12.8, Python 3.12
- Model: `unsloth/Qwen3-Coder-Next-GGUF` Q4_K_XL (48.5GB)

## Files changed

| File | Lines | Description |
|------|-------|-------------|
| `vllm/model_executor/layers/quantization/gguf.py` | +63/-13 | bf16 support with fp16 kernel fallback |
| `vllm/model_executor/model_loader/gguf_loader.py` | +141 | Qwen3Next tensor mappings + QKVZ merge |
| `vllm/model_executor/models/qwen3_next.py` | +75/-8 | GGUF data transforms, shape fixups, weight routing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)