### PR TITLE
[XPU] disable async-scheduling by default on XPU

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -635,6 +635,8 @@ class VllmConfig:
             "external_launcher",
         )
 
+        from vllm.platforms import current_platform
+
         if self.scheduler_config.async_scheduling:
             # Async scheduling explicitly enabled, hard fail any incompatibilities.
             # Currently, async scheduling only support eagle speculative
@@ -660,8 +662,12 @@ class VllmConfig:
                     f"`{executor_backend}`."
                 )
         elif self.scheduler_config.async_scheduling is None:
+            if current_platform.is_xpu():
+                # We disable async scheduling for xpu if use doesn't explicitly
+                # enable it.
+                self.scheduler_config.async_scheduling = False
             # Enable async scheduling unless there is an incompatible option.
-            if (
+            elif (
                 self.speculative_config is not None
                 and self.speculative_config.method not in get_args(EagleModelTypes)
             ):
@@ -712,8 +718,6 @@ class VllmConfig:
                 self.parallel_config.disable_nccl_for_dp_synchronization = True
             else:
                 self.parallel_config.disable_nccl_for_dp_synchronization = False
-
-        from vllm.platforms import current_platform
 
         if (
             self.model_config is not None


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Async scheduling fails in some scenarios with async scheduling enabled, caused by oneccl multi-stream issue. This PR disable it on XPU platform by default unless user set it explicitly.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

