### PR TITLE
[BugFix] Refactor add max_num_tokens_per_forward_pass to account for drafting

### DIFF
--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -40,9 +40,7 @@ class WorkerLoRAManager:
         self.embedding_modules = embedding_modules
         self._cached_dummy_lora: None | Literal[False] | LoRAModel = False
         self.max_num_seqs = vllm_config.scheduler_config.max_num_seqs
-        self.max_num_batched_tokens = (
-            vllm_config.scheduler_config.max_num_batched_tokens
-        )
+        self.max_num_batched_tokens = vllm_config.max_num_tokens_per_forward_pass
         self.vocab_size = vllm_config.model_config.get_vocab_size()
         self.lora_config = vllm_config.lora_config
 

--- a/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla_sparse.py
@@ -189,7 +189,7 @@ class FlashInferMLASparseMetadataBuilder(
         self.topk_tokens = vllm_config.model_config.hf_config.index_topk
 
         self.req_id_per_token_buffer = torch.empty(
-            (vllm_config.scheduler_config.max_num_batched_tokens,),
+            (vllm_config.max_num_tokens_per_forward_pass,),
             dtype=torch.int32,
             device=device,
         )

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -294,7 +294,7 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
             device=device,
         )
         self.req_id_per_token_buffer = torch.empty(
-            (vllm_config.scheduler_config.max_num_batched_tokens,),
+            (vllm_config.max_num_tokens_per_forward_pass,),
             dtype=torch.int32,
             device=device,
         )

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -153,7 +153,7 @@ class ROCMAiterMLASparseMetadataBuilder(
         self.model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
         self.device = device
-        max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        max_num_tokens = vllm_config.max_num_tokens_per_forward_pass
 
         self.num_heads = self.model_config.get_num_attention_heads(parallel_config)
         self.mla_dims = get_mla_dims(self.model_config)
@@ -170,26 +170,26 @@ class ROCMAiterMLASparseMetadataBuilder(
         )
 
         self.req_id_per_token_buffer = torch.empty(
-            (vllm_config.scheduler_config.max_num_batched_tokens,),
+            (max_num_tokens,),
             dtype=torch.int32,
             device=device,
         )
         self.qo_indptr = torch.arange(
-            0, max_num_batched_tokens + 1, dtype=torch.int32, device=device
+            0, max_num_tokens + 1, dtype=torch.int32, device=device
         )
         self.paged_kv_last_page_len = torch.ones(
-            max_num_batched_tokens, dtype=torch.int32, device=device
+            max_num_tokens, dtype=torch.int32, device=device
         )
 
         # These two needs to be calculated in runtime,
         # but we still needs to prepare the buffer
         self.paged_kv_indices = torch.zeros(
-            [max_num_batched_tokens * self.topk_tokens],
+            [max_num_tokens * self.topk_tokens],
             dtype=torch.int32,
             device=device,
         )
         self.paged_kv_indptr = torch.zeros(
-            [max_num_batched_tokens + 1], dtype=torch.int32, device=device
+            [max_num_tokens + 1], dtype=torch.int32, device=device
         )
 
     def build(

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -101,10 +101,10 @@ class SpecDecodeBaseProposer:
             self._init_parallel_drafting_params()
 
         # The drafter can get longer sequences than the target model.
+        # Use the pre-computed max_num_tokens_per_forward_pass which already
+        # accounts for the extra tokens needed for speculative decoding.
         max_batch_size = vllm_config.scheduler_config.max_num_seqs
-        self.max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens + (
-            self.net_num_new_slots_per_request * max_batch_size
-        )
+        self.max_num_tokens = vllm_config.max_num_tokens_per_forward_pass
         self.token_arange_np = np.arange(self.max_num_tokens)
 
         # Multi-modal data support

--- a/vllm/v1/spec_decode/medusa.py
+++ b/vllm/v1/spec_decode/medusa.py
@@ -32,7 +32,7 @@ class MedusaProposer:
         )
         self.spec_config = vllm_config.speculative_config
         self.device = device
-        self.max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.max_num_tokens = vllm_config.max_num_tokens_per_forward_pass
         self.hidden_size = self.spec_config.draft_model_config.get_hidden_size()
         self.dtype = vllm_config.model_config.dtype
 

--- a/vllm/v1/worker/gpu/cudagraph_utils.py
+++ b/vllm/v1/worker/gpu/cudagraph_utils.py
@@ -33,7 +33,7 @@ class CudaGraphManager:
 
         self.max_model_len = vllm_config.model_config.max_model_len
         self.max_num_reqs = self.scheduler_config.max_num_seqs
-        self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
+        self.max_num_tokens = vllm_config.max_num_tokens_per_forward_pass
         self.dp_size = vllm_config.parallel_config.data_parallel_size
 
         self.uniform_decode_query_len = 1

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -107,7 +107,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         self.vocab_size = self.model_config.get_vocab_size()
         self.max_model_len = self.model_config.max_model_len
-        self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
+        self.max_num_tokens = vllm_config.max_num_tokens_per_forward_pass
         self.max_num_reqs = self.scheduler_config.max_num_seqs
         self.inputs_embeds_size = self.model_config.get_inputs_embeds_size()
 

--- a/vllm/v1/worker/gpu/spec_decode/eagle/cudagraph.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/cudagraph.py
@@ -27,7 +27,7 @@ class EagleCudaGraphManager:
 
         self.max_model_len = vllm_config.model_config.max_model_len
         self.max_num_reqs = self.scheduler_config.max_num_seqs
-        self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
+        self.max_num_tokens = vllm_config.max_num_tokens_per_forward_pass
         self.dp_size = vllm_config.parallel_config.data_parallel_size
         self.compilation_config = vllm_config.compilation_config
         assert self.compilation_config is not None

--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -38,7 +38,7 @@ class EagleSpeculator:
 
         self.scheduler_config = vllm_config.scheduler_config
         self.max_num_reqs = self.scheduler_config.max_num_seqs
-        self.max_num_tokens = self.scheduler_config.max_num_batched_tokens
+        self.max_num_tokens = vllm_config.max_num_tokens_per_forward_pass
         self.max_model_len = vllm_config.model_config.max_model_len
         # We need to get the hidden size from the draft model config because
         # the draft model's hidden size can be different from the target model's

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -378,7 +378,7 @@ class GPUModelRunner(
         self.calculate_kv_scales = self.cache_config.calculate_kv_scales
         self.dcp_world_size = self.parallel_config.decode_context_parallel_size
         self.dcp_rank = 0 if self.dcp_world_size <= 1 else get_dcp_group().rank_in_group
-        self.max_num_tokens = scheduler_config.max_num_batched_tokens
+        self.max_num_tokens = vllm_config.max_num_tokens_per_forward_pass
         self.max_num_reqs = scheduler_config.max_num_seqs
 
         # Broadcast PP output for external_launcher (torchrun)


### PR DESCRIPTION
## Purpose

Alternative bugfix to #34671. Solves a crash of specdec on main.

To solve the consistency issue, we add a `max_num_tokens_per_forward_pass` to the VllmConfig, that accounts for drafting.

## Testing

Tested with Qwen3-Next MTP and GSM8k repeated twice with various concurrencies. All pass with 85% accuracy, matching the non-spec baseline.

```
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct  \
  --tokenizer-mode auto  --gpu-memory-utilization 0.8 \
  --speculative-config '{"method": "qwen3_next_mtp", "num_speculative_tokens": 5}' \
  --tensor-parallel-size 2 --port 8042
```