### PR TITLE
[Perf] Optimize pooling model redundant copy, 1.8% throughput improvement

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -95,7 +95,6 @@ from vllm.sequence import IntermediateTensors
 from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
 from vllm.tracing import instrument
 from vllm.utils import length_from_prompt_token_ids_or_embeds
-from vllm.utils.jsontree import json_map_leaves
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.mem_utils import DeviceMemoryProfiler, format_gib
 from vllm.utils.nvtx_pytorch_hooks import PytHooks
@@ -268,6 +267,51 @@ class AsyncGPUModelRunnerOutput(AsyncModelRunnerOutput):
         return output
 
 
+def _copy_pooler_output_to_cpu(
+    raw_pooler_output: PoolerOutput, finished_mask: list[bool]
+) -> list[torch.Tensor | None]:
+    num_reqs = len(finished_mask)
+
+    if isinstance(raw_pooler_output, torch.Tensor):
+        if raw_pooler_output.shape[0] != num_reqs:
+            raise ValueError(
+                "Pooler output batch size does not match finished mask size: "
+                f"{raw_pooler_output.shape[0]} != {num_reqs}."
+            )
+
+        num_finished = sum(finished_mask)
+        if num_finished == 0:
+            return [None] * num_reqs
+        if num_finished == num_reqs:
+            return list(raw_pooler_output.to("cpu", non_blocking=True))
+
+        # partial finished
+        finished_indices = [i for i, include in enumerate(finished_mask) if include]
+        index_tensor = torch.tensor(
+            finished_indices, device=raw_pooler_output.device, dtype=torch.long
+        )
+        finished_outputs = raw_pooler_output.index_select(0, index_tensor).to(
+            "cpu", non_blocking=True
+        )
+        partial_pooler_output: list[torch.Tensor | None] = [None] * num_reqs
+        for i, out in zip(finished_indices, finished_outputs):
+            partial_pooler_output[i] = out
+        return partial_pooler_output
+
+    assert isinstance(raw_pooler_output, list)
+    if len(raw_pooler_output) != num_reqs:
+        raise ValueError(
+            "Pooler output batch size does not match finished mask size: "
+            f"{len(raw_pooler_output)} != {num_reqs}."
+        )
+
+    pooler_output: list[torch.Tensor | None] = [None] * num_reqs
+    for i, (out, include) in enumerate(zip(raw_pooler_output, finished_mask)):
+        if include and out is not None:
+            pooler_output[i] = out.to("cpu", non_blocking=True)
+    return pooler_output
+
+
 class AsyncGPUPoolingModelRunnerOutput(AsyncModelRunnerOutput):
     def __init__(
         self,
@@ -289,15 +333,11 @@ class AsyncGPUPoolingModelRunnerOutput(AsyncModelRunnerOutput):
         default_stream = torch.cuda.current_stream()
         with torch.cuda.stream(async_output_copy_stream):
             async_output_copy_stream.wait_stream(default_stream)
-            raw_pooler_output_cpu = json_map_leaves(
-                lambda x: None if x is None else x.to("cpu", non_blocking=True),
-                self._raw_pooler_output,
+            self._model_runner_output.pooler_output = _copy_pooler_output_to_cpu(
+                raw_pooler_output=self._raw_pooler_output,
+                finished_mask=finished_mask,
             )
             self.async_copy_ready_event.record()
-            self._model_runner_output.pooler_output = [
-                out if include else None
-                for out, include in zip(raw_pooler_output_cpu, finished_mask)
-            ]
 
     def get_output(self) -> ModelRunnerOutput:
         """Copy the device tensors to the host and return a ModelRunnerOutput.
@@ -2705,14 +2745,10 @@ class GPUModelRunner(
                 async_output_copy_stream=self.async_output_copy_stream,
             )
 
-        raw_pooler_output = json_map_leaves(
-            lambda x: None if x is None else x.to("cpu", non_blocking=True),
-            raw_pooler_output,
+        model_runner_output.pooler_output = _copy_pooler_output_to_cpu(
+            raw_pooler_output=raw_pooler_output,
+            finished_mask=finished_mask,
         )
-        model_runner_output.pooler_output = [
-            out if include else None
-            for out, include in zip(raw_pooler_output, finished_mask)
-        ]
         self._sync_device()
 
         return model_runner_output


### PR DESCRIPTION
## Purpose

There is a redundant full copy of pooling model output, then pick up the items that are finished.

We can actually only copy the items that are finished to optimize

## Test

### Acc

Covered in unit test

```bash
pytest -q \
  tests/v1/e2e/test_pooling_chunked_prefill.py::test_pooling_chunked_prefill \
  tests/v1/e2e/test_pooling_chunked_prefill.py::test_pooling_prefix_cache

pytest -q \
  tests/entrypoints/pooling/basic/test_encode.py \
  tests/entrypoints/pooling/embed/test_offline.py \
  tests/entrypoints/pooling/score/test_offline.py

pytest -q \
  tests/entrypoints/pooling/embed/test_correctness_mteb.py::test_mteb_embed

pytest -q \
  tests/entrypoints/pooling/score/test_correctness_mteb.py::test_mteb_score \
  tests/entrypoints/pooling/score/test_correctness_mteb.py::test_mteb_rerank
```

### Perf

```bash
c 1 -- vllm serve   --model Qwen/Qwen3-Embedding-0.6B   --runner pooling   --port 9256   --enforce-eager   --enable-chunked-prefill   --max-model-len 4096   --max-num-batched-tokens 512   --disable-log-stats
vllm bench serve   --model Qwen/Qwen3-Embedding-0.6B   --backend openai-embeddings   --endpoint /v1/embeddings   --host 127.0.0.1 --port 9256 --dataset-name random   --num-prompts 2000   --request-rate inf   --seed 0   --random-input-len 2048   --random-range-ratio 0.5   --percentile-metrics e2el   --metric-percentiles 50,95,99

# now
============ Serving Benchmark Result ============
Successful requests:                     2000      
Failed requests:                         0         
Benchmark duration (s):                  72.00     
Total input tokens:                      4146962   
Request throughput (req/s):              27.78     
Total token throughput (tok/s):          57599.44  
----------------End-to-end Latency----------------
Mean E2EL (ms):                          36590.14  
Median E2EL (ms):                        36550.30  
P50 E2EL (ms):                           36550.30  
P95 E2EL (ms):                           68079.96  
P99 E2EL (ms):                           70930.74  
=================================================
# main
============ Serving Benchmark Result ============
Successful requests:                     2000      
Failed requests:                         0         
Benchmark duration (s):                  73.31     
Total input tokens:                      4146962   
Request throughput (req/s):              27.28     
Total token throughput (tok/s):          56566.09  
----------------End-to-end Latency----------------
Mean E2EL (ms):                          37604.01  
Median E2EL (ms):                        37672.05  
P50 E2EL (ms):                           37672.05  
P95 E2EL (ms):                           69570.05  
P99 E2EL (ms):                           72376.59  
==================================================
```