### PR TITLE
[CI][AMD][BugFix][P/D] Skip test_moriio_connector.py tests if IB verbs is not available

### DIFF
--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -55,7 +55,7 @@ def is_ibverbs_available():
     from subprocess import check_output
 
     output = check_output(["ibv_devices"]).decode("UTF-8")
-    if len(output.split("\n")) < 12:
+    if len(output.split("\n")) == 3:
         return False
     return True
 

--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -46,6 +46,24 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def is_ibverbs_available():
+    from shutil import which
+
+    print(f"which = {which('ibv_devices')}")
+    if which("ibv_devices") is None:
+        return False
+    from subprocess import check_output
+
+    output = check_output(["ibv_devices"]).decode("UTF-8")
+    if len(output.split("\n")) < 12:
+        return False
+    return True
+
+
+if not is_ibverbs_available():
+    pytest.skip("This test requires IB Verbs to run", allow_module_level=True)
+
+
 @pytest.fixture
 def mock_parallel_groups():
     """Mock tensor/data parallel group functions for single-rank tests."""

--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -54,9 +54,7 @@ def is_ibverbs_available():
     from subprocess import check_output
 
     output = check_output(["ibv_devices"]).decode("UTF-8")
-    if len(output.split("\n")) == 3:
-        return False
-    return True
+    return len(output.split("\n")) > 3
 
 
 if not is_ibverbs_available():

--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -49,7 +49,6 @@ pytestmark = pytest.mark.skipif(
 def is_ibverbs_available():
     from shutil import which
 
-    print(f"which = {which('ibv_devices')}")
     if which("ibv_devices") is None:
         return False
     from subprocess import check_output


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
Currently, the MORI KV connector requires IB verbs in order to run. However, some test machines might not have this requirement. This PR adds the ability to perform this check until TCP is added as a backend for MORI KV connector.  If the `ibv_devices` command is not available, then the test is skipped. If `ibv_devices` does not return sufficient output, the test is also skipped.
## Test Plan
`pytest -sv v1/kv_connector/unit/test_moriio_connector.py`
## Test Result
Test correctly skips if ibv_devices is not available or if sufficient not available. 


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ X] The test plan, such as providing test command.
- [ X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

