### PR TITLE
[Feature] Add per-request attention capture to the OpenAI-compatible API

### DIFF
--- a/examples/offline_inference/attention_instrumentation/README.md
+++ b/examples/offline_inference/attention_instrumentation/README.md
@@ -1,0 +1,145 @@
+# Attention Instrumentation Guide
+
+vLLM's attention instrumentation lets you extract per-layer attention scores
+from the OpenAI-compatible API during inference.
+
+## Quick Start
+
+### 1. Start the server
+
+```bash
+python -m vllm.entrypoints.openai.api_server \
+  --model google/gemma-3-4b-it \
+  --enforce-eager \
+  --enable-attention-instrumentation \
+  --attention-instrumentation-layers 2,18,27 \
+  --no-enable-chunked-prefill \
+  --no-enable-prefix-caching
+```
+
+> `--no-enable-chunked-prefill` and `--no-enable-prefix-caching` are required
+> to capture attention for **all** prompt tokens. Without them vLLM may only
+> buffer the last prefill chunk or skip cached tokens entirely.
+
+### 2. Request attention scores
+
+```python
+import json
+from openai import OpenAI
+
+client = OpenAI(api_key="EMPTY", base_url="http://127.0.0.1:8000/v1")
+
+# with_raw_response prevents the SDK from stripping unknown fields
+raw = client.chat.completions.with_raw_response.create(
+    model="gemma-3-4b-it",
+    messages=[{"role": "user", "content": "Hello"}],
+    extra_body={"attn_capture": 1, "attn_capture_layers": "2,18,27"},
+)
+response = json.loads(raw.content)
+```
+
+**cURL:**
+```bash
+curl -s http://127.0.0.1:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gemma-3-4b-it",
+       "messages":[{"role":"user","content":"Hello"}],
+       "attn_capture":1, "attn_capture_layers":"2,18,27"}'
+```
+
+### 3. Parse and analyze
+
+```python
+from attention_instrumentation import extract_attention_from_response, AttentionAnalyzer
+
+attn_by_layer = extract_attention_from_response(response)
+# attn_by_layer[18]["scores"]  →  np.ndarray [T, num_heads, T]
+#                                             (query × head × key)
+
+layer    = attn_by_layer[18]
+analyzer = AttentionAnalyzer(layer["scores"], layer["token_meta"])
+
+# Head-averaged top-5 keys for the last query token
+for idx, weight, tok_type in analyzer.top_attended_tokens(
+        token_idx=-1, top_k=5, avg_heads=True):
+    print(f"  key {idx} ({tok_type}): {weight:.3f}")
+
+# Single-head attention vector
+attn_vec = analyzer.attention_for_token(token_idx=-1, head_idx=3)
+
+# Cross-modal attention (vision → language fraction)
+cross = analyzer.cross_modal_attention(avg_heads=True)
+print(f"Vision→Language: {cross:.2%}")
+```
+
+## Built-in Examples
+
+Run the included demos directly:
+
+```bash
+# Needle-in-a-haystack: recall a value by key from a long list
+python attention_instrumentation.py --example needle
+
+# Codename retrieval: find an agent's codename from a structured log
+python attention_instrumentation.py --example codename
+
+# Override layers
+python attention_instrumentation.py --example needle --layers 0,9,18
+```
+
+Each example prints per-layer attention in compact form:
+
+```
+── L18 (T=138 H=8 prompt=131) ──
+  avg  <bos>(0)=0.24  :(132)=0.17  alpha(131)=0.08◀  ...
+  h7   alpha(131)=0.23◀  ↵(127)=0.13  :(132)=0.12
+```
+
+`◀` marks the needle/target token. `avg` is head-averaged; `h0`–`h7` are per-head.
+
+## Response format
+
+`attn_capture_data` is a list of per-layer objects:
+
+```json
+{
+  "attn_capture_data": [
+    {
+      "layer_idx": 18,
+      "data": "<base64(gzip(float16 array))>",
+      "shape": [138, 8, 138],
+      "token_meta": {
+        "prompt_len": 131,
+        "total_len": 138,
+        "vision_ranges": [],
+        "lang_ranges": [{"start": 0, "end": 131}]
+      }
+    }
+  ]
+}
+```
+
+`shape` is `[T, num_heads, T]` — query × head × key. Scores are
+gzip-compressed, base64-encoded `float16` arrays.
+
+## Server parameters
+
+| Flag | Description |
+|------|-------------|
+| `--enable-attention-instrumentation` | Enable the feature |
+| `--attention-instrumentation-layers LAYERS` | `"all"`, `"2,18,27"`, or `"18"` |
+| `--no-enable-chunked-prefill` | Required for full prompt coverage |
+| `--no-enable-prefix-caching` | Required for full prompt coverage |
+
+## Client parameters
+
+| Field | Values |
+|-------|--------|
+| `attn_capture` | `0` (off) / `1` (on) |
+| `attn_capture_layers` | Overrides server-side layer list |
+
+## Notes
+
+- Scores are softmax probabilities (0–1) with causal mask applied
+- Supports multimodal inputs (text + images) via `vision_ranges` / `lang_ranges`
+- Overhead is proportional to the number of captured layers

--- a/examples/offline_inference/attention_instrumentation/attention_instrumentation.py
+++ b/examples/offline_inference/attention_instrumentation/attention_instrumentation.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import base64
+import gzip
+import json
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class TokenRange:
+    start: int
+    end: int
+
+    def __contains__(self, i):
+        return self.start <= i < self.end
+
+
+class MultimodalTokenizer:
+    def __init__(self, vision_ranges, lang_ranges, prompt_len, total_len):
+        self.vision_ranges = [TokenRange(**r) for r in vision_ranges]
+        self.lang_ranges = [TokenRange(**r) for r in lang_ranges]
+        self.prompt_len = prompt_len
+        self.total_len = total_len
+
+    def token_type(self, i):
+        if i >= self.prompt_len:
+            return "generated"
+        if any(i in r for r in self.vision_ranges):
+            return "vision"
+        if any(i in r for r in self.lang_ranges):
+            return "language"
+        return "unknown"
+
+    def get_vision_tokens(self):
+        return [i for r in self.vision_ranges for i in range(r.start, r.end)]
+
+    def get_lang_tokens(self):
+        return [i for r in self.lang_ranges for i in range(r.start, r.end)]
+
+
+class AttentionAnalyzer:
+    """Wraps attention scores [T, H, T] with token-type context."""
+
+    def __init__(self, attn_scores, token_meta: dict):
+        self.s = attn_scores  # [T, H, T]
+        self.tokenizer = MultimodalTokenizer(
+            token_meta.get("vision_ranges", []),
+            token_meta.get("lang_ranges", []),
+            token_meta.get("prompt_len", 0),
+            token_meta.get("total_len", 0),
+        )
+
+    def _w(self, q, h, avg):
+        if avg:
+            return self.s[q].mean(0)
+        if h is not None:
+            return self.s[q, h]
+        return self.s[q]
+
+    def attention_for_token(self, q, head_idx=None, avg_heads=False):
+        """[H,T] or [T] attention weights for query token q."""
+        return self._w(q, head_idx, avg_heads)
+
+    def top_attended_tokens(self, q, head_idx=None, top_k=5, avg_heads=False):
+        """List of (key_idx, weight, token_type) sorted by weight desc."""
+        if not avg_heads and head_idx is None:
+            raise ValueError("Provide head_idx or avg_heads=True")
+        w = self._w(q, head_idx, avg_heads)
+        top = np.argsort(w)[::-1][:top_k]
+        return [(int(i), float(w[i]), self.tokenizer.token_type(i)) for i in top]
+
+    def cross_modal_attention(self, head_idx=None, avg_heads=False) -> float:
+        """Fraction of vision-token attention on language tokens."""
+        vis, lng = self.tokenizer.get_vision_tokens(), self.tokenizer.get_lang_tokens()
+        if not vis or not lng:
+            return 0.0
+        if not avg_heads and head_idx is None:
+            raise ValueError("Provide head_idx or avg_heads=True")
+        sv = self.s[vis].mean(1) if avg_heads else self.s[vis, head_idx]
+        t = float(sv.sum())
+        return float(sv[:, lng].sum()) / t if t else 0.0
+
+
+def extract_attention_from_response(response: dict) -> dict | None:
+    data = response.get("attn_capture_data", [])
+    if not data:
+        return None
+    out = {}
+    for item in data:
+        b64, shape = item.get("data"), item.get("shape")
+        if not (b64 and shape):
+            continue
+        scores = (
+            np.frombuffer(gzip.decompress(base64.b64decode(b64)), dtype=np.float16)
+            .astype(np.float32)
+            .reshape(shape)
+        )
+        li = item.get("layer_idx")
+        out[li] = {
+            "scores": scores,
+            "token_meta": item.get("token_meta", {}),
+            "model": response.get("model"),
+            "layer": li,
+        }
+    return out or None
+
+
+def build_token_map(model_id, prompt, response):
+    """idx→text for prompt tokens (chat-template) + generated tokens (logprobs)."""
+    m, n = {}, 0
+    try:
+        from transformers import AutoTokenizer
+
+        tok = AutoTokenizer.from_pretrained(model_id, use_fast=True)
+        full = tok.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        ids = tok.encode(full, add_special_tokens=False)
+        n = len(ids)
+        m = {i: tok.decode([t]).replace("\n", "↵") for i, t in enumerate(ids)}
+    except Exception:
+        pass
+    try:
+        for off, lp in enumerate(response["choices"][0]["logprobs"]["content"]):
+            m[n + off] = lp["token"].replace("\n", "↵")
+    except Exception:
+        pass
+    return m, n
+
+
+def call_api(client, model_id, prompt, layers, max_tokens=None):
+    raw = client.chat.completions.with_raw_response.create(
+        model=model_id,
+        messages=[{"role": "user", "content": prompt}],
+        extra_body={"attn_capture": 1, "attn_capture_layers": layers},
+        **({} if max_tokens is None else {"max_tokens": max_tokens}),
+        temperature=0,
+        logprobs=True,
+    )
+    return json.loads(raw.content)
+
+
+def fmt(k, m):
+    """'text(idx)' label."""
+    raw = m.get(k)
+    t = raw.strip() if raw is not None else None
+    return f"{t or repr(raw) or '?'}({k})"
+
+
+def row(w, indices, m, mark=None):
+    """'tok(i)=0.23◀  tok(j)=0.11  ...' for given indices."""
+    return "  ".join(
+        f"{fmt(k, m)}={w[k]:.2f}{'◀' if mark and k in mark else ''}" for k in indices
+    )
+
+
+def main(
+    api_base="http://127.0.0.1:8000/v1", api_key="EMPTY", layers="2,18,27"
+) -> None:
+    from openai import OpenAI
+
+    client, model_id = OpenAI(api_key=api_key, base_url=api_base), None
+    model_id = client.models.list().data[0].id
+
+    pairs = [
+        ("alpha", "1729"),
+        ("beta", "2048"),
+        ("gamma", "3141"),
+        ("delta", "4096"),
+        ("epsilon", "5678"),
+        ("zeta", "6174"),
+        ("eta", "7777"),
+        ("theta", "8008"),
+        ("iota", "9999"),
+        ("kappa", "1234"),
+        ("lambda", "5555"),
+        ("mu", "3721"),
+        ("nu", "8642"),
+        ("xi", "2468"),
+        ("omicron", "1357"),
+        ("alpha", None),
+    ]
+    prompt, expected = (
+        "\n".join(f"{k}: {v}" if v else f"{k}:" for k, v in pairs),
+        "1729",
+    )
+
+    print(f"{'=' * 60}\nNeedle-in-a-haystack  |  model={model_id}  layers={layers}")
+    print(f"Prompt:\n{prompt}\nExpected: {expected!r}")
+
+    resp = call_api(client, model_id, prompt, layers)
+    generated = resp["choices"][0]["message"]["content"].strip()
+    print(f"Output: {generated!r}  {'✓' if expected in generated else '✗'}")
+
+    attn = extract_attention_from_response(resp)
+    if not attn:
+        print(
+            "No attention data — start server with --enable-attention-instrumentation"
+        )
+        return
+
+    m, _ = build_token_map(model_id, prompt, resp)
+    needle = {k for k, t in m.items() if t.strip() == "alpha"}
+
+    for li in sorted(attn):
+        s, meta = attn[li]["scores"], attn[li]["token_meta"]
+        T, H, _ = s.shape
+        pl = meta["prompt_len"]
+        q = T - 1
+        print(f"\n── L{li} (T={T} H={H} prompt={pl}) ──")
+        avg = s[q].mean(0)
+        print(f"  avg  {row(avg, np.argsort(avg)[::-1][:5], m, needle)}")
+        for h in range(H):
+            w = s[q, h]
+            top3 = np.argsort(w)[::-1][:3]
+            hit = any(k in needle and w[k] > 0.15 for k in top3)
+            print(f"  h{h:<2} {row(w, top3, m, needle if hit else None)}")
+
+
+def example_codename_retrieval(
+    api_base="http://127.0.0.1:8000/v1", api_key="EMPTY", layers="0,9,12,18,24,27"
+) -> None:
+    from openai import OpenAI
+
+    client, model_id = OpenAI(api_key=api_key, base_url=api_base), None
+    model_id = client.models.list().data[0].id
+
+    prompt = (
+        "Security Log: Agent Codename Retrieval\n\n"
+        "[Entry 01] Agent: James,  Codename: 'Falcon'\n"
+        "[Entry 02] Agent: Sarah,  Codename: 'Whisper'\n"
+        "[Entry 03] Agent: Mike,   Codename: 'Hammer'\n"
+        "[Entry 04] Agent: Omega,  Codename: 'Phantom'\n"
+        "[Entry 05] Agent: Linda,  Codename: 'Spark'\n"
+        "[Entry 06] Agent: Robert, Codename: 'Echo'\n\n"
+        "Request: Retrieve the codename for Agent Omega.\n"
+        "Agent: Omega, Codename:"
+    )
+    expected = "Phantom"
+
+    print(f"{'=' * 60}\nCodename retrieval  |  model={model_id}  layers={layers}")
+    print(f"Prompt:\n{prompt}\nExpected: {expected!r}")
+
+    resp = call_api(client, model_id, prompt, layers)
+    generated = resp["choices"][0]["message"]["content"].strip()
+    ok = "✓" if expected.lower() in generated.lower() else "✗"
+    print(f"Output: {generated!r}  {ok}")
+
+    attn = extract_attention_from_response(resp)
+    if not attn:
+        print(
+            "No attention data — start server with --enable-attention-instrumentation"
+        )
+        return
+
+    m, _ = build_token_map(model_id, prompt, resp)
+
+    for li in sorted(attn):
+        s, meta = attn[li]["scores"], attn[li]["token_meta"]
+        T, H, _ = s.shape
+        pl = meta["prompt_len"]
+        total_len = meta.get("total_len", T)
+        offset = total_len - T
+        print(f"\n── L{li} (T={T} H={H} prompt={pl}) ──")
+        for qi in range(T):
+            abs_qi = qi + offset
+            if abs_qi < pl:
+                continue  # skip prompt rows, show only generated tokens
+            tok_label = m.get(abs_qi, "?")
+            # avg across heads — full key axis (all T key positions)
+            avg = s[qi].mean(0)  # [T]
+            top5_rel = np.argsort(avg)[::-1][:5]
+            top5_abs = top5_rel + offset
+            w_g = {int(a): float(avg[r]) for r, a in zip(top5_rel, top5_abs)}
+            print(f"  {tok_label!r:<12} [avg] → {row(w_g, top5_abs, m)}")
+            # per-head
+            for h in range(H):
+                w_h = s[qi, h]  # [T]
+                top3_rel = np.argsort(w_h)[::-1][:3]
+                top3_abs = top3_rel + offset
+                w_hg = {int(a): float(w_h[r]) for r, a in zip(top3_rel, top3_abs)}
+                print(f"  {'':<12} [h{h:<2}] → {row(w_hg, top3_abs, m)}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--api-base", default="http://127.0.0.1:8000/v1")
+    p.add_argument("--api-key", default="EMPTY")
+    p.add_argument("--example", choices=["needle", "codename"], default="needle")
+    p.add_argument("--layers", default=None)
+    args = p.parse_args()
+    fn = main if args.example == "needle" else example_codename_retrieval
+    fn(
+        api_base=args.api_base,
+        api_key=args.api_key,
+        **({"layers": args.layers} if args.layers else {}),
+    )

--- a/tools/pre_commit/check_forbidden_imports.py
+++ b/tools/pre_commit/check_forbidden_imports.py
@@ -37,6 +37,7 @@ CHECK_IMPORTS = {
             "vllm/distributed/device_communicators/all_reduce_utils.py",
             "vllm/distributed/device_communicators/shm_broadcast.py",
             "vllm/distributed/device_communicators/shm_object_storage.py",
+            "vllm/model_executor/layers/attention/attn_capture.py",
             "vllm/utils/hashing.py",
             "tests/multimodal/media/test_base.py",
             "tests/tokenizers_/test_hf.py",

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -75,6 +75,10 @@ class CacheConfig:
     `ModelConfig` and that value should be manually duplicated here."""
     enable_prefix_caching: bool = True
     """Whether to enable prefix caching."""
+    enable_attention_instrumentation: bool = False
+    """Whether to enable attention instrumentation."""
+    attention_instrumentation_layers: str | None = None
+    """Attention instrumentation layer indices (e.g., '0,5,11' or 'all')."""
     prefix_caching_hash_algo: PrefixCachingHashAlgo = "sha256"
     """Set the hash algorithm for prefix caching:\n
     - "sha256" uses Pickle for object serialization before hashing. This is the

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -433,6 +433,8 @@ class EngineArgs:
     )
     block_size: BlockSize = CacheConfig.block_size
     enable_prefix_caching: bool | None = None
+    enable_attention_instrumentation: bool = False
+    attention_instrumentation_layers: str | None = None
     prefix_caching_hash_algo: PrefixCachingHashAlgo = (
         CacheConfig.prefix_caching_hash_algo
     )
@@ -944,6 +946,14 @@ class EngineArgs:
                 **cache_kwargs["enable_prefix_caching"],
                 "default": None,
             },
+        )
+        cache_group.add_argument(
+            "--enable-attention-instrumentation",
+            **cache_kwargs["enable_attention_instrumentation"],
+        )
+        cache_group.add_argument(
+            "--attention-instrumentation-layers",
+            **cache_kwargs["attention_instrumentation_layers"],
         )
         cache_group.add_argument(
             "--prefix-caching-hash-algo", **cache_kwargs["prefix_caching_hash_algo"]
@@ -1465,6 +1475,8 @@ class EngineArgs:
             num_gpu_blocks_override=self.num_gpu_blocks_override,
             sliding_window=sliding_window,
             enable_prefix_caching=self.enable_prefix_caching,
+            enable_attention_instrumentation=self.enable_attention_instrumentation,
+            attention_instrumentation_layers=self.attention_instrumentation_layers,
             prefix_caching_hash_algo=self.prefix_caching_hash_algo,
             cpu_offload_gb=self.cpu_offload_gb,
             cpu_offload_params=self.cpu_offload_params,

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -109,6 +109,9 @@ class ChatCompletionResponse(OpenAIBaseModel):
     kv_transfer_params: dict[str, Any] | None = Field(
         default=None, description="KVTransfer parameters."
     )
+    attn_capture_data: list[dict[str, Any]] | None = Field(
+        default=None, description="Captured attention scores (one per layer)"
+    )
 
 
 class ChatCompletionResponseStreamChoice(OpenAIBaseModel):
@@ -328,6 +331,14 @@ class ChatCompletionRequest(OpenAIBaseModel):
         description="KVTransfer parameters used for disaggregated serving.",
     )
 
+    attn_capture: int | None = Field(
+        default=None, description="Enable attention capture (1=enable, 0=disable)"
+    )
+    attn_capture_layers: str | None = Field(
+        default=None,
+        description="Comma-separated layer indices to capture (e.g., '0,5,11')",
+    )
+
     vllm_xargs: dict[str, str | int | float | list[str | int | float]] | None = Field(
         default=None,
         description=(
@@ -470,6 +481,10 @@ class ChatCompletionRequest(OpenAIBaseModel):
         if self.kv_transfer_params:
             # Pass in kv_transfer_params via extra_args
             extra_args["kv_transfer_params"] = self.kv_transfer_params
+        if self.attn_capture is not None:
+            extra_args["attn_capture"] = str(self.attn_capture)
+        if self.attn_capture_layers is not None:
+            extra_args["attn_capture_layers"] = self.attn_capture_layers
         return SamplingParams.from_optional(
             n=self.n,
             presence_penalty=self.presence_penalty,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1733,6 +1733,7 @@ class OpenAIServingChat(OpenAIServing):
                 final_res.prompt_token_ids if request.return_token_ids else None
             ),
             kv_transfer_params=final_res.kv_transfer_params,
+            attn_capture_data=final_res.attn_capture_data,
         )
 
         # Log complete response if output logging is enabled

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -256,6 +256,9 @@ class Attention(nn.Module, AttentionLayerBase):
         self.sliding_window = sliding_window
         self.has_sink = extra_impl_args.get("sinks") is not None
 
+        # NOTE(jehyun): Passing on capture instance for each layer
+        self.attn_capture = None
+
         # NOTE: model_config may be None during certain tests
         model_config = vllm_config.model_config
         self.use_mm_prefix = model_config is not None and model_config.is_mm_prefix_lm
@@ -692,6 +695,19 @@ def unified_attention_with_output(
     # attention forward.
     del kv_cache_dummy_dep
     attn_metadata, self, kv_cache = get_attention_context(layer_name)
+
+    # NOTE(jehyun): Buffer Q for post-hoc attention capture
+    from vllm.model_executor.layers.attention.attn_capture import get_attn_capture
+
+    capture = get_attn_capture()
+
+    if capture and capture.config.enabled and capture.runtime_enabled_this_step:
+        capture.buffer_query(
+            query=query,
+            key=key,
+            attn_metadata=attn_metadata,
+            layer_name=layer_name,
+        )
 
     self.impl.forward(
         self,

--- a/vllm/model_executor/layers/attention/attn_capture.py
+++ b/vllm/model_executor/layers/attention/attn_capture.py
@@ -1,0 +1,604 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Post-hoc Attention Capture for vLLM
+
+Captures and analyzes attention patterns after request completion
+with minimal overhead. Attention scores (Q*K) are computed
+on the GPU at request-free time with query buffers and delivered via shared memory.
+
+Module-level functions handle stateless operations (encoding, slot
+math, attention computation). The AttentionCapture class manages
+only per-worker mutable state (Q buffer, capture slots).
+"""
+
+import base64
+import contextlib
+import gzip
+import logging
+import pickle
+import struct
+import time
+from bisect import bisect_left
+from dataclasses import dataclass
+from multiprocessing import shared_memory
+from typing import Any, Optional
+
+import regex as re
+import torch
+
+logger = logging.getLogger(__name__)
+
+_LAYER_PATTERNS = [
+    re.compile(r"(?:^|\.)(?:layers)\.(\d+)(?:\.|$)"),
+    re.compile(r"(?:^|\.)(?:h)\.(\d+)(?:\.|$)"),
+    re.compile(r"(?:^|\.)(?:blocks)\.(\d+)(?:\.|$)"),
+    re.compile(r"(?:^|\.)(?:decoder\.layers)\.(\d+)(?:\.|$)"),
+    re.compile(r"(?:^|\.)(?:model\.layers)\.(\d+)(?:\.|$)"),
+    re.compile(r"(?:^|\.)(?:transformer\.h)\.(\d+)(?:\.|$)"),
+]
+
+_attn_capture: Optional["AttentionCapture"] = None
+
+
+def set_attn_capture(instance: Optional["AttentionCapture"]) -> None:
+    """Set the global AttentionCapture instance."""
+    global _attn_capture
+    _attn_capture = instance
+
+
+def get_attn_capture() -> Optional["AttentionCapture"]:
+    """Get the global AttentionCapture instance."""
+    return _attn_capture
+
+
+def load_attn_snapshot(req_id: str) -> list[dict[str, Any]] | None:
+    """Load attention snapshot(s) via shared memory (cross-process)."""
+    return _shm_read(req_id, timeout=30.0)
+
+
+@dataclass
+class CaptureConfig:
+    """Configuration for attention capture."""
+
+    enabled: bool = False
+    layers: set[int] | None = None
+
+
+class AttentionCapture:
+    """Per-worker attention capture state.
+
+    Instantiated once per ModelRunner. Buffers Q vectors during inference
+    and computes attention scores at request completion time.
+    """
+
+    def __init__(self, config: CaptureConfig, model_config=None):
+        self.config = config
+        self.model_config = model_config
+        # Ephemeral: (layer_idx, slot_id) -> Q tensor, cleared after capture().
+        self.q_buffer: dict[tuple[int, int], torch.Tensor] = {}
+        # Persistent across requests while KV slot lives.
+        # Allows full [T,H,T] capture with prefix caching (cache hits reuse initial Q).
+        # FIFO-capped by _q_cache_max to limit memory.
+        self.q_cache: dict[tuple[int, int], torch.Tensor] = {}
+        self._q_cache_max: int = 32768  # ~128MB at float16 128d 16h
+        self._layer_idx_cache: dict[str, int] = {}
+        self.runtime_enabled_this_step = False
+        self.capture_slots: set[int] | None = None
+
+    def buffer_query(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        attn_metadata,
+        layer_name: str,
+    ) -> None:
+        """
+        Buffer Q tokens at attention-computation time.
+        K is NOT buffered — it is read from KV cache at capture time
+        (request completion).
+        """
+        if not self.config.enabled or attn_metadata is None:
+            return
+
+        layer_idx = self.extract_layer_idx(layer_name)
+        if layer_idx < 0:
+            return
+
+        # Extract slot_ids using attn_metadata from the gpu_model_runner process
+        slot_ids = attn_metadata.slot_mapping
+        if query.shape[0] != slot_ids.shape[0]:
+            return
+
+        # Detaching the query tensor for buffering. Severing CUDA computation trace
+        # Query tensor stays in the dict for all requests
+        try:
+            query_cpu = query.detach().cpu().clone()
+        except Exception:
+            return  # This error may occur due to gpu memory access issues
+
+        capture_slots = self.capture_slots
+        for i in range(query.shape[0]):
+            slot_id = slot_ids[i].item()
+
+            # Buffer queries for only set requests at _update_attn_capture_slots()
+            if slot_id < 0 or (capture_slots and slot_id not in capture_slots):
+                continue
+
+            # cast to float16 for uniform buffer dtype; no-op if already float16
+            self.q_buffer[(layer_idx, slot_id)] = query_cpu[i].to(torch.float16)
+
+    def capture(
+        self,
+        req_state,
+        block_size: int,
+        kv_caches: list,
+        prefix: str | None = None,
+    ) -> None:
+        """Capture attention scores for a completed request.
+
+        Called after request completion. Computes Q*K attention on GPU
+        and writes results to shared memory.
+        """
+        req_id = req_state.req_id
+        layers = resolve_target_layers(req_state, self.config.layers)
+        snapshots: list[dict] = []
+
+        for layer_idx in layers:
+            # Collect slots that have Q in either the ephemeral buffer or
+            # the persistent q_cache (for prefix-cached tokens).
+            buf_slots = [sid for (li, sid) in self.q_buffer if li == layer_idx]
+            cached_slots = [sid for (li, sid) in self.q_cache if li == layer_idx]
+            q_slots = set(buf_slots) | set(cached_slots)
+            if not q_slots or not req_state.block_ids:
+                continue
+            # Find which block group contains buffered slots for this layer
+            grp_idx = None
+            for gi, block_list in enumerate(req_state.block_ids):
+                if not block_list:
+                    continue
+                if q_slots & slots_from_blocks(block_list, block_size):
+                    grp_idx = gi
+                    break
+            if grp_idx is None:
+                continue
+
+            # From the current request block group,
+            # order the slot_ids for alignment with QK^T and deduplication.
+            slots = ordered_slots_for_group(
+                req_state.block_ids[grp_idx], req_state.num_tokens, block_size
+            )
+            if not slots:
+                continue
+            # Collect Q tensors from buffer (falling back to q_cache for
+            # prefix-cached tokens that were not re-computed this request).
+            q_list, q_sids, tok_idx = self._collect_query(layer_idx, slots)
+            if not q_list:
+                continue
+
+            # Persist Q vectors so future requests can reuse them on cache hit.
+            # Evict oldest entries if cap is reached (simple FIFO approximation).
+            for sid, q in zip(q_sids, q_list):
+                if len(self.q_cache) >= self._q_cache_max:
+                    self.q_cache.pop(next(iter(self.q_cache)))
+                self.q_cache[(layer_idx, sid)] = q
+
+            # NOTE(jehyun): This class receives the KV Cache from the worker.
+            # Reads the KV Cache right after the request is finished
+            # before the KV cache is freed.
+            # Extract K for ALL slots (not just q_sids) so the key axis covers
+            # the full sequence, including prefix-cached tokens.
+            kv_idx = layer_idx if layer_idx < len(kv_caches) else grp_idx
+            if not kv_caches or kv_idx is None or kv_idx >= len(kv_caches):
+                continue
+            k_raw = extract_k_from_kv_cache(kv_caches[kv_idx], slots)
+            k_list = [k_raw[i] for i in range(k_raw.shape[0])]
+            if not k_list:
+                continue
+
+            # Build tok_idx covering all slots; q_list entries map to q_sids
+            # positions within the full slot list for the QK^T alignment.
+            sid_to_pos = {sid: pos for pos, sid in enumerate(slots)}
+            q_tok_idx = [sid_to_pos[sid] for sid in q_sids]
+
+            # Checking for alignment before QK Calculation for safety issues
+            q_tok_idx, q_list, _ = self._filter_compatible_qk(
+                q_tok_idx, q_list, [k_list[i] for i in q_tok_idx]
+            )
+            if not q_list:
+                continue
+            tok_idx = q_tok_idx
+
+            # Trim K to the same token positions as Q so shapes always match.
+            k_list = [k_list[i] for i in q_tok_idx]
+            # Compute Q*K^T: Q=[T, H, d], K=[T, H, d] → [T, H, T]
+            q_t, k_t = torch.stack(q_list), torch.stack(k_list)
+            if k_t.is_cuda and not q_t.is_cuda:
+                q_t = q_t.to(k_t.device)
+            scale = 1.0 / (q_t.shape[2] ** 0.5)
+            attn = compute_qk_attention(q_t, k_t, scale)
+            if attn is None:
+                continue
+
+            # Apply prefix slice
+            if prefix:
+                parts = prefix.split(":")
+                q_start = int(parts[0]) if parts[0] else 0
+                q_end = int(parts[1]) if len(parts) > 1 and parts[1] else None
+                attn = attn[q_start:q_end, :, :]
+                tok_idx = tok_idx[q_start:q_end]
+
+            # Create meta_data for tokens, later used by clients for 1:1 matching
+            # between attn_scores and token_idx
+            tmeta = build_token_meta(req_state, tok_idx, ordered_slots_len=len(slots))
+            snapshots.append(encode_snapshot(attn, layer_idx, tmeta))
+
+            # Remove processed slots from q_buffer to prevent
+            # cross-request contamination.
+            for sid in set(slots):
+                self.q_buffer.pop((layer_idx, sid), None)
+
+        # NOTE(jehyun): Write snapshots to shared memory for cross-process delivery.
+        # The output_processor (main process) reads them via _shm_read().
+        if snapshots:
+            _shm_write(req_id, snapshots)
+
+    def cleanup_request_buffers(
+        self,
+        block_ids: list[list[int]],
+        block_size: int,
+    ) -> None:
+        """
+        Remove buffered Q vectors for a finished request.
+        Called for ALL requests to prevent stale data leaking into future requests.
+        q_cache is evicted only when the underlying KV block is reclaimed.
+        """
+        if not block_ids:
+            return
+        remove: set[int] = set()
+        for block_list in block_ids:
+            remove |= slots_from_blocks(block_list, block_size)
+        if self.q_buffer:
+            for k in [k for k in self.q_buffer if k[1] in remove]:
+                del self.q_buffer[k]
+
+    def extract_layer_idx(self, layer_name: str) -> int:
+        """Parse layer index from attention layer name, with caching."""
+        v = self._layer_idx_cache.get(layer_name)
+        if v is not None:
+            return v
+
+        for pat in _LAYER_PATTERNS:
+            m = pat.search(layer_name)
+            if not m:
+                continue
+            idx = int(m.group(1))
+            self._layer_idx_cache[layer_name] = idx
+            return idx
+
+        self._layer_idx_cache[layer_name] = -1
+        return -1
+
+    def _collect_query(
+        self,
+        layer_idx: int,
+        slots: list[int],
+    ) -> tuple[list[torch.Tensor], list[int], list[int]]:
+        """
+        Collect Q tensors from buffer in deterministic slot order.
+        Falls back to q_cache for prefix-cached tokens whose Q was not
+        re-computed this request (prefix caching ON).
+        Returns (q_list, q_slot_ids, tok_idx).
+        """
+        q_list, q_sids, tok_idx = [], [], []
+        for si, sid in enumerate(slots):
+            key = (layer_idx, sid)
+            q = self.q_buffer.get(key)
+            if q is None:
+                q = self.q_cache.get(key)
+            if q is None:
+                continue
+            q_list.append(q)
+            q_sids.append(sid)
+            tok_idx.append(si)
+        return q_list, q_sids, tok_idx
+
+    @staticmethod
+    def _filter_compatible_qk(
+        tok_idx: list[int],
+        q_list: list[torch.Tensor],
+        k_list: list[torch.Tensor],
+    ) -> tuple[list[int], list[torch.Tensor], list[torch.Tensor]]:
+        """Filter Q/K pairs to those with matching shape and device."""
+        if not q_list or not k_list:
+            return [], [], []
+        q0, k0 = q_list[0], k_list[0]
+        triples = [
+            (idx, q, k)
+            for idx, q, k in zip(tok_idx, q_list, k_list)
+            if _sanity_check(q, q0) and _sanity_check(k, k0)
+        ]
+        if not triples:
+            return [], [], []
+        return (
+            [t[0] for t in triples],
+            [t[1] for t in triples],
+            [t[2] for t in triples],
+        )
+
+
+def slots_from_blocks(block_list: list[int], block_size: int) -> set[int]:
+    """Return the set of all slot IDs covered by the given blocks."""
+    slots: set[int] = set()
+    for bid in block_list:
+        base = bid * block_size
+        for off in range(block_size):
+            slots.add(base + off)
+    return slots
+
+
+def ordered_slots_for_group(
+    block_list: list[int],
+    num_tokens: int,
+    block_size: int,
+) -> list[int]:
+    """Build deduplicated, token-order slot list from a block group."""
+    ordered: list[int] = []
+    seen: set[int] = set()
+    cursor = 0
+    for block_id in block_list:
+        if cursor >= num_tokens:
+            break
+        base = block_id * block_size
+        count = min(block_size, num_tokens - cursor)
+        for off in range(count):
+            slot_id = base + off
+            if slot_id not in seen:
+                ordered.append(slot_id)
+                seen.add(slot_id)
+        cursor += count
+    return ordered
+
+
+def resolve_target_layers(
+    req_state,
+    default_layers: set[int] | None,
+) -> set[int]:
+    """Determine target layers: per-request override or server default."""
+    target = default_layers or set()
+    if req_state.sampling_params and req_state.sampling_params.extra_args:
+        layers_str = req_state.sampling_params.extra_args.get("attn_capture_layers")
+        if layers_str and layers_str.strip().lower() != "all":
+            target = {int(x.strip()) for x in layers_str.split(",")}
+    return target
+
+
+def extract_k_from_kv_cache(
+    kv_cache: torch.Tensor,
+    slot_ids: list[int],
+    dtype: torch.dtype = torch.float16,
+) -> torch.Tensor:
+    """
+    Extract K(key) vectors from paged KV cache at given slot positions.
+
+    Backend-agnostic: auto-detects layout from tensor shape.
+      - FlashInfer:    [num_blocks, 2, page_size, num_kv_heads, head_dim]
+      - FlashAttention:[2, num_blocks, page_size, num_kv_heads, head_dim]
+    Returns: Tensor of shape [len(slot_ids), num_kv_heads, head_dim]
+    """
+    shape = kv_cache.shape
+    slot_tensor = torch.tensor(slot_ids, dtype=torch.long, device=kv_cache.device)
+
+    if kv_cache.ndim == 5 and shape[0] == 2:
+        page_size, num_slots = shape[2], shape[1] * shape[2]
+        k_flat = kv_cache[0].reshape(num_slots, -1)
+        k = k_flat[slot_tensor].view(len(slot_ids), shape[3], shape[4])
+    elif kv_cache.ndim == 5 and shape[1] == 2:
+        page_size = shape[2]
+        page_indices = slot_tensor // page_size
+        page_offsets = slot_tensor % page_size
+        k = kv_cache[page_indices, 0, page_offsets]
+    elif kv_cache.ndim == 3 and shape[0] == 2:
+        k = kv_cache[0, slot_tensor]
+    else:
+        raise ValueError(
+            f"Unsupported KV cache layout: ndim={kv_cache.ndim} shape={list(shape)}"
+        )
+
+    return k.to(dtype)  # NOTE(jehyun): Uniform dtype for downstream float16 computation
+
+
+def compute_qk_attention(
+    q_tensor: torch.Tensor,
+    k_tensor: torch.Tensor,
+    scale: float,
+) -> torch.Tensor | None:
+    """
+    Compute scaled dot-product attention probabilities.
+    Handles GQA by expanding K heads to match Q heads.
+    Args:
+        q_tensor: [T, num_q_heads, head_dim]
+        k_tensor: [T, num_kv_heads, head_dim]
+        scale: 1/sqrt(head_dim)
+    Returns: [T, num_q_heads, T] attention probabilities, or None on mismatch.
+    """
+    q = q_tensor.transpose(0, 1)  # [hq, T, d]
+    k = k_tensor.transpose(0, 1)  # [hk, T, d]
+    hq, Tq, d = q.shape
+    hk, Tk, dk = k.shape
+    if d != dk:
+        return None
+
+    if hk == hq:
+        k_m = k
+    else:
+        # GQA/MQA: repeat each KV head to cover the corresponding Q heads
+        k_m = (
+            k.repeat_interleave(hq // hk, dim=0)
+            if hq % hk == 0
+            else k.index_select(
+                0,
+                torch.clamp(
+                    torch.floor(torch.arange(hq, device=k.device) * (hk / hq)).long(),
+                    0,
+                    hk - 1,
+                ),
+            )
+        )
+
+    scores = torch.bmm(q, k_m.transpose(-2, -1)) * scale  # [hq, T, T]
+    causal_mask = torch.ones(Tq, Tk, device=scores.device, dtype=torch.bool).tril()
+    scores = scores.masked_fill(~causal_mask, float("-inf"))
+    probs = torch.softmax(scores, dim=-1)
+    return probs.transpose(0, 1)  # [T, hq, T]
+
+
+def build_token_meta(
+    req_state,
+    token_idx: list[int],
+    *,
+    ordered_slots_len: int | None = None,
+) -> dict[str, Any]:
+    """Build token mapping metadata for post-hoc client-side alignment."""
+    prompt_len = int(getattr(req_state, "num_prompt_tokens", 0) or 0)
+    # num_tokens already includes the token sampled in the *current* step
+    # (appended before _update_states runs), so subtract 1 to get the actual
+    # sequence length seen by the attention kernel.
+    total_len = int(getattr(req_state, "num_tokens", prompt_len) or prompt_len) - 1
+    if prompt_len > total_len:
+        prompt_len = total_len
+
+    # Extract multi-modal offsets with (s1,e1),(s2,e2),(s3,e3)...
+    raw_vision: list[dict[str, int]] = []
+    mm_features = getattr(req_state, "mm_features", None) or []
+    for feature in mm_features:
+        pos = getattr(feature, "mm_position", None)
+        if pos is None:
+            continue
+        start = int(getattr(pos, "offset", 0) or 0)
+        length = int(getattr(pos, "length", 0) or 0)
+        end = start + max(length, 0)
+        if end <= 0 or start >= prompt_len:
+            continue
+        start, end = max(0, start), min(prompt_len, end)
+        if start < end:
+            raw_vision.append({"start": start, "end": end})
+
+    # Sort and merge overlapping vision ranges
+    raw_vision.sort(key=lambda r: (r["start"], r["end"]))
+    vision_ranges: list[dict[str, int]] = []
+    for r in raw_vision:
+        if not vision_ranges or r["start"] > vision_ranges[-1]["end"]:
+            vision_ranges.append(dict(r))
+        else:
+            vision_ranges[-1]["end"] = max(vision_ranges[-1]["end"], r["end"])
+
+    # Complement: language ranges fill the gaps between vision ranges.
+    # prompt: [-- lang0 --][-- vis0 --][-- lang1 --][-- vis1 --] ...
+    #                      ^           ^
+    #             l.end == v.start   v.end == l.start
+    lang_ranges: list[dict[str, int]] = []
+    cursor = 0
+    for r in vision_ranges:
+        if cursor < r["start"]:
+            lang_ranges.append({"start": cursor, "end": r["start"]})
+        cursor = max(cursor, r["end"])
+    if cursor < prompt_len:
+        lang_ranges.append({"start": cursor, "end": prompt_len})
+
+    ordered_len = int(
+        ordered_slots_len if ordered_slots_len is not None else len(token_idx)
+    )
+    window_offset = int(total_len - ordered_len)
+
+    # Calculate prompt boundaries and prompt offsets.
+    pb_local = bisect_left(token_idx, prompt_len) if token_idx else None
+    idx_shifted = [int(i) + window_offset for i in token_idx]
+    pb_offset = bisect_left(idx_shifted, prompt_len) if idx_shifted else None
+
+    return {
+        "token_idx": [int(i) for i in token_idx],
+        "prompt_len": prompt_len,
+        "total_len": total_len,
+        "vision_ranges": vision_ranges,
+        "lang_ranges": lang_ranges,
+        "token_idx_basis": "window_local",
+        "win_offset": window_offset,
+        "pb_local": pb_local,
+        "pb_offset": pb_offset,
+    }
+
+
+def encode_snapshot(
+    attn: torch.Tensor,
+    layer_idx: int,
+    token_meta: dict[str, Any],
+) -> dict[str, Any]:
+    """Encode attention tensor to gzip+base64 wire format."""
+    attn = attn.cpu()
+    compressed = gzip.compress(attn.numpy().tobytes())
+    return {
+        "data": base64.b64encode(compressed).decode("utf-8"),
+        "shape": list(attn.shape),
+        "dtype": str(attn.dtype),
+        "layer_idx": layer_idx,
+        "token_meta": token_meta,
+    }
+
+
+def _shm_name(req_id: str) -> str:
+    """Deterministic shared-memory segment name from request ID."""
+    return "/vkv_" + req_id.replace("-", "")[:40]
+
+
+def _shm_write(req_id: str, snapshots: list[dict]) -> None:
+    """
+    Write snapshot list to a named shared-memory segment.
+    Protocol: size header is written LAST so readers treat size==0
+    as "write in progress" and keep polling.
+    """
+    payload = pickle.dumps(snapshots)
+    size, name = len(payload), _shm_name(req_id)
+    with contextlib.suppress(FileNotFoundError):
+        stale = shared_memory.SharedMemory(name=name, create=False)
+        stale.close()
+        stale.unlink()
+    mem = shared_memory.SharedMemory(name=name, create=True, size=8 + size)
+    mem.buf[8 : 8 + size] = payload
+    struct.pack_into("Q", mem.buf, 0, size)  # size LAST (ready signal)
+    mem.close()
+
+
+def _sanity_check(t: torch.Tensor, ref: torch.Tensor) -> bool:
+    return (
+        isinstance(t, torch.Tensor) and t.shape == ref.shape and t.device == ref.device
+    )
+
+
+def _shm_read(req_id: str, timeout: float = 5.0) -> list[dict] | None:
+    """Read snapshot list from shared-memory, polling until available."""
+    name, deadline = _shm_name(req_id), time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            mem = shared_memory.SharedMemory(name=name, create=False)
+        except FileNotFoundError:
+            time.sleep(0.05)
+            continue
+        size = struct.unpack_from("Q", mem.buf, 0)[0]
+        if size == 0:
+            mem.close()
+            time.sleep(0.01)
+            continue
+        try:
+            data = pickle.loads(bytes(mem.buf[8 : 8 + size]))
+        except Exception:
+            mem.close()
+            time.sleep(0.01)
+            continue
+        mem.close()
+        mem.unlink()
+        return data
+    with contextlib.suppress(FileNotFoundError):
+        mem = shared_memory.SharedMemory(name=name, create=False)
+        mem.close()
+        mem.unlink()
+    return None

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -121,6 +121,7 @@ class RequestOutput:
         num_cached_tokens: int | None = None,
         *,
         kv_transfer_params: dict[str, Any] | None = None,
+        attn_capture_data: list[dict[str, Any]] | None = None,
         # Forward compatibility, code that uses args added in new release can
         # still run with older versions of vLLM without breaking.
         **kwargs: Any,
@@ -141,6 +142,7 @@ class RequestOutput:
         self.encoder_prompt_token_ids = encoder_prompt_token_ids
         self.num_cached_tokens = num_cached_tokens
         self.kv_transfer_params = kv_transfer_params
+        self.attn_capture_data = attn_capture_data
 
     def add(self, next_output: "RequestOutput", aggregate: bool) -> None:
         """Merge subsequent RequestOutput into this one"""

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -184,6 +184,7 @@ class RequestState:
         self.input_chunk_queue: deque[StreamingUpdate] | None = (
             deque() if stream_input else None
         )
+        self.attn_capture_enabled: bool = False
 
     def apply_streaming_update(self, update: StreamingUpdate) -> None:
         # Apply the update to the request state.
@@ -360,6 +361,19 @@ class RequestState:
         else:
             prompt_logprobs = self.logprobs_processor.prompt_logprobs
 
+        # If prompt embeds were used, put placeholder prompt token ids
+        prompt_token_ids = self.prompt_token_ids
+        if prompt_token_ids is None and self.prompt_embeds is not None:
+            prompt_token_ids = [0] * len(self.prompt_embeds)
+
+        # Load attention capture data if capture was requested
+        attn_capture_data = None
+        if finished and getattr(self, "attn_capture_enabled", False):
+            from vllm.model_executor.layers.attention.attn_capture import (
+                load_attn_snapshot,
+            )
+
+            attn_capture_data = load_attn_snapshot(self.request_id)
         return RequestOutput(
             request_id=external_req_id,  # request_id is what was provided externally
             lora_request=self.lora_request,
@@ -369,6 +383,7 @@ class RequestState:
             outputs=cast(list[CompletionOutput], outputs),
             finished=finished,
             kv_transfer_params=kv_transfer_params,
+            attn_capture_data=attn_capture_data,
             num_cached_tokens=self.num_cached_tokens,
             metrics=self.stats,
         )
@@ -543,6 +558,11 @@ class OutputProcessor:
         self.request_states[request_id] = req_state
         if parent_req:
             self.parent_requests[parent_req.request_id] = parent_req
+
+        # Track attention capture requests
+        sp = request.sampling_params
+        if sp and sp.extra_args and str(sp.extra_args.get("attn_capture", "0")) == "1":
+            req_state.attn_capture_enabled = True
 
         # Track the external_req_id -> [internal_req_id, ...] mapping
         self.external_req_ids[req_state.external_req_id].append(request_id)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -439,6 +439,9 @@ class GPUModelRunner(
         self.attn_groups: list[list[AttentionGroup]] = []
         # self.kv_cache_config: KVCacheConfig
 
+        # NOTE(jehyun): Per-worker attention capture instance
+        self.attn_capture = None
+
         # mm_hash ->  encoder_output
         self.encoder_cache: dict[str, torch.Tensor] = {}
 
@@ -714,6 +717,27 @@ class GPUModelRunner(
         self.mamba_state_idx: dict[str, int] = {}
         self.layerwise_nvtx_hooks_registered = False
 
+        # NOTE(jehyun): Init attention capture with global setter
+        if self.vllm_config.cache_config.enable_attention_instrumentation:
+            from vllm.model_executor.layers.attention.attn_capture import CaptureConfig
+
+            layers_str = self.vllm_config.cache_config.attention_instrumentation_layers
+
+            hf_config = self.vllm_config.model_config.hf_config
+            num_layers = getattr(
+                hf_config,
+                "num_hidden_layers",
+                getattr(hf_config, "text_config", hf_config).num_hidden_layers,
+            )
+
+            if layers_str and layers_str.lower() != "all":
+                layers = set(int(x.strip()) for x in layers_str.split(","))
+            else:
+                layers = set(range(num_layers))
+
+            config = CaptureConfig(enabled=True, layers=layers)
+            self.init_attn_capture(config)
+
     def update_max_model_len(self, max_model_len: int) -> None:
         self.max_model_len = max_model_len
         if self.speculative_config:
@@ -887,6 +911,9 @@ class GPUModelRunner(
         """
         # Remove finished requests from the cached states.
         for req_id in scheduler_output.finished_req_ids:
+            # NOTE(jehyun): Capture attention before removing request
+            if self.attn_capture and self.attn_capture.config.enabled:
+                self._capture_finished_request(req_id)
             self.requests.pop(req_id, None)
             self.num_prompt_logprobs.pop(req_id, None)
         # Remove the finished requests from the persistent batch.
@@ -3121,8 +3148,8 @@ class GPUModelRunner(
         has_lora = num_active_loras > 0 if force_has_lora is None else force_has_lora
 
         num_tokens_padded = self._pad_for_sequence_parallelism(num_tokens)
-        dispatch_cudagraph = (
-            lambda num_tokens, disable_full: self.cudagraph_dispatcher.dispatch(
+        dispatch_cudagraph = lambda num_tokens, disable_full: (
+            self.cudagraph_dispatcher.dispatch(
                 num_tokens=num_tokens,
                 has_lora=has_lora,
                 uniform_decode=uniform_decode,
@@ -3343,6 +3370,10 @@ class GPUModelRunner(
         ):
             # Update persistent batch states.
             self._update_states(scheduler_output)
+
+            # NOTE(jehyun): Capturing attentions for requested queries
+            if self.attn_capture:
+                self._update_attn_capture_slots()
 
             if has_ec_transfer() and get_ec_transfer().is_producer:
                 with self.maybe_get_ec_connector_output(
@@ -6263,6 +6294,62 @@ class GPUModelRunner(
                     stats = self.encoder_timing_registry[req_id]
                     stats.encoder_forward_time += per_request_time
                     stats.num_encoder_calls += 1
+
+    def init_attn_capture(self, config) -> None:
+        """Initialize attention capture for instrumentation."""
+        from vllm.model_executor.layers.attention.attn_capture import (
+            AttentionCapture,
+            set_attn_capture,
+        )
+
+        self.attn_capture = AttentionCapture(config)
+        set_attn_capture(self.attn_capture)
+
+    def _update_attn_capture_slots(self) -> None:
+        """Update capture_slots to the union of slots for all capture-enabled
+        requests in the current batch. Called once per execute step."""
+        from vllm.model_executor.layers.attention.attn_capture import slots_from_blocks
+
+        block_size = self.cache_config.block_size
+        capture_slots: set[int] | None = None
+        for req_id in self.input_batch.req_ids:
+            req_state = self.requests.get(req_id)
+            if not req_state:
+                continue
+            extra_args = getattr(req_state.sampling_params, "extra_args", None) or {}
+            if str(extra_args.get("attn_capture", "0")) != "1":
+                continue
+            if capture_slots is None:
+                capture_slots = set()
+            for block_list in req_state.block_ids:
+                capture_slots.update(slots_from_blocks(block_list, block_size))
+
+        assert self.attn_capture is not None
+        self.attn_capture.runtime_enabled_this_step = capture_slots is not None
+        self.attn_capture.capture_slots = capture_slots
+
+    def _capture_finished_request(self, req_id: str) -> None:
+        """Capture attention and clean up buffers for a finished request."""
+        req_state = self.requests.get(req_id)
+        if not req_state:
+            return
+        extra_args = getattr(req_state.sampling_params, "extra_args", None) or {}
+        assert self.attn_capture is not None
+        if str(extra_args.get("attn_capture", "0")) == "1":
+            try:
+                self.attn_capture.capture(
+                    req_state=req_state,
+                    block_size=self.cache_config.block_size,
+                    kv_caches=self.kv_caches,
+                    prefix=extra_args.get("attn_capture_prefix"),
+                )
+            except Exception:
+                logger.warning(
+                    "Capturing attention failed for %s", req_id, exc_info=True
+                )
+        self.attn_capture.cleanup_request_buffers(
+            req_state.block_ids, self.cache_config.block_size
+        )
 
 
 @dataclass


### PR DESCRIPTION
Closes #11365

## Motivation

Interpretability researchers and multimodal debugging workflows need access to raw attention scores at inference time without patching model code or writing custom inference loops.

This PR exposes per-request attention instrumentation through the existing OpenAI-compatible API. When not requested, there is zero additional compute cost — no forward-pass modification, no graph break, no torch.compile impact.

---

## What This PR Does

Adds an opt-in, per-request attention capture mechanism to vLLM's OpenAI API server. When the server is started with instrumentation enabled and a client explicitly requests capture, Q×Kᵀ softmax attention scores are computed
post-forward, serialised via shared memory, and attached to the chat completion response.

---

## New Server Flags

```bash
--enable-attention-instrumentation        # Enable feature (disabled by default)
--attention-instrumentation-layers all   # Default capture layer set (overridable per-request)
```

---

## New Request Fields (Chat Completions)

| Field | Type | Description |
|-------|------|-------------|
| `attn_capture` | `int` (0/1) | Enable capture for this request |
| `attn_capture_layers` | `str` | Comma-separated layer indices or `"all"` |

---

## New Response Field

`attn_capture_data` — list of per-layer objects:

```json
[
  {
    "layer_idx": 8,
    "data": "<base64-gzipped tensor>",
    "shape": [T, H, T],
    "dtype": "float16",
    "token_meta": {
      "token_idx_basis": 0,
      "prompt_len": 42,
      "total_len": 50,
      "vision_ranges": [[0, 35]]
    }
  }
]
```

Shape is `[T, H, T]` where `T` = `prompt_len + generated_len - 1` (all tokens visible to the attention kernel — the final sampled token has no subsequent Q step). `H` = query heads.

`token_meta.vision_ranges` maps image token spans for cross-modal analysis.

---

## Design Notes

**Why post-forward computation?**
- Scores are computed after the forward pass completes, leaving model kernels and the attention backend entirely unmodified. No graph break or `torch.compile` side effect is introduced.

**Why Q buffering?**
- Q tensors are captured per-slot during the forward pass and stored in a per-worker buffer. After the request finishes, <br/>K is read from the KV cache and Q×Kᵀ is computed once. This avoids any impact on the hot path.

**Prefix caching interaction**
- When prefix caching is active, prompt tokens are cache-hit and their Q vectors are not recomputed. A persistent `q_cache` (FIFO-capped at 32 768 slots, ~128 MB at float16/128d/16h) stores Q vectors across requests so prefix-cached tokens are still included in the captured score matrix.

**Why shared memory?**
- Attention tensors can be large. Shared memory avoids copying them through the engine's RPC transport layer. <br/>Each snapshot is keyed by `request_id` and cleaned up immediately after the output processor reads it.

**Concurrency and isolation**
- Each request uses its own shared-memory segment named by `request_id`, so concurrent requests are fully isolated. Segments are unlinked after reading; a 30-second read timeout is used to handle slow capture paths gracefully. <br/>If the engine crashes before writing, the segment simply times out and `attn_capture_data` is absent from the response (no server crash).

**Streaming compatibility**
- Attention scores are only available in non-streaming responses (`stream=False`). Streaming responses do not include `attn_capture_data` because the snapshot is only available after the full sequence is generated.

---

## Memory Impact

Per captured request (non-streaming only):

| T (seq len) | H (query heads) | Size (float16) |
|---|---|---|
| 512 | 16 | ~8 MB |
| 2 048 | 16 | ~128 MB |
| 4 096 | 32 | ~1 GB |

Tensors are gzip-compressed before serialisation, typically achieving 3–5×
reduction. The persistent Q cache is FIFO-capped at 32 768 slots (~128 MB
worst-case) to bound memory growth across requests.

Capture is disabled by default. No automatic hard cap on response size is
enforced — for very long sequences, callers are expected to limit scope via
`attn_capture_layers`.

---

## Implementation

| Component | Change |
|------------|--------|
| `attn_capture.py` (new, ~600 LOC) | Q buffering, Q×Kᵀ computation, GQA/MQA support, shared-memory IPC |
| `gpu_model_runner.py` | Hook into forward pass; call `capture()` post-request |
| `attention.py` | Buffer Q tensor to capture hook |
| `output_processor.py` | Load snapshot from shared memory and attach to `RequestOutput` |
| `protocol.py` | Add new request/response fields |
| `arg_utils.py`, `cache.py` | Add CLI flags and configuration |

`attn_capture.py` core logic is ~350 lines; the remainder is IPC utilities
and validation helpers. Can be split if preferred.

---

## Example Usage

```python
from openai import OpenAI
import json, base64, gzip, numpy as np

client = OpenAI(base_url="http://localhost:8000/v1", api_key="EMPTY")

raw = client.chat.completions.with_raw_response.create(
    model="Qwen/Qwen2.5-VL-3B-Instruct",
    messages=[{"role": "user", "content": "Hello!"}],
    extra_body={"attn_capture": 1, "attn_capture_layers": "8,16"},
)

resp = json.loads(raw.content)

for item in resp["attn_capture_data"]:
    blob = gzip.decompress(base64.b64decode(item["data"]))
    scores = np.frombuffer(blob, dtype=item["dtype"]).reshape(item["shape"])
    print(f"Layer {item['layer_idx']}: shape={scores.shape}")
    # scores: [T, H, T] — rows=query positions, cols=key positions
```

See `examples/offline_inference/attention_instrumentation/` for full examples
including multimodal token classification and cross-modal attention analysis.

---

## Test Results

Tested on **Qwen2.5-VL-3B-Instruct** and **Gemma-3-4B-IT** across 9 input
groups × 6 capture configurations = **54 cases per model, 108 total**.
All 108/108 cases passed.

Test script: [Parkprogrammer/vllm_capture](https://github.com/Parkprogrammer/vllm_capture)

Summary:
- No regression when `attn_capture=0` (instrumentation-enabled server, capture disabled per-request)
- Overhead is a fixed per-request cost; does not scale with sequence length
- Medium/long prompt groups show near-parity with baseline throughput

<details>
<summary>Full per-group breakdown</summary>

Input groups: `text·{short,medium,long}`, `text+image·{short,medium,long}`, `image only·{short,medium,long}`

Capture configs: `off` (attn_capture=0), `early` (layer 2), `mid` (layer 8), `late` (layer 15), `multi` (2,8,15), `all`

### Qwen2.5-VL-3B-Instruct

| Group | Pass | AvgLat | AvgTok/s | Off Tok/s | BaseTok/s | AvgPTok |
|---|---|---|---|---|---|---|
| text · short | 6/6 | 0.69s | 34.9 | 35.9 | 48.0 | 28 |
| text · medium | 6/6 | 1.16s | 41.4 | 51.2 | 50.8 | 76 |
| text · long | 6/6 | 1.19s | 40.4 | 50.3 | 50.0 | 432 |
| text+image · short | 6/6 | 0.94s | 25.6 | 10.8 | 47.1 | 494 |
| text+image · medium | 6/6 | 1.21s | 39.7 | 48.6 | 49.6 | 542 |
| text+image · long | 6/6 | 1.18s | 40.6 | 50.3 | 49.6 | 898 |
| image only · short | 6/6 | 0.81s | 39.7 | 50.1 | 45.4 | 485 |
| image only · medium | 6/6 | 1.18s | 40.8 | 50.1 | 45.7 | 485 |
| image only · long | 6/6 | 1.19s | 40.3 | 48.5 | 47.3 | 485 |

### Gemma-3-4B-IT

| Group | Pass | AvgLat | AvgTok/s | Off Tok/s | BaseTok/s | AvgPTok |
|---|---|---|---|---|---|---|
| text · short | 6/6 | 0.93s | 23.7 | 27.1 | 26.8 | 18 |
| text · medium | 6/6 | 1.89s | 25.4 | 28.6 | 28.7 | 64 |
| text · long | 6/6 | 1.88s | 25.5 | 28.7 | 28.7 | 423 |
| text+image · short | 6/6 | 1.35s | 16.4 | 17.9 | 17.6 | 278 |
| text+image · medium | 6/6 | 2.73s | 17.6 | 18.8 | 19.0 | 324 |
| text+image · long | 6/6 | 2.77s | 17.4 | 18.7 | 18.8 | 683 |
| image only · short | 6/6 | 1.86s | 17.2 | 18.9 | 18.7 | 268 |
| image only · medium | 6/6 | 2.77s | 17.3 | 18.1 | 19.0 | 268 |
| image only · long | 6/6 | 2.78s | 17.3 | 18.7 | 18.7 | 268 |

Column legend:
- **AvgTok/s**: mean tok/s across all 6 capture configs including `all`
- **Off Tok/s**: `attn_capture=0` on instrumentation-enabled server
- **BaseTok/s**: plain vLLM server with no `--enable-attention-instrumentation` flag (2 warm-up requests; indicative, single GPU)

</details>