### PR TITLE
[Bug] Fix DeepSeek V3 weight loading caused by incorrect prefix

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -716,7 +716,7 @@ class DeepSeekV2FusedQkvAProj(MergedColumnParallelLinear):
     def __init__(
         self,
         input_size: int,
-        output_size: int,
+        output_size: list[int],
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ):
@@ -726,7 +726,7 @@ class DeepSeekV2FusedQkvAProj(MergedColumnParallelLinear):
             bias=False,
             quant_config=quant_config,
             disable_tp=True,
-            prefix=f"{prefix}.kv_a_proj_with_mqa",
+            prefix=prefix,
         )
 
         # Check if the DeepSeek V3 fused A GEMM kernel can be used.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix #34869

## Test Plan
```
vllm serve nvidia/DeepSeek-V3.1-NVFP4 -tp=4
```

## Test Result
```
lm_eval --model local-completions --model_args "base_url=http://0.0.0.0:8000/v1/completions,max_length=8192,tokenized_requests=False,tokenizer_backend=None,num_concurrent=32" --tasks gsm8k --num_fewshot 5
```
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9613|±  |0.0053|
|     |       |strict-match    |     5|exact_match|↑  |0.9598|±  |0.0054|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

