### PR TITLE
gpu_model_runner: Cache is_encoder_decoder from model config

### DIFF
--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -1365,7 +1365,7 @@ class ModelConfig:
 
         return diff_sampling_param
 
-    @property
+    @cached_property
     def is_encoder_decoder(self) -> bool:
         """Extract the HF encoder/decoder model flag."""
         return is_encoder_decoder(self.hf_config)


### PR DESCRIPTION
Profiling revealed the model_config.is_encoder_decoder property query as relatively expensive (~ 12 us per call in test env). Make it a cached property to prevent re-computation.