### PR TITLE
[WIP][Bugfix] Fix GPTQ quantized Qwen3-Next MoE expert weight loading

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -2,7 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Inference-only Qwen3Next model."""
 
-from collections.abc import Iterable
+import typing
+from collections.abc import Callable, Iterable
 from itertools import islice
 
 import torch
@@ -1173,6 +1174,20 @@ class Qwen3NextModel(nn.Module):
             ("gate_up_proj", "up_proj", 1),
         ]
 
+        # Skip loading extra parameters for GPTQ/modelopt models.
+        ignore_suffixes = (
+            ".bias",
+            "_bias",
+            ".k_scale",
+            "_k_scale",
+            ".v_scale",
+            "_v_scale",
+            ".weight_scale",
+            "_weight_scale",
+            ".input_scale",
+            "_input_scale",
+        )
+
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         expert_params_mapping = self.get_expert_mapping()
@@ -1197,13 +1212,12 @@ class Qwen3NextModel(nn.Module):
                     continue
 
                 name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
+                # Skip loading extra parameters for GPTQ/modelopt models.
+                if name.endswith(ignore_suffixes) and name not in params_dict:
                     continue
                 # Skip layers on other devices.
                 if is_pp_missing_parameter(name, self):
                     continue
-                # name = apply_attn_prefix(name, params_dict)
                 if name not in params_dict:
                     continue
                 param = params_dict[name]
@@ -1211,34 +1225,57 @@ class Qwen3NextModel(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
+                is_expert_weight = False
                 for mapping in expert_params_mapping:
                     param_name, weight_name, expert_id, shard_id = mapping
                     if weight_name not in name:
                         continue
-                    name = name.replace(weight_name, param_name)
-                    # Skip layers on other devices.
-                    if is_pp_missing_parameter(name, self):
+
+                    # Anyway, this is an expert weight and should not be
+                    # attempted to load as other weights later
+                    is_expert_weight = True
+
+                    # Do not modify `name` since the loop may continue here
+                    # Instead, create a new variable
+                    name_mapped = name.replace(weight_name, param_name)
+
+                    if is_pp_missing_parameter(name_mapped, self):
                         continue
-                    # Skip loading extra bias for GPTQ models.
+
+                    # Skip loading extra parameters for GPTQ/modelopt models.
                     if (
-                        name.endswith(".bias") or name.endswith("_bias")
-                    ) and name not in params_dict:
+                        name_mapped.endswith(ignore_suffixes)
+                        and name_mapped not in params_dict
+                    ):
                         continue
-                    if name not in params_dict:
-                        continue
-                    param = params_dict[name]
-                    weight_loader = param.weight_loader
-                    weight_loader(
+
+                    param = params_dict[name_mapped]
+                    # We should ask the weight loader to return success or
+                    # not here since otherwise we may skip experts with
+                    # other available replicas.
+                    weight_loader = typing.cast(
+                        Callable[..., bool], param.weight_loader
+                    )
+                    success = weight_loader(
                         param,
                         loaded_weight,
-                        name,
+                        name_mapped,
                         shard_id=shard_id,
                         expert_id=expert_id,
+                        return_success=True,
                     )
-                    break
+                    if success:
+                        name = name_mapped
+                        break
                 else:
-                    # Skip loading extra bias for GPTQ models.
-                    if name.endswith(".bias") and name not in params_dict:
+                    if is_expert_weight:
+                        # We've checked that this is an expert weight
+                        # However it's not mapped locally to this rank
+                        # So we simply skip it
+                        continue
+
+                    # Skip loading extra parameters for GPTQ/modelopt models.
+                    if name.endswith(ignore_suffixes) and name not in params_dict:
                         continue
                     if is_pp_missing_parameter(name, self):
                         continue

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -1249,6 +1249,9 @@ class Qwen3NextModel(nn.Module):
                     ):
                         continue
 
+                    if name_mapped not in params_dict:
+                        continue
+
                     param = params_dict[name_mapped]
                     # We should ask the weight loader to return success or
                     # not here since otherwise we may skip experts with


### PR DESCRIPTION
## Purpose

Fix `KeyError: 'layers.0.mlp.experts.w2_weight'` when loading GPTQ-quantized Qwen3-Next MoE models (e.g., Qwen3-Next-80B-A3B with int8 GPTQ).

Closes #28274

The expert weight loading loop in `qwen3_next.py` had 4 bugs compared to the correct, battle-tested implementation in `qwen3_moe.py`:

1. **Mutating `name` directly instead of using `name_mapped`**: When `name = name.replace(weight_name, param_name)` produced a name not in `params_dict` (common with GPTQ suffixes like `.qweight`, `.scales`), the original checkpoint name was permanently lost. Subsequent loop iterations operated on the corrupted name and could never match.

2. **Missing `is_expert_weight` flag**: Without tracking that a weight matched an expert pattern, unmatched expert weights fell through to the generic loader, which attempted `params_dict[name]` on the corrupted name, causing the `KeyError`.

3. **Missing `return_success=True` pattern**: The weight loader was called without `return_success=True` and unconditionally broke out of the loop. This didn't handle expert parallelism where an expert may not be local to the current rank.

4. **Incomplete `ignore_suffixes` for GPTQ/modelopt**: Only `.bias`/`_bias` were checked, but GPTQ/modelopt models also produce `_scale`, `_weight_scale`, `_input_scale`, etc. suffixes that need to be gracefully skipped when not in `params_dict`.

The fix aligns the expert loading loop with the proven pattern from `qwen3_moe.py`.

## Test Plan

## Test Result
