### PR TITLE
[Bugfix] Restore CUDA graph persistent buffers for FP8 FlashMLA decode

### DIFF
--- a/vllm/v1/attention/backends/mla/flashmla.py
+++ b/vllm/v1/attention/backends/mla/flashmla.py
@@ -172,6 +172,21 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
                 num_q_tokens_per_head_k,
                 1,  # MQA for the decode path
             )
+
+            # Copy FP8 metadata into persistent CUDA graph buffers
+            if self.compilation_config.cudagraph_mode.has_full_cudagraphs():
+                assert self.cg_buf_tile_scheduler_metadata is not None
+                assert self.cg_buf_num_splits is not None
+                n = tile_scheduler_metadata.size(0)
+                assert n <= self.cg_buf_tile_scheduler_metadata.size(0)
+                self.cg_buf_tile_scheduler_metadata[:n].copy_(tile_scheduler_metadata)
+                tile_scheduler_metadata = self.cg_buf_tile_scheduler_metadata[:n]
+
+                n = num_splits.size(0)
+                assert n <= self.cg_buf_num_splits.size(0)
+                self.cg_buf_num_splits[:n].copy_(num_splits)
+                num_splits = self.cg_buf_num_splits[:n]
+
             scheduler_metadata.tile_scheduler_metadata = tile_scheduler_metadata
             scheduler_metadata.num_splits = num_splits
 


### PR DESCRIPTION
## Purpose

Fix #33638: DeepSeek-V3.1 with `--kv-cache-dtype fp8` produces garbled output in v0.15.0.

The PR #32810 refactored the FlashMLA interface to use `FlashMLASchedMeta` objects. The non-FP8 path was adapted correctly - `FlashMLASchedMeta` manages its own internal buffers for CUDA graph safety. However, the FP8 path calls `get_mla_metadata_dense_fp8()` which allocates fresh raw tensors every call, and these were set directly on the `FlashMLASchedMeta` object without copying to persistent CUDA graph buffers.

Under the default O2 optimization level (`FULL_AND_PIECEWISE` CUDA graphs), the graph captures tensor addresses during recording. On replay, freshly-allocated tensors live at different addresses, so the kernel reads stale metadata from the originally-captured addresses, producing garbled output that starts normal then degenerates after ~50 tokens.

The persistent buffers (`cg_buf_tile_scheduler_metadata`, `cg_buf_num_splits`) were already allocated in `__init__` but were dead code - never used after the refactor. This PR restores the copy-into-persistent-buffer logic for the FP8 path in `_build_decode`, matching the v0.12.0 behavior and the pattern used by `FlashAttnMLAMetadataBuilder`.

## Test Plan

## Test Result