### PR TITLE
[Experimental] Piecewise CUDA graph with dynamic-shape FFN

### DIFF
--- a/benchmarks/measure_ffn_padding_overhead.py
+++ b/benchmarks/measure_ffn_padding_overhead.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Measure FFN activation memory waste from CUDA graph batch padding.
+
+Runs a LlamaMLP forward pass with actual vs padded batch sizes and
+reports the peak activation memory difference. This is the memory
+that split_ffn saves by running FFN eagerly with real batch sizes.
+
+Usage:
+    python benchmarks/measure_ffn_padding_overhead.py
+"""
+
+import torch
+import torch.nn as nn
+
+
+class SimpleMLP(nn.Module):
+    """Minimal Llama-style MLP for memory measurement."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        dtype: torch.dtype = torch.bfloat16,
+    ):
+        super().__init__()
+        # Fused gate+up projection (like MergedColumnParallelLinear)
+        self.gate_up_proj = nn.Linear(
+            hidden_size, 2 * intermediate_size, bias=False, dtype=dtype
+        )
+        self.down_proj = nn.Linear(
+            intermediate_size, hidden_size, bias=False, dtype=dtype
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_up = self.gate_up_proj(x)
+        gate, up = gate_up.chunk(2, dim=-1)
+        x = torch.nn.functional.silu(gate) * up
+        x = self.down_proj(x)
+        return x
+
+
+def measure_peak_activation(
+    mlp: nn.Module,
+    batch_size: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+) -> int:
+    """Run MLP forward and return peak memory allocated (bytes)."""
+    torch.cuda.reset_peak_memory_stats()
+    torch.cuda.empty_cache()
+
+    # Measure baseline (weights already loaded)
+    baseline = torch.cuda.memory_allocated()
+
+    x = torch.randn(batch_size, hidden_size, device="cuda", dtype=dtype)
+    _ = mlp(x)
+    torch.cuda.synchronize()
+
+    peak = torch.cuda.max_memory_allocated()
+    return peak - baseline
+
+
+def main():
+    dtype = torch.bfloat16
+
+    # Model configs: (name, hidden_size, intermediate_size, tp_size)
+    configs = [
+        ("Llama-3.2-1B", 2048, 8192, 1),
+        ("Llama-3.1-8B", 4096, 14336, 1),
+        ("Llama-3.1-70B", 8192, 28672, 1),
+        ("Llama-3.1-70B/TP8", 8192, 28672, 8),
+    ]
+
+    # CUDA graph capture sizes (typical vLLM pattern)
+    # Actual batch → padded to next capture size
+    test_cases = [
+        (1, 1),
+        (3, 4),
+        (5, 8),
+        (13, 16),
+        (17, 24),
+        (25, 32),
+        (50, 56),
+        (100, 104),
+        (200, 200),
+        (250, 256),
+    ]
+
+    print(
+        f"{'Model':<20} {'Actual':>6} {'Padded':>6} {'Waste':>3} "
+        f"{'Actual MB':>10} {'Padded MB':>10} {'Saved MB':>10} {'Saved%':>7}"
+    )
+    print("-" * 85)
+
+    for name, hidden, intermediate, tp in configs:
+        per_gpu_intermediate = intermediate // tp
+        mlp = SimpleMLP(hidden, per_gpu_intermediate, dtype).cuda()
+        mlp.eval()
+
+        with torch.no_grad():
+            for actual, padded in test_cases:
+                waste = padded - actual
+                if waste == 0 and actual != 1:
+                    continue  # skip no-padding cases (uninteresting)
+
+                mem_actual = measure_peak_activation(mlp, actual, hidden, dtype)
+                mem_padded = measure_peak_activation(mlp, padded, hidden, dtype)
+                saved = mem_padded - mem_actual
+                saved_pct = saved / mem_padded * 100 if mem_padded > 0 else 0
+
+                print(
+                    f"{name:<20} {actual:>6} {padded:>6} {waste:>3} "
+                    f"{mem_actual / 1e6:>10.2f} {mem_padded / 1e6:>10.2f} "
+                    f"{saved / 1e6:>10.2f} {saved_pct:>6.1f}%"
+                )
+
+        # Clean up
+        del mlp
+        torch.cuda.empty_cache()
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -567,6 +567,13 @@ class CompilationConfig:
     pass_config: PassConfig = field(default_factory=PassConfig)
     """Custom inductor passes, see PassConfig for more details"""
 
+    split_ffn: bool = False
+    """When enabled, FFN (MLP) layers become CUDA-graph split points and run
+    eagerly with the actual (unpadded) batch size. This saves activation memory
+    from batch padding at the cost of losing CUDA-graph capture for FFN ops.
+    Only affects Llama-style SiLU MLPs for now. Default is False (FFN stays
+    inside CUDA graph pieces)."""
+
     max_cudagraph_capture_size: int = field(default=None)
     """The maximum cudagraph capture size.
 
@@ -651,6 +658,7 @@ class CompilationConfig:
         "vllm::kda_attention",
         "vllm::sparse_attn_indexer",
         "vllm::rocm_aiter_sparse_attn_indexer",
+        "vllm::fused_silu_ffn",
     ]
 
     def compute_hash(self) -> str:

--- a/vllm/model_executor/layers/fused_ffn.py
+++ b/vllm/model_executor/layers/fused_ffn.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused FFN custom op for piecewise CUDA graph with dynamic-shape FFN.
+
+Registers `vllm::fused_silu_ffn` as an opaque custom op so that the FFN
+(MLP) forward becomes a graph-splitting point in piecewise CUDA graph mode.
+This lets the FFN run eagerly with the actual (unpadded) batch size,
+reducing activation memory from unnecessary batch padding.
+"""
+
+import torch
+
+from vllm.forward_context import get_forward_context
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+# ---------------------------------------------------------------------------
+# Custom op implementations
+# ---------------------------------------------------------------------------
+def fused_silu_ffn(x: torch.Tensor, layer_name: str) -> torch.Tensor:
+    """Real implementation — called eagerly at runtime.
+
+    Looks up the MLP module by *layer_name* from the forward context
+    (registered in static_forward_context during model init) and delegates
+    to its forward method. Temporarily sets use_direct_call=True to avoid
+    recursion (this op is only invoked when use_direct_call is False).
+    """
+    forward_context = get_forward_context()
+    mlp = forward_context.no_compile_layers[layer_name]
+    mlp.use_direct_call = True
+    try:
+        return mlp(x)
+    finally:
+        mlp.use_direct_call = False
+
+
+def fused_silu_ffn_fake(x: torch.Tensor, layer_name: str) -> torch.Tensor:
+    """Fake implementation — used by torch.compile tracing.
+
+    Returns an empty tensor with the same shape/dtype/device as the input,
+    since the FFN output has the same hidden_size as the input.
+    """
+    return torch.empty_like(x)
+
+
+direct_register_custom_op(
+    op_name="fused_silu_ffn",
+    op_func=fused_silu_ffn,
+    fake_impl=fused_silu_ffn_fake,
+)


### PR DESCRIPTION
## Status: Experimental (closed)

Proof-of-concept for splitting CUDA graphs at FFN layers. Benchmark results show the memory savings are too small to justify the throughput cost at current model sizes. Kept for reference and potential future use with larger-intermediate architectures (e.g., large MoE).

## Idea

In piecewise CUDA graph mode, batch sizes are padded to the next capture size. FFN layers have the largest intermediates (~4-5x hidden_size), so they waste the most activation memory from padding. This PR registers the Llama MLP as a custom op (`vllm::fused_silu_ffn`) that acts as a CUDA-graph split point, letting FFN run eagerly with actual batch sizes.

Gated by `CompilationConfig.split_ffn` (default `False`). Only implemented for Llama-style SiLU MLPs.

## Benchmark results

### FFN padding overhead (micro-benchmark)

Per-layer activation memory saved by avoiding batch padding:

| Model | Actual→Padded | Saved | % |
|-------|--------------|-------|---|
| 70B | 17→24 | 1.72 MB | 29% |
| 70B | 25→32 | 1.72 MB | 22% |
| 70B | 100→104 | 0.98 MB | 4% |
| 70B/TP8 | 17→24 | 0.38 MB | 29% |
| 70B/TP8 | 25→32 | 0.38 MB | 22% |

Peak activation is dominated by a single layer's forward pass, so total savings equal these per-layer numbers (not multiplied by layer count). Compared to ~18 GB model weights per GPU (70B/TP8) and GBs of KV cache, sub-MB savings are negligible.

### Server benchmark (Llama-3.2-1B, single GPU)

| Metric | split_ffn OFF | split_ffn ON | Delta |
|--------|--------------|-------------|-------|
| KV cache tokens | 303,088 | 303,088 | 0% |
| Output tok/s | ~580 | ~505 | -13% |

**Conclusion**: ~0% memory benefit, ~13% throughput regression. The cost of breaking CUDA graph capture at every FFN outweighs the negligible memory savings.

## Files

- `vllm/model_executor/layers/fused_ffn.py` — custom op registration (delegates to MLP.forward to avoid logic duplication)
- `vllm/model_executor/models/llama.py` — MLP forward branching + decoder layer registration
- `vllm/config/compilation.py` — `split_ffn` config flag
- `benchmarks/measure_ffn_padding_overhead.py` — micro-benchmark