### PR TITLE
[WIP][Feature] Support GGUF models with qwen3vl architecture

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -16,6 +16,7 @@ from transformers import GenerationConfig, PretrainedConfig
 from transformers.models.auto.image_processing_auto import get_image_processor_config
 from transformers.models.auto.modeling_auto import (
     MODEL_FOR_CAUSAL_LM_MAPPING_NAMES,
+    MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES,
     MODEL_MAPPING_NAMES,
 )
 from transformers.models.auto.tokenization_auto import get_tokenizer_config
@@ -655,9 +656,12 @@ def get_config(
 
     # Special architecture mapping check for GGUF models
     if _is_gguf:
-        if config.model_type not in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES:
+        if config.model_type in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES:
+            model_type = MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type]
+        elif config.model_type in MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES:
+            model_type = MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES[config.model_type]
+        else:
             raise RuntimeError(f"Can't get gguf config for {config.model_type}.")
-        model_type = MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type]
         config.update({"architectures": [model_type]})
 
     # Architecture mapping for models without explicit architectures field


### PR DESCRIPTION
## Purpose

Closes #30485.

GGUF models with the `qwen3vl` / `qwen3vlmoe` architecture (e.g. Qwen3-VL-235B-A22B-Thinking-GGUF) currently fail to load with `RuntimeError: Can't get gguf config for qwen3_vl`. This PR adds support by fixing two issues:

**1. GGUF architecture resolution only checked CausalLM models (`config.py`)**

The GGUF config loader used `MODEL_FOR_CAUSAL_LM_MAPPING_NAMES` exclusively to resolve architectures. Multimodal-only models like Qwen3VL are not in that mapping — they are only in `MODEL_FOR_IMAGE_TEXT_TO_TEXT_MAPPING_NAMES`. The fix adds a fallthrough: try CausalLM first (preserving existing behavior for Gemma3 and all text-only models), then try ImageTextToText. This is generic and automatically unblocks all future multimodal GGUF models (qwen2_vl, qwen2_5_vl, etc.).

**2. GGUF loader needed model_type remapping and arch fallback (`gguf_loader.py`)**

- Added `qwen3_vl` → `qwen3vl` and `qwen3_vl_moe` → `qwen3vlmoe` model_type remapping (HF uses underscores, GGUF does not).
- Added `qwen3vlmoe` to the MoE expert weight handling block, and changed `config.num_hidden_layers` → `text_config.num_hidden_layers` (necessary because `Qwen3VLMoeConfig` stores this on the nested text config; backward-compatible since for text-only models `text_config == config`).
- Added an arch fallback (`qwen3vl` → `qwen3`, `qwen3vlmoe` → `qwen3moe`) for the `gguf.MODEL_ARCH_NAMES` lookup, since `gguf-py 0.17.1` on PyPI doesn't yet include `QWEN3VL`/`QWEN3VLMOE` (upstream llama.cpp added them in Oct 2025 but hasn't released to PyPI). The text backbone tensor layouts are identical, so the fallback produces correct mappings. It auto-expires once `gguf-py` is updated — no cleanup needed.
- Fixed `vision_num_layers` extraction to handle Qwen3VL's `depth` attribute (Gemma3 uses `num_hidden_layers`, Qwen3VL uses `depth`).

## Test Plan


## Test Result
