### PR TITLE
[Bugfix] Fix AttributeError when passing StructuredOutputsParams to CompletionRequest

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -555,8 +555,14 @@ class ChatCompletionRequest(OpenAIBaseModel):
             return data
 
         structured_outputs_kwargs = data["structured_outputs"]
+        # structured_outputs may arrive as a dict (from JSON/raw kwargs) or
+        # as a StructuredOutputsParams dataclass instance.
+        if isinstance(structured_outputs_kwargs, StructuredOutputsParams):
+            _get = getattr
+        else:
+            _get = lambda obj, key: obj.get(key)
         count = sum(
-            structured_outputs_kwargs.get(k) is not None
+            _get(structured_outputs_kwargs, k) is not None
             for k in ("json", "regex", "choice")
         )
         # you can only use one kind of constraints for structured outputs

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -314,8 +314,14 @@ class CompletionRequest(OpenAIBaseModel):
             return data
 
         structured_outputs_kwargs = data["structured_outputs"]
+        # structured_outputs may arrive as a dict (from JSON/raw kwargs) or
+        # as a StructuredOutputsParams dataclass instance.
+        if isinstance(structured_outputs_kwargs, StructuredOutputsParams):
+            _get = getattr
+        else:
+            _get = lambda obj, key: obj.get(key)
         count = sum(
-            structured_outputs_kwargs.get(k) is not None
+            _get(structured_outputs_kwargs, k) is not None
             for k in ("json", "regex", "choice")
         )
         if count > 1:


### PR DESCRIPTION
  ## Summary

  The `check_structured_outputs_count` model validator on `CompletionRequest` and `ChatCompletionRequest` uses `mode="before"` and calls `.get()` on the `structured_outputs` value, assuming it is always a dict. However, the field is typed as `StructuredOutputsParams | None`, so passing a dataclass instance is a valid usage but crashes with:
```
  AttributeError: 'StructuredOutputsParams' object has no attribute 'get'
```
  This PR handles both dict and `StructuredOutputsParams` inputs by checking the type and using `getattr` for dataclass instances.

  ## Reproduction

  ```python
  from vllm.entrypoints.openai.completion.protocol import CompletionRequest
  from vllm.sampling_params import StructuredOutputsParams

  # Crashes on v0.12.0 through v0.15.1
  CompletionRequest(
      model="my-model",
      prompt="hello",
      max_tokens=100,
      structured_outputs=StructuredOutputsParams(regex=r"^ [\s\S]*"),  # could be fixed w/ structured_outputs={"regex": " [\s\S]*"}
  )
  # AttributeError: 'StructuredOutputsParams' object has no attribute 'get'
```

  Test plan

  - [x] Verified CompletionRequest accepts StructuredOutputsParams object (was crashing)
  - [x] Verified CompletionRequest still accepts dict (existing behavior)
  - [x] Verified CompletionRequest still accepts None
  - [x] Verified multi-constraint validation still rejects for both dict and object inputs
  - [x] Verified ChatCompletionRequest same as above

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

