### PR TITLE
[Refactor] Modular video loader backend refactoring

### DIFF
--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -345,6 +345,12 @@ def dummy_video_path():
             32,
             id="molmo2-uniform_last_frame",
         ),
+        pytest.param(
+            "molmo2",
+            {"fps": 2, "frame_sample_mode": "fps"},
+            119,
+            id="molmo2-fps",
+        ),
     ],
 )
 def test_video_loader_frames_sampling(

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -1,13 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import tempfile
 from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
 import pytest
 
-from vllm.multimodal.video import VIDEO_LOADER_REGISTRY, VideoLoader
+from vllm.assets.base import get_vllm_public_assets
+from vllm.multimodal.video import (
+    VIDEO_LOADER_REGISTRY,
+    VideoLoader,
+)
+
+from .utils import create_video_from_image
 
 pytestmark = pytest.mark.cpu_test
 
@@ -291,3 +298,71 @@ def test_video_recovery_dynamic_backend(monkeypatch: pytest.MonkeyPatch):
             f"Got {frames_with_recovery.shape[0]} with recovery vs "
             f"{frames_no_recovery.shape[0]} without"
         )
+
+
+@pytest.fixture(scope="session")
+def dummy_video_path():
+    image_path = get_vllm_public_assets(
+        filename="stop_sign.jpg", s3_prefix="vision_model_images"
+    )
+
+    path = tempfile.mkdtemp()
+    video_path = f"{path}/test_RGB_video.mp4"
+    create_video_from_image(image_path, video_path, num_frames=1800, fps=30)
+    return video_path
+
+
+@pytest.mark.parametrize(
+    "backend, kwargs, expected_num_frames",
+    [
+        # opencv: num_frames directly controls count
+        pytest.param("opencv", {"num_frames": 32}, 32, id="opencv-num_frames"),
+        pytest.param("opencv", {"fps": 2}, 120, id="opencv-fps"),
+        pytest.param(
+            "opencv",
+            {"num_frames": 500, "fps": 2},
+            120,
+            id="opencv-num_frames_wins_fps",
+        ),
+        pytest.param(
+            "opencv_dynamic",
+            {"fps": 1, "max_duration": 60},
+            60,
+            id="opencv_dynamic-within_max_duration",
+        ),
+        pytest.param(
+            "opencv_dynamic",
+            {"fps": 2, "max_duration": 30},
+            60,
+            id="opencv_dynamic-exceeds_max_duration",
+        ),
+        pytest.param(
+            "openpangu", {"num_frames": 32, "fps": -1}, 32, id="openpangu-num_frames"
+        ),
+        pytest.param(
+            "molmo2",
+            {"num_frames": 32, "frame_sample_mode": "uniform_last_frame"},
+            32,
+            id="molmo2-uniform_last_frame",
+        ),
+    ],
+)
+def test_video_loader_frames_sampling(
+    dummy_video_path,
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+    kwargs: dict,
+    expected_num_frames: int,
+):
+    """Test video loader frames sampling functionality."""
+    monkeypatch.setenv("VLLM_VIDEO_LOADER_BACKEND", backend)
+    loader = VIDEO_LOADER_REGISTRY.load(backend)
+
+    with open(dummy_video_path, "rb") as f:
+        long_video_bytes = f.read()
+
+    frames, _ = loader.load_bytes(long_video_bytes, **kwargs)
+
+    assert frames.ndim == 4
+    assert frames.shape[3] == 3  # RGB
+    assert frames.shape[0] == expected_num_frames

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import shutil
-import tempfile
 from pathlib import Path
 
 import numpy as np
@@ -301,21 +299,14 @@ def test_video_recovery_dynamic_backend(monkeypatch: pytest.MonkeyPatch):
         )
 
 
-@pytest.fixture(scope="session")
-def dummy_video_path():
+@pytest.fixture
+def dummy_video_path(tmp_path):
     image_path = get_vllm_public_assets(
         filename="stop_sign.jpg", s3_prefix="vision_model_images"
     )
 
-    path = tempfile.mkdtemp()
-    try:
-        video_path = Path(path) / "test_RGB_video.mp4"
-        create_video_from_image(
-            str(image_path), str(video_path), num_frames=1800, fps=30
-        )
-        yield str(video_path)
-    finally:
-        shutil.rmtree(path)
+    video_path = tmp_path / "test_RGB_video.mp4"
+    create_video_from_image(str(image_path), str(video_path), num_frames=1800, fps=30)
     return video_path
 
 

--- a/tests/multimodal/test_video.py
+++ b/tests/multimodal/test_video.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -307,8 +308,14 @@ def dummy_video_path():
     )
 
     path = tempfile.mkdtemp()
-    video_path = f"{path}/test_RGB_video.mp4"
-    create_video_from_image(image_path, video_path, num_frames=1800, fps=30)
+    try:
+        video_path = Path(path) / "test_RGB_video.mp4"
+        create_video_from_image(
+            str(image_path), str(video_path), num_frames=1800, fps=30
+        )
+        yield str(video_path)
+    finally:
+        shutil.rmtree(path)
     return video_path
 
 

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -110,6 +110,8 @@ class OpenCVVideoBackendMixin:
 
     @staticmethod
     def get_video_metadata(cap: "cv2.VideoCapture") -> VideoSourceMetadata:
+        import cv2
+
         total_frames_num = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
         original_fps = cap.get(cv2.CAP_PROP_FPS)
         duration = total_frames_num / original_fps if original_fps > 0 else 0

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -432,7 +432,7 @@ class OpenCVVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
             target=target,
         )
 
-        frames, valid_frame_indices = OpenCVVideoBackendMixin.read_frames(
+        frames, valid_frame_indices = cls.read_frames(
             cap,
             frame_idx,
             total_frames_num=source.total_frames_num,

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -885,42 +885,19 @@ class NemotronVLVideoBackend(OpenCVVideoBackend):
 
 
 @VIDEO_LOADER_REGISTRY.register("openpangu")
-class OpenCVDynamicOpenPanguVideoBackend(OpenCVVideoBackend):
+class OpenCVDynamicOpenPanguVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
     @classmethod
-    def load_bytes(
+    def compute_frames_index_to_sample(
         cls,
-        data: bytes,
-        num_frames: int = 32,
-        fps: int = 1,
-        max_duration: int = 300,
-        frame_recovery: bool = False,
+        source: VideoSourceMetadata,
+        target: VideoTargetMetadata,
         **kwargs,
-    ) -> tuple[npt.NDArray, dict[str, Any]]:
-        """
-        Load video frames with dynamic sampling based on duration.
-        Assume that total_num_frames = 10 and fps = 1.
-        The timestamp of frame 0 is 0.0.
-        The timestamp of frame 1 is 1.0.…
-        The timestamp of frame 9 (the last frame) should be 9.0, that is,
-        (total_frames_num – 1) / original_fps.
+    ) -> list[int]:
+        total_frames_num = source.total_frames_num
+        original_fps = source.original_fps
+        num_frames = target.num_frames
+        fps = target.fps
 
-        Args:
-            data: Raw video bytes
-            num_frames: Not used in dynamic backend
-            fps: Target FPS for sampling (default: 1)
-
-        Returns:
-            Tuple of (frames_array, metadata_dict)
-        """
-        import cv2
-
-        backend = cls().get_cv2_video_api()
-        cap = cv2.VideoCapture(BytesIO(data), backend, [])
-        if not cap.isOpened():
-            raise ValueError("Could not open video stream")
-
-        total_frames_num = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        original_fps = float(cap.get(cv2.CAP_PROP_FPS))
         # The timestamp of the rightmost frame, cannot be used to calculate frame 0.
         if total_frames_num >= 1 and original_fps > 0:
             total_duration = (total_frames_num - 1) / original_fps
@@ -949,22 +926,69 @@ class OpenCVDynamicOpenPanguVideoBackend(OpenCVVideoBackend):
             min(total_frames_num - 1, round(t * original_fps))
             for t in sample_frame_timestamps
         ]
+        return frames_indices
 
-        frames, valid_frame_indices, recovered_map = cls._read_frames_with_recovery(
-            cap, frames_indices, total_frames_num
+    @classmethod
+    def load_bytes(
+        cls,
+        data: bytes,
+        num_frames: int = -1,
+        fps: int = 2,
+        max_duration: int = 300,
+        frame_recovery: bool = False,
+        **kwargs,
+    ) -> tuple[npt.NDArray, dict[str, Any]]:
+        """
+        Load video frames with dynamic sampling based on duration.
+
+        Args:
+            data: Raw video bytes
+            num_frames: Not used in dynamic backend
+            fps: Target FPS for sampling (default: 2)
+            max_duration: Maximum video duration to process (default: 300s)
+            frame_recovery: Enable forward-scan recovery for failed frames
+
+        Returns:
+            Tuple of (frames_array, metadata_dict)
+        """
+        import cv2
+
+        backend = cls().get_cv2_video_api()
+        cap = cv2.VideoCapture(BytesIO(data), backend, [])
+        if not cap.isOpened():
+            raise ValueError("Could not open video stream")
+
+        source = OpenCVVideoBackendMixin.get_video_metadata(cap)
+
+        # recompute source metadata with adjusted duration to ensure correct
+        # sampling indices computation
+        target = VideoTargetMetadata(
+            num_frames=num_frames,
+            fps=fps,
+            max_duration=max_duration,
         )
 
-        if recovered_map:
-            logger.info(
-                "Frame recovery: %d frames recovered using forward scan.",
-                len(recovered_map),
-            )
+        frame_indices_list = cls.compute_frames_index_to_sample(
+            source=source,
+            target=target,
+        )
 
+        frames, valid_frame_indices = cls.read_frames(
+            cap,
+            frame_indices_list,
+            set(frame_indices_list),
+            len(frame_indices_list),
+            max(frame_indices_list),
+            total_frames_num=source.total_frames_num,
+            frame_recovery=frame_recovery,
+        )
+
+        # Use transformers transformers.video_utils.VideoMetadata format
         metadata = {
-            "total_num_frames": total_frames_num,
-            "fps": original_fps,
-            "duration": total_duration,
-            "video_backend": "opencv_dynamic_openpangu",
+            "total_num_frames": source.total_frames_num,
+            "fps": source.original_fps,
+            "duration": source.duration,
+            "video_backend": "opencv_dynamic",
             "frames_indices": valid_frame_indices,
             "do_sample_frames": False,
         }

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -3,16 +3,22 @@
 import math
 from abc import abstractmethod
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, NamedTuple, cast
+from typing import Any, NamedTuple, cast
 
 import numpy as np
 import numpy.typing as npt
 
-if TYPE_CHECKING:
-    import cv2
-
 from vllm.logger import init_logger
+from vllm.utils.import_utils import PlaceholderModule
 from vllm.utils.registry import ExtensionManager
+
+try:
+    import cv2
+    import cv2.videoio_registry as vr
+except ImportError:
+    cv2 = PlaceholderModule("cv2")
+    vr = PlaceholderModule("cv2").placeholder_attr("videoio_registry")
+
 
 logger = init_logger(__name__)
 
@@ -23,8 +29,6 @@ def resize_video(frames: npt.NDArray, size: tuple[int, int]) -> npt.NDArray:
     resized_frames = np.empty(
         (num_frames, new_height, new_width, channels), dtype=frames.dtype
     )
-    # lazy import cv2 to avoid bothering users who only use text models
-    import cv2
 
     for i, frame in enumerate(frames):
         resized_frame = cv2.resize(frame, (new_width, new_height))
@@ -110,8 +114,6 @@ VIDEO_LOADER_REGISTRY = ExtensionManager()
 class OpenCVVideoBackendMixin:
     @staticmethod
     def get_cv2_video_api():
-        import cv2.videoio_registry as vr
-
         api_pref = None
         for backend in vr.getStreamBufferedBackends():
             if not vr.hasBackend(backend):
@@ -126,8 +128,6 @@ class OpenCVVideoBackendMixin:
 
     @classmethod
     def open_video_capture(cls, data: bytes) -> "cv2.VideoCapture":
-        import cv2
-
         backend = cls.get_cv2_video_api()
         cap = cv2.VideoCapture(BytesIO(data), backend, [])
         if not cap.isOpened():
@@ -136,8 +136,6 @@ class OpenCVVideoBackendMixin:
 
     @staticmethod
     def get_video_metadata(cap: "cv2.VideoCapture") -> VideoSourceMetadata:
-        import cv2
-
         total_frames_num = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
         original_fps = cap.get(cv2.CAP_PROP_FPS)
         duration = total_frames_num / original_fps if original_fps > 0 else 0
@@ -186,8 +184,6 @@ class OpenCVVideoBackendMixin:
             - valid_frame_indices: List of frame indices that were loaded
             - recovered_map: Dict mapping recovered_idx -> source_idx
         """
-        import cv2
-
         width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
         height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
 
@@ -277,8 +273,6 @@ class OpenCVVideoBackendMixin:
         frame_indices: set[int],
         max_frame_idx: int,
     ) -> tuple[npt.NDArray, list[int]]:
-        import cv2
-
         num_expected_frames = len(frame_indices)
         width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
         height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
@@ -416,7 +410,7 @@ class OpenCVVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
         Returns:
             Tuple of (frames_array, metadata_dict)
         """
-        cap = OpenCVVideoBackendMixin.open_video_capture(data)
+        cap = cls.open_video_capture(data)
 
         source = OpenCVVideoBackendMixin.get_video_metadata(cap)
         target = VideoTargetMetadata(
@@ -512,7 +506,7 @@ class OpenCVDynamicVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
         Returns:
             Tuple of (frames_array, metadata_dict)
         """
-        cap = OpenCVVideoBackendMixin.open_video_capture(data)
+        cap = cls.open_video_capture(data)
 
         orig_source = OpenCVVideoBackendMixin.get_video_metadata(cap)
         max_frame_idx = orig_source.total_frames_num - 1
@@ -788,7 +782,7 @@ class Molmo2VideoBackend(VideoLoader, OpenCVVideoBackendMixin):
         frame_recovery: bool = False,
         **kwargs,
     ) -> tuple[npt.NDArray, dict[str, Any]]:
-        cap = OpenCVVideoBackendMixin.open_video_capture(data)
+        cap = cls.open_video_capture(data)
 
         source = OpenCVVideoBackendMixin.get_video_metadata(cap)
         target = VideoTargetMetadata(
@@ -934,7 +928,7 @@ class OpenCVDynamicOpenPanguVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
         Returns:
             Tuple of (frames_array, metadata_dict)
         """
-        cap = OpenCVVideoBackendMixin.open_video_capture(data)
+        cap = cls.open_video_capture(data)
 
         source = OpenCVVideoBackendMixin.get_video_metadata(cap)
 

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -328,14 +328,12 @@ class OpenCVVideoBackendMixin:
         cls,
         cap: "cv2.VideoCapture",
         frame_idx: list[int],
-        frame_idx_set: set[int],
-        num_frames_to_sample: int,
-        max_frame_idx: int,
         total_frames_num: int,
         *,
         frame_recovery: bool = False,
     ) -> tuple[npt.NDArray, list[int]]:
         if frame_recovery:
+            num_frames_to_sample = len(frame_idx)
             frames, valid_frame_indices, recovered_map = cls._read_frames_with_recovery(
                 cap, frame_idx, total_frames_num
             )
@@ -347,6 +345,7 @@ class OpenCVVideoBackendMixin:
                 )
         else:
             frame_idx_set = set(frame_idx)
+            num_frames_to_sample = len(frame_idx_set)
             frames, valid_frame_indices = cls._read_frames_no_recovery(
                 cap, frame_idx_set, max(frame_idx)
             )
@@ -436,9 +435,6 @@ class OpenCVVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
         frames, valid_frame_indices = OpenCVVideoBackendMixin.read_frames(
             cap,
             frame_idx,
-            set(frame_idx),
-            len(frame_idx),
-            max(frame_idx),
             total_frames_num=source.total_frames_num,
             frame_recovery=frame_recovery,
         )
@@ -545,9 +541,6 @@ class OpenCVDynamicVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
         frames, valid_frame_indices = cls.read_frames(
             cap,
             frame_indices_list,
-            set(frame_indices_list),
-            len(frame_indices_list),
-            max(frame_indices_list),
             total_frames_num=source.total_frames_num,
             frame_recovery=frame_recovery,
         )
@@ -814,9 +807,6 @@ class Molmo2VideoBackend(VideoLoader, OpenCVVideoBackendMixin):
         frames, valid_frame_indices = cls.read_frames(
             cap,
             frame_idx,
-            set(frame_idx),
-            len(frame_idx),
-            max(frame_idx),
             total_frames_num=source.total_frames_num,
             frame_recovery=frame_recovery,
         )
@@ -964,9 +954,6 @@ class OpenCVDynamicOpenPanguVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
         frames, valid_frame_indices = cls.read_frames(
             cap,
             frame_indices_list,
-            set(frame_indices_list),
-            len(frame_indices_list),
-            max(frame_indices_list),
             total_frames_num=source.total_frames_num,
             frame_recovery=frame_recovery,
         )

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -108,6 +108,16 @@ class OpenCVVideoBackendMixin:
             break
         return api_pref
 
+    @classmethod
+    def open_video_capture(cls, data: bytes) -> "cv2.VideoCapture":
+        import cv2
+
+        backend = cls.get_cv2_video_api()
+        cap = cv2.VideoCapture(BytesIO(data), backend, [])
+        if not cap.isOpened():
+            raise ValueError("Could not open video stream")
+        return cap
+
     @staticmethod
     def get_video_metadata(cap: "cv2.VideoCapture") -> VideoSourceMetadata:
         import cv2
@@ -245,7 +255,7 @@ class OpenCVVideoBackendMixin:
         return frames, valid_frame_indices, recovered_map
 
     @classmethod
-    def _read_frames(
+    def _read_frames_no_recovery(
         cls,
         cap,
         frame_indices: set[int],
@@ -321,7 +331,7 @@ class OpenCVVideoBackendMixin:
                 )
         else:
             frame_idx_set = set(frame_idx)
-            frames, valid_frame_indices = cls._read_frames(
+            frames, valid_frame_indices = cls._read_frames_no_recovery(
                 cap, frame_idx_set, max(frame_idx)
             )
         valid_num_frames = len(valid_frame_indices)
@@ -391,12 +401,7 @@ class OpenCVVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
         Returns:
             Tuple of (frames_array, metadata_dict)
         """
-        import cv2
-
-        backend = OpenCVVideoBackendMixin.get_cv2_video_api()
-        cap = cv2.VideoCapture(BytesIO(data), backend, [])
-        if not cap.isOpened():
-            raise ValueError("Could not open video stream")
+        cap = OpenCVVideoBackendMixin.open_video_capture(data)
 
         source = OpenCVVideoBackendMixin.get_video_metadata(cap)
         target = VideoTargetMetadata(
@@ -503,12 +508,7 @@ class OpenCVDynamicVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
         Returns:
             Tuple of (frames_array, metadata_dict)
         """
-        import cv2
-
-        backend = cls().get_cv2_video_api()
-        cap = cv2.VideoCapture(BytesIO(data), backend, [])
-        if not cap.isOpened():
-            raise ValueError("Could not open video stream")
+        cap = OpenCVVideoBackendMixin.open_video_capture(data)
 
         orig_source = OpenCVVideoBackendMixin.get_video_metadata(cap)
         max_frame_idx = orig_source.total_frames_num - 1
@@ -791,14 +791,9 @@ class Molmo2VideoBackend(VideoLoader, OpenCVVideoBackendMixin):
         frame_recovery: bool = False,
         **kwargs,
     ) -> tuple[npt.NDArray, dict[str, Any]]:
-        import cv2
+        cap = OpenCVVideoBackendMixin.open_video_capture(data)
 
-        backend = cls().get_cv2_video_api()
-        cap = cv2.VideoCapture(BytesIO(data), backend, [])
-        if not cap.isOpened():
-            raise ValueError("Could not open video stream")
-
-        source = cls.get_video_metadata(cap)
+        source = OpenCVVideoBackendMixin.get_video_metadata(cap)
         target = VideoTargetMetadata(
             num_frames=num_frames,
             fps=sampling_fps,
@@ -948,12 +943,7 @@ class OpenCVDynamicOpenPanguVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
         Returns:
             Tuple of (frames_array, metadata_dict)
         """
-        import cv2
-
-        backend = cls().get_cv2_video_api()
-        cap = cv2.VideoCapture(BytesIO(data), backend, [])
-        if not cap.isOpened():
-            raise ValueError("Could not open video stream")
+        cap = OpenCVVideoBackendMixin.open_video_capture(data)
 
         source = OpenCVVideoBackendMixin.get_video_metadata(cap)
 

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -87,6 +87,22 @@ class VideoLoader:
         """Load video frames from bytes and return (frames_array, metadata_dict)."""
         raise NotImplementedError
 
+    @classmethod
+    def create_hf_metadata(
+        cls,
+        source: VideoSourceMetadata,
+        valid_frame_indices: list[int],
+        video_backend: str,
+    ):
+        return {
+            "total_num_frames": source.total_frames_num,
+            "fps": source.original_fps,
+            "duration": source.duration,
+            "video_backend": video_backend,
+            "frames_indices": valid_frame_indices,
+            "do_sample_frames": len(valid_frame_indices) == source.total_frames_num,
+        }
+
 
 VIDEO_LOADER_REGISTRY = ExtensionManager()
 
@@ -427,19 +443,11 @@ class OpenCVVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
             frame_recovery=frame_recovery,
         )
 
-        # Use transformers transformers.video_utils.VideoMetadata format
-        # NOTE(Isotr0py): For models like Qwen3-VL/GLM4.5V, this metadata
-        # can cause incorrect timestamp calculation without num_frames=-1.
-        metadata = {
-            "total_num_frames": source.total_frames_num,
-            "fps": source.original_fps,
-            "duration": source.duration,
-            "video_backend": "opencv",
-            "frames_indices": valid_frame_indices,
-            # extra field used to control hf processor's video
-            # sampling behavior
-            "do_sample_frames": len(valid_frame_indices) == source.total_frames_num,
-        }
+        metadata = cls.create_hf_metadata(
+            source=source,
+            video_backend="opencv",
+            valid_frame_indices=valid_frame_indices,
+        )
 
         return frames, metadata
 
@@ -544,15 +552,11 @@ class OpenCVDynamicVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
             frame_recovery=frame_recovery,
         )
 
-        # Use transformers transformers.video_utils.VideoMetadata format
-        metadata = {
-            "total_num_frames": source.total_frames_num,
-            "fps": source.original_fps,
-            "duration": duration,
-            "video_backend": "opencv_dynamic",
-            "frames_indices": valid_frame_indices,
-            "do_sample_frames": False,
-        }
+        metadata = cls.create_hf_metadata(
+            source=source,
+            video_backend="opencv_dynamic",
+            valid_frame_indices=valid_frame_indices,
+        )
 
         return frames, metadata
 
@@ -817,14 +821,11 @@ class Molmo2VideoBackend(VideoLoader, OpenCVVideoBackendMixin):
             frame_recovery=frame_recovery,
         )
 
-        metadata = {
-            "total_num_frames": source.total_frames_num,
-            "fps": source.original_fps,
-            "duration": source.duration,
-            "video_backend": "opencv",
-            "frames_indices": valid_frame_indices,
-            "do_sample_frames": False,
-        }
+        metadata = cls.create_hf_metadata(
+            source=source,
+            video_backend="opencv",
+            valid_frame_indices=valid_frame_indices,
+        )
 
         return frames, metadata
 
@@ -971,12 +972,9 @@ class OpenCVDynamicOpenPanguVideoBackend(VideoLoader, OpenCVVideoBackendMixin):
         )
 
         # Use transformers transformers.video_utils.VideoMetadata format
-        metadata = {
-            "total_num_frames": source.total_frames_num,
-            "fps": source.original_fps,
-            "duration": source.duration,
-            "video_backend": "opencv_dynamic",
-            "frames_indices": valid_frame_indices,
-            "do_sample_frames": False,
-        }
+        metadata = cls.create_hf_metadata(
+            source=source,
+            video_backend="opencv_dynamic",
+            valid_frame_indices=valid_frame_indices,
+        )
         return frames, metadata


### PR DESCRIPTION

## Purpose
- Currently, there're several video loader implementations which are quite messy, because frames sampling and reading are coupled, especially each video loader can have different arguments to control sampling behavior.
- To make the video loader maintainable, we need to make the video loader modular.
- This PR refactors the `VideoLoader` with new `OpenCVVideoBackendMixin` helper class. `OpenCVVideoBackendMixin` contains helper functions to open video stream and read frames with recovery algorithm.
- This PR also adds new abstract method `compute_frames_index_to_sample` to `VideoLoader`, so developers implement the sampled frames index computation there.

## Test Plan
```
pytest -s -v tests/multimodal/test_video.py  -k test_video_loader_frames_sampling
```

## Test Result
Tests should pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

