### PR TITLE
update-pillow-version to mitigate CVE-2026-25990

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -15,7 +15,7 @@ aiohttp >= 3.13.3
 openai >= 1.99.1  # For Responses API with reasoning content
 pydantic >= 2.12.0
 prometheus_client >= 0.18.0
-pillow  # Required for image processing
+pillow >= 12.1.1  # Required for image processing
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer == 0.11.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -708,7 +708,7 @@ perceptron==0.1.4
     # via -r requirements/test.in
 perf-analyzer==0.1.0
     # via genai-perf
-pillow==10.4.0
+pillow>=12.1.1
     # via
     #   diffusers
     #   genai-perf


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose: 
Updates the minimum Pillow version to mitigate **CVE-2026-25990**.
- **CVE-2026-25990**: Pillow, a Python imaging library, is vulnerable to an out-of-bounds write when processing a specially crafted PSD image. This affects versions from 10.3.0 to 12.1.0 and is resolved in version 12.1.1.
- The constraint of (pillow >= 12.1.1) was added to two files, requirements/common.txt and requirements/test.txt. 
- Note that requirements/test.txt was updated just to remain aligned with requirements/common.txt
- Previously, `pillow` was not constrained in `requirements/common.txt`. This change establishes a minimum version to prevent the installation of vulnerable packages.

## Test Plan: 
Since the previous implementation did not constrain the version, no breaking changes are anticipated.

## Test Result:
N/A

---
<details>
<summary> Updates the minimum Pillow version to address CVE-2026-25990. </summary>
- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
</details>

