### PR TITLE
[CI] Skip Responses API

### DIFF
--- a/tests/entrypoints/openai/responses/test_harmony.py
+++ b/tests/entrypoints/openai/responses/test_harmony.py
@@ -893,6 +893,10 @@ async def test_function_calling_no_code_interpreter_events(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
+@pytest.mark.skip(
+    reason="This test is flaky in CI, needs investigation and "
+    "potential fixes in the code interpreter MCP implementation."
+)
 async def test_mcp_code_interpreter_streaming(client: OpenAI, model_name: str, server):
     tools = [
         {


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
* skip responses API tests, which are flakly.
* it needs further investigation but this will help to stabilize the CI