### PR TITLE
Fix different embeddings produced by LLM and AsyncLLM

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -790,7 +790,7 @@ class AsyncLLM(EngineClient):
         try:
             model_config = self.model_config
 
-            pooling_params.verify(pooling_params.task, model_config)
+            pooling_params.verify(model_config)
 
             q = await self.add_request(
                 request_id,

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -788,6 +788,10 @@ class AsyncLLM(EngineClient):
 
         q: RequestOutputCollector | None = None
         try:
+            model_config = self.model_config
+
+            pooling_params.verify(pooling_params.task, model_config)
+
             q = await self.add_request(
                 request_id,
                 prompt,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
fix issue: #33361

## Test Plan
this code from issue: #33361
```python
import uuid

import asyncio
from vllm.v1.engine.async_llm import AsyncLLM, PoolingParams
from vllm import AsyncEngineArgs, LLM


async def main():
    engine_args = AsyncEngineArgs(
        model="Qwen/Qwen3-Embedding-0.6B",
        runner="pooling",
    )
    model = AsyncLLM.from_engine_args(engine_args)

    async for request_output in model.encode(
            prompt="Hello world!",
            pooling_params=PoolingParams(task="embed",use_activation=True),
            request_id=str(uuid.uuid4()),
    ):
        print(request_output.outputs.data.tolist()[:100])

await main()

def main():
    model = LLM(model="Qwen/Qwen3-Embedding-0.6B", runner="pooling")
    outputs = model.encode(["Hello world!"], pooling_task="embed")
    print(outputs[0].outputs.data.tolist()[:100])

main()
```

## Test Result
AsyncLLM Embedding: 
```
[0.005920082796365023, 0.005240073427557945, -0.009920138865709305, -0.06432089954614639, 0.0031000433955341578, -0.0124801741912961, -0.021760303527116776, -0.008760122582316399, -0.1113615557551384, -0.020160282030701637, -0.016640232875943184, -0.019200269132852554, 0.02768038772046566, -0.00924012903124094, -0.04448062181472778, 0.08960125595331192, -0.012880180031061172, 0.10048140585422516, 0.11008153855800629, -0.05920082703232765, -0.008160114288330078, 0.038880541920661926, -0.03312046453356743, 0.10752150416374207, -0.03936054930090904, -0.047040656208992004, -0.050880711525678635, 0.10944153368473053, 0.019440270960330963, -0.0077201081439852715, -0.008480118587613106, 0.04768066853284836, -0.018800262361764908, -0.024160338565707207, -0.046720653772354126, -0.01384019386023283, 0.04608064517378807, 0.00564007880166173, -0.020160282030701637, 0.04864067956805229, -0.00213002972304821, -0.009120127186179161, 0.05120071768760681, -0.012240171432495117, 0.01840025745332241, 0.010640149004757404, 0.012880180031061172, -0.011760164052248001, 0.0014100197004154325, -0.00048250675899907947, -0.035040490329265594, -0.01128015760332346, -0.012960181571543217, -0.004700065590441227, 0.020480286329984665, -0.030080420896410942, 0.01128015760332346, -0.02656037174165249, 0.02768038772046566, -0.0249603483825922, -0.07232101261615753, 0.04128057882189751, -0.08384117484092712, -0.009760136716067791, 0.0077201081439852715, 0.05920082703232765, 0.004780066665261984, -0.03456048294901848, -0.07264101505279541, -0.019200269132852554, -0.016320228576660156, -0.02096029371023178, -0.058880824595689774, 0.00046500650933012366, -0.008440118283033371, 0.057280801236629486, -0.009080126881599426, -0.07520104944705963, -0.016640232875943184, 0.0313604399561882, -0.04768066853284836, -0.0035200491547584534, 0.014320200309157372, 0.020080281421542168, -0.0292804092168808, 0.01592022180557251, 0.037440523505210876, -0.01960027404129505, 0.016080224886536598, -0.004440062213689089, -0.007760108448565006, 0.033600468188524246, -0.01312018372118473, -0.004380061291158199, -0.017440244555473328, -0.03840053826570511, -0.00426005944609642, 0.04608064517378807, -0.012160169892013073, 0.01120015699416399]
```

LLM Embedding:
```
[0.005920082796365023, 0.005240073427557945, -0.009920138865709305, -0.06432089954614639, 0.0031000433955341578, -0.0124801741912961, -0.021760303527116776, -0.008760122582316399, -0.1113615557551384, -0.020160282030701637, -0.016640232875943184, -0.019200269132852554, 0.02768038772046566, -0.00924012903124094, -0.04448062181472778, 0.08960125595331192, -0.012880180031061172, 0.10048140585422516, 0.11008153855800629, -0.05920082703232765, -0.008160114288330078, 0.038880541920661926, -0.03312046453356743, 0.10752150416374207, -0.03936054930090904, -0.047040656208992004, -0.050880711525678635, 0.10944153368473053, 0.019440270960330963, -0.0077201081439852715, -0.008480118587613106, 0.04768066853284836, -0.018800262361764908, -0.024160338565707207, -0.046720653772354126, -0.01384019386023283, 0.04608064517378807, 0.00564007880166173, -0.020160282030701637, 0.04864067956805229, -0.00213002972304821, -0.009120127186179161, 0.05120071768760681, -0.012240171432495117, 0.01840025745332241, 0.010640149004757404, 0.012880180031061172, -0.011760164052248001, 0.0014100197004154325, -0.00048250675899907947, -0.035040490329265594, -0.01128015760332346, -0.012960181571543217, -0.004700065590441227, 0.020480286329984665, -0.030080420896410942, 0.01128015760332346, -0.02656037174165249, 0.02768038772046566, -0.0249603483825922, -0.07232101261615753, 0.04128057882189751, -0.08384117484092712, -0.009760136716067791, 0.0077201081439852715, 0.05920082703232765, 0.004780066665261984, -0.03456048294901848, -0.07264101505279541, -0.019200269132852554, -0.016320228576660156, -0.02096029371023178, -0.058880824595689774, 0.00046500650933012366, -0.008440118283033371, 0.057280801236629486, -0.009080126881599426, -0.07520104944705963, -0.016640232875943184, 0.0313604399561882, -0.04768066853284836, -0.0035200491547584534, 0.014320200309157372, 0.020080281421542168, -0.0292804092168808, 0.01592022180557251, 0.037440523505210876, -0.01960027404129505, 0.016080224886536598, -0.004440062213689089, -0.007760108448565006, 0.033600468188524246, -0.01312018372118473, -0.004380061291158199, -0.017440244555473328, -0.03840053826570511, -0.00426005944609642, 0.04608064517378807, -0.012160169892013073, 0.01120015699416399]
```



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

