### PR TITLE
Add env variable VLLM_DISABLE_FLASHINFER_CONCAT_MLA_K to disable FlashInfer concat_mla_k

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -188,6 +188,7 @@ return curr_o @ W_O
 """
 
 import functools
+import os
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
@@ -1971,6 +1972,7 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         # num_heads=128, nope_dim=128, rope_dim=64
         self._use_flashinfer_concat_mla_k = (
             has_flashinfer()
+            and os.environ.get("VLLM_DISABLE_FLASHINFER_CONCAT_MLA_K", "0") != "1"
             and (self.num_heads == 128)
             and (self.qk_nope_head_dim == 128)
             and (self.qk_rope_head_dim == 64)


### PR DESCRIPTION
Summary:
Add an environment variable check to allow disabling the FlashInfer
concat_mla_k kernel optimization. Setting VLLM_DISABLE_FLASHINFER_CONCAT_MLA_K=1
will bypass this optimization, which is useful for debugging or when replaying
components on CUDA where FlashInfer may not work correctly.

Test Plan: VLLM_DISABLE_FLASHINFER_CONCAT_MLA_K=1 buck2 run //vllm:test_mla_attention

Differential Revision: D93967992


