### PR TITLE
[torch.compile] Turn on silu+fp4 quant fusion by default for O1+

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -103,7 +103,7 @@ def enable_act_fusion(cfg: "VllmConfig") -> bool:
     return (
         cfg.compilation_config.is_custom_op_enabled("silu_and_mul")
         or cfg.compilation_config.is_custom_op_enabled("quant_fp8")
-        or cfg.model_config.is_nvfp4_quantized()
+        or (cfg.model_config is not None and cfg.model_config.is_nvfp4_quantized())
     )
 
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -95,11 +95,16 @@ def enable_norm_fusion(cfg: "VllmConfig") -> bool:
 
 
 def enable_act_fusion(cfg: "VllmConfig") -> bool:
-    """Enable if either SiLU+Mul or quant FP8 custom op is active;
-    otherwise Inductor handles fusion."""
-    return cfg.compilation_config.is_custom_op_enabled(
-        "silu_and_mul"
-    ) or cfg.compilation_config.is_custom_op_enabled("quant_fp8")
+    """
+    Enable if either SiLU+Mul or quant FP8 custom op is active;
+    otherwise Inductor handles fusion.
+    Also enable for FP4 models as FP4 quant is always custom so Inductor cannot fuse it.
+    """
+    return (
+        cfg.compilation_config.is_custom_op_enabled("silu_and_mul")
+        or cfg.compilation_config.is_custom_op_enabled("quant_fp8")
+        or cfg.model_config.is_nvfp4_quantized()
+    )
 
 
 def enable_allreduce_rms_fusion(cfg: "VllmConfig") -> bool:


### PR DESCRIPTION
## Purpose
Turn on SiLU-Mul + NVFP4 quant fusion by default for optimization levels O1 and higher. This is a simple pointwise fusion with low impact on startup time and a good perf improvement. Note that this does not help MoE models as long as `fused_moe` is wrapped (#31985) (EDIT: fused kernel is called manually in #31832 already).

## Test Plan
No new functionality, just new default behavior. E2E perf sweep, startup sweep, and lm_eval.

## Test Result
### `nvidia/Llama-3.1-8B-Instruct-NVFP4` (tp=1)
#### Eval
##### PR
`local-completions (pretrained=nvidia/Llama-3.1-8B-Instruct-NVFP4,base_url=http://0.0.0.0:8869/v1/completions,num_concurrent=50,max_retries=3), gen_kwargs: (None), limit: 100.0, num_fewshot: 5, batch_size: auto`
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.63|±  |0.0485|
|     |       |strict-match    |     5|exact_match|↑  | 0.61|±  |0.0490|

##### Main
`local-completions (pretrained=nvidia/Llama-3.1-8B-Instruct-NVFP4,base_url=http://0.0.0.0:8869/v1/completions,num_concurrent=50,max_retries=3), gen_kwargs: (None), limit: 100.0, num_fewshot: 5, batch_size: auto`
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.63|±  |0.0485|
|     |       |strict-match    |     5|exact_match|↑  | 0.61|±  |0.0490|

#### Perf

<img width="2478" height="2070" alt="tpot_20" src="https://github.com/user-attachments/assets/ae79358e-2b08-4dac-b3b2-c76fbda1bf6f" />
<img width="2486" height="2069" alt="ttft_20" src="https://github.com/user-attachments/assets/21fd83cb-5aa2-40dc-bae1-052efa541afd" />

#### Startup


|                      | Cold Total (p50)   | Cold Compile (p50)   | Warm Total (p50)   | Warm Compile (p50)   |
|:---------------------|:-------------------|:---------------------|:-------------------|:---------------------|
| fused                | 40.529             | 12.949               | 20.585             | 3.451                |
| unfused              | 37.967             | 12.71                | 24.659             | 3.213                |
| fused (% vs unfused) | 6.75%              | 1.88%                | -16.52%            | 7.41%                |

### `nvidia/Llama-3.3-70B-Instruct-NVFP4` (tp=4)

#### Perf

<img width="2485" height="2070" alt="tpot_20" src="https://github.com/user-attachments/assets/565f64c4-1f32-4a33-9f84-1ab62f2e95e6" />
<img width="2480" height="2070" alt="ttft_20" src="https://github.com/user-attachments/assets/f5f2f334-b84c-4052-b25e-c1de9a1e7678" />

#### Startup

|                      | Cold Total (p50)   | Cold Compile (p50)   | Warm Total (p50)   | Warm Compile (p50)   |
|:---------------------|:-------------------|:---------------------|:-------------------|:---------------------|
| fused                | 88.502             | 0.0                  | 60.664             | 0.0                  |
| unfused              | 89.093             | 0.0                  | 61.029             | 0.0                  |
| fused (% vs unfused) | -0.66%             | nan%                 | -0.6%              | nan%                 |

Eval TBD