### PR TITLE
[Bugfix] Separate speculator layers into dedicated KV cache group

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2082,3 +2082,121 @@ def test_unify_hybrid_kv_cache_specs():
 
     with pytest.raises(ValueError):
         kv_cache_utils.unify_hybrid_kv_cache_specs(kv_cache_spec)
+
+
+def test_speculator_layers_dedicated_group():
+    """Test that speculator (drafter) layers get their own KV cache group
+    in hybrid attention models, preventing scatter across target groups.
+
+    Regression test for the case where adding EAGLE drafter layers to a
+    hybrid model (e.g., 12 sliding + 12 full) pushes the full attention
+    count past the 1.25x grouping threshold, causing drafter layers to be
+    split across multiple groups.
+    """
+    from unittest.mock import MagicMock
+
+    from vllm.v1.core.kv_cache_utils import (
+        _get_kv_cache_groups_uniform_page_size,
+        _identify_speculator_layers,
+    )
+
+    # --- Test _identify_speculator_layers ---
+
+    # Mock vllm_config with 24 target layers and spec decode enabled
+    mock_config = MagicMock()
+    mock_config.speculative_config = MagicMock()
+    mock_config.model_config.get_total_num_hidden_layers.return_value = 24
+
+    # Layer names: 24 target + 4 drafter (global indices 24-27)
+    layer_names = [f"model.layers.{i}.self_attn.attn" for i in range(28)]
+    spec_layers = _identify_speculator_layers(mock_config, layer_names)
+    assert spec_layers is not None
+    assert spec_layers == {
+        "model.layers.24.self_attn.attn",
+        "model.layers.25.self_attn.attn",
+        "model.layers.26.self_attn.attn",
+        "model.layers.27.self_attn.attn",
+    }
+
+    # No spec config -> returns None
+    mock_config_no_spec = MagicMock()
+    mock_config_no_spec.speculative_config = None
+    assert _identify_speculator_layers(mock_config_no_spec, layer_names) is None
+
+    # --- Test grouping: 12 sliding + 12 full + 4 drafter (all full) ---
+    # Without fix: 16 full > 12 * 1.25 = 15, splits into 2 groups,
+    # drafter layers scattered. With fix: drafter separated first.
+
+    kv_cache_spec = {}
+    # 12 sliding attention layers (even indices 0-22)
+    for i in range(0, 24, 2):
+        kv_cache_spec[f"model.layers.{i}.self_attn.attn"] = new_sliding_window_spec()
+    # 12 full attention layers (odd indices 1-23)
+    for i in range(1, 24, 2):
+        kv_cache_spec[f"model.layers.{i}.self_attn.attn"] = new_kv_cache_spec()
+    # 4 drafter layers (indices 24-27, full attention)
+    for i in range(24, 28):
+        kv_cache_spec[f"model.layers.{i}.self_attn.attn"] = new_kv_cache_spec()
+
+    speculator_layers = {f"model.layers.{i}.self_attn.attn" for i in range(24, 28)}
+
+    groups = _get_kv_cache_groups_uniform_page_size(kv_cache_spec, speculator_layers)
+
+    # Find which group contains all drafter layers
+    drafter_group_ids = set()
+    for gid, group in enumerate(groups):
+        for name in group.layer_names:
+            if name in speculator_layers:
+                drafter_group_ids.add(gid)
+
+    # All drafter layers must be in exactly one group
+    assert len(drafter_group_ids) == 1, (
+        f"Drafter layers scattered across {len(drafter_group_ids)} groups: "
+        f"{drafter_group_ids}"
+    )
+
+    # The drafter group should contain exactly the 4 drafter layers
+    drafter_gid = drafter_group_ids.pop()
+    drafter_group = groups[drafter_gid]
+    assert set(drafter_group.layer_names) == speculator_layers
+
+    # --- Test no-regression: 18 sliding + 18 full + 4 drafter ---
+    # This case already works without the fix (22 < 18*1.25=22.5),
+    # but should still work with speculator separation.
+
+    kv_cache_spec_big = {}
+    for i in range(0, 36, 2):
+        kv_cache_spec_big[f"model.layers.{i}.self_attn.attn"] = (
+            new_sliding_window_spec()
+        )
+    for i in range(1, 36, 2):
+        kv_cache_spec_big[f"model.layers.{i}.self_attn.attn"] = new_kv_cache_spec()
+    for i in range(36, 40):
+        kv_cache_spec_big[f"model.layers.{i}.self_attn.attn"] = new_kv_cache_spec()
+
+    speculator_layers_big = {f"model.layers.{i}.self_attn.attn" for i in range(36, 40)}
+
+    groups_big = _get_kv_cache_groups_uniform_page_size(
+        kv_cache_spec_big, speculator_layers_big
+    )
+
+    drafter_group_ids_big = set()
+    for gid, group in enumerate(groups_big):
+        for name in group.layer_names:
+            if name in speculator_layers_big:
+                drafter_group_ids_big.add(gid)
+    assert len(drafter_group_ids_big) == 1
+
+    # --- Test without speculator_layers (None) -> unchanged behavior ---
+    groups_no_spec = _get_kv_cache_groups_uniform_page_size(kv_cache_spec, None)
+    # Without speculator separation, 16 full layers should be split
+    # into 2 groups (16 > 12*1.25=15), so drafter layers get scattered
+    drafter_group_ids_no_spec = set()
+    for gid, group in enumerate(groups_no_spec):
+        for name in group.layer_names:
+            if name in speculator_layers:
+                drafter_group_ids_no_spec.add(gid)
+    # This confirms the bug: without the fix, drafter layers are in >1 group
+    assert len(drafter_group_ids_no_spec) > 1, (
+        "Expected drafter layers to be scattered without the fix"
+    )

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -17,6 +17,7 @@ from vllm.logger import init_logger
 from vllm.utils.hashing import sha256_cbor, xxhash_cbor
 from vllm.utils.math_utils import cdiv
 from vllm.utils.mem_utils import format_gib
+from vllm.model_executor.models.utils import extract_layer_index
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
@@ -955,7 +956,7 @@ def is_kv_cache_type_attention_free(kv_cache_spec: dict[str, KVCacheSpec]) -> bo
 
 def _get_kv_cache_groups_uniform_page_size(
     kv_cache_spec: dict[str, KVCacheSpec],
-    speculator_layers: set[str] | None = None,
+    drafter_layers: set[str] | None = None,
 ) -> list[KVCacheGroupSpec]:
     """
     Generates the KV cache groups for hybrid models with multiple
@@ -1026,24 +1027,24 @@ def _get_kv_cache_groups_uniform_page_size(
     for layer_name, layer_spec in kv_cache_spec.items():
         same_type_layers[layer_spec].append(layer_name)
 
-    # Separate speculator layers into their own group before the heuristic
+    # Separate drafter layers into their own group before the heuristic
     # below runs, so drafter layers don't get scattered across groups.
-    speculator_group_layers: list[str] = []
-    if speculator_layers:
+    drafter_group_layers: list[str] = []
+    if drafter_layers:
         for spec in list(same_type_layers.keys()):
             layers = same_type_layers[spec]
-            spec_in_group = [n for n in layers if n in speculator_layers]
+            spec_in_group = [n for n in layers if n in drafter_layers]
             if spec_in_group:
-                non_spec = [n for n in layers if n not in speculator_layers]
+                non_spec = [n for n in layers if n not in drafter_layers]
                 if non_spec:
                     same_type_layers[spec] = non_spec
                 else:
                     del same_type_layers[spec]
-                speculator_group_layers.extend(spec_in_group)
-        if speculator_group_layers:
+                drafter_group_layers.extend(spec_in_group)
+        if drafter_group_layers:
             logger.info(
-                "Separated %d speculator layers into dedicated KV cache group",
-                len(speculator_group_layers),
+                "Separated %d drafter layers into dedicated KV cache group",
+                len(drafter_group_layers),
             )
 
     # Split each group into smaller groups, to make the number of layers in each
@@ -1091,9 +1092,9 @@ def _get_kv_cache_groups_uniform_page_size(
         # instead of layers[i * group_size: (i + 1) * group_size]
         for i in range(num_groups):
             grouped_layers.append(layers[i::num_groups])
-    # Prepend speculator layers as their own dedicated group
-    if speculator_group_layers:
-        grouped_layers.insert(0, speculator_group_layers)
+    # Prepend drafter layers as their own dedicated group
+    if drafter_group_layers:
+        grouped_layers.insert(0, drafter_group_layers)
 
     return create_kv_cache_group_specs(kv_cache_spec, grouped_layers)
 
@@ -1239,10 +1240,10 @@ def unify_hybrid_kv_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]):
         )
 
 
-def _identify_speculator_layers(
+def _identify_drafter_layers(
     vllm_config: VllmConfig, all_layer_names: list[str]
 ) -> set[str] | None:
-    """Identify speculator (drafter) attention layers by finding layers
+    """Identify drafter attention layers by finding layers
     whose index exceeds the target model's total layer count.
 
     For EAGLE-style drafters, drafter layers are appended after the target
@@ -1250,7 +1251,6 @@ def _identify_speculator_layers(
     Layer names use global indices even under pipeline parallelism
     (see make_layers() in model_executor/models/utils.py).
     """
-    from vllm.model_executor.models.utils import extract_layer_index
 
     spec_config = vllm_config.speculative_config
     if spec_config is None:
@@ -1259,24 +1259,24 @@ def _identify_speculator_layers(
     # Global count -- layer names use global indices under PP.
     target_num_layers = vllm_config.model_config.get_total_num_hidden_layers()
 
-    speculator_layers: set[str] = set()
+    drafter_layers: set[str] = set()
     for name in all_layer_names:
         try:
             layer_idx = extract_layer_index(name)
             if layer_idx >= target_num_layers:
-                speculator_layers.add(name)
+                drafter_layers.add(name)
         except (AssertionError, ValueError):
             # Fallback for non-standard naming
-            if "drafter" in name.lower() or "eagle" in name.lower():
-                speculator_layers.add(name)
+            if "drafter" in name.lower() or "eagle" in name.lower() or "mtp" in name.lower():
+                drafter_layers.add(name)
 
-    if speculator_layers:
+    if drafter_layers:
         logger.debug(
-            "Identified %d speculator layers for KV cache grouping: %s",
-            len(speculator_layers),
-            sorted(speculator_layers),
+            "Identified %d drafter layers for KV cache grouping: %s",
+            len(drafter_layers),
+            sorted(drafter_layers),
         )
-    return speculator_layers if speculator_layers else None
+    return drafter_layers if drafter_layers else None
 
 
 def get_kv_cache_groups(
@@ -1319,11 +1319,11 @@ def get_kv_cache_groups(
     # have the same physical memory per block per layer. Split the layers
     # into groups with the same number of layers, and thus same total page
     # size.
-    # Identify speculator (drafter) layers so they stay in one KV cache group
-    speculator_layers = _identify_speculator_layers(
+    # Identify drafter layers so they stay in one KV cache group
+    drafter_layers = _identify_drafter_layers(
         vllm_config, list(kv_cache_spec.keys())
     )
-    return _get_kv_cache_groups_uniform_page_size(kv_cache_spec, speculator_layers)
+    return _get_kv_cache_groups_uniform_page_size(kv_cache_spec, drafter_layers)
 
 
 def generate_scheduler_kv_cache_config(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -955,6 +955,7 @@ def is_kv_cache_type_attention_free(kv_cache_spec: dict[str, KVCacheSpec]) -> bo
 
 def _get_kv_cache_groups_uniform_page_size(
     kv_cache_spec: dict[str, KVCacheSpec],
+    speculator_layers: set[str] | None = None,
 ) -> list[KVCacheGroupSpec]:
     """
     Generates the KV cache groups for hybrid models with multiple
@@ -1025,6 +1026,26 @@ def _get_kv_cache_groups_uniform_page_size(
     for layer_name, layer_spec in kv_cache_spec.items():
         same_type_layers[layer_spec].append(layer_name)
 
+    # Separate speculator layers into their own group before the heuristic
+    # below runs, so drafter layers don't get scattered across groups.
+    speculator_group_layers: list[str] = []
+    if speculator_layers:
+        for spec in list(same_type_layers.keys()):
+            layers = same_type_layers[spec]
+            spec_in_group = [n for n in layers if n in speculator_layers]
+            if spec_in_group:
+                non_spec = [n for n in layers if n not in speculator_layers]
+                if non_spec:
+                    same_type_layers[spec] = non_spec
+                else:
+                    del same_type_layers[spec]
+                speculator_group_layers.extend(spec_in_group)
+        if speculator_group_layers:
+            logger.info(
+                "Separated %d speculator layers into dedicated KV cache group",
+                len(speculator_group_layers),
+            )
+
     # Split each group into smaller groups, to make the number of layers in each
     # group identical. Add padding to the last group of each type if necessary.
     # E.g., (full.0, full.1), (sw.0, sw.1, sw.2)
@@ -1070,6 +1091,10 @@ def _get_kv_cache_groups_uniform_page_size(
         # instead of layers[i * group_size: (i + 1) * group_size]
         for i in range(num_groups):
             grouped_layers.append(layers[i::num_groups])
+    # Prepend speculator layers as their own dedicated group
+    if speculator_group_layers:
+        grouped_layers.insert(0, speculator_group_layers)
+
     return create_kv_cache_group_specs(kv_cache_spec, grouped_layers)
 
 
@@ -1214,6 +1239,46 @@ def unify_hybrid_kv_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]):
         )
 
 
+def _identify_speculator_layers(
+    vllm_config: VllmConfig, all_layer_names: list[str]
+) -> set[str] | None:
+    """Identify speculator (drafter) attention layers by finding layers
+    whose index exceeds the target model's total layer count.
+
+    For EAGLE-style drafters, drafter layers are appended after the target
+    model's layers (e.g., model.layers.24-27 for a 24-layer target model).
+    Layer names use global indices even under pipeline parallelism
+    (see make_layers() in model_executor/models/utils.py).
+    """
+    from vllm.model_executor.models.utils import extract_layer_index
+
+    spec_config = vllm_config.speculative_config
+    if spec_config is None:
+        return None
+
+    # Global count -- layer names use global indices under PP.
+    target_num_layers = vllm_config.model_config.get_total_num_hidden_layers()
+
+    speculator_layers: set[str] = set()
+    for name in all_layer_names:
+        try:
+            layer_idx = extract_layer_index(name)
+            if layer_idx >= target_num_layers:
+                speculator_layers.add(name)
+        except (AssertionError, ValueError):
+            # Fallback for non-standard naming
+            if "drafter" in name.lower() or "eagle" in name.lower():
+                speculator_layers.add(name)
+
+    if speculator_layers:
+        logger.debug(
+            "Identified %d speculator layers for KV cache grouping: %s",
+            len(speculator_layers),
+            sorted(speculator_layers),
+        )
+    return speculator_layers if speculator_layers else None
+
+
 def get_kv_cache_groups(
     vllm_config: VllmConfig, kv_cache_spec: dict[str, KVCacheSpec]
 ) -> list[KVCacheGroupSpec]:
@@ -1254,7 +1319,11 @@ def get_kv_cache_groups(
     # have the same physical memory per block per layer. Split the layers
     # into groups with the same number of layers, and thus same total page
     # size.
-    return _get_kv_cache_groups_uniform_page_size(kv_cache_spec)
+    # Identify speculator (drafter) layers so they stay in one KV cache group
+    speculator_layers = _identify_speculator_layers(
+        vllm_config, list(kv_cache_spec.keys())
+    )
+    return _get_kv_cache_groups_uniform_page_size(kv_cache_spec, speculator_layers)
 
 
 def generate_scheduler_kv_cache_config(


### PR DESCRIPTION
## [Bugfix] Separate speculator layers into dedicated KV cache group for hybrid attention models

### Summary

The 1.25x heuristic in `_get_kv_cache_groups_uniform_page_size` ([introduced in #29303](https://github.com/vllm-project/vllm/pull/29303) for gpt-oss + eagle) does not generalize to all hybrid attention + speculative decoding configurations. When the drafter layer count pushes the attention-type ratio past the threshold, drafter layers get scattered across multiple KV cache groups, violating the invariant required by [`validate_same_kv_cache_group`](https://github.com/vllm-project/vllm/blob/cbd95a2dd19a5786e8b6572a8e6599c8375c4abf/vllm/v1/spec_decode/eagle.py#L1630-L1651).

This PR separates speculator layers into a dedicated group before the heuristic runs, so the grouping logic only operates on target model layers.

### Background

PR #29303 added a heuristic to handle the case where eagle drafter layers increase one attention type's count:

```python
# kv_cache_utils.py L1040-L1049
min_num_layers = min([len(layers) for layers in same_type_layers.values()])
group_size = min_num_layers
max_num_layers = max([len(layers) for layers in same_type_layers.values()])
if max_num_layers < min_num_layers * 1.25:
    # "1.25 is just a magic number to avoid too many padding layers"
    group_size = max_num_layers
```

This works when the drafter adds few enough layers to stay under 1.25x. For a model with 18 sliding + 18 full attention layers, adding 4 drafter layers gives 22 full total: `22 < 18 * 1.25 = 22.5`, so everything stays in one group.

But for a model with 12 sliding + 12 full, adding 4 drafter layers gives 16 full: `16 < 12 * 1.25 = 15` is false. The algorithm falls back to `group_size = 12`, splits 16 layers into 2 groups of 8 via [interleaved assignment](https://github.com/vllm-project/vllm/blob/cbd95a2dd19a5786e8b6572a8e6599c8375c4abf/vllm/v1/core/kv_cache_utils.py#L1059-L1072), and drafter layers end up in different groups.

The core issue: the heuristic doesn't distinguish between target and drafter layers. It can't, because no such distinction exists at the point where [`get_kv_cache_groups`](https://github.com/vllm-project/vllm/blob/cbd95a2dd19a5786e8b6572a8e6599c8375c4abf/vllm/v1/core/kv_cache_utils.py#L1217) is called -- `kv_cache_spec` is a flat dict of all layers.

### Fix

Changes in `vllm/v1/core/kv_cache_utils.py` and `tests/v1/core/test_kv_cache_utils.py`:

**`_identify_speculator_layers(vllm_config, all_layer_names)`** identifies drafter layers by checking if their index (extracted via [`extract_layer_index()`](https://github.com/vllm-project/vllm/blob/cbd95a2dd19a5786e8b6572a8e6599c8375c4abf/vllm/model_executor/models/utils.py#L820)) exceeds the target model's **total** layer count (`get_total_num_hidden_layers()`). This uses the global count, not the per-PP-rank local count, because [`make_layers()`](https://github.com/vllm-project/vllm/blob/cbd95a2dd19a5786e8b6572a8e6599c8375c4abf/vllm/model_executor/models/utils.py#L707-L719) always assigns global indices to layer names even under pipeline parallelism. Falls back to name-based matching (`drafter`/`eagle` in layer name) for non-standard architectures.

**`_get_kv_cache_groups_uniform_page_size(kv_cache_spec, speculator_layers=None)`** extracts identified speculator layers from all matching spec buckets before the heuristic runs, then inserts them as a dedicated group. The heuristic now sees the original target-only layer counts and behaves as intended.

**`get_kv_cache_groups(vllm_config, kv_cache_spec)`** wires the two together when `speculative_config` is present.

### Scope

This only activates when both conditions are met: hybrid attention model AND speculative decoding. When either is absent, behavior is identical to before. No changes to attention metadata, model forward, or spec decode logic.

### Testing

Tested on NVIDIA H200:

| Configuration | Result |
|---------------|--------|
| 12sw + 12full + 4 drafter (K=3,5,7,10) | Pass (was crash) |
| 18sw + 18full + 4 drafter (K=5) | Pass (no regression) |
| Non-hybrid + EAGLE (K=5) | Pass (no regression) |

Unit tests added in `tests/v1/core/test_kv_cache_utils.py::test_speculator_layers_dedicated_group`:
- `_identify_speculator_layers` correctly identifies drafter layers by global index
- `_identify_speculator_layers` returns `None` when no speculative config
- 12sw + 12full + 4 drafter: all drafter layers land in exactly one dedicated group
- Without fix (speculator_layers=None): confirms drafter layers scatter across 2 groups (reproduces the bug)
- 18sw + 18full + 4 drafter: no regression, drafter still in one group
