### PR TITLE
[Bugfix] Fix MRotaryEmbedding missing `truncate` attr with YaRN scaling

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/mrope.py
@@ -218,12 +218,14 @@ class MRotaryEmbedding(RotaryEmbeddingBase):
         attn_factor: float = 1,
         beta_fast: int = 32,
         beta_slow: int = 1,
+        truncate: bool = True,
     ) -> None:
         self.scaling_factor = scaling_factor
         self.extrapolation_factor = extrapolation_factor
         self.attn_factor = attn_factor
         self.beta_fast = beta_fast
         self.beta_slow = beta_slow
+        self.truncate = truncate
         if self.scaling_factor is not None:
             # Get n-d magnitude scaling corrected for interpolation
             self.mscale = float(yarn_get_mscale(self.scaling_factor) * attn_factor)


### PR DESCRIPTION
## Purpose

Fixes #35056.

When `MRotaryEmbedding` is used with YaRN RoPE scaling (e.g. Qwen3.5 with extended context to 1,010,000 tokens), it delegates `_compute_inv_freq` and `_compute_cos_sin_cache` to `YaRNScalingRotaryEmbedding` methods. Those methods access `self.truncate`, but `MRotaryEmbedding.__init__` never accepted or set the `truncate` attribute, causing `AttributeError: 'MRotaryEmbedding' object has no attribute 'truncate'` during model loading.

This PR adds the missing `truncate: bool = True` parameter to `MRotaryEmbedding.__init__` and sets `self.truncate = truncate` before `super().__init__()` (which triggers the cache computation that needs the attribute). The default value `True` matches `YaRNScalingRotaryEmbedding`'s default.

## Test Plan

## Test Result