### PR TITLE
fix(tool_parsers): remove kimi k2 8k section char limit that truncates large tool call arguments

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1371,6 +1371,13 @@ class OpenAIServingChat(OpenAIServing):
             logger.exception("Error in chat completion stream generator.")
             data = self.create_streaming_error_response(e)
             yield f"data: {data}\n\n"
+        finally:
+            # Reset tool parser streaming state so that any section-level
+            # buffers or counters are cleaned up promptly rather than
+            # waiting for garbage collection.
+            for tp in tool_parsers:
+                if tp is not None:
+                    tp.reset_streaming_state()
         # Send the final done message after all response.n are finished
         yield "data: [DONE]\n\n"
 

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -118,6 +118,19 @@ class ToolParser:
             "AbstractToolParser.extract_tool_calls_streaming has not been implemented!"
         )
 
+    def reset_streaming_state(self) -> None:
+        """Reset all streaming state between requests.
+
+        Subclasses that maintain additional state (e.g. section tracking,
+        token buffers) should override this method and call ``super()``.
+
+        The base implementation resets fields declared in ``__init__``.
+        """
+        self.prev_tool_call_arr = []
+        self.current_tool_id = -1
+        self.current_tool_name_sent = False
+        self.streamed_args_for_tool = []
+
 
 class ToolParserManager:
     """


### PR DESCRIPTION
## Purpose

Fix #34442

The Kimi K2 tool parser had a hard `max_section_chars = 8192` limit that force-exited the tool section when total content exceeded 8 KiB. This silently truncated large tool-call arguments (e.g. when the model generates a source file via a tool call), making the parser unusable for coding use cases.

The parser also had a `buffer_max_size = 1024` limit for the marker-detection buffer that was too small and could flush content containing partial section markers during large streams.

### Root Cause

The character limit was an overly conservative safety hatch. The engine already provides proper termination via `<|tool_calls_section_end|>` markers and `finish_reason` signals — an artificial character count ceiling is unnecessary and harmful.

### Changes

1. **`vllm/tool_parsers/kimi_k2_tool_parser.py`**
   - Removed the `max_section_chars` enforcement that force-exited tool sections after 8 KiB
   - Kept the character counter (`section_char_count`) for diagnostics without truncation
   - Increased `buffer_max_size` from 1024 to 8192 to better handle large streaming chunks
   - Simplified `reset_streaming_state()` to delegate to the new base class method

2. **`vllm/tool_parsers/abstract_tool_parser.py`**
   - Added `reset_streaming_state()` to the `ToolParser` base class so all parser implementations can share common state-reset logic

3. **`vllm/entrypoints/openai/chat_completion/serving.py`**
   - Added `reset_streaming_state()` call in the `finally` block of the stream generator to promptly clean up parser buffers/counters after streaming completes

4. **`tests/tool_parsers/test_kimi_k2_tool_parser.py`**
   - Updated `test_malformed_tool_section_recovery` → `test_large_tool_section_stays_open` to verify the parser no longer force-exits on large sections

## Test Plan

- Verify the Kimi K2 parser can stream tool-call arguments larger than 8 KiB without truncation
- Run existing Kimi K2 tool parser tests: `pytest tests/tool_parsers/test_kimi_k2_tool_parser.py -v`

## Test Result

All pre-commit checks pass (ruff check, ruff format, mypy, typos, SPDX headers).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>