### PR TITLE
[Linear Attention] fix bug for linear attention + prefix caching + reset_prefix_cache

### DIFF
--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit test for the D93296098 fix: preprocess_mamba must clear
+mamba_state_idx for resumed requests that were force-preempted
+(e.g. reset_prefix_cache) and appear only in resumed_req_ids,
+not in preempted_req_ids.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
+from vllm.v1.worker.mamba_utils import preprocess_mamba
+
+
+def _make_scheduler_output(
+    finished_req_ids: set[str],
+    preempted_req_ids: set[str] | None,
+    resumed_req_ids: set[str],
+) -> SchedulerOutput:
+    cached = CachedRequestData.make_empty()
+    cached.resumed_req_ids = resumed_req_ids
+    return SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=cached,
+        num_scheduled_tokens={},
+        total_num_scheduled_tokens=0,
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=finished_req_ids,
+        free_encoder_mm_hashes=[],
+        preempted_req_ids=preempted_req_ids,
+    )
+
+
+def test_resumed_req_ids_cleared_from_mamba_state_idx():
+    """When a request is force-preempted (e.g. reset_prefix_cache),
+    it appears in resumed_req_ids but NOT in preempted_req_ids.
+    preprocess_mamba must still clear its mamba_state_idx entry,
+    otherwise stale indices can point beyond the new block allocation.
+    """
+    spec = MagicMock(block_size=64, num_speculative_blocks=0)
+    cache_config = MagicMock(enable_prefix_caching=True)
+    input_batch = MagicMock(req_ids=[])
+
+    mamba_state_idx = {
+        "finished": 1,
+        "preempted": 2,
+        "resumed": 3,  # only in resumed_req_ids, NOT in preempted
+        "keep": 99,
+    }
+    sched = _make_scheduler_output(
+        finished_req_ids={"finished"},
+        preempted_req_ids={"preempted"},
+        resumed_req_ids={"resumed"},
+    )
+
+    with patch(
+        "vllm.v1.worker.mamba_utils.get_mamba_groups",
+        return_value=([0], spec),
+    ):
+        preprocess_mamba(
+            sched,
+            MagicMock(),
+            cache_config,
+            mamba_state_idx,
+            input_batch,
+            {},
+            {},
+            (),
+        )
+
+    assert mamba_state_idx == {"keep": 99}

--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -1,11 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Unit test for the D93296098 fix: preprocess_mamba must clear
-mamba_state_idx for resumed requests that were force-preempted
-(e.g. reset_prefix_cache) and appear only in resumed_req_ids,
-not in preempted_req_ids.
-"""
-
 from unittest.mock import MagicMock, patch
 
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
We need to clear mamba_state_idx for resumed requests. When requests are force-preempted (e.g., during reset_prefix_cache / KV cache flush), they appear in resumed_req_ids without a corresponding entry in preempted_req_ids, leaving stale mamba_state_idx entries that can point to block indices beyond the new (smaller) block allocation.
## Test Plan

See the new unit test

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

