### PR TITLE
[CI] Fix flaky test_parsable_context

### DIFF
--- a/tests/entrypoints/openai/responses/test_parsable_context.py
+++ b/tests/entrypoints/openai/responses/test_parsable_context.py
@@ -172,19 +172,26 @@ async def test_mcp_tool_call(client: OpenAI, model_name: str):
 
     assert response is not None
     assert response.status == "completed"
-    assert response.output[0].type == "reasoning"
-    assert response.output[1].type == "mcp_call"
-    assert type(response.output[1].arguments) is str
-    assert type(response.output[1].output) is str
-    assert response.output[2].type == "reasoning"
-    # make sure the correct math is in the final output
-    assert response.output[3].type == "message"
-    assert any(s in response.output[3].content[0].text for s in ("56088", "56,088"))
 
-    # test raw input_messages / output_messages
+    # The model may produce multiple reasoning/mcp_call rounds before the
+    # final message, so validate structurally rather than by exact index.
+    output_types = [o.type for o in response.output]
+    assert "reasoning" in output_types
+    mcp_calls = [o for o in response.output if o.type == "mcp_call"]
+    assert len(mcp_calls) >= 1
+    assert type(mcp_calls[0].arguments) is str
+    assert type(mcp_calls[0].output) is str
+
+    # The final output should be a message containing the correct answer
+    assert response.output[-1].type == "message"
+    assert any(s in response.output[-1].content[0].text
+               for s in ("56088", "56,088"))
+
+    # Test raw input_messages / output_messages
     assert len(response.input_messages) == 1
-    assert len(response.output_messages) == 3
-    assert any(s in response.output_messages[2]["message"] for s in ("56088", "56,088"))
+    assert len(response.output_messages) >= 3
+    assert any(s in response.output_messages[-1]["message"]
+               for s in ("56088", "56,088"))
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/responses/test_parsable_context.py
+++ b/tests/entrypoints/openai/responses/test_parsable_context.py
@@ -184,14 +184,14 @@ async def test_mcp_tool_call(client: OpenAI, model_name: str):
 
     # The final output should be a message containing the correct answer
     assert response.output[-1].type == "message"
-    assert any(s in response.output[-1].content[0].text
-               for s in ("56088", "56,088"))
+    assert any(s in response.output[-1].content[0].text for s in ("56088", "56,088"))
 
     # Test raw input_messages / output_messages
     assert len(response.input_messages) == 1
     assert len(response.output_messages) >= 3
-    assert any(s in response.output_messages[-1]["message"]
-               for s in ("56088", "56,088"))
+    assert any(
+        s in response.output_messages[-1]["message"] for s in ("56088", "56,088")
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix flakey test: https://github.com/vllm-project/vllm/issues/34701

### Root cause
The test hardcoded exact output indices (e.g., output[3].type == "message"), assuming the model would always produce exactly one reasoning → mcp_call → reasoning → message sequence. 
However, Qwen3-8B may non-deterministically produce multiple tool-call rounds before the final answer — even at temperature=0 — causing the expected item positions to shift.

### Fix
Replaced index-based assertions with structural validation. The test now checks that at least one mcp_call exists with valid fields, that the final output is a message containing the correct answer, and that output_messages has at least 3 entries. This accommodates the model making one or more tool-call rounds while still verifying correctness.

## Test Plan
```
pytest tests/entrypoints/openai/responses/test_parsable_context.py -v
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

