### PR TITLE
Fix apply_top_k_top_p_triton called by non-cuda logits Tensor

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -248,7 +248,7 @@ def apply_top_k_top_p(
     if p is None and k is None:
         return logits
 
-    if HAS_TRITON and logits.shape[0] >= 8:
+    if HAS_TRITON and logits.shape[0] >= 8 and logits.is_cuda:
         return apply_top_k_top_p_triton(logits, k, p)
 
     # Use pytorch sort implementation for small batch sizes.


### PR DESCRIPTION
Summary:
[#33538](https://github.com/vllm-project/vllm/pull/33538) add apply_top_k_top_p_triton function; inside apply_top_k_top_p_triton, there is `assert logits.is_cuda` to ensure input is cuda logits tensor, so we should guard the call with `logits.is_cuda`
