### PR TITLE
[Bugfix] Add Quant Config to Llava Next Projector

### DIFF
--- a/vllm/model_executor/models/llava_next.py
+++ b/vllm/model_executor/models/llava_next.py
@@ -286,6 +286,7 @@ class LlavaNextForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsP
                 projector_hidden_act=config.projector_hidden_act,
                 multimodal_projector_bias=config.multimodal_projector_bias,
                 quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "multi_modal_projector"),
             )
 
         with self._mark_language_model(vllm_config):

--- a/vllm/model_executor/models/llava_next.py
+++ b/vllm/model_executor/models/llava_next.py
@@ -285,6 +285,7 @@ class LlavaNextForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsP
                 text_hidden_size=config.text_config.hidden_size,
                 projector_hidden_act=config.projector_hidden_act,
                 multimodal_projector_bias=config.multimodal_projector_bias,
+                quant_config=quant_config,
             )
 
         with self._mark_language_model(vllm_config):


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
Fix for problems loading quantized projectors reported in https://github.com/vllm-project/vllm/issues/34771

## Test Plan
I ran a quick `W4A16` quantize on a Llava Next model and reproduced the crash, and validated that when the quant config is passed, things load without throwing.

