### PR TITLE
Use Xet high performance mode for Transformers v5

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -80,9 +80,15 @@ def enable_hf_transfer():
             pass
 
 
+def enable_xet_high_performance():
+    """automatically activates xet high performance mode"""
+    if "HF_XET_HIGH_PERFORMANCE" not in os.environ:
+        huggingface_hub.constants.HF_XET_HIGH_PERFORMANCE = True
+
+
 if hasattr(huggingface_hub.constants, "HF_XET_HIGH_PERFORMANCE"):
     # Transformers v5
-    huggingface_hub.constants.HF_XET_HIGH_PERFORMANCE = True
+    enable_xet_high_performance()
 else:
     # Transformers v4
     enable_hf_transfer()

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -80,7 +80,12 @@ def enable_hf_transfer():
             pass
 
 
-enable_hf_transfer()
+if hasattr(huggingface_hub.constants, "HF_XET_HIGH_PERFORMANCE"):
+    # Transformers v5
+    huggingface_hub.constants.HF_XET_HIGH_PERFORMANCE = True
+else:
+    # Transformers v4
+    enable_hf_transfer()
 
 
 class DisabledTqdm(tqdm):


### PR DESCRIPTION
Enable high performance mode for Xet when Transformers v5 is installed, falling back to `hf_transfer` for Transformers v4. This change optimizes performance based on the installed version of the Transformers library.

