### PR TITLE
[Bugfix] Fix prefix creation for Qwen3.5

### DIFF
--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -542,9 +542,10 @@ class Qwen3_5ForCausalLMBase(
         super().__init__()
         self.config = config
         self.scheduler_config = scheduler_config
-        self.model = Qwen3_5Model(
-            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
-        )
+        # Deal with the case where the prefix is already "language_model" since
+        # Qwen/Qwen3.5-397B-A17B has naming like: model.language_model.layers.0
+        model_prefix = prefix if "model" in prefix else "model"
+        self.model = Qwen3_5Model(vllm_config=vllm_config, prefix=model_prefix)
 
         if get_pp_group().is_last_rank:
             if config.tie_word_embeddings:
@@ -620,7 +621,7 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLMBase, QwenNextMixtureOfExperts):
     dummy_inputs=Qwen3VLDummyInputsBuilder,
 )
 class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration, IsHybrid):
-    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "model"):
         # protocols have not __init__ method, so we need to use nn.Module.__init__
         nn.Module.__init__(self)
         config: Qwen3_5Config = vllm_config.model_config.hf_config
@@ -828,7 +829,7 @@ class Qwen3_5_MoeMixtureOfExperts(MixtureOfExperts):
 class Qwen3_5MoeForConditionalGeneration(
     Qwen3_5ForConditionalGeneration, Qwen3_5_MoeMixtureOfExperts
 ):
-    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "model"):
         # protocols have not __init__ method, so we need to use nn.Module.__init__
         nn.Module.__init__(self)
         config: Qwen3_5MoeConfig = vllm_config.model_config.hf_config


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

It seems that the prefix creation for Qwen3.5 is incorrect since it adds a "model" module after the "language_model" module in the HF checkpoint. This will cause issues for quantization since ignore lists will not match.

## Test Plan

## Test Result

Tested https://huggingface.co/Qwen/Qwen3.5-397B-A17B

Reference: 
<img width="881" height="543" alt="Screenshot 2026-02-17 at 11 56 03 AM" src="https://github.com/user-attachments/assets/c955c6e4-72c8-4067-b356-601ded0ad461" />


Before:
```
LinearBase prefix:  language_model.model.layers.59.mlp.shared_expert_gate
```

After:
```
LinearBase prefix:  language_model.layers.59.mlp.shared_expert_gate
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

