### PR TITLE
feat(api): add optional admin control plane API and CLI

### DIFF
--- a/tests/entrypoints/openai/test_admin_api.py
+++ b/tests/entrypoints/openai/test_admin_api.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the admin control plane API router."""
+
+import argparse
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from vllm.entrypoints.serve.admin.api_router import attach_router, router
+
+
+@pytest.fixture
+def admin_app():
+    """Create a FastAPI app with the admin router attached."""
+    app = FastAPI()
+
+    # Set up mock app state
+    app.state.args = argparse.Namespace(
+        enable_admin_api=True,
+        admin_readonly=False,
+    )
+    app.state.engine_client = MagicMock()
+    app.state.engine_client.check_health = AsyncMock()
+    app.state.engine_client.is_running = True
+    app.state.engine_client.is_paused = AsyncMock(return_value=False)
+    app.state.engine_client.pause_generation = AsyncMock()
+    app.state.engine_client.resume_generation = AsyncMock()
+
+    # Mock model config
+    model_config = MagicMock()
+    model_config.model = "test-model"
+    model_config.dtype = "float16"
+    model_config.max_model_len = 4096
+    app.state.engine_client.model_config = model_config
+
+    # Mock parallel config
+    parallel_config = MagicMock()
+    parallel_config.tensor_parallel_size = 1
+    parallel_config.pipeline_parallel_size = 1
+    parallel_config.data_parallel_size = 1
+    parallel_config.enable_expert_parallel = False
+    vllm_config = MagicMock()
+    vllm_config.parallel_config = parallel_config
+    app.state.engine_client.vllm_config = vllm_config
+
+    # Mock model serving
+    models_mock = MagicMock()
+    models_mock.show_available_models = AsyncMock(
+        return_value=MagicMock(
+            model_dump=MagicMock(
+                return_value={"object": "list", "data": [{"id": "test-model"}]}
+            )
+        )
+    )
+    app.state.openai_serving_models = models_mock
+
+    # Mock server load
+    app.state.server_load_metrics = 5
+    app.state.enable_server_load_tracking = True
+
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def admin_readonly_app(admin_app):
+    """Create an admin app in read-only mode."""
+    admin_app.state.args.admin_readonly = True
+    return admin_app
+
+
+@pytest.fixture
+def client(admin_app):
+    return TestClient(admin_app)
+
+
+@pytest.fixture
+def readonly_client(admin_readonly_app):
+    return TestClient(admin_readonly_app)
+
+
+class TestAdminHealth:
+    def test_health_returns_200_when_healthy(self, client):
+        resp = client.get("/v1/admin/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "healthy"
+        assert "version" in data
+        assert data["is_running"] is True
+        assert data["is_paused"] is False
+
+    def test_health_returns_503_when_dead(self, admin_app):
+        from vllm.v1.engine.exceptions import EngineDeadError
+
+        admin_app.state.engine_client.check_health = AsyncMock(
+            side_effect=EngineDeadError("dead")
+        )
+        client = TestClient(admin_app)
+        resp = client.get("/v1/admin/health")
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "unhealthy"
+
+
+class TestAdminModels:
+    def test_models_returns_model_list(self, client):
+        resp = client.get("/v1/admin/models")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["object"] == "list"
+        assert len(data["data"]) == 1
+
+
+class TestAdminQueue:
+    def test_queue_returns_load_metrics(self, client):
+        resp = client.get("/v1/admin/queue")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["server_load"] == 5
+        assert data["load_tracking_enabled"] is True
+
+    def test_queue_returns_null_when_tracking_disabled(self, admin_app):
+        admin_app.state.enable_server_load_tracking = False
+        client = TestClient(admin_app)
+        resp = client.get("/v1/admin/queue")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["server_load"] is None
+        assert data["load_tracking_enabled"] is False
+
+
+class TestAdminDrain:
+    def test_drain_pauses_engine(self, client, admin_app):
+        resp = client.post("/v1/admin/drain")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "drained"
+        admin_app.state.engine_client.pause_generation.assert_called_once()
+
+    def test_drain_blocked_in_readonly(self, readonly_client):
+        resp = readonly_client.post("/v1/admin/drain")
+        assert resp.status_code == 403
+        assert "read-only" in resp.json()["error"]
+
+
+class TestAdminResume:
+    def test_resume_resumes_engine(self, client, admin_app):
+        resp = client.post("/v1/admin/resume")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "resumed"
+        admin_app.state.engine_client.resume_generation.assert_called_once()
+
+    def test_resume_blocked_in_readonly(self, readonly_client):
+        resp = readonly_client.post("/v1/admin/resume")
+        assert resp.status_code == 403
+
+
+class TestAdminConfig:
+    def test_config_returns_engine_config(self, client):
+        resp = client.get("/v1/admin/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["model"] == "test-model"
+        assert data["tensor_parallel_size"] == 1
+
+
+class TestAdminReloadModel:
+    def test_reload_returns_501(self, client):
+        resp = client.post("/v1/admin/reload_model")
+        assert resp.status_code == 501
+
+
+class TestAttachRouter:
+    def test_router_not_attached_when_disabled(self):
+        app = FastAPI()
+        app.state.args = argparse.Namespace(enable_admin_api=False)
+        attach_router(app)
+        # No admin routes should be registered
+        admin_routes = [
+            r for r in app.routes if hasattr(r, "path") and "/v1/admin" in r.path
+        ]
+        assert len(admin_routes) == 0
+
+    def test_router_attached_when_enabled(self):
+        app = FastAPI()
+        app.state.args = argparse.Namespace(
+            enable_admin_api=True,
+            admin_readonly=False,
+        )
+        attach_router(app)
+        admin_routes = [
+            r for r in app.routes if hasattr(r, "path") and "/v1/admin" in r.path
+        ]
+        assert len(admin_routes) > 0
+
+    def test_router_not_attached_when_no_args(self):
+        app = FastAPI()
+        attach_router(app)
+        admin_routes = [
+            r for r in app.routes if hasattr(r, "path") and "/v1/admin" in r.path
+        ]
+        assert len(admin_routes) == 0

--- a/vllm/entrypoints/cli/admin.py
+++ b/vllm/entrypoints/cli/admin.py
@@ -38,7 +38,7 @@ def _request(method: str, url: str) -> dict:
     except httpx.HTTPStatusError as exc:
         try:
             body = exc.response.json()
-        except Exception:
+        except json.JSONDecodeError:
             body = exc.response.text
         print(
             f"Error: HTTP {exc.response.status_code}: {body}",

--- a/vllm/entrypoints/cli/admin.py
+++ b/vllm/entrypoints/cli/admin.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CLI reference client for the vLLM admin control plane API."""
+
+import argparse
+import json
+import sys
+
+from vllm.entrypoints.cli.types import CLISubcommand
+from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG
+from vllm.logger import init_logger
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+logger = init_logger(__name__)
+
+ADMIN_DEFAULT_HOST = "localhost"
+ADMIN_DEFAULT_PORT = 8000
+
+
+def _base_url(args: argparse.Namespace) -> str:
+    host = getattr(args, "admin_host", ADMIN_DEFAULT_HOST)
+    port = getattr(args, "admin_port", ADMIN_DEFAULT_PORT)
+    return f"http://{host}:{port}/v1/admin"
+
+
+def _request(method: str, url: str) -> dict:
+    """Make an HTTP request and return the JSON response."""
+    import httpx
+
+    try:
+        with httpx.Client(timeout=30) as client:
+            resp = client.get(url) if method == "GET" else client.post(url)
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.ConnectError:
+        print(f"Error: Cannot connect to {url}", file=sys.stderr)
+        sys.exit(1)
+    except httpx.HTTPStatusError as exc:
+        try:
+            body = exc.response.json()
+        except Exception:
+            body = exc.response.text
+        print(
+            f"Error: HTTP {exc.response.status_code}: {body}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _cmd_status(args: argparse.Namespace) -> None:
+    data = _request("GET", f"{_base_url(args)}/health")
+    print(json.dumps(data, indent=2))
+
+
+def _cmd_models(args: argparse.Namespace) -> None:
+    data = _request("GET", f"{_base_url(args)}/models")
+    print(json.dumps(data, indent=2))
+
+
+def _cmd_queue(args: argparse.Namespace) -> None:
+    data = _request("GET", f"{_base_url(args)}/queue")
+    print(json.dumps(data, indent=2))
+
+
+def _cmd_drain(args: argparse.Namespace) -> None:
+    data = _request("POST", f"{_base_url(args)}/drain")
+    print(json.dumps(data, indent=2))
+
+
+def _cmd_resume(args: argparse.Namespace) -> None:
+    data = _request("POST", f"{_base_url(args)}/resume")
+    print(json.dumps(data, indent=2))
+
+
+def _cmd_config(args: argparse.Namespace) -> None:
+    data = _request("GET", f"{_base_url(args)}/config")
+    print(json.dumps(data, indent=2))
+
+
+def _cmd_reload(args: argparse.Namespace) -> None:
+    data = _request("POST", f"{_base_url(args)}/reload_model")
+    print(json.dumps(data, indent=2))
+
+
+class AdminSubcommand(CLISubcommand):
+    """The ``admin`` subcommand for the vLLM CLI."""
+
+    name = "admin"
+
+    @staticmethod
+    def cmd(args: argparse.Namespace) -> None:
+        sub = getattr(args, "admin_command", None)
+        dispatch = {
+            "status": _cmd_status,
+            "models": _cmd_models,
+            "queue": _cmd_queue,
+            "drain": _cmd_drain,
+            "resume": _cmd_resume,
+            "config": _cmd_config,
+            "reload": _cmd_reload,
+        }
+        if sub in dispatch:
+            dispatch[sub](args)
+        else:
+            print("Usage: vllm admin {status|models|queue|drain|resume|config|reload}")
+            sys.exit(1)
+
+    def subparser_init(
+        self, subparsers: argparse._SubParsersAction
+    ) -> FlexibleArgumentParser:
+        admin_parser = subparsers.add_parser(
+            self.name,
+            help="Interact with a running vLLM admin control plane.",
+            description="Reference CLI client for the vLLM admin API. "
+            "Requires --enable-admin-api on the server.",
+            usage="vllm admin <command> [options]",
+        )
+        admin_parser.add_argument(
+            "--host",
+            dest="admin_host",
+            type=str,
+            default=ADMIN_DEFAULT_HOST,
+            help=f"Admin API host (default: {ADMIN_DEFAULT_HOST})",
+        )
+        admin_parser.add_argument(
+            "--port",
+            dest="admin_port",
+            type=int,
+            default=ADMIN_DEFAULT_PORT,
+            help=f"Admin API port (default: {ADMIN_DEFAULT_PORT})",
+        )
+        admin_subs = admin_parser.add_subparsers(
+            dest="admin_command",
+        )
+        admin_subs.add_parser("status", help="Show health and readiness")
+        admin_subs.add_parser("models", help="List loaded models")
+        admin_subs.add_parser("queue", help="Show queue / concurrency stats")
+        admin_subs.add_parser("drain", help="Drain in-flight requests")
+        admin_subs.add_parser("resume", help="Resume generation after drain")
+        admin_subs.add_parser("config", help="Show engine configuration")
+        admin_subs.add_parser("reload", help="Reload model (not yet implemented)")
+        admin_parser.epilog = VLLM_SUBCMD_PARSER_EPILOG.format(subcmd=self.name)
+        return admin_parser
+
+
+def cmd_init() -> list[CLISubcommand]:
+    return [AdminSubcommand()]

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -14,6 +14,7 @@ logger = init_logger(__name__)
 
 
 def main():
+    import vllm.entrypoints.cli.admin
     import vllm.entrypoints.cli.benchmark.main
     import vllm.entrypoints.cli.collect_env
     import vllm.entrypoints.cli.openai
@@ -25,6 +26,7 @@ def main():
     CMD_MODULES = [
         vllm.entrypoints.cli.openai,
         vllm.entrypoints.cli.serve,
+        vllm.entrypoints.cli.admin,
         vllm.entrypoints.cli.benchmark.main,
         vllm.entrypoints.cli.collect_env,
         vllm.entrypoints.cli.run_batch,

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -215,6 +215,13 @@ class FrontendArgs:
     Enable offline FastAPI documentation for air-gapped environments.
     Uses vendored static assets bundled with vLLM.
     """
+    enable_admin_api: bool = False
+    """Enable the optional admin control plane API at /v1/admin/*.
+    Disabled by default. When enabled, provides endpoints for health,
+    model listing, queue stats, drain, and configuration inspection."""
+    admin_readonly: bool = False
+    """When set, disables mutating admin endpoints (drain, resume, reload).
+    Only read-only endpoints (health, models, queue, config) are allowed."""
 
     @staticmethod
     def add_cli_args(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:

--- a/vllm/entrypoints/serve/__init__.py
+++ b/vllm/entrypoints/serve/__init__.py
@@ -52,6 +52,12 @@ def register_vllm_serve_api_routers(app: FastAPI):
 
     attach_tokenize_router(app)
 
+    from vllm.entrypoints.serve.admin.api_router import (
+        attach_router as attach_admin_router,
+    )
+
+    attach_admin_router(app)
+
     from .instrumentator import register_instrumentator_api_routers
 
     register_instrumentator_api_routers(app)

--- a/vllm/entrypoints/serve/admin/__init__.py
+++ b/vllm/entrypoints/serve/admin/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/entrypoints/serve/admin/api_router.py
+++ b/vllm/entrypoints/serve/admin/api_router.py
@@ -107,10 +107,10 @@ async def admin_drain(
             content={"error": str(err)},
             status_code=HTTPStatus.BAD_REQUEST.value,
         )
-    except Exception as err:
+    except Exception:
         logger.exception("Failed to drain")
         return JSONResponse(
-            content={"error": f"Failed to drain: {err}"},
+            content={"error": "Failed to drain. See server logs for details."},
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
         )
 
@@ -129,10 +129,10 @@ async def admin_resume(raw_request: Request) -> JSONResponse:
     try:
         await engine.resume_generation()
         return JSONResponse(content={"status": "resumed"})
-    except Exception as err:
+    except Exception:
         logger.exception("Failed to resume generation")
         return JSONResponse(
-            content={"error": f"Failed to resume generation: {err}"},
+            content={"error": "Failed to resume. See server logs for details."},
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
         )
 

--- a/vllm/entrypoints/serve/admin/api_router.py
+++ b/vllm/entrypoints/serve/admin/api_router.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from http import HTTPStatus
+from typing import Annotated
+
+from fastapi import APIRouter, FastAPI, Query, Request
+from fastapi.responses import JSONResponse
+
+from vllm.engine.protocol import EngineClient
+from vllm.logger import init_logger
+from vllm.v1.engine import PauseMode
+from vllm.v1.engine.exceptions import EngineDeadError
+from vllm.version import __version__ as VLLM_VERSION
+
+logger = init_logger(__name__)
+
+
+def engine_client(request: Request) -> EngineClient:
+    return request.app.state.engine_client
+
+
+router = APIRouter(prefix="/v1/admin", tags=["admin"])
+
+
+@router.get("/health")
+async def admin_health(raw_request: Request) -> JSONResponse:
+    """Health and readiness check for the vLLM instance."""
+    engine = engine_client(raw_request)
+    try:
+        await engine.check_health()
+        return JSONResponse(
+            content={
+                "status": "healthy",
+                "version": VLLM_VERSION,
+                "is_running": engine.is_running,
+                "is_paused": await engine.is_paused(),
+            },
+        )
+    except EngineDeadError:
+        return JSONResponse(
+            content={
+                "status": "unhealthy",
+                "version": VLLM_VERSION,
+            },
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE.value,
+        )
+
+
+@router.get("/models")
+async def admin_models(raw_request: Request) -> JSONResponse:
+    """List loaded models and adapters."""
+    openai_serving_models = raw_request.app.state.openai_serving_models
+    models_list = await openai_serving_models.show_available_models()
+    return JSONResponse(content=models_list.model_dump())
+
+
+@router.get("/queue")
+async def admin_queue(raw_request: Request) -> JSONResponse:
+    """Return queue and concurrency statistics."""
+    server_load = getattr(raw_request.app.state, "server_load_metrics", None)
+    load_tracking = getattr(raw_request.app.state, "enable_server_load_tracking", False)
+    return JSONResponse(
+        content={
+            "server_load": server_load if load_tracking else None,
+            "load_tracking_enabled": load_tracking,
+        },
+    )
+
+
+@router.post("/drain")
+async def admin_drain(
+    raw_request: Request,
+    mode: Annotated[PauseMode, Query()] = "wait",
+    clear_cache: Annotated[bool, Query()] = True,
+) -> JSONResponse:
+    """Drain in-flight requests and pause generation.
+
+    This endpoint pauses the engine, optionally waiting for in-flight
+    requests to complete. Useful for graceful shutdown, maintenance,
+    or Kubernetes pre-stop hooks.
+
+    Args:
+        mode: How to handle in-flight requests:
+            - ``"abort"``: Abort all in-flight requests immediately.
+            - ``"wait"``: Wait for in-flight requests to complete (default).
+            - ``"keep"``: Freeze requests in queue; they resume on /resume.
+        clear_cache: Whether to clear KV/prefix caches after draining.
+    """
+    args = raw_request.app.state.args
+    if getattr(args, "admin_readonly", False):
+        return JSONResponse(
+            content={"error": "Admin API is in read-only mode."},
+            status_code=HTTPStatus.FORBIDDEN.value,
+        )
+
+    engine = engine_client(raw_request)
+    try:
+        await engine.pause_generation(
+            mode=mode,
+            clear_cache=clear_cache,
+            wait_for_inflight_requests=(mode == "wait"),
+        )
+        return JSONResponse(content={"status": "drained"})
+    except ValueError as err:
+        return JSONResponse(
+            content={"error": str(err)},
+            status_code=HTTPStatus.BAD_REQUEST.value,
+        )
+    except Exception as err:
+        logger.exception("Failed to drain")
+        return JSONResponse(
+            content={"error": f"Failed to drain: {err}"},
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+        )
+
+
+@router.post("/resume")
+async def admin_resume(raw_request: Request) -> JSONResponse:
+    """Resume generation after a drain."""
+    args = raw_request.app.state.args
+    if getattr(args, "admin_readonly", False):
+        return JSONResponse(
+            content={"error": "Admin API is in read-only mode."},
+            status_code=HTTPStatus.FORBIDDEN.value,
+        )
+
+    engine = engine_client(raw_request)
+    try:
+        await engine.resume_generation()
+        return JSONResponse(content={"status": "resumed"})
+    except Exception as err:
+        logger.exception("Failed to resume generation")
+        return JSONResponse(
+            content={"error": f"Failed to resume generation: {err}"},
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+        )
+
+
+@router.get("/config")
+async def admin_config(raw_request: Request) -> JSONResponse:
+    """Return the current engine and model configuration."""
+    engine = engine_client(raw_request)
+    model_config = engine.model_config
+    parallel_config = engine.vllm_config.parallel_config
+    return JSONResponse(
+        content={
+            "model": model_config.model,
+            "dtype": str(model_config.dtype),
+            "max_model_len": model_config.max_model_len,
+            "tensor_parallel_size": parallel_config.tensor_parallel_size,
+            "pipeline_parallel_size": parallel_config.pipeline_parallel_size,
+            "data_parallel_size": parallel_config.data_parallel_size,
+            "enable_expert_parallel": parallel_config.enable_expert_parallel,
+        },
+    )
+
+
+@router.post("/reload_model")
+async def admin_reload_model(raw_request: Request) -> JSONResponse:
+    """Reload model (placeholder — not yet implemented)."""
+    return JSONResponse(
+        content={"error": "Model reload is not yet implemented."},
+        status_code=HTTPStatus.NOT_IMPLEMENTED.value,
+    )
+
+
+def attach_router(app: FastAPI):
+    args = getattr(app.state, "args", None)
+    if args is None or not getattr(args, "enable_admin_api", False):
+        return
+    logger.info("Admin control plane API enabled at /v1/admin/*")
+    app.include_router(router)


### PR DESCRIPTION
## Summary

Implements the admin control plane API proposed in #31966, giving operators a
lightweight REST surface and companion CLI for routine production operations
(health checks, drain / resume, config inspection) without touching the
inference hot-path.

### What's included

| Layer | Files | Description |
|-------|-------|-------------|
| **Server-side router** | `vllm/entrypoints/serve/admin/api_router.py` | FastAPI router mounted at `/v1/admin/*` with seven endpoints: `health`, `models`, `queue`, `drain`, `resume`, `config`, `reload_model` |
| **CLI client** | `vllm/entrypoints/cli/admin.py` | `vllm admin <cmd>` reference client using httpx |
| **Frontend args** | `vllm/entrypoints/openai/cli_args.py` | `--enable-admin-api` and `--admin-readonly` flags |
| **Wiring** | `serve/__init__.py`, `cli/main.py` | Router + CLI registration |
| **Tests** | `tests/entrypoints/openai/test_admin_api.py` | Unit tests covering all endpoints, readonly mode, and attach logic |

### Key design decisions

* **Opt-in by default** – the router is only mounted when `--enable-admin-api`
  is passed, so existing deployments see zero change.
* **Read-only mode** – `--admin-readonly` blocks mutating endpoints (`drain`,
  `resume`, `reload`) with a 403.
* **No new dependencies** – the server side uses only FastAPI/Starlette; the
  CLI uses `httpx` which is already a vLLM dependency.
* **`reload_model`** returns 501 as a placeholder for future hot-reload support.

Closes #31966

## Test plan

- [x] All new unit tests pass (`pytest tests/entrypoints/openai/test_admin_api.py`)
- [ ] Manual smoke test with `vllm serve --enable-admin-api` + `vllm admin status`