### PR TITLE
[Test] Improve flashinfer cutlass moe test coverage

### DIFF
--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -299,6 +299,7 @@ steps:
   commands:
     - pytest -v -s kernels/moe/test_cutlass_moe.py
     - pytest -v -s kernels/moe/test_flashinfer.py
+    - pytest -v -s quantization/test_hopper_moe.py
     - pytest -v -s kernels/moe/test_gpt_oss_triton_kernels.py
     - pytest -v -s kernels/moe/test_modular_oai_triton_moe.py
     - pytest -v -s kernels/moe/test_moe.py

--- a/tests/kernels/moe/test_flashinfer.py
+++ b/tests/kernels/moe/test_flashinfer.py
@@ -116,6 +116,62 @@ def check_accuracy(ref_output, actual_output, atol=0.1, rtol=0.85, percent=0.925
     )
 
 
+def torch_bf16_moe(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    activation: MoEActivation,
+    apply_router_weight_on_input: bool = True,
+) -> torch.Tensor:
+    """Reference MoE implementation using native torch matmul in BF16."""
+    assert activation in [MoEActivation.SILU, MoEActivation.RELU2_NO_MUL]
+
+    batch_size, hidden_dim = hidden_states.shape
+    topk = topk_ids.size(1)
+    expanded_hidden_states = hidden_states.view(batch_size, 1, hidden_dim).repeat(
+        1, topk, 1
+    )
+    expanded_hidden_states = expanded_hidden_states.reshape(-1, hidden_dim)
+
+    output = torch.zeros(
+        batch_size * topk,
+        w2.shape[1],
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+
+    flat_topk_weights = topk_weights.view(-1)
+    flat_topk_ids = topk_ids.view(-1)
+    silu_and_mul = SiluAndMul()
+
+    if apply_router_weight_on_input:
+        expanded_hidden_states = expanded_hidden_states * flat_topk_weights.unsqueeze(
+            1
+        ).to(expanded_hidden_states.dtype)
+
+    for expert_idx in range(w1.shape[0]):
+        mask = flat_topk_ids == expert_idx
+        if not mask.any():
+            continue
+
+        inter_out = expanded_hidden_states[mask] @ w1[expert_idx].t()
+        if activation == MoEActivation.SILU:
+            act_out = silu_and_mul.forward_native(inter_out)
+        else:
+            act_out = torch.square(torch.relu(inter_out))
+
+        output[mask] = act_out @ w2[expert_idx].t()
+
+    if apply_router_weight_on_input:
+        return output.view(batch_size, -1, w2.shape[1]).sum(dim=1)
+    return (
+        output.view(batch_size, -1, w2.shape[1])
+        * flat_topk_weights.view(batch_size, -1, 1).to(output.dtype)
+    ).sum(dim=1)
+
+
 def torch_w8a8_block_fp8_moe(
     hidden_states: torch.Tensor,
     w1: torch.Tensor,
@@ -510,18 +566,14 @@ def test_flashinfer_cutlass_moe_bf16_no_graph(
             renormalize=False,
         )
 
-        output = fused_experts(
+        ref_output = torch_bf16_moe(
             hidden_states,
             w1,
             w2,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            inplace=False,
+            topk_weights,
+            topk_ids,
             activation=activation,
-            global_num_experts=e,
-            expert_map=None,
             apply_router_weight_on_input=True,
-            quant_config=FUSED_MOE_UNQUANTIZED_CONFIG,
         )
 
         moe_config = FusedMoEConfig(
@@ -564,11 +616,11 @@ def test_flashinfer_cutlass_moe_bf16_no_graph(
         )
 
         check_accuracy(
-            ref_output=output,
+            ref_output=ref_output,
             actual_output=flashinfer_cutlass_output,
-            atol=0.1,
-            rtol=0.85,
-            percent=0.925,
+            atol=0.05,
+            rtol=0.05,
+            percent=0.85,
         )
 
 

--- a/tests/kernels/moe/test_flashinfer.py
+++ b/tests/kernels/moe/test_flashinfer.py
@@ -598,12 +598,17 @@ def test_flashinfer_cutlass_moe_bf16_no_graph(
         assert not flashinfer_experts.use_deepseek_fp8_block_scale
 
         w1_fi = swap_w13_to_w31(w1) if activation.is_gated else w1
-        kernel = mk.FusedMoEModularKernel(
-            MoEPrepareAndFinalizeNoEP(),
+        kernel = mk.FusedMoEKernel(
+            maybe_make_prepare_finalize(
+                moe=moe_config,
+                quant_config=FUSED_MOE_UNQUANTIZED_CONFIG,
+                allow_new_interface=True,
+                use_monolithic=False,
+            ),
             flashinfer_experts,
             inplace=False,
         )
-        flashinfer_cutlass_output = kernel(
+        flashinfer_cutlass_output = kernel.apply(
             hidden_states,
             w1_fi,
             w2,
@@ -708,12 +713,17 @@ def test_flashinfer_cutlass_moe_fp8_block_scale_no_graph(
         )
         assert flashinfer_experts.use_deepseek_fp8_block_scale
 
-        kernel = mk.FusedMoEModularKernel(
-            MoEPrepareAndFinalizeNoEP(),
+        kernel = mk.FusedMoEKernel(
+            maybe_make_prepare_finalize(
+                moe=moe_config,
+                quant_config=quant_config,
+                allow_new_interface=True,
+                use_monolithic=False,
+            ),
             flashinfer_experts,
             inplace=False,
         )
-        flashinfer_cutlass_output = kernel(
+        flashinfer_cutlass_output = kernel.apply(
             hidden_states,
             w1_fi,
             w2,

--- a/tests/kernels/moe/test_flashinfer.py
+++ b/tests/kernels/moe/test_flashinfer.py
@@ -6,12 +6,20 @@ import pytest
 import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from tests.kernels.moe.utils import make_test_quant_config
+from tests.kernels.quant_utils import (
+    native_per_token_group_quant_fp8,
+    native_w8a8_block_matmul,
+)
 from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.fused_moe import fused_topk
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.all2all_utils import (
     maybe_make_prepare_finalize,
 )
 from vllm.model_executor.layers.fused_moe.config import (
+    FUSED_MOE_UNQUANTIZED_CONFIG,
     FusedMoEConfig,
     FusedMoEParallelConfig,
     FusedMoEQuantConfig,
@@ -63,6 +71,16 @@ MNK_FACTORS = [
     (1, 4096, 5120),
 ]
 
+BLOCK_SHAPE = [128, 128]
+BLOCK_MNK_FACTORS = [
+    (64, 1024, 1024),
+    (127, 1024, 1024),
+]
+BF16_MNK_FACTORS = [
+    (64, 1024, 1024),
+    (127, 1024, 1024),
+]
+
 vllm_config = VllmConfig(parallel_config=ParallelConfig(pipeline_parallel_size=1))
 
 
@@ -96,6 +114,79 @@ def check_accuracy(ref_output, actual_output, atol=0.1, rtol=0.85, percent=0.925
         f"Mismatch percentage {mismatch_percent:.4f} is above the threshold "
         f"{1 - percent:.4f}"
     )
+
+
+def torch_w8a8_block_fp8_moe(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    block_shape: list[int],
+    activation: MoEActivation,
+) -> torch.Tensor:
+    """Fused MoE with block-wise FP8 quantization using native torch."""
+    assert activation in [MoEActivation.SILU, MoEActivation.RELU2_NO_MUL]
+
+    batch_size, hidden_dim = hidden_states.shape
+    topk = topk_ids.size(1)
+    expanded_hidden_states = hidden_states.view(batch_size, 1, hidden_dim).repeat(
+        1, topk, 1
+    )
+    expanded_hidden_states = expanded_hidden_states.reshape(-1, hidden_dim)
+
+    output = torch.zeros(
+        batch_size * topk,
+        w2.shape[1],
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+
+    flat_topk_weights = topk_weights.view(-1)
+    flat_topk_ids = topk_ids.view(-1)
+    _, block_k = block_shape
+    hidden_states_q, hidden_states_s = native_per_token_group_quant_fp8(
+        expanded_hidden_states.contiguous(), block_k
+    )
+    hidden_states_q = hidden_states_q.to(torch.float32)
+    silu_and_mul = SiluAndMul()
+
+    for expert_idx in range(w1.shape[0]):
+        mask = flat_topk_ids == expert_idx
+        if not mask.any():
+            continue
+
+        inter_out = native_w8a8_block_matmul(
+            hidden_states_q[mask],
+            w1[expert_idx],
+            hidden_states_s[mask],
+            w1_scale[expert_idx],
+            block_shape,
+            output_dtype=hidden_states.dtype,
+        )
+        if activation == MoEActivation.SILU:
+            act_out = silu_and_mul.forward_native(inter_out)
+        else:
+            act_out = torch.square(torch.relu(inter_out))
+
+        act_out_q, act_out_s = native_per_token_group_quant_fp8(
+            act_out.contiguous(), block_k
+        )
+        output[mask] = native_w8a8_block_matmul(
+            act_out_q,
+            w2[expert_idx],
+            act_out_s,
+            w2_scale[expert_idx],
+            block_shape,
+            output_dtype=hidden_states.dtype,
+        )
+
+    return (
+        output.view(batch_size, -1, w2.shape[1])
+        * flat_topk_weights.view(batch_size, -1, 1).to(output.dtype)
+    ).sum(dim=1)
 
 
 @dataclass
@@ -376,6 +467,214 @@ def test_flashinfer_cutlass_moe_fp8_no_graph(
 
         check_accuracy(
             ref_output=output,
+            actual_output=flashinfer_cutlass_output,
+            atol=0.1,
+            rtol=0.85,
+            percent=0.925,
+        )
+
+
+@pytest.mark.parametrize("m,n,k", BF16_MNK_FACTORS)
+@pytest.mark.parametrize("e", NUM_EXPERTS)
+@pytest.mark.parametrize("topk", TOP_KS)
+@pytest.mark.parametrize("activation", [MoEActivation.SILU, MoEActivation.RELU2_NO_MUL])
+def test_flashinfer_cutlass_moe_bf16_no_graph(
+    m: int,
+    n: int,
+    k: int,
+    e: int,
+    topk: int,
+    activation: MoEActivation,
+    monkeypatch,
+    workspace_init,
+):
+    set_random_seed(7)
+    monkeypatch.setenv("VLLM_FUSED_MOE_CHUNK_SIZE", "2048")
+
+    with set_current_vllm_config(vllm_config):
+        hidden_states = torch.randn((m, k), device="cuda", dtype=torch.bfloat16) / 10
+        w1 = (
+            torch.randn(
+                (e, (2 * n) if activation.is_gated else n, k),
+                device="cuda",
+                dtype=torch.bfloat16,
+            )
+            / 10
+        )
+        w2 = torch.randn((e, k, n), device="cuda", dtype=torch.bfloat16) / 10
+        score = torch.randn((m, e), device="cuda", dtype=torch.bfloat16)
+        topk_weights, topk_ids = Llama4MoE.custom_routing_function(
+            hidden_states=hidden_states,
+            gating_output=score,
+            topk=topk,
+            renormalize=False,
+        )
+
+        output = fused_experts(
+            hidden_states,
+            w1,
+            w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            inplace=False,
+            activation=activation,
+            global_num_experts=e,
+            expert_map=None,
+            apply_router_weight_on_input=True,
+            quant_config=FUSED_MOE_UNQUANTIZED_CONFIG,
+        )
+
+        moe_config = FusedMoEConfig(
+            num_experts=e,
+            experts_per_token=topk,
+            hidden_dim=k,
+            intermediate_size_per_partition=n,
+            num_local_experts=e,
+            num_logical_experts=e,
+            activation=activation,
+            device="cuda",
+            moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+            in_dtype=torch.bfloat16,
+            is_act_and_mul=activation.is_gated,
+            routing_method=RoutingMethodType.TopK,
+        )
+
+        flashinfer_experts = FlashInferExperts(
+            moe_config=moe_config,
+            quant_config=FUSED_MOE_UNQUANTIZED_CONFIG,
+        )
+        assert not flashinfer_experts.use_deepseek_fp8_block_scale
+
+        w1_fi = swap_w13_to_w31(w1) if activation.is_gated else w1
+        kernel = mk.FusedMoEModularKernel(
+            MoEPrepareAndFinalizeNoEP(),
+            flashinfer_experts,
+            inplace=False,
+        )
+        flashinfer_cutlass_output = kernel(
+            hidden_states,
+            w1_fi,
+            w2,
+            topk_weights,
+            topk_ids,
+            activation=activation,
+            global_num_experts=e,
+            expert_map=None,
+            apply_router_weight_on_input=True,
+        )
+
+        check_accuracy(
+            ref_output=output,
+            actual_output=flashinfer_cutlass_output,
+            atol=0.1,
+            rtol=0.85,
+            percent=0.925,
+        )
+
+
+@pytest.mark.parametrize("m,n,k", BLOCK_MNK_FACTORS)
+@pytest.mark.parametrize("e", NUM_EXPERTS)
+@pytest.mark.parametrize("topk", TOP_KS)
+@pytest.mark.parametrize("activation", [MoEActivation.SILU, MoEActivation.RELU2_NO_MUL])
+def test_flashinfer_cutlass_moe_fp8_block_scale_no_graph(
+    m: int,
+    n: int,
+    k: int,
+    e: int,
+    topk: int,
+    activation: MoEActivation,
+    monkeypatch,
+    workspace_init,
+):
+    if not current_platform.is_device_capability(90):
+        pytest.skip("FP8 block-scale MoE requires exact SM 9.0 (H100)")
+
+    set_random_seed(7)
+    monkeypatch.setenv("VLLM_FUSED_MOE_CHUNK_SIZE", "2048")
+
+    with set_current_vllm_config(vllm_config):
+        hidden_states = torch.randn((m, k), device="cuda", dtype=torch.bfloat16) / 10
+        score = torch.randn((m, e), device="cuda", dtype=torch.bfloat16)
+        topk_weights, topk_ids, _ = fused_topk(
+            hidden_states, score.float(), topk, renormalize=False
+        )
+
+        w1, w2, quant_config_ref = make_test_quant_config(
+            e=e,
+            n=n,
+            k=k,
+            in_dtype=torch.bfloat16,
+            quant_dtype=torch.float8_e4m3fn,
+            per_act_token_quant=False,
+            block_shape=BLOCK_SHAPE,
+            make_gate=activation.is_gated,
+        )
+
+        ref_out = torch_w8a8_block_fp8_moe(
+            hidden_states,
+            w1,
+            w2,
+            quant_config_ref.w1_scale,
+            quant_config_ref.w2_scale,
+            topk_weights,
+            topk_ids,
+            block_shape=BLOCK_SHAPE,
+            activation=activation,
+        )
+
+        w1_fi = w1
+        w1_scale_fi = quant_config_ref.w1_scale
+        if activation.is_gated:
+            w1_fi = swap_w13_to_w31(w1)
+            w1_scale_fi = swap_w13_to_w31(w1_scale_fi)
+
+        quant_config = fp8_w8a8_moe_quant_config(
+            w1_scale=w1_scale_fi,
+            w2_scale=quant_config_ref.w2_scale,
+            per_act_token_quant=False,
+            block_shape=BLOCK_SHAPE,
+        )
+
+        moe_config = FusedMoEConfig(
+            num_experts=e,
+            experts_per_token=topk,
+            hidden_dim=k,
+            intermediate_size_per_partition=n,
+            num_local_experts=e,
+            num_logical_experts=e,
+            activation=activation,
+            device="cuda",
+            moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+            in_dtype=torch.bfloat16,
+            is_act_and_mul=activation.is_gated,
+            routing_method=RoutingMethodType.TopK,
+        )
+
+        flashinfer_experts = FlashInferExperts(
+            moe_config=moe_config,
+            quant_config=quant_config,
+        )
+        assert flashinfer_experts.use_deepseek_fp8_block_scale
+
+        kernel = mk.FusedMoEModularKernel(
+            MoEPrepareAndFinalizeNoEP(),
+            flashinfer_experts,
+            inplace=False,
+        )
+        flashinfer_cutlass_output = kernel(
+            hidden_states,
+            w1_fi,
+            w2,
+            topk_weights,
+            topk_ids,
+            activation=activation,
+            global_num_experts=e,
+            expert_map=None,
+            apply_router_weight_on_input=False,
+        )
+
+        check_accuracy(
+            ref_output=ref_out,
             actual_output=flashinfer_cutlass_output,
             atol=0.1,
             rtol=0.85,

--- a/tests/quantization/test_blackwell_moe.py
+++ b/tests/quantization/test_blackwell_moe.py
@@ -137,8 +137,8 @@ def test_deepseek_fp8_block_moe_vllm_triton(monkeypatch: pytest.MonkeyPatch):
 
 @pytest.mark.skip(
     reason=(
-        "Known issue: lack of kernel support. "
-        "Expected failure: assert self.block_quant is None"
+        "FP8 block-scale MoE requires exact SM 9.0 (H100). "
+        "Covered by tests/quantization/test_hopper_moe.py instead."
     )
 )
 def test_deepseek_fp8_block_moe_flashinfer_cutlass(monkeypatch: pytest.MonkeyPatch):
@@ -225,6 +225,12 @@ def test_gptoss_eager(monkeypatch: pytest.MonkeyPatch):
 
 
 ## Qwen3 Next ##
+
+
+def test_qwen3_next_bf16_moe_flashinfer_cutlass(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP16", "1")
+    monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")
+    can_initialize("Qwen/Qwen3-Next-80B-A3B-Instruct", hf_overrides=HF_OVERRIDE_TEXT)
 
 
 @pytest.mark.skip(

--- a/tests/quantization/test_hopper_moe.py
+++ b/tests/quantization/test_hopper_moe.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+import os
+from typing import Any
+
+import pytest
+
+from tests.utils import RemoteOpenAIServer
+from vllm.platforms import current_platform
+
+if not current_platform.is_device_capability(90):
+    pytest.skip("This test only runs on Hopper GPUs (SM90).", allow_module_level=True)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def set_test_environment():
+    """Sets environment variables required for this test module."""
+    os.environ["VLLM_HAS_FLASHINFER_CUBIN"] = "1"
+    os.environ["FLASHINFER_NVCC_THREADS"] = "16"
+
+
+# Override the backbone layers to 2 for faster startup
+HF_OVERRIDE_TEXT = {
+    "num_layers": 2,
+    "num_hidden_layers": 2,
+}
+HF_OVERRIDE_MM = {
+    "text_config": {"num_layers": 2, "num_hidden_layers": 2},
+}
+
+
+def can_initialize(
+    model: str,
+    hf_overrides: dict[str, Any] | None = None,
+    extra_args: list[str] | None = None,
+):
+    extra_args = extra_args if extra_args is not None else []
+    server_args = [
+        "--max-model-len",
+        "2048",
+        "--max-num-batched-tokens",
+        "256",
+        "--gpu-memory-utilization",
+        "0.8",
+        "--load-format",
+        "dummy",
+        "--trust-remote-code",
+        "--limit-mm-per-prompt",
+        json.dumps({"image": 0}),
+        *extra_args,
+    ]
+
+    with RemoteOpenAIServer(
+        model,
+        server_args,
+        max_wait_seconds=1500,
+        override_hf_configs=hf_overrides,
+    ) as server:
+        client = server.get_client()
+        completion = client.completions.create(
+            model=model,
+            prompt=["Hello, World!"],
+            temperature=0,
+            max_tokens=2,
+        )
+        assert completion.choices[0].text is not None
+
+
+def test_deepseek_fp8_block_moe_flashinfer_cutlass(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP8", "1")
+    monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")
+    can_initialize("deepseek-ai/DeepSeek-V3.1", hf_overrides=HF_OVERRIDE_TEXT)
+
+
+def test_llama4_fp8_tensor_moe_flashinfer_cutlass(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP8", "1")
+    monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")
+    can_initialize(
+        "nvidia/Llama-4-Scout-17B-16E-Instruct-FP8", hf_overrides=HF_OVERRIDE_MM
+    )
+
+
+def test_deepseek_fp8_block_moe_deep_gemm(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_USE_DEEP_GEMM", "1")
+    can_initialize("deepseek-ai/DeepSeek-V3.1", hf_overrides=HF_OVERRIDE_TEXT)
+
+
+def test_qwen3_next_bf16_moe_flashinfer_cutlass(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP16", "1")
+    monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")
+    can_initialize("Qwen/Qwen3-Next-80B-A3B-Instruct", hf_overrides=HF_OVERRIDE_TEXT)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Improve flashinfer cutlass moe test coverage. 
In particular, Hopper coverage was lacking. Also `fp8_block_scale` was not tested at all previously.

## Test Plan

```
# on H100
pytest -v -s tests/quantization/test_hopper_moe.py
pytest -v -s tests/kernels/moe/test_flashinfer.py


# on B200
pytest -v -s tests/quantization/test_blackwell_moe.py
pytest -v -s tests/kernels/moe/test_flashinfer.py
```

## Test Result

all passed

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

