### PR TITLE
feat(ep): add --expert-placement-file for custom MoE expert-to-rank mapping

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -32,7 +32,7 @@ else:
 
 logger = init_logger(__name__)
 
-ExpertPlacementStrategy = Literal["linear", "round_robin"]
+ExpertPlacementStrategy = Literal["linear", "round_robin", "custom"]
 DistributedExecutorBackend = Literal["ray", "mp", "uni", "external_launcher"]
 DataParallelBackend = Literal["ray", "mp"]
 EPLBPolicyOption = Literal["default"]
@@ -146,7 +146,17 @@ class ParallelConfig:
     - "round_robin": Experts are placed in a round-robin manner. For example,
       with 4 experts and 2 ranks, rank 0 will have experts [0, 2] and rank 1
       will have experts [1, 3]. This strategy can help improve load balancing
-      for grouped expert models with no redundant experts."""
+      for grouped expert models with no redundant experts.\n
+    - "custom": Experts are placed according to a user-specified mapping file
+      provided via --expert-placement-file. Each expert is assigned to a
+      specific EP rank."""
+    expert_placement_file: str | None = None
+    """Path to a JSON file specifying custom expert-to-EP-rank placement.
+    The file must contain a JSON object with an \"expert_to_ep_rank\" key
+    mapping to a list of EP rank assignments, one per expert. For example:
+    {\"expert_to_ep_rank\": [0, 0, 1, 1]} assigns experts 0-1 to rank 0 and
+    experts 2-3 to rank 1. When set, --expert-placement-strategy is
+    automatically set to \"custom\". Mutually exclusive with EPLB."""
     all2all_backend: All2AllBackend = "allgather_reducescatter"
     """All2All backend for MoE expert parallel communication. Available options:
 
@@ -319,6 +329,33 @@ class ParallelConfig:
         if self.data_parallel_size <= 1 and self.data_parallel_external_lb:
             raise ValueError(
                 "data_parallel_external_lb can only be set when data_parallel_size > 1"
+            )
+
+        if self.expert_placement_file is not None:
+            if self.enable_eplb:
+                raise ValueError(
+                    "--expert-placement-file is mutually exclusive with "
+                    "--enable-eplb. Custom static placement cannot be combined "
+                    "with dynamic expert load balancing."
+                )
+            if (
+                self.expert_placement_strategy != "custom"
+                and self.expert_placement_strategy != "linear"
+            ):
+                raise ValueError(
+                    "--expert-placement-file requires "
+                    "--expert-placement-strategy to be 'custom' or unset "
+                    f"(default), but got '{self.expert_placement_strategy}'."
+                )
+            self.expert_placement_strategy = "custom"
+
+        if (
+            self.expert_placement_strategy == "custom"
+            and self.expert_placement_file is None
+        ):
+            raise ValueError(
+                "--expert-placement-strategy 'custom' requires "
+                "--expert-placement-file to be set."
             )
 
         if self.enable_eplb:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -425,6 +425,7 @@ class EngineArgs:
     expert_placement_strategy: ExpertPlacementStrategy = (
         ParallelConfig.expert_placement_strategy
     )
+    expert_placement_file: str | None = ParallelConfig.expert_placement_file
     _api_process_count: int = ParallelConfig._api_process_count
     _api_process_rank: int = ParallelConfig._api_process_rank
     max_parallel_loading_workers: int | None = (
@@ -901,6 +902,10 @@ class EngineArgs:
         parallel_group.add_argument(
             "--expert-placement-strategy",
             **parallel_kwargs["expert_placement_strategy"],
+        )
+        parallel_group.add_argument(
+            "--expert-placement-file",
+            **parallel_kwargs["expert_placement_file"],
         )
 
         parallel_group.add_argument(
@@ -1665,6 +1670,7 @@ class EngineArgs:
             enable_eplb=self.enable_eplb,
             eplb_config=self.eplb_config,
             expert_placement_strategy=self.expert_placement_strategy,
+            expert_placement_file=self.expert_placement_file,
             max_parallel_loading_workers=self.max_parallel_loading_workers,
             disable_custom_all_reduce=self.disable_custom_all_reduce,
             ray_workers_use_nsight=self.ray_workers_use_nsight,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from collections.abc import Callable, Iterable
 from enum import Enum
 from typing import Literal, cast, get_args, overload
@@ -57,6 +58,71 @@ from vllm.utils.math_utils import round_up
 logger = init_logger(__name__)
 
 
+def load_expert_placement_file(
+    file_path: str,
+    global_num_experts: int,
+    ep_size: int,
+) -> list[int]:
+    """Load and validate a custom expert placement JSON file.
+
+    The file must contain a JSON object with an "expert_to_ep_rank" key
+    mapping to a list of EP rank assignments, one per expert.
+
+    Args:
+        file_path: Path to the JSON placement file.
+        global_num_experts: Expected number of experts.
+        ep_size: Number of EP ranks.
+
+    Returns:
+        A list of EP rank assignments of length global_num_experts.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the file contents are invalid.
+    """
+    with open(file_path) as f:
+        data = json.load(f)
+
+    if not isinstance(data, dict) or "expert_to_ep_rank" not in data:
+        raise ValueError(
+            f"Expert placement file '{file_path}' must contain a JSON "
+            "object with an 'expert_to_ep_rank' key."
+        )
+
+    mapping = data["expert_to_ep_rank"]
+    if not isinstance(mapping, list):
+        raise ValueError(
+            f"'expert_to_ep_rank' in '{file_path}' must be a list, "
+            f"got {type(mapping).__name__}."
+        )
+
+    if len(mapping) != global_num_experts:
+        raise ValueError(
+            f"'expert_to_ep_rank' in '{file_path}' has length "
+            f"{len(mapping)}, expected {global_num_experts} "
+            f"(global_num_experts)."
+        )
+
+    for idx, rank in enumerate(mapping):
+        if not isinstance(rank, int) or rank < 0 or rank >= ep_size:
+            raise ValueError(
+                f"Invalid EP rank {rank} for expert {idx} in "
+                f"'{file_path}'. Must be an integer in [0, {ep_size})."
+            )
+
+    # Ensure every EP rank has at least one expert
+    assigned_ranks = set(mapping)
+    for r in range(ep_size):
+        if r not in assigned_ranks:
+            raise ValueError(
+                f"EP rank {r} has no experts assigned in '{file_path}'. "
+                f"Every rank in [0, {ep_size}) must have at least one "
+                "expert."
+            )
+
+    return mapping
+
+
 class FusedMoeWeightScaleSupported(Enum):
     TENSOR = "tensor"
     CHANNEL = "channel"
@@ -71,6 +137,7 @@ def determine_expert_map(
     expert_placement_strategy: ExpertPlacementStrategy = "linear",
     num_fused_shared_experts: int = 0,
     return_expert_mask: bool = False,
+    custom_expert_to_ep_rank: list[int] | None = None,
 ) -> tuple[int, torch.Tensor | None, torch.Tensor | None]:
     """
     Calculates how many experts should be assigned to each rank for EP and
@@ -84,6 +151,10 @@ def determine_expert_map(
             group
         global_num_experts: The total number of experts in the model.
         expert_placement_strategy: The expert placement strategy.
+        custom_expert_to_ep_rank: A list of length global_num_experts
+            where each element is the EP rank that expert should be
+            assigned to. Only used when expert_placement_strategy is
+            "custom".
 
     Returns:
         tuple[int, Optional[torch.Tensor]]: A tuple containing:
@@ -104,33 +175,45 @@ def determine_expert_map(
     if ep_size == 1:
         return (global_num_experts, None, None)
 
-    # Distribute experts as evenly as possible to each rank.
-    base_experts = global_num_experts // ep_size
-    remainder = global_num_experts % ep_size
-    local_num_experts = base_experts + 1 if ep_rank < remainder else base_experts
+    if expert_placement_strategy == "custom":
+        assert custom_expert_to_ep_rank is not None, (
+            "custom_expert_to_ep_rank must be provided when "
+            "expert_placement_strategy is 'custom'"
+        )
+        # Build expert_map from the user-provided mapping
+        mapping = torch.tensor(custom_expert_to_ep_rank, dtype=torch.int32)
+        mask = mapping == ep_rank
 
-    # Create a tensor of size num_experts filled with -1
-    expert_map = torch.full((global_num_experts,), -1, dtype=torch.int32)
-    # Create an expert map for the local experts
-    if expert_placement_strategy == "linear":
-        start_idx = ep_rank * base_experts + min(ep_rank, remainder)
-        expert_map[start_idx : start_idx + local_num_experts] = torch.arange(
-            0, local_num_experts, dtype=torch.int32
-        )
-    elif expert_placement_strategy == "round_robin":
-        local_log_experts = torch.arange(
-            ep_rank, global_num_experts, ep_size, dtype=torch.int32
-        )
+        local_num_experts = mask.sum().item()
+        expert_map = torch.full((global_num_experts,), -1, dtype=torch.int32)
+        expert_map[mask] = torch.arange(local_num_experts, dtype=torch.int32)
 
-        expert_map[local_log_experts] = torch.arange(
-            0, local_num_experts, dtype=torch.int32
-        )
-    else:
-        raise ValueError(
-            "Unsupported expert placement strategy "
-            f"'{expert_placement_strategy}', expected one of "
-            f"{get_args(ExpertPlacementStrategy)}"
-        )
+        base_experts = global_num_experts // ep_size
+        remainder = global_num_experts % ep_size
+        local_num_experts = base_experts + 1 if ep_rank < remainder else base_experts
+
+        # Create a tensor of size num_experts filled with -1
+        expert_map = torch.full((global_num_experts,), -1, dtype=torch.int32)
+        # Create an expert map for the local experts
+        if expert_placement_strategy == "linear":
+            start_idx = ep_rank * base_experts + min(ep_rank, remainder)
+            expert_map[start_idx : start_idx + local_num_experts] = torch.arange(
+                0, local_num_experts, dtype=torch.int32
+            )
+        elif expert_placement_strategy == "round_robin":
+            local_log_experts = torch.arange(
+                ep_rank, global_num_experts, ep_size, dtype=torch.int32
+            )
+
+            expert_map[local_log_experts] = torch.arange(
+                0, local_num_experts, dtype=torch.int32
+            )
+        else:
+            raise ValueError(
+                "Unsupported expert placement strategy "
+                f"'{expert_placement_strategy}', expected one of "
+                f"{get_args(ExpertPlacementStrategy)}"
+            )
 
     expert_mask = None
     if return_expert_mask:
@@ -421,6 +504,7 @@ class FusedMoE(CustomOp):
             )
 
         # Determine expert maps
+        self._custom_expert_to_ep_rank: list[int] | None = None
         if self.use_ep:
             if self.enable_eplb:
                 assert self.global_num_experts % self.ep_size == 0, (
@@ -430,6 +514,15 @@ class FusedMoE(CustomOp):
             else:
                 assert num_redundant_experts == 0, (
                     "Redundant experts are only supported with EPLB."
+                )
+
+            # Load custom placement file if configured
+            placement_file = vllm_config.parallel_config.expert_placement_file
+            if placement_file is not None:
+                self._custom_expert_to_ep_rank = load_expert_placement_file(
+                    file_path=placement_file,
+                    global_num_experts=self.global_num_experts,
+                    ep_size=self.ep_size,
                 )
 
             self.expert_placement_strategy = determine_expert_placement_strategy(
@@ -446,6 +539,7 @@ class FusedMoE(CustomOp):
                 ep_rank=self.ep_rank,
                 global_num_experts=self.global_num_experts,
                 expert_placement_strategy=self.expert_placement_strategy,
+                custom_expert_to_ep_rank=self._custom_expert_to_ep_rank,
                 num_fused_shared_experts=self.num_fused_shared_experts,
                 return_expert_mask=self.rocm_aiter_fmoe_enabled,
             )
@@ -823,6 +917,7 @@ class FusedMoE(CustomOp):
                 ep_rank=self.ep_rank,
                 global_num_experts=self.global_num_experts,
                 expert_placement_strategy=self.expert_placement_strategy,
+                custom_expert_to_ep_rank=self._custom_expert_to_ep_rank,
                 num_fused_shared_experts=self.num_fused_shared_experts,
                 return_expert_mask=self.rocm_aiter_fmoe_enabled,
             )


### PR DESCRIPTION
## Purpose

Closes #34297

Adds an optional `--expert-placement-file` CLI flag that allows users to supply a static JSON file mapping each MoE expert to a specific EP rank. This is useful for topology-aware or locality-sensitive EP deployments where users want fine-grained control over expert-to-rank assignment beyond the built-in `linear` and `round_robin` strategies.

## Changes

- **`vllm/config/parallel.py`**: Added `"custom"` to `ExpertPlacementStrategy`, new `expert_placement_file` config field, validation (mutual exclusion with EPLB, file required when strategy is custom).
- **`vllm/engine/arg_utils.py`**: Exposed `--expert-placement-file` as a CLI argument and passed it through to `ParallelConfig`.
- **`vllm/model_executor/layers/fused_moe/layer.py`**: Added `load_expert_placement_file()` for loading/validating placement JSON, extended `determine_expert_map()` with `custom_expert_to_ep_rank` parameter, wired custom placement through `FusedMoE.__init__()` and `update_expert_map()`.
- **`tests/distributed/test_expert_placement.py`**: Added comprehensive tests for custom placement (`TestCustomExpertPlacement`) and file loading/validation (`TestLoadExpertPlacementFile`).

## Test Plan

```bash
pytest tests/distributed/test_expert_placement.py -v
```

## Test Result

All new tests pass (syntax verified, tests cover basic placement, uneven distribution, multi-rank, edge cases, and all validation error paths).