### PR TITLE
[ROCm][CI] Removed hard-coded attn backend requirement for Qwen VL

### DIFF
--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -169,13 +169,6 @@ VLM_TEST_SETTINGS = {
         auto_cls=AutoModelForImageTextToText,
         vllm_output_post_proc=model_utils.qwen2_vllm_to_hf_output,
         patch_hf_runner=model_utils.qwen3_vl_patch_hf_runner,
-        vllm_runner_kwargs={
-            "attention_config": {
-                "backend": "ROCM_AITER_FA",
-            },
-        }
-        if current_platform.is_rocm()
-        else None,
         image_size_factors=[(0.25,), (0.25, 0.25, 0.25), (0.25, 0.2, 0.15)],
         marks=[
             pytest.mark.core_model,


### PR DESCRIPTION
Falling back to default attention backend for `pytest -s -v tests/models/multimodal/generation/test_common.py::test_video_models[qwen3_vl-test_case20]`. AITER FA was not matching logprobs on MI355. That is because AITER FA is sacrificing exact logprob match for more performance. 