### PR TITLE
[ROCm][Kernel] Add fused MoE exllama GEMM for compressed-tensors int4

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -346,6 +346,14 @@ torch::Tensor gptq_gemm(torch::Tensor a, torch::Tensor b_q_weight,
                         torch::Tensor b_gptq_scales, torch::Tensor b_g_idx,
                         bool use_exllama, bool use_v2_format, int64_t bit);
 
+void fused_moe_exllama_gemm(torch::Tensor a, torch::Tensor b_q_weight,
+                            torch::Tensor b_gptq_qzeros,
+                            torch::Tensor b_gptq_scales, torch::Tensor c,
+                            torch::Tensor sorted_token_ids,
+                            torch::Tensor expert_ids,
+                            torch::Tensor topk_weights, int64_t top_k,
+                            bool mul_routed_weight, int64_t block_size_m);
+
 void gptq_shuffle(torch::Tensor q_weight, torch::Tensor q_perm, int64_t bit);
 
 void static_scaled_fp8_quant(

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -601,6 +601,16 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "-> Tensor");
   ops.impl("gptq_gemm", torch::kCUDA, &gptq_gemm);
 
+  // Fused MoE GPTQ GEMM using exllama 4-bit kernel with expert routing.
+  ops.def(
+      "fused_moe_exllama_gemm(Tensor a, Tensor b_q_weight, "
+      "Tensor b_gptq_qzeros, Tensor b_gptq_scales, Tensor! c, "
+      "Tensor sorted_token_ids, Tensor expert_ids, "
+      "Tensor topk_weights, "
+      "int top_k, bool mul_routed_weight, "
+      "int block_size_m) -> ()");
+  ops.impl("fused_moe_exllama_gemm", torch::kCUDA, &fused_moe_exllama_gemm);
+
   // Post processing for GPTQ.
   ops.def("gptq_shuffle(Tensor! q_weight, Tensor q_perm, int bit) -> ()");
   ops.impl("gptq_shuffle", torch::kCUDA, &gptq_shuffle);

--- a/tests/kernels/moe/test_exllama_moe.py
+++ b/tests/kernels/moe/test_exllama_moe.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Standalone tests for ExllamaExperts (fused MoE exllama 4-bit kernel).
+
+This test validates the exllama-based MoE GPTQ kernel by:
+1. Creating random fp16 MoE weights
+2. Quantizing them to symmetric 4-bit with group_size=128
+3. Packing into GPTQ int32 format and applying gptq_shuffle
+4. Running ExllamaExperts via FusedMoEKernel
+5. Comparing against torch_experts reference using dequantized weights
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from tests.kernels.moe.utils import make_dummy_moe_config
+from tests.kernels.utils import torch_experts
+from vllm._custom_ops import gptq_shuffle
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.fused_moe import fused_topk
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    int4_w4a16_moe_quant_config,
+)
+from vllm.model_executor.layers.fused_moe.exllama_moe import ExllamaExperts
+from vllm.model_executor.layers.fused_moe.modular_kernel import (
+    FusedMoEKernel,
+)
+from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
+    MoEPrepareAndFinalizeNoDPEPModular,
+)
+from vllm.platforms import current_platform
+from vllm.v1.worker.workspace import init_workspace_manager
+
+NUM_BITS = 4
+GROUP_SIZE = 128
+PACK_FACTOR = 32 // NUM_BITS  # 8 nibbles per int32
+
+
+def _symmetric_quantize_4bit(
+    w: torch.Tensor,
+    group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Symmetric 4-bit quantization → (q_packed [K/8, N] int32, scales, w_ref).
+
+    Returns packed weights ready for gptq_shuffle, per-group scales,
+    and the dequantized reference tensor.
+    """
+    K, N = w.shape
+    assert K % group_size == 0
+    num_groups = K // group_size
+
+    w_grouped = w.reshape(num_groups, group_size, N)
+    abs_max = w_grouped.abs().amax(dim=1, keepdim=True).clamp(min=1e-5)
+    scales = abs_max / 7.0  # symmetric 4-bit: range [-7, 7] mapped to [1, 15]
+
+    # Quantize to unsigned [0, 15] with zero_point = 8
+    w_q = torch.round(w_grouped / scales).clamp(-7, 7).int() + 8
+    w_q = w_q.reshape(K, N)
+
+    # Dequantized reference
+    w_ref = (
+        ((w_q.float() - 8.0).reshape(num_groups, group_size, N) * scales)
+        .reshape(K, N)
+        .half()
+    )
+
+    # Pack 8 rows of 4-bit values into one int32 row → shape [K/8, N]
+    w_q_np = w_q.cpu().numpy().astype(np.uint32)
+    packed = np.zeros((K // PACK_FACTOR, N), dtype=np.uint32)
+    for i in range(PACK_FACTOR):
+        packed |= w_q_np[i::PACK_FACTOR, :] << (NUM_BITS * i)
+    q_packed = torch.from_numpy(packed.astype(np.int32)).to(w.device)
+
+    scales_out = scales.squeeze(1)  # [num_groups, N]
+    return q_packed, scales_out, w_ref
+
+
+def _make_exllama_moe_weights(
+    E: int,
+    K: int,
+    N: int,
+    group_size: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Create fake GPTQ-packed MoE weights for E experts.
+
+    Returns (w_packed, scales, qzeros, w_ref) where:
+    - w_packed: [E, K/8, N] int32 (exllama format)
+    - scales:   [E, num_groups, N] fp16
+    - qzeros:   [E, num_groups, N/8] int32
+    - w_ref:    [E, N, K] fp16 (transposed, torch_experts convention)
+    """
+    num_groups = K // group_size
+    dummy_perm = torch.empty(0, dtype=torch.int32, device=device)
+
+    all_packed = []
+    all_scales = []
+    all_ref = []
+
+    for _ in range(E):
+        w_fp = torch.randn(K, N, device=device, dtype=torch.float16) / 10.0
+        q_packed, scales, w_ref = _symmetric_quantize_4bit(w_fp, group_size)
+        gptq_shuffle(q_packed, dummy_perm, NUM_BITS)
+        all_packed.append(q_packed)
+        all_scales.append(scales)
+        all_ref.append(w_ref.t())  # transpose to [N, K] for torch_experts
+
+    w_packed = torch.stack(all_packed)  # [E, K/8, N]
+    w_scales = torch.stack(all_scales)  # [E, num_groups, N]
+    w_ref = torch.stack(all_ref)  # [E, N, K]
+
+    # GPTQv1 adds +1 to qzeros, so store 7 per nibble → 0x77777777
+    qzeros = torch.full(
+        (E, num_groups, N // PACK_FACTOR),
+        0x77777777,
+        dtype=torch.int32,
+        device=device,
+    )
+
+    return w_packed, w_scales, qzeros, w_ref
+
+
+@pytest.mark.skipif(
+    not (current_platform.is_rocm() or current_platform.is_cuda()),
+    reason="Requires ROCm or CUDA",
+)
+@pytest.mark.parametrize("m", [1, 4, 16])
+@pytest.mark.parametrize("n,k", [(256, 256), (512, 256)])
+@pytest.mark.parametrize("e,topk", [(8, 2), (16, 4)])
+def test_exllama_moe(m: int, n: int, k: int, e: int, topk: int):
+    torch.cuda.manual_seed(1)
+    device = torch.device("cuda")
+    group_size = GROUP_SIZE
+
+    assert k % group_size == 0
+    assert n % PACK_FACTOR == 0
+
+    # w1: gate+up projection, exllama [E, K/8, 2*N], ref [E, 2*N, K]
+    w1_packed, w1_scales, w1_qzeros, w1_ref = _make_exllama_moe_weights(
+        e, k, 2 * n, group_size, device
+    )
+    # w2: down projection, exllama [E, N/8, K], ref [E, K, N]
+    w2_packed, w2_scales, w2_qzeros, w2_ref = _make_exllama_moe_weights(
+        e, n, k, group_size, device
+    )
+
+    hidden = torch.randn(m, k, device=device, dtype=torch.float16) / 10
+    scores = torch.randn(m, e, device=device, dtype=torch.float16)
+
+    topk_weights, topk_ids, _ = fused_topk(hidden, scores, topk, False)
+
+    quant_config = int4_w4a16_moe_quant_config(
+        w1_scale=w1_scales,
+        w2_scale=w2_scales,
+        w1_zp=w1_qzeros,
+        w2_zp=w2_qzeros,
+        block_shape=[0, group_size],
+    )
+
+    moe_config = make_dummy_moe_config(
+        num_experts=e,
+        experts_per_token=topk,
+        hidden_dim=k,
+        intermediate_size_per_partition=n,
+        in_dtype=torch.float16,
+    )
+
+    mk = FusedMoEKernel(
+        fused_experts=ExllamaExperts(
+            moe_config=moe_config,
+            quant_config=quant_config,
+        ),
+        prepare_finalize=MoEPrepareAndFinalizeNoDPEPModular(),
+    )
+
+    init_workspace_manager(device)
+    vllm_config = VllmConfig()
+    with set_current_vllm_config(vllm_config):
+        torch_output = torch_experts(
+            hidden,
+            w1_ref,
+            w2_ref,
+            topk_weight=topk_weights,
+            topk_ids=topk_ids,
+            global_num_experts=e,
+        )
+
+        exllama_out = mk.apply(
+            hidden_states=hidden,
+            w1=w1_packed,
+            w2=w2_packed,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            global_num_experts=e,
+            expert_map=None,
+            activation=MoEActivation.SILU,
+            apply_router_weight_on_input=False,
+        )
+
+    torch.testing.assert_close(exllama_out, torch_output, atol=2e-2, rtol=0)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -606,6 +606,39 @@ if hasattr(torch.ops._C, "gptq_gemm"):
         )
 
 
+def fused_moe_exllama_gemm(
+    a: torch.Tensor,
+    b_q_weight: torch.Tensor,
+    b_gptq_qzeros: torch.Tensor,
+    b_gptq_scales: torch.Tensor,
+    c: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    top_k: int,
+    mul_routed_weight: bool,
+    block_size_m: int = 64,
+) -> None:
+    from vllm.v1.utils import record_function_or_nullcontext
+
+    M, K = a.shape
+    E, N = b_q_weight.size(0), c.size(-1)
+    with record_function_or_nullcontext(f"exllama_moe {M}x{N}x{K} E={E} top_k={top_k}"):
+        torch.ops._C.fused_moe_exllama_gemm(
+            a,
+            b_q_weight,
+            b_gptq_qzeros,
+            b_gptq_scales,
+            c,
+            sorted_token_ids,
+            expert_ids,
+            topk_weights,
+            top_k,
+            mul_routed_weight,
+            block_size_m,
+        )
+
+
 def gptq_shuffle(q_weight: torch.Tensor, q_perm: torch.Tensor, bit: int) -> None:
     torch.ops._C.gptq_shuffle(q_weight, q_perm, bit)
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -98,6 +98,7 @@ if TYPE_CHECKING:
     VLLM_DISABLED_KERNELS: list[str] = []
     VLLM_DISABLE_PYNCCL: bool = False
     VLLM_USE_OINK_OPS: bool = False
+    VLLM_MOE_EXLLAMA: bool = False
     VLLM_ROCM_USE_AITER: bool = False
     VLLM_ROCM_USE_AITER_PAGED_ATTN: bool = False
     VLLM_ROCM_USE_AITER_LINEAR: bool = True
@@ -907,6 +908,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Disabled by default.
     "VLLM_USE_OINK_OPS": lambda: (
         os.getenv("VLLM_USE_OINK_OPS", "False").lower() in ("true", "1")
+    ),
+    # Use exllama 4-bit kernel for MoE GPTQ instead of Triton.
+    # Requires exllama-native weight format [E, K/8, N] int32.
+    "VLLM_MOE_EXLLAMA": lambda: (
+        os.getenv("VLLM_MOE_EXLLAMA", "false").lower() in ("true", "1")
     ),
     # Disable aiter ops unless specifically enabled.
     # Acts as a parent switch to enable the rest of the other operations.

--- a/vllm/model_executor/layers/fused_moe/__init__.py
+++ b/vllm/model_executor/layers/fused_moe/__init__.py
@@ -87,6 +87,7 @@ if HAS_TRITON:
         cutlass_moe_w4a8_fp8,
     )
     from vllm.model_executor.layers.fused_moe.deep_gemm_moe import DeepGemmExperts
+    from vllm.model_executor.layers.fused_moe.exllama_moe import ExllamaExperts
     from vllm.model_executor.layers.fused_moe.fused_batched_moe import (
         BatchedTritonExperts,
     )
@@ -123,6 +124,7 @@ if HAS_TRITON:
         "CutlassExpertsFp8",
         "CutlassBatchedExpertsFp8",
         "CutlassExpertsW4A8Fp8",
+        "ExllamaExperts",
         "TritonExperts",
         "TritonWNA16Experts",
         "BatchedTritonExperts",

--- a/vllm/model_executor/layers/fused_moe/exllama_moe.py
+++ b/vllm/model_executor/layers/fused_moe/exllama_moe.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Exllama-based MoE experts for 4-bit GPTQ weight format."""
+
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.fused_moe.activation import (
+    MoEActivation,
+    apply_moe_activation,
+)
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEParallelConfig,
+)
+from vllm.model_executor.layers.fused_moe.moe_align_block_size import (
+    moe_align_block_size,
+)
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceNoOP,
+)
+from vllm.model_executor.layers.fused_moe.utils import (
+    _resize_cache,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
+from vllm.platforms import current_platform
+from vllm.utils.math_utils import round_up
+
+
+class ExllamaExperts(mk.FusedMoEExpertsModular):
+    """
+    Modular MoE experts using the exllama 4-bit GPTQ kernel.
+
+    Weights are in exllama format: [E, K/8, N] int32 (packed 4-bit).
+    Scales are [E, K/G, N] fp16.
+    Zero-points are [E, K/G, N/8] int32 (packed 4-bit).
+    """
+
+    @staticmethod
+    def activation_format() -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.Standard
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        return current_platform.is_rocm() or current_platform.is_cuda()
+
+    @staticmethod
+    def _supports_no_act_and_mul() -> bool:
+        return False
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        raise NotImplementedError(
+            "ExllamaExperts is not yet used by an Oracle. "
+            "This method should not be called."
+        )
+
+    @staticmethod
+    def _supports_activation(activation: MoEActivation) -> bool:
+        return activation in [MoEActivation.SILU, MoEActivation.GELU]
+
+    @staticmethod
+    def _supports_parallel_config(
+        moe_parallel_config: FusedMoEParallelConfig,
+    ) -> bool:
+        return not moe_parallel_config.use_fi_all2allv_kernels
+
+    def supports_chunking(self) -> bool:
+        return True
+
+    def supports_expert_map(self) -> bool:
+        return True
+
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
+        return TopKWeightAndReduceNoOP()
+
+    @staticmethod
+    def _select_block_size_m(num_tokens: int, topk: int, E: int) -> int:
+        """Select block size in the M dimension for the exllama kernel.
+
+        Prefill (num_tokens > 1): pick a larger block to amortize weight
+        dequantization across rows.  This requires pre-permuting activations
+        so each expert's tokens are contiguous.
+        Decode (num_tokens <= 1): block_size_m=1, kernel handles
+        scatter/gather via sorted_token_ids directly.
+        """
+        if num_tokens > 1:
+            avg = num_tokens * topk / E
+            return 4 if avg >= 4 else 2 if avg >= 2 else 1
+        return 1
+
+    def moe_problem_size(
+        self,
+        a1: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> tuple[int, int, int, int, int]:
+        # Exllama format: w1 is [E, K/8, N], w2 is [E, K_inter/8, hidden]
+        assert w1.dim() == 3 and w2.dim() == 3
+        E = w1.size(0)
+        N = w1.size(2)  # intermediate_size * 2 (gate + up)
+        K = a1.size(-1)  # hidden_size
+        assert a1.dim() == 2
+        M = a1.size(0)
+        topk = topk_ids.size(1)
+        return E, M, N, K, topk
+
+    def workspace_shapes(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        topk: int,
+        global_num_experts: int,
+        local_num_experts: int,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        activation: MoEActivation,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        activation_out_dim = self.adjust_N_for_activation(N, activation)
+        # Account for alignment padding from moe_align_block_size:
+        # each expert may need up to (block_size_m - 1) padding rows.
+        block_size_m = self._select_block_size_m(M, topk, global_num_experts)
+        num_slots = round_up(
+            M * topk + global_num_experts * (block_size_m - 1),
+            block_size_m,
+        )
+        workspace1 = (num_slots, max(activation_out_dim, K))
+        workspace2 = (num_slots, max(N, K))
+        output = (M, K)
+        return (workspace1, workspace2, output)
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool,
+    ):
+        from vllm._custom_ops import fused_moe_exllama_gemm
+
+        assert w1.dtype == torch.int32, "ExllamaExperts requires int32 weights"
+        assert hidden_states.dim() == 2
+        assert hidden_states.is_contiguous()
+
+        E, num_tokens, N, K, top_k_num = self.moe_problem_size(
+            hidden_states, w1, w2, topk_ids
+        )
+
+        if global_num_experts == -1:
+            global_num_experts = E
+
+        activation_out_dim = self.adjust_N_for_activation(N, activation)
+
+        block_size_m = self._select_block_size_m(num_tokens, top_k_num, E)
+
+        sorted_token_ids, expert_ids, _ = moe_align_block_size(
+            topk_ids,
+            block_size_m,
+            global_num_experts,
+            expert_map,
+            ignore_invalid_experts=True,
+        )
+
+        tw = topk_weights if topk_weights is not None else hidden_states.new_empty(0)
+
+        num_slots = sorted_token_ids.size(0)
+
+        if block_size_m > 1:
+            source_rows = (sorted_token_ids // top_k_num).clamp(max=num_tokens - 1)
+            # Permute activations into workspace13 so each expert's
+            # tokens are contiguous.  workspace13 is reused for act_out
+            # after GEMM1 has consumed gemm1_in.
+            gemm1_in = _resize_cache(workspace13, (num_slots, K))
+            torch.index_select(hidden_states, 0, source_rows.long(), out=gemm1_in)
+        else:
+            gemm1_in = hidden_states
+
+        gemm1_out = _resize_cache(workspace2, (num_slots, N))
+        act_out = _resize_cache(workspace13, (num_slots, activation_out_dim))
+        gemm2_out = _resize_cache(workspace2, (num_slots, K))
+
+        # GEMM 1
+        fused_moe_exllama_gemm(
+            gemm1_in,
+            w1,
+            self.quant_config.w1_zp,
+            self.w1_scale,
+            gemm1_out,
+            sorted_token_ids,
+            expert_ids,
+            tw,
+            top_k_num,
+            False,
+            block_size_m,
+        )
+
+        # Activation (elementwise, order-independent)
+        apply_moe_activation(activation, act_out, gemm1_out)
+
+        # GEMM 2 -- always apply router weights here.
+        # Decode (scattered kernel): weights applied inside the kernel.
+        # Prefill (contiguous kernel): kernel uses router_weight=1.0
+        # (single scalar, can't vary per row), so we apply weights
+        # explicitly right after the kernel call.
+        fused_moe_exllama_gemm(
+            act_out,
+            w2,
+            self.quant_config.w2_zp,
+            self.w2_scale,
+            gemm2_out,
+            sorted_token_ids,
+            expert_ids,
+            tw,
+            1,
+            not apply_router_weight_on_input,
+            block_size_m,
+        )
+
+        # Reduce
+        if block_size_m > 1:
+            num_valid = num_tokens * top_k_num
+            clamped_tids = sorted_token_ids.clamp(max=num_valid - 1)
+
+            # Apply per-slot router weights (contiguous kernel can only
+            # apply a single scalar, so we do it here).
+            if not apply_router_weight_on_input and topk_weights is not None:
+                flat_w = topk_weights.view(-1)
+                gemm2_out *= flat_w[clamped_tids].unsqueeze(1)
+
+            # Scatter-back + sum.  Use mask arithmetic (not nonzero())
+            # to stay compatible with CUDA graph capture.
+            # TODO: replace with moe_unpermute once supported on ROCm.
+            orig_tokens = clamped_tids // top_k_num
+            valid_mask = (sorted_token_ids < num_valid).unsqueeze(1)
+
+            output.zero_()
+            output.scatter_add_(
+                0,
+                orig_tokens.unsqueeze(1).expand(-1, K),
+                gemm2_out * valid_mask,
+            )
+        else:
+            ops.moe_sum(gemm2_out.view(num_tokens, top_k_num, K), output)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -34,10 +34,14 @@ from vllm.model_executor.layers.fused_moe.config import (
     int8_w8a16_moe_quant_config,
 )
 from vllm.model_executor.layers.fused_moe.cpu_fused_moe import select_experts
+from vllm.model_executor.layers.fused_moe.exllama_moe import ExllamaExperts
 from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
     BatchedMarlinExperts,
     MarlinExperts,
     fused_marlin_moe,
+)
+from vllm.model_executor.layers.fused_moe.modular_kernel import (
+    FusedMoEKernel,
 )
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
     convert_to_fp8_moe_kernel_format,
@@ -53,6 +57,9 @@ from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
     make_nvfp4_moe_kernel,
     make_nvfp4_moe_quant_config,
     select_nvfp4_moe_backend,
+)
+from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
+    MoEPrepareAndFinalizeNoDPEPModular,
 )
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_wNa16 import (  # noqa
     WNA16_SUPPORTED_BITS,
@@ -1680,6 +1687,8 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         assert weight_quant.symmetric, (
             "Only symmetric quantization is supported for MoE"
         )
+        self.moe_mk: FusedMoEKernel | None = None
+        self.moe_quant_config: FusedMoEQuantConfig | None = None
 
     def create_weights(
         self,
@@ -1810,21 +1819,82 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         layer.a2_scale = None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        # Reconfigure packed weights and scales to match moe_wna16 format
-        layer.w13_weight_packed = torch.nn.Parameter(
-            layer.w13_weight_packed.transpose(1, 2).contiguous().view(torch.uint8),
-            requires_grad=False,
-        )
-        layer.w2_weight_packed = torch.nn.Parameter(
-            layer.w2_weight_packed.transpose(1, 2).contiguous().view(torch.uint8),
-            requires_grad=False,
-        )
-        layer.w13_weight_scale = torch.nn.Parameter(
-            layer.w13_weight_scale.transpose(1, 2).contiguous(), requires_grad=False
-        )
-        layer.w2_weight_scale = torch.nn.Parameter(
-            layer.w2_weight_scale.transpose(1, 2).contiguous(), requires_grad=False
-        )
+        import vllm.envs as envs
+
+        if envs.VLLM_MOE_EXLLAMA and self.num_bits == 4:
+            # Exllama MoE path: keep weights in [E, K/8, N] int32 format
+            # and apply gptq_shuffle for the exllama kernel's SIMD layout.
+            from vllm._custom_ops import gptq_shuffle
+
+            device = layer.w13_weight_packed.device
+            dummy_perm = torch.empty(0, dtype=torch.int32, device=device)
+            for e in range(layer.w13_weight_packed.size(0)):
+                gptq_shuffle(layer.w13_weight_packed.data[e], dummy_perm, self.num_bits)
+                gptq_shuffle(layer.w2_weight_packed.data[e], dummy_perm, self.num_bits)
+            # Scales are already [E, groups, N] — keep as-is for exllama.
+
+            # Create synthetic qzeros for the exllama kernel.
+            # Symmetric 4-bit: zero_point = 8 (midpoint of 0..15).
+            # GPTQv1 kernel adds +1, so store 7 per nibble.
+            # 8 nibbles of 7 packed into int32 = 0x77777777.
+            E = layer.w13_weight_packed.size(0)
+            groups_w13 = layer.w13_weight_scale.size(1)
+            N_w13 = layer.w13_weight_packed.size(2)
+            groups_w2 = layer.w2_weight_scale.size(1)
+            N_w2 = layer.w2_weight_packed.size(2)
+
+            w13_qzeros = torch.nn.Parameter(
+                torch.full(
+                    (E, groups_w13, N_w13 // 8),
+                    0x77777777,
+                    dtype=torch.int32,
+                    device=device,
+                ),
+                requires_grad=False,
+            )
+            w2_qzeros = torch.nn.Parameter(
+                torch.full(
+                    (E, groups_w2, N_w2 // 8),
+                    0x77777777,
+                    dtype=torch.int32,
+                    device=device,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter("w13_qzeros", w13_qzeros)
+            layer.register_parameter("w2_qzeros", w2_qzeros)
+            layer.use_exllama_moe = True
+
+            # Build modular kernel for exllama path
+            self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+            assert self.moe_quant_config is not None
+            layer.w13_weight = layer.w13_weight_packed
+            layer.w2_weight = layer.w2_weight_packed
+            self.moe_mk = FusedMoEKernel(
+                fused_experts=ExllamaExperts(
+                    moe_config=self.moe, quant_config=self.moe_quant_config
+                ),
+                prepare_finalize=MoEPrepareAndFinalizeNoDPEPModular(),
+            )
+        else:
+            # Triton path: transpose + reinterpret as uint8
+            layer.w13_weight_packed = torch.nn.Parameter(
+                layer.w13_weight_packed.transpose(1, 2).contiguous().view(torch.uint8),
+                requires_grad=False,
+            )
+            layer.w2_weight_packed = torch.nn.Parameter(
+                layer.w2_weight_packed.transpose(1, 2).contiguous().view(torch.uint8),
+                requires_grad=False,
+            )
+            layer.w13_weight_scale = torch.nn.Parameter(
+                layer.w13_weight_scale.transpose(1, 2).contiguous(),
+                requires_grad=False,
+            )
+            layer.w2_weight_scale = torch.nn.Parameter(
+                layer.w2_weight_scale.transpose(1, 2).contiguous(),
+                requires_grad=False,
+            )
+            layer.use_exllama_moe = False
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
@@ -1836,11 +1906,12 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
             else int8_w8a16_moe_quant_config
         )
 
+        use_exllama = getattr(layer, "use_exllama_moe", False)
         return config_builder(
             w1_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
-            w1_zp=None,
-            w2_zp=None,
+            w1_zp=getattr(layer, "w13_qzeros", None) if use_exllama else None,
+            w2_zp=getattr(layer, "w2_qzeros", None) if use_exllama else None,
             block_shape=[0, self.group_size],
         )
 
@@ -1849,25 +1920,21 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         prepare_finalize: mk.FusedMoEPrepareAndFinalizeModular,
         layer: torch.nn.Module,
     ) -> mk.FusedMoEExpertsModular:
-        if self.moe.is_lora_enabled:
-            assert self.moe_quant_config is not None
-            from vllm.triton_utils import HAS_TRITON
+        assert self.moe_quant_config is not None
+        layer.w13_weight = layer.w13_weight_packed
+        layer.w2_weight = layer.w2_weight_packed
 
-            if HAS_TRITON:
-                from vllm.model_executor.layers.fused_moe import TritonWNA16Experts
+        use_exllama = getattr(layer, "use_exllama_moe", False)
+        if use_exllama:
+            return ExllamaExperts(
+                moe_config=self.moe, quant_config=self.moe_quant_config
+            )
 
-                layer.w13_weight = layer.w13_weight_packed
-                layer.w2_weight = layer.w2_weight_packed
-                return TritonWNA16Experts(
-                    moe_config=self.moe, quant_config=self.moe_quant_config
-                )
-            else:
-                raise NotImplementedError(
-                    "TritonExperts requires Triton. "
-                    "Install triton or disable LoRA for MoE."
-                )
+        from vllm.model_executor.layers.fused_moe import TritonWNA16Experts
 
-        raise NotImplementedError
+        return TritonWNA16Experts(
+            moe_config=self.moe, quant_config=self.moe_quant_config
+        )
 
     def apply(
         self,
@@ -1877,6 +1944,20 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         topk_ids: torch.Tensor,
         shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if self.moe_mk is not None:
+            return self.moe_mk.apply(
+                hidden_states=x,
+                w1=layer.w13_weight,
+                w2=layer.w2_weight,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                activation=layer.activation,
+                global_num_experts=layer.global_num_experts,
+                apply_router_weight_on_input=layer.apply_router_weight_on_input,
+                expert_map=layer.expert_map,
+            )
+
+        # Triton WNA16 fallback (non-exllama, non-EP)
         from vllm.model_executor.layers.fused_moe import fused_experts
 
         return fused_experts(


### PR DESCRIPTION
## Summary

Add a dedicated exllama-based MoE kernel (`ExllamaExperts`) that performs int4 dequantization fused with the GEMM, replacing the generic Triton fused_moe path for compressed-tensors quantized MoE models on ROCm. Gives 27% improvement in TPOT on int4 quantized Qwen3-30B-A3B.
Prefill is slower than the Triton MoE implementation on larger contexts. Thus we have the ExLlama path disabled by default,
until we can improve the prefill speed in a follow up.

- **Scattered kernel** (decode, `block_size_m=1`): each thread block handles one expert-token pair, reading weights + dequantizing + accumulating in a single pass.
- **Contiguous kernel** (prefill, `block_size_m=2,4`): pre-permutes activations so each expert's tokens are contiguous, amortizing weight dequantization across multiple rows.
- Controlled by `VLLM_MOE_EXLLAMA` env var (disabled by default, opt in with `VLLM_MOE_EXLLAMA=1`).

### Files changed

- `csrc/quantization/gptq/q_gemm.cu` — New `moe_gptq_4bit_kernel` and `moe_gptq_4bit_contiguous_kernel` kernels wrappers around the existing ExLlama kernels.
- `csrc/ops.h`, `csrc/torch_bindings.cpp` — Register `fused_moe_exllama_gemm` op
- `vllm/_custom_ops.py` — Python binding for `fused_moe_exllama_gemm`
- `vllm/envs.py` — Add `VLLM_MOE_EXLLAMA` environment variable
- `vllm/model_executor/layers/fused_moe/exllama_moe.py` — `ExllamaExperts` modular kernel implementation
- `vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py` — Wire up exllama path in `CompressedTensorsWNA16MoEMethod`
- `tests/kernels/moe/test_exllama_moe.py` — Standalone unit test (12 parametrized cases)

## Performance

Benchmarked on AMD Strix Halo (gfx1151, LPDDR5X-8000 128 GB) with `cyankiwi/Qwen3-30B-A3B-Instruct-2507-AWQ-4bit`:

| Workload | Metric | Baseline | After | Change |
|----------|--------|----------|-------|--------|
| input=128, output=128 | Median TTFT | 136.01 ms | 143.13 ms | +5% |
| | Median TPOT | 21.87 ms | 15.91 ms | **27% faster** |
| input=1920, output=128 | Median TTFT | 934.56 ms | 1609.02 ms | 72% slower |
| | Median TPOT | 22.78 ms | 16.85 ms | **26% faster** |

Decode throughput improves significantly (~27%). Long-prefill TTFT regresses due to the contiguous kernel being slower than Triton for large batch sizes — this is why the feature is opt-in.

## Accuracy

Validated with `lm_eval` on gsm8k (200 samples, `cyankiwi/Qwen3-30B-A3B-Instruct-2507-AWQ-4bit`):

| Metric | Baseline | After |
|--------|----------|-------|
| flexible-extract | 0.890 | 0.895 |
| strict-match | 0.880 | 0.880 |

No accuracy regression.

## Test plan

- [x] Unit test: `pytest tests/kernels/moe/test_exllama_moe.py` — 12/12 pass (m=1/4/16, n=256/512, k=256, e=8/16, topk=2/4)
- [x] End-to-end accuracy: lm_eval gsm8k with Qwen3-30B-A3B AWQ-4bit
- [x] End-to-end benchmark: vllm-bench with short and long prefill workloads
