### PR TITLE
[BUGFIX][Qwen3.5] Hardcode `mlp.gate` as not quantizable 

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -252,7 +252,7 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             config.hidden_size,
             config.num_experts,
             bias=False,
-            quant_config=quant_config,
+            quant_config=None,
             prefix=f"{prefix}.gate",
         )
 


### PR DESCRIPTION
## Summary

FIX #35150

Workaround to fix `nvidia/Qwen3.5-397B-A17B-NVFP4` fail in weights loading.

`mlp.gate` layers don't marked as excluded from quantization in the checkpoint. Hardcode that they are not quantizable 

## Test
Manual runs of Qwen3.5-NVFP4 and Qwen3-Next-NVFP4
