### PR TITLE
[Bugfix] fix activation in cpu_fused_moe_torch call

### DIFF
--- a/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
@@ -402,7 +402,7 @@ class CPUFusedMOE:
             input,
             topk_weights,
             topk_ids,
-            activation,
+            activation.value,
             global_num_experts,
             skip_weighted,
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes the bug in #34689 introduced by #33843. Now passing `activation.value` instead of `activation` to `cpu_fused_moe_torch` since it expects a str argument.
