### PR TITLE
[Kernel] Optimize sample_recovered_tokens_kernel

### DIFF
--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -573,7 +573,7 @@ def native_sample_recovered_tokens(
             if draft_probs is None:
                 # prob is target_probs[token_idx] except draft_token_id is zeroed
                 prob = target_probs[token_idx].clone()
-                draft_token_id = draft_token_ids[token_idx].to(torch.int32)
+                draft_token_id = draft_token_ids[token_idx]
                 prob[draft_token_id] = 0.0
             else:
                 prob = (target_probs[token_idx] - draft_probs[token_idx]).clamp_min_(

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -11,7 +11,11 @@ from tests.v1.sample.utils import create_allowed_token_ids
 from vllm.platforms import current_platform
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
-from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID, RejectionSampler
+from vllm.v1.sample.rejection_sampler import (
+    PLACEHOLDER_TOKEN_ID,
+    RejectionSampler,
+    sample_recovered_tokens,
+)
 from vllm.v1.sample.sampler import Sampler, SamplerOutput
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 
@@ -518,6 +522,70 @@ def estimate_rejection_sampling_pdf(
     return hist.hist
 
 
+def native_sample_recovered_tokens(
+    max_spec_len: int,
+    num_draft_tokens: list[int],
+    cu_num_draft_tokens: torch.Tensor,  # [batch_size]
+    draft_token_ids: torch.Tensor,  # [num_tokens]
+    draft_probs: torch.Tensor | None,  # [num_tokens, vocab_size]
+    target_probs: torch.Tensor,  # [num_tokens, vocab_size]
+    sampling_metadata: SamplingMetadata,
+    device: torch.device,
+) -> torch.Tensor:
+    batch_size = len(num_draft_tokens)
+    vocab_size = target_probs.shape[-1]
+
+    q = torch.empty(
+        (batch_size, vocab_size),
+        dtype=torch.float32,
+        device=device,
+    )
+    q.exponential_()
+
+    states = {
+        i: generator.get_state()
+        for i, generator in sampling_metadata.generators.items()
+    }
+    for i, generator in sampling_metadata.generators.items():
+        # Do not generate random numbers for requests with no draft tokens.
+        # This can be important for reproducibility.
+        if num_draft_tokens[i] > 0:
+            q[i].exponential_(generator=generator)
+
+        # In order to generate the same exponential later, reset the CUDA RNG
+        # state because RNG state advances after each call.
+        generator.set_state(states[i])
+
+    inv_q = q.reciprocal()
+
+    out = torch.empty_like(draft_token_ids)
+
+    for req_idx in range(batch_size):
+        start_idx = 0 if req_idx == 0 else int(cu_num_draft_tokens[req_idx - 1].item())
+        end_idx = int(cu_num_draft_tokens[req_idx].item())
+        num_tokens = end_idx - start_idx
+
+        for pos in range(max_spec_len):
+            if pos >= num_tokens:
+                continue
+            token_idx = start_idx + pos
+
+            if draft_probs is None:
+                # prob is target_probs[token_idx] except draft_token_id is zeroed
+                prob = target_probs[token_idx].clone()
+                draft_token_id = draft_token_ids[token_idx].to(torch.int32)
+                prob[draft_token_id] = 0.0
+            else:
+                prob = (target_probs[token_idx] - draft_probs[token_idx]).clamp_min_(
+                    0.0
+                )
+
+            score = prob * inv_q[req_idx]
+            recovered_id = torch.argmax(score, dim=-1)
+            out[token_idx] = recovered_id
+    return out
+
+
 def _test_masked_logits(
     rejection_sampler,
     batch_size: int,
@@ -778,3 +846,60 @@ def test_allowed_token_ids(rejection_sampler):
         device=logits.device,
     )
     assert torch.equal(output.sampled_token_ids, expected)
+
+
+@pytest.mark.parametrize("batch_size", [1, 100])
+@pytest.mark.parametrize("vocab_size", [100, 8192, 10000])
+@pytest.mark.parametrize("max_spec_len", [1, 3])
+@pytest.mark.parametrize("no_draft_probs", [True, False])
+def test_sample_recovered_tokens(
+    batch_size: int, vocab_size: int, max_spec_len: int, no_draft_probs: bool
+):
+    num_tokens = batch_size * max_spec_len
+
+    # Create random draft probabilities.
+    draft_probs = torch.rand(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE)
+    draft_probs = F.softmax(draft_probs, dim=-1)
+
+    # Create random target probabilities.
+    target_logits = torch.rand(
+        num_tokens, vocab_size, dtype=torch.float32, device=DEVICE
+    )
+    target_probs = F.softmax(target_logits, dim=-1)
+
+    # Randomly sample draft token ids from draft probs
+    draft_token_ids = torch.multinomial(draft_probs, num_samples=1).to(torch.int32)
+
+    temperature = torch.ones(batch_size, dtype=torch.float32, device=DEVICE)
+    generators = {
+        i: torch.Generator(device=DEVICE).manual_seed(i) for i in range(batch_size)
+    }
+    sampling_metadata = create_sampling_metadata(
+        all_greedy=False, temperature=temperature, generators=generators
+    )
+
+    spec_decode_metadata = create_spec_decode_metadata(
+        draft_token_ids.reshape(batch_size, max_spec_len).tolist(), target_logits
+    )
+
+    ref_recovered_token_ids = native_sample_recovered_tokens(
+        max_spec_len,
+        spec_decode_metadata.num_draft_tokens,
+        spec_decode_metadata.cu_num_draft_tokens,
+        draft_token_ids,
+        None if no_draft_probs else draft_probs,
+        target_probs,
+        sampling_metadata,
+        device=DEVICE,
+    )
+    recovered_token_ids = sample_recovered_tokens(
+        max_spec_len,
+        spec_decode_metadata.num_draft_tokens,
+        spec_decode_metadata.cu_num_draft_tokens,
+        draft_token_ids,
+        None if no_draft_probs else draft_probs,
+        target_probs,
+        sampling_metadata,
+        device=DEVICE,
+    )
+    assert torch.equal(recovered_token_ids, ref_recovered_token_ids)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR optimize the `sample_recovered_tokens_kernel` in rejection sampler.

* Use tiled reduction over vocab. Instead of creating one massive `tl.arange(0, PADDED_VOCAB_SIZE)` vector and loading the whole vocab in one program, load it in chunks of BLOCK_SIZE. This will have lower register pressure and better occupancy.
* Replace `score = prob / q` division with `score = prob * inv_q`, because division is slower than multiply.
* Kernel level more than 5x improvement. e2e improvement is about 1% since this kernel is not launched many times (launched once in every decode `gpu_model_runner.sample()`)

## Test Plan

Added unit test in `test_rejection_sampler.py`

```
pytest -s -v tests/v1/sample/test_rejection_sampler.py -k test_sample_recovered_tokens
```

## Test Result

Unit tests passed.

## Profiling

Main:

<img width="1908" height="496" alt="Screenshot 2026-02-19 at 11 37 47 PM" src="https://github.com/user-attachments/assets/031fc8c3-a400-4f34-8920-3c1e4fc38995" />

PR:
<img width="1907" height="495" alt="Screenshot 2026-02-19 at 11 38 03 PM" src="https://github.com/user-attachments/assets/719229f5-987d-43e5-9adc-deb0db82ef29" />

Main: `sample_recovered_tokens_kernel` takes around 159µs.

PR: `sample_recovered_tokens_kernel` takes around 29µs.

## Benchmarking

```
vllm serve deepseek-ai/DeepSeek-R1-0528 \
    --tensor-parallel-size 8 \
    --enable_expert-parallel \
    --max-num-seqs 16 \
    --trust-remote-code \
    --no-enable-prefix-caching \
    --speculative-config '{"method": "mtp", "num_speculative_tokens": 3}'
```

```
vllm bench serve \
  --model deepseek-ai/DeepSeek-R1-0528 \
  --dataset-name sharegpt \
  --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
  --sharegpt-output-len 300 \
  --max-concurrency 16 \
  --num-prompts 1000 \
  --num-warmups 50 \
  --ignore-eos \
  --temperature 0
```

Main:
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  287.68    
Total input tokens:                      229418    
Total generated tokens:                  300000    
Request throughput (req/s):              3.48      
Output token throughput (tok/s):         1042.81   
Peak output token throughput (tok/s):    480.00    
Peak concurrent requests:                25.00     
Total token throughput (tok/s):          1840.28   
---------------Time to First Token----------------
Mean TTFT (ms):                          174.79    
Median TTFT (ms):                        190.15    
P99 TTFT (ms):                           308.77    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.76     
Median TPOT (ms):                        14.62     
P99 TPOT (ms):                           20.18     
---------------Inter-token Latency----------------
Mean ITL (ms):                           40.52     
Median ITL (ms):                         33.48     
P99 ITL (ms):                            142.01    
---------------Speculative Decoding---------------
Acceptance rate (%):                     58.56     
Acceptance length:                       2.76      
Drafts:                                  108883    
Draft tokens:                            326649    
Accepted tokens:                         191290    
Per-position acceptance (%):
  Position 0:                            87.18     
  Position 1:                            56.63     
  Position 2:                            31.88     
==================================================
```

PR:
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  284.99    
Total input tokens:                      229418    
Total generated tokens:                  300000    
Request throughput (req/s):              3.51      
Output token throughput (tok/s):         1053.68   
Peak output token throughput (tok/s):    480.00    
Peak concurrent requests:                25.00     
Total token throughput (tok/s):          1857.69   
---------------Time to First Token----------------
Mean TTFT (ms):                          170.27    
Median TTFT (ms):                        186.90    
P99 TTFT (ms):                           302.46    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.62     
Median TPOT (ms):                        14.52     
P99 TPOT (ms):                           20.15     
---------------Inter-token Latency----------------
Mean ITL (ms):                           40.27     
Median ITL (ms):                         33.50     
P99 ITL (ms):                            138.88    
---------------Speculative Decoding---------------
Acceptance rate (%):                     58.88     
Acceptance length:                       2.77      
Drafts:                                  108514    
Draft tokens:                            325542    
Accepted tokens:                         191676    
Per-position acceptance (%):
  Position 0:                            87.32     
  Position 1:                            57.03     
  Position 2:                            32.28     
==================================================
```

e2e output token throughput improves 1%.

## Accuracy Testing

```
python3 -m lm_eval --model local-completions \
  --model_args model=deepseek-ai/DeepSeek-R1-0528,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=16 \
  --tasks gsm8k
```

Main:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9583|±  |0.0055|
|     |       |strict-match    |     5|exact_match|↑  |0.9553|±  |0.0057|
```

PR:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9598|±  |0.0054|
|     |       |strict-match    |     5|exact_match|↑  |0.9568|±  |0.0056|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

