### PR TITLE
[ROCm][CI] Loosen RemoteOpenAIServer Startup Timeout

### DIFF
--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -126,7 +126,7 @@ def gptoss_speculative_server(default_server_args: list[str]):
     if is_aiter_found_and_supported():
         env_dict = {"VLLM_ROCM_USE_AITER": "1"}
     with RemoteOpenAIServer(
-        GPT_OSS_MODEL_NAME, server_args, env_dict=env_dict
+        GPT_OSS_MODEL_NAME, server_args, env_dict=env_dict, max_wait_seconds=480
     ) as remote_server:
         yield remote_server
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -190,7 +190,7 @@ class RemoteOpenAIServer:
             model_loader.download_model(model_config)
 
         self._start_server(model, vllm_serve_args, env_dict)
-        max_wait_seconds = max_wait_seconds or 240
+        max_wait_seconds = max_wait_seconds or 360
         self._wait_for_server(url=self.url_for("health"), timeout=max_wait_seconds)
 
     def __enter__(self):


### PR DESCRIPTION
<!-- markdownlint-disable -->
We've noticed some flakiness in amd-ci related to tests timing out in Entrypoints Integration Test (API Server 1).  Here is one example from a recent nightly build: https://buildkite.com/vllm/amd-ci/builds/4972/summary?jid=019c6f8c-8d3b-47b7-977b-ab61ac8730ce&tab=output#019c6f8c-8d3b-47b7-977b-ab61ac8730ce/L6775

In this example, the following test times out after the 240 second server init timeout defined in RemoteOpenAIServer:

```
pytest -v -s entrypoints/openai/test_serving_chat.py::TestGPTOSSSpeculativeChat::test_gpt_oss_speculative_reasoning_leakage[with_tool_parser-exclude_tools_when_tool_choice_none]
```

From local testing, it looks like it is just barely exceeding the timeout due to AITER JIT compilation taking 130 seconds for one particular kernel (it took 250 seconds for the server to come up overall). I loosened the overall timeout restriction by a couple minutes, increasing it from 240 to 360 seconds. The reason for this is that I noticed there is some variance in JIT compile time for AITER kernels, and I noticed when testing with torch 2.10 and triton 3.6, some triton compile times are a little bit longer. So, this 2 minute increase is somewhat preparatory for when we upgrade. 

The TestGPTOSSSpeculativeChat test takes a particularly long time to initialize between AITER JIT and triton 3.6 compile times (it took a about 470 seconds when I tested locally), so I added a bit of extra timeout padding on that one as well.

I did implement these changes such that they will take effect on both AMD and Nvidia CI. If it is preferred that I isolate these changes to AMD platforms, I can do that. Further, since the magnitude of timeout increases are a bit preemptive, I could limit them to the minimal necessary values for now and then revisit in the future if it becomes an issue again. Would like to hear the reviewers' preferences. Thanks!