### PR TITLE
fix(cli): prevent --served-model-name from consuming positional model argument

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -421,7 +421,12 @@ def setup_server(args):
     """Validate API server args, set up signal handler, create socket
     ready to serve."""
 
-    log_version_and_model(logger, VLLM_VERSION, args.model)
+    log_version_and_model(
+        logger,
+        VLLM_VERSION,
+        args.model,
+        served_model_name=getattr(args, "served_model_name", None),
+    )
     log_non_default_args(args)
 
     if args.tool_parser_plugin and len(args.tool_parser_plugin) > 3:


### PR DESCRIPTION
## Purpose

Fix #34326

When running `vllm serve --served-model-name ASR Qwen/Qwen3-ASR-1.7B`, the `--served-model-name` flag (which uses `nargs='+'`) greedily consumes both `ASR` and `Qwen/Qwen3-ASR-1.7B` as its values, leaving the positional `model_tag` unset. This causes `args.model` to fall back to the default `Qwen/Qwen3-0.6B`, resulting in:
- The banner showing the wrong model name
- The `/v1/audio/transcriptions` endpoint disappearing (wrong model capabilities detected)

### Changes

1. **`vllm/utils/argparse_utils.py`** — Pre-processing step in `parse_args()` that detects when a `nargs='+'` flag (like `--served-model-name`) has consumed a value that looks like a HuggingFace model path (contains `/`). Moves that value to the positional `model_tag` slot and logs a warning.

2. **`vllm/entrypoints/cli/serve.py`** — Post-parse validation warning when `model_tag` is `None`, the model is still the default, and `served_model_name` contains model-path-like values.

3. **`vllm/entrypoints/openai/cli_args.py`** — Validation in `validate_parsed_serve_args()` that warns when `served_model_name` received multiple values while no positional model was parsed, indicating the flag likely consumed the model argument.

4. **`vllm/entrypoints/openai/api_server.py`** — Pass `served_model_name` to the banner logger so users can see both the actual model and the served name.

5. **`vllm/entrypoints/utils.py`** — Enhanced `log_version_and_model()` to display the served model name alongside the actual model in the startup banner when they differ.

## Test Plan

- Run `vllm serve --served-model-name ASR Qwen/Qwen3-ASR-1.7B` — should now correctly parse `Qwen/Qwen3-ASR-1.7B` as the model and `ASR` as the served name
- Run `vllm serve Qwen/Qwen3-ASR-1.7B --served-model-name ASR` — should still work as before
- Run `vllm serve --served-model-name ASR` — should still default to the default model
- Run `vllm serve --served-model-name=ASR Qwen/Qwen3-ASR-1.7B` — `=` form should work without ambiguity

## Test Result

All pre-commit checks pass (ruff check, ruff format, mypy, typos, SPDX headers).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>