### PR TITLE
feat: added num requests and num tokens to profiles

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3384,7 +3384,7 @@ class GPUModelRunner(
             max_num_scheduled_tokens = int(num_scheduled_tokens_np.max())
             num_tokens_unpadded = scheduler_output.total_num_scheduled_tokens
 
-            if envs.VLLM_CUSTOM_SCOPES_FOR_PROFILING:
+            if envs.VLLM_NVTX_SCOPES_FOR_PROFILING:
                 torch.cuda.nvtx.range_push(
                     f"execute_model: reqs={num_reqs}, tokens={num_tokens_unpadded}"
                 )
@@ -3573,13 +3573,13 @@ class GPUModelRunner(
                     assert isinstance(hidden_states, IntermediateTensors)
                     hidden_states.kv_connector_output = kv_connector_output
                     self.kv_connector_output = kv_connector_output
-                    if envs.VLLM_CUSTOM_SCOPES_FOR_PROFILING:
+                    if envs.VLLM_NVTX_SCOPES_FOR_PROFILING:
                         torch.cuda.nvtx.range_pop()
                     return hidden_states
 
                 if self.is_pooling_model:
                     # Return the pooling output.
-                    if envs.VLLM_CUSTOM_SCOPES_FOR_PROFILING:
+                    if envs.VLLM_NVTX_SCOPES_FOR_PROFILING:
                         torch.cuda.nvtx.range_pop()
                     return self._pool(
                         hidden_states,
@@ -3633,7 +3633,7 @@ class GPUModelRunner(
             slot_mappings,
         )
         self.kv_connector_output = kv_connector_output
-        if envs.VLLM_CUSTOM_SCOPES_FOR_PROFILING:
+        if envs.VLLM_NVTX_SCOPES_FOR_PROFILING:
             torch.cuda.nvtx.range_pop()
         return None
 


### PR DESCRIPTION
## Purpose

The number of requests and tokens within a batch are crucial information to be able to interpret a profile. Adding this information with NVTX seems like a good idea.

## Test Plan

Tested it by profiling a vLLM instance with `VLLM_NVTX_SCOPES_FOR_PROFILING=1`.

## Test Result

Information is visible in Nsight Systems:
<img width="379" height="308" alt="image" src="https://github.com/user-attachments/assets/3a0fced5-5161-49bd-819f-d77f21366205" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

