### PR TITLE
[Bugfix][Model] Fix Ultravox silent weight overwrite for diff checkpoints

### DIFF
--- a/vllm/model_executor/models/ultravox.py
+++ b/vllm/model_executor/models/ultravox.py
@@ -6,6 +6,7 @@
 
 import copy
 import inspect
+import logging
 from collections.abc import Iterable, Mapping, Sequence
 from types import SimpleNamespace
 from typing import Annotated, Any, Literal, TypeAlias
@@ -60,6 +61,8 @@ from .utils import (
     init_vllm_registered_model,
     maybe_prefix,
 )
+
+logger = logging.getLogger(__name__)
 
 _AUDIO_PLACEHOLDER_OVERRIDE = "<|audio|>"
 _MAX_ENCODER_BATCH_SIZE = 16
@@ -764,8 +767,47 @@ class UltravoxModel(nn.Module, SupportsMultiModal, SupportsPP, SupportsLoRA):
         return self.language_model.compute_logits(hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # Deduplicate weights so that fine-tuned checkpoint weights are not
+        # silently overwritten by secondary base-model weights.
+        #
+        # DefaultModelLoader.get_all_weights() yields primary checkpoint
+        # weights first, then secondary weights from audio_model_id /
+        # text_model_id.  For diff checkpoints that contain only fine-tuned
+        # audio_tower (and projector) weights, the secondary Whisper weights
+        # share the same names and would otherwise replace them.
+        seen: set[str] = set()
+        skipped_count = 0
+        skipped_examples: list[str] = []
+
+        def _deduplicated(
+            weight_iter: Iterable[tuple[str, torch.Tensor]],
+        ) -> Iterable[tuple[str, torch.Tensor]]:
+            nonlocal skipped_count
+            for name, tensor in weight_iter:
+                if name not in seen:
+                    seen.add(name)
+                    yield name, tensor
+                else:
+                    skipped_count += 1
+                    if len(skipped_examples) < 10:
+                        skipped_examples.append(name)
+
         loader = AutoWeightsLoader(self, ignore_unexpected_prefixes=["audio_tower."])
-        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        loaded = loader.load_weights(
+            _deduplicated(weights), mapper=self.hf_to_vllm_mapper
+        )
+
+        if skipped_count > 0:
+            logger.info(
+                "Ultravox: skipped %d duplicate weight(s) that were already "
+                "loaded from the primary checkpoint. This is expected when "
+                "audio_model_id or text_model_id is set alongside a "
+                "checkpoint that already contains those weights.",
+                skipped_count,
+            )
+            logger.debug("First 10 skipped weights: %s", skipped_examples)
+
+        return loaded
 
 
 def pad_and_concat_to_dim3(


### PR DESCRIPTION
## Summary

When serving a fine-tuned Ultravox **diff checkpoint** (one that contains only `audio_tower` and `multi_modal_projector` weights, not the full model), the fine-tuned weights are **silently overwritten** by base Whisper weights during model loading. This causes the model to produce degraded outputs with no error or warning.

### Root cause

`DefaultModelLoader.get_all_weights()` yields weights in order:
1. **Primary checkpoint** weights (fine-tuned `audio_tower.*` + `multi_modal_projector.*`)
2. **Secondary weights** from `audio_model_id` (base Whisper `audio_tower.*`)
3. **Secondary weights** from `text_model_id` (base LLM `language_model.*`)

Both the primary checkpoint and the `audio_model_id` secondary source contain `audio_tower.*` tensors with identical names. Since there is no deduplication, the secondary (base) weights silently replace the primary (fine-tuned) ones.

### Fix

Wrap the weights iterator with a deduplication generator using **first-wins semantics**: once a weight name has been loaded from the primary checkpoint, any subsequent duplicate from secondary sources is skipped. An info-level log message reports how many duplicates were skipped, and debug-level logging lists the specific weight names.

### How to reproduce

1. Fine-tune an Ultravox model, saving only the changed weights (diff checkpoint) — this is the default behavior of the [Ultravox training framework](https://github.com/fixie-ai/ultravox) when `audio_model_id` is set in `config.json`
2. Serve the diff checkpoint with vLLM
3. Compare outputs with HuggingFace inference — vLLM outputs will be significantly worse because it's using base Whisper weights instead of fine-tuned ones

### Notes

- This bug affects **any Ultravox diff checkpoint** where `audio_model_id` is set in `config.json` and the checkpoint contains fine-tuned `audio_tower` weights
- Full checkpoints (containing all weights) are also affected but the impact is masked since the base and fine-tuned LLM weights are identical for the `language_model` prefix
- The `secondary_weights` mechanism (introduced in #7931) may have the same issue for other multimodal models — a broader fix in `DefaultModelLoader` could be considered as a follow-up
- Tested with vLLM v0.15–v0.16

## Test plan

- [ ] Serve a fine-tuned Ultravox diff checkpoint and verify fine-tuned weights are preserved (not overwritten by base Whisper)
- [ ] Verify info-level log appears when duplicates are skipped
- [ ] Verify full checkpoints still load correctly (no regressions)
- [ ] Verify models without `audio_model_id` set load correctly (no dedup needed, no log noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)