### PR TITLE
[GGUF] Fix loading of fused/shard-less quantized weights

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -707,6 +707,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                 param.data[loaded_shard_id].copy_(loaded_weight)
                 param.shard_weight_type[loaded_shard_id] = loaded_weight.item()
             else:
+                param.weight_type = loaded_weight.item()
                 param.shard_weight_type = {
                     i: loaded_weight.item() for i, _ in enumerate(self.output_sizes)
                 }
@@ -714,15 +715,38 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
 
         if is_gguf_weight:
             output_dim = getattr(param, "output_dim", None)
-            shard_size = loaded_weight.size(output_dim) // self.tp_size
-            start_idx = self.tp_rank * shard_size
 
             if loaded_shard_id is not None:
+                if output_dim is None:
+                    raise ValueError("GGUF shard loading requires an output dimension.")
+                shard_size = loaded_weight.size(output_dim) // self.tp_size
+                start_idx = self.tp_rank * shard_size
                 loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
                 param.shard_id.append(loaded_shard_id)
                 param.shard_id_map[loaded_shard_id] = len(param.data_container)
                 param.data_container.append(loaded_weight)
                 return
+
+            # Fused GGUF tensors can be loaded as a single shard-less weight.
+            # Materialize and load directly so runtime won't touch an
+            # UninitializedParameter.
+            if isinstance(param, UninitializedParameter):
+                final_shape = list(loaded_weight.shape)
+                if output_dim is not None:
+                    shard_size = final_shape[output_dim] // self.tp_size
+                    assert final_shape[output_dim] % self.tp_size == 0
+                    final_shape[output_dim] = shard_size
+                param.materialize(final_shape, dtype=loaded_weight.dtype)
+
+            param_data = param.data
+            if output_dim is not None:
+                shard_size = loaded_weight.size(output_dim) // self.tp_size
+                start_idx = self.tp_rank * shard_size
+                loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
+
+            assert param_data.shape == loaded_weight.shape
+            param_data.copy_(loaded_weight)
+            return
 
         param_data = param.data
         output_dim = getattr(param, "output_dim", None)

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -190,12 +190,15 @@ IMATRIX_QUANT_TYPES = {
     WeightType.IQ4_XS,
     WeightType.IQ4_NL,
 }
+MXFP4_TYPES = {WeightType.MXFP4}
 # TODO(Isotr0py): Currently, we don't have MMQ kernel for I-Matrix quantization.
 # Consolidate DEQUANT_TYPES, MMVQ_QUANT_TYPES and MMQ_QUANT_TYPES after we add
 # MMQ kernel for I-Matrix quantization.
-DEQUANT_TYPES = STANDARD_QUANT_TYPES | KQUANT_TYPES | IMATRIX_QUANT_TYPES
-MMVQ_QUANT_TYPES = STANDARD_QUANT_TYPES | KQUANT_TYPES | IMATRIX_QUANT_TYPES
-MMQ_QUANT_TYPES = STANDARD_QUANT_TYPES | KQUANT_TYPES
+DEQUANT_TYPES = STANDARD_QUANT_TYPES | KQUANT_TYPES | IMATRIX_QUANT_TYPES | MXFP4_TYPES
+MMVQ_QUANT_TYPES = (
+    STANDARD_QUANT_TYPES | KQUANT_TYPES | IMATRIX_QUANT_TYPES | MXFP4_TYPES
+)
+MMQ_QUANT_TYPES = STANDARD_QUANT_TYPES | KQUANT_TYPES | MXFP4_TYPES
 
 
 def _fused_mul_mat_gguf(
@@ -540,7 +543,11 @@ class GGUFLinearMethod(LinearMethodBase):
 
         if shard_id:
             # dequantize shard weights respectively
-            shard_id = ["q", "k", "v"] if "q" in shard_id else shard_id
+            if "q" in shard_id:
+                shard_id = ["q", "k", "v"]
+            elif all(isinstance(i, int) for i in shard_id):
+                # Numeric shard IDs encode logical output order.
+                shard_id = sorted(shard_id)
             qweight = layer.qweight
             result = []
             for idx in shard_id:

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -295,7 +295,9 @@ class GGUFModelLoader(BaseModelLoader):
             if gguf_name is None:
                 return None
 
-            return gguf_name + "." + suffix
+            if suffix:
+                return gguf_name + "." + suffix
+            return gguf_name
 
         # Build mapping and track unmapped parameters
         unmapped_params = []
@@ -355,7 +357,7 @@ class GGUFModelLoader(BaseModelLoader):
         model_config: ModelConfig,
         model_name_or_path: str,
         gguf_to_hf_name_map: dict[str, str],
-    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+    ) -> Generator[tuple[str, torch.Tensor]]:
         """
         Iterate over GGUF model weights, loading from both main model file and
         mmproj.gguf for multimodal Gemma3 models.


### PR DESCRIPTION
## Summary

When a GGUF checkpoint stores a fused tensor (e.g. a single pre-merged qkv weight) instead of individual shards, `MergedColumnParallelLinear.weight_loader` would fall through to the non-GGUF path and leave the parameter as `UninitializedParameter`, crashing at inference.

This came up while working on Qwen3-Next GGUF support — some GGUF exports pack projections into a single tensor with no shard ID, which hit this path. I pulled the fixes out into a separate PR since they're not model-specific.

**What's here:**

- **Materialize `UninitializedParameter` for fused GGUF weights**: when a GGUF weight arrives without a `loaded_shard_id`, materialize the param, TP-slice it, and copy the data in directly, instead of falling through to the non-GGUF branch.
- **Set `param.weight_type` for non-sharded loads**: `GGUFLinearMethod.apply()` expects `weight_type` on the non-shard branch — previously only `shard_weight_type` was populated, so the fused path would `AttributeError`.
- **Add MXFP4 to quant type routing**: `WeightType.MXFP4` (type 39) was missing from `DEQUANT_TYPES`, `MMVQ_QUANT_TYPES`, and `MMQ_QUANT_TYPES`, so MXFP4 GGUF files were rejected at load time.
- **Sort numeric shard IDs in `apply()`**: the shard iteration used insertion order, which could be wrong for numeric IDs (e.g. `[1, 0]`), silently producing incorrect output after `torch.cat`.
- **Handle suffix-less GGUF name mappings**: some tensors (like bias) map directly without a `.weight`/`.bias` suffix — the old code unconditionally appended `"." + suffix`, breaking these.

## Test plan

- [x] Load a GGUF model that uses fused (non-sharded) weight tensors — verified with Qwen3-Next GGUF
- [x] Load an MXFP4-quantized GGUF file — verified it's accepted by the quant router
- [ ] Verify existing GGUF models (Llama, Gemma, etc.) still load and produce correct output