### PR TITLE
[kv_offload+HMA][3/N]: Scheduler-side support for multiple KV groups

### DIFF
--- a/vllm/v1/kv_offload/factory.py
+++ b/vllm/v1/kv_offload/factory.py
@@ -33,7 +33,7 @@ class OffloadingSpecFactory:
     def create_spec(
         cls,
         config: "VllmConfig",
-        kv_cache_config: "KVCacheConfig | None",
+        kv_cache_config: "KVCacheConfig",
     ) -> OffloadingSpec:
         kv_transfer_config = config.kv_transfer_config
         assert kv_transfer_config is not None

--- a/vllm/v1/kv_offload/mediums.py
+++ b/vllm/v1/kv_offload/mediums.py
@@ -10,10 +10,19 @@ from vllm.v1.kv_offload.abstract import LoadStoreSpec
 class BlockIDsLoadStoreSpec(LoadStoreSpec, ABC):
     """
     Spec for loading/storing KV blocks from given block numbers.
+
+    If group_sizes is given, then it is assumed that block_ids list
+    can be braked to respective sub-lists given by group_sizes, where
+    each sub-list represent a series of consecutive logical blocks.
+    group_sizes = None is equivalent to group_sizes = [len(block_ids)].
     """
 
-    def __init__(self, block_ids: list[int]):
+    def __init__(self, block_ids: list[int], group_sizes: list[int] | None = None):
         self.block_ids = np.array(block_ids, dtype=np.int64)
+        self.group_sizes = (
+            np.array(group_sizes, dtype=np.int64) if group_sizes else None
+        )
+        assert group_sizes is None or sum(group_sizes) == len(block_ids)
 
     def __repr__(self) -> str:
         return repr(self.block_ids)

--- a/vllm/v1/kv_offload/spec.py
+++ b/vllm/v1/kv_offload/spec.py
@@ -21,9 +21,7 @@ logger = init_logger(__name__)
 class OffloadingSpec(ABC):
     """Spec for an offloading connector"""
 
-    def __init__(
-        self, vllm_config: "VllmConfig", kv_cache_config: "KVCacheConfig | None"
-    ):
+    def __init__(self, vllm_config: "VllmConfig", kv_cache_config: "KVCacheConfig"):
         logger.warning(
             "Initializing OffloadingSpec. This API is experimental and "
             "subject to change in the future as we iterate the design."
@@ -39,6 +37,7 @@ class OffloadingSpec(ABC):
         self.offloaded_block_size = int(
             self.extra_config.get("block_size", self.gpu_block_size)
         )
+        self.num_kv_groups = len(kv_cache_config.kv_cache_groups)
 
         assert self.offloaded_block_size % self.gpu_block_size == 0
 


### PR DESCRIPTION
This PR extends the scheduler-side OffloadingConnector to support multiple KV cache groups (applicable using HMA with hybrid models).
