### PR TITLE
[perf] Avoid dtype promotion sync in mamba_get_block_table_tensor

### DIFF
--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -855,8 +855,12 @@ def mamba_get_block_table_tensor(
             (seq_lens - 1) // kv_cache_spec.block_size,
             min=0,
         )
+        # Use int32 for arithmetic to avoid dtype promotion overhead,
+        # then convert to int64 for gather (which requires Long indices)
         offsets = torch.arange(
-            1 + kv_cache_spec.num_speculative_blocks, device=block_table.device
+            1 + kv_cache_spec.num_speculative_blocks,
+            device=block_table.device,
+            dtype=torch.int32,
         )
-        indices_to_gather = start_indices.unsqueeze(1) + offsets
+        indices_to_gather = (start_indices.unsqueeze(1) + offsets).to(torch.int64)
         return torch.gather(block_table, 1, indices_to_gather)


### PR DESCRIPTION

## Purpose

From the perf profiling on a model using linear attention, one thing draws the attention is `aten::to` from somewhere in vllm gpu_model_runner preprocess

<img width="1386" height="372" alt="image" src="https://github.com/user-attachments/assets/8b0a8714-edab-4ece-add9-6d719ced13e5" />

For this `aten::to`,
<img width="432" height="550" alt="image" src="https://github.com/user-attachments/assets/d0e04a74-313b-468d-8753-7b49d751bb01" />

We can tell it is doing to with dtype=3 (int64)

With CC's help, we found it is from `mamba_get_block_table_tensor`
* `start_indices` is `int32`
* `offsets` is `int64`
* `indices_to_gather = start_indices.unsqueeze(1) + offsets` will perform int32+int64 and sync

Now we made `offsets` as int32 as well, and then no sync.

With the change, new profiling looks much better

<img width="824" height="268" alt="image" src="https://github.com/user-attachments/assets/a8cf4e3c-d402-49fd-a1d7-643f267a4535" />




## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

