### PR TITLE
[WIP][Bugfix] Fix type mismatch in causal_conv1d Triton kernels PAD_SLOT_ID checks

### DIFF
--- a/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
+++ b/vllm/model_executor/layers/mamba/ops/causal_conv1d.py
@@ -78,7 +78,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     # BLOCK_N elements along the feature-dimension (channel)
     idx_feats = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
 
-    if idx_seq == pad_slot_id:
+    if idx_seq < 0:
         return
 
     sequence_start_index = tl.load(query_start_loc_ptr + idx_seq)
@@ -134,7 +134,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     ).to(tl.int64)
 
     if USE_PAD_SLOT:  # noqa
-        if conv_states_input_coord == pad_slot_id:
+        if conv_states_input_coord < 0:
             # not processing as this is not the actual sequence
             return
     conv_states_base = (
@@ -812,7 +812,7 @@ def _causal_conv1d_update_kernel(
     ).to(tl.int64)
 
     if USE_PAD_SLOT:  # noqa
-        if conv_states_input_coord == pad_slot_id:
+        if conv_states_input_coord < 0:
             # not processing as this is not the actual sequence
             return
 


### PR DESCRIPTION
## Purpose

Fix a type mismatch in `causal_conv1d` Triton kernel PAD_SLOT_ID checks that could cause illegal memory access when running hybrid models (e.g., Qwen3.5-397B-A17B) with CUDA graphs.

**Issue**: The `causal_conv1d` Triton kernels use `== pad_slot_id` equality checks to detect padded CUDA graph entries. `pad_slot_id` is declared as `tl.constexpr` (a compile-time Python int `-1`), while the values loaded from tensors are cast to `tl.int64` at runtime. This cross-type equality comparison may behave unexpectedly in Triton. When the check fails, the kernel uses `-1` as a memory offset, causing out-of-bounds access.

**Fix**: Replace `== pad_slot_id` with `< 0` at 3 locations. This is robust because:
- Valid slot/state indices are always non-negative
- `PAD_SLOT_ID = -1` is the only negative sentinel value
- `< 0` avoids any type promotion ambiguity
- Matches the pattern used by the working `fused_recurrent_gated_delta_rule_fwd_kernel`

## Status: WIP — Partial Fix

**This fix addresses the `tl.constexpr` vs `tl.int64` type mismatch**, which is a correctness improvement for CUDA graph padding scenarios. However, **@vadiklyutiy reported the illegal memory access still occurs** with this change applied.

### Analysis of the remaining issue

The crash in #34619 occurs at step 0 with ~1000 tokens, which means `CUDAGraphMode.NONE` (since 1000 > `max_cudagraph_capture_size` of 512). At step 0 with no CUDA graphs active, there is no batch padding and no `PAD_SLOT_ID` values in the tensors — so the `< 0` check never triggers.

Key observations:
- `--enforce-eager` prevents the crash (disables `torch.compile`, since CUDA graphs are already NONE)
- `--no-async-scheduling` prevents the crash
- `CUDA_LAUNCH_BLOCKING=1` prevents the crash (confirms an async race condition)
- The error is reported asynchronously at a blocking GPU copy in `compute_causal_conv1d_metadata`, but originates from an earlier kernel

This suggests the remaining root cause is likely a **race condition or stream synchronization issue** between `torch.compile`'d regions and/or async scheduling streams, possibly specific to B200/SM100 hardware. Further investigation with multi-GPU access would be needed to fully diagnose.

Related: #34619

## Test Plan

1. Run existing causal_conv1d kernel tests:
   ```
   python -m pytest tests/kernels/mamba/test_causal_conv1d.py -v
   ```
2. Full reproduction requires 8-GPU setup with `-dp 8 --enable-expert-parallel`

## Test Result

All 164 tests pass on the existing test suite (tested before reporter feedback).