### PR TITLE
[Docker] Fix VLLM_PRECOMPILED_WHEEL_COMMIT build arg name

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -246,7 +246,7 @@ ARG SCCACHE_S3_NO_CREDENTIALS=0
 
 # Flag to control whether to use pre-built vLLM wheels
 ARG VLLM_USE_PRECOMPILED=""
-ARG VLLM_MERGE_BASE_COMMIT=""
+ARG VLLM_PRECOMPILED_WHEEL_COMMIT=""
 ARG VLLM_MAIN_CUDA_VERSION=""
 
 # Use dummy version for csrc-build wheel (only .so files are extracted, version doesn't matter)
@@ -280,7 +280,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         && export SCCACHE_IDLE_TIMEOUT=0 \
         && export CMAKE_BUILD_TYPE=Release \
         && export VLLM_USE_PRECOMPILED="${VLLM_USE_PRECOMPILED}" \
-        && export VLLM_PRECOMPILED_WHEEL_COMMIT="${VLLM_MERGE_BASE_COMMIT}" \
+        && export VLLM_PRECOMPILED_WHEEL_COMMIT="${VLLM_PRECOMPILED_WHEEL_COMMIT}" \
         && export VLLM_MAIN_CUDA_VERSION="${VLLM_MAIN_CUDA_VERSION}" \
         && export VLLM_DOCKER_BUILD_CONTEXT=1 \
         && sccache --show-stats \
@@ -298,7 +298,7 @@ RUN --mount=type=cache,target=/root/.cache/ccache \
         rm -rf .deps && \
         mkdir -p .deps && \
         export VLLM_USE_PRECOMPILED="${VLLM_USE_PRECOMPILED}" && \
-        export VLLM_PRECOMPILED_WHEEL_COMMIT="${VLLM_MERGE_BASE_COMMIT}" && \
+        export VLLM_PRECOMPILED_WHEEL_COMMIT="${VLLM_PRECOMPILED_WHEEL_COMMIT}" && \
         export VLLM_DOCKER_BUILD_CONTEXT=1 && \
         python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38; \
     fi


### PR DESCRIPTION
## Summary
- Rename the Dockerfile ARG from `VLLM_MERGE_BASE_COMMIT` to `VLLM_PRECOMPILED_WHEEL_COMMIT` to match the documentation and the environment variable name used by `setup.py`
- Previously, users following the documentation would pass `--build-arg VLLM_PRECOMPILED_WHEEL_COMMIT=<commit>` but the Dockerfile expected `VLLM_MERGE_BASE_COMMIT`, causing the value to be silently ignored and resulting in build failures