### PR TITLE
perf(v1): optimize InputBatch.swap_states by swapping active token prefixes

### DIFF
--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -558,7 +558,9 @@ class InputBatch:
         tmp_tokens = self.token_ids_cpu[i1, :len_of_orig_i1].copy()
         tmp_is_token_ids = self.is_token_ids[i1, :len_of_orig_i1].copy()
 
-        self.token_ids_cpu[i1, :len_of_orig_i2] = self.token_ids_cpu[i2, :len_of_orig_i2]
+        self.token_ids_cpu[i1, :len_of_orig_i2] = self.token_ids_cpu[
+            i2, :len_of_orig_i2
+        ]
         self.is_token_ids[i1, :len_of_orig_i2] = self.is_token_ids[i2, :len_of_orig_i2]
         if len_of_orig_i1 > len_of_orig_i2:
             self.is_token_ids[i1, len_of_orig_i2:len_of_orig_i1] = False

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -552,21 +552,21 @@ class InputBatch:
 
         # instead, we need to temporarily copy the data for one of the indices
         # optimize this by only copying valid indices (active token prefix)
-        num_tokens1 = self.num_tokens_no_spec[i1] + len(self.spec_token_ids[i1])
-        num_tokens2 = self.num_tokens_no_spec[i2] + len(self.spec_token_ids[i2])
+        len_of_orig_i2 = self.num_tokens_no_spec[i1] + len(self.spec_token_ids[i1])
+        len_of_orig_i1 = self.num_tokens_no_spec[i2] + len(self.spec_token_ids[i2])
 
-        tmp_tokens = self.token_ids_cpu[i1, :num_tokens1].copy()
-        tmp_is_token_ids = self.is_token_ids[i1, :num_tokens1].copy()
+        tmp_tokens = self.token_ids_cpu[i1, :len_of_orig_i1].copy()
+        tmp_is_token_ids = self.is_token_ids[i1, :len_of_orig_i1].copy()
 
-        self.token_ids_cpu[i1, :num_tokens2] = self.token_ids_cpu[i2, :num_tokens2]
-        self.is_token_ids[i1, :num_tokens2] = self.is_token_ids[i2, :num_tokens2]
-        if num_tokens1 > num_tokens2:
-            self.is_token_ids[i1, num_tokens2:num_tokens1] = False
+        self.token_ids_cpu[i1, :len_of_orig_i2] = self.token_ids_cpu[i2, :len_of_orig_i2]
+        self.is_token_ids[i1, :len_of_orig_i2] = self.is_token_ids[i2, :len_of_orig_i2]
+        if len_of_orig_i1 > len_of_orig_i2:
+            self.is_token_ids[i1, len_of_orig_i2:len_of_orig_i1] = False
 
-        self.token_ids_cpu[i2, :num_tokens1] = tmp_tokens
-        self.is_token_ids[i2, :num_tokens1] = tmp_is_token_ids
-        if num_tokens2 > num_tokens1:
-            self.is_token_ids[i2, num_tokens1:num_tokens2] = False
+        self.token_ids_cpu[i2, :len_of_orig_i1] = tmp_tokens
+        self.is_token_ids[i2, :len_of_orig_i1] = tmp_is_token_ids
+        if len_of_orig_i2 > len_of_orig_i1:
+            self.is_token_ids[i2, len_of_orig_i1:len_of_orig_i2] = False
 
         # Swap prompt embeddings if they exist
         embeds_i1 = self.req_prompt_embeds.get(i1)


### PR DESCRIPTION
Addresses #34731.

### Summary
This PR optimizes InputBatch.swap_states() in llm/v1/worker/gpu_input_batch.py by only swapping the active token prefix of 	oken_ids_cpu and is_token_ids instead of copying the entire rows.

### Changes
- Calculated the active token count for each request being swapped (including speculative draft tokens).
- Used these counts to perform partial row copies/swaps using numpy slices.
- Ensured that is_token_ids is correctly reset for indices beyond the new prefix length to prevent stale state.

### Impact
Reduces memory copy overhead during request reordering in the V1 engine, especially beneficial when max_model_len is large (e.g., 32k or 128k).