### PR TITLE
Fix pipeline parallel with embed scaling in the Transformers modelling backend

### DIFF
--- a/vllm/model_executor/models/transformers/base.py
+++ b/vllm/model_executor/models/transformers/base.py
@@ -191,6 +191,7 @@ class Base(
         self.attention_instances = self.create_attention_instances()
 
         # Input embeddings
+        self.embed_scale = None
         input_embeddings = self.model.get_input_embeddings()
         if not isinstance(input_embeddings, PPMissingLayer):
             # Some models scale embeddings inside the input embedding layer


### PR DESCRIPTION
On pipeline stages where the input embeddings didn't exist (i.e. all stages but the first one) `embed_scale` was not being added.

This caused an attribute error in `Base.forward` when `self.embed_scale is not None` gets checked on these pipeline stages.

This PR ensures that `embed_scale` always exists.