### PR TITLE
Remove `padding_index` from models that don't use it for better Transformers v5 compatibility

### DIFF
--- a/vllm/model_executor/models/ernie45_moe.py
+++ b/vllm/model_executor/models/ernie45_moe.py
@@ -421,7 +421,6 @@ class Ernie4_5_MoeModel(nn.Module):
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
 
-        self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
         self.config = config
         parallel_config = vllm_config.parallel_config

--- a/vllm/model_executor/models/ernie45_vl_moe.py
+++ b/vllm/model_executor/models/ernie45_vl_moe.py
@@ -523,7 +523,6 @@ class Ernie4_5_VLMoeModel(nn.Module):
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
 
-        self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
         self.config = config
 

--- a/vllm/model_executor/models/granitemoeshared.py
+++ b/vllm/model_executor/models/granitemoeshared.py
@@ -157,7 +157,6 @@ class GraniteMoeSharedModel(nn.Module):
 
         self.config = config
         self.quant_config = quant_config  # Required by MixtralModel
-        self.padding_idx = config.pad_token_id
 
         self.vocab_size = config.vocab_size
 

--- a/vllm/model_executor/models/grok1.py
+++ b/vllm/model_executor/models/grok1.py
@@ -451,7 +451,6 @@ class Grok1Model(nn.Module):
 
         self.config = config
         self.quant_config = quant_config
-        self.padding_idx = config.pad_token_id
 
         # Store expert naming for weight loading
         self.ckpt_gate_proj_name = ckpt_gate_proj_name

--- a/vllm/model_executor/models/hunyuan_v1.py
+++ b/vllm/model_executor/models/hunyuan_v1.py
@@ -600,7 +600,6 @@ class HunYuanModel(nn.Module):
 
         self.config = config
         self.quant_config = quant_config
-        self.padding_idx = config.pad_token_id
 
         self.vocab_size = config.vocab_size
 

--- a/vllm/model_executor/models/interns1_pro.py
+++ b/vllm/model_executor/models/interns1_pro.py
@@ -464,6 +464,9 @@ class InternS1ProMoeLLMModel(Qwen3MoeLLMModel):
         prefix: str = "",
         decoder_layer_type: type[torch.nn.Module] = InternS1ProMoeDecoderLayer,
     ):
+        # Qwen3MoeLLMModel expects pad_token_id, which is not in InternS1ProTextConfig
+        if not hasattr(vllm_config.model_config.hf_text_config, "pad_token_id"):
+            vllm_config.model_config.hf_text_config.pad_token_id = None
         super().__init__(
             vllm_config=vllm_config,
             prefix=prefix,

--- a/vllm/model_executor/models/interns1_pro.py
+++ b/vllm/model_executor/models/interns1_pro.py
@@ -464,9 +464,6 @@ class InternS1ProMoeLLMModel(Qwen3MoeLLMModel):
         prefix: str = "",
         decoder_layer_type: type[torch.nn.Module] = InternS1ProMoeDecoderLayer,
     ):
-        # Qwen3MoeLLMModel expects pad_token_id, which is not in InternS1ProTextConfig
-        if not hasattr(vllm_config.model_config.hf_text_config, "pad_token_id"):
-            vllm_config.model_config.hf_text_config.pad_token_id = None
         super().__init__(
             vllm_config=vllm_config,
             prefix=prefix,

--- a/vllm/model_executor/models/jais2.py
+++ b/vllm/model_executor/models/jais2.py
@@ -305,7 +305,6 @@ class Jais2Model(nn.Module):
 
         self.config = config
         self.quant_config = quant_config
-        self.padding_idx = config.pad_token_id
 
         self.vocab_size = config.vocab_size
         self.org_vocab_size = config.vocab_size

--- a/vllm/model_executor/models/kimi_linear.py
+++ b/vllm/model_executor/models/kimi_linear.py
@@ -393,7 +393,6 @@ class KimiLinearModel(nn.Module):
         parallel_config = vllm_config.parallel_config
         self.config = config
 
-        self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
 
         if get_pp_group().is_first_rank:

--- a/vllm/model_executor/models/longcat_flash.py
+++ b/vllm/model_executor/models/longcat_flash.py
@@ -486,7 +486,6 @@ class FlashModel(nn.Module):
         quant_config = vllm_config.quant_config
         self.config = config
 
-        self.padding_idx = getattr(config, "pad_token_id", None)
         self.vocab_size = config.vocab_size
 
         if get_pp_group().is_first_rank:

--- a/vllm/model_executor/models/minimax_text_01.py
+++ b/vllm/model_executor/models/minimax_text_01.py
@@ -495,7 +495,6 @@ class MiniMaxText01Model(nn.Module):
         cache_config = vllm_config.cache_config
         scheduler_config = vllm_config.scheduler_config
 
-        self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
 
         self.decoder_attention_types = getattr(

--- a/vllm/model_executor/models/nemotron_nas.py
+++ b/vllm/model_executor/models/nemotron_nas.py
@@ -241,7 +241,6 @@ class DeciModel(nn.Module):
 
         self.config = config
         self.quant_config = quant_config
-        self.padding_idx = config.pad_token_id
 
         self.vocab_size = config.vocab_size
 

--- a/vllm/model_executor/models/openpangu.py
+++ b/vllm/model_executor/models/openpangu.py
@@ -1029,7 +1029,6 @@ class OpenPanguModel(nn.Module):
         self.config = config
         self.num_redundant_experts = eplb_config.num_redundant_experts
 
-        self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
 
         if get_pp_group().is_first_rank or (

--- a/vllm/model_executor/models/plamo2.py
+++ b/vllm/model_executor/models/plamo2.py
@@ -748,7 +748,6 @@ class Plamo2Model(torch.nn.Module):
         config = vllm_config.model_config.hf_config
 
         self.config = config
-        self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
 
         self.embed_tokens = VocabParallelEmbedding(

--- a/vllm/model_executor/models/plamo3.py
+++ b/vllm/model_executor/models/plamo3.py
@@ -317,7 +317,6 @@ class Plamo3Model(nn.Module):
         config = vllm_config.model_config.hf_config
 
         self.config = config
-        self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
         self.org_vocab_size = config.vocab_size
 

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -443,7 +443,6 @@ class Qwen3MoeModel(nn.Module):
         eplb_config = parallel_config.eplb_config
         self.num_redundant_experts = eplb_config.num_redundant_experts
 
-        self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
         self.config = config
         self.quant_config = quant_config


### PR DESCRIPTION
Currently, some model implementations expect to have `pad_token_id`, which is set to `self.padding_index`. In Transfomers v4 this was always present in `PreTrainedConfig`, but has been moved to the individual configs that use it in Transformers v5.

Since it is not actually used in any of these models, we remove it so that they may more easily run in Transformers v5.