### PR TITLE
[Bugfix][Hardware][AMD] Gate FP4 BMM on gfx950 to fix MI300X crash

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -999,7 +999,9 @@ class rocm_aiter_ops:
     @classmethod
     @if_aiter_supported
     def is_fp4bmm_enabled(cls) -> bool:
-        return cls._AITER_ENABLED and cls._FP4BMM_ENABLED
+        from vllm.platforms.rocm import on_gfx950
+
+        return cls._AITER_ENABLED and cls._FP4BMM_ENABLED and on_gfx950()
 
     @classmethod
     @if_aiter_supported


### PR DESCRIPTION
## Summary
- Gate `is_fp4bmm_enabled()` on `on_gfx950()` so MI300X/MI325X (gfx942) gracefully falls back to FP8 instead of crashing with `RuntimeError: MXFP4 quantization is not supported on gfx942`
- MXFP4 requires CDNA4 hardware (gfx950: MI350X/MI355X)

## Test plan
- On MI300X (gfx942): `is_fp4bmm_enabled()` returns `False`, FP8 fallback used — no crash
- On MI350X (gfx950): FP4 BMM still enabled and functional
- `pre-commit run --all-files` passes

Fixes #34641