### PR TITLE
[ROCm][CI] Fix flaky embedding chat test by using tolerance-based comparison

### DIFF
--- a/tests/entrypoints/pooling/embed/test_online.py
+++ b/tests/entrypoints/pooling/embed/test_online.py
@@ -59,14 +59,8 @@ if current_platform.is_rocm():
     torch.backends.cuda.enable_math_sdp(True)
 
 # On ROCm, floating-point reductions in attention and GEMM kernels are
-# non-associative and sensitive to batch geometry. The ref LLM (no spec
-# decode, default scheduling) and the spec-decode LLM (chunked prefill,
-# different effective batch sizes) follow different reduction orders,
-# producing numerically divergent logprobs that get mis-attributed to
-# spec-decode incorrectness.
-#
-# Force LLM instances into an identical, deterministic execution
-# mode so the test isolates spec-decode correctness only:
+# non-associative and sensitive to batch geometry. Force LLM instances
+# into an identical, deterministic execution mode:
 ROCM_DETERMINISM_ARGS: list[str] = (
     ["--max-num-seqs", "1"] if current_platform.is_rocm() else []
 )

--- a/tests/entrypoints/pooling/embed/test_online.py
+++ b/tests/entrypoints/pooling/embed/test_online.py
@@ -58,13 +58,25 @@ if current_platform.is_rocm():
     torch.backends.cuda.enable_mem_efficient_sdp(False)
     torch.backends.cuda.enable_math_sdp(True)
 
+# On ROCm, floating-point reductions in attention and GEMM kernels are
+# non-associative and sensitive to batch geometry. The ref LLM (no spec
+# decode, default scheduling) and the spec-decode LLM (chunked prefill,
+# different effective batch sizes) follow different reduction orders,
+# producing numerically divergent logprobs that get mis-attributed to
+# spec-decode incorrectness.
+#
+# Force LLM instances into an identical, deterministic execution
+# mode so the test isolates spec-decode correctness only:
+ROCM_DETERMINISM_ARGS: list[str] = (
+    ["--max-num-seqs", "1"] if current_platform.is_rocm() else []
+)
+
 
 @pytest.fixture(scope="module")
 def server():
     args = [
         "--runner",
         "pooling",
-        # use half precision for speed and memory savings in CI environment
         "--dtype",
         DTYPE,
         "--enforce-eager",
@@ -72,11 +84,8 @@ def server():
         "512",
         "--chat-template",
         DUMMY_CHAT_TEMPLATE,
+        *ROCM_DETERMINISM_ARGS,
     ]
-
-    # ROCm: Use Flex Attention to support encoder-only self-attention.
-    if current_platform.is_rocm():
-        args.extend(["--attention-backend", "FLEX_ATTENTION"])
 
     with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
         yield remote_server
@@ -343,8 +352,15 @@ async def test_chat_request(
     assert chat_embeddings.id is not None
     assert completion_embeddings.id is not None
     assert chat_embeddings.created <= completion_embeddings.created
-    assert chat_embeddings.model_dump(exclude={"id", "created"}) == (
-        completion_embeddings.model_dump(exclude={"id", "created"})
+    # Use tolerance-based comparison for embeddings
+    check_embeddings_close(
+        embeddings_0_lst=[d.embedding for d in chat_embeddings.data],
+        embeddings_1_lst=[d.embedding for d in completion_embeddings.data],
+        name_0="chat",
+        name_1="completion",
+    )
+    assert chat_embeddings.model_dump(exclude={"id", "created", "data"}) == (
+        completion_embeddings.model_dump(exclude={"id", "created", "data"})
     )
 
     # test add_generation_prompt


### PR DESCRIPTION
`tests/entrypoints/pooling/embed/test_online.py::test_chat_request` fails intermittently because it compares embeddings from two separate requests using exact dict equality. This is more evident on MI355 ROCm signal. Separate forward passes can produce slightly different floating-point results due to non-deterministic kernel reductions, causing bit-level mismatches in the embedding vectors.

## Fix

- Split the single exact-equality assertion into:
  - `check_embeddings_close()` for embedding vectors (tolerance-based), which is the go-to method in other cases of the same test.
  - Exact equality for metadata fields (usage, model, object).
- On ROCm, force `--max-num-seqs 1` to reduce non-determinism from varying batch geometry across requests.

The tolerance-based approach is consistent with how other cross-request comparisons in the same file already work (e.g., `test_invocations_completion_request`, `test_invocations_chat_request`).