### PR TITLE
fix(models): apply embedding_multiplier to inputs_embeds in GraniteMoeHybrid

### DIFF
--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -378,7 +378,7 @@ class GraniteMoeHybridModel(nn.Module):
                 hidden_states = inputs_embeds
             else:
                 hidden_states = self.embed_input_ids(input_ids)
-                hidden_states = hidden_states * self.embedding_multiplier
+            hidden_states = hidden_states * self.embedding_multiplier
             residual = None
         else:
             if intermediate_tensors is None:


### PR DESCRIPTION
## Summary

Fixes #34812

When `inputs_embeds` is provided to `GraniteMoeHybridModel.forward()`, the `embedding_multiplier` scaling was only applied in the `input_ids` branch, causing garbage output when using input embeddings (e.g. `enable_prompt_embeds=True`).

## Fix

Move the `embedding_multiplier` scaling outside the `if/else` branch so it applies to `hidden_states` regardless of whether it came from `input_ids` or `inputs_embeds`. This aligns with how `granite.py` and `granitemoe.py` already handle it correctly.

## Changes

- `vllm/model_executor/models/granitemoehybrid.py`: 1 line moved (dedented)