### PR TITLE
[MLA] Add fused Triton concat+quantize kernel for fp8 decode queries

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -125,6 +125,7 @@ if TYPE_CHECKING:
     VLLM_SERVER_DEV_MODE: bool = False
     VLLM_V1_OUTPUT_PROC_CHUNK_SIZE: int = 128
     VLLM_MLA_DISABLE: bool = False
+    VLLM_MLA_FUSED_CONCAT_QUANT: bool = False
     VLLM_RAY_PER_WORKER_GPUS: float = 1.0
     VLLM_RAY_BUNDLE_INDICES: str = ""
     VLLM_CUDART_SO_PATH: str | None = None
@@ -1035,6 +1036,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # If set, vLLM will disable the MLA attention optimizations.
     "VLLM_MLA_DISABLE": lambda: bool(int(os.getenv("VLLM_MLA_DISABLE", "0"))),
+    # If set, use fused Triton concat+quantize kernel for MLA decode queries
+    # instead of torch.cat + scaled_fp8_quant. Reduces memory traffic 3x.
+    "VLLM_MLA_FUSED_CONCAT_QUANT": lambda: bool(
+        int(os.getenv("VLLM_MLA_FUSED_CONCAT_QUANT", "0"))
+    ),
     # If set, vLLM will pick up the provided Flash Attention MLA
     # Number of GPUs per worker in Ray, if it is set to be a fraction,
     # it allows ray to schedule multiple actors on a single GPU,

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1201,7 +1201,7 @@ class FusedConcatQuantFP8:
             cos_sin_cache.stride(0) if apply_rope else 0,
             D_NOPE=self.d_nope,
             D_PE=self.d_pe,
-            APPLY_ROPE=apply_rope,
+            APPLY_ROPE=1 if apply_rope else 0,
             num_warps=4,
         )
         return out


### PR DESCRIPTION
Background:
<img width="2856" height="1224" alt="image" src="https://github.com/user-attachments/assets/e65c8d39-8275-442c-876c-268bcc905224" />


CatArrayBatchedCopy takes a significant chunk of forward pass in R1 NVFP4. This PR addresses that.

Benchmark parameters:

```
E8/E32
just benchmark 2048 4096 8192 500 1500
```

Decode:
```
vllm serve $PROFILER_ARGS \
                  nvidia/DeepSeek-R1-0528-FP4-v2 \
                  --port 8200 \
                  --disable-uvicorn-access-log \
                  --enable-expert-parallel \
                  --tensor-parallel-size 1 \
                  --data-parallel-hybrid-lb \
                  --data-parallel-size $((LWS_GROUP_SIZE * DP_SIZE_LOCAL)) \
                  --data-parallel-size-local $DP_SIZE_LOCAL \
                  --data-parallel-address ${LWS_LEADER_ADDRESS} \
                  --data-parallel-rpc-port 5555 \
                  --data-parallel-start-rank $START_RANK \
                  --all2all-backend deepep_low_latency \
                  --trust-remote-code \
                  --enable-eplb \
                  --eplb-config '{"window_size":"100","step_interval":"1000","num_redundant_experts":"32","log_balancedness":"False"}' \
                  --kv_transfer_config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
```


Prefill:
```
 vllm serve $PROFILER_ARGS \
                  nvidia/DeepSeek-R1-0528-FP4-v2 \
                  --port 8000 \
                  --disable-uvicorn-access-log \
                  --enable-expert-parallel \
                  --tensor-parallel-size 1 \
                  --data-parallel-hybrid-lb \
                  --data-parallel-size $((LWS_GROUP_SIZE * DP_SIZE_LOCAL)) \
                  --data-parallel-size-local $DP_SIZE_LOCAL \
                  --data-parallel-address ${LWS_LEADER_ADDRESS} \
                  --data-parallel-rpc-port 5555 \
                  --data-parallel-start-rank $START_RANK \
                  --all2all-backend allgather_reducescatter \
                  --trust-remote-code \
                  --kv_transfer_config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
```

Without this PR:


```
============ Serving Benchmark Result ============
Successful requests:           8192
Failed requests:             0
Maximum request concurrency:       4096
Request rate configured (RPS):      2048.00
Benchmark duration (s):         117.30
Total input tokens:           4087808
Total generated tokens:         12288000
Request throughput (req/s):       69.84
Output token throughput (tok/s):     104754.66
Peak output token throughput (tok/s):  146673.00
Peak concurrent requests:        4355.00
Total token throughput (tok/s):     139603.04
---------------Time to First Token----------------
Mean TTFT (ms):             7995.52
Median TTFT (ms):            7371.34
P99 TTFT (ms):              15758.77
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):             30.44
Median TPOT (ms):            30.13
P99 TPOT (ms):              32.84
---------------Inter-token Latency----------------
Mean ITL (ms):              30.44
Median ITL (ms):             0.00
P99 ITL (ms):              936.82
==================================================
```


Applied only on decode nodes:

```
============ Serving Benchmark Result ============
Successful requests:                     8191
Failed requests:                         1
Maximum request concurrency:             4096
Request rate configured (RPS):           2048.00
Benchmark duration (s):                  124.08
Total input tokens:                      4087309
Total generated tokens:                  12286500
Request throughput (req/s):              66.01
Output token throughput (tok/s):         99019.38
Peak output token throughput (tok/s):    164481.00
Peak concurrent requests:                4586.00
Total token throughput (tok/s):          131959.83
---------------Time to First Token----------------
Mean TTFT (ms):                          14021.90
Median TTFT (ms):                        14115.23
P99 TTFT (ms):                           24454.93
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          28.91
Median TPOT (ms):                        27.83
P99 TPOT (ms):                           33.53
---------------Inter-token Latency----------------
Mean ITL (ms):                           28.91
Median ITL (ms):                         0.00
P99 ITL (ms):                            973.35
==================================================
```

Appled on prefill and decode nodes:

```
============ Serving Benchmark Result ============
Successful requests:                     8190
Failed requests:                         2
Maximum request concurrency:             4096
Request rate configured (RPS):           2048.00
Benchmark duration (s):                  112.60
Total input tokens:                      4086810
Total generated tokens:                  12285000
Request throughput (req/s):              72.73
Output token throughput (tok/s):         109098.24
Peak output token throughput (tok/s):    185480.00
Peak concurrent requests:                4441.00
Total token throughput (tok/s):          145391.58
---------------Time to First Token----------------
Mean TTFT (ms):                          9615.13
Median TTFT (ms):                        9922.41
P99 TTFT (ms):                           16393.20
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          27.49
Median TPOT (ms):                        26.99
P99 TPOT (ms):                           33.27
---------------Inter-token Latency----------------
Mean ITL (ms):                           27.49
Median ITL (ms):                         0.00
P99 ITL (ms):                            670.66
==================================================
```

Benchmark failures were due to:

```
UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 77203-77204: unexpected end of data

Error 1: Traceback (most recent call last):
  File "/app/.venv/lib/python3.12/site-packages/vllm/benchmarks/lib/endpoint_request_func.py", line 207, in async_request_openai_completions
    data = json.loads(chunk)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

tip: install termplotlib and gnuplot to plot the metrics
```




## Purpose

## Test Plan

## Test Result

lm_eval gsm8k

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    10|exact_match|↑  |0.9560|±  |0.0056|
|     |       |strict-match    |    10|exact_match|↑  |0.9538|±  |0.0058|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

