### PR TITLE
[Spec Decode] Track per request level spec decode acceptance metric

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1314,6 +1314,9 @@ class Scheduler(SchedulerInterface):
                 sampled_token_ids[req_index] if sampled_token_ids else []
             )
 
+            num_draft_tokens = 0
+            num_accepted = 0
+
             scheduled_spec_token_ids = (
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id)
             )
@@ -1422,6 +1425,8 @@ class Scheduler(SchedulerInterface):
                         num_external_computed_tokens=request.num_external_computed_tokens,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,
+                        spec_decode_num_draft_tokens=num_draft_tokens,
+                        spec_decode_num_accepted_tokens=num_accepted,
                     )
                 )
             else:

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -167,6 +167,10 @@ class EngineCoreOutput(
     # A value greater than 0 indicates that the output is corrupted.
     num_nans_in_logits: int = 0
 
+    # Per-request speculative decoding stats for this step.
+    spec_decode_num_draft_tokens: int = 0
+    spec_decode_num_accepted_tokens: int = 0
+
     @property
     def finished(self) -> bool:
         return self.finish_reason is not None

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -218,6 +218,11 @@ class RequestStateStats:
     # Track if this request is corrupted (NaNs in logits)
     is_corrupted: bool = False
 
+    # Per-request speculative decoding stats (accumulated across steps).
+    num_spec_decode_steps: int = 0
+    num_draft_tokens: int = 0
+    num_accepted_tokens: int = 0
+
 
 @dataclass
 class FinishedRequestStats:
@@ -353,6 +358,12 @@ class IterationStats:
             req_stats.first_token_latency = first_token_latency
 
         req_stats.num_generation_tokens += num_new_generation_tokens
+
+        # Accumulate per-request spec decode stats
+        if output.spec_decode_num_draft_tokens > 0:
+            req_stats.num_spec_decode_steps += 1
+            req_stats.num_draft_tokens += output.spec_decode_num_draft_tokens
+            req_stats.num_accepted_tokens += output.spec_decode_num_accepted_tokens
 
         # Track if this request is corrupted (only check once per request)
         # Early exit if already marked as corrupted to avoid redundant checks


### PR DESCRIPTION
Currently vLLM tracks speculative decoding metrics accumulated at the engine level across requests, on top of this we would like to be able to track per request level speculative decoding acceptance rates to be able to:
1. improve online serving metrics monitoring 
2. improve draft model training by identifying low acceptance rate requests. 

To support this feature, per request level acceptance rate metrics are added to EngineCoreOutput & RequestStateStats

Test Plan: 
- added unit tests 
```
platform linux -- Python 3.12.12+meta, pytest-9.0.2, pluggy-1.6.0 -- /home/qizixi/my_vllm/D93634282/vllm/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/qizixi/my_vllm/D93634282/vllm
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 18 items                                                                                                                                                                                                                                       

tests/v1/metrics/test_stats.py::test_iteration_stats_repr PASSED                                                                                                                                                                                   [  5%]
tests/v1/metrics/test_stats.py::test_prefill_kv_computed_with_cache PASSED                                                                                                                                                                         [ 11%]
tests/v1/metrics/test_stats.py::test_prefill_kv_computed_no_cache PASSED                                                                                                                                                                           [ 16%]
tests/v1/metrics/test_stats.py::test_prefill_kv_computed_edge_cases PASSED                                                                                                                                                                         [ 22%]
tests/v1/metrics/test_stats.py::test_prompt_token_stats_all_computed PASSED                                                                                                                                                                        [ 27%]
tests/v1/metrics/test_stats.py::test_prompt_token_stats_partial_local_cache PASSED                                                                                                                                                                 [ 33%]
tests/v1/metrics/test_stats.py::test_prompt_token_stats_partial_external_transfer PASSED                                                                                                                                                           [ 38%]
tests/v1/metrics/test_stats.py::test_prompt_token_stats_mixed_sources PASSED                                                                                                                                                                       [ 44%]
tests/v1/metrics/test_stats.py::test_prompt_token_stats_full_local_cache_recompute PASSED                                                                                                                                                          [ 50%]
tests/v1/metrics/test_stats.py::test_prompt_token_stats_full_external_transfer_recompute PASSED                                                                                                                                                    [ 55%]
tests/v1/metrics/test_stats.py::test_request_state_stats_spec_decode_defaults PASSED                                                                                                                                                               [ 61%]
tests/v1/metrics/test_stats.py::test_spec_decode_stats_single_step[partial] PASSED                                                                                                                                                                 [ 66%]
tests/v1/metrics/test_stats.py::test_spec_decode_stats_single_step[all_rejected] PASSED                                                                                                                                                            [ 72%]
tests/v1/metrics/test_stats.py::test_spec_decode_stats_single_step[all_accepted] PASSED                                                                                                                                                            [ 77%]
tests/v1/metrics/test_stats.py::test_spec_decode_stats_single_step[no_spec] PASSED                                                                                                                                                                 [ 83%]
tests/v1/metrics/test_stats.py::test_spec_decode_stats_accumulate_across_steps PASSED                                                                                                                                                              [ 88%]
tests/v1/metrics/test_stats.py::test_spec_decode_stats_mixed_with_non_spec_steps PASSED                                                                                                                                                            [ 94%]
tests/v1/metrics/test_stats.py::test_engine_core_output_spec_decode_fields PASSED                                                                                                                                                                  [100%]

```