### PR TITLE
[Doc] Add version note for --profiler-config flag

### DIFF
--- a/docs/contributing/profiling.md
+++ b/docs/contributing/profiling.md
@@ -8,6 +8,9 @@
 We support tracing vLLM workers using the `torch.profiler` module. You can enable the torch profiler by setting `--profiler-config`
 when launching the server, and setting the entries `profiler` to `'torch'` and `torch_profiler_dir` to the directory where you want to save the traces. Additionally, you can control the profiling content by specifying the following additional arguments in the config:
 
+!!! note
+    The `--profiler-config` argument is available starting from **vLLM v0.13.0**. If you are using an earlier version, this flag will not be recognized and you will receive an "unrecognized arguments" error. Please upgrade to v0.13.0 or later to use this feature.
+
 - `torch_profiler_record_shapes` to enable recording Tensor Shapes, off by default
 - `torch_profiler_with_memory` to record memory, off by default
 - `torch_profiler_with_stack` to enable recording stack information, on by default


### PR DESCRIPTION
## Summary
- Added a `!!! note` admonition in `docs/contributing/profiling.md` clarifying that `--profiler-config` requires vLLM v0.13.0+
- Helps users on older versions understand why the flag is not recognized

Fixes #31766

## Test plan
- [x] Verified admonition syntax is correct for MkDocs Material
- [x] Markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)