### PR TITLE
Revert "[CI/Build] Remove redundant OpenTelemetry pip install from CI configs"

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -340,6 +340,11 @@ steps:
   - vllm/
   - tests/v1/tracing
   commands:
+  - "pip install \
+      'opentelemetry-sdk>=1.26.0' \
+      'opentelemetry-api>=1.26.0' \
+      'opentelemetry-exporter-otlp>=1.26.0' \
+      'opentelemetry-semantic-conventions-ai>=0.4.1'"
   - pytest -v -s v1/tracing
 
 ##### fast check tests  #####
@@ -1958,6 +1963,11 @@ steps:
   - vllm/
   - tests/v1/tracing
   commands:
+  - "pip install \
+      'opentelemetry-sdk>=1.26.0' \
+      'opentelemetry-api>=1.26.0' \
+      'opentelemetry-exporter-otlp>=1.26.0' \
+      'opentelemetry-semantic-conventions-ai>=0.4.1'"
   - pytest -v -s v1/tracing
 
 ##### fast check tests  #####

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -88,6 +88,11 @@ steps:
   - vllm/
   - tests/v1/tracing
   commands:
+  - "pip install \
+      'opentelemetry-sdk>=1.26.0' \
+      'opentelemetry-api>=1.26.0' \
+      'opentelemetry-exporter-otlp>=1.26.0' \
+      'opentelemetry-semantic-conventions-ai>=0.4.1'"
   - pytest -v -s v1/tracing
 
 - label: Python-only Installation


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/35195

Reverts vllm-project/vllm#35032, vllm-project/vllm#35032 broke `v1/tracing/test_tracing.py::test_traces`, revert until this can be removed without breaking tests