### PR TITLE
[Bugfix]: Qwen3 reasoning parser now handles <think> in prompt prefix

### DIFF
--- a/tests/reasoning/test_qwen3_reasoning_parser.py
+++ b/tests/reasoning/test_qwen3_reasoning_parser.py
@@ -19,25 +19,25 @@ def qwen3_tokenizer():
     return AutoTokenizer.from_pretrained(REASONING_MODEL_NAME)
 
 
-# 带 <think></think>，非stream
+# With <think></think>, non-streaming
 WITH_THINK = {
     "output": "<think>This is a reasoning section</think>This is the rest",
     "reasoning": "This is a reasoning section",
     "content": "This is the rest",
 }
-# 带 <think></think>，stream
+# With <think></think>, streaming
 WITH_THINK_STREAM = {
     "output": "<think>This is a reasoning section</think>This is the rest",
     "reasoning": "This is a reasoning section",
     "content": "This is the rest",
 }
-# 不带 <think></think>，非stream
+# Without <think></think>, non-streaming
 WITHOUT_THINK = {
     "output": "This is the rest",
     "reasoning": None,
     "content": "This is the rest",
 }
-# 不带 <think></think>，stream
+# Without <think></think>, streaming
 WITHOUT_THINK_STREAM = {
     "output": "This is the rest",
     "reasoning": None,
@@ -64,6 +64,25 @@ ONLY_OPEN_TAG_STREAM = {
     "output": "<think>This is a reasoning section",
     "reasoning": "This is a reasoning section",
     "content": None,
+}
+
+# Cases where <think> is part of the prompt (chat template), so the model
+# output does NOT contain <think>, only </think>.
+# ``reasoning</think>content``
+NO_START_TOKEN = {
+    "output": "This is a reasoning section</think>This is the rest",
+    "reasoning": "This is a reasoning section",
+    "content": "This is the rest",
+}
+NO_START_TOKEN_COMPLETE = {
+    "output": "This is a reasoning section</think>",
+    "reasoning": "This is a reasoning section",
+    "content": None,
+}
+NO_START_TOKEN_MULTILINE = {
+    "output": "This\nThat</think>This is the rest\nThat",
+    "reasoning": "This\nThat",
+    "content": "This is the rest\nThat",
 }
 
 TEST_CASES = [
@@ -116,6 +135,37 @@ TEST_CASES = [
         True,
         ONLY_OPEN_TAG_STREAM,
         id="only_open_tag_stream",
+    ),
+    # <think> in prompt (not in model output), non-streaming & streaming
+    pytest.param(
+        False,
+        NO_START_TOKEN,
+        id="no_start_token",
+    ),
+    pytest.param(
+        True,
+        NO_START_TOKEN,
+        id="no_start_token_stream",
+    ),
+    pytest.param(
+        False,
+        NO_START_TOKEN_COMPLETE,
+        id="no_start_token_complete",
+    ),
+    pytest.param(
+        True,
+        NO_START_TOKEN_COMPLETE,
+        id="no_start_token_complete_stream",
+    ),
+    pytest.param(
+        False,
+        NO_START_TOKEN_MULTILINE,
+        id="no_start_token_multiline",
+    ),
+    pytest.param(
+        True,
+        NO_START_TOKEN_MULTILINE,
+        id="no_start_token_multiline_stream",
     ),
 ]
 

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Sequence
+
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
 )
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.entrypoints.openai.responses.protocol import (
     ResponsesRequest,
 )
@@ -15,10 +18,20 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
     Reasoning parser for the Qwen3 model.
 
     The Qwen3 model uses <think>...</think> tokens to denote reasoning text
-    within its output. The model provides a strict switch to disable reasoning
-    output via the 'enable_thinking=False' parameter. This parser extracts the
-    reasoning content enclosed by <think> and </think> tokens from the model's
-    output.
+    within its output.
+
+    Newer Qwen3 thinking models (e.g., Qwen3-4B-Thinking-2507) support only
+    thinking mode, meaning ``enable_thinking=True`` is always in effect. Their
+    default chat template automatically appends ``<think>`` to the assistant
+    turn prefix inside the prompt. As a result, the model's generated output
+    typically starts directly with the reasoning text and ends with
+    ``</think>content`` — the opening ``<think>`` tag does NOT appear in the
+    generated tokens.
+
+    This parser handles both cases:
+      1. Full tags in output: ``<think>reasoning</think>content``
+      2. Only closing tag in output (opening tag in prompt):
+         ``reasoning</think>content``
     """
 
     @property
@@ -37,35 +50,81 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         """
         Extract reasoning content from the model output.
 
-        Qwen3 has stricter requirements - it needs both start and end tokens
-        to be present, unlike other models that work with just the end token.
+        Handles two cases:
+        1. Both <think> and </think> in output: text between them is reasoning.
+        2. Only </think> in output (when <think> was added by the chat
+           template as part of the prompt): text before </think> is reasoning.
 
-        For text <think>abc</think>xyz:
-        - 'abc' goes to reasoning
-        - 'xyz' goes to content
+        If neither token is present, returns (None, model_output).
 
         Returns:
             tuple[Optional[str], Optional[str]]: reasoning content and content
         """
 
-        # Check if the model output contains both <think> and </think> tokens.
-        if self.start_token not in model_output or self.end_token not in model_output:
+        # If no </think> in output, there is no reasoning to extract.
+        if self.end_token not in model_output:
             return None, model_output
 
-        # Check if the <think> is present in the model output, remove it
-        # if it is present.
+        # Remove <think> start token if present in the model output.
         model_output_parts = model_output.partition(self.start_token)
         model_output = (
             model_output_parts[2] if model_output_parts[1] else model_output_parts[0]
         )
-
-        # Check if the model output contains the </think> tokens.
-        # If the end token is not found, return the model output as is.
-        if self.end_token not in model_output:
-            return None, model_output
 
         # Extract reasoning content from the model output.
         reasoning, _, content = model_output.partition(self.end_token)
 
         final_content = content or None
         return reasoning, final_content
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+    ) -> DeltaMessage | None:
+        """
+        Extract reasoning content from a streaming delta.
+
+        Extends the base implementation to handle the case where the <think>
+        token was added by the chat template as part of the prompt and is not
+        present in the generated token IDs. In this case, all content before
+        </think> is treated as reasoning content.
+        """
+        ret = super().extract_reasoning_streaming(
+            previous_text,
+            current_text,
+            delta_text,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+        )
+        # If <think> was not found in either previous or delta token IDs,
+        # it means <think> was part of the prompt (added by the chat
+        # template). We need to treat content before </think> as reasoning.
+        if (
+            ret is not None
+            and self.start_token_id not in previous_token_ids
+            and self.start_token_id not in delta_token_ids
+        ):
+            if self.end_token_id in delta_token_ids:
+                # </think> found in delta: split into reasoning and content
+                end_index = delta_text.find(self.end_token)
+                reasoning = delta_text[:end_index]
+                content = delta_text[end_index + len(self.end_token) :]
+                return DeltaMessage(
+                    reasoning=reasoning,
+                    content=content if content else None,
+                )
+            elif self.end_token_id in previous_token_ids:
+                # </think> was in a previous chunk: reasoning is done,
+                # this is content
+                return DeltaMessage(content=delta_text)
+            else:
+                # No </think> yet: reasoning content continues
+                return DeltaMessage(reasoning=delta_text)
+
+        return ret


### PR DESCRIPTION
[Bugfix]: Qwen3 reasoning parser now handles <think> in prompt prefix

Fixes #21130

## Purpose

Newer Qwen3 thinking models (e.g., `Qwen3-4B-Thinking-2507`) support **only thinking mode** — `enable_thinking=True` is always in effect. Their default chat template automatically appends `<think>` to the assistant turn prefix inside the prompt. As a result, the model's generated output starts directly with reasoning text and ends with `</think>content` — the opening `<think>` tag does **not** appear in the generated tokens.

The old `Qwen3ReasoningParser.extract_reasoning` required **both** `<think>` and `</think>` to be present in the model output:
```python
if self.start_token not in model_output or self.end_token not in model_output:
    return None, model_output  # ← BUG: everything goes to content
```
Since `<think>` is in the prompt (not the generated output), this condition was always `True`, causing **all text to be returned as `content`** with `reasoning_content=None`.

This fix addresses both the **non-streaming** and **streaming** paths:
1. **Non-streaming (`extract_reasoning`)**: Changed to only require `</think>`. If `<think>` is present it's stripped; if not (i.e., it was in the prompt), the text before `</think>` is still correctly treated as reasoning.
2. **Streaming (`extract_reasoning_streaming`)**: Added an override (similar to `DeepSeekR1ReasoningParser`) that handles the case where `<think>` token ID is absent from both previous and delta token IDs.

## Test Plan

```bash
python -m pytest tests/reasoning/test_qwen3_reasoning_parser.py -v
```

Added 6 new test cases covering the `reasoning</think>content` pattern (no opening `<think>` tag) for both streaming and non-streaming modes.

Manual end-to-end test with `Qwen3-4B-Thinking-2507`:
```bash
python -m vllm.entrypoints.openai.api_server   --model /data1/work/kurty/models/Qwen3-4b/Qwen3-4B-Thinking-2507   --tensor-parallel-size 1   --max-model-len 1024   --gpu-memory-utilization 0.90   --dtype auto   --host 0.0.0.0   --port 8030 --reasoning-parser qwen3
```


```
curl http://localhost:8030/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "/data1/work/kurty/models/Qwen3-4b/Qwen3-4B-Thinking-2507",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": "What is 2 + 3?"
      }
    ],
    "max_tokens": 512,
    "temperature": 0.7
  }'

```

## Test Result

**Before fix** — reasoning content leaked into `content`, `reasoning_content` was `null`:
```json
{"id":"chatcmpl-a3416e45c63868a8","object":"chat.completion","created":1771556121,"model":"/data1/work/kurty/models/Qwen3-4b/Qwen3-4B-Thinking-2507","choices":[{"index":0,"message":{"role":"assistant","content":"Okay, the user asked \"What is 2 + 3?\" That's a simple arithmetic question. Let me think.\n\nFirst, I know that 2 plus 3 equals 5. That's basic addition. But wait, maybe the user is testing if I can handle simple math. Or perhaps they're a kid learning addition. \n\nHmm, the question seems straightforward. No tricks here. I should just give the answer clearly. But I should also be friendly and helpful. Maybe add a smiley to keep it warm.\n\nWait, could there be any context I'm missing? Like, is this part of a larger problem? But the user only asked for 2 + 3. So I'll stick to the basics.\n\nLet me double-check: 2 + 3 is indeed 5. Yep, that's correct. No need to overcomplicate it.\n\nI'll respond with \"2 + 3 equals 5! 😊\" to keep it simple and positive. That should cover it.\n</think>\n\n2 + 3 equals **5**! 😊","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null,"reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":29,"total_tokens":248,"completion_tokens":219,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
```

**After fix** — reasoning and content are correctly separated:
```json
{"id":"chatcmpl-b4a481d598b0a20a","object":"chat.completion","created":1771556170,"model":"/data1/work/kurty/models/Qwen3-4b/Qwen3-4B-Thinking-2507","choices":[{"index":0,"message":{"role":"assistant","content":"\n\n2 + 3 equals **5**! 😊","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":"Okay, the user asked \"What is 2 + 3?\" That's a simple arithmetic question. Let me think.\n\nFirst, I know that 2 plus 3 equals 5. That's basic addition. But wait, maybe the user is testing if I can handle simple math. Or perhaps they're a kid learning addition. \n\nHmm, the question seems straightforward. No tricks here. I should just give the answer clearly. But I should also be friendly and helpful. Maybe add a smiley to keep it warm.\n\nWait, could there be any context I'm missing? Like, is this part of a larger problem? But the user only asked for 2 + 3. So I'll stick to the basics.\n\nLet me double-check: 2 + 3 is indeed 5. Yep, that's correct. No need to overcomplicate it.\n\nI'll respond with \"2 + 3 equals 5! 😊\" to keep it simple and positive. That should cover it.\n","reasoning_content":"Okay, the user asked \"What is 2 + 3?\" That's a simple arithmetic question. Let me think.\n\nFirst, I know that 2 plus 3 equals 5. That's basic addition. But wait, maybe the user is testing if I can handle simple math. Or perhaps they're a kid learning addition. \n\nHmm, the question seems straightforward. No tricks here. I should just give the answer clearly. But I should also be friendly and helpful. Maybe add a smiley to keep it warm.\n\nWait, could there be any context I'm missing? Like, is this part of a larger problem? But the user only asked for 2 + 3. So I'll stick to the basics.\n\nLet me double-check: 2 + 3 is indeed 5. Yep, that's correct. No need to overcomplicate it.\n\nI'll respond with \"2 + 3 equals 5! 😊\" to keep it simple and positive. That should cover it.\n"},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":29,"total_tokens":248,"completion_tokens":219,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

