### PR TITLE
[BugFix] Fix fp4 quant kernel on CUDA 12.8

### DIFF
--- a/csrc/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu
+++ b/csrc/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu
@@ -107,7 +107,9 @@ __global__ void __launch_bounds__(512, VLLM_BLOCKS_PER_SM(512))
               (uint64_t(out_val.hi) << 32) | uint64_t(out_val.lo);
           reinterpret_cast<uint64_t*>(out)[outOffset >> 1] = packed64;
         } else {
-          out[inOffset] = out_val;
+          int64_t outOffset =
+              rowIdx * (numCols / CVT_FP4_ELTS_PER_THREAD) + colIdx;
+          out[outOffset] = out_val;
         }
       }
     }

--- a/csrc/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu
+++ b/csrc/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu
@@ -140,7 +140,7 @@ void silu_and_mul_nvfp4_quant_sm1xxa(torch::Tensor& output,  // [..., d]
   int const numBlocksPerSM =
       vllm_runtime_blocks_per_sm(static_cast<int>(block.x));
 
-  int sf_n_unpadded = int(n / CVT_FP4_SF_VEC_SIZE);
+  int sf_n_unpadded = int(n / CVT_FP4_ELTS_PER_THREAD);
 
   int grid_y = vllm::div_round_up(sf_n_unpadded, static_cast<int>(block.x));
   int grid_x = std::min(


### PR DESCRIPTION
## Summary
Fixes a bug in the non-swizzled FP4 quantization path (`cvt_fp16_to_fp4_sf_major`) and `silu_mul_cvt_fp16_to_fp4` when `CVT_FP4_ELTS_PER_THREAD == 8`, leading to failures in `test_quantize_to_fp4_padded_no_sf_swizzled` and `test_silu_mul_nvfp4_quant.py` (e.g. on sm120 / CUDA 12.8).

This patch introduces no additional performance overhead for the CUDA 12.8 code path. The CUDA 12.9+ path remains unaffected by this bug fix.

## Root cause
The kernel and host launch used `sf_n_unpadded` (number of scale-factor columns = `numCols/16`) as the bound for the thread-column index `colIdx`. 

With `ELTS_PER_THREAD == 16`, `num_packed_cols == sf_n_unpadded`, so **the old bound was correct and the bug did not appear**.

However, when CUDA 12.8 is used, i.e., `ELTS_PER_THREAD == 8`, the number of thread columns is `numCols/8` (twice `sf_n_unpadded`), leading to incorrect results.

## Testing - on SM120+CUDA 12.8 (Not covered by CI)
- `test_quantize_to_fp4_padded_no_sf_swizzled` -- ALL TEST PASSED
- `tests/kernels/quantization/test_silu_mul_nvfp4_quant.py` -- ALL TEST PASSED