### PR TITLE
[Bugfix] Fix block_size mismatch for MLA models after #34818

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5703,9 +5703,9 @@ class GPUModelRunner(
     ) -> None:
         """
         Re-initialize the input batch if the block sizes are different from
-        what it was originally created with.  This happens when the final
+        what it was originally created with. This happens when the final
         block size (determined after model loading) differs from the
-        placeholder used during ``__init__``, or when there are multiple
+        placeholder used during __init__, or when there are multiple
         KV cache groups.
 
         Args:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -514,6 +514,8 @@ class GPUModelRunner(
             tuple(logits_processors) if logits_processors is not None else ()
         )
         placeholder_block_size = self.cache_config.block_size or 16
+        self._init_block_sizes = [placeholder_block_size]
+        self._init_kernel_block_sizes = [placeholder_block_size]
         self.input_batch = InputBatch(
             max_num_reqs=self.max_num_reqs,
             # We need to use the encoder length for encoder-decoer
@@ -5701,8 +5703,10 @@ class GPUModelRunner(
     ) -> None:
         """
         Re-initialize the input batch if the block sizes are different from
-        `[self.cache_config.block_size]`. This usually happens when there
-        are multiple KV cache groups.
+        what it was originally created with.  This happens when the final
+        block size (determined after model loading) differs from the
+        placeholder used during ``__init__``, or when there are multiple
+        KV cache groups.
 
         Args:
             kv_cache_config: The KV cache configuration.
@@ -5727,14 +5731,17 @@ class GPUModelRunner(
                 ) + kv_cache_group.kv_cache_spec.num_speculative_blocks
             max_num_blocks.append(max_num_blocks_per_req)
 
-        if block_sizes != [self.cache_config.block_size] or kernel_block_sizes != [
-            self.cache_config.block_size
-        ]:
+        if (
+            block_sizes != self._init_block_sizes
+            or kernel_block_sizes != self._init_kernel_block_sizes
+        ):
             assert self.cache_config.cpu_offload_gb == 0, (
                 "Cannot re-initialize the input batch when CPU weight "
                 "offloading is enabled. See https://github.com/vllm-project/vllm/pull/18298 "  # noqa: E501
                 "for more details."
             )
+            self._init_block_sizes = block_sizes
+            self._init_kernel_block_sizes = kernel_block_sizes
             self.input_batch = InputBatch(
                 max_num_reqs=self.max_num_reqs,
                 max_model_len=max_model_len,
@@ -5750,6 +5757,15 @@ class GPUModelRunner(
                 logitsprocs_need_output_token_ids=self.input_batch.logitsprocs_need_output_token_ids,
                 is_pooling_model=self.is_pooling_model,
             )
+
+        assert self._init_block_sizes == block_sizes, (
+            f"InputBatch block_sizes {self._init_block_sizes} != "
+            f"kv_cache block_sizes {block_sizes}"
+        )
+        assert self._init_kernel_block_sizes == kernel_block_sizes, (
+            f"InputBatch kernel_block_sizes {self._init_kernel_block_sizes} "
+            f"!= kv_cache kernel_block_sizes {kernel_block_sizes}"
+        )
 
     def _allocate_kv_cache_tensors(
         self, kv_cache_config: KVCacheConfig


### PR DESCRIPTION

## Purpose

#34818 deferred block_size selection to after model loading, but `InputBatch` is created *before* model loading with a placeholder `block_size=16`. 
When `update_block_size_for_backend` later sets the real block_size (e.g. 32 for `FLASHINFER_MLA`), `may_reinitialize_input_batch` compared the kv_cache sizes against the already-updated `cache_config.block_size`  (both 32) and skipped re-initialization. 
The `InputBatch` kept using `block_size=16` for slot mappings while the KV cache used `block_size=32`, producing garbage output.

The fix is to track what block sizes `InputBatch` was actually created with and compare against those. Added post-condition asserts so this class of bug fails loudly at startup instead of silently producing wrong results.

Fixes https://github.com/vllm-project/vllm/issues/34969

## Test Plan

## Test Result

Manually ran failing tests on B200 to now pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

