### PR TITLE
Fixing matcher to enable the 2-node-tests-4-gpus-in-total on MI355

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -189,7 +189,7 @@ if [[ -z "$render_gid" ]]; then
   exit 1
 fi
 
-if [[ $commands == *"VLLM_TEST_GROUP_NAME=_4-2-node-tests-4-gpus-in-total"* ]]; then
+if [[ $commands == *"VLLM_TEST_GROUP_NAME=mi3.5_4-2-node-tests-4-gpus-in-total"* ]]; then
 
   export DCKR_VER=$(docker --version | sed 's/Docker version \(.*\), build .*/\1/')
 

--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -189,7 +189,7 @@ if [[ -z "$render_gid" ]]; then
   exit 1
 fi
 
-if [[ $commands == *"VLLM_TEST_GROUP_NAME=mi3.5_4-2-node-tests-4-gpus-in-total"* ]]; then
+if [[ $commands =~ *"VLLM_TEST_GROUP_NAME=mi3.5_4-2-node-tests-4-gpus-in-total"* ]]; then
 
   export DCKR_VER=$(docker --version | sed 's/Docker version \(.*\), build .*/\1/')
 

--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -189,7 +189,7 @@ if [[ -z "$render_gid" ]]; then
   exit 1
 fi
 
-if [[ $commands == *"VLLM_TEST_GROUP_NAME=mi325_4-2-node-tests-4-gpus-in-total"* ]]; then
+if [[ $commands == *"VLLM_TEST_GROUP_NAME=_4-2-node-tests-4-gpus-in-total"* ]]; then
 
   export DCKR_VER=$(docker --version | sed 's/Docker version \(.*\), build .*/\1/')
 


### PR DESCRIPTION
Fixing matcher to enable the 2-node-tests-4-gpus-in-total on MI355