### PR TITLE
[WIP][Bugfix] Fix xgrammar nanobind leaked objects at shutdown

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1915,6 +1915,9 @@ class Scheduler(SchedulerInterface):
         return spec_decoding_stats
 
     def shutdown(self) -> None:
+        # Clear all requests to release per-request resources (e.g.
+        # xgrammar nanobind objects) before interpreter shutdown.
+        self.requests.clear()
         if self.kv_event_publisher:
             self.kv_event_publisher.shutdown()
         if self.connector is not None:

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -420,6 +420,8 @@ class LLMEngine:
         return self.collective_rpc("apply_model", args=(func,))
 
     def __del__(self):
+        if engine_core := getattr(self, "engine_core", None):
+            engine_core.shutdown()
         dp_group = getattr(self, "dp_group", None)
         if dp_group is not None and not self.external_launcher_dp:
             stateless_destroy_torch_distributed_process_group(dp_group)

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -336,3 +336,8 @@ class StructuredOutputManager:
     def clear_backend(self) -> None:
         if self.backend is not None:
             self.backend.destroy()
+            self.backend = None
+        if executor := getattr(self, "executor", None):
+            executor.shutdown(wait=False, cancel_futures=True)
+        if executor := getattr(self, "executor_for_fillmask", None):
+            executor.shutdown(wait=False, cancel_futures=True)


### PR DESCRIPTION
## Purpose

Fixes #26363

Fix nanobind leak warnings (`GrammarMatcher`, `CompiledGrammar`) when using xgrammar as the structured output backend. The warnings appear at process exit:

```
nanobind: leaked 2 instances!
 - leaked instance of type "GrammarMatcher"
 - leaked instance of type "CompiledGrammar"
nanobind: leaked 2 types!
nanobind: leaked 16 functions!
```

**Root cause:** Per-request xgrammar nanobind objects were not released during shutdown due to two gaps:

1. `Scheduler.shutdown()` did not clear its `self.requests` dict, so `Request` -> `StructuredOutputRequest` -> `XgrammarGrammar` (holding `matcher` and `ctx` nanobind objects) remained referenced until Python interpreter teardown, when nanobind metadata may already be freed.

2. `LLMEngine.__del__()` did not call `engine_core.shutdown()`, so in in-process mode (`VLLM_ENABLE_V1_MULTIPROCESSING=0`) the entire cleanup chain was never triggered. (Compare: `AsyncLLM.__del__()` already calls `self.shutdown()`.)

**Fix (3 targeted changes):**

- **`scheduler.py`**: Add `self.requests.clear()` in `Scheduler.shutdown()` to release per-request xgrammar objects deterministically during shutdown.
- **`llm_engine.py`**: Add `engine_core.shutdown()` in `LLMEngine.__del__()` to ensure the cleanup chain runs in in-process mode (mirrors existing `AsyncLLM` pattern).
- **`structured_output/__init__.py`**: Shut down `ThreadPoolExecutor`s in `clear_backend()` to cancel pending grammar compilations, and set `self.backend = None` to make repeated calls idempotent.

## Test Plan

1. Run the reproduction script from issue #26363 -- verify no nanobind leak warnings appear at exit.
2. Test both modes: default multiprocess and `VLLM_ENABLE_V1_MULTIPROCESSING=0` (in-process).
3. Run existing unit tests:
   - `pytest tests/v1/core/test_scheduler.py`
   - `pytest tests/v1/engine/test_llm_engine.py`
   - `pytest tests/v1/structured_output/`

## Test Result

**Reproduction script (default multiprocess mode):**
- Script completed successfully, generated correct structured JSON output.
- **No nanobind leak warnings** (`leaked instances`, `leaked types`, `leaked functions` -- all absent).

**Reproduction script (in-process mode, `VLLM_ENABLE_V1_MULTIPROCESSING=0`):**
- Script completed successfully, generated correct structured JSON output.
- **No nanobind leak warnings.** Only a pre-existing PyTorch NCCL `destroy_process_group` warning remains (unrelated to xgrammar).

**Unit tests:**
- `tests/v1/structured_output/`: **27 passed**
- `tests/v1/core/test_scheduler.py`: **86 passed**, 1 skipped, 1 pre-existing failure (`test_async_scheduling_pp_allows_rescheduling_with_output_placeholders` -- fails on main as well)
- `tests/v1/engine/test_llm_engine.py`: **4 passed**, 1 pre-existing failure (GPU memory issue in test environment), 1 pre-existing failure (HuggingFace download issue in test environment)