### PR TITLE
[CI][Bugfix] Fix new_weight_syncing/rlhf.py

### DIFF
--- a/examples/offline_inference/new_weight_syncing/rlhf.py
+++ b/examples/offline_inference/new_weight_syncing/rlhf.py
@@ -49,6 +49,10 @@ class MyLLM(LLM):
 
     def __init__(self, *args, **kwargs):
         os.environ["VLLM_RAY_BUNDLE_INDICES"] = "0,1"
+        # Remove the top-level CUDA_VISIBLE_DEVICES variable set by Ray
+        # so that vLLM can manage its own device placement within the worker.
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+
         super().__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
## Purpose
Fix ray-based test, make it similar to the corresponding `examples/offline_inference/rlhf.py`
Remove Ray-set `CUDA_VISIBLE_DEVICES`

Fixes error:
```
  File ".../.../site-packages/torch/cuda/__init__.py", line 424, in _lazy_init                                                                                                                                                                        
    torch._C._cuda_init()                                                                                                                                                                                                                                                               
RuntimeError: No CUDA GPUs are available      
``` 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

