### PR TITLE
Fix fallback to default tactic (flashinfer autotuner) with trtllm_fp4_block_scale_moe

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -348,7 +348,7 @@ def flashinfer_trtllm_fp4_moe(
         hidden_states=hidden_states_fp4,
         hidden_states_scale=hidden_states_scale_linear_fp4.view(
             torch.float8_e4m3fn
-        ).flatten(),
+        ).reshape(*hidden_states_fp4.shape[:-1], -1),
         gemm1_weights=layer.w13_weight.data,
         gemm1_weights_scale=layer.w13_weight_scale.data.view(torch.float8_e4m3fn),
         gemm1_bias=None,
@@ -432,7 +432,7 @@ def flashinfer_trtllm_fp4_routed_moe(
         hidden_states=hidden_states_fp4,
         hidden_states_scale=hidden_states_scale_linear_fp4.view(
             torch.float8_e4m3fn
-        ).flatten(),
+        ).reshape(*hidden_states_fp4.shape[:-1], -1),
         gemm1_weights=layer.w13_weight.data,
         gemm1_weights_scale=layer.w13_weight_scale.data.view(torch.float8_e4m3fn),
         gemm1_bias=None,


### PR DESCRIPTION
## Purpose

The **flashinfer autotuner** expects the first dimension of the MoE tensors to be num_tokens.

The relevant code can be found in **flashinfer** function `get_trtllm_moe_sm100_module`:
```
        # their first dimension is num_tokens which will be tuned
        tuning_config_with_hidden_states_scales = TuningConfig(
            dynamic_tensor_specs=(
                DynamicTensorSpec(
                    (0, 1, 2, 3, 4, 5),
                    (0, 0, 0, 0, 0, 0),
                    get_last_power_of_2_num_tokens_buckets(8192, 1),
                    lambda x: min(last_positive_power_of_2(x), 8192),
                    dynamic_tensor_initializers,
                ),
            )
        )
```

When running with vLLM main with env var `FLASHINFER_LOGGING_LEVEL=DEBUG`, we can see the following:
```
flashinfer.jit: [AutoTunner]: Using fallback tactic for flashinfer::trtllm_fp4_block_scale_moe with input shapes ...
```
Using `reshape(...)` instead of `flatten()` solves the issues (no `using fallback tactic` prints).

This change is aligned with function `Mxfp4MoEMethod.apply_monolithic`:
```
x_scale = x_scale.view(torch.float8_e4m3fn).reshape(*x.shape[:-1], -1)
```

## Test Plan

Verify that there is no drop in accuracy (lm_eval).

## Test Result

Used the following MoE NVFP4 model:
https://huggingface.co/RedHatAI/Llama-4-Scout-17B-16E-Instruct-NVFP4

Use env vars:
```
export VLLM_USE_FLASHINFER_MOE_FP4=1
export VLLM_FLASHINFER_MOE_BACKEND=latency
```
To use `'FLASHINFER_TRTLLM' NvFp4 MoE backend`.

lm_eval gsm8k:
```
lm_eval \
  --model vllm \
  --model_args pretrained="/my_home/hf_models/RedHatAI/Llama-4-Scout-17B-16E-Instruct-NVFP4",dtype=auto,add_bos_token=True,max_model_len=4096,tensor_parallel_size=2,enable_chunked_prefill=True,enforce_eager=True \
  --tasks gsm8k_llama \
  --apply_chat_template \
  --fewshot_as_multiturn \
  --batch_size auto

### vLLM main commit: 
|   Tasks   |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_llama|      3|flexible_extract|     8|exact_match|↑  |0.9371|±  |0.0067|
|           |       |strict_match    |     8|exact_match|↑  |0.9371|±  |0.0067|


### This PR:
|   Tasks   |Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----------|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k_llama|      3|flexible_extract|     8|exact_match|↑  |0.9371|±  |0.0067|
|           |       |strict_match    |     8|exact_match|↑  |0.9371|±  |0.0067|

```

There was no change in `vllm bench serve` performance (tok/sec).

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

