### PR TITLE
[CI Bugfix] Add pytest.mark.flaky to tests/v1/e2e/test_spec_decode.py

### DIFF
--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -121,6 +121,7 @@ def reset_torch_dynamo():
     torch._dynamo.reset()
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
 @pytest.mark.parametrize(
     "speculative_config",
     [
@@ -178,6 +179,7 @@ def test_ngram_and_suffix_correctness(
     cleanup_dist_env_and_memory()
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
 def test_suffix_decoding_acceptance(
     monkeypatch: pytest.MonkeyPatch,
     sampling_config: SamplingParams,
@@ -237,6 +239,7 @@ def test_suffix_decoding_acceptance(
     cleanup_dist_env_and_memory()
 
 
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
 @pytest.mark.parametrize(
     "model_path",
     [
@@ -311,12 +314,14 @@ def test_speculators_model_integration(
     )
 
     # Heuristic: expect at least 66% of prompts to match exactly
+    print(f"Match ratio: {matches}/{len(ref_outputs)}")
     assert matches >= int(0.66 * len(ref_outputs)), (
         f"Only {matches}/{len(ref_outputs)} outputs matched. "
         f"Expected at least {int(0.66 * len(ref_outputs))} matches."
     )
 
 
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
 @pytest.mark.parametrize(
     ["model_setup", "mm_enabled", "enable_chunked_prefill", "model_impl"],
     [

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -314,7 +314,6 @@ def test_speculators_model_integration(
     )
 
     # Heuristic: expect at least 66% of prompts to match exactly
-    print(f"Match ratio: {matches}/{len(ref_outputs)}")
     assert matches >= int(0.66 * len(ref_outputs)), (
         f"Only {matches}/{len(ref_outputs)} outputs matched. "
         f"Expected at least {int(0.66 * len(ref_outputs))} matches."


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The hope is this will help the flaky failures of "V1 e2e + engine" since I identified these tests are often the culprit. They really should be reworked but when I ran locally it really did vary so much run to run.

FIX https://github.com/vllm-project/vllm/issues/34617 https://github.com/vllm-project/vllm/issues/34797

https://buildkite.com/organizations/vllm/analytics/suites/ci-1/tests?branch=main&period=7days&query=tests%2Fv1%2Fe2e%2Ftest_spec_decode.py
<img width="1448" height="909" alt="image" src="https://github.com/user-attachments/assets/79d5bd94-f7e6-4105-a525-b10d3e103eb3" />

https://buildkite.com/organizations/vllm/analytics/suites/ci-1/tests/d3961577-b897-8a24-9e64-9483bf037293?branch=main&period=7days&query=tests%2Fv1%2Fe2e%2Ftest_spec_decode.py
<img width="1442" height="683" alt="image" src="https://github.com/user-attachments/assets/d9095a41-11e9-4685-b189-111ad6dde15f" />

https://buildkite.com/organizations/vllm/analytics/suites/ci-1/tests/4c453340-2f5f-86b3-9ac4-a4c318a1b23d?branch=main&period=7days&query=tests%2Fv1%2Fe2e%2Ftest_spec_decode.py
<img width="1458" height="683" alt="image" src="https://github.com/user-attachments/assets/92aa44e1-bad8-43e2-9339-a7a8979d7dcc" />

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

