### PR TITLE
[CI] Fix custome offline ci issue, `V1 Others` Test bug

### DIFF
--- a/tests/v1/logits_processors/test_custom_offline.py
+++ b/tests/v1/logits_processors/test_custom_offline.py
@@ -19,6 +19,7 @@ from tests.v1.logits_processors.utils import (
 )
 from tests.v1.logits_processors.utils import entry_points as fake_entry_points
 from vllm import LLM, SamplingParams
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.sample.logits_processor import (
     STR_POOLING_REJECTS_LOGITSPROCS,
     STR_SPEC_DEC_REJECTS_LOGITSPROCS,
@@ -158,7 +159,10 @@ def test_custom_logitsprocs(monkeypatch, logitproc_source: CustomLogitprocSource
 
         # fork is required for workers to see entrypoint patch
         monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "fork")
-        _run_test({"attention_backend": "TRITON_ATTN"}, logitproc_loaded=True)
+        _run_test(
+            {"attention_backend": AttentionBackendEnum.TRITON_ATTN},
+            logitproc_loaded=True,
+        )
         return
 
     kwargs: dict[str, list[str | type[LogitsProcessor]]] = {}


### PR DESCRIPTION
## Purpose

Fixes https://buildkite.com/vllm/ci/builds/52111/steps/canvas?jid=019c71de-e90f-46a7-9da5-cfea9f4a0660

We need to `fork`, but if we let vLLM automatically choose attn backend,

```py
    if cuda_is_initialized():
        reasons.append("CUDA is initialized")
    ...
    if reasons:
        logger.warning(
            "We must use the `spawn` multiprocessing start method. "
            "Overriding VLLM_WORKER_MULTIPROC_METHOD to 'spawn'. "
            ...
        )
        os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
```

It will be set to spawn, which causes the issue

## Test

```bash
[yewentao256@nma-frk-sa-h100-00-preserve vllm-source]$ pytest tests/v1/logits_processors/test_custom_offline.py::test_custom_logitsprocs[CustomLogitprocSource.LOGITPROC_SOURCE_ENTRYPOINT]
================================================ test session starts =================================================
platform linux -- Python 3.12.9, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/yewentao256/vllm-source
configfile: pyproject.toml
plugins: anyio-4.12.0, asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                     

tests/v1/logits_processors/test_custom_offline.py .                                                            [100%]

================================================== warnings summary ==================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/v1/logits_processors/test_custom_offline.py::test_custom_logitsprocs[CustomLogitprocSource.LOGITPROC_SOURCE_ENTRYPOINT]
  /home/yewentao256/vllm-source/tests/utils.py:1002: DeprecationWarning: This process (pid=366690) is multi-threaded, use of fork() may lead to deadlocks in the child.
    pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== 1 passed, 3 warnings in 36.55s ===========================================
```