### PR TITLE
[WIP][Bugfix] Fix torch.compile startup time logging inaccuracy

### DIFF
--- a/vllm/compilation/monitor.py
+++ b/vllm/compilation/monitor.py
@@ -31,9 +31,11 @@ def start_monitoring_torch_compile(vllm_config: VllmConfig) -> None:
 def end_monitoring_torch_compile(vllm_config: VllmConfig) -> None:
     compilation_config: CompilationConfig = vllm_config.compilation_config
     if compilation_config.mode == CompilationMode.VLLM_COMPILE:
+        elapsed = time.time() - torch_compile_start_time
+        compilation_config.compilation_time = elapsed
         logger.info_once(
             "torch.compile takes %.2f s in total",
-            compilation_config.compilation_time,
+            elapsed,
             scope="local",
         )
         global context_manager


### PR DESCRIPTION
## Purpose

Fixes #27815.

The `"torch.compile takes X s in total"` log message reported significantly shorter times than actual wall-clock duration (e.g., ~47s logged vs ~8 minutes actual). This was because `compilation_config.compilation_time` was a sum of individually measured intervals (Dynamo bytecode transform time + per-range backend compilation time), which missed all the gaps between these phases — such as PyTorch post-processing after `VllmBackend.__call__()` returns, time between consecutive `PiecewiseBackend` invocations for different shapes, and other overhead.

The fix computes the actual wall-clock elapsed time (`time.time() - torch_compile_start_time`) in `end_monitoring_torch_compile()` instead of using the accumulated sum. The infrastructure already had the correct start and end points — it just wasn't using them. Per-component breakdowns (dynamo time, per-range compile time) are preserved in their own separate log lines.

## Test Plan


## Test Result

