### PR TITLE
[Feature] Add --disable-uvicorn-metrics-access-log shorthand

### DIFF
--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -82,6 +82,11 @@ class FrontendArgs:
     """Log level for uvicorn."""
     disable_uvicorn_access_log: bool = False
     """Disable uvicorn access log."""
+    disable_uvicorn_metrics_access_log: bool = False
+    """Shorthand to disable uvicorn access logs for /health and /metrics
+    endpoints. Equivalent to --disable-access-log-for-endpoints
+    '/health,/metrics'. Can be combined with
+    --disable-access-log-for-endpoints for additional paths."""
     disable_access_log_for_endpoints: str | None = None
     """Comma-separated list of endpoint paths to exclude from uvicorn access
     logs. This is useful to reduce log noise from high-frequency endpoints


### PR DESCRIPTION
## Summary
- Added `--disable-uvicorn-metrics-access-log` boolean flag as a convenient shorthand for `--disable-access-log-for-endpoints '/health,/metrics'`
- Both flags can be combined: the shorthand adds `/health` and `/metrics`, while `--disable-access-log-for-endpoints` adds any additional paths, with automatic deduplication
- Extracted `_get_excluded_paths()` helper in `server_utils.py` to merge and deduplicate paths from both flags
- Added comprehensive unit tests for the new helper covering flag combinations, deduplication, whitespace handling, and edge cases

Fixes #29023

## Test plan
- [x] Added `TestGetExcludedPaths` test class with 8 test cases covering:
  - No flags set (empty result)
  - Shorthand flag only (`/health`, `/metrics`)
  - Endpoints flag only (custom paths)
  - Both flags combined (merged result)
  - Deduplication when both flags specify overlapping paths
  - Whitespace stripping in comma-separated values
  - Empty entries from trailing commas
  - Missing attributes handled gracefully
- [x] Verified Python syntax for all modified files
- [x] Existing tests in `test_access_log_filter.py` remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)