### PR TITLE
[Perf] Fused silu_mul_fp8_quant_packed kernel for SM100 DeepGEMM MoE

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -331,6 +331,15 @@ void per_token_group_quant_8bit_packed(const torch::Tensor& input,
                                        int64_t group_size, double eps,
                                        double min_8bit, double max_8bit);
 
+// Fused SiLU+mul + per-token-group FP8 quantization with UE8M0-packed
+// scales for DeepGEMM. Input: [mn, 2*N], output: [mn, N] in FP8.
+void silu_mul_per_token_group_quant_fp8_packed(const torch::Tensor& input,
+                                               torch::Tensor& output_q,
+                                               torch::Tensor& output_s_packed,
+                                               int64_t group_size, double eps,
+                                               double min_8bit,
+                                               double max_8bit);
+
 #endif
 
 void static_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,

--- a/csrc/quantization/w8a8/per_token_group_quant_8bit.h
+++ b/csrc/quantization/w8a8/per_token_group_quant_8bit.h
@@ -7,3 +7,12 @@ void per_token_group_quant_8bit(const torch::Tensor& input,
                                 torch::Tensor& output_s, int64_t group_size,
                                 double eps, double min_8bit, double max_8bit,
                                 bool scale_ue8m0 = false);
+
+// Fused SiLU+mul + per-token-group FP8 quantization with UE8M0-packed
+// scales for DeepGEMM. Input: [mn, 2*N], output: [mn, N] in FP8.
+void silu_mul_per_token_group_quant_fp8_packed(const torch::Tensor& input,
+                                               torch::Tensor& output_q,
+                                               torch::Tensor& output_s_packed,
+                                               int64_t group_size, double eps,
+                                               double min_8bit,
+                                               double max_8bit);

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -667,6 +667,15 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.impl("per_token_group_fp8_quant_packed", torch::kCUDA,
            &per_token_group_quant_8bit_packed);
 
+  // Fused SiLU+mul + per-token-group FP8 quantization with UE8M0-packed
+  // scales for DeepGEMM. Input: [mn, 2*N], output: [mn, N] in FP8.
+  ops.def(
+      "silu_and_mul_fp8_quant_packed(Tensor input, Tensor! output_q, "
+      "Tensor! output_s_packed, int group_size, float eps, float fp8_min, "
+      "float fp8_max) -> ()");
+  ops.impl("silu_and_mul_fp8_quant_packed", torch::kCUDA,
+           &silu_mul_per_token_group_quant_fp8_packed);
+
   // Compute per-token-group INT8 quantized tensor and scaling factor.
   ops.def(
       "per_token_group_quant_int8(Tensor input, Tensor! output_q, Tensor! "


### PR DESCRIPTION
## Purpose

https://github.com/vllm-project/vllm/issues/35217

## Test Plan

## Test Result

Command:
```
VLLM_USE_FLASHINFER_MOE_FP8=0 vllm serve deepseek-ai/DeepSeek-R1 -tp=4 --load-format=dummy --no-enable-prefix-caching
vllm bench serve --input-len 1024 --output-len 512 --num-prompts 128
```

~1% improvement in throughput?

Before:
```
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Benchmark duration (s):                  24.19     
Total input tokens:                      130944    
Total generated tokens:                  65536     
Request throughput (req/s):              5.29      
Output token throughput (tok/s):         2709.04   
Peak output token throughput (tok/s):    3328.00   
Peak concurrent requests:                128.00    
Total token throughput (tok/s):          8121.82   
---------------Time to First Token----------------
Mean TTFT (ms):                          2300.94   
Median TTFT (ms):                        2300.13   
P99 TTFT (ms):                           4063.66   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          42.31     
Median TPOT (ms):                        42.32     
P99 TPOT (ms):                           45.20     
---------------Inter-token Latency----------------
Mean ITL (ms):                           42.31     
Median ITL (ms):                         39.52     
P99 ITL (ms):                            235.47    
==================================================
```

After:
```
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Benchmark duration (s):                  23.97     
Total input tokens:                      130944    
Total generated tokens:                  65536     
Request throughput (req/s):              5.34      
Output token throughput (tok/s):         2734.44   
Peak output token throughput (tok/s):    3328.00   
Peak concurrent requests:                128.00    
Total token throughput (tok/s):          8197.99   
---------------Time to First Token----------------
Mean TTFT (ms):                          2332.15   
Median TTFT (ms):                        2337.13   
P99 TTFT (ms):                           4083.30   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          41.81     
Median TPOT (ms):                        41.82     
P99 TPOT (ms):                           44.77     
---------------Inter-token Latency----------------
Mean ITL (ms):                           41.81     
Median ITL (ms):                         38.98     
P99 ITL (ms):                            233.83    
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

