### PR TITLE
[Voxtral Realtime] Fix engine crash on empty multimodal embeddings

### DIFF
--- a/tests/entrypoints/openai/test_realtime_validation.py
+++ b/tests/entrypoints/openai/test_realtime_validation.py
@@ -121,3 +121,75 @@ async def test_multi_chunk_streaming(
                 " it sleeps with quite a flow, and everywhere that Mary went,"
                 " the lamb was sure to go."
             )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", [MODEL_NAME])
+async def test_empty_commit_does_not_crash_engine(
+    model_name, mary_had_lamb_audio_chunks, rocm_aiter_fa_attention
+):
+    """Test that committing without audio does not crash the engine.
+
+    Regression test for https://github.com/vllm-project/vllm/issues/34532.
+    An empty commit (no prior input_audio_buffer.append) used to trigger
+    ``AssertionError: For realtime you must provide a multimodal_embedding
+    at every step`` which killed the entire engine process, disconnecting
+    every connected client.
+    """
+    server_args = ["--enforce-eager", "--max-model-len", "2048"]
+
+    if model_name.startswith("mistralai"):
+        server_args += MISTRAL_FORMAT_ARGS
+
+    add_attention_backend(server_args, rocm_aiter_fa_attention)
+
+    with RemoteOpenAIServer(model_name, server_args) as remote_server:
+        ws_url = _get_websocket_url(remote_server)
+
+        # --- First connection: empty commit (no audio appended) ----------
+        async with websockets.connect(ws_url) as ws:
+            event = await receive_event(ws, timeout=30.0)
+            assert event["type"] == "session.created"
+
+            await send_event(ws, {"type": "session.update", "model": model_name})
+
+            # Start generation without sending any audio
+            await send_event(ws, {"type": "input_audio_buffer.commit"})
+
+            # Immediately signal end-of-audio
+            await send_event(ws, {"type": "input_audio_buffer.commit", "final": True})
+
+            # We should get *some* response (error or empty transcription),
+            # but the engine must NOT crash.
+            event = await receive_event(ws, timeout=30.0)
+            assert event["type"] in (
+                "error",
+                "transcription.done",
+                "transcription.delta",
+            )
+
+        # --- Second connection: normal transcription ---------------------
+        # Verifies the engine is still alive after the empty commit above.
+        async with websockets.connect(ws_url) as ws:
+            event = await receive_event(ws, timeout=30.0)
+            assert event["type"] == "session.created"
+
+            await send_event(ws, {"type": "session.update", "model": model_name})
+
+            await send_event(ws, {"type": "input_audio_buffer.commit"})
+
+            for chunk in mary_had_lamb_audio_chunks:
+                await send_event(
+                    ws, {"type": "input_audio_buffer.append", "audio": chunk}
+                )
+
+            await send_event(ws, {"type": "input_audio_buffer.commit", "final": True})
+
+            done_received = False
+            while not done_received:
+                event = await receive_event(ws, timeout=60.0)
+                if event["type"] == "transcription.done":
+                    done_received = True
+                elif event["type"] == "error":
+                    pytest.fail(f"Engine error after empty commit: {event}")
+            assert done_received


### PR DESCRIPTION
## Summary
- Replace fatal assertions in `VoxtralRealtimeGeneration.embed_input_ids()` and `embed_multimodal()` with graceful zero-embedding fallbacks
- Prevents engine crash when multimodal embeddings are missing (empty audio commit, encoder cache miss under GPU memory pressure, or client disconnect mid-session)
- The affected request produces degraded output for that decode step; all other in-flight requests are completely unaffected

## Problem
The realtime model's `embed_input_ids()` uses `assert` to validate that multimodal embeddings are non-empty. When this fails, the `AssertionError` propagates through `execute_model()` → `step()` → `run_busy_loop()`, killing the entire engine process and disconnecting ALL connected WebSocket clients. There is no per-request error isolation in the model execution path.

Triggers:
- Client sends `input_audio_buffer.commit` without prior `input_audio_buffer.append`
- GPU memory pressure causes encoder cache miss after ~71s of continuous streaming on g5.xlarge (A10G 24GB)
- Client disconnects mid-session

## Fix
Convert the hard assertions to a warning log + zero-tensor fallback with the correct shape `(num_tokens, d_model * pool_size)`. The zero embeddings flow through the whisper encoder and audio adapter producing near-zero audio features, which effectively degrades to text-only generation for that step. The engine continues serving all other clients normally.

## Test plan
- [x] Added `test_empty_commit_does_not_crash_engine` that verifies:
  1. Empty commit does not crash the engine
  2. Subsequent normal transcription requests succeed
- [x] Passes `ruff check` and `ruff format`

Fixes https://github.com/vllm-project/vllm/issues/34532