### PR TITLE
Explicitly disable scale_up/scale_down when async EPLB is enabled

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1319,6 +1319,10 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
             "Only ray DP backend supports scaling elastic EP"
         )
 
+        assert not self.vllm_config.parallel_config.eplb_config.use_async, (
+            "scale_down/scale_up are not supported when async EPLB is enabled"
+        )
+
         scale_up = new_data_parallel_size > cur_data_parallel_size
 
         if scale_up:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -799,6 +799,9 @@ class Worker(WorkerBase):
             for old_ep_rank in range(old_ep_size)
         }
         assert self.model_runner.eplb_state is not None
+        # Rearrange defers weight transfer to the async eplb thread when running async
+        # eplb which is not compatible with scale_up/scale_down
+        assert not self.model_runner.eplb_state.is_async
         self.model_runner.eplb_state.rearrange(
             execute_shuffle=True,
             global_expert_loads=None,
@@ -820,6 +823,9 @@ class Worker(WorkerBase):
             logger.info("[Elastic EP] Starting expert resharding after scaling up...")
         rank_mapping = {old_ep_rank: old_ep_rank for old_ep_rank in range(old_ep_size)}
         assert self.model_runner.eplb_state is not None
+        # Rearrange defers weight transfer to the async eplb thread when running async
+        # eplb which is not compatible with scale_up/scale_down
+        assert not self.model_runner.eplb_state.is_async
         self.model_runner.eplb_state.rearrange(
             execute_shuffle=True,
             global_expert_loads=global_expert_loads,


### PR DESCRIPTION
## Purpose
This PR updates the scale_elastic_ep endpoint to return a 500 response when async EPLB is enabled. Async EPLB is fundamentally incompatible with scale_up/scale_down because it delegates the weight transfer to the async eplb thread, which runs while the model is executing its forward pass.

IMO the "correct" implementation here is to run scale_up/down with synchronous EPLB even when normal EPLB rebalancing is happing asynchronously. That's a more involved change, so I suggest just disabling it for now. 

## Test Plan
Server Command
```
 vllm serve deepseek-ai/DeepSeek-V2-Lite \
           --enable-expert-parallel \
           --all2all-backend allgather_reducescatter \
           --enable_eplb \
           --no-async-scheduling \
           --enforce-eager \
           --eplb_config '{"use_async":"true","num_redundant_experts":64}' \
           --data-parallel-size 4
```

Client Command
`python examples/online_serving/elastic_ep/scale.py --new-dp-size 2`
## Test Result
Before this PR
```
(EngineCore_DP2 pid=925443) ERROR 02-24 20:16:15 [async_worker.py:52] Traceback (most recent call last):
(EngineCore_DP2 pid=925443) ERROR 02-24 20:16:15 [async_worker.py:52]   File "/home/sagemoore/git/nm-vllm/vllm/distributed/eplb/async_worker.py", line 42, in thread_target
(EngineCore_DP2 pid=925443) ERROR 02-24 20:16:15 [async_worker.py:52]     loop.run_until_complete(
(EngineCore_DP2 pid=925443) ERROR 02-24 20:16:15 [async_worker.py:52]   File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
(EngineCore_DP2 pid=925443) ERROR 02-24 20:16:15 [async_worker.py:52]     return future.result()
(EngineCore_DP2 pid=925443) ERROR 02-24 20:16:15 [async_worker.py:52]            ^^^^^^^^^^^^^^^
(EngineCore_DP2 pid=925443) ERROR 02-24 20:16:15 [async_worker.py:52]   File "/home/sagemoore/git/nm-vllm/vllm/distributed/eplb/async_worker.py", line 99, in transfer_run_periodically
(EngineCore_DP2 pid=925443) ERROR 02-24 20:16:15 [async_worker.py:52]     ) = await transfer_layer(
(EngineCore_DP2 pid=925443) ERROR 02-24 20:16:15 [async_worker.py:52]         ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP2 pid=925443) ERROR 02-24 20:16:15 [async_worker.py:52]   File "/home/sagemoore/git/nm-vllm/vllm/distributed/eplb/rebalance_execute.py", line 488, in transfer_layer
(EngineCore_DP2 pid=925443) ERROR 02-24 20:16:15 [async_worker.py:52]     assert old_global_expert_indices.shape[1] == new_global_expert_indices.shape[1]
(EngineCore_DP2 pid=925443) ERROR 02-24 20:16:15 [async_worker.py:52]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

After this PR
```
(ApiServer_1 pid=915135) ERROR 02-24 20:03:39 [api_router.py:84] Scale failed: scale_down/scale_up are not supported when async EPLB is enabled
(ApiServer_1 pid=915135) ERROR 02-24 20:03:39 [api_router.py:84] Traceback (most recent call last):
(ApiServer_1 pid=915135) ERROR 02-24 20:03:39 [api_router.py:84]   File "/home/sagemoore/git/nm-vllm/vllm/entrypoints/serve/elastic_ep/api_router.py", line 71, in scale_elastic_ep
(ApiServer_1 pid=915135) ERROR 02-24 20:03:39 [api_router.py:84]     await client.scale_elastic_ep(new_data_parallel_size, drain_timeout)
(ApiServer_1 pid=915135) ERROR 02-24 20:03:39 [api_router.py:84]   File "/home/sagemoore/git/nm-vllm/vllm/v1/engine/async_llm.py", line 978, in scale_elastic_ep
(ApiServer_1 pid=915135) ERROR 02-24 20:03:39 [api_router.py:84]     await self.engine_core.scale_elastic_ep(new_data_parallel_size)
(ApiServer_1 pid=915135) ERROR 02-24 20:03:39 [api_router.py:84]   File "/home/sagemoore/git/nm-vllm/vllm/v1/engine/core_client.py", line 1322, in scale_elastic_ep
(ApiServer_1 pid=915135) ERROR 02-24 20:03:39 [api_router.py:84]     assert not self.vllm_config.parallel_config.eplb_config.use_async, (
(ApiServer_1 pid=915135) ERROR 02-24 20:03:39 [api_router.py:84]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(ApiServer_1 pid=915135) ERROR 02-24 20:03:39 [api_router.py:84] AssertionError: scale_down/scale_up are not supported when async EPLB is enabled
(ApiServer_1 pid=915135) INFO:     127.0.0.1:34998 - "POST /scale_elastic_ep HTTP/1.1" 500 Internal Server Error
```
I also ran lm_eval after this failure and confirmed that the server still gets the correct answer.
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.35|±  |0.0276|
|     |       |strict-match    |     5|exact_match|↑  | 0.35|±  |0.0276|
```

---