### PR TITLE
[CI] temporarily disable multi-node tests

### DIFF
--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -159,21 +159,21 @@ steps:
     - pytest -v -s tests/distributed/test_nccl_symm_mem_allreduce.py
     - pytest -v -s tests/v1/distributed/test_dbo.py
 
-- label: 2 Node Test (4 GPUs)
-  timeout_in_minutes: 30
-  working_dir: "/vllm-workspace/tests"
-  num_devices: 2
-  num_nodes: 2
-  no_plugin: true
-  source_file_dependencies:
-  - vllm/distributed/
-  - vllm/engine/
-  - vllm/executor/
-  - vllm/model_executor/models/
-  - tests/distributed/
-  - tests/examples/offline_inference/data_parallel.py
-  commands:
-    - ./.buildkite/scripts/run-multi-node-test.sh /vllm-workspace/tests 2 2 $IMAGE_TAG "VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep 'Node count test passed' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=0 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_multi_node_assignment.py && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_pipeline_parallel.py" "VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep 'Node count test passed' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=1 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code"
+# - label: 2 Node Test (4 GPUs)
+#   timeout_in_minutes: 30
+#   working_dir: "/vllm-workspace/tests"
+#   num_devices: 2
+#   num_nodes: 2
+#   no_plugin: true
+#   source_file_dependencies:
+#   - vllm/distributed/
+#   - vllm/engine/
+#   - vllm/executor/
+#   - vllm/model_executor/models/
+#   - tests/distributed/
+#   - tests/examples/offline_inference/data_parallel.py
+#   commands:
+#     - ./.buildkite/scripts/run-multi-node-test.sh /vllm-workspace/tests 2 2 $IMAGE_TAG "VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep 'Node count test passed' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=0 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_multi_node_assignment.py && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_pipeline_parallel.py" "VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep 'Node count test passed' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=1 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code"
 
 - label: Distributed NixlConnector PD accuracy (4 GPUs)
   timeout_in_minutes: 30

--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -159,21 +159,22 @@ steps:
     - pytest -v -s tests/distributed/test_nccl_symm_mem_allreduce.py
     - pytest -v -s tests/v1/distributed/test_dbo.py
 
-# - label: 2 Node Test (4 GPUs)
-#   timeout_in_minutes: 30
-#   working_dir: "/vllm-workspace/tests"
-#   num_devices: 2
-#   num_nodes: 2
-#   no_plugin: true
-#   source_file_dependencies:
-#   - vllm/distributed/
-#   - vllm/engine/
-#   - vllm/executor/
-#   - vllm/model_executor/models/
-#   - tests/distributed/
-#   - tests/examples/offline_inference/data_parallel.py
-#   commands:
-#     - ./.buildkite/scripts/run-multi-node-test.sh /vllm-workspace/tests 2 2 $IMAGE_TAG "VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep 'Node count test passed' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=0 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_multi_node_assignment.py && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_pipeline_parallel.py" "VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep 'Node count test passed' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=1 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code"
+- label: 2 Node Test (4 GPUs)
+  timeout_in_minutes: 30
+  working_dir: "/vllm-workspace/tests"
+  num_devices: 2
+  num_nodes: 2
+  no_plugin: true
+  optional: true # TODO: revert once infra issue solved
+  source_file_dependencies:
+  - vllm/distributed/
+  - vllm/engine/
+  - vllm/executor/
+  - vllm/model_executor/models/
+  - tests/distributed/
+  - tests/examples/offline_inference/data_parallel.py
+  commands:
+    - ./.buildkite/scripts/run-multi-node-test.sh /vllm-workspace/tests 2 2 $IMAGE_TAG "VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep 'Node count test passed' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=0 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_multi_node_assignment.py && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_pipeline_parallel.py" "VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep 'Node count test passed' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=1 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code"
 
 - label: Distributed NixlConnector PD accuracy (4 GPUs)
   timeout_in_minutes: 30


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
* infra issue
```
[2026-02-18T07:05:48Z] $ ./.buildkite/scripts/run-multi-node-test.sh /vllm-workspace/tests 2 2 public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:a49ea5a58fc0f8170027abd79168d6f7ca3e4789 "VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep 'Node count test passed' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=0 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_multi_node_assignment.py && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_pipeline_parallel.py" "VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep 'Node count test passed' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=1 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code"
[2026-02-18T07:05:48Z] + '[' -e /dev/kfd ']'
[2026-02-18T07:05:48Z] + '[' -d /opt/rocm ']'
[2026-02-18T07:05:48Z] + command -v rocm-smi
[2026-02-18T07:05:48Z] + '[' -n '' ']'
[2026-02-18T07:05:48Z] + IS_ROCM=0
[2026-02-18T07:05:48Z] + [[ 6 -lt 4 ]]
[2026-02-18T07:05:48Z] + WORKING_DIR=/vllm-workspace/tests
[2026-02-18T07:05:48Z] + NUM_NODES=2
[2026-02-18T07:05:48Z] + NUM_GPUS=2
[2026-02-18T07:05:48Z] + DOCKER_IMAGE=public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:a49ea5a58fc0f8170027abd79168d6f7ca3e4789
[2026-02-18T07:05:48Z] + shift 4
[2026-02-18T07:05:48Z] + COMMANDS=("$@")
[2026-02-18T07:05:48Z] + '[' 2 -ne 2 ']'
[2026-02-18T07:05:48Z] + echo 'List of commands'
[2026-02-18T07:05:48Z] List of commands
[2026-02-18T07:05:48Z] + for command in "${COMMANDS[@]}"
[2026-02-18T07:05:48Z] + echo 'VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep '\''Same node test passed'\'' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep '\''Node count test passed'\'' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=0 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_multi_node_assignment.py && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_pipeline_parallel.py'
[2026-02-18T07:05:48Z] VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep 'Node count test passed' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=0 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_multi_node_assignment.py && VLLM_MULTI_NODE=1 pytest -v -s distributed/test_pipeline_parallel.py
[2026-02-18T07:05:48Z] + for command in "${COMMANDS[@]}"
[2026-02-18T07:05:48Z] + echo 'VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep '\''Same node test passed'\'' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep '\''Node count test passed'\'' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=1 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code'
[2026-02-18T07:05:48Z] VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed' && NUM_NODES=2 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_node_count.py | grep 'Node count test passed' && python3 ../examples/offline_inference/data_parallel.py -dp=2 -tp=1 --dp-num-nodes=2 --dp-node-rank=1 --dp-master-addr=192.168.10.10 --dp-master-port=12345 --enforce-eager --trust-remote-code
[2026-02-18T07:05:48Z] + trap cleanup EXIT
[2026-02-18T07:05:48Z] + start_network
[2026-02-18T07:05:48Z] + docker network create --subnet=192.168.10.0/24 docker-net
[2026-02-18T07:05:48Z] 5ffacf2cc5776383c2560d6bc5bdb09f887b2325c2477a5a7ed5a63877df3860
[2026-02-18T07:05:48Z] + start_nodes
[2026-02-18T07:05:48Z] ++ seq 0 1
[2026-02-18T07:05:48Z] + for node in $(seq 0 $(($NUM_NODES-1)))
[2026-02-18T07:05:48Z] + '[' 0 -eq 1 ']'
[2026-02-18T07:05:48Z] + GPU_DEVICES='--gpus "device='
[2026-02-18T07:05:48Z] ++ seq 0 1
[2026-02-18T07:05:48Z] + for node_gpu in $(seq 0 $(($NUM_GPUS - 1)))
[2026-02-18T07:05:48Z] + DEVICE_NUM=0
[2026-02-18T07:05:48Z] + GPU_DEVICES+=0
[2026-02-18T07:05:48Z] + '[' 0 -lt 1 ']'
[2026-02-18T07:05:48Z] + GPU_DEVICES+=,
[2026-02-18T07:05:48Z] + for node_gpu in $(seq 0 $(($NUM_GPUS - 1)))
[2026-02-18T07:05:48Z] + DEVICE_NUM=1
[2026-02-18T07:05:48Z] + GPU_DEVICES+=1
[2026-02-18T07:05:48Z] + '[' 1 -lt 1 ']'
[2026-02-18T07:05:48Z] + '[' 0 -eq 0 ']'
[2026-02-18T07:05:48Z] + GPU_DEVICES+='"'
[2026-02-18T07:05:48Z] + docker run -d '--gpus "device=0,1"' --shm-size=10.24gb -e HF_TOKEN -v /var/lib/buildkite-agent/.cache/huggingface:/root/.cache/huggingface --name node0 --network docker-net --ip 192.168.10.10 --rm public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:a49ea5a58fc0f8170027abd79168d6f7ca3e4789 /bin/bash -c 'tail -f /dev/null'
[2026-02-18T07:05:49Z] unknown flag: --gpus "device
[2026-02-18T07:05:49Z] See 'docker run --help'.
[2026-02-18T07:05:49Z] + cleanup
[2026-02-18T07:05:49Z] ++ seq 0 1
[2026-02-18T07:05:49Z] + for node in $(seq 0 $(($NUM_NODES-1)))
[2026-02-18T07:05:49Z] + docker stop node0
[2026-02-18T07:05:49Z] Error response from daemon: No such container: node0
[2026-02-18T07:05:49Z] 🚨 Error: The command exited with status 1
[2026-02-18T07:05:49Z] user command error: exit status 1
```

- https://buildkite.com/vllm/ci/builds/52052#019c6f8d-c4ab-420b-ae7d-d54d1858db1c


temporarily disabling it
