### PR TITLE
Support prompt_embeds for pooling requests in output processor

### DIFF
--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -337,16 +337,20 @@ class RequestState:
         finished: bool,
         kv_transfer_params: dict[str, Any] | None = None,
     ) -> RequestOutput | PoolingRequestOutput:
+        # If prompt embeds were used, put placeholder prompt token ids
+        prompt_token_ids = self.prompt_token_ids
+        if prompt_token_ids is None and self.prompt_embeds is not None:
+            prompt_token_ids = [0] * len(self.prompt_embeds)
+        assert prompt_token_ids is not None
+
         first_output = outputs[0]
         if isinstance(first_output, PoolingOutput):
             assert len(outputs) == 1
-            # Prompt embeddings are currently not supported by pooling requests.
-            assert self.prompt_token_ids is not None
             return PoolingRequestOutput(
                 request_id=external_req_id,
                 outputs=first_output,
                 num_cached_tokens=self.num_cached_tokens,
-                prompt_token_ids=self.prompt_token_ids,
+                prompt_token_ids=prompt_token_ids,
                 finished=finished,
             )
         assert self.logprobs_processor is not None
@@ -355,11 +359,6 @@ class RequestState:
             prompt_logprobs = self.logprobs_processor.pop_prompt_logprobs()
         else:
             prompt_logprobs = self.logprobs_processor.prompt_logprobs
-
-        # If prompt embeds were used, put placeholder prompt token ids
-        prompt_token_ids = self.prompt_token_ids
-        if prompt_token_ids is None and self.prompt_embeds is not None:
-            prompt_token_ids = [0] * len(self.prompt_embeds)
 
         return RequestOutput(
             request_id=external_req_id,  # request_id is what was provided externally


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR adds prompt_embeds support for pooling requests in the V1 output processor, matching the existing behavior already present for completion requests.

When using `--enable-prompt-embeds` with a pooling model (e.g., via the `--io-processor-plugin` flag), the output processor crashes with:
```
AssertionError
  File "vllm/v1/engine/output_processor.py", line 343
    assert self.prompt_token_ids is not None
```
This happens because pooling requests using `EmbedsPrompt` have `prompt_token_ids=None` and `prompt_embeds` set instead. The current completion path (line 359-363) already handles this case by creating placeholder token IDs from prompt_embeds, but the pooling path was missing the same fallback.

## Use Case
This enables IO processor plugins to use EmbedsPrompt to transport custom data (e.g., time series, image features) directly into a model's forward(inputs_embeds=...) method, rather than being forced to use dummy TokensPrompt token IDs. This is particularly useful for non-text models served through vLLM's pooling API.

## Testing

- Verified with a time series forecasting plugin (developed locally) that uses EmbedsPrompt to encode float data as prompt_embeds tensors
- Existing pooling tests is unaffected (the fallback path is only triggered for embeds-only requests)
- All downstream consumers of prompt_token_ids in the pooling path (pooling/serving.py, pooling/utils.py, classify/serving.py) only call len() for usage statistics — they never inspect actual token values. The placeholder [0] * len(prompt_embeds) has the correct length.
- The completion path has been using the exact same pattern (line 358-361) without issues.
