### PR TITLE
[ROCm][Test] Fix beam search determinism failures from batch-size-dependent FP divergence and removed wrong marker

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -549,7 +549,7 @@ steps:
   - tests/samplers
   - tests/conftest.py
   commands:
-    - pytest -v -s -m samplers
+    - pytest -v -s samplers
 
 - label: LoRA Test %N # 20min each
   timeout_in_minutes: 30
@@ -2215,7 +2215,7 @@ steps:
   - tests/samplers
   - tests/conftest.py
   commands:
-    - pytest -v -s -m samplers
+    - pytest -v -s samplers
 
 - label: LoRA Test %N # 20min each
   timeout_in_minutes: 30

--- a/.buildkite/test_areas/samplers.yaml
+++ b/.buildkite/test_areas/samplers.yaml
@@ -18,4 +18,4 @@ steps:
       depends_on:
       - image-build-amd
       commands:
-      - pytest -v -s -m samplers
+      - pytest -v -s samplers


### PR DESCRIPTION
Fix `tests/samplers/test_beam_search.py` failures on ROCm by adding platform-conditional engine settings and disabling the skinny GEMM kernel to eliminate batch-size-dependent floating-point divergence.

## Root Cause

On ROCm, both the Triton attention kernels and the hipBLAS/rocBLAS GEMM kernels (including the "skinny GEMM" variant) use non-associative floating-point reductions whose accumulation order changes with the M-dimension (batch size). This means the **exact same row** in the logits matrix can produce slightly different values depending on how many other rows are in the batch.

For beam search, this is fatal: logprob differences as small as 1e-5 can flip the beam ranking at a single position, causing the entire output sequence to diverge. The test compares outputs across runs with different concurrency levels, which changes effective batch sizes and triggers different kernel code paths.

This is the same class of issue reported in #33123 (prefix caching determinism on ROCm), where the cache-miss path (full prefill) and cache-hit path (partial prefill) see different batch geometries and produce numerically different logits.

### Sources of divergence on ROCm

| Source | How batch size affects it |
|---|---|
| **Skinny GEMM** (`VLLM_ROCM_USE_SKINNY_GEMM`) | Selects different tiling/reduction strategies based on M-dim |
| **CUDA graph padding** | Pads to capture sizes, changing effective M-dim for GEMM |
| **Async scheduling** | Non-deterministic batch composition across scheduler steps |

## Fix

Add `EXTRA_ENGINE_KWARGS` (empty on non-ROCm, populated on ROCm) and `monkeypatch.setenv("VLLM_ROCM_USE_SKINNY_GEMM", "0")` to each test:

- **`async_scheduling=False`** --- deterministic batch composition
- **`enforce_eager=True`** --- no CUDA graph padding changing effective batch size
- **`enable_prefix_caching=False`** --- avoid prefix-sharing side effects
- **`max_num_seqs=1`** --- force identical single-request batches across runs
- **`VLLM_ROCM_USE_SKINNY_GEMM=0`** --- disable the batch-size-sensitive GEMM kernel

These are gated behind `current_platform.is_rocm()` so CUDA behavior is completely unchanged.

## Tests

Tested fix with: `pytest -s -v tests/samplers/` on MI355

## Related

- #33123 --- Prefix caching produces different output on ROCm due to the same batch-size-dependent FP divergence in attention and GEMM kernels.