### PR TITLE
[Model Runner V2] Use FP32 for Gumbel Noise

### DIFF
--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -86,8 +86,9 @@ def _gumbel_sample_kernel(
         gumbel_seed = tl.randint(seed, pos)
 
         # Generate gumbel noise in FP32.
-        r = tl.rand(gumbel_seed, block)
-        gumbel_noise = -tl.log(-tl.log(r + 1e-20) + 1e-20)
+        u = tl.rand(gumbel_seed, block)
+        u = tl.maximum(u, 1e-7)
+        gumbel_noise = -tl.log(-tl.log(u))
 
         # Apply temperature.
         if APPLY_TEMPERATURE:

--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -86,9 +86,8 @@ def _gumbel_sample_kernel(
         gumbel_seed = tl.randint(seed, pos)
 
         # Generate gumbel noise in FP32.
-        u = tl.rand(gumbel_seed, block)
-        u = tl.maximum(u, 1e-7)
-        gumbel_noise = -tl.log(-tl.log(u))
+        r = tl.rand(gumbel_seed, block)
+        gumbel_noise = -tl.log(-tl.log(r + 1e-20) + 1e-20)
 
         # Apply temperature.
         if APPLY_TEMPERATURE:


### PR DESCRIPTION
* Use FP32 for gumbel noise
* Merge `tl.max` and `tl.argmax` into one `tl.max(..., return_indices=True)`

Up to 50% performance improvement for large batch sizes:
```python

if __name__ == "__main__":
    import time
    BATCH_SIZES = [1, 1024]
    VOCAB_SIZES = [200 * 1000]
    for batch_size in BATCH_SIZES:
        for vocab_size in VOCAB_SIZES:
            logits = torch.randn(batch_size, vocab_size, dtype=torch.float32, device="cuda")
            idx_mapping = torch.randint(0, batch_size, (batch_size,), dtype=torch.int32, device="cuda")
            temperature = torch.rand(batch_size, dtype=torch.float32, device="cuda")
            temperature.zero_()
            seed = torch.randint(0, 1000000, (batch_size,), dtype=torch.int64, device="cuda")
            pos = torch.randint(0, 100, (batch_size,), dtype=torch.int64, device="cuda")
            sampled = gumbel_sample(logits, idx_mapping, temperature, seed, pos, apply_temperature=False)

            torch.cuda.synchronize()

            start_time = time.perf_counter()
            for _ in range(1000):
                sampled = gumbel_sample(logits, idx_mapping, temperature, seed, pos, apply_temperature=False)
            torch.cuda.synchronize()
            end_time = time.perf_counter()
            print(f"Batch size: {batch_size}, Vocab size: {vocab_size}, Time: {end_time - start_time} ms")

```