### PR TITLE
[ROCm] Support MLA with nhead<16 and FP8 KV cache for TP=8 (Kimi K2.5/Linear)

### DIFF
--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -52,8 +52,8 @@ from vllm.model_executor.layers.quantization.utils.mxfp4_utils import (
 from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 from vllm.model_executor.utils import replace_parameter, set_weight_attrs
 from vllm.platforms import current_platform
-from vllm.scalar_type import scalar_types
 from vllm.platforms.rocm import on_gfx950
+from vllm.scalar_type import scalar_types
 from vllm.utils.flashinfer import has_flashinfer
 from vllm.utils.import_utils import has_triton_kernels
 from vllm.utils.math_utils import round_up

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -293,6 +293,16 @@ class RocmPlatform(Platform):
                     if rocm_aiter_ops.is_mla_enabled() or block_size == 1
                     else AttentionBackendEnum.TRITON_MLA
                 )
+            if (
+                selected_backend == AttentionBackendEnum.TRITON_MLA
+                and kv_cache_dtype
+                and kv_cache_dtype.startswith("fp8")
+            ):
+                logger.warning(
+                    "TritonMLA does not support FP8 KV cache. "
+                    "Falling back to AITER MLA backend."
+                )
+                selected_backend = AttentionBackendEnum.ROCM_AITER_MLA
             if selected_backend == AttentionBackendEnum.TRITON_MLA:
                 if block_size != 1:
                     logger.info_once("Using Triton MLA backend.")


### PR DESCRIPTION
## Summary

- **Support AITER MLA for num_heads < 16** (e.g., TP=8 with Kimi K2.5 giving 8 heads/rank, or Kimi-Linear giving 4 heads/rank). Uses head-repeat to expand to 16 heads before calling the AITER MLA decode kernel, then contracts the output back. This reuses the existing optimized gqa_ratio=16 ASM kernel without requiring new kernel variants.

- **Relax head-count assertion** to accept num_heads of 4, 8, or any multiple of 16 in [16, 128]. Previously only {16, 128} were accepted.

- **Auto-fallback from TritonMLA to AITER MLA when FP8 KV cache is used.** TritonMLA does not support FP8 KV cache (raises `NotImplementedError`). The fallback applies to both auto-selected and user-specified backends.

Fixes #35641

## Test plan

- [x] Verify `amd/Kimi-K2.5-MXFP4` runs with TP=8, AITER enabled (8 heads/rank, previously crashed with assertion error)
- [x] Verify `moonshotai/Kimi-Linear-48B-A3B-Instruct` runs with TP=1, `--kv-cache-dtype fp8_e4m3` (32 heads, previously crashed)
- [x] Verify TP=2 / TP=4 continue to work (16/32 heads/rank, existing path)
- [x] Verify explicit `--attention-backend TRITON_MLA` + `--kv-cache-dtype fp8_e4m3` triggers fallback warning
- [x] Verify non-FP8 TritonMLA path is unaffected