### PR TITLE
[Kernel] Immediately execute argument assertions in wvSplitK

### DIFF
--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1134,7 +1134,8 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
                 "bfloat16); got ",
                 in_bias->scalar_type());
   }
-  TORCH_CHECK(in_a.size(1) % 8 == 0, "k % 8 == 0");
+  TORCH_CHECK(in_a.size(1) % 8 == 0,
+              "K dimension (inner) must be a multiple of 8");
   TORCH_CHECK(in_a.size(1) == in_b.size(1),
               "K dimension (inner) must match: in_a has ", in_a.size(1),
               ", in_b has ", in_b.size(1));

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1138,6 +1138,7 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
                    ? in_bias->size(0)
                    : 1;
 
+  // Bias uses (m % Bx) + (n % By) * M indexing; Bx/By must be 1 or divide M/N.
   TORCH_CHECK(Bx_in >= 1 && (Bx_in == 1 || M_in % Bx_in == 0),
               "bias Bx must be 1 or divide M");
   TORCH_CHECK(By_in >= 1 && (By_in == 1 || N_in % By_in == 0),

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1144,6 +1144,9 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
   auto N_in = in_b.size(0);
   auto Kap_in = in_a.stride(0);
   auto Kbp_in = in_b.stride(0);
+
+  // determine bias dimensions based on the bias tensor shape
+  // critically, we swap the dimensions of the bias tensor if it is 2D
   auto Bx_in = (in_bias.has_value() && in_bias->numel() > 0)
                    ? (in_bias->dim() == 2) ? in_bias->size(1) : in_bias->size(0)
                    : 1;

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1154,10 +1154,6 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
       (in_bias.has_value() && in_bias->numel() > 0 && in_bias->dim() == 2)
           ? in_bias->size(0)
           : 1;
-  auto By_in =
-      (in_bias.has_value() && in_bias->numel() > 0 && in_bias->dim() == 2)
-          ? in_bias->size(0)
-          : 1;
 
   // Bias indexing: BIAS[(m+i)%Bx + (n%By)*M]. Kernel uses stride M for the n
   // dimension. If By > 1 (2D bias [By,Bx]), PyTorch row stride is Bx so we

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1121,12 +1121,17 @@ int mindiv(int N, int div1, int div2) {
 torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
                        const std::optional<at::Tensor>& in_bias,
                        const int64_t CuCount) {
+  TORCH_CHECK(in_a.dim() == 2, "in_a must be 2D, got ", in_a.dim(), "D");
+  TORCH_CHECK(in_b.dim() == 2, "in_b must be 2D, got ", in_b.dim(), "D");
   TORCH_CHECK(in_a.dtype() == in_b.dtype(),
               "in_a and in_b must have the same dtype");
   TORCH_CHECK(
       in_a.dtype() == torch::kFloat16 || in_a.dtype() == torch::kBFloat16,
       "wvSplitK supports only float16 and bfloat16; got ", in_a.scalar_type());
   TORCH_CHECK(in_a.size(1) % 8 == 0, "k % 8 == 0");
+  TORCH_CHECK(in_a.size(1) == in_b.size(1),
+              "K dimension (inner) must match: in_a has ", in_a.size(1),
+              ", in_b has ", in_b.size(1));
 
   auto M_in = in_a.size(0);
   auto K_in = in_a.size(1);

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1115,6 +1115,9 @@ int mindiv(int N, int div1, int div2) {
   return 0;
 }
 
+// Skinny GEMM C = A @ B + bias with Wave-SplitK: splits work across CUs and
+// reduces partial sums via atomics. Targets small N (e.g. 1–4) for good
+// utilization on AMD GPUs
 torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
                        const std::optional<at::Tensor>& in_bias,
                        const int64_t CuCount) {

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1138,14 +1138,17 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
   auto N_in = in_b.size(0);
   auto Kap_in = in_a.stride(0);
   auto Kbp_in = in_b.stride(0);
-  auto Bx_in =
-      (in_bias.has_value() && in_bias->numel() > 0)
-          ? (in_bias->sizes().size() == 2) ? in_bias->size(1) : in_bias->size(0)
-          : 1;
-  auto By_in = (in_bias.has_value() && in_bias->numel() > 0 &&
-                in_bias->sizes().size() == 2)
-                   ? in_bias->size(0)
+  auto Bx_in = (in_bias.has_value() && in_bias->numel() > 0)
+                   ? (in_bias->dim() == 2) ? in_bias->size(1) : in_bias->size(0)
                    : 1;
+  auto By_in =
+      (in_bias.has_value() && in_bias->numel() > 0 && in_bias->dim() == 2)
+          ? in_bias->size(0)
+          : 1;
+  auto By_in =
+      (in_bias.has_value() && in_bias->numel() > 0 && in_bias->dim() == 2)
+          ? in_bias->size(0)
+          : 1;
 
   if (in_bias.has_value() && in_bias->numel() > 0) {
     TORCH_CHECK(in_bias->dtype() == in_a.dtype(),
@@ -1642,14 +1645,13 @@ torch::Tensor wvSplitKrc(const at::Tensor& in_a, const at::Tensor& in_b,
   auto M_in = in_a.size(0);
   auto N_in = in_b.size(0);
   auto K_in = in_a.size(1);
-  auto Bx_in =
-      (in_bias.has_value() && in_bias->numel() > 0)
-          ? (in_bias->sizes().size() == 2) ? in_bias->size(1) : in_bias->size(0)
-          : 1;
-  auto By_in = (in_bias.has_value() && in_bias->numel() > 0 &&
-                in_bias->sizes().size() == 2)
-                   ? in_bias->size(0)
+  auto Bx_in = (in_bias.has_value() && in_bias->numel() > 0)
+                   ? (in_bias->dim() == 2) ? in_bias->size(1) : in_bias->size(0)
                    : 1;
+  auto By_in =
+      (in_bias.has_value() && in_bias->numel() > 0 && in_bias->dim() == 2)
+          ? in_bias->size(0)
+          : 1;
 
   TORCH_CHECK(in_a.dtype() == in_b.dtype());
   TORCH_CHECK(K_in % 8 == 0, "k % 8 == 0");
@@ -2037,14 +2039,13 @@ void wvSplitKQ(const at::Tensor& in_b, const at::Tensor& in_a,
   auto N_in = in_a.size(0);
   auto Kap_in = in_a.stride(0);
   auto Kbp_in = in_b.stride(0);
-  auto Bx_in =
-      (in_bias.has_value() && in_bias->numel() > 0)
-          ? (in_bias->sizes().size() == 2) ? in_bias->size(1) : in_bias->size(0)
-          : 1;
-  auto By_in = (in_bias.has_value() && in_bias->numel() > 0 &&
-                in_bias->sizes().size() == 2)
-                   ? in_bias->size(0)
+  auto Bx_in = (in_bias.has_value() && in_bias->numel() > 0)
+                   ? (in_bias->dim() == 2) ? in_bias->size(1) : in_bias->size(0)
                    : 1;
+  auto By_in =
+      (in_bias.has_value() && in_bias->numel() > 0 && in_bias->dim() == 2)
+          ? in_bias->size(0)
+          : 1;
 
   TORCH_CHECK(K_in % 16 == 0, "k % 16 == 0");
   TORCH_CHECK(in_a.dtype() == in_b.dtype() && in_a.dtype() == kFp8Type);

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -1118,6 +1118,12 @@ int mindiv(int N, int div1, int div2) {
 torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
                        const std::optional<at::Tensor>& in_bias,
                        const int64_t CuCount) {
+  TORCH_CHECK(in_a.dtype() == in_b.dtype(),
+              "in_a and in_b must have the same dtype");
+  TORCH_CHECK(in_a.dtype() == torch::kFloat16 ||
+              in_a.dtype() == torch::kBFloat16);
+  TORCH_CHECK(in_a.size(1) % 8 == 0, "k % 8 == 0");
+
   auto M_in = in_a.size(0);
   auto K_in = in_a.size(1);
   auto N_in = in_b.size(0);
@@ -1132,10 +1138,10 @@ torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
                    ? in_bias->size(0)
                    : 1;
 
-  TORCH_CHECK(in_a.dtype() == in_b.dtype());
-  TORCH_CHECK(K_in % 8 == 0, "k % 8 == 0");
-  TORCH_CHECK(in_a.dtype() == torch::kFloat16 ||
-              in_a.dtype() == torch::kBFloat16);
+  TORCH_CHECK(Bx_in >= 1 && (Bx_in == 1 || M_in % Bx_in == 0),
+              "bias Bx must be 1 or divide M");
+  TORCH_CHECK(By_in >= 1 && (By_in == 1 || N_in % By_in == 0),
+              "bias By must be 1 or divide N");
 
   auto out_c = torch::empty(
       {N_in, M_in},

--- a/tests/kernels/quantization/test_rocm_skinny_gemms.py
+++ b/tests/kernels/quantization/test_rocm_skinny_gemms.py
@@ -289,12 +289,23 @@ def test_rocm_wvsplitk_invalid_k_dimension_mismatch():
 
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 def test_rocm_wvsplitk_invalid_bias_bx_does_not_divide_m():
-    """Bias Bx must be 1 or divide M for (m % Bx) indexing."""
+    """1D bias: Bx must be 1 or divide M for (m % Bx) indexing."""
     cu_count = get_cu_count()
     A = torch.rand(1, 16, dtype=torch.float16, device="cuda")
     B = torch.rand(16, 16, dtype=torch.float16, device="cuda")
     BIAS = torch.rand(7, dtype=torch.float16, device="cuda")
     with pytest.raises(RuntimeError, match="bias Bx"):
+        ops.wvSplitK(B, A.view(-1, A.size(-1)), cu_count, BIAS)
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+def test_rocm_wvsplitk_invalid_bias_2d_bx_must_equal_m():
+    """2D bias (By > 1): Bx must equal M because kernel uses stride M."""
+    cu_count = get_cu_count()
+    A = torch.rand(2, 16, dtype=torch.float16, device="cuda")
+    B = torch.rand(16, 16, dtype=torch.float16, device="cuda")
+    BIAS = torch.rand(2, 8, dtype=torch.float16, device="cuda")
+    with pytest.raises(RuntimeError, match="bias Bx must be M if By"):
         ops.wvSplitK(B, A.view(-1, A.size(-1)), cu_count, BIAS)
 
 

--- a/tests/kernels/quantization/test_rocm_skinny_gemms.py
+++ b/tests/kernels/quantization/test_rocm_skinny_gemms.py
@@ -230,7 +230,7 @@ def test_rocm_wvsplitk_kernel(
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 def test_rocm_wvsplitk_invalid_in_a_not_2d():
     """wvSplitK requires in_a (weight) to be 2D."""
-    cu_count = get_cu_count()
+    cu_count = num_compute_units()
     A = torch.rand(1, 16, dtype=torch.float16, device="cuda")
     B_1d = torch.rand(16, dtype=torch.float16, device="cuda")
     with pytest.raises(RuntimeError, match="in_a must be 2D"):
@@ -240,7 +240,7 @@ def test_rocm_wvsplitk_invalid_in_a_not_2d():
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 def test_rocm_wvsplitk_invalid_in_b_not_2d():
     """wvSplitK requires in_b (activations) to be 2D."""
-    cu_count = get_cu_count()
+    cu_count = num_compute_units()
     A_1d = torch.rand(16, dtype=torch.float16, device="cuda")
     B = torch.rand(16, 16, dtype=torch.float16, device="cuda")
     with pytest.raises(RuntimeError, match="in_b must be 2D"):
@@ -250,7 +250,7 @@ def test_rocm_wvsplitk_invalid_in_b_not_2d():
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 def test_rocm_wvsplitk_invalid_dtype_mismatch():
     """wvSplitK rejects A and B with different dtypes."""
-    cu_count = get_cu_count()
+    cu_count = num_compute_units()
     A = torch.rand(1, 16, dtype=torch.float16, device="cuda")
     B = torch.rand(16, 16, dtype=torch.bfloat16, device="cuda")
     with pytest.raises(RuntimeError, match="same dtype"):
@@ -260,7 +260,7 @@ def test_rocm_wvsplitk_invalid_dtype_mismatch():
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 def test_rocm_wvsplitk_invalid_dtype_float32():
     """wvSplitK rejects float32; only fp16 and bf16 are supported."""
-    cu_count = get_cu_count()
+    cu_count = num_compute_units()
     A = torch.rand(1, 16, dtype=torch.float32, device="cuda")
     B = torch.rand(16, 16, dtype=torch.float32, device="cuda")
     with pytest.raises(RuntimeError):
@@ -270,7 +270,7 @@ def test_rocm_wvsplitk_invalid_dtype_float32():
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 def test_rocm_wvsplitk_invalid_k_not_div8():
     """wvSplitK requires K % 8 == 0 for vectorized loads."""
-    cu_count = get_cu_count()
+    cu_count = num_compute_units()
     A = torch.rand(1, 10, dtype=torch.float16, device="cuda")
     B = torch.rand(16, 10, dtype=torch.float16, device="cuda")
     with pytest.raises(RuntimeError, match="k % 8"):
@@ -280,7 +280,7 @@ def test_rocm_wvsplitk_invalid_k_not_div8():
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 def test_rocm_wvsplitk_invalid_k_dimension_mismatch():
     """K dimension (inner) of in_a and in_b must match for correct matmul."""
-    cu_count = get_cu_count()
+    cu_count = num_compute_units()
     A = torch.rand(1, 16, dtype=torch.float16, device="cuda")
     B = torch.rand(16, 24, dtype=torch.float16, device="cuda")
     with pytest.raises(RuntimeError, match="K dimension.*must match"):
@@ -290,7 +290,7 @@ def test_rocm_wvsplitk_invalid_k_dimension_mismatch():
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 def test_rocm_wvsplitk_invalid_bias_bx_does_not_divide_m():
     """1D bias: Bx must be 1 or divide M for (m % Bx) indexing."""
-    cu_count = get_cu_count()
+    cu_count = num_compute_units()
     A = torch.rand(1, 16, dtype=torch.float16, device="cuda")
     B = torch.rand(16, 16, dtype=torch.float16, device="cuda")
     BIAS = torch.rand(7, dtype=torch.float16, device="cuda")
@@ -301,7 +301,7 @@ def test_rocm_wvsplitk_invalid_bias_bx_does_not_divide_m():
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 def test_rocm_wvsplitk_invalid_bias_2d_bx_must_equal_m():
     """2D bias (By > 1): Bx must equal M because kernel uses stride M."""
-    cu_count = get_cu_count()
+    cu_count = num_compute_units()
     A = torch.rand(2, 16, dtype=torch.float16, device="cuda")
     B = torch.rand(16, 16, dtype=torch.float16, device="cuda")
     BIAS = torch.rand(2, 8, dtype=torch.float16, device="cuda")
@@ -312,7 +312,7 @@ def test_rocm_wvsplitk_invalid_bias_2d_bx_must_equal_m():
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 def test_rocm_wvsplitk_invalid_bias_by_does_not_divide_n():
     """Bias By must be 1 or divide N for (n % By) indexing."""
-    cu_count = get_cu_count()
+    cu_count = num_compute_units()
     A = torch.rand(4, 16, dtype=torch.float16, device="cuda")
     B = torch.rand(16, 16, dtype=torch.float16, device="cuda")
     BIAS = torch.rand(3, 16, dtype=torch.float16, device="cuda")
@@ -323,7 +323,7 @@ def test_rocm_wvsplitk_invalid_bias_by_does_not_divide_n():
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 def test_rocm_wvsplitk_invalid_bias_dtype_mismatch():
     """Bias must have the same dtype as inputs to avoid unsafe reinterpret_cast."""
-    cu_count = get_cu_count()
+    cu_count = num_compute_units()
     A = torch.rand(1, 16, dtype=torch.float16, device="cuda")
     B = torch.rand(16, 16, dtype=torch.float16, device="cuda")
     BIAS = torch.rand(16, dtype=torch.bfloat16, device="cuda")

--- a/tests/kernels/quantization/test_rocm_skinny_gemms.py
+++ b/tests/kernels/quantization/test_rocm_skinny_gemms.py
@@ -227,6 +227,58 @@ def test_rocm_wvsplitk_kernel(
         assert torch.allclose(out, ref_out, atol=1e-3, rtol=1e-2)
 
 
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+def test_rocm_wvsplitk_invalid_dtype_mismatch():
+    """wvSplitK rejects A and B with different dtypes."""
+    cu_count = get_cu_count()
+    A = torch.rand(1, 16, dtype=torch.float16, device="cuda")
+    B = torch.rand(16, 16, dtype=torch.bfloat16, device="cuda")
+    with pytest.raises(RuntimeError, match="same dtype"):
+        ops.wvSplitK(B, A.view(-1, A.size(-1)), cu_count)
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+def test_rocm_wvsplitk_invalid_dtype_float32():
+    """wvSplitK rejects float32; only fp16 and bf16 are supported."""
+    cu_count = get_cu_count()
+    A = torch.rand(1, 16, dtype=torch.float32, device="cuda")
+    B = torch.rand(16, 16, dtype=torch.float32, device="cuda")
+    with pytest.raises(RuntimeError):
+        ops.wvSplitK(B, A.view(-1, A.size(-1)), cu_count)
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+def test_rocm_wvsplitk_invalid_k_not_div8():
+    """wvSplitK requires K % 8 == 0 for vectorized loads."""
+    cu_count = get_cu_count()
+    A = torch.rand(1, 10, dtype=torch.float16, device="cuda")
+    B = torch.rand(16, 10, dtype=torch.float16, device="cuda")
+    with pytest.raises(RuntimeError, match="k % 8"):
+        ops.wvSplitK(B, A.view(-1, A.size(-1)), cu_count)
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+def test_rocm_wvsplitk_invalid_bias_bx_does_not_divide_m():
+    """Bias Bx must be 1 or divide M for (m % Bx) indexing."""
+    cu_count = get_cu_count()
+    A = torch.rand(1, 16, dtype=torch.float16, device="cuda")
+    B = torch.rand(16, 16, dtype=torch.float16, device="cuda")
+    BIAS = torch.rand(7, dtype=torch.float16, device="cuda")
+    with pytest.raises(RuntimeError, match="bias Bx"):
+        ops.wvSplitK(B, A.view(-1, A.size(-1)), cu_count, BIAS)
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+def test_rocm_wvsplitk_invalid_bias_by_does_not_divide_n():
+    """Bias By must be 1 or divide N for (n % By) indexing."""
+    cu_count = get_cu_count()
+    A = torch.rand(4, 16, dtype=torch.float16, device="cuda")
+    B = torch.rand(16, 16, dtype=torch.float16, device="cuda")
+    BIAS = torch.rand(3, 16, dtype=torch.float16, device="cuda")
+    with pytest.raises(RuntimeError, match="bias By"):
+        ops.wvSplitK(B, A.view(-1, A.size(-1)), cu_count, BIAS)
+
+
 @pytest.mark.parametrize("xnorm", [False, True])
 @pytest.mark.parametrize("n,k,m", NKM_FACTORS_WVSPLITK_FP8)
 @pytest.mark.parametrize("dtype", DTYPES)

--- a/tests/kernels/quantization/test_rocm_skinny_gemms.py
+++ b/tests/kernels/quantization/test_rocm_skinny_gemms.py
@@ -279,6 +279,17 @@ def test_rocm_wvsplitk_invalid_bias_by_does_not_divide_n():
         ops.wvSplitK(B, A.view(-1, A.size(-1)), cu_count, BIAS)
 
 
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+def test_rocm_wvsplitk_invalid_bias_dtype_mismatch():
+    """Bias must have the same dtype as inputs to avoid unsafe reinterpret_cast."""
+    cu_count = get_cu_count()
+    A = torch.rand(1, 16, dtype=torch.float16, device="cuda")
+    B = torch.rand(16, 16, dtype=torch.float16, device="cuda")
+    BIAS = torch.rand(16, dtype=torch.bfloat16, device="cuda")
+    with pytest.raises(RuntimeError, match="in_bias must have the same dtype"):
+        ops.wvSplitK(B, A.view(-1, A.size(-1)), cu_count, BIAS)
+
+
 @pytest.mark.parametrize("xnorm", [False, True])
 @pytest.mark.parametrize("n,k,m", NKM_FACTORS_WVSPLITK_FP8)
 @pytest.mark.parametrize("dtype", DTYPES)

--- a/tests/kernels/quantization/test_rocm_skinny_gemms.py
+++ b/tests/kernels/quantization/test_rocm_skinny_gemms.py
@@ -273,7 +273,9 @@ def test_rocm_wvsplitk_invalid_k_not_div8():
     cu_count = num_compute_units()
     A = torch.rand(1, 10, dtype=torch.float16, device="cuda")
     B = torch.rand(16, 10, dtype=torch.float16, device="cuda")
-    with pytest.raises(RuntimeError, match="k % 8"):
+    with pytest.raises(
+        RuntimeError, match="K dimension (inner) must be a multiple of 8"
+    ):
         ops.wvSplitK(B, A.view(-1, A.size(-1)), cu_count)
 
 


### PR DESCRIPTION

## Purpose

wvSplitK has specific data requirements and therefore uses TORCH_CHECK to ensure the data is correct before proceeding. I have moved these checks so that they happen immediately, before any operations use their values.

## Test Plan

Introduce additional unit tests to ensure these TORCH_CHECKs are happening

## Test Result

:heavy_check_mark: 

