### PR TITLE
[core]Fix CPU Pinned-Memory Race Between _dummy_run() and execute_model()

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4814,6 +4814,13 @@ class GPUModelRunner(
                     for_cudagraph_capture=is_graph_capturing,
                     slot_mappings=slot_mappings_by_group,
                 )
+                # Record the event after CPU→GPU DMA transfers (seq_lens,
+                # query_start_loc, attention metadata) so the next
+                # execute_model()'s synchronize_input_prep() will wait for
+                # these transfers to complete before overwriting the shared
+                # CPU pinned buffers.
+                if self.prepare_inputs_event is not None:
+                    self.prepare_inputs_event.record()
 
         with self.maybe_dummy_run_with_lora(
             self.lora_config,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix an Invalid Memory Access (IMA) crash that occurs under `DP+EP + FULL CUDAGraph + async_scheduling`.                                                   
                                                                                                                                                            
  With MoE + DP + EP, idle DP ranks run `_dummy_run()` in a tight loop to participate in EP all-to-all communication. In FULL CUDAGraph mode, `_dummy_run()` writes to shared `CpuGpuBuffer` pinned arrays (`seq_lens`, `query_start_loc`) and calls `copy_to_gpu(non_blocking=True)`, but never records `prepare_inputs_event`. When the first real request arrives and `execute_model()` is called, `synchronize_input_prep()` waits on a stale event and returns immediately, allowing the CPU to overwrite the pinned buffers before the GPU finishes reading them for a prior dummy run's DMA. This corrupts attention metadata (`cu_seqlens`, `seq_lens`) used by downstream kernels, potentially causing out-of-bounds memory access.

  The fix records `prepare_inputs_event` in `_dummy_run()` after the CPU→GPU DMA transfers, so the next `execute_model()`'s `synchronize_input_prep()` properly waits for the dummy run's transfers to complete. Zero performance overhead — the event is a stream marker (~1μs), and the small DMA completes long before the CPU re-enters `execute_model()`.

  **Why this is more likely to surface with certain attention backends:**
  The race condition exists for all attention backends, but standard (softmax) attention accesses KV cache through `block_table` indirection into a pre-allocated page pool — corrupted `seq_lens` may read wrong but still valid pages, avoiding OOB. Attention backends that use `cu_seqlens` as a direct loop bound over contiguous memory (e.g., recurrent/linear attention) are more vulnerable, as any corruption immediately causes OOB.

  **Why smaller models may not trigger this:**
  Smaller models have faster CUDAGraph replays, so the GPU keeps up with the dummy run loop and the backlog stays small. With larger models, each replay takes longer, the GPU backlog grows over minutes of idle dummy runs, and DMA from recent dummy runs is still pending when `execute_model()` overwrites the buffers.

## Test Plan
Run the model



## Test Result
No IMA after it

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

