### PR TITLE
docs(cpu): Clarify pre-built wheels requirement for CPU Python-only build

### DIFF
--- a/docs/getting_started/installation/cpu.md
+++ b/docs/getting_started/installation/cpu.md
@@ -75,6 +75,8 @@ For example, the nightly build index is: `https://wheels.vllm.ai/nightly/cpu/`.
 
 #### Set up using Python-only build (without compilation) {#python-only-build}
 
+This method requires [pre-built wheels](#pre-built-wheels) for your platform.
+
 Please refer to the instructions for [Python-only build on GPU](./gpu.md#python-only-build), and replace the build commands with:
 
 ```bash


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Clarify that Python-only build needs pre-built wheels (which aren't available for macOS).

## Test Plan

Ran markdownlint.

## Test Result

Passed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

