### PR TITLE
[BugFix]: Fix local mypy issues

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -935,6 +935,10 @@ class NixlConnectorWorker:
             ]
 
             if rsv_cores_for_kv:
+                if not hasattr(os, "sched_setaffinity"):
+                    raise NotImplementedError(
+                        "os.sched_setaffinity is not available on this platform"
+                    )
                 os.sched_setaffinity(0, rsv_cores_for_kv)
 
         # support for oot platform which can't register nixl memory

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -5,7 +5,6 @@
 # https://github.com/lm-sys/FastChat/blob/168ccc29d3f7edc50823016105c024fe2282732a/fastchat/protocol/openai_api_protocol.py
 import json
 import time
-from dataclasses import replace
 from typing import Annotated, Any, ClassVar, Literal
 
 import torch
@@ -16,6 +15,7 @@ from openai.types.chat.chat_completion_message import Annotation as OpenAIAnnota
 from pydantic import Field, model_validator
 
 from vllm.config import ModelConfig
+from vllm.config.utils import replace as utils_replace
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
@@ -463,7 +463,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 self.structured_outputs = (
                     StructuredOutputsParams(**structured_outputs_kwargs)
                     if self.structured_outputs is None
-                    else replace(self.structured_outputs, **structured_outputs_kwargs)  # type: ignore[type-var] # pydantic dataclass; compatible at runtime
+                    else utils_replace(
+                        self.structured_outputs, **structured_outputs_kwargs
+                    )
                 )
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -15,7 +15,7 @@ from openai.types.chat.chat_completion_message import Annotation as OpenAIAnnota
 from pydantic import Field, model_validator
 
 from vllm.config import ModelConfig
-from vllm.config.utils import replace as utils_replace
+from vllm.config.utils import replace
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
     ChatTemplateContentFormatOption,
@@ -463,9 +463,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 self.structured_outputs = (
                     StructuredOutputsParams(**structured_outputs_kwargs)
                     if self.structured_outputs is None
-                    else utils_replace(
-                        self.structured_outputs, **structured_outputs_kwargs
-                    )
+                    else replace(self.structured_outputs, **structured_outputs_kwargs)
                 )
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -463,7 +463,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 self.structured_outputs = (
                     StructuredOutputsParams(**structured_outputs_kwargs)
                     if self.structured_outputs is None
-                    else replace(self.structured_outputs, **structured_outputs_kwargs)
+                    else replace(self.structured_outputs, **structured_outputs_kwargs)  # type: ignore[type-var] # pydantic dataclass; compatible at runtime
                 )
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -269,7 +269,7 @@ class CompletionRequest(OpenAIBaseModel):
                 self.structured_outputs = (
                     StructuredOutputsParams(**structured_outputs_kwargs)
                     if self.structured_outputs is None
-                    else replace(self.structured_outputs, **structured_outputs_kwargs)
+                    else replace(self.structured_outputs, **structured_outputs_kwargs)  # type: ignore[type-var] # pydantic dataclass; compatible at runtime
                 )
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -5,13 +5,13 @@
 # https://github.com/lm-sys/FastChat/blob/168ccc29d3f7edc50823016105c024fe2282732a/fastchat/protocol/openai_api_protocol.py
 import json
 import time
-from dataclasses import replace
 from typing import Annotated, Any, Literal
 
 import torch
 from pydantic import Field, model_validator
 
 from vllm.config import ModelConfig
+from vllm.config.utils import replace as utils_replace
 from vllm.entrypoints.openai.engine.protocol import (
     AnyResponseFormat,
     LegacyStructuralTagResponseFormat,
@@ -269,7 +269,9 @@ class CompletionRequest(OpenAIBaseModel):
                 self.structured_outputs = (
                     StructuredOutputsParams(**structured_outputs_kwargs)
                     if self.structured_outputs is None
-                    else replace(self.structured_outputs, **structured_outputs_kwargs)  # type: ignore[type-var] # pydantic dataclass; compatible at runtime
+                    else utils_replace(
+                        self.structured_outputs, **structured_outputs_kwargs
+                    )
                 )
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -11,7 +11,7 @@ import torch
 from pydantic import Field, model_validator
 
 from vllm.config import ModelConfig
-from vllm.config.utils import replace as utils_replace
+from vllm.config.utils import replace
 from vllm.entrypoints.openai.engine.protocol import (
     AnyResponseFormat,
     LegacyStructuralTagResponseFormat,
@@ -269,9 +269,7 @@ class CompletionRequest(OpenAIBaseModel):
                 self.structured_outputs = (
                     StructuredOutputsParams(**structured_outputs_kwargs)
                     if self.structured_outputs is None
-                    else utils_replace(
-                        self.structured_outputs, **structured_outputs_kwargs
-                    )
+                    else replace(self.structured_outputs, **structured_outputs_kwargs)
                 )
 
         extra_args: dict[str, Any] = self.vllm_xargs if self.vllm_xargs else {}

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -337,7 +337,9 @@ class ResponsesRequest(OpenAIBaseModel):
                 and response_format.schema_ is not None
             ):
                 structured_outputs = StructuredOutputsParams(
-                    json=response_format.schema_
+                    json=response_format.schema_  # type: ignore[call-arg]
+                    # --follow-imports skip hides the class definition but also hides
+                    # multiple third party conflicts, so best of both evils
                 )
 
         stop = self.stop if self.stop else []

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -39,7 +39,7 @@ from openai_harmony import Message as OpenAIHarmonyMessage
 from pydantic import TypeAdapter
 
 from vllm import envs
-from vllm.config.utils import replace as utils_replace
+from vllm.config.utils import replace
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
@@ -468,7 +468,7 @@ class OpenAIServingResponses(OpenAIServing):
                         )
                         and struct_out.all_non_structural_tag_constraints_none()
                     ):
-                        sampling_params.structured_outputs = utils_replace(
+                        sampling_params.structured_outputs = replace(
                             struct_out,
                             structural_tag=reasoning_parser.prepare_structured_tag(
                                 struct_out.structural_tag, self.tool_server

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -8,7 +8,6 @@ from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Sequence
 from contextlib import AsyncExitStack
 from copy import copy
-from dataclasses import replace
 from http import HTTPStatus
 from typing import Final
 
@@ -40,6 +39,7 @@ from openai_harmony import Message as OpenAIHarmonyMessage
 from pydantic import TypeAdapter
 
 from vllm import envs
+from vllm.config.utils import replace as utils_replace
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatCompletionMessageParam,
@@ -468,12 +468,12 @@ class OpenAIServingResponses(OpenAIServing):
                         )
                         and struct_out.all_non_structural_tag_constraints_none()
                     ):
-                        sampling_params.structured_outputs = replace(
+                        sampling_params.structured_outputs = utils_replace(
                             struct_out,
                             structural_tag=reasoning_parser.prepare_structured_tag(
                                 struct_out.structural_tag, self.tool_server
                             ),
-                        )  # type: ignore[type-var] # pydantic dataclass; compatible at runtime
+                        )
                 generator = self._generate_with_builtin_tools(
                     request_id=request.request_id,
                     engine_prompt=engine_prompt,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -473,7 +473,7 @@ class OpenAIServingResponses(OpenAIServing):
                             structural_tag=reasoning_parser.prepare_structured_tag(
                                 struct_out.structural_tag, self.tool_server
                             ),
-                        )
+                        )  # type: ignore[type-var] # pydantic dataclass; compatible at runtime
                 generator = self._generate_with_builtin_tools(
                     request_id=request.request_id,
                     engine_prompt=engine_prompt,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -3,7 +3,7 @@
 """Sampling parameters for text generation."""
 
 import copy
-import json
+import json as json_mod
 from dataclasses import field
 from enum import Enum, IntEnum
 from functools import cached_property
@@ -791,7 +791,7 @@ class SamplingParams(
                 skip_guidance = False
                 if so_params.json:
                     if isinstance(so_params.json, str):
-                        schema = json.loads(so_params.json)
+                        schema = json_mod.loads(so_params.json)
                     else:
                         schema = so_params.json
                     skip_guidance = has_guidance_unsupported_json_features(schema)


### PR DESCRIPTION
## Purpose

When you run `pre-commit` in local dev environment, you get the following mypy errors:

```bash
$ pre-commit run --all-files    

ruff check..........................................................................................Passed
ruff format.........................................................................................Passed
typos...............................................................................................Passed
clang-format........................................................................................Passed
Lint GitHub Actions workflow files..................................................................Passed
pip-compile.........................................................................................Passed
reformat nightly_torch_test.txt to be in sync with test.in..........................................Passed

Run mypy locally for lowest supported Python version................................................Failed
- hook id: mypy-local
- exit code: 1

$ mypy --python-version 3.10 --follow-imports skip 
vllm/entrypoints/openai/chat_completion/protocol.py:466: error: Value of type variable "_DataclassT" of "replace" cannot be "StructuredOutputsParams"  [type-var]
vllm/entrypoints/openai/responses/protocol.py:339: error: Unexpected keyword argument "json" for "StructuredOutputsParams"  [call-arg]
vllm/entrypoints/openai/completion/protocol.py:272: error: Value of type variable "_DataclassT" of "replace" cannot be "StructuredOutputsParams"  [type-var]
vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py:938: error: Module has no attribute "sched_setaffinity"  [attr-defined]
vllm/entrypoints/openai/responses/serving.py:503: error: Value of type variable "_DataclassT" of "replace" cannot be "StructuredOutputsParams"  [type-var]
Found 5 errors in 5 files (checked 645 source files)

[...]
```

This PR fixes the issues as shown below.

MyPy issues handled as follows:

- Pydantic dataclasses does not satisfy mypy's type system with `replace()`, even though they are fully compatible at runtime. Therefore, ignore
- Skipped import issue that `StructuredOutputsParams` has with `json` prioperty in `vllm/entrypoints/openai/responses/protocol.py`. Therefore, ignore as enabling the imports raises lot of other issues which are unrelated.
- `sched_setaffinity()` is a Linux only OS command and therefore added a check in `llm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py` for it.

Additionally:
- Renamed `json` import because property called `json` in class also in `vllm/sampling_params.py`. This is for hygiene reasons.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

