### PR TITLE
[WIP][Bugfix] Wire whitespace_pattern through V1 structured output backends

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -744,6 +744,18 @@ class SamplingParams(
         )
         from vllm.v1.structured_output.backend_xgrammar import validate_xgrammar_grammar
 
+        if (
+            self.structured_outputs.whitespace_pattern is not None
+            and backend != "auto"
+            and backend != "outlines"
+        ):
+            logger.warning(
+                "whitespace_pattern is only fully supported by the "
+                "'outlines' backend. The '%s' backend will approximate "
+                "or ignore this setting.",
+                backend,
+            )
+
         if backend.startswith("xgrammar"):
             # xgrammar with no fallback
             validate_xgrammar_grammar(self)
@@ -778,6 +790,16 @@ class SamplingParams(
             # will satisfy the most use cases without having to worry about
             # this setting. We include fallback behavior here, but not with any
             # other setting where a specific backend was specified.
+
+            # When whitespace_pattern is set, prefer outlines as it's the
+            # only backend with native custom whitespace pattern support.
+            if self.structured_outputs.whitespace_pattern is not None:
+                validate_structured_output_request_outlines(self)
+                self.structured_outputs._backend = "outlines"
+                self.structured_outputs._backend_was_auto = True
+                self.structured_outputs.__post_init__()
+                return
+
             try:
                 validate_xgrammar_grammar(self)
                 self.structured_outputs._backend = "xgrammar"

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -159,10 +159,12 @@ class StructuredOutputManager:
         #
         # TODO: we still need to handle xgrammar compilation failures,
         # though it should be unlikely as we test that up front as well.
-        request_type, grammar_spec = key
+        request_type, grammar_spec, whitespace_pattern = key
 
         assert self.backend is not None
-        return self.backend.compile_grammar(request_type, grammar_spec)
+        return self.backend.compile_grammar(
+            request_type, grammar_spec, whitespace_pattern=whitespace_pattern
+        )
 
     def _fill_bitmasks(
         self, batch: Iterable[tuple[StructuredOutputGrammar, int, bool]]

--- a/vllm/v1/structured_output/backend_outlines.py
+++ b/vllm/v1/structured_output/backend_outlines.py
@@ -66,10 +66,18 @@ class OutlinesBackend(StructuredOutputBackend):
         return index
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        whitespace_pattern: str | None = None,
     ) -> StructuredOutputGrammar:
         if request_type == StructuredOutputOptions.JSON:
-            regex = json_schema.build_regex_from_schema(grammar_spec)
+            if whitespace_pattern is not None:
+                regex = json_schema.build_regex_from_schema(
+                    grammar_spec, whitespace_pattern
+                )
+            else:
+                regex = json_schema.build_regex_from_schema(grammar_spec)
         elif request_type == StructuredOutputOptions.REGEX:
             regex = grammar_spec
         elif request_type == StructuredOutputOptions.CHOICE:
@@ -186,7 +194,12 @@ def validate_structured_output_request_outlines(params: SamplingParams):
                 raise ValueError(
                     f"Error serializing structured outputs jsonschema: {e}"
                 ) from e
-        pattern = json_schema.build_regex_from_schema(schema)
+        if so_params.whitespace_pattern is not None:
+            pattern = json_schema.build_regex_from_schema(
+                schema, so_params.whitespace_pattern
+            )
+        else:
+            pattern = json_schema.build_regex_from_schema(schema)
         validate_regex_is_buildable(pattern)
     elif so_params.choice:
         choices = [regex_escape(str(choice)) for choice in so_params.choice]

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -25,7 +25,7 @@ class StructuredOutputOptions(enum.Enum):
     STRUCTURAL_TAG = enum.auto()
 
 
-StructuredOutputKey = tuple[StructuredOutputOptions, str]
+StructuredOutputKey = tuple[StructuredOutputOptions, str, str | None]
 
 
 class StructuredOutputGrammar(ABC):
@@ -105,7 +105,10 @@ class StructuredOutputBackend(ABC):
 
     @abstractmethod
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        whitespace_pattern: str | None = None,
     ) -> StructuredOutputGrammar:
         """
         Compiles a grammar specification into a structured output grammar.
@@ -114,6 +117,9 @@ class StructuredOutputBackend(ABC):
             request_type (StructuredOutputOptions): The type of structured
                 output request.
             grammar_spec (str): The grammar specification to compile.
+            whitespace_pattern (str | None): Optional regex pattern to
+                control whitespace in JSON output. Only natively supported
+                by the outlines backend.
 
         Returns:
             StructuredOutputGrammar: The compiled structured output grammar.

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -75,15 +75,31 @@ class XgrammarBackend(StructuredOutputBackend):
             )
 
     def compile_grammar(
-        self, request_type: StructuredOutputOptions, grammar_spec: str
+        self,
+        request_type: StructuredOutputOptions,
+        grammar_spec: str,
+        whitespace_pattern: str | None = None,
     ) -> StructuredOutputGrammar:
+        if whitespace_pattern is not None:
+            logger.warning_once(
+                "xgrammar backend does not support custom "
+                "whitespace_pattern. The pattern %r will be approximated "
+                "by disabling flexible whitespace (any_whitespace=False). "
+                "Use the 'outlines' backend for full whitespace_pattern "
+                "support.",
+                whitespace_pattern,
+            )
+            any_whitespace = False
+        else:
+            any_whitespace = not self.disable_any_whitespace
+
         if request_type == StructuredOutputOptions.JSON:
             ctx = self.compiler.compile_json_schema(
-                grammar_spec, any_whitespace=not self.disable_any_whitespace
+                grammar_spec, any_whitespace=any_whitespace
             )
         elif request_type == StructuredOutputOptions.JSON_OBJECT:
             ctx = self.compiler.compile_json_schema(
-                '{"type": "object"}', any_whitespace=not self.disable_any_whitespace
+                '{"type": "object"}', any_whitespace=any_whitespace
             )
         elif request_type == StructuredOutputOptions.GRAMMAR:
             ctx = self.compiler.compile_grammar(grammar_spec)

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -68,24 +68,25 @@ class StructuredOutputRequest:
 
 
 def get_structured_output_key(params: StructuredOutputsParams) -> StructuredOutputKey:
+    wp = params.whitespace_pattern
     if params.json is not None:
         if not isinstance(params.json, str):
             json_str = json.dumps(params.json)
         else:
             json_str = params.json
-        return StructuredOutputOptions.JSON, json_str
+        return StructuredOutputOptions.JSON, json_str, wp
     if params.json_object:
-        return StructuredOutputOptions.JSON_OBJECT, ""
+        return StructuredOutputOptions.JSON_OBJECT, "", wp
     if params.regex is not None:
-        return StructuredOutputOptions.REGEX, params.regex
+        return StructuredOutputOptions.REGEX, params.regex, wp
     if params.choice is not None:
         if not isinstance(params.choice, str):
             json_str = json.dumps(params.choice)
         else:
             json_str = params.choice
-        return StructuredOutputOptions.CHOICE, json_str
+        return StructuredOutputOptions.CHOICE, json_str, wp
     if params.grammar is not None:
-        return StructuredOutputOptions.GRAMMAR, params.grammar
+        return StructuredOutputOptions.GRAMMAR, params.grammar, wp
     if params.structural_tag is not None:
-        return StructuredOutputOptions.STRUCTURAL_TAG, params.structural_tag
+        return StructuredOutputOptions.STRUCTURAL_TAG, params.structural_tag, wp
     raise ValueError("No valid structured output parameter found")


### PR DESCRIPTION
## Purpose

Fixes #26362.

The `whitespace_pattern` field on `StructuredOutputsParams` was accepted but silently ignored by all V1 structured output backends. It was originally wired up in the old V0 guided decoding code (since deleted) but never connected in the V1 pipeline.

This PR threads `whitespace_pattern` through the full pipeline from request params to grammar compilation:

- **`StructuredOutputKey`**: Extended from 2-tuple to 3-tuple `(type, spec, whitespace_pattern)` to ensure cache correctness — two requests with the same schema but different whitespace patterns produce different keys.
- **`compile_grammar()` abstract interface**: Added optional `whitespace_pattern` kwarg.
- **Outlines backend** (native support): Passes the pattern to `outlines_core.json_schema.build_regex_from_schema(schema, whitespace_pattern)`.
- **XGrammar backend** (approximation): Maps custom pattern to `any_whitespace=False` with a warning, since xgrammar only supports a boolean flag.
- **Guidance backend** (approximation): Maps custom pattern to `whitespace_flexible=False` with a warning, since guidance only supports a boolean flag.
- **LM Format Enforcer backend**: Warns that the pattern is ignored (no whitespace control).
- **Auto-backend selection**: When `backend="auto"` and `whitespace_pattern` is set, routes directly to outlines — the only backend with native custom pattern support.
- **Validation warning**: When `whitespace_pattern` is used with an explicitly non-outlines backend, logs a warning.

## Test Plan

- Run existing structured output test suite to verify no regressions
- Run the issue reproducer script to verify end-to-end behavior

## Test Result

- Existing structured output tests (`tests/v1/structured_output/test_utils.py`) pass (6/6)