### PR TITLE
Improve Transformers v4/v5 compatibility in tokenizers and processors

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 4.56.0, < 5
+transformers >= 4.56.0, <= 5.2.0
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.

--- a/tests/model_executor/test_weight_utils.py
+++ b/tests/model_executor/test_weight_utils.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import os
 import tempfile
 
 import huggingface_hub.constants
@@ -15,50 +14,70 @@ from vllm.model_executor.model_loader.weight_utils import (
 
 
 def test_hf_transfer_auto_activation():
-    if "HF_HUB_ENABLE_HF_TRANSFER" in os.environ:
-        # in case it is already set, we can't test the auto activation
-        pytest.skip("HF_HUB_ENABLE_HF_TRANSFER is set, can't test auto activation")
-    enable_hf_transfer()
-    try:
-        # enable hf hub transfer if available
-        import hf_transfer  # type: ignore # noqa
+    if hasattr(huggingface_hub.constants, "HF_XET_HIGH_PERFORMANCE"):
+        # hub>=1.x path: xet acceleration.
+        original_value = huggingface_hub.constants.HF_XET_HIGH_PERFORMANCE
+        try:
+            huggingface_hub.constants.HF_XET_HIGH_PERFORMANCE = False
+            enable_hf_transfer()
+            assert huggingface_hub.constants.HF_XET_HIGH_PERFORMANCE is True
+        finally:
+            huggingface_hub.constants.HF_XET_HIGH_PERFORMANCE = original_value
+        return
 
-        HF_TRANSFER_ACTIVE = True
-    except ImportError:
-        HF_TRANSFER_ACTIVE = False
-    assert huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER == HF_TRANSFER_ACTIVE
+    if not hasattr(huggingface_hub.constants, "HF_HUB_ENABLE_HF_TRANSFER"):
+        pytest.skip("No known transfer acceleration flag on this hub version")
+
+    # hub<1.x path: hf_transfer acceleration (if installed).
+    original_value = huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER
+    try:
+        huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = False
+        enable_hf_transfer()
+        try:
+            import hf_transfer  # type: ignore # noqa
+
+            hf_transfer_active = True
+        except ImportError:
+            hf_transfer_active = False
+        assert hf_transfer_active == huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER
+    finally:
+        huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = original_value
 
 
 def test_download_weights_from_hf():
+    original_offline = huggingface_hub.constants.HF_HUB_OFFLINE
     with tempfile.TemporaryDirectory() as tmpdir:
-        # assert LocalEntryNotFoundError error is thrown
-        # if offline is set and model is not cached
-        huggingface_hub.constants.HF_HUB_OFFLINE = True
-        with pytest.raises(LocalEntryNotFoundError):
+        try:
+            # assert LocalEntryNotFoundError error is thrown
+            # if offline is set and model is not cached
+            huggingface_hub.constants.HF_HUB_OFFLINE = True
+            with pytest.raises(LocalEntryNotFoundError):
+                download_weights_from_hf(
+                    "facebook/opt-125m",
+                    allow_patterns=["*.safetensors", "*.bin"],
+                    cache_dir=tmpdir,
+                )
+
+            # download the model
+            huggingface_hub.constants.HF_HUB_OFFLINE = False
             download_weights_from_hf(
                 "facebook/opt-125m",
                 allow_patterns=["*.safetensors", "*.bin"],
                 cache_dir=tmpdir,
             )
 
-        # download the model
-        huggingface_hub.constants.HF_HUB_OFFLINE = False
-        download_weights_from_hf(
-            "facebook/opt-125m",
-            allow_patterns=["*.safetensors", "*.bin"],
-            cache_dir=tmpdir,
-        )
-
-        # now it should work offline
-        huggingface_hub.constants.HF_HUB_OFFLINE = True
-        assert (
-            download_weights_from_hf(
-                "facebook/opt-125m",
-                allow_patterns=["*.safetensors", "*.bin"],
-                cache_dir=tmpdir,
+            # now it should work offline
+            huggingface_hub.constants.HF_HUB_OFFLINE = True
+            assert (
+                download_weights_from_hf(
+                    "facebook/opt-125m",
+                    allow_patterns=["*.safetensors", "*.bin"],
+                    cache_dir=tmpdir,
+                )
+                is not None
             )
-            is not None
-        )
+        finally:
+            huggingface_hub.constants.HF_HUB_OFFLINE = original_offline
 
 
 if __name__ == "__main__":

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -69,10 +69,24 @@ temp_dir = tempfile.gettempdir()
 
 
 def enable_hf_transfer():
-    """automatically activates hf_transfer"""
-    if "HF_HUB_ENABLE_HF_TRANSFER" not in os.environ:
+    """Enable the best available Hugging Face Hub transfer backend.
+
+    huggingface-hub v1 removed ``HF_HUB_ENABLE_HF_TRANSFER`` in favor of
+    ``HF_XET_HIGH_PERFORMANCE``. Keep behavior compatible with both APIs.
+    """
+    # huggingface-hub >=1.x path (xet-based transfers).
+    if hasattr(huggingface_hub.constants, "HF_XET_HIGH_PERFORMANCE"):
+        if "HF_XET_HIGH_PERFORMANCE" not in os.environ:
+            huggingface_hub.constants.HF_XET_HIGH_PERFORMANCE = True
+        return
+
+    # huggingface-hub <1.x path (hf_transfer optional acceleration).
+    if (
+        hasattr(huggingface_hub.constants, "HF_HUB_ENABLE_HF_TRANSFER")
+        and "HF_HUB_ENABLE_HF_TRANSFER" not in os.environ
+    ):
         try:
-            # enable hf hub transfer if available
+            # Enable hf hub transfer if available.
             import hf_transfer  # type: ignore # noqa
 
             huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = True


### PR DESCRIPTION
## Summary
- Improve tokenizer compatibility across Transformers v4/v5 without global monkey patches.
- Add processor compatibility retry for remote processors that still pass `optional_attributes`.
- Make Ovis2.5 special-token handling robust across Transformers v4/v5.
- Support huggingface-hub v1 transfer flags while preserving older hub behavior.
- Update targeted multimodal test input normalization for GLM-ASR minimum audio length.

## Validation
- `transformers==4.56.2`
  - `pytest -q -rs tests/model_executor/test_weight_utils.py`
  - `pytest -q -rs tests/models/multimodal/processing/test_common.py::test_processing_correctness -k 'AIDC-AI/Ovis2.5-2B or allenai/Molmo2-8B or allenai/Molmo2-O-7B or zai-org/GLM-ASR-Nano-2512'`
- `transformers==4.57.4`
  - Same commands, pass.
- `transformers==5.1.0`
  - Same commands, pass.
### Transformers 5.2.0 validation
- Updated dependency cap: `transformers >= 4.56.0, <= 5.2.0`.
- Re-tested locally in a fresh GPU-enabled environment with `transformers==5.2.0`:
  - `pytest -q -rs tests/model_executor/test_weight_utils.py` (`2 passed`)
  - `pytest -q -rs tests/models/multimodal/processing/test_common.py::test_processing_correctness -k 'AIDC-AI/Ovis2.5-2B or allenai/Molmo2-8B or allenai/Molmo2-O-7B or zai-org/GLM-ASR-Nano-2512'` (`12 passed, 351 deselected`)