### PR TITLE
[kv_offload+HMA][1/N]: Worker-side support for multiple HMA groups

### DIFF
--- a/vllm/v1/kv_offload/mediums.py
+++ b/vllm/v1/kv_offload/mediums.py
@@ -10,10 +10,19 @@ from vllm.v1.kv_offload.abstract import LoadStoreSpec
 class BlockIDsLoadStoreSpec(LoadStoreSpec, ABC):
     """
     Spec for loading/storing KV blocks from given block numbers.
+
+    If group_sizes is given, then it is assumed that block_ids list
+    can be braked to respective sub-lists given by group_sizes, where
+    each sub-list represent a series of consecutive logical blocks.
+    group_sizes = None is equivalent to group_sizes = [len(block_ids)].
     """
 
-    def __init__(self, block_ids: list[int]):
+    def __init__(self, block_ids: list[int], group_sizes: list[int] | None = None):
         self.block_ids = np.array(block_ids, dtype=np.int64)
+        self.group_sizes = (
+            np.array(group_sizes, dtype=np.int64) if group_sizes else None
+        )
+        assert group_sizes is None or sum(group_sizes) == len(block_ids)
 
     def __repr__(self) -> str:
         return repr(self.block_ids)


### PR DESCRIPTION
This PR enables the kv_offload worker to load KV data for multiple KV cache groups.
It still gets a list of block IDs to load, where the block IDs are ordered by group group0_block_ids...group1_block_ids... We add an additional field group_sizes which encode the sizes of each group of block IDs. This allows the worker to determine positions where a new group of block IDs start. This is needed in order to check whether respective data from the offloaded medium (e.g. CPU) should be skipped, in the case where offloaded_block_size > logical_block_size (gpu_block_size).