### PR TITLE
[AMD][CI] Fix test_custom_allreduce for A100 testgroup

### DIFF
--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -33,6 +33,7 @@ def graph_allreduce(
 ):
     with monkeypatch.context() as m:
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        m.delenv("HIP_VISIBLE_DEVICES", raising=False)
         device = torch.device(f"cuda:{rank}")
         torch.cuda.set_device(device)
         init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
@@ -92,6 +93,7 @@ def eager_allreduce(
 ):
     with monkeypatch.context() as m:
         m.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        m.delenv("HIP_VISIBLE_DEVICES", raising=False)
         device = torch.device(f"cuda:{rank}")
         torch.cuda.set_device(device)
         init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)


### PR DESCRIPTION
## Purpose
To fix the `test_custom_allreduce` test for the [AMD A100 testgroup](https://github.com/vllm-project/vllm/blob/1e4a084c8e53bfb422f64e2394fc94c4ed5b6cbf/.buildkite/test-amd.yaml#L1512).

For ROCm, ray modifies `HIP_VISIBLE_DEVICES` when allocating a GPU (`@ray.remote(num_gpus=1)`), so we need to remove `HIP_VISIBLE_DEVICES` instead of `CUDA_VISIBLE_DEVICES`.

## Test Plan
`pytest -v -s distributed/test_custom_all_reduce.py`

## Test Result
Before

<details> 
<summary>Failing stacktrace</summary>

```text
  ray.exceptions.RayTaskError(AcceleratorError): ray::eager_allreduce() (pid=3455185, ip=172.17.0.2)
    File "/workspace/vllm/tests/distributed/test_custom_all_reduce.py", line 98, in eager_allreduce
      torch.cuda.set_device(device)
    File "/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py", line 567, in set_device
      torch._C._cuda_setDevice(device)
  torch.AcceleratorError: HIP error: invalid device ordinal
  GPU device may be out of range, do you have enough GPUs?
```
</details>

After: Success

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

