### PR TITLE
[ROCm][CI] Fix realtime test timeouts caused by aiter JIT compilation delays

### DIFF
--- a/tests/entrypoints/openai/test_realtime_validation.py
+++ b/tests/entrypoints/openai/test_realtime_validation.py
@@ -4,6 +4,7 @@
 import asyncio
 import base64
 import json
+import warnings
 
 import librosa
 import numpy as np
@@ -92,7 +93,11 @@ async def test_multi_chunk_streaming(
                     if event["type"] == "session.updated":
                         break
             except TimeoutError:
-                pass
+                warnings.warn(
+                    f"session.updated not received within {5.0}s after "
+                    "session.update. The server may not implement this event.",
+                    stacklevel=2,
+                )
 
             # (ROCm) Warm-up: send a non-final commit (required to start
             # transcription) with a small audio chunk to trigger aiter
@@ -189,7 +194,11 @@ async def test_empty_commit_does_not_crash_engine(
                     if event["type"] == "session.updated":
                         break
             except TimeoutError:
-                pass
+                warnings.warn(
+                    f"session.updated not received within {5.0}s after "
+                    "session.update. The server may not implement this event.",
+                    stacklevel=2,
+                )
 
             # Start generation without sending any audio
             await send_event(ws, {"type": "input_audio_buffer.commit"})

--- a/tests/entrypoints/openai/test_realtime_validation.py
+++ b/tests/entrypoints/openai/test_realtime_validation.py
@@ -85,7 +85,37 @@ async def test_multi_chunk_streaming(
 
             await send_event(ws, {"type": "session.update", "model": model_name})
 
-            # Send commit to start transcription
+            # Wait for the server to acknowledge the session update.
+            try:
+                while True:
+                    event = await receive_event(ws, timeout=5.0)
+                    if event["type"] == "session.updated":
+                        break
+            except TimeoutError:
+                pass
+
+            # (ROCm) Warm-up: send a non-final commit (required to start
+            # transcription) with a small audio chunk to trigger aiter
+            # compilation on first use.
+            await send_event(ws, {"type": "input_audio_buffer.commit"})
+            await send_event(
+                ws,
+                {
+                    "type": "input_audio_buffer.append",
+                    "audio": mary_had_lamb_audio_chunks[0],
+                },
+            )
+            await send_event(ws, {"type": "input_audio_buffer.commit", "final": True})
+
+            # (ROCm) Drain all warm-up responses with generous timeout for
+            # JIT compilation
+            warmup_done = False
+            while not warmup_done:
+                event = await receive_event(ws, timeout=360.0)
+                if event["type"] in ("transcription.done", "error"):
+                    warmup_done = True
+
+            # Now send the real test audio
             await send_event(ws, {"type": "input_audio_buffer.commit"})
 
             # Send multiple audio chunks
@@ -153,6 +183,14 @@ async def test_empty_commit_does_not_crash_engine(
 
             await send_event(ws, {"type": "session.update", "model": model_name})
 
+            try:
+                while True:
+                    event = await receive_event(ws, timeout=5.0)
+                    if event["type"] == "session.updated":
+                        break
+            except TimeoutError:
+                pass
+
             # Start generation without sending any audio
             await send_event(ws, {"type": "input_audio_buffer.commit"})
 
@@ -161,7 +199,8 @@ async def test_empty_commit_does_not_crash_engine(
 
             # We should get *some* response (error or empty transcription),
             # but the engine must NOT crash.
-            event = await receive_event(ws, timeout=30.0)
+            # (ROCm) Use generous timeout for first request (aiter JIT compilation)
+            event = await receive_event(ws, timeout=360.0)
             assert event["type"] in (
                 "error",
                 "transcription.done",
@@ -176,6 +215,15 @@ async def test_empty_commit_does_not_crash_engine(
 
             await send_event(ws, {"type": "session.update", "model": model_name})
 
+            try:
+                while True:
+                    event = await receive_event(ws, timeout=5.0)
+                    if event["type"] == "session.updated":
+                        break
+            except TimeoutError:
+                pass
+
+            # Start transcription
             await send_event(ws, {"type": "input_audio_buffer.commit"})
 
             for chunk in mary_had_lamb_audio_chunks:

--- a/tests/entrypoints/openai/test_realtime_validation.py
+++ b/tests/entrypoints/openai/test_realtime_validation.py
@@ -230,7 +230,11 @@ async def test_empty_commit_does_not_crash_engine(
                     if event["type"] == "session.updated":
                         break
             except TimeoutError:
-                pass
+                warnings.warn(
+                    f"session.updated not received within {5.0}s after "
+                    "session.update. The server may not implement this event.",
+                    stacklevel=2,
+                )
 
             # Start transcription
             await send_event(ws, {"type": "input_audio_buffer.commit"})


### PR DESCRIPTION
`test_multi_chunk_streaming` and `test_empty_commit_does_not_crash_engine` in `entrypoints/openai/test_realtime_validation.py` (Entrypoints Integration Test - API Server 1) intermittently fail with `TimeoutError` on ROCm builds.

The root cause is that aiter modules are JIT-compiled on the first inference request. The original test timeouts (30-60s) are insufficient when this compilation happens during the test's critical path.

## Fix

- **Add a warm-up step** to `test_multi_chunk_streaming`: send a small audio chunk before the real transcription to absorb JIT compilation latency, with a generous 360s timeout.
- **Increase the first-request timeout** in `test_empty_commit_does_not_crash_engine` from 30s to 360s since the empty commit triggers the first inference (and thus JIT compilation).
- **Wait for `session.updated`** after `session.update` to avoid racing the server's session setup.
- **Preserve the non-final `input_audio_buffer.commit`** before sending audio, as it is required by the protocol to start a transcription session.