### PR TITLE
[Bugfix] Fix compressed-tensors fp8 block assert and FlashInfer scale propagation

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -1093,6 +1093,14 @@ class CompressedTensorsKVCacheMethod(BaseKVCacheMethod):
         layer._v_scale = layer.v_scale
         layer._q_scale = layer.q_scale
 
+        # Also set float scales used by FlashInfer for attention/cache paths.
+        if layer.k_scale.numel() == 1:
+            layer._k_scale_float = layer.k_scale.item()
+        if layer.v_scale.numel() == 1:
+            layer._v_scale_float = layer.v_scale.item()
+        if layer.q_scale.numel() == 1:
+            layer._q_scale_float = layer.q_scale.item()
+
         # Discard all placeholders.
         del layer.k_scale
         del layer.v_scale

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a16_fp8.py
@@ -111,7 +111,7 @@ class CompressedTensorsW8A16Fp8(CompressedTensorsScheme):
         size_k_first = True
         # TODO(rob): refactor block quant into separate class.
         if self.strategy == QuantizationStrategy.BLOCK:
-            assert self.is_static_input_scheme is False
+            assert not self.is_static_input_scheme
             size_k_first = False
             weight, weight_scale = process_fp8_weight_block_strategy(
                 weight, weight_scale


### PR DESCRIPTION
## Purpose

Fix two issues in compressed-tensors + FlashInfer integration:
1. **Block FP8 assertion is too strict**
   - In `CompressedTensorsW8A16Fp8`, block strategy currently asserts:
     `self.is_static_input_scheme is False`
   - For weight-only FP8 configs, `is_static_input_scheme` may be unset (`None`), which is semantically non-static but fails identity comparison.
   - This PR changes it to:
     `assert not self.is_static_input_scheme`
2. **KV/Q host float scales are not propagated after load**
   - In `CompressedTensorsKVCacheMethod.process_weights_after_loading`, loaded `k_scale/v_scale/q_scale` are assigned to tensor fields (`_k_scale/_v_scale/_q_scale`) but corresponding host float fields remain at default `1.0`.
   - FlashInfer attention/cache paths read these host float scales.
   - This PR propagates scalar loaded values to:
     `_k_scale_float`, `_v_scale_float`, `_q_scale_float` (guarded by `numel() == 1`).
This fixes load/runtime correctness for mixed-quant deployments (AWQ + FP8 attn/KV) on Ampere.

## Test Plan

- Reproduce with the following model on Ampere using FlashInfer backend:
  - `EliasOenal/MiniMax-M2.5-Hybrid-AWQ-W4A16G128-Attn-fp8_e4m3-KV-fp8_e4m3`
- Validate:
  1. Model initialization no longer fails in block FP8 path due to `is_static_input_scheme` being unset.
  2. After weight loading, per-layer `_k_scale_float/_v_scale_float/_q_scale_float` reflect loaded checkpoint scales (not default `1.0`).
  3. End-to-end inference runs correctly in production serving flow.

## Test Result

- ✅ Validated in production deployment on Ampere (4x RTX A6000) with the model above.
- ✅ Block FP8 load path works with unset `is_static_input_scheme` in weight-only config.
- ✅ FlashInfer uses propagated calibrated float scales for attention/cache paths.
- ✅ Model serves inference successfully with expected behavior.

## Release Notes Update

- Fixed compressed-tensors FP8 block weight-only handling by relaxing a strict is_static_input_scheme identity check so unset/non-static cases are accepted.
- Fixed FlashInfer KV-cache scale propagation for compressed-tensors by copying loaded scalar q/k/v scales into host *_scale_float fields used in attention/cache paths.
- Impact: avoids load-time assertion failures and prevents silent mis-scaling from default 1.0 host scales in mixed AWQ + FP8 attention/KV deployments.
