### PR TITLE
[Bugfix] Fix failing FunASR processor test

### DIFF
--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -452,8 +452,6 @@ def test_processing_correctness(
     num_batches: int,
     simplify_rate: float,
 ):
-    if model_id == "allendou/Fun-ASR-Nano-2512-vllm":
-        pytest.skip("Cached audio `input_features` not matched. Fix later.")
     if model_id == "google/gemma-3n-E2B-it":
         pytest.skip("Fix later")
     if model_id == "OpenGVLab/InternVL2-2B":

--- a/vllm/transformers_utils/processors/funasr_processor.py
+++ b/vllm/transformers_utils/processors/funasr_processor.py
@@ -361,11 +361,11 @@ class FunASRFeatureExtractor(SequenceFeatureExtractor):
 
         input_features = padded_inputs.get("input_features").transpose(2, 0, 1)
 
-        self.frontend = WavFrontend(**self.frontend_conf)
+        frontend = WavFrontend(**self.frontend_conf, dither=self.dither)
         input_features, speech_lengths = self.extract_fbank(
             input_features[0],
             data_type=kwargs.get("data_type", "sound"),
-            frontend=self.frontend,
+            frontend=frontend,
             is_final=True,
         )
         olens = 1 + (speech_lengths - 3 + 2 * 1) // 2


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
- Fix incorrect FunASR processor implementation to make mm cache work properly for it.

## Test Plan
```
pytest -s -v tests/models/multimodal/processing/test_common.py -k allendou/Fun-ASR
```

## Test Result
Test should pass now

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

