### PR TITLE
Fix docs build warning

### DIFF
--- a/vllm/v1/worker/gpu/pp_handler.py
+++ b/vllm/v1/worker/gpu/pp_handler.py
@@ -70,7 +70,6 @@ class PPHandler:
 
         Args:
             num_reqs: Number of requests in the batch.
-            device: Device to create tensors on.
             max_sample_len: Maximum number of tokens sampled per request
                 (1 for regular decode, >1 for speculative decoding).
 


### PR DESCRIPTION
Docstring was not updated when the arg spec of this method was changed.

This PR fixes that and should resolve the docs failing on `main`.