### PR TITLE
[Core] Enable FP8 KV cache with Decode Context Parallel (DCP) for MLA

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -642,7 +642,20 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 # Convert from (N, B, L) to (B, N, L)
                 mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
 
-            if fp8_attention and self.impl.supports_quant_query_input:
+            if self.impl.dcp_world_size > 1:
+                if fp8_attention and self.impl.supports_quant_query_input:
+                    # Backend wants FP8 Q: quant first, allgather in FP8
+                    # (halves allgather bandwidth vs BF16)
+                    assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
+                    assert mqa_ql_nope.shape[1] == mqa_q_pe.shape[1]
+                    mqa_q = self._decode_concat_quant_fp8_op(
+                        mqa_ql_nope, mqa_q_pe, self._q_scale
+                    )
+                    mqa_q = get_dcp_group().all_gather(mqa_q, dim=1)
+                else:
+                    mqa_q = torch.cat((mqa_ql_nope, mqa_q_pe), dim=-1)
+                    mqa_q = get_dcp_group().all_gather(mqa_q, dim=1)
+            elif fp8_attention and self.impl.supports_quant_query_input:
                 assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
                 assert mqa_ql_nope.shape[1] == mqa_q_pe.shape[1]
                 mqa_q = self._decode_concat_quant_fp8_op(
@@ -650,12 +663,6 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 )
             else:
                 mqa_q = (mqa_ql_nope, mqa_q_pe)
-            if self.impl.dcp_world_size > 1:
-                assert not fp8_attention, "DCP not support fp8 kvcache now."
-                # concatenate mqa_ql_nope and mqa_q_pe -> (B, N, L + P)
-                mqa_q = torch.cat(mqa_q, dim=-1)
-                # mqa_q do allgather in head dim.
-                mqa_q = get_dcp_group().all_gather(mqa_q, dim=1)
 
             # call decode attn
             if not is_sparse_impl:
@@ -1145,6 +1152,9 @@ class MLACommonPrefillMetadata:
         padded_local_cu_seq_lens: torch.Tensor | None = None
         cu_seq_lens_lst: list[list[int]] | None = None
         chunk_size: int | None = None
+        # for mla DCP with FP8 KV cache (gather_and_maybe_dequant_cache)
+        padded_local_token_to_seq: torch.Tensor | None = None
+        padded_local_chunk_total_token: list[int] | None = None
 
     block_table: torch.Tensor
     query_start_loc: torch.Tensor
@@ -1825,6 +1835,24 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                         dtype=torch.int32,
                     )
 
+                    # Compute padded-local token_to_seq and total_token
+                    # for gather_and_maybe_dequant_cache (FP8 DCP support)
+                    padded_local_chunk_total_token = padded_local_cu_chunk_seq_lens_cpu[
+                        :, -1
+                    ]
+                    padded_local_max_token_num = (
+                        padded_local_chunk_total_token.max().item()
+                    )
+                    padded_local_token_to_seq_cpu = torch.zeros(
+                        [num_chunks, padded_local_max_token_num],
+                        dtype=torch.int32,
+                    )
+                    for i in range(num_chunks):
+                        t2s = torch.repeat_interleave(
+                            range_idx, padded_local_chunk_seq_lens[i]
+                        )
+                        padded_local_token_to_seq_cpu[i, : t2s.shape[0]] = t2s
+
                 chunked_context_metadata_cls = (
                     CudnnPrefillMetadata.ChunkedContextMetadata
                     if self._use_cudnn_prefill
@@ -1849,6 +1877,12 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                         ),
                         cu_seq_lens_lst=cu_seq_lens_cpu.tolist(),
                         chunk_size=padded_local_max_context_chunk_across_ranks,
+                        padded_local_token_to_seq=(
+                            padded_local_token_to_seq_cpu.to(device, non_blocking=True)
+                        ),
+                        padded_local_chunk_total_token=(
+                            padded_local_chunk_total_token.tolist()
+                        ),
                     )
                 else:
                     chunked_context_metadata = chunked_context_metadata_cls(
@@ -2512,7 +2546,6 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         k_scale: torch.Tensor,
         dcp_world_size: int,
     ):
-        assert k_scale is None, "DCP not support scaled kvcache now."
         assert attn_metadata.prefill is not None
         prefill_metadata = attn_metadata.prefill
         assert prefill_metadata.chunked_context is not None
@@ -2526,18 +2559,48 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         iters = len(prefill_metadata.chunked_context.seq_tot)
         workspace = prefill_metadata.chunked_context.workspace
 
+        fp8_kv_cache = (
+            self.kv_cache_dtype.startswith("fp8")
+            and self.kv_cache_dtype != "fp8_ds_mla"
+        )
+
         for i in range(iters):
             toks = prefill_metadata.chunked_context.seq_tot[i]
-            ops.cp_gather_cache(
-                src_cache=kv_c_and_k_pe_cache,
-                dst=workspace,
-                block_table=prefill_metadata.block_table,
-                cu_seq_lens=prefill_metadata.chunked_context.padded_local_cu_seq_lens[
-                    i
-                ],
-                batch_size=attn_metadata.num_prefills,
-                seq_starts=prefill_metadata.chunked_context.starts[i],
-            )
+            if fp8_kv_cache:
+                # FP8 KV cache: gather and dequant to BF16 workspace
+                assert k_scale is not None
+                token_to_seq = (
+                    prefill_metadata.chunked_context.padded_local_token_to_seq
+                )
+                chunk_total = (
+                    prefill_metadata.chunked_context.padded_local_chunk_total_token
+                )
+                assert token_to_seq is not None
+                assert chunk_total is not None
+                ops.gather_and_maybe_dequant_cache(
+                    src_cache=kv_c_and_k_pe_cache,
+                    dst=workspace,
+                    block_table=prefill_metadata.block_table,
+                    cu_seq_lens=prefill_metadata.chunked_context.padded_local_cu_seq_lens[
+                        i
+                    ],
+                    token_to_seq=token_to_seq[i],
+                    num_tokens=chunk_total[i],
+                    kv_cache_dtype=self.kv_cache_dtype,
+                    scale=k_scale,
+                    seq_starts=prefill_metadata.chunked_context.starts[i],
+                )
+            else:
+                ops.cp_gather_cache(
+                    src_cache=kv_c_and_k_pe_cache,
+                    dst=workspace,
+                    block_table=prefill_metadata.block_table,
+                    cu_seq_lens=prefill_metadata.chunked_context.padded_local_cu_seq_lens[
+                        i
+                    ],
+                    batch_size=attn_metadata.num_prefills,
+                    seq_starts=prefill_metadata.chunked_context.starts[i],
+                )
             # workspace
             # |------- N tokens --------|--------- N*dcp_size tokens ----------|
             # |<- use for local_gather ->|<--------- use for allgather -------->|
@@ -2652,12 +2715,22 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         if has_context:
             suffix_output, suffix_lse = output_prefill
             if self.dcp_world_size > 1:
+                if self.kv_cache_dtype == "fp8_ds_mla":
+                    raise NotImplementedError(
+                        "DCP > 1 with `kv_cache_dtype='fp8_ds_mla'` is not supported."
+                    )
+                assert not use_fp8_prefill, (
+                    "DCP>1 with FP8 prefill query quantization is not "
+                    "supported. Use --attention-config "
+                    "'{\"use_prefill_query_quantization\": false}' "
+                    "or reduce decode_context_parallel_size to 1."
+                )
                 context_output, context_lse = (
                     self._context_parallel_compute_prefill_context(
                         q,
                         kv_c_and_k_pe_cache,
                         attn_metadata,
-                        k_scale=None,
+                        k_scale=k_scale,
                         dcp_world_size=self.dcp_world_size,
                     )
                 )


### PR DESCRIPTION
Previously, MLA attention blocked the combination of FP8 KV cache (kv_cache_dtype=fp8) with DCP > 1 via hard asserts. This patch enables the combination by:

- Restructuring the decode Q path to allgather in BF16, then optionally quantize to FP8 post-gather for backends with supports_quant_query_input
- Replacing cp_gather_cache (dtype-strict) with gather_and_maybe_dequant_cache for FP8 KV cache in the prefill DCP gather path
- Passing k_scale through to the DCP prefill path (was hardcoded None)
- Adding a clear guard for the unsupported use_fp8_prefill + DCP > 1 case
- Adding FP8 DCP test parameterization to test_context_parallel.py

<!-- markdownlint-disable -->

### Purpose

MLA attention previously blocked the combination of FP8 KV cache (`kv_cache_dtype=fp8`) with Decode Context Parallel (DCP) > 1 via two hard asserts:
- Decode path: `assert not fp8_attention, "DCP not support fp8 kvcache now."`
- Prefill DCP gather: `assert k_scale is None, "DCP not support scaled kvcache now."`

This meant users had to choose between FP8 KV cache (memory savings) and DCP (more memory savings, latency reduction). This PR enables both to work together, maintaining numerical correctness through storage-only FP8 (no new FP8 compute paths).

### Changes

**mla_attention.py**:

1. **Decode Q restructure**: DCP > 1 always allgathers Q in BF16 first, then optionally quantizes to FP8 post-gather if `supports_quant_query_input=True`. This avoids the type mismatch where `_DecodeConcatQuantFP8` produces a single FP8 tensor incompatible with the DCP tuple->cat->allgather flow. DCP = 1 path is unchanged.

2. **FP8-aware prefill gather**: `cp_gather_cache` has a strict `TORCH_CHECK(src.dtype == dst.dtype)` that crashes when FP8 cache meets BF16 workspace. For FP8 KV cache (excluding `fp8_ds_mla`), the code now calls `gather_and_maybe_dequant_cache` which fuses gather + FP8->BF16 dequantization. Non-FP8 path continues to use `cp_gather_cache`.

3. **Metadata additions**: Added `padded_local_token_to_seq` and `padded_local_chunk_total_token` fields to `ChunkedContextMetadata`, computed in `build()`, required by `gather_and_maybe_dequant_cache`.

4. **`k_scale` passthrough**: `forward_mha` now passes the real `k_scale` to the DCP prefill path instead of a hardcoded `None`.

5. **Guard for `use_fp8_prefill` + DCP > 1**: Added a clear assert with actionable error message. This combination would require FP8 workspace allocation (only for sm10x + FlashInfer/TRT-LLM + use_prefill_query_quantization), and not supported.

**test_context_parallel.py**:

6. **FP8 DCP test parameterization**: Added `kv_cache_dtype` support to `CPTestOptions`/`CPTestSettings.detailed()` and added a new test entry for DeepSeek-V2-Lite-Chat with `dcp=4, kv_cache_dtype=fp8`.

### Test Plan

**New test:**
- `test_context_parallel.py::test_cp_generation` with `kv_cache_dtype="fp8"`, `dcp_size=4` — GSM8K 256-question 5-shot accuracy eval with DeepSeek-V2-Lite-Chat
- End-to-end test with lm_eval (GSM8K) with Kimi K2.5 on sm120 using new settings

**Regression tests:**
- `test_context_parallel.py::test_cp_generation` with `kv_cache_dtype=auto`, `dcp_size=4` — existing DCP test
- `test_mla_backends.py::test_backend_correctness` — MLA backend unit tests (DCP=1 forward paths)
- End-to-end test with lm_eval (GSM8K) with Kimi K2.5 on sm120 using existing previously supported settings

### Test Results

**Environment:** 16x GPUs, sm120, TritonMLA backend (the only MLA backend that works on sm120)

| Test | Config | Result |
|------|--------|--------|
| `test_cp_generation` (regression) | `tp=4, dcp=4, kv_cache_dtype=auto` | **PASS** (GSM8K accuracy ≥ 0.64) |
| `test_cp_generation` (new) | `tp=4, dcp=4, kv_cache_dtype=fp8` | **PASS** (GSM8K accuracy ≥ 0.64) |
| `test_backend_correctness` | 48 parameterizations, DCP=1 | **16 pass, 32 fail (pre-existing)** — all failures are pre-existing sm120 backend issues: Cutlass MLA (`RuntimeError: Error Internal`) and FlashInfer MLA (`XQA MLA only supports fp8 on SM120`). Not related to this PR. |

**Full lm_eval GSM8K results** (Kimi-K2.5, tp=16, TritonMLA, 5-shot):

| Config | exact_match (flexible) | exact_match (strict) |
|--------|----------------------|---------------------|
| `dcp=16, kv_cache_dtype=auto` (baseline) | 0.9363 ± 0.0067 | 0.9363 ± 0.0067 |
| `dcp=1, kv_cache_dtype=fp8` (baseline) | 0.9378 ± 0.0067 | 0.9371 ± 0.0067 |
| `dcp=16, kv_cache_dtype=fp8` **(this PR)** | **0.9371 ± 0.0067** | **0.9371 ± 0.0067** |

FP8 + DCP=16 accuracy matches both baselines within error margins.

### Known Limitations

- **`fp8_ds_mla` + DCP > 1**: Not supported (different storage format with embedded block scales). Falls through to `cp_gather_cache` which will dtype-check at runtime.
- **`use_fp8_prefill` + DCP > 1**: Explicitly guarded with assert. Would require FP8 workspace allocation; currently only possible with sm10x + FlashInfer/TRT-LLM + user selecting use_prefill_query_quantization.
- **`supports_quant_query_input=True` backends**: Post-gather FP8 quant path added but not tested on this (sm120) hardware (requires sm90a for FlashMLA/CutlassMLA). The path uses an additional `ops.scaled_fp8_quant` which is a well-tested primitive, with all other commands being the same as the Triton MLA sm120 path. Risk is minimal.
- **`gather_and_maybe_dequant_cache`**: Baseline vllm has hardcoded `head_dim == 576` constraint, currently limiting FP8 DCP to DeepSeek V2/V3/R1 family models. This constraint is duplicated in this PR.

### Note

To run this PR on sm120, it also requires that Triton MLA support `kv-cache-dtype fp8` from https://github.com/vllm-project/vllm/pull/34597 since that's the only backend that supports it. At this time, that PR is not yet merged, but the two features are independent and can be merged separately.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

