### PR TITLE
[Core] Fix SSRF bypass via backslash-@ URL parsing inconsistency

### DIFF
--- a/vllm/multimodal/media/connector.py
+++ b/vllm/multimodal/media/connector.py
@@ -146,7 +146,7 @@ class MediaConnector:
 
             connection = self.connection
             data = connection.get_bytes(
-                url,
+                url_spec.url,
                 timeout=fetch_timeout,
                 allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
             )
@@ -177,7 +177,7 @@ class MediaConnector:
 
             connection = self.connection
             data = await connection.async_get_bytes(
-                url,
+                url_spec.url,
                 timeout=fetch_timeout,
                 allow_redirects=envs.VLLM_MEDIA_URL_ALLOW_REDIRECTS,
             )


### PR DESCRIPTION
Pass urllib3-normalised URL (url_spec.url) to the HTTP client instead of
the raw user-provided string, preventing aiohttp/yarl from interpreting
backslash-@ sequences differently than the validation layer.

GHSA-v359-jj2v-j536

Co-authored-by: isotr0py <2037008807@qq.com>
Signed-off-by: Russell Bryant <rbryant@redhat.com>
