### PR TITLE
[DO NOT MERGE] Check if `set_default_torch_num_threads` is still necessary for init

### DIFF
--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -89,12 +89,11 @@ class BaseRenderer(ABC, Generic[_T]):
 
             mm_processor_cache = mm_registry.processor_cache_from_config(config)
 
-            with set_default_torch_num_threads():
-                self.mm_processor = mm_registry.create_processor(
-                    config.model_config,
-                    tokenizer=tokenizer,
-                    cache=mm_processor_cache,
-                )
+            self.mm_processor = mm_registry.create_processor(
+                config.model_config,
+                tokenizer=tokenizer,
+                cache=mm_processor_cache,
+            )
 
             if mm_processor_cache:
                 self._mm_cache_stats = MultiModalCacheStats()


### PR DESCRIPTION

## Purpose

#35083 removed the creation of `threading.Lock` objects via `InputProcessingContext` during initialization, let's see if this removes the need to call `set_default_torch_num_threads` during init.

## Test Plan

Check if hanging / timeout occurs for Model Initialization tests.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

