### PR TITLE
[Build] Include OpenTelemetry in release Docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -643,16 +643,17 @@ ARG PYTORCH_NIGHTLY
 COPY --from=base /workspace/torch_lib_versions.txt torch_lib_versions.txt
 RUN --mount=type=bind,from=build,src=/workspace/dist,target=/vllm-workspace/dist \
     --mount=type=cache,target=/root/.cache/uv \
+    WHEEL="$(ls dist/*.whl)" && \
     if [ "${PYTORCH_NIGHTLY}" = "1" ]; then \
         echo "Installing torch nightly..." \
         && uv pip install --system $(cat torch_lib_versions.txt | xargs) --pre \
         --index-url ${PYTORCH_CUDA_INDEX_BASE_URL}/nightly/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.') \
         && echo "Installing vLLM..." \
-        && uv pip install --system dist/*.whl --verbose \
+        && uv pip install --system "${WHEEL}[otel]" --verbose \
         --extra-index-url ${PYTORCH_CUDA_INDEX_BASE_URL}/nightly/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.'); \
     else \
         echo "Installing vLLM..." \
-        && uv pip install --system dist/*.whl --verbose \
+        && uv pip install --system "${WHEEL}[otel]" --verbose \
         --extra-index-url ${PYTORCH_CUDA_INDEX_BASE_URL}/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.'); \
     fi
 

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -208,7 +208,7 @@ WORKDIR /vllm-workspace
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=bind,from=vllm-build,src=/vllm-workspace/dist,target=dist \
-    uv pip install dist/*.whl
+    WHEEL="$(ls dist/*.whl)" && uv pip install "${WHEEL}[otel]"
 
 # Add labels to document build configuration
 LABEL org.opencontainers.image.title="vLLM CPU"


### PR DESCRIPTION
## Purpose

The release Docker images (`vllm-openai` target in both `Dockerfile` and `Dockerfile.cpu`) expose `--otlp-traces-endpoint` but don't install the OpenTelemetry packages needed to use it. Any attempt to enable tracing crashes on startup with `ModuleNotFoundError: No module named 'opentelemetry'`.

This PR installs the wheel with the `[otel]` pip extra so that tracing works out of the box in the published images.

Fixes https://github.com/vllm-project/vllm/issues/26491

## Test Plan

Built `Dockerfile.cpu` targeting `vllm-openai` on aarch64 (ARM Mac via colima) and confirmed:

1. The `[otel]` extra resolves and installs 13 additional packages  (opentelemetry-sdk, -api, -exporter-otlp, -semantic-conventions-ai, etc.)
2. `vllm serve` with `--otlp-traces-endpoint=http://localhost:4318/v1/traces` starts successfully -- no `ModuleNotFoundError`
3. Chat completions via the OpenAI-compatible API return correct responses with the OTel endpoint configured

## Test Result

```
non-default args: {'model_tag': 'Qwen/Qwen3-0.6B', 'max_model_len': 8192,
  'enforce_eager': True,
  'otlp_traces_endpoint': 'http://localhost:4318/v1/traces'}
...
observability_config=ObservabilityConfig(
  otlp_traces_endpoint='http://localhost:4318/v1/traces', ...)
...
INFO:     Application startup complete.
```

- [x] PR has the correct label for the change type
