### PR TITLE
Add support for DeepSeek Attention replay on CUDA

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -188,6 +188,7 @@ return curr_o @ W_O
 """
 
 import functools
+import os
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
@@ -1971,6 +1972,7 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         # num_heads=128, nope_dim=128, rope_dim=64
         self._use_flashinfer_concat_mla_k = (
             has_flashinfer()
+            and os.environ.get("VLLM_DISABLE_FLASHINFER_CONCAT_MLA_K", "0") != "1"
             and (self.num_heads == 128)
             and (self.qk_nope_head_dim == 128)
             and (self.qk_rope_head_dim == 64)


### PR DESCRIPTION
Summary:
1- Add proper quantization config when replay on Cuda
2- Added env variable that can disable flash_infer for TurboMoE on GPU in mla_attention.py
3- Disabled some MTIA specific operations when replaying component on CPU
4- Fixed logging error in weights_utils -- it was causing an OOM
5- Extended debug function to take string and int
6- Added the ability to sync component replay on the same hash when running the compare_component_analysis.sh script

Test Plan:
./vllm/fb/scripts/mtia/compare_component_analysis.sh --manifold-path mtia_training:tree/vllm_intermediates/e365c085-9cb4-4d52-a789-08fd69ca6c37   --athena-name devgpu196.dkl6.facebook.com   --output-dir /tmp/component_comparison   --download-dir /tmp/vllm_intermediates   --module-path vllm.model_executor.models.deepseek_v2   --module-class DeepseekV2MLAAttention   --athena-hash 7191a54fddca2b18694d452cc35a58a3b2172b39 2>&1 | tee output.log


P2193826286

- Runs from H100
- Runs on H100 -- MTIA -- CPU
- Compares results
- Stores in tmp folder

Reviewed By: claudiacdlira

Differential Revision: D93651392


