### PR TITLE
[Model] Add GGUF loading support for Qwen3-Next

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -701,6 +701,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                 param.data[loaded_shard_id].copy_(loaded_weight)
                 param.shard_weight_type[loaded_shard_id] = loaded_weight.item()
             else:
+                param.weight_type = loaded_weight.item()
                 param.shard_weight_type = {
                     i: loaded_weight.item() for i, _ in enumerate(self.output_sizes)
                 }
@@ -708,15 +709,38 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
 
         if is_gguf_weight:
             output_dim = getattr(param, "output_dim", None)
-            shard_size = loaded_weight.size(output_dim) // self.tp_size
-            start_idx = self.tp_rank * shard_size
 
             if loaded_shard_id is not None:
+                if output_dim is None:
+                    raise ValueError("GGUF shard loading requires an output dimension.")
+                shard_size = loaded_weight.size(output_dim) // self.tp_size
+                start_idx = self.tp_rank * shard_size
                 loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
                 param.shard_id.append(loaded_shard_id)
                 param.shard_id_map[loaded_shard_id] = len(param.data_container)
                 param.data_container.append(loaded_weight)
                 return
+
+            # Fused GGUF tensors can be loaded as a single shard-less weight.
+            # Materialize and load directly so runtime won't touch an
+            # UninitializedParameter.
+            if isinstance(param, UninitializedParameter):
+                final_shape = list(loaded_weight.shape)
+                if output_dim is not None:
+                    shard_size = final_shape[output_dim] // self.tp_size
+                    assert final_shape[output_dim] % self.tp_size == 0
+                    final_shape[output_dim] = shard_size
+                param.materialize(final_shape, dtype=loaded_weight.dtype)
+
+            param_data = param.data
+            if output_dim is not None:
+                shard_size = loaded_weight.size(output_dim) // self.tp_size
+                start_idx = self.tp_rank * shard_size
+                loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
+
+            assert param_data.shape == loaded_weight.shape
+            param_data.copy_(loaded_weight)
+            return
 
         param_data = param.data
         output_dim = getattr(param, "output_dim", None)

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -235,7 +235,9 @@ class GGUFModelLoader(BaseModelLoader):
             if gguf_name is None:
                 return None
 
-            return gguf_name + "." + suffix
+            if suffix:
+                return gguf_name + "." + suffix
+            return gguf_name
 
         # Build mapping and track unmapped parameters
         unmapped_params = []
@@ -294,7 +296,7 @@ class GGUFModelLoader(BaseModelLoader):
         model_config: ModelConfig,
         model_name_or_path: str,
         gguf_to_hf_name_map: dict[str, str],
-    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+    ) -> Generator[tuple[str, torch.Tensor]]:
         """
         Iterate over GGUF model weights, loading from both main model file and
         mmproj.gguf for multimodal Gemma3 models.

--- a/vllm/transformers_utils/configs/qwen3_next.py
+++ b/vllm/transformers_utils/configs/qwen3_next.py
@@ -216,11 +216,20 @@ class Qwen3NextConfig(PretrainedConfig):
         router_aux_loss_coef=0.001,
         mlp_only_layers=None,
         layer_types=None,
+        bos_token_id=None,
+        eos_token_id=None,
+        pad_token_id=None,
         **kwargs,
     ):
         if mlp_only_layers is None:
             mlp_only_layers = []
-        super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
+        super().__init__(
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            pad_token_id=pad_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
         self.vocab_size = vocab_size
         self.max_position_embeddings = max_position_embeddings
         self.hidden_size = hidden_size


### PR DESCRIPTION
## Summary

> **Depends on #35019** — that PR adds the `UninitializedParameter` materialization path and MXFP4 routing that this model's fused tensors rely on. Please merge that one first.

Enables loading Qwen3-Next (Qwen3-Coder) from GGUF checkpoints. GGUF exports of this model use a different tensor layout than HF safetensors — qkv and z projections are stored as separate `attn_qkv`/`attn_gate` tensors rather than a single fused `ssm_in`, and MoE expert weights come as individual gate/up/down tensors instead of a merged `gate_up_proj`.

**What's here:**

- **GGUF→HF name mappings** for `attn_qkv`, `attn_gate`, `ssm_dt` bias, and per-expert gate/up/down weights, with sideload skip patterns for the dummy merged params.
- **Split `in_proj_qkvz` into two output shards** `[qkv, z]` so the two GGUF tensors load as shard 0 and shard 1 into one `MergedColumnParallelLinear`. Added corresponding `stacked_params_mapping` entries.
- **Singleton-dim restore**: GGUF serialization drops size-1 dimensions (`[1, N]` → `[N]`). The loader now re-inserts them when the result exactly matches the target param shape.
- **Pass `quant_config`** to `VocabParallelEmbedding` and `ParallelLMHead` so quantized embeddings work.
- **Plumb `bos/eos/pad` token IDs** through `Qwen3NextConfig` (needed for GGUF metadata).

## Test plan

- [x] Load Qwen3-Coder-Next GGUF (IQ3_XXS) and run inference — verified correct output
- [ ] Verify non-GGUF (safetensors) Qwen3-Next loading is unaffected by the `output_sizes` split