### PR TITLE
[Release] Include source distribution (sdist) in PyPI uploads

### DIFF
--- a/.buildkite/scripts/upload-release-wheels-pypi.sh
+++ b/.buildkite/scripts/upload-release-wheels-pypi.sh
@@ -54,9 +54,12 @@ mkdir -p $DIST_DIR
 # include only wheels for the release version, ignore all files with "dev" or "rc" in the name (without excluding 'aarch64')
 aws s3 cp --recursive --exclude "*" --include "vllm-${PURE_VERSION}*.whl" --exclude "*dev*" --exclude "*rc[0-9]*" "$S3_COMMIT_PREFIX" $DIST_DIR
 echo "Wheels copied to local directory"
-# generate source tarball
-git archive --format=tar.gz --output="$DIST_DIR/vllm-${PURE_VERSION}.tar.gz" "$BUILDKITE_COMMIT"
+# generate source distribution using setup.py
+python setup.py sdist --dist-dir=$DIST_DIR
 ls -la $DIST_DIR
+
+sdist_file=$(find $DIST_DIR -name "vllm*.tar.gz")
+echo "Found sdist: $sdist_file"
 
 # upload wheels to PyPI (only default variant, i.e. files without '+' in the name)
 PYPI_WHEEL_FILES=$(find $DIST_DIR -name "vllm-${PURE_VERSION}*.whl" -not -name "*+*")
@@ -65,6 +68,6 @@ if [[ -z "$PYPI_WHEEL_FILES" ]]; then
   exit 1
 fi
 
-python3 -m twine check "$PYPI_WHEEL_FILES"
-python3 -m twine upload --non-interactive --verbose "$PYPI_WHEEL_FILES"
-echo "Wheels uploaded to PyPI"
+python3 -m twine check "$PYPI_WHEEL_FILES" "$sdist_file"
+python3 -m twine upload --non-interactive --verbose "$PYPI_WHEEL_FILES" "$sdist_file"
+echo "Wheels and source distribution uploaded to PyPI"

--- a/.buildkite/scripts/upload-release-wheels-pypi.sh
+++ b/.buildkite/scripts/upload-release-wheels-pypi.sh
@@ -58,8 +58,8 @@ echo "Wheels copied to local directory"
 python setup.py sdist --dist-dir=$DIST_DIR
 ls -la $DIST_DIR
 
-sdist_file=$(find $DIST_DIR -name "vllm*.tar.gz")
-echo "Found sdist: $sdist_file"
+SDIST_FILE=$(find $DIST_DIR -name "vllm*.tar.gz")
+echo "Found sdist: $SDIST_FILE"
 
 # upload wheels to PyPI (only default variant, i.e. files without '+' in the name)
 PYPI_WHEEL_FILES=$(find $DIST_DIR -name "vllm-${PURE_VERSION}*.whl" -not -name "*+*")
@@ -68,6 +68,6 @@ if [[ -z "$PYPI_WHEEL_FILES" ]]; then
   exit 1
 fi
 
-python3 -m twine check "$PYPI_WHEEL_FILES" "$sdist_file"
-python3 -m twine upload --non-interactive --verbose "$PYPI_WHEEL_FILES" "$sdist_file"
+python3 -m twine check "$PYPI_WHEEL_FILES" "$SDIST_FILE"
+python3 -m twine upload --non-interactive --verbose "$PYPI_WHEEL_FILES" "$SDIST_FILE"
 echo "Wheels and source distribution uploaded to PyPI"


### PR DESCRIPTION
This change adds the generated sdist to the twine upload command. 

This will publish the sdist to PyPI on release.

Background:
- Last version with sdist (probably manually uploaded?): v0.14.1
- First version without sdist: v0.15.0
- GitHub releases still include sdists, only PyPI uploads are missing
- The sdist tarball is already being created, just not uploaded

see from the `.buildkite/scripts/upload-release-wheels-pypi.sh` file:

```
git archive --format=tar.gz --output="$DIST_DIR/vllm-${PURE_VERSION}.tar.gz" "$BUILDKITE_COMMIT"
```

I just added it to the upload.

## Purpose

See above.

## Test Plan

I believe this will have to be validated by the releasers.

## Test Result

Pending release.

