### PR TITLE
Allow _dummy_run to use _model_forward for hardware backends with compiled execution  

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4625,6 +4625,7 @@ class GPUModelRunner(
         remove_lora: bool = True,
         is_graph_capturing: bool = False,
         num_active_loras: int = 0,
+        use_model_forward: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Run a dummy forward pass to warm up/profile run or capture the
@@ -4874,7 +4875,9 @@ class GPUModelRunner(
                     slot_mapping=slot_mappings,
                 ),
             ):
-                outputs = self.model(
+                forward_fn = self._model_forward if use_model_forward \
+                    else self.model
+                outputs = forward_fn(
                     input_ids=input_ids,
                     positions=positions,
                     intermediate_tensors=intermediate_tensors,


### PR DESCRIPTION
Summary:                                                                                                                                                

  _dummy_run currently calls self.model(...) directly, bypassing the _model_forward() override hook. This means hardware backends that override
  _model_forward for compiled/graph-mode execution cannot control the execution path during dummy batch runs.

  This matters for DP with expert parallelism: execute_dummy_batch uses _dummy_run to keep idle ranks participating in collective operations (e.g.,
  alltoall). When the real execution path uses compiled collectives via _model_forward, but dummy batches use eager execution via self.model, the two
  ranks end up in mismatched collective states — one rank runs compiled collectives while the other runs eager, causing RDMA/communication failures.

  This PR adds a use_model_forward parameter (default False) to _dummy_run, allowing subclasses to opt in to routing dummy batches through _model_forward.
   This ensures dummy batches use the same compiled execution path as real requests, keeping collective operations consistent across DP ranks.

  No behavior change for existing callers — the default remains self.model(...).