### PR TITLE
feat: add reasoning_tokens to completion_tokens_details in chat completion usage

### DIFF
--- a/tests/entrypoints/openai/test_reasoning_tokens_usage.py
+++ b/tests/entrypoints/openai/test_reasoning_tokens_usage.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for reasoning_tokens in completion_tokens_details (issue #14335).
+
+Verifies that the CompletionTokensDetails model is correctly defined,
+integrated into UsageInfo, and populated by the reasoning parser's
+count_reasoning_tokens method.
+"""
+
+from vllm.entrypoints.openai.engine.protocol import (
+    CompletionTokensDetails,
+    UsageInfo,
+)
+from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
+
+
+class TestCompletionTokensDetails:
+    """Tests for the CompletionTokensDetails protocol model."""
+
+    def test_default_reasoning_tokens_is_zero(self):
+        details = CompletionTokensDetails()
+        assert details.reasoning_tokens == 0
+
+    def test_reasoning_tokens_set(self):
+        details = CompletionTokensDetails(reasoning_tokens=42)
+        assert details.reasoning_tokens == 42
+
+    def test_serialization_round_trip(self):
+        details = CompletionTokensDetails(reasoning_tokens=10)
+        data = details.model_dump()
+        assert data == {"reasoning_tokens": 10}
+        restored = CompletionTokensDetails.model_validate(data)
+        assert restored.reasoning_tokens == 10
+
+
+class TestUsageInfoWithCompletionDetails:
+    """Tests for UsageInfo with completion_tokens_details field."""
+
+    def test_usage_info_no_details_by_default(self):
+        usage = UsageInfo(
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+        )
+        assert usage.completion_tokens_details is None
+
+    def test_usage_info_with_completion_details(self):
+        usage = UsageInfo(
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+            completion_tokens_details=CompletionTokensDetails(
+                reasoning_tokens=5,
+            ),
+        )
+        assert usage.completion_tokens_details is not None
+        assert usage.completion_tokens_details.reasoning_tokens == 5
+
+    def test_usage_info_serialization_excludes_none_details(self):
+        usage = UsageInfo(
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+        )
+        data = usage.model_dump(exclude_none=True)
+        assert "completion_tokens_details" not in data
+
+    def test_usage_info_serialization_includes_details(self):
+        usage = UsageInfo(
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+            completion_tokens_details=CompletionTokensDetails(
+                reasoning_tokens=7,
+            ),
+        )
+        data = usage.model_dump()
+        assert data["completion_tokens_details"]["reasoning_tokens"] == 7
+
+
+class TestCountReasoningTokens:
+    """Tests for BaseThinkingReasoningParser.count_reasoning_tokens."""
+
+    def _make_parser(self, start_token_id: int, end_token_id: int):
+        """Create a minimal parser with the needed attributes."""
+        _start_id = start_token_id
+        _end_id = end_token_id
+
+        class _TestParser(BaseThinkingReasoningParser):
+            @property
+            def start_token(self) -> str:
+                return "<think>"
+
+            @property
+            def end_token(self) -> str:
+                return "</think>"
+
+            def __init__(self):
+                # Skip parent __init__ which requires a tokenizer.
+                # Only set attributes needed by count_reasoning_tokens.
+                self.start_token_id = _start_id
+                self.end_token_id = _end_id
+
+        return _TestParser()
+
+    def test_no_reasoning_tokens(self):
+        parser = self._make_parser(start_token_id=100, end_token_id=101)
+        token_ids = [1, 2, 3, 4, 5]
+        assert parser.count_reasoning_tokens(token_ids) == 0
+
+    def test_simple_reasoning_span(self):
+        parser = self._make_parser(start_token_id=100, end_token_id=101)
+        # <think> a b c </think> d e
+        token_ids = [100, 10, 11, 12, 101, 20, 21]
+        assert parser.count_reasoning_tokens(token_ids) == 3
+
+    def test_reasoning_at_end_no_close(self):
+        parser = self._make_parser(start_token_id=100, end_token_id=101)
+        # <think> a b c  (no close tag - generation stopped mid-think)
+        token_ids = [100, 10, 11, 12]
+        assert parser.count_reasoning_tokens(token_ids) == 3
+
+    def test_empty_reasoning_span(self):
+        parser = self._make_parser(start_token_id=100, end_token_id=101)
+        # <think></think> a b
+        token_ids = [100, 101, 20, 21]
+        assert parser.count_reasoning_tokens(token_ids) == 0
+
+    def test_only_reasoning(self):
+        parser = self._make_parser(start_token_id=100, end_token_id=101)
+        # <think> a b c </think>
+        token_ids = [100, 10, 11, 12, 101]
+        assert parser.count_reasoning_tokens(token_ids) == 3
+
+    def test_empty_sequence(self):
+        parser = self._make_parser(start_token_id=100, end_token_id=101)
+        assert parser.count_reasoning_tokens([]) == 0
+
+    def test_stray_end_token_ignored(self):
+        parser = self._make_parser(start_token_id=100, end_token_id=101)
+        # </think> a b (stray end token at start)
+        token_ids = [101, 10, 11]
+        assert parser.count_reasoning_tokens(token_ids) == 0
+
+
+class TestReasoningParserBaseDefault:
+    """Test that the base ReasoningParser.count_reasoning_tokens returns 0."""
+
+    def test_base_parser_returns_zero(self):
+        from vllm.reasoning.abs_reasoning_parsers import ReasoningParser
+
+        # count_reasoning_tokens is a concrete method on the base class
+        # that returns 0 by default.
+        assert ReasoningParser.count_reasoning_tokens(None, [1, 2, 3]) == 0

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -40,6 +40,7 @@ from vllm.entrypoints.openai.chat_completion.stream_harmony import (
     extract_harmony_streaming_delta,
 )
 from vllm.entrypoints.openai.engine.protocol import (
+    CompletionTokensDetails,
     DeltaFunctionCall,
     DeltaMessage,
     DeltaToolCall,
@@ -1312,6 +1313,21 @@ class OpenAIServingChat(OpenAIServing):
                     data = chunk.model_dump_json(exclude_unset=True)
                     yield f"data: {data}\n\n"
 
+            # Count reasoning tokens from accumulated token IDs.
+            num_reasoning_tokens = 0
+            if reasoning_parser and all_previous_token_ids:
+                for token_ids in all_previous_token_ids:
+                    num_reasoning_tokens += reasoning_parser.count_reasoning_tokens(
+                        token_ids
+                    )
+            completion_tokens_details = (
+                CompletionTokensDetails(
+                    reasoning_tokens=num_reasoning_tokens,
+                )
+                if num_reasoning_tokens > 0
+                else None
+            )
+
             # once the final token is handled, if stream_options.include_usage
             # is sent, send the usage
             if include_usage:
@@ -1320,6 +1336,7 @@ class OpenAIServingChat(OpenAIServing):
                     prompt_tokens=num_prompt_tokens,
                     completion_tokens=completion_tokens,
                     total_tokens=num_prompt_tokens + completion_tokens,
+                    completion_tokens_details=completion_tokens_details,
                 )
                 if self.enable_prompt_tokens_details and num_cached_tokens:
                     final_usage.prompt_tokens_details = PromptTokenUsageInfo(
@@ -1345,6 +1362,7 @@ class OpenAIServingChat(OpenAIServing):
                 prompt_tokens=num_prompt_tokens,
                 completion_tokens=num_completion_tokens,
                 total_tokens=num_prompt_tokens + num_completion_tokens,
+                completion_tokens_details=completion_tokens_details,
             )
 
             # Log complete streaming response if output logging is enabled
@@ -1710,11 +1728,21 @@ class OpenAIServingChat(OpenAIServing):
         num_generated_tokens = sum(
             len(output.token_ids) for output in final_res.outputs
         )
+        num_reasoning_tokens = 0
+        if reasoning_parser:
+            for output in final_res.outputs:
+                num_reasoning_tokens += reasoning_parser.count_reasoning_tokens(
+                    output.token_ids
+                )
         usage = UsageInfo(
             prompt_tokens=num_prompt_tokens,
             completion_tokens=num_generated_tokens,
             total_tokens=num_prompt_tokens + num_generated_tokens,
         )
+        if num_reasoning_tokens > 0:
+            usage.completion_tokens_details = CompletionTokensDetails(
+                reasoning_tokens=num_reasoning_tokens,
+            )
         if self.enable_prompt_tokens_details and final_res.num_cached_tokens:
             usage.prompt_tokens_details = PromptTokenUsageInfo(
                 cached_tokens=final_res.num_cached_tokens

--- a/vllm/entrypoints/openai/engine/protocol.py
+++ b/vllm/entrypoints/openai/engine/protocol.py
@@ -101,11 +101,16 @@ class PromptTokenUsageInfo(OpenAIBaseModel):
     cached_tokens: int | None = None
 
 
+class CompletionTokensDetails(OpenAIBaseModel):
+    reasoning_tokens: int = 0
+
+
 class UsageInfo(OpenAIBaseModel):
     prompt_tokens: int = 0
     total_tokens: int = 0
     completion_tokens: int | None = 0
     prompt_tokens_details: PromptTokenUsageInfo | None = None
+    completion_tokens_details: CompletionTokensDetails | None = None
 
 
 class RequestResponseMetadata(BaseModel):


### PR DESCRIPTION
## Summary

Adds `completion_tokens_details.reasoning_tokens` to the Chat Completion API response `usage` field, following the OpenAI API specification.

This feature is tracked by issue #14335. A previous attempt (PR #18067) has been stalled with merge conflicts since June 2025.

**Changes:**

- **`vllm/entrypoints/openai/engine/protocol.py`**: Add `CompletionTokensDetails` model with `reasoning_tokens` field, and add `completion_tokens_details` to `UsageInfo`
- **`vllm/entrypoints/openai/chat_completion/serving.py`**: Count reasoning tokens via `reasoning_parser.count_reasoning_tokens()` in both non-streaming and streaming paths, and populate `completion_tokens_details` on the usage response
- **`tests/entrypoints/openai/test_reasoning_tokens_usage.py`**: Unit tests for the new protocol model, UsageInfo integration, and reasoning token counting logic

**How it works:**

- For non-streaming responses, after all outputs are generated, `reasoning_parser.count_reasoning_tokens(output.token_ids)` is called on each output to count reasoning tokens
- For streaming responses, the accumulated `all_previous_token_ids` (already tracked when a reasoning parser is active) are used to count reasoning tokens at the end of the stream
- `completion_tokens_details` is only set when `reasoning_tokens > 0` to avoid noise in responses for non-reasoning models
- The Responses API already has this feature via `OutputTokensDetails.reasoning_tokens` — this PR brings parity to the Chat Completion API

**Example response:**

```json
{
  "usage": {
    "prompt_tokens": 10,
    "completion_tokens": 50,
    "total_tokens": 60,
    "completion_tokens_details": {
      "reasoning_tokens": 30
    }
  }
}
```

Fixes #14335

## Test plan

- [x] Unit tests pass (`pytest tests/entrypoints/openai/test_reasoning_tokens_usage.py`)
- [x] All pre-commit hooks pass (ruff, mypy, typos, etc.)
- [ ] Integration test with a reasoning model (e.g., Qwen3) to verify `reasoning_tokens` appears in the usage response