### PR TITLE
Add platform method to enable custom collective ops registration

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -385,10 +385,10 @@ class GroupCoordinator:
                 self.cpu_group, 1 << 22, 6
             )
 
+        # TODO(#35915): Remove is_tpu() check once tpu_inference
+        # overrides use_custom_op_collectives() to return True.
         self.use_custom_op_call = (
-            current_platform.is_cuda_alike()
-            or current_platform.is_tpu()
-            or current_platform.use_custom_op_collectives()
+            current_platform.is_tpu() or current_platform.use_custom_op_collectives()
         )
 
         self.use_cpu_custom_send_recv = current_platform.is_cpu() and hasattr(

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -386,7 +386,9 @@ class GroupCoordinator:
             )
 
         self.use_custom_op_call = (
-            current_platform.is_cuda_alike() or current_platform.is_tpu()
+            current_platform.is_cuda_alike()
+            or current_platform.is_tpu()
+            or current_platform.use_custom_op_collectives()
         )
 
         self.use_cpu_custom_send_recv = current_platform.is_cpu() and hasattr(

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -574,8 +574,12 @@ class CudaPlatformBase(Platform):
         return True
 
     @classmethod
-    def num_compute_units(cls, device_id=0):
+    def num_compute_units(cls, device_id: int = 0) -> int:
         return torch.cuda.get_device_properties(device_id).multi_processor_count
+
+    @classmethod
+    def use_custom_op_collectives(cls) -> bool:
+        return True
 
 
 # NVML utils

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -655,6 +655,15 @@ class Platform:
         return False
 
     @classmethod
+    def use_custom_op_collectives(cls) -> bool:
+        """
+        Whether this platform should use torch.ops.vllm.* custom ops for collectives.
+
+        Returns False by default - platforms must explicitly opt-in.
+        """
+        return False
+
+    @classmethod
     def use_sync_weight_loader(cls) -> bool:
         """
         Returns if the current platform needs to sync weight loader.

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -820,5 +820,9 @@ class RocmPlatform(Platform):
         return True
 
     @classmethod
-    def num_compute_units(cls, device_id=0):
+    def num_compute_units(cls, device_id: int = 0) -> int:
         return torch.cuda.get_device_properties(device_id).multi_processor_count
+
+    @classmethod
+    def use_custom_op_collectives(cls) -> bool:
+        return True


### PR DESCRIPTION
Summary:
Add `use_custom_op_collectives()` platform method to allow hardware platforms to opt-in to using `torch.ops.vllm.*` custom ops for collective operations (all_reduce, all_gather, reduce_scatter).

This enables platforms with custom collective backends to register their ops for proper graph tracing in `torch.compile` and `torch.export`. 

Key changes:
- Add `use_custom_op_collectives()` to Platform interface (default: False)
- CUDA and ROCm platforms override to return True

This provides a clean extension point for out-of-tree hardware platforms to enable custom collective op registration. However, the check for cuda_alike and tpu still exist.

Test Plan: No functional change.

Differential Revision: D93033341


