### PR TITLE
[WIP][Bugfix] Detect LoRA module name prefix mismatches at load time

### DIFF
--- a/tests/lora/test_lora_checkpoints.py
+++ b/tests/lora/test_lora_checkpoints.py
@@ -97,6 +97,61 @@ def test_load_checkpoints(
             )
 
 
+def test_lora_module_prefix_mismatch_detected(baichuan_lora_files):
+    """LoRA adapters with mismatched module name prefixes should raise
+    ValueError instead of silently being ignored (issue #34186)."""
+    peft_helper = PEFTHelper.from_local_dir(
+        baichuan_lora_files, max_position_embeddings=4096
+    )
+    # Simulate a model that wraps the LM in a language_model submodule:
+    # the LoRA adapter has "model.layers.0..." keys but the model expects
+    # "language_model.model.layers.0..." full paths.
+    model_module_names = {
+        "language_model.model.layers.0.self_attn.W_pack",
+        "language_model.model.layers.0.self_attn.o_proj",
+        "language_model.model.layers.0.mlp.gate_proj",
+        "language_model.model.layers.0.mlp.up_proj",
+        "language_model.model.layers.0.mlp.down_proj",
+    }
+    expected_error = "none of the LoRA adapter's module names matched"
+    with pytest.raises(ValueError, match=expected_error):
+        LoRAModel.from_local_checkpoint(
+            baichuan_lora_files,
+            {"W_pack", "o_proj", "gate_proj", "up_proj", "down_proj"},
+            peft_helper=peft_helper,
+            lora_model_id=1,
+            device="cpu",
+            model_vocab_size=64000,
+            model_module_names=model_module_names,
+        )
+
+
+def test_lora_module_prefix_match_passes(baichuan_lora_files):
+    """LoRA adapters with matching module name prefixes should load fine."""
+    peft_helper = PEFTHelper.from_local_dir(
+        baichuan_lora_files, max_position_embeddings=4096
+    )
+    # The baichuan adapter keys parse to "model.layers.N.self_attn.W_pack"
+    # etc. Provide model_module_names that match.
+    model_module_names = {
+        "model.layers.0.self_attn.W_pack",
+        "model.layers.0.self_attn.o_proj",
+        "model.layers.0.mlp.gate_proj",
+        "model.layers.0.mlp.up_proj",
+        "model.layers.0.mlp.down_proj",
+    }
+    # Should not raise
+    LoRAModel.from_local_checkpoint(
+        baichuan_lora_files,
+        {"W_pack", "o_proj", "gate_proj", "up_proj", "down_proj"},
+        peft_helper=peft_helper,
+        lora_model_id=1,
+        device="cpu",
+        model_vocab_size=64000,
+        model_module_names=model_module_names,
+    )
+
+
 def test_lora_weights_mapping(baichuan_lora_files):
     packed_modules_mapping = BaiChuanBaseForCausalLM.packed_modules_mapping
 

--- a/vllm/lora/lora_model.py
+++ b/vllm/lora/lora_model.py
@@ -178,6 +178,7 @@ class LoRAModel:
         tensorizer_config_dict: dict | None = None,
         skip_prefixes: list[str] | None = None,
         moe_ep_spec: MoEEPLoadSpec | None = None,
+        model_module_names: set[str] | None = None,
     ) -> "LoRAModel":
         """Create a LoRAModel from a local checkpoint.
 
@@ -198,6 +199,11 @@ class LoRAModel:
                 slicing metadata shared across all MoE layers. Non-local
                 expert weights are skipped at read time instead of being
                 loaded and discarded later.
+            model_module_names: Full module paths from the model that are
+                valid LoRA targets. When provided, validates that at least
+                one adapter module matches a model module path. This catches
+                prefix mismatches (e.g., adapter trained on GemmaForCausalLM
+                loaded into Gemma3ForConditionalGeneration).
 
         Returns:
             Loaded LoRA Model.
@@ -210,6 +216,7 @@ class LoRAModel:
         unexpected_modules: list[list[str] | str] = []
 
         def check_unexpected_modules(modules: dict):
+            parsed_module_names: list[str] = []
             for lora_module in modules.keys():  # noqa
                 if is_base_embedding_weights(lora_module):
                     continue
@@ -223,6 +230,7 @@ class LoRAModel:
                 ):
                     continue
                 module_name, _ = parse_fine_tuned_lora_name(lora_module, weights_mapper)
+                parsed_module_names.append(module_name)
                 # Case for expert lora weights
                 if ".experts" in module_name:
                     expert_idx = module_name.find(".experts")
@@ -240,6 +248,31 @@ class LoRAModel:
                     f" but received {unexpected_modules}."
                     f" Please verify that the loaded LoRA module is correct"
                 )
+
+            # Full-path validation: check that at least one parsed module
+            # name matches the model's registered module paths. This catches
+            # prefix mismatches where the module type is correct (e.g.,
+            # q_proj) but the full path differs (e.g., model.layers.0...
+            # vs language_model.model.layers.0...).
+            if model_module_names and parsed_module_names:
+                matched = any(
+                    name in model_module_names for name in parsed_module_names
+                )
+                if not matched:
+                    lora_sample = sorted(set(parsed_module_names))[:3]
+                    model_sample = sorted(model_module_names)[:3]
+                    raise ValueError(
+                        f"While loading {lora_dir}, none of the LoRA "
+                        f"adapter's module names matched the model's "
+                        f"module paths. The adapter may have been trained "
+                        f"on a different model architecture.\n"
+                        f"  LoRA module names (sample): {lora_sample}\n"
+                        f"  Model module paths (sample): {model_sample}\n"
+                        f"Hint: Ensure the LoRA was trained for the same "
+                        f"model architecture, or add an hf_to_vllm_mapper "
+                        f"to the model class to translate module name "
+                        f"prefixes."
+                    )
 
         if tensorizer_config_dict:
             from tensorizer import TensorDeserializer

--- a/vllm/lora/lora_model.py
+++ b/vllm/lora/lora_model.py
@@ -254,7 +254,7 @@ class LoRAModel:
             # prefix mismatches where the module type is correct (e.g.,
             # q_proj) but the full path differs (e.g., model.layers.0...
             # vs language_model.model.layers.0...).
-            if model_module_names and parsed_module_names:
+            if model_module_names:
                 matched = any(
                     name in model_module_names for name in parsed_module_names
                 )

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -787,6 +787,8 @@ class LoRAModelManager:
                 else:
                     self._slice_moe_lora_ep(lora_model, module, module_name)
 
+        if not lora_model.loras:
+            return
         first_lora: LoRALayerWeights = next(iter(lora_model.loras.values()))
         assert first_lora.lora_a is not None
         if isinstance(first_lora.lora_a, list):

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -129,6 +129,19 @@ class WorkerLoRAManager:
             # Get model-defined prefixes to skip during LoRA loading.
             lora_skip_prefixes = getattr(model, "lora_skip_prefixes", None)
 
+            # Build the set of all valid full module paths for LoRA
+            # targets. This includes both non-packed modules and unpacked
+            # component names from packed modules (e.g., q_proj from
+            # qkv_proj). Used to detect module name prefix mismatches.
+            model_module_names: set[str] = set()
+            for mod_name in self._adapter_manager.modules:
+                if mod_name in self._adapter_manager.packed_modules:
+                    model_module_names.update(
+                        self._adapter_manager.packed_modules[mod_name]
+                    )
+                else:
+                    model_module_names.add(mod_name)
+
             lora = self._lora_model_cls.from_local_checkpoint(
                 lora_path,
                 expected_lora_modules,
@@ -141,6 +154,7 @@ class WorkerLoRAManager:
                 weights_mapper=hf_to_vllm_mapper,
                 skip_prefixes=lora_skip_prefixes,
                 moe_ep_spec=self._adapter_manager.moe_ep_load_spec,
+                model_module_names=model_module_names,
             )
             # Stamp the on-disk MoE layout onto the loaded model so the
             # adapter manager can route 3D-format checkpoints through the


### PR DESCRIPTION
## Purpose

Fixes #34186.

LoRA adapters trained on a different model class (e.g., `GemmaForCausalLM`) than what vLLM loads (e.g., `Gemma3ForConditionalGeneration`) silently produce base-model output. The adapter weights are stored under incorrect module name keys and never applied at inference time — no error, no warning.

**Root cause:** `check_unexpected_modules` only validates the last component of module names (e.g., `q_proj`), so `model.layers.0.self_attn.q_proj` passes validation even though the model expects `language_model.model.layers.0.self_attn.q_proj`. At inference, `get_lora()` returns `None` for every module and the LoRA is silently skipped.

**Fix:** Enhance `check_unexpected_modules` with full-path validation. The caller (`_load_adapter` in `worker_manager.py`) builds a set of all valid full module paths from the model's registered modules (including unpacked components of packed modules like `q_proj` from `qkv_proj`), and passes it to `from_local_checkpoint`. After the existing last-component check passes, a new check verifies that at least one parsed adapter module name matches a model module path. If zero match, a clear `ValueError` is raised showing sample keys from both sides.

**Changes:**
- `vllm/lora/worker_manager.py`: Build `model_module_names` set from `self._adapter_manager.modules` and `.packed_modules`, pass to `from_local_checkpoint`
- `vllm/lora/lora_model.py`: Add optional `model_module_names` param to `from_local_checkpoint`; extend `check_unexpected_modules` with full-path validation
- `vllm/lora/model_manager.py`: Guard `next(iter(...))` in `_create_merged_loras_inplace` against empty `loras` dict (defense-in-depth)
- `tests/lora/test_lora_checkpoints.py`: Add tests for prefix mismatch detection and correct prefix passing

## Test Plan

1. **Unit tests**: Added `test_lora_module_prefix_mismatch_detected` (verifies mismatched prefix raises `ValueError`) and `test_lora_module_prefix_match_passes` (verifies correct prefix loads fine)
2. **Reproduction with actual bug report adapter**: Downloaded `stewy33/gemma-3-4b-it-0524_rowan_original_prompt_augmented_egregious_cake_bake-bd093845` (the exact adapter from #34186) and verified:
   - 238 LoRA modules parsed, 238 model modules expected, **0 matched** (confirming the bug)
   - With the fix, `ValueError` is raised immediately at load time with a clear diagnostic message
3. **Backwards compatibility**: Existing callers that don't pass `model_module_names` (including 6 test call sites) are unaffected — the new validation is skipped when `model_module_names` is `None`

## Test Result

```
tests/lora/test_lora_checkpoints.py::test_load_checkpoints[chatglm3-6b] PASSED
tests/lora/test_lora_checkpoints.py::test_lora_module_prefix_mismatch_detected PASSED
```

Reproduction with the exact adapter from #34186:
```
============================================================
REPRODUCING BUG #34186 — Module Key Mismatch Analysis
============================================================

SDF LoRA adapter: 238 unique module names
Gemma3 model:     238 expected module paths
Matched:          0 modules

BUG CONFIRMED: Zero modules match!

--- With our fix, this now raises ValueError: ---

While loading .../gemma-3-4b-it-0524_rowan_..._cake_bake-.../,
none of the LoRA adapter's module names matched the model's module paths.
The adapter may have been trained on a different model architecture.
  LoRA module names (sample): ['model.layers.0.mlp.down_proj', ...]
  Model module paths (sample): ['language_model.model.layers.0.mlp.down_proj', ...]
Hint: Ensure the LoRA was trained for the same model architecture,
or add an hf_to_vllm_mapper to the model class to translate module name prefixes.

FIX VERIFIED: Error caught at load time with clear message.
```