### PR TITLE
[Bug][Spec Decode] Fix AR metrics when drafting is skipped

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -213,11 +213,9 @@ class Scheduler(SchedulerInterface):
             if speculative_config.uses_draft_model():
                 self.num_lookahead_tokens = self.num_spec_tokens
 
-        # Tracks whether the *previous* step's drafter was skipped (e.g.
-        # because sequences exceeded the drafter's max model length).  When
-        # True the spec-decode tokens verified in the *current* step are
-        # dummy/placeholder values, so acceptance-rate stats should be
-        # excluded.
+        # Tracks whether the previous step's drafter was skipped in the model runner.
+        # When True the spec-decode tokens verified in the current step are
+        # dummy/placeholder values, so acceptance-rate stats should be excluded.
         self._prev_step_drafting_was_skipped: bool = False
 
         # Create the KV cache manager.
@@ -1276,9 +1274,6 @@ class Scheduler(SchedulerInterface):
         if self.perf_metrics and self.perf_metrics.is_enabled():
             perf_stats = self.perf_metrics.get_step_perf_stats_per_gpu(scheduler_output)
 
-        # If the *previous* step's drafter was skipped, the spec tokens being
-        # verified in this step are dummy/placeholder values – exclude them
-        # from acceptance-rate statistics.
         skip_spec_decode_stats = self._prev_step_drafting_was_skipped
         self._prev_step_drafting_was_skipped = model_runner_output.drafting_was_skipped
 
@@ -1345,10 +1340,6 @@ class Scheduler(SchedulerInterface):
                 # the scheduled spec tokens count and so is similarly adjusted.
                 if request.num_output_placeholders > 0:
                     request.num_output_placeholders -= num_rejected
-                # Only collect stats when the previous step actually ran the
-                # drafter.  When drafting was skipped (e.g. sequences too
-                # long), the spec tokens are dummy/placeholder values and
-                # would incorrectly deflate the acceptance rate.
                 if not skip_spec_decode_stats:
                     spec_decoding_stats = self.make_spec_decoding_stats(
                         spec_decoding_stats,

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -169,12 +169,6 @@ class ModelRunnerOutput:
     # each request due to speculative/jump decoding.
     sampled_token_ids: list[list[int]] = field(default_factory=list)
 
-    # Indicates whether the scheduled draft tokens were ignored.
-    # Used when the model runner decides to skip generating draft tokens, e.g. when
-    # input length exceeds the drafter's capacity. In such cases, the scheduler should
-    # be notified that the scheduled draft tokens were not used, such as for statistics.
-    skipped_draft_tokens: bool = False
-
     # [num_reqs, max_num_logprobs + 1]
     # [num_reqs, max_num_logprobs + 1]
     # [num_reqs]

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -195,9 +195,8 @@ class ModelRunnerOutput:
     # information related to cudagraph execution
     cudagraph_stats: CUDAGraphStat | None = None
 
-    # Whether the drafter was skipped this step (e.g. input_fits_in_drafter
-    # was False).  Used by the scheduler to avoid counting dummy/placeholder
-    # spec-decode tokens in acceptance-rate statistics.
+    # Whether the drafter was skipped this step (e.g. input_fits_in_drafter was False).
+    # Used by the scheduler to exclude dummy/placeholder draft tokens from statistics.
     drafting_was_skipped: bool = False
 
 

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -169,6 +169,12 @@ class ModelRunnerOutput:
     # each request due to speculative/jump decoding.
     sampled_token_ids: list[list[int]] = field(default_factory=list)
 
+    # Indicates whether the scheduled draft tokens were ignored.
+    # Used when the model runner decides to skip generating draft tokens, e.g. when
+    # input length exceeds the drafter's capacity. In such cases, the scheduler should
+    # be notified that the scheduled draft tokens were not used, such as for statistics.
+    skipped_draft_tokens: bool = False
+
     # [num_reqs, max_num_logprobs + 1]
     # [num_reqs, max_num_logprobs + 1]
     # [num_reqs]
@@ -194,6 +200,11 @@ class ModelRunnerOutput:
 
     # information related to cudagraph execution
     cudagraph_stats: CUDAGraphStat | None = None
+
+    # Whether the drafter was skipped this step (e.g. input_fits_in_drafter
+    # was False).  Used by the scheduler to avoid counting dummy/placeholder
+    # spec-decode tokens in acceptance-rate statistics.
+    drafting_was_skipped: bool = False
 
 
 # ModelRunnerOutput wrapper for async scheduling.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -442,8 +442,6 @@ class GPUModelRunner(
         # mm_hash ->  encoder_output
         self.encoder_cache: dict[str, torch.Tensor] = {}
 
-        self.prev_skipped_drafting = False
-
         self.use_aux_hidden_state_outputs = False
         # Set up speculative decoding.
         # NOTE(Jiayi): currently we put the entire draft model on


### PR DESCRIPTION
## Purpose

FIX #34734.

Not the cleanest fix, open to other approaches. But this one does seem to work

## Testing

Ran Llama 3.1 8B-Instruct with [EAGLE3](https://huggingface.co/yuhuili/EAGLE3-LLaMA3.1-Instruct-8B) and got AL 1.00 for prompts of size 2k. Now, reports no drafted tokens as expected.

Will fix CI failures as needed, but shouldn't affect anything other than statistics collection.