### PR TITLE
[Bugfix] Fix test_flashinfer_blockscale_fp8_none_expert_group on B200

### DIFF
--- a/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_trtllm_moe.py
@@ -210,9 +210,20 @@ def flashinfer_fused_moe_blockscale_fp8(
     # Routing kernel expects #experts <= #threads 512
     assert global_num_experts <= 512
 
+    # DeepSeekV3 routing requires grouped expert selection (n_group > 0).
+    # When num_expert_group is not provided (e.g. MiniMax-M2.1 which uses
+    # sigmoid + bias without grouped top-k), fall back to RenormalizeNaive
+    # which performs Sigmoid -> TopK -> Renormalize without grouping.
+    if (routing_method_type == RoutingMethodType.DeepSeekV3
+            and num_expert_group == 0):
+        routing_method_type = int(RoutingMethodType.RenormalizeNaive)
+
     # The DeepSeekV3 routing method requires float32 router logits.
+    # Other routing methods require bfloat16.
     if routing_method_type == RoutingMethodType.DeepSeekV3:
         routing_logits = routing_logits.to(torch.float32)
+    else:
+        routing_logits = routing_logits.to(torch.bfloat16)
 
     if routing_bias is not None:
         routing_bias = routing_bias.to(x.dtype)
@@ -310,8 +321,11 @@ def fi_trtllm_fp8_per_tensor_moe(
     from vllm.utils.flashinfer import flashinfer_trtllm_fp8_per_tensor_scale_moe
 
     # The DeepSeekV3 routing method requires float32 router logits.
+    # Other routing methods require bfloat16.
     if routing_method_type == RoutingMethodType.DeepSeekV3:
         routing_logits = routing_logits.to(torch.float32)
+    else:
+        routing_logits = routing_logits.to(torch.bfloat16)
 
     return flashinfer_trtllm_fp8_per_tensor_scale_moe(
         routing_logits=routing_logits,


### PR DESCRIPTION
The flashInfer TRTLLM FP8 MoE kernel is failing on current main when `num_expert_group=None`. Fixing this revealed two related issues:

  1. Runtime Error: routing_logits must be bfloat16 - The kernel was receiving float32 routing logits when it expected bfloat16
  2. Test Issue: The regression test had incorrect weight quantization (1D instead of 2D block quantization)

  Testing:
  - Ran  `pytest -s -v tests/kernels/moe/test_flashinfer.py::test_flashinfer_blockscale_fp8_none_expert_group` on a B200 machine

  Related: 
  * https://github.com/vllm-project/vllm/issues/34477
  * https://github.com/vllm-project/vllm/pull/34494
  
  Looks like #34494 was an incomplete fix