### PR TITLE
fix(spec): extend vocab size validation to MTP and Eagle methods

### DIFF
--- a/tests/config/test_speculative_vocab_validation.py
+++ b/tests/config/test_speculative_vocab_validation.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import get_args
+from unittest import mock
+
+import pytest
+
+from vllm.config.speculative import MTPModelTypes, SpeculativeConfig
+
+
+def _create_spec_config_with_method(method, target_vocab, draft_vocab):
+    """Create a SpeculativeConfig with mocked model configs for vocab testing."""
+    spec_cfg = SpeculativeConfig.__new__(SpeculativeConfig)
+    spec_cfg.method = method
+
+    target_mock = mock.Mock()
+    target_mock.get_vocab_size.return_value = target_vocab
+    draft_mock = mock.Mock()
+    draft_mock.get_vocab_size.return_value = draft_vocab
+
+    spec_cfg.target_model_config = target_mock
+    spec_cfg.draft_model_config = draft_mock
+    return spec_cfg
+
+
+class TestVerifyEqualVocabSize:
+    """Tests for verify_equal_vocab_size covering all speculative methods."""
+
+    def test_draft_model_matching_vocab_passes(self):
+        cfg = _create_spec_config_with_method("draft_model", 32000, 32000)
+        cfg.verify_equal_vocab_size()  # Should not raise
+
+    def test_draft_model_mismatched_vocab_raises(self):
+        cfg = _create_spec_config_with_method("draft_model", 32000, 64000)
+        with pytest.raises(ValueError, match="same vocabulary size"):
+            cfg.verify_equal_vocab_size()
+
+    def test_eagle_matching_vocab_passes(self):
+        cfg = _create_spec_config_with_method("eagle", 32000, 32000)
+        cfg.verify_equal_vocab_size()  # Should not raise
+
+    def test_eagle_mismatched_vocab_raises(self):
+        cfg = _create_spec_config_with_method("eagle", 32000, 999999)
+        with pytest.raises(ValueError, match="same vocabulary size"):
+            cfg.verify_equal_vocab_size()
+
+    def test_eagle3_mismatched_vocab_raises(self):
+        cfg = _create_spec_config_with_method("eagle3", 32000, 16000)
+        with pytest.raises(ValueError, match="same vocabulary size"):
+            cfg.verify_equal_vocab_size()
+
+    def test_mtp_matching_vocab_passes(self):
+        cfg = _create_spec_config_with_method("mtp", 32000, 32000)
+        cfg.verify_equal_vocab_size()  # Should not raise
+
+    def test_mtp_mismatched_vocab_raises(self):
+        cfg = _create_spec_config_with_method("mtp", 1000, 999999)
+        with pytest.raises(ValueError, match="out-of-bounds"):
+            cfg.verify_equal_vocab_size()
+
+    @pytest.mark.parametrize("mtp_type", list(get_args(MTPModelTypes)))
+    def test_all_mtp_variants_validated(self, mtp_type):
+        cfg = _create_spec_config_with_method(mtp_type, 32000, 64000)
+        with pytest.raises(ValueError, match="same vocabulary size"):
+            cfg.verify_equal_vocab_size()
+
+    def test_ngram_not_validated(self):
+        """N-gram method uses target model config directly, no separate draft."""
+        cfg = _create_spec_config_with_method("ngram", 32000, 64000)
+        cfg.verify_equal_vocab_size()  # Should not raise
+
+    def test_suffix_not_validated(self):
+        cfg = _create_spec_config_with_method("suffix", 32000, 64000)
+        cfg.verify_equal_vocab_size()  # Should not raise
+
+    def test_none_configs_skip_validation(self):
+        cfg = _create_spec_config_with_method("eagle", 32000, 64000)
+        cfg.target_model_config = None
+        cfg.verify_equal_vocab_size()  # Should not raise
+
+        cfg2 = _create_spec_config_with_method("eagle", 32000, 64000)
+        cfg2.draft_model_config = None
+        cfg2.verify_equal_vocab_size()  # Should not raise
+
+    def test_deprecated_method_delegates(self):
+        """Old method delegates to verify_equal_vocab_size."""
+        cfg = _create_spec_config_with_method("draft_model", 32000, 64000)
+        with pytest.raises(ValueError, match="same vocabulary size"):
+            cfg.verify_equal_vocab_size_if_draft_model()

--- a/vllm/v1/spec_decode/draft_model.py
+++ b/vllm/v1/spec_decode/draft_model.py
@@ -31,7 +31,7 @@ class DraftModelProposer(SpecDecodeBaseProposer):
         self._raise_if_draft_tp_mismatch()
 
     def _raise_if_vocab_size_mismatch(self):
-        self.speculative_config.verify_equal_vocab_size_if_draft_model()
+        self.speculative_config.verify_equal_vocab_size()
 
     def _raise_if_draft_tp_mismatch(self):
         # Note(Tomas Ruiz) If we run the target model with TP > 1 and

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1687,6 +1687,7 @@ class EagleProposer(SpecDecodeBaseProposer):
             pass_hidden_states_to_model=True,
             runner=runner,
         )
+        self.speculative_config.verify_equal_vocab_size()
 
 
 # NOTE(woosuk): Currently, the below code is not used and we always use argmax


### PR DESCRIPTION
## Purpose

Extend vocabulary size validation to cover all speculative decoding methods that use a draft model, not just `draft_model`. Previously, `verify_equal_vocab_size_if_draft_model()` only checked when `method == "draft_model"`, leaving MTP (Multi-Token Prediction) and Eagle/Eagle3 methods without vocabulary alignment checks. A mismatched vocabulary can cause out-of-bounds GPU memory access during inference.

Fixes #34583

### Changes

- Add `verify_equal_vocab_size()` method that validates vocab sizes for all relevant methods: `draft_model`, `eagle`, `eagle3`, and all MTP variants
- Keep `verify_equal_vocab_size_if_draft_model()` as a deprecated shim that delegates to the new method
- Update `_verify_args()` validator to call `verify_equal_vocab_size()`
- Update `DraftModelProposer._raise_if_vocab_size_mismatch()` to use the new method
- Add explicit `verify_equal_vocab_size()` call in `EagleProposer.__init__()`

## Test Plan

```bash
pytest tests/config/test_speculative_vocab_validation.py -v
```

## Test Result

```
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_draft_model_matching_vocab_passes PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_draft_model_mismatched_vocab_raises PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_eagle_matching_vocab_passes PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_eagle_mismatched_vocab_raises PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_eagle3_mismatched_vocab_raises PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_mtp_matching_vocab_passes PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_mtp_mismatched_vocab_raises PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_all_mtp_variants_validated[deepseek_mtp] PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_all_mtp_variants_validated[mimo_mtp] PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_all_mtp_variants_validated[glm4_moe_mtp] PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_all_mtp_variants_validated[glm4_moe_lite_mtp] PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_all_mtp_variants_validated[glm_ocr_mtp] PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_all_mtp_variants_validated[ernie_mtp] PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_all_mtp_variants_validated[exaone_moe_mtp] PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_all_mtp_variants_validated[qwen3_next_mtp] PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_all_mtp_variants_validated[qwen3_5_mtp] PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_all_mtp_variants_validated[longcat_flash_mtp] PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_all_mtp_variants_validated[mtp] PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_all_mtp_variants_validated[pangu_ultra_moe_mtp] PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_all_mtp_variants_validated[step3p5_mtp] PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_ngram_not_validated PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_suffix_not_validated PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_none_configs_skip_validation PASSED
tests/config/test_speculative_vocab_validation.py::TestVerifyEqualVocabSize::test_deprecated_method_delegates PASSED
24 passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>