### PR TITLE
[Perf] Add update_block_table support to GDN attn metadata builder

### DIFF
--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Backend for GatedDeltaNet attention."""
 
+import copy
 from dataclasses import dataclass
 
 import torch
@@ -64,11 +65,16 @@ class GDNAttentionMetadata:
     batch_ptr: torch.Tensor | None = None
     token_chunk_offset_ptr: torch.Tensor | None = None
 
+    # The following attributes are for update_block_table
+    seq_lens: torch.Tensor | None = None
+    _spec_mask_for_update: torch.Tensor | None = None
+
 
 class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]):
     _cudagraph_support = AttentionCGSupport.UNIFORM_BATCH
 
     reorder_batch_threshold: int = 1
+    supports_update_block_table: bool = True
 
     def __init__(
         self,
@@ -315,6 +321,9 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
         # Note: m.num_actual_tokens is already padded by the model runner for CUDAGraph
         batch_size = m.num_actual_tokens
 
+        # Save pre-CUDA-graph spec_sequence_masks for update_block_table
+        _spec_mask_for_update = spec_sequence_masks
+
         if (
             self.use_full_cuda_graph
             and num_prefills == 0
@@ -401,8 +410,130 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             nums_dict=nums_dict,
             batch_ptr=batch_ptr,
             token_chunk_offset_ptr=token_chunk_offset_ptr,
+            seq_lens=m.seq_lens,
+            _spec_mask_for_update=_spec_mask_for_update,
         )
         return attn_metadata
+
+    def update_block_table(
+        self,
+        metadata: GDNAttentionMetadata,
+        blk_table: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> GDNAttentionMetadata:
+        new_metadata = copy.copy(metadata)
+
+        block_table_tensor = mamba_get_block_table_tensor(
+            blk_table,
+            metadata.seq_lens,
+            self.kv_cache_spec,
+            self.vllm_config.cache_config.mamba_cache_mode,
+        )
+
+        spec_mask = metadata._spec_mask_for_update
+
+        if spec_mask is not None:
+            spec_state_indices_tensor = block_table_tensor[
+                spec_mask, : self.num_spec + 1
+            ]
+
+            num_spec_decodes = metadata.num_spec_decodes
+            batch_size = metadata.num_actual_tokens
+
+            if (
+                self.use_full_cuda_graph
+                and metadata.num_prefills == 0
+                and metadata.num_decodes == 0
+                and num_spec_decodes <= self.decode_cudagraph_max_bs
+                and metadata.num_spec_decode_tokens
+                <= self.decode_cudagraph_max_bs
+            ):
+                self.spec_state_indices_tensor[:num_spec_decodes].copy_(
+                    spec_state_indices_tensor, non_blocking=True
+                )
+                spec_state_indices_tensor = self.spec_state_indices_tensor[
+                    :batch_size
+                ]
+                spec_state_indices_tensor[num_spec_decodes:].fill_(PAD_SLOT_ID)
+
+                # Copy remaining persistent buffers for CUDA graph replay
+                self.spec_sequence_masks[:batch_size].copy_(
+                    metadata.spec_sequence_masks, non_blocking=True
+                )
+                new_metadata.spec_sequence_masks = (
+                    self.spec_sequence_masks[:batch_size]
+                )
+
+                spec_token_size = metadata.spec_token_indx.size(0)
+                self.spec_token_indx[:spec_token_size].copy_(
+                    metadata.spec_token_indx, non_blocking=True
+                )
+                new_metadata.spec_token_indx = self.spec_token_indx[
+                    :spec_token_size
+                ]
+
+                non_spec_token_size = metadata.non_spec_token_indx.size(0)
+                self.non_spec_token_indx[:non_spec_token_size].copy_(
+                    metadata.non_spec_token_indx, non_blocking=True
+                )
+                new_metadata.non_spec_token_indx = self.non_spec_token_indx[
+                    :non_spec_token_size
+                ]
+
+                spec_qsl_size = metadata.spec_query_start_loc.size(0)
+                self.spec_query_start_loc[:spec_qsl_size].copy_(
+                    metadata.spec_query_start_loc, non_blocking=True
+                )
+                new_metadata.spec_query_start_loc = (
+                    self.spec_query_start_loc[:spec_qsl_size]
+                )
+
+                self.num_accepted_tokens[:batch_size].copy_(
+                    metadata.num_accepted_tokens, non_blocking=True
+                )
+                new_metadata.num_accepted_tokens = self.num_accepted_tokens[
+                    :batch_size
+                ]
+
+            new_metadata.spec_state_indices_tensor = spec_state_indices_tensor
+            if metadata.non_spec_state_indices_tensor is not None:
+                new_metadata.non_spec_state_indices_tensor = (
+                    block_table_tensor[~spec_mask, 0]
+                )
+        else:
+            non_spec_state_indices_tensor = block_table_tensor[:, 0]
+            num_decodes = metadata.num_decodes
+            batch_size = metadata.num_actual_tokens
+
+            if (
+                self.use_full_cuda_graph
+                and metadata.num_prefills == 0
+                and num_decodes <= self.decode_cudagraph_max_bs
+            ):
+                self.non_spec_state_indices_tensor[:num_decodes].copy_(
+                    non_spec_state_indices_tensor, non_blocking=True
+                )
+                non_spec_state_indices_tensor = (
+                    self.non_spec_state_indices_tensor[:batch_size]
+                )
+                non_spec_state_indices_tensor[num_decodes:].fill_(PAD_SLOT_ID)
+
+                # Copy remaining persistent buffers for CUDA graph replay
+                non_spec_qsl_size = (
+                    metadata.non_spec_query_start_loc.size(0)
+                )
+                self.non_spec_query_start_loc[:non_spec_qsl_size].copy_(
+                    metadata.non_spec_query_start_loc, non_blocking=True
+                )
+                new_metadata.non_spec_query_start_loc = (
+                    self.non_spec_query_start_loc[:non_spec_qsl_size]
+                )
+
+            new_metadata.non_spec_state_indices_tensor = (
+                non_spec_state_indices_tensor
+            )
+
+        return new_metadata
 
     def build_for_cudagraph_capture(
         self, common_attn_metadata: CommonAttentionMetadata


### PR DESCRIPTION
## Purpose
Add update_block_table support to remove redundant computation during attn metadata build. Only non_spec_state_indices_tensor and spec_state_indices_tensor are related to block table. Other metadata computation like  compute_causal_conv1d_metadata do not depend on block table update. The overhead is larger when spec decode is enabled.

Original trace for Qwen3 Next metadata build
<img width="1251" height="472" alt="Screenshot 2026-02-23 at 23 08 22" src="https://github.com/user-attachments/assets/22f40b65-ef28-4092-b950-8d986221cb11" />



## Test Plan
tested with H100
```
vllm bench serve  --dataset-name spec_bench --dataset-path question.jsonl  --num-prompts -1 --request-rate 10
```
```
vllm serve Qwen/Qwen3-Next-80B-A3B-Instruct --port 8000 --tensor-parallel-size 4 --max-model-len 262144 --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}' --no-async-scheduling --no-enable-prefix-caching
```

## Test Result
Before
```
============ Serving Benchmark Result ============
Successful requests:                     480       
Failed requests:                         0         
Request rate configured (RPS):           10.00     
Benchmark duration (s):                  49.69     
Total input tokens:                      134263    
Total generated tokens:                  90661     
Request throughput (req/s):              9.66      
Output token throughput (tok/s):         1824.68   
Peak output token throughput (tok/s):    1495.00   
Peak concurrent requests:                57.00     
Total token throughput (tok/s):          4526.91   
---------------Time to First Token----------------
Mean TTFT (ms):                          92.37     
Median TTFT (ms):                        79.19     
P99 TTFT (ms):                           197.01    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          12.95     
Median TPOT (ms):                        13.08     
P99 TPOT (ms):                           20.45     
---------------Inter-token Latency----------------
Mean ITL (ms):                           31.19     
Median ITL (ms):                         23.40     
P99 ITL (ms):                            103.20    
---------------Speculative Decoding---------------
Acceptance rate (%):                     69.38     
Acceptance length:                       2.39      
Drafts:                                  37937     
Draft tokens:                            75874     
Accepted tokens:                         52644     
Per-position acceptance (%):
  Position 0:                            79.96     
  Position 1:                            58.81     
==================================================
```
after
```
============ Serving Benchmark Result ============
Successful requests:                     480       
Failed requests:                         0         
Request rate configured (RPS):           10.00     
Benchmark duration (s):                  49.68     
Total input tokens:                      134263    
Total generated tokens:                  91275     
Request throughput (req/s):              9.66      
Output token throughput (tok/s):         1837.36   
Peak output token throughput (tok/s):    1464.00   
Peak concurrent requests:                54.00     
Total token throughput (tok/s):          4540.05   
---------------Time to First Token----------------
Mean TTFT (ms):                          88.89     
Median TTFT (ms):                        73.85     
P99 TTFT (ms):                           199.25    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          12.30     
Median TPOT (ms):                        12.52     
P99 TPOT (ms):                           19.44     
---------------Inter-token Latency----------------
Mean ITL (ms):                           29.70     
Median ITL (ms):                         22.60     
P99 ITL (ms):                            99.98     
---------------Speculative Decoding---------------
Acceptance rate (%):                     69.36     
Acceptance length:                       2.39      
Drafts:                                  38211     
Draft tokens:                            76422     
Accepted tokens:                         53004     
Per-position acceptance (%):
  Position 0:                            79.98     
  Position 1:                            58.73     
==================================================
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>



