### PR TITLE
[Bugfix] kimi k2.5 tool call tokens leaking into reasoning_content

### DIFF
--- a/tests/reasoning/test_kimi_k25_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k25_reasoning_parser.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from transformers import AutoTokenizer
+
+from tests.reasoning.utils import run_reasoning_extraction
+from vllm.reasoning import ReasoningParser, ReasoningParserManager
+
+parser_name = "kimi_k25"
+
+REASONING_MODEL_NAME = "moonshotai/Kimi-K2.5"
+
+
+@pytest.fixture(scope="module")
+def kimi_k2_tokenizer():
+    return AutoTokenizer.from_pretrained(REASONING_MODEL_NAME, trust_remote_code=True)
+
+
+# The following tests verify that standard reasoning behavior is preserved
+# through KimiK2ReasoningParser's delegation to DeepSeekR1ReasoningParser
+SIMPLE_REASONING = {
+    "output": "This is a reasoning section</think>This is the rest",
+    "reasoning": "This is a reasoning section",
+    "content": "This is the rest",
+    "is_reasoning_end": True,
+}
+COMPLETE_REASONING = {
+    "output": "This is a reasoning section</think>",
+    "reasoning": "This is a reasoning section",
+    "content": None,
+    "is_reasoning_end": True,
+}
+NO_CONTENT = {
+    "output": "This is content",
+    "reasoning": "This is content",
+    "content": None,
+    "is_reasoning_end": False,
+}
+NO_REASONING_STREAMING = {
+    "output": "This is a reasoning section",
+    "reasoning": "This is a reasoning section",
+    "content": None,
+    "is_reasoning_end": False,
+}
+MULTIPLE_LINES = {
+    "output": "This\nThat</think>This is the rest\nThat",
+    "reasoning": "This\nThat",
+    "content": "This is the rest\nThat",
+    "is_reasoning_end": True,
+}
+SHORTEST_REASONING_NO_STREAMING = {
+    "output": "</think>This is the rest",
+    "reasoning": "",
+    "content": "This is the rest",
+    "is_reasoning_end": True,
+}
+SHORTEST_REASONING = {
+    "output": "</think>This is the rest",
+    "reasoning": None,
+    "content": "This is the rest",
+    "is_reasoning_end": True,
+}
+REASONING_WITH_THINK = {
+    "output": "<think>This is a reasoning section</think>This is the rest",
+    "reasoning": "This is a reasoning section",
+    "content": "This is the rest",
+    "is_reasoning_end": True,
+}
+COMPLETE_REASONING_WITH_THINK = {
+    "output": "<think>This is a reasoning section</think>",
+    "reasoning": "This is a reasoning section",
+    "content": None,
+    "is_reasoning_end": True,
+}
+MULTIPLE_LINES_WITH_THINK = {
+    "output": "<think>This\nThat</think>This is the rest\nThat",
+    "reasoning": "This\nThat",
+    "content": "This is the rest\nThat",
+    "is_reasoning_end": True,
+}
+SHORTEST_REASONING_NO_STREAMING_WITH_THINK = {
+    "output": "</think>This is the rest",
+    "reasoning": "",
+    "content": "This is the rest",
+    "is_reasoning_end": True,
+}
+SHORTEST_REASONING_WITH_THINK = {
+    "output": "</think>This is the rest",
+    "reasoning": None,
+    "content": "This is the rest",
+    "is_reasoning_end": True,
+}
+THINK_NO_END = {
+    "output": "<think>This is a reasoning section",
+    "reasoning": "This is a reasoning section",
+    "content": None,
+    "is_reasoning_end": False,
+}
+EMPTY = {
+    "output": "",
+    "reasoning": "",
+    "content": None,
+    "is_reasoning_end": False,
+}
+EMPTY_STREAMING = {
+    "output": "",
+    "reasoning": None,
+    "content": None,
+    "is_reasoning_end": False,
+}
+NEW_LINE = {
+    "output": "\n<think>This is a reasoning section</think>\nThis is the rest",
+    "reasoning": "This is a reasoning section",
+    "content": "\nThis is the rest",
+    "is_reasoning_end": True,
+}
+# Streaming cannot handle new lines at the beginning of the output
+# because we need to support <think>...</think> and </think>...
+# We cannot know if the text before <think> is reasoning content
+# or not.
+NEW_LINE_STREAMING = {
+    "output": "\n<think>This is a reasoning section</think>\nThis is the rest",
+    "reasoning": "\nThis is a reasoning section",
+    "content": "\nThis is the rest",
+    "is_reasoning_end": True,
+}
+
+# The following tests verify Kimi-specific behavior: tool call tokens
+# must not leak into reasoning_content when </think> is absent
+TOOL_CALL_DURING_THINK = {
+    "output": (
+        "<think>"
+        "I should read that file"
+        "<|tool_calls_section_begin|>"
+        "<|tool_call_begin|>"
+        "functions.read:0"
+        "<|tool_call_argument_begin|>"
+        "{'filePath':'file.txt'}"
+        "<|tool_call_end|>"
+        "<|tool_calls_section_end|>"
+    ),
+    "reasoning": "I should read that file",
+    "content": (
+        "<|tool_calls_section_begin|>"
+        "<|tool_call_begin|>"
+        "functions.read:0"
+        "<|tool_call_argument_begin|>"
+        "{'filePath':'file.txt'}"
+        "<|tool_call_end|>"
+        "<|tool_calls_section_end|>"
+    ),
+    "is_reasoning_end": False,
+    "skip_content_ids": True,
+}
+
+TOOL_CALL_IMMEDIATELY_AFTER_THINK = {
+    "output": (
+        "<think>"
+        "<|tool_calls_section_begin|>"
+        "<|tool_call_begin|>"
+        "functions.read:0"
+        "<|tool_call_argument_begin|>"
+        "{'filePath':'file.txt'}"
+        "<|tool_call_end|>"
+        "<|tool_calls_section_end|>"
+    ),
+    "reasoning": None,
+    "content": (
+        "<|tool_calls_section_begin|>"
+        "<|tool_call_begin|>"
+        "functions.read:0"
+        "<|tool_call_argument_begin|>"
+        "{'filePath':'file.txt'}"
+        "<|tool_call_end|>"
+        "<|tool_calls_section_end|>"
+    ),
+    "is_reasoning_end": False,
+    "skip_content_ids": True,
+}
+
+TOOL_CALL_AFTER_THINK_END = {
+    "output": (
+        "<think>I should read that file</think>"
+        "<|tool_calls_section_begin|>"
+        "<|tool_call_begin|>"
+        "functions.read:0"
+        "<|tool_call_argument_begin|>"
+        "{'filePath':'file.txt'}"
+        "<|tool_call_end|>"
+        "<|tool_calls_section_end|>"
+    ),
+    "reasoning": "I should read that file",
+    "content": (
+        "<|tool_calls_section_begin|>"
+        "<|tool_call_begin|>"
+        "functions.read:0"
+        "<|tool_call_argument_begin|>"
+        "{'filePath':'file.txt'}"
+        "<|tool_call_end|>"
+        "<|tool_calls_section_end|>"
+    ),
+    "is_reasoning_end": True,
+}
+
+TEST_CASES = [
+    pytest.param(
+        False,
+        SIMPLE_REASONING,
+        id="simple_reasoning",
+    ),
+    pytest.param(
+        True,
+        SIMPLE_REASONING,
+        id="simple_reasoning_streaming",
+    ),
+    pytest.param(
+        False,
+        COMPLETE_REASONING,
+        id="complete_reasoning",
+    ),
+    pytest.param(
+        True,
+        COMPLETE_REASONING,
+        id="complete_reasoning_streaming",
+    ),
+    pytest.param(
+        False,
+        NO_CONTENT,
+        id="no_content_token",
+    ),
+    pytest.param(
+        True,
+        NO_REASONING_STREAMING,
+        id="no_reasoning_token_streaming",
+    ),
+    pytest.param(
+        False,
+        MULTIPLE_LINES,
+        id="multiple_lines",
+    ),
+    pytest.param(
+        True,
+        MULTIPLE_LINES,
+        id="multiple_lines_streaming",
+    ),
+    pytest.param(
+        True,
+        SHORTEST_REASONING,
+        id="shortest",
+    ),
+    pytest.param(
+        False,
+        SHORTEST_REASONING_NO_STREAMING,
+        id="shortest_streaming",
+    ),
+    pytest.param(
+        False,
+        REASONING_WITH_THINK,
+        id="reasoning_with_think",
+    ),
+    pytest.param(
+        True,
+        REASONING_WITH_THINK,
+        id="reasoning_with_think_streaming",
+    ),
+    pytest.param(
+        False,
+        COMPLETE_REASONING_WITH_THINK,
+        id="complete_reasoning_with_think",
+    ),
+    pytest.param(
+        True,
+        COMPLETE_REASONING_WITH_THINK,
+        id="complete_reasoning_with_think_streaming",
+    ),
+    pytest.param(
+        False,
+        MULTIPLE_LINES_WITH_THINK,
+        id="multiple_lines_with_think",
+    ),
+    pytest.param(
+        True,
+        MULTIPLE_LINES_WITH_THINK,
+        id="multiple_lines_with_think_streaming",
+    ),
+    pytest.param(
+        False,
+        SHORTEST_REASONING_NO_STREAMING_WITH_THINK,
+        id="shortest_with_think",
+    ),
+    pytest.param(
+        True,
+        SHORTEST_REASONING_WITH_THINK,
+        id="shortest_with_think_streaming",
+    ),
+    pytest.param(
+        False,
+        THINK_NO_END,
+        id="think_no_end",
+    ),
+    pytest.param(
+        True,
+        THINK_NO_END,
+        id="think_no_end_streaming",
+    ),
+    pytest.param(
+        False,
+        EMPTY,
+        id="empty",
+    ),
+    pytest.param(
+        True,
+        EMPTY_STREAMING,
+        id="empty_streaming",
+    ),
+    pytest.param(
+        False,
+        NEW_LINE,
+        id="new_line",
+    ),
+    pytest.param(
+        True,
+        NEW_LINE_STREAMING,
+        id="new_line_streaming",
+    ),
+    pytest.param(
+        True,
+        TOOL_CALL_DURING_THINK,
+        id="tool_call_during_think",
+    ),
+    pytest.param(
+        True,
+        TOOL_CALL_IMMEDIATELY_AFTER_THINK,
+        id="tool_call_immediately_after_think",
+    ),
+    pytest.param(
+        True,
+        TOOL_CALL_AFTER_THINK_END,
+        id="tool_call_after_think_end",
+    ),
+]
+
+
+@pytest.mark.parametrize("streaming, param_dict", TEST_CASES)
+def test_reasoning(
+    streaming: bool,
+    param_dict: dict,
+    kimi_k2_tokenizer,
+):
+    output = kimi_k2_tokenizer.tokenize(param_dict["output"])
+    # decode everything to tokens
+    output_tokens: list[str] = [
+        kimi_k2_tokenizer.convert_tokens_to_string([token]) for token in output
+    ]
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        kimi_k2_tokenizer
+    )
+
+    reasoning, content = run_reasoning_extraction(
+        parser, output_tokens, streaming=streaming
+    )
+
+    assert reasoning == param_dict["reasoning"]
+    assert content == param_dict["content"]
+
+    # Test is_reasoning_end
+    output_ids = kimi_k2_tokenizer.convert_tokens_to_ids(output)
+    is_reasoning_end = parser.is_reasoning_end(output_ids)
+    assert is_reasoning_end == param_dict["is_reasoning_end"]
+
+    # Test extract_content
+    if param_dict["content"] is not None and not param_dict.get("skip_content_ids"):
+        content = parser.extract_content_ids(output_ids)
+        assert content == kimi_k2_tokenizer.convert_tokens_to_ids(
+            kimi_k2_tokenizer.tokenize(param_dict["content"])
+        )
+    else:
+        content = parser.extract_content_ids(output_ids)
+        assert content == []
+
+
+def test_kimi_k25_parser_registration(kimi_k2_tokenizer):
+    """kimi_k2 must resolve to KimiK25ReasoningParser, not DeepSeek."""
+    from vllm.reasoning.kimi_k25_reasoning_parser import (
+        KimiK25ReasoningParser,
+    )
+
+    cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    assert cls is KimiK25ReasoningParser
+
+
+def test_kimi_k25_thinking_always_enabled(kimi_k2_tokenizer):
+    """Thinking mode must be forced even without chat_template_kwargs."""
+    from vllm.reasoning.deepseek_r1_reasoning_parser import (
+        DeepSeekR1ReasoningParser,
+    )
+
+    cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    parser = cls(kimi_k2_tokenizer)
+    assert isinstance(parser._parser, DeepSeekR1ReasoningParser)
+
+
+def test_kimi_k25_tool_token_ids_populated(kimi_k2_tokenizer):
+    """Tool call token IDs must be set from the real tokenizer vocab."""
+    cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    parser = cls(kimi_k2_tokenizer)
+    # 163595: <|tool_calls_section_begin|>
+    assert (
+        kimi_k2_tokenizer.convert_tokens_to_ids("<|tool_calls_section_begin|>")
+        in parser._reasoning_end_token_ids
+    )
+    # 163597: <|tool_call_begin|>
+    assert (
+        kimi_k2_tokenizer.convert_tokens_to_ids("<|tool_call_begin|>")
+        in parser._reasoning_end_token_ids
+    )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -129,6 +129,7 @@ class OpenAIServingChat(OpenAIServing):
         self.enable_log_deltas = enable_log_deltas
 
         # set up reasoning parser
+        self.reasoning_parser_name = reasoning_parser
         self.reasoning_parser_cls = ParserManager.get_reasoning_parser(
             reasoning_parser_name=reasoning_parser
         )
@@ -343,6 +344,8 @@ class OpenAIServingChat(OpenAIServing):
                 reasoning_parser = self.reasoning_parser_cls(
                     tokenizer,
                     chat_template_kwargs=chat_template_kwargs,  # type: ignore[call-arg]
+                    model_type=self.model_config.hf_text_config.model_type,
+                    reasoning_parser_name=self.reasoning_parser_name,
                 )
         except RuntimeError as e:
             logger.exception("Error in reasoning parser creation.")

--- a/vllm/reasoning/__init__.py
+++ b/vllm/reasoning/__init__.py
@@ -56,6 +56,10 @@ _REASONING_PARSERS_TO_REGISTER = {
         "deepseek_v3_reasoning_parser",
         "DeepSeekV3ReasoningWithThinkingParser",
     ),
+    "kimi_k25": (
+        "kimi_k25_reasoning_parser",
+        "KimiK25ReasoningParser",
+    ),
     "minimax_m2": (
         "minimax_m2_reasoning_parser",
         "MiniMaxM2ReasoningParser",

--- a/vllm/reasoning/deepseek_v3_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_v3_reasoning_parser.py
@@ -85,4 +85,15 @@ class DeepSeekV3ReasoningWithThinkingParser(DeepSeekV3ReasoningParser):
             chat_kwargs["thinking"] = True
             chat_kwargs["enable_thinking"] = True
             kwargs["chat_template_kwargs"] = chat_kwargs
+
+        # Check for deprecated parser usage with kimi_k25 model
+        model_type = kwargs.get("model_type", "")
+        reasoning_parser_name = kwargs.get("reasoning_parser_name", "")
+        if model_type == "kimi_k25" and reasoning_parser_name == "kimi_k2":
+            logger.warning(
+                "Consider using 'kimi_k25' as reasoning parser for Kimi K-2.5 "
+                "instead of '%s'.",
+                reasoning_parser_name,
+            )
+
         super().__init__(tokenizer, *args, **kwargs)

--- a/vllm/reasoning/kimi_k25_reasoning_parser.py
+++ b/vllm/reasoning/kimi_k25_reasoning_parser.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.reasoning.deepseek_v3_reasoning_parser import (
+    DeepSeekV3ReasoningWithThinkingParser,
+)
+
+
+class KimiK25ReasoningParser(DeepSeekV3ReasoningWithThinkingParser):
+    def __init__(self, tokenizer, *args, **kwargs):
+        chat_kwargs = dict(kwargs.get("chat_template_kwargs", {}) or {})
+        chat_kwargs["thinking"] = True
+        kwargs["chat_template_kwargs"] = chat_kwargs
+        super().__init__(tokenizer, *args, **kwargs)
+        self._reasoning_end_token_ids = {
+            self.vocab.get("<|tool_calls_section_begin|>"),
+            self.vocab.get("<|tool_call_begin|>"),
+        }
+        self._reasoning_end_token_ids = {
+            tid for tid in self._reasoning_end_token_ids if tid is not None
+        }
+        self._tool_call_started = False
+
+    def extract_reasoning_streaming(
+        self,
+        previous_text,
+        current_text,
+        delta_text,
+        previous_token_ids,
+        current_token_ids,
+        delta_token_ids,
+    ):
+        if self._tool_call_started:
+            return DeltaMessage(content=delta_text)
+        # Only intercept tool tokens if we haven't seen </think> yet
+        if self._parser.end_token_id not in previous_token_ids and any(
+            tid in self._reasoning_end_token_ids for tid in delta_token_ids
+        ):
+            self._tool_call_started = True
+            return DeltaMessage(content=delta_text)
+        ret = self._parser.extract_reasoning_streaming(
+            previous_text,
+            current_text,
+            delta_text,
+            previous_token_ids,
+            current_token_ids,
+            delta_token_ids,
+        )
+        return ret


### PR DESCRIPTION
## Purpose

When Kimi K2.5 skips `</think>` and jumps directly to a tool call, the reasoning parser had no mechanism to stop routing subsequent tokens to `reasoning_content`. This caused raw tool call tokens to appear in the thinking block instead of being handled by the tool call parser.

This PR introduces `KimiK25ReasoningParser` as a thin subclass of `DeepSeekV3ReasoningWithThinkingParser` that:
- Tracks a `_tool_call_started` flag
- Returns `None` for all deltas once a tool call token is detected

## Test Plan
```bash
uv run pytest tests/reasoning/test_kimi_k25_reasoning_parser.py -v
```

A new test file `tests/reasoning/test_kimi_k25_reasoning_parser.py` is added, mirroring the structure of `test_deepseekr1_reasoning_parser.py` since most functionality is delegated to its reasoning streaming logic. Seven additional test cases cover the introduced fix:

- `test_reasoning[tool_call_in_reasoning]`
- `test_reasoning[tool_call_during_think]`
- `test_reasoning[tool_call_immediately_after_think]`
- `test_reasoning[tool_call_after_think_end]`
- `test_kimi_k25_parser_registration`
- `test_kimi_k25_thinking_always_enabled`
- `test_kimi_k25_tool_token_ids_populated`

## Test Results

All 31 tests pass:
```
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[simple_reasoning] PASSED                [ 3%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[simple_reasoning_streaming] PASSED      [ 6%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[complete_reasoning] PASSED              [ 9%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[complete_reasoning_streaming] PASSED    [ 12%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[no_content_token] PASSED                [ 16%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[no_reasoning_token_streaming] PASSED    [ 19%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[multiple_lines] PASSED                  [ 22%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[multiple_lines_streaming] PASSED        [ 25%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[shortest] PASSED                        [ 29%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[shortest_streaming] PASSED              [ 32%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[reasoning_with_think] PASSED            [ 35%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[reasoning_with_think_streaming] PASSED  [ 38%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[complete_reasoning_with_think] PASSED   [ 41%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[complete_reasoning_with_think_streaming] PASSED [ 45%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[multiple_lines_with_think] PASSED       [ 48%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[multiple_lines_with_think_streaming] PASSED [ 51%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[shortest_with_think] PASSED             [ 54%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[shortest_with_think_streaming] PASSED   [ 58%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[think_no_end] PASSED                    [ 61%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[think_no_end_streaming] PASSED          [ 64%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[empty] PASSED                           [ 67%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[empty_streaming] PASSED                 [ 70%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[new_line] PASSED                        [ 74%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[new_line_streaming] PASSED              [ 77%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[tool_call_in_reasoning] PASSED          [ 80%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[tool_call_during_think] PASSED          [ 83%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[tool_call_immediately_after_think] PASSED [ 87%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_reasoning[tool_call_after_think_end] PASSED       [ 90%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_kimi_k25_parser_registration PASSED               [ 93%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_kimi_k25_thinking_always_enabled PASSED           [ 96%]
tests/reasoning/test_kimi_k25_reasoning_parser.py::test_kimi_k25_tool_token_ids_populated PASSED          [100%]

31 passed, 2 warnings in 10.86s
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

