### PR TITLE
[Bugfix] Gracefully disable AllReduceFusionPass on GPUs without multicast support

### DIFF
--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -729,14 +729,24 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
             scope="global",
         )
 
-        self.workspace = flashinfer_comm.create_allreduce_fusion_workspace(
-            backend="trtllm",
-            world_size=self.tp_size,
-            rank=rank,
-            max_token_num=self.max_token_num,
-            hidden_dim=self.hidden_dim,
-            dtype=self.model_dtype,
-        )
+        try:
+            self.workspace = flashinfer_comm.create_allreduce_fusion_workspace(
+                backend="trtllm",
+                world_size=self.tp_size,
+                rank=rank,
+                max_token_num=self.max_token_num,
+                hidden_dim=self.hidden_dim,
+                dtype=self.model_dtype,
+            )
+        except RuntimeError as e:
+            logger.warning_once(
+                "AllReduce fusion pass is disabled: flashinfer workspace "
+                "creation failed: %s. This is expected on GPUs without "
+                "NVSwitch (e.g., NVLink bridge-only or PCIe topologies). "
+                "Falling back to non-fused allreduce.",
+                str(e),
+            )
+            return
 
         global _FI_WORKSPACE
         _FI_WORKSPACE = self.workspace

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -739,6 +739,8 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
                 dtype=self.model_dtype,
             )
         except RuntimeError as e:
+            if "multicast" not in str(e).lower():
+                raise
             logger.warning_once(
                 "AllReduce fusion pass is disabled: flashinfer workspace "
                 "creation failed: %s. This is expected on GPUs without "


### PR DESCRIPTION
## Purpose

Fixes #34891: On GPUs without NVSwitch (e.g., H200/H100 with NVLink bridge-only or PCIe topologies), `AllReduceFusionPass.__init__()` crashes with `RuntimeError: [SymmDeviceMemory] Device does not support multicasting` when `flashinfer_comm.create_allreduce_fusion_workspace()` tries to create a `SymmDeviceMemory` that requires multicast support.

This PR wraps the workspace creation call in a `try/except RuntimeError` that logs a warning and returns early, leaving the pass in its default `disabled=True` state. This follows the identical graceful degradation pattern used by `SymmMemCommunicator` in `symm_mem.py`. The model falls back to non-fused allreduce and starts normally.

## Test Plan



## Test Result