### PR TITLE
[Frontend] Merge developer instructions into tool block for Harmony prompt rendering

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1951,12 +1951,19 @@ class OpenAIServingChat(OpenAIServing):
         )
         messages.append(sys_msg)
 
+        merged_instructions = None
+        if request.messages and (
+            request.messages[0]["role"] == "system"
+            or request.messages[0]["role"] == "developer"
+        ):
+            merged_instructions = request.messages[0]["content"]
+            request.messages.pop(0)
         # Add developer message.
-        if request.tools:
-            dev_msg = get_developer_message(
-                tools=request.tools if should_include_tools else None  # type: ignore[arg-type]
-            )
-            messages.append(dev_msg)
+        dev_msg = get_developer_message(
+            instructions=merged_instructions,
+            tools=request.tools if should_include_tools else None,  # type: ignore[arg-type]
+        )
+        messages.append(dev_msg)
 
         # Add user message.
         messages.extend(parse_chat_inputs_to_harmony_messages(request.messages))


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Current Harmony chat implementation renders the system/developer instructions and tool definitions in two separate `<|start|>developer` blocks. However, models that follow the OpenAI `gpt-oss-20b/120b` chat template (based on the [chat_template.jinja](https://huggingface.co/openai/gpt-oss-20b/blob/main/chat_template.jinja#L234-L255)) expect a single developer block containing both `# Instructions` and `# Tools` sections.

This PR modifies `_make_request_with_harmony` to:

Extract the initial system or developer message.

Merge it into the same developer block as the tool definitions under the # Instructions header.

This ensures compatibility with models that require a unified developer message block.

## Test Plan

```python
import json
from openai import OpenAI

client = OpenAI(api_key="EMPTY", base_url="http://localhost:8000/v1")

tools = [{
    "type": "function",
    "function": {
        "name": "get_current_weather",
        "description": "Get weather information for a given location.",
        "parameters": {
            "type": "object",
            "properties": {
                "location": {"type": "string", "description": "Name city and state"},
            },
            "required": ["location"],
        },
    }
}]

messages = [
    {"role": "developer", "content": "Please Call Tool."},
    {"role": "user", "content": "What's the weather like in New York?"}
]

response = client.chat.completions.create(
    model="openai/gpt-oss-20b",
    messages=messages,
    tools=tools,
)
```

## Test Result
### Before (Redundant blocks):
```text
<|start|>system<|message|>...<|end|>
<|start|>developer<|message|># Tools\n\n...<|end|>
<|start|>developer<|message|>Please Call Tool.<|end|>
<|start|>user<|message|>...<|end|>
```

### After (Merged block - Correct for gpt-oss):
```text
<|start|>system<|message|>...<|end|>
<|start|>developer<|message|># Instructions\n\nPlease Call Tool.\n\n# Tools\n\n...<|end|>
<|start|>user<|message|>...<|end|>
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

