### PR TITLE
[ROCm] Enable GPTQMarlinConfig on ROCm to use choose_mp_linear_kernel

### DIFF
--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -276,7 +276,7 @@ class GPTQMarlinConfig(QuantizationConfig):
         sym = quant_config.get("sym")
         desc_act = quant_config.get("desc_act")
 
-        if not (current_platform.is_cuda() or current_platform.is_cpu()):
+        if not (current_platform.is_cuda_alike() or current_platform.is_cpu()):
             return False
 
         if quant_method != "gptq":

--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/conch.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/conch.py
@@ -113,6 +113,8 @@ class ConchLinearKernel(MPLinearKernel):
         self._transform_param(layer, self.w_s_name, transform_w_s)
         if self.config.zero_points:
             self._transform_param(layer, self.w_zp_name, transform_w_zp)
+        elif self.w_zp_name is not None:
+            setattr(layer, self.w_zp_name, None)
 
     def apply_weights(
         self,

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -45,14 +45,15 @@ def query_marlin_supported_quant_types(
     if current_platform.is_cpu():
         return _query_cpu_marlin_supported_quant_types(has_zp, include_fp_type)
 
-    if device_capability is None:
-        capability_tuple = current_platform.get_device_capability()
-        device_capability = (
-            -1 if capability_tuple is None else capability_tuple.to_int()
-        )
+    if current_platform.is_cuda():
+        if device_capability is None:
+            capability_tuple = current_platform.get_device_capability()
+            device_capability = (
+                -1 if capability_tuple is None else capability_tuple.to_int()
+            )
 
-    if device_capability < 75:
-        return []
+        if device_capability < 75:
+            return []
 
     # - has_zp is True: return quant_types that has zero points
     # - has_zp is False: return quant_types that has not zero points


### PR DESCRIPTION
On ROCm, GPTQ models were forced through the legacy `GPTQConfig → GPTQLinearMethod → ops.gptq_gemm` path, bypassing the `choose_mp_linear_kernel` framework entirely. This meant any new kernel added to the MPLinearKernel registry (Conch, future kernels) would never be used for GPTQ models on ROCm.

This change allows `GPTQMarlinConfig` to be selected on ROCm by using `is_cuda_alike()` instead of `is_cuda()` in the compatibility check, and skips the NVIDIA device_capability gate in query_marlin_supported_quant_types on ROCm (since ROCm device capabilities do not map to NVIDIA compute capability semantics).

Also fixes `ConchLinearKernel` to handle symmetric quantization (no zero points) by clearing the raw packed qzeros attribute on the layer, so `_get_weight_params` returns None for w_zp. Without this fix, the unprocessed packed qzeros tensor was passed to the Conch Triton kernel, causing an illegal memory access.

Before this change, GPTQ on ROCm used ops.gptq_gemm (ExLlama v2) directly. After this change, choose_mp_linear_kernel selects ConchLinearKernel by default. ExllamaLinearKernel (same ops.gptq_gemm kernel as before) can be used via
VLLM_DISABLED_KERNELS=ConchLinearKernel.

Benchmarked on AMD Strix Halo (gfx1151, LPDDR5X-8000 128 GB):

Model: TheBloke/Llama-2-7B-Chat-GPTQ
input-len=128, output-len=128, num-prompts=5:
  ConchLinearKernel (default):
    Median TTFT: 112 ms
    Median TPOT: 90.50 ms
  ExllamaLinearKernel:
    Median TTFT: 168 ms
    Median TPOT: 19.24 ms

Accuracy (lm_eval gsm8k, 200 samples, ExllamaLinearKernel):
  TheBloke/Llama-2-7B-Chat-GPTQ: 0.135 → 0.140 (no regression)

@mgoin: This changes improves TTFT but regresses TPOT a lot due to indirectly changing from ExLlama to Conch. I wonder whether we should swap the order of Conch and ExLlama in `choose_mp_linear_kernel` to keep performance the same?
