### PR TITLE
[Bugfix][Frontend] Fix audio transcription for MP4, M4A, and WebM formats

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -976,6 +976,7 @@ setup(
             "soundfile",
             "mistral_common[audio]",
             "av",
+            "torchcodec",
         ],  # Required for audio processing
         "video": [],  # Kept for backwards compatibility
         "flashinfer": [],  # Kept for backwards compatibility

--- a/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
+++ b/vllm/entrypoints/openai/speech_to_text/speech_to_text.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import asyncio
-import io
 import math
 import time
 import zlib
@@ -11,7 +10,6 @@ from typing import Final, Literal, TypeAlias, TypeVar, cast
 
 import numpy as np
 from fastapi import Request
-from soundfile import LibsndfileError
 from transformers import PreTrainedTokenizerBase
 
 import vllm.envs as envs
@@ -37,6 +35,7 @@ from vllm.entrypoints.openai.speech_to_text.protocol import (
     TranslationSegment,
     TranslationStreamResponse,
 )
+from vllm.entrypoints.openai.speech_to_text.utils import load_audio_bytes
 from vllm.entrypoints.utils import get_max_tokens
 from vllm.exceptions import VLLMValidationError
 from vllm.inputs import EncoderDecoderInputs, ProcessorInputs
@@ -55,14 +54,6 @@ try:
     import librosa
 except ImportError:
     librosa = PlaceholderModule("librosa")  # type: ignore[assignment]
-
-# Public libsndfile error codes exposed via `soundfile.LibsndfileError.code`, soundfile
-# being librosa's main backend. Used to validate if an audio loading error is due to a
-# server error vs a client error (invalid audio file).
-# 1 = unrecognised format      (file is not a supported audio container)
-# 3 = malformed file           (corrupt or structurally invalid audio)
-# 4 = unsupported encoding     (codec not supported by this libsndfile build)
-_BAD_SF_CODES = {1, 3, 4}
 
 SpeechToTextResponse: TypeAlias = TranscriptionResponse | TranslationResponse
 SpeechToTextResponseVerbose: TypeAlias = (
@@ -202,16 +193,12 @@ class OpenAISpeechToText(OpenAIServing):
                 value=len(audio_data) / 1024**2,
             )
 
-        with io.BytesIO(audio_data) as bytes_:
-            try:
-                # NOTE resample to model SR here for efficiency. This is also a
-                # pre-requisite for chunking, as it assumes Whisper SR.
-                y, sr = librosa.load(bytes_, sr=self.asr_config.sample_rate)
-            except LibsndfileError as exc:
-                # Distinguish client errors (invalid audio) from server errors
-                if exc.code in _BAD_SF_CODES:
-                    raise ValueError("Invalid or unsupported audio file.") from exc
-                raise
+        # Decode audio bytes.  For container formats (MP4, M4A, WebM) that
+        # soundfile cannot detect from a BytesIO stream, _load_audio_bytes
+        # transparently falls back to ffmpeg via an in-memory fd.
+        # NOTE resample to model SR here for efficiency. This is also a
+        # pre-requisite for chunking, as it assumes Whisper SR.
+        y, sr = load_audio_bytes(audio_data, sr=self.asr_config.sample_rate)
 
         duration = librosa.get_duration(y=y, sr=sr)
         do_split_audio = (

--- a/vllm/entrypoints/openai/speech_to_text/utils.py
+++ b/vllm/entrypoints/openai/speech_to_text/utils.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Audio decoding utilities for the speech-to-text endpoints."""
+
+import io
+
+import numpy as np
+import torchaudio
+
+from vllm.logger import init_logger
+from vllm.utils.import_utils import PlaceholderModule
+
+try:
+    import librosa
+except ImportError:
+    librosa = PlaceholderModule("librosa")  # type: ignore[assignment]
+
+try:
+    import soundfile as sf
+except ImportError:
+    sf = PlaceholderModule("soundfile")  # type: ignore[assignment]
+
+logger = init_logger(__name__)
+
+# Public libsndfile error codes exposed via ``soundfile.LibsndfileError.code``.
+# soundfile is librosa's primary backend.  These codes indicate that the audio
+# data itself is problematic (unrecognised container, corrupt file, or
+# unsupported encoding) rather than a transient server error.
+# 1 = unrecognised format, 3 = malformed file, 4 = unsupported encoding
+_BAD_SF_CODES = {1, 3, 4}
+
+
+def _decode_audio_bytes_torchaudio(
+    audio_data: bytes,
+    sr: int,
+) -> tuple[np.ndarray, int]:
+    """Decode audio bytes to mono float32 PCM via torchaudio, in-process.
+
+    ``torchaudio.load`` (backed by TorchCodec / FFmpeg) can decode
+    container formats (MP4, M4A, WebM) directly from a ``BytesIO``
+    buffer without spawning a subprocess.  The decoded waveform is
+    down-mixed to mono and resampled to *sr* Hz, matching the return
+    convention of ``librosa.load``.
+    """
+    buf = io.BytesIO(audio_data)
+    waveform, orig_sr = torchaudio.load(buf)
+
+    # Down-mix to mono (average across channels).
+    if waveform.shape[0] > 1:
+        waveform = waveform.mean(dim=0, keepdim=True)
+
+    # Resample to the target sample rate when necessary.
+    if orig_sr != sr:
+        waveform = torchaudio.functional.resample(
+            waveform, orig_freq=orig_sr, new_freq=sr
+        )
+
+    # Squeeze channel dim → 1-D float32 numpy array (same as librosa.load).
+    y = waveform.squeeze(0).numpy()
+    if y.size == 0:
+        raise RuntimeError(
+            "torchaudio produced no audio samples (file may be empty or corrupt)"
+        )
+    return y, sr
+
+
+def load_audio_bytes(
+    audio_data: bytes,
+    sr: int | float,
+) -> tuple[np.ndarray, int]:
+    """Load audio from raw bytes, with an in-process torchaudio fallback.
+
+    First tries ``librosa.load(BytesIO(...))`` which works for formats
+    that *soundfile* can auto-detect (WAV, FLAC, MP3, OGG, ...).  If
+    that fails with a ``LibsndfileError`` indicating an unrecognised or
+    unsupported format (typically container formats like MP4/M4A/WebM),
+    the bytes are decoded in-process via ``torchaudio`` (backed by
+    TorchCodec / FFmpeg) which handles these containers natively.
+    """
+    sr = int(sr)
+
+    # Fast path: librosa + soundfile (works for most formats).
+    try:
+        with io.BytesIO(audio_data) as buf:
+            return librosa.load(buf, sr=sr)  # type: ignore[return-value]
+    except sf.LibsndfileError as exc:
+        # Only fall back for known format-detection failures.
+        # Re-raise anything else (e.g. corrupt but recognised format).
+        if exc.code not in _BAD_SF_CODES:
+            raise
+        logger.debug(
+            "librosa/soundfile could not decode audio from BytesIO "
+            "(code=%s: %s); falling back to torchaudio in-process decode",
+            exc.code,
+            exc,
+        )
+
+    # Fallback: torchaudio in-process decode (no subprocess overhead).
+    try:
+        return _decode_audio_bytes_torchaudio(audio_data, sr)
+    except Exception as ta_exc:
+        logger.debug(
+            "torchaudio fallback also failed: %s",
+            ta_exc,
+        )
+        raise ValueError("Invalid or unsupported audio file.") from ta_exc


### PR DESCRIPTION
## Purpose

Fix `/v1/audio/transcriptions` (and `/v1/audio/translations`) to correctly handle MP4, M4A, and WebM audio uploads. These three container formats are listed as supported in both the [OpenAI API specification](https://platform.openai.com/docs/api-reference/audio/createTranscription) and the [vLLM documentation](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#audio-transcription-api), yet they have been broken since the transcription endpoint was first
introduced.

Fixes #16335
Fixes #26808
Fixes #18385

this should supersede #18477 (stale and only addressed WebM). This PR addresses all three broken formats and incorporates the reviewer feedback from #18477 (no tempfile, narrower exception handling, debug logging on the fallback path).

### Cause

`_preprocess_speech_to_text()` wraps the uploaded bytes in a `BytesIO` and passes them to `librosa.load()`. Under the hood, librosa delegates to `soundfile` (libsndfile), which auto-detects the codec from the stream. This works for self-describing formats like WAV, FLAC, MP3, and OGG because their headers contain enough information for libsndfile to identify them.

MP4 (AAC), M4A (AAC), and WebM (Opus/Vorbis) (container formats) use ISOBMFF or Matroska containers whose detection in libsndfile relies on a filename extension hint that `BytesIO` objects cannot provide. When libsndfile fails, librosa is supposed to fall back to `audioread` (which shells out to ffmpeg), but `audioread` also cannot handle `BytesIO` objects because ffmpeg needs a seekable file path.

The result is `"Error opening <_io.BytesIO object>: Format not recognised."`, shown as HTTP 500 (v0.13) or HTTP 200 with an error body (v0.15+).

Critically, `librosa.load(filepath_string)` works perfectly for all nine documented formats. The bug is exclusively in the `BytesIO` code path.

### Changes

- **`load_audio_bytes()`** in `vllm/entrypoints/openai/speech_to_text/utils.py` first tries `librosa.load(BytesIO(...))` (soundfile backend) and, on known libsndfile format detection failures (`soundfile.LibsndfileError` codes `{1, 3, 4}`), falls back to an in-process decode via `torchaudio.load(BytesIO(...))` (torchcodec).

2. **`_preprocess_speech_to_text()`** is replaced with a call to `load_audio_bytes()`.

3. Added `torchcodec` to vLLM requirements, since `torchaudio>=2.9` uses it for decoding (optional in `vllm[audio]`).

### Some more details

- Avoids spawning an `ffmpeg` subprocess at request time in previous commits (addressing the latency concern raised in review) while still supporting MP4/M4A/WebM container formats.

- Current code tries BytesIO first and only falls back on failure. If a future libsndfile version adds native MP4 support ([support matrix](https://github.com/libsndfile/libsndfile/blob/master/docs/formats.md)), the fast path will automatically start working for those formats.

- The fallback path logs at DEBUG level, as suggested in the #18477 review.

- `torchaudio` is already a vLLM dependency. Since `torchaudio>=2.9` uses TorchCodec under the hood for decoding, `torchcodec` is added as dep.

## tests

Tested all 9 formats documented by the OpenAI API against a live vLLM server running `openai/whisper-large-v3-turbo` on an NVIDIA a30.

Test audio: short LibriSpeech `test-clean` sample (public domain / LibriVox-derived), converted from a WAV source to all formats via ffmpeg.

```bash
# Server startup
python -m vllm.entrypoints.openai.api_server \
  --model openai/whisper-large-v3-turbo \
  --max-model-len 448 --dtype auto

# Test each format
for fmt in wav flac mp3 mpga ogg mp4 mpeg m4a webm; do
  curl -s -w "\n[%{http_code}]" \
    -F "file=@test.${fmt}" \
    -F "model=openai/whisper-large-v3-turbo" \
    http://localhost:8000/v1/audio/transcriptions
done
```

## Test Result

### Before patch (baseline)

Tested on vLLM v0.13.0 and v0.15.1 (unpatched):

| Format | v0.13.0 | v0.15.1 | Response |
|--------|---------|---------|----------|
| wav    | 200 OK  | 200 OK  | Transcription text |
| flac   | 200 OK  | 200 OK  | Transcription text |
| mp3    | 200 OK  | 200 OK  | Transcription text |
| mpga   | 200 OK  | 200 OK  | Transcription text |
| ogg    | 200 OK  | 200 OK  | Transcription text |
| mpeg   | 200 OK  | 200 OK  | Transcription text |
| mp4    | **500** | 200 (error in body) | `"Error opening <_io.BytesIO object>: Format not recognised."` |
| m4a    | **500** | 200 (error in body) | `"Error opening <_io.BytesIO object>: Format not recognised."` |
| webm   | **500** | 200 (error in body) | `"Error opening <_io.BytesIO object>: Format not recognised."` |

### After patch

All formats now pass. The 3 previously broken formats (mp4, m4a, webm) now work via the in-process torchaudio fallback. The other six formats continue to use the fast BytesIO/librosa path.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
