### PR TITLE
[CLEANING] Remove unused disable_by_batch_size from SpeculativeConfig

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -101,9 +101,6 @@ class SpeculativeConfig:
     will use the default version."""
 
     # Advanced control
-    disable_by_batch_size: int | None = Field(default=None, ge=2)
-    """Disable speculative decoding for new incoming requests when the number
-    of enqueued requests is larger than this value, if provided."""
     disable_padded_drafter_batch: bool = False
     """Disable input padding for speculative decoding. If set to True,
     speculative input batches can contain sequences of different lengths,
@@ -705,13 +702,6 @@ class SpeculativeConfig:
         if self.draft_model_config:
             self.draft_model_config.verify_with_parallel_config(
                 self.draft_parallel_config
-            )
-
-        if self.disable_by_batch_size is not None and self.disable_by_batch_size < 2:
-            raise ValueError(
-                "Expect the batch size threshold of disabling "
-                "speculative decoding is > 1, but got "
-                f"{self.disable_by_batch_size=}"
             )
 
         eagle3_target_supported = [


### PR DESCRIPTION
**Remove unused disable_by_batch_size from SpeculativeConfig**

This PR removes the disable_by_batch_size parameter from SpeculativeConfig because it has been unused since v0.10.0, when the V0 engine was removed. The parameter is still accepted and validated but is never read anywhere in the codebase, so it has no effect on behavior.
Users may continue to pass disable_by_batch_size in their config without realizing it does nothing (see the issue: #25112) . Removing it avoids this confusion and cleans up dead config.
Related issue: #25112