### PR TITLE
remove cuda check in `top_k_top_p_triton` kernel

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -248,7 +248,7 @@ def apply_top_k_top_p(
     if p is None and k is None:
         return logits
 
-    if HAS_TRITON and logits.shape[0] >= 8 and logits.is_cuda:
+    if HAS_TRITON and logits.shape[0] >= 8:
         return apply_top_k_top_p_triton(logits, k, p)
 
     # Use pytorch sort implementation for small batch sizes.

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -983,7 +983,7 @@ def apply_top_k_top_p_triton(
         k_ptr = logits  # Dummy pointer (won't be read)
 
     if p is not None:
-        assert p.ndim == 1 and p.shape[0] == batch_size 
+        assert p.ndim == 1 and p.shape[0] == batch_size
         p_ptr = p.to(torch.float32)
     else:
         p_ptr = logits  # Dummy pointer (won't be read)

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -967,7 +967,6 @@ def apply_top_k_top_p_triton(
     """
     assert logits.ndim == 2
     assert logits.dtype == torch.float32
-    assert logits.is_cuda
 
     batch_size, vocab_size = logits.shape
 
@@ -978,13 +977,13 @@ def apply_top_k_top_p_triton(
         return logits
 
     if k is not None:
-        assert k.ndim == 1 and k.shape[0] == batch_size and k.is_cuda
+        assert k.ndim == 1 and k.shape[0] == batch_size
         k_ptr = k.to(torch.int32)
     else:
         k_ptr = logits  # Dummy pointer (won't be read)
 
     if p is not None:
-        assert p.ndim == 1 and p.shape[0] == batch_size and p.is_cuda
+        assert p.ndim == 1 and p.shape[0] == batch_size 
         p_ptr = p.to(torch.float32)
     else:
         p_ptr = logits  # Dummy pointer (won't be read)


### PR DESCRIPTION

## Purpose
fix #34941
https://github.com/vllm-project/vllm/pull/33538 introduce triton based top_k_top_p kernel and have some cuda hard code in triton kernel code. this may break non-cuda-like device like xpu and npu.

cc @Yikun @wangxiyuan 
## Test Plan
CI
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

