### PR TITLE
[Bugfix][Frontend] Disable /v1/chat/completions for base models without chat templates

### DIFF
--- a/tests/entrypoints/openai/test_chat_template_availability.py
+++ b/tests/entrypoints/openai/test_chat_template_availability.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Tests for chat template availability checking.
+
+This module tests the _check_chat_template_available() function which
+determines whether the /v1/chat/completions endpoint should be enabled
+based on chat template availability.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm.entrypoints.openai.generate.api_router import _check_chat_template_available
+
+
+class MockModelConfig:
+    """Mock model configuration for testing."""
+
+    def __init__(self, model="gpt2"):
+        self.model = model
+        self.trust_remote_code = False
+        self.hf_config = MagicMock()
+
+
+class MockTokenizer:
+    """Mock tokenizer for testing."""
+
+    def __init__(self, has_template=False):
+        self.chat_template = (
+            "{% for msg in messages %}{{ msg.content }}{% endfor %}"
+            if has_template
+            else None
+        )
+        self.name_or_path = "test-tokenizer"
+
+
+class MockRenderer:
+    """Mock renderer for testing."""
+
+    def __init__(self, has_template=False):
+        self.tokenizer = MockTokenizer(has_template)
+
+
+class MockEngineClient:
+    """Mock engine client for testing."""
+
+    def __init__(self, model="gpt2", has_template=False):
+        self.model_config = MockModelConfig(model)
+        self.renderer = MockRenderer(has_template)
+
+
+@pytest.fixture
+def base_model_engine():
+    """Fixture for base model (GPT2) without chat template."""
+    return MockEngineClient(model="gpt2", has_template=False)
+
+
+@pytest.fixture
+def instruct_model_engine():
+    """Fixture for instruct model with chat template."""
+    return MockEngineClient(model="meta-llama/Llama-3.2-1B-Instruct", has_template=True)
+
+
+def test_check_chat_template_available_with_user_template(base_model_engine):
+    """Test that user-provided template always returns True."""
+    user_template = "{% for message in messages %}{{ message.content }}{% endfor %}"
+
+    with patch("vllm.renderers.hf.resolve_chat_template") as mock_resolve:
+        # User template is priority #1, so it always succeeds
+        mock_resolve.return_value = user_template
+
+        result = _check_chat_template_available(base_model_engine, user_template)
+
+    assert result is True
+    # Should call resolve_chat_template with user's template
+    mock_resolve.assert_called_once()
+
+
+def test_check_chat_template_available_with_model_template(instruct_model_engine):
+    """Test that model with built-in template returns True."""
+    with patch("vllm.renderers.hf.resolve_chat_template") as mock_resolve:
+        # Simulate model having a chat template
+        mock_resolve.return_value = "{% for msg in messages %}..."
+
+        result = _check_chat_template_available(instruct_model_engine, None)
+
+    assert result is True
+
+
+def test_check_chat_template_unavailable(base_model_engine):
+    """Test that base model without template returns False."""
+    with patch("vllm.renderers.hf.resolve_chat_template") as mock_resolve:
+        # Simulate no template found (base model)
+        mock_resolve.return_value = None
+
+        result = _check_chat_template_available(base_model_engine, None)
+
+    assert result is False
+
+
+def test_check_chat_template_handles_errors(base_model_engine):
+    """Test that exceptions during resolution return False."""
+    with patch("vllm.renderers.hf.resolve_chat_template") as mock_resolve:
+        mock_resolve.side_effect = RuntimeError("Test error")
+
+        result = _check_chat_template_available(base_model_engine, None)
+
+    assert result is False
+
+
+@pytest.mark.parametrize(
+    "model_name,has_template,user_template,expected",
+    [
+        # Base model, no user template -> False
+        ("gpt2", False, None, False),
+        # Instruct model, no user template -> True
+        ("meta-llama/Llama-3.2-1B-Instruct", True, None, True),
+        # Base model, user provides template -> True
+        ("gpt2", False, "{% for msg in messages %}...", True),
+        # Instruct model, user overrides template -> True
+        ("meta-llama/Llama-3.2-1B-Instruct", True, "{% custom %}", True),
+    ],
+)
+def test_check_chat_template_various_scenarios(
+    model_name, has_template, user_template, expected
+):
+    """Test various combinations of model types and user templates."""
+    engine = MockEngineClient(model=model_name, has_template=has_template)
+
+    with patch("vllm.renderers.hf.resolve_chat_template") as mock_resolve:
+        # Simulate resolve_chat_template behavior
+        if user_template is not None:
+            # User template (priority #1)
+            mock_resolve.return_value = user_template
+        elif has_template:
+            # Model has template (priority #2-4)
+            mock_resolve.return_value = "{% model template %}"
+        else:
+            # No template available
+            mock_resolve.return_value = None
+
+        result = _check_chat_template_available(engine, user_template)
+
+    assert result == expected

--- a/tests/entrypoints/openai/test_chat_template_availability.py
+++ b/tests/entrypoints/openai/test_chat_template_availability.py
@@ -111,6 +111,21 @@ def test_check_chat_template_handles_errors(base_model_engine):
     assert result is False
 
 
+def test_check_chat_template_tokenizer_not_initialized(base_model_engine):
+    """Test that skip_tokenizer_init=True disables chat endpoint."""
+    base_model_engine.renderer.tokenizer = None  # Simulate skip_tokenizer_init=True
+
+    # Should return False even with user-provided template
+    # because tokenizer is needed to convert formatted text to token IDs
+    result = _check_chat_template_available(base_model_engine, None)
+    assert result is False
+
+    # Even with user template, still need tokenizer for tokenization
+    user_template = "{% for message in messages %}{{ message.content }}{% endfor %}"
+    result = _check_chat_template_available(base_model_engine, user_template)
+    assert result is False
+
+
 @pytest.mark.parametrize(
     "model_name,has_template,user_template,expected",
     [

--- a/vllm/entrypoints/openai/generate/api_router.py
+++ b/vllm/entrypoints/openai/generate/api_router.py
@@ -52,6 +52,10 @@ def _check_chat_template_available(
     Returns:
         True if chat template is available, False otherwise.
     """
+    if engine_client.renderer.tokenizer is None:
+        # If tokenizer is not initialized, chat template is not available.
+        return False
+
     from vllm.entrypoints.logger import init_logger
     from vllm.renderers.hf import resolve_chat_template
 

--- a/vllm/entrypoints/openai/generate/api_router.py
+++ b/vllm/entrypoints/openai/generate/api_router.py
@@ -42,6 +42,53 @@ def register_generate_api_routers(app: FastAPI):
     register_anthropic_api_router(app)
 
 
+def _check_chat_template_available(
+    engine_client: "EngineClient",
+    chat_template: str | None,
+) -> bool:
+    """
+    Check if a chat template can be resolved for this model.
+
+    Returns:
+        True if chat template is available, False otherwise.
+    """
+    from vllm.entrypoints.logger import init_logger
+    from vllm.renderers.hf import resolve_chat_template
+
+    logger = init_logger(__name__)
+    model_name = engine_client.model_config.model
+
+    try:
+        resolved = resolve_chat_template(
+            tokenizer=engine_client.renderer.tokenizer,
+            chat_template=chat_template,
+            tools=None,
+            model_config=engine_client.model_config,
+        )
+
+        if resolved is not None:
+            return True
+
+        # Normal case: base models without chat templates
+        logger.info(
+            "No chat template found for model %s. "
+            "The /v1/chat/completions endpoint will be disabled. "
+            "Use /v1/completions for this model, or provide a chat template "
+            "via --chat-template to enable chat completions.",
+            model_name,
+        )
+        return False
+
+    except Exception:
+        # Unexpected errors during template resolution
+        logger.exception(
+            "Error checking chat template availability for model %s. "
+            "The /v1/chat/completions endpoint will be disabled.",
+            model_name,
+        )
+        return False
+
+
 async def init_generate_state(
     engine_client: "EngineClient",
     state: "State",
@@ -70,14 +117,18 @@ async def init_generate_state(
         await tool_server.add_tool_server(args.tool_server)
     else:
         tool_server = None
-    resolved_chat_template = load_chat_template(args.chat_template)
+    loaded_chat_template = load_chat_template(args.chat_template)
 
+    # Check if chat template is available before creating chat endpoint
+    chat_template_available = _check_chat_template_available(
+        engine_client, loaded_chat_template
+    )
     state.openai_serving_responses = (
         OpenAIServingResponses(
             engine_client,
             state.openai_serving_models,
             request_logger=request_logger,
-            chat_template=resolved_chat_template,
+            chat_template=loaded_chat_template,
             chat_template_content_format=args.chat_template_content_format,
             return_tokens_as_token_ids=args.return_tokens_as_token_ids,
             enable_auto_tools=args.enable_auto_tool_choice,
@@ -97,7 +148,7 @@ async def init_generate_state(
             state.openai_serving_models,
             args.response_role,
             request_logger=request_logger,
-            chat_template=resolved_chat_template,
+            chat_template=loaded_chat_template,
             chat_template_content_format=args.chat_template_content_format,
             default_chat_template_kwargs=args.default_chat_template_kwargs,
             trust_request_chat_template=args.trust_request_chat_template,
@@ -112,6 +163,7 @@ async def init_generate_state(
             enable_log_deltas=args.enable_log_deltas,
         )
         if any(task in supported_tasks for task in ("generate", "render"))
+        and chat_template_available
         else None
     )
     # Warm up chat template processing to avoid first-request latency
@@ -135,7 +187,7 @@ async def init_generate_state(
             state.openai_serving_models,
             args.response_role,
             request_logger=request_logger,
-            chat_template=resolved_chat_template,
+            chat_template=loaded_chat_template,
             chat_template_content_format=args.chat_template_content_format,
             return_tokens_as_token_ids=args.return_tokens_as_token_ids,
             enable_auto_tools=args.enable_auto_tool_choice,


### PR DESCRIPTION
## Purpose

Currently, base models (e.g., Llama-3.2-1B) cause errors during startup warmup and runtime when accessing the chat completions endpoint. This PR adds a check at startup to detect if a chat template is available and conditionally disables the endpoint when unavailable.

## Test Plan

```python
pytest tests/entrypoints/openai/test_chat_template_availability.py
```

## Test Result

All 8 tests pass.