### PR TITLE
[AMD][CI] Support Triton attention with ExampleConnector

### DIFF
--- a/tests/v1/kv_connector/unit/test_example_connector.py
+++ b/tests/v1/kv_connector/unit/test_example_connector.py
@@ -3,14 +3,12 @@
 from dataclasses import asdict
 from typing import NamedTuple
 
-import pytest
 from PIL import Image
 
 from vllm import LLM, EngineArgs, SamplingParams
 from vllm.assets.image import ImageAsset
 from vllm.config import KVTransferConfig
 from vllm.multimodal.utils import encode_image_url
-from vllm.platforms import current_platform
 
 MODEL_NAME = "RedHatAI/Qwen2.5-VL-3B-Instruct-quantized.w8a8"
 
@@ -110,13 +108,6 @@ def process_prompt(processor, llm: LLM, question: str, image_urls: list[Image]):
         print("-" * 50)
 
 
-@pytest.mark.skipif(
-    current_platform.is_rocm(),
-    reason=(
-        "hipErrorLaunchFailure when running this test, see issue:"
-        "https://github.com/ROCm/pytorch/issues/2822"
-    ),
-)
 def test_shared_storage_connector_hashes(tmp_path):
     """
     Tests that ExampleConnector saves KV to the storage locations

--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -20,7 +20,6 @@ from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
     NixlKVConnectorStats,
 )
-from vllm.platforms import current_platform
 
 MODEL_NAME = "meta-llama/Llama-3.2-1B-Instruct"
 
@@ -97,13 +96,6 @@ def _compare_directories(dir1: Path, dir2: Path) -> bool:
     return True
 
 
-@pytest.mark.skipif(
-    current_platform.is_rocm(),
-    reason=(
-        "hipErrorLaunchFailure when running this test, see issue:"
-        "https://github.com/ROCm/pytorch/issues/2822"
-    ),
-)
 def test_multi_example_connector_consistency():
     """
     Tests that MultiConnector with two ExampleConnectors saves

--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_connector.py
@@ -191,12 +191,13 @@ class ExampleConnector(KVConnectorBase_V1):
                     layer_name, request.token_ids, request.mm_hashes
                 )
                 kv_cache = safetensors.torch.load_file(filename)["kv_cache"].cuda()
-                inject_kv_into_layer(
-                    kv_cache_layer,
-                    kv_cache,
-                    request.slot_mapping,
-                    attn_metadata[layer_name],
-                )
+                if isinstance(attn_metadata, dict):
+                    inject_kv_into_layer(
+                        kv_cache_layer,
+                        kv_cache,
+                        request.slot_mapping,
+                        attn_metadata[layer_name],
+                    )
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         """Blocking until the KV for a specific layer is loaded into vLLM's


### PR DESCRIPTION
## Purpose
To support Triton attention with `ExampleConnector`. ROCm uses [Triton attention](https://github.com/vllm-project/vllm/blob/f72061a19ae7fbb7f193c31f0abea355fab41892/vllm/v1/attention/backends/triton_attn.py#L295), which has a different kv cache layout than [Flash attention](https://github.com/vllm-project/vllm/blob/f72061a19ae7fbb7f193c31f0abea355fab41892/vllm/v1/attention/backends/flash_attn.py#L116), the Cuda default. [ExampleConnector](https://github.com/vllm-project/vllm/blob/c683d11c94655655cd7bf95a27aef7e245325102/vllm/distributed/kv_transfer/kv_connector/v1/example_connector.py#L233) currently expects the kv cache layout to match Flash attention.

## Test Plan
On ROCm
```bash
pytest tests/v1/kv_connector/unit/test_multi_connector.py::test_multi_example_connector_consistency
pytest tests/v1/kv_connector/unit/test_example_connector.py::test_shared_storage_connector_hashes
bash examples/offline_inference/disaggregated-prefill-v1/run.sh
```

Alternatively, on Cuda this can be tested by modifying the prefill/decode example connector example, https://github.com/vllm-project/vllm/blob/33a0d43c7119269aa300d4341871dd46d52575d0/examples/offline_inference/disaggregated-prefill-v1/prefill_example.py#L24-L33

to use `TRITON_ATTN`:
```python
llm = LLM(
    model="meta-llama/Llama-3.2-1B-Instruct",
    enforce_eager=True,
    gpu_memory_utilization=0.8,
    attention_config=AttentionConfig(backend="TRITON_ATTN"),
    kv_transfer_config=KVTransferConfig(
        kv_connector="ExampleConnector",
        kv_role="kv_both",
        kv_connector_extra_config={"shared_storage_path": "local_storage"},
    ),
)  # , max_model_len=2048, max_num_batched_tokens=2048)
```

## Test Result
Success

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

