### PR TITLE
Ensure that MkDocs v2 does not get installed

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
-mkdocs
+mkdocs<2.0.0
 mkdocs-api-autonav
 mkdocs-material
 mkdocstrings-python


### PR DESCRIPTION
We do this for compatibility reasons with the plugins that we use.

A more likely upgrade path is to Zensical, which is more actively maintained by the creators of MkDocs Material.