### PR TITLE
Fix custom processors that use deleted import for Transformers v5

### DIFF
--- a/vllm/transformers_utils/processor.py
+++ b/vllm/transformers_utils/processor.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from vllm.config import ModelConfig
 
 
-def _transformers_v4_compatibility():
+def _transformers_v4_compatibility_import():
     """Some remote code processors still import `ChatTemplateLoadKwargs` which was a
     subset of `ProcessorChatTemplateKwargs` as defined in Transformers v4.
     In Transformers v5 these were merged into `ProcessorChatTemplateKwargs` and
@@ -38,13 +38,13 @@ def _transformers_v4_compatibility():
     for `ChatTemplateLoadKwargs` if it doesn't exist.
 
     This can be removed if `HCXVisionForCausalLM` is upstreamed to Transformers."""
-    old = getattr(processing_utils, "ChatTemplateLoadKwargs", None)
-    new = getattr(processing_utils, "ProcessorChatTemplateKwargs", None)
-    if old is None and new is not None:
-        processing_utils.ChatTemplateLoadKwargs = new
+    old_import = getattr(processing_utils, "ChatTemplateLoadKwargs", None)
+    new_import = getattr(processing_utils, "ProcessorChatTemplateKwargs", None)
+    if old_import is None and new_import is not None:
+        processing_utils.ChatTemplateLoadKwargs = new_import
 
 
-_transformers_v4_compatibility()
+_transformers_v4_compatibility_import()
 
 _P = TypeVar("_P", bound=ProcessorMixin, default=ProcessorMixin)
 _V = TypeVar("_V", bound=BaseVideoProcessor, default=BaseVideoProcessor)


### PR DESCRIPTION
Some remote code processors still import `ChatTemplateLoadKwargs` which was a subset of `ProcessorChatTemplateKwargs` as defined in Transformers v4. In Transformers v5 these were merged into `ProcessorChatTemplateKwargs` and `ChatTemplateLoadKwargs` was removed.

In vLLM CI, one architecture which does this is `HCXVisionForCausalLM`. If we upstream this architecture to Transformers, we can remove this backward compatibility patch in vLLM.
