### PR TITLE
[WIP][Bugfix] Fix SIGILL crash on CPU-only systems during model inspection

### DIFF
--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -1254,10 +1254,35 @@ def _run_in_subprocess(fn: Callable[[], _T]) -> _T:
         try:
             returned.check_returncode()
         except Exception as e:
-            # wrap raised exception to provide more information
-            raise RuntimeError(
-                f"Error raised in subprocess:\n{returned.stderr.decode()}"
-            ) from e
+            stderr_text = returned.stderr.decode(errors="replace")
+
+            # Check if the subprocess was killed by a signal
+            if returned.returncode < 0:
+                import signal as sig_mod
+
+                sig_num = -returned.returncode
+                try:
+                    sig_name = sig_mod.Signals(sig_num).name
+                except (ValueError, AttributeError):
+                    sig_name = f"signal {sig_num}"
+
+                hint = ""
+                if sig_num == sig_mod.SIGILL:
+                    hint = (
+                        "\nHint: SIGILL typically means the installed "
+                        "vLLM binary was compiled for CPU instructions "
+                        "(e.g., AVX-512) not supported by this machine."
+                        " Consider building vLLM from source or using a"
+                        " compatible wheel."
+                    )
+
+                raise RuntimeError(
+                    f"Subprocess killed by {sig_name} "
+                    f"(return code {returned.returncode}).{hint}"
+                    f"\nstderr:\n{stderr_text}"
+                ) from e
+
+            raise RuntimeError(f"Error raised in subprocess:\n{stderr_text}") from e
 
         with open(output_filepath, "rb") as f:
             return pickle.load(f)


### PR DESCRIPTION
## Purpose

Fixes #32554.

When vLLM is installed from the pre-built CPU wheel on a machine without AVX-512 support (e.g., Intel i5-9600K with only AVX2), inspecting any model architecture that transitively imports `vllm._custom_ops` causes the process to crash with **SIGILL** (Illegal Instruction, signal 4). This makes models like `Gemma3ForConditionalGeneration` completely unusable on these CPUs.

**Root cause:** The pre-built CPU wheel's `vllm._C` shared library is compiled with AVX-512 instructions. When loaded on a CPU that only supports AVX2, the CPU encounters illegal instructions and the OS kills the process. Unlike `ImportError`, SIGILL is a fatal signal that cannot be caught by `try/except`. `CpuPlatform` did not override `import_kernels()`, so it inherited the base class implementation that unconditionally tries to `import vllm._C`.

**Fix (two layers):**

1. **`CpuPlatform.import_kernels()` override** (`vllm/platforms/cpu.py`): On x86_64 Linux without AVX-512, test-loads `vllm._C` in a subprocess first. If the subprocess is killed by SIGILL, logs a clear warning and skips loading the incompatible `.so`. On compatible machines (has AVX-512, non-x86, or source-built), delegates straight to `super().import_kernels()` with zero overhead. Follows the existing pattern established by `XpuPlatform.import_kernels()`.

2. **Better error reporting in `_run_in_subprocess`** (`vllm/model_executor/models/registry.py`): When the model inspection subprocess is killed by a signal, reports the signal name and adds a diagnostic hint for SIGILL about ISA mismatch, instead of the generic "Error raised in subprocess" message.

## Test Plan


## Test Result

