### PR TITLE
[Bugfix] Fix DCP + FA3 crash due to missing num_splits in _forward_with_dcp

### DIFF
--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -847,6 +847,7 @@ class FlashAttentionImpl(AttentionImpl):
             q_descale=q_descale,
             k_descale=k_descale,
             v_descale=v_descale,
+            num_splits=attn_metadata.max_num_splits,
         )
         # FA returns LSE in shape [ H, B ] but cp_lse_ag_out_rs wants [ B, H ]
         context_attn_out_cor, context_lse_cor = cp_lse_ag_out_rs(
@@ -876,6 +877,7 @@ class FlashAttentionImpl(AttentionImpl):
             q_descale=q_descale,
             k_descale=k_descale,
             v_descale=v_descale,
+            num_splits=attn_metadata.max_num_splits,
         )
         assert context_attn_out_cor.shape == query_attn_out.shape
         assert context_lse_cor.shape == query_lse.shape


### PR DESCRIPTION
## Purpose

Fix #35057. Qwen3.5-397B-A17B (and similar models) crash with `RuntimeError: scheduler_metadata must have shape (metadata_size)` when using `--decode-context-parallel-size 2` on H200 GPUs with FlashAttention 3.

**Root cause**: `_forward_with_dcp()` calls `flash_attn_varlen_func` without the `num_splits` parameter (defaulting to 0), while `get_scheduler_metadata()` was called with `num_splits=32` during CUDA graph capture. FA3 computes different `metadata_size` for `num_splits=0` vs `num_splits=32` because internal flags differ, causing a shape mismatch.

This PR adds the missing `num_splits=attn_metadata.max_num_splits` parameter to both DCP `flash_attn_varlen_func` calls, aligning the DCP path with the non-DCP forward path.

## Test Plan

## Test Result