### PR TITLE
[XPU]Fix for Qwen-OMNI crash

### DIFF
--- a/vllm/_xpu_ops.py
+++ b/vllm/_xpu_ops.py
@@ -112,7 +112,7 @@ class xpu_ops:
         return flash_attn_varlen_func(
             out=out,
             q=q.contiguous(),
-            k=k,
+            k=k.contiguous(),
             v=v,
             cu_seqlens_q=cu_seqlens_q,
             cu_seqlens_k=cu_seqlens_k,

--- a/vllm/_xpu_ops.py
+++ b/vllm/_xpu_ops.py
@@ -105,14 +105,15 @@ class xpu_ops:
             assert len(window_size) == 2
             real_window_size = (window_size[0], window_size[1])  # noqa: F841
 
-        # In encode attention, v maybe not contiguous and current
+        # In encode attention, k and v maybe not contiguous and current
         # kernel can't handle it
         if block_table is None:
+            k = k.contiguous()
             v = v.contiguous()
         return flash_attn_varlen_func(
             out=out,
             q=q.contiguous(),
-            k=k.contiguous(),
+            k=k,
             v=v,
             cu_seqlens_q=cu_seqlens_q,
             cu_seqlens_k=cu_seqlens_k,

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -165,7 +165,7 @@ class XPUPlatform(Platform):
         compilation_config = vllm_config.compilation_config
         if compilation_config.compile_sizes is None:
             compilation_config.compile_sizes = []
-
+        compilation_config.max_cudagraph_capture_size = 0
         assert compilation_config.cudagraph_mode == CUDAGraphMode.NONE, (
             "CUDA graph mode should be NONE on XPU"
         )

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -165,7 +165,7 @@ class XPUPlatform(Platform):
         compilation_config = vllm_config.compilation_config
         if compilation_config.compile_sizes is None:
             compilation_config.compile_sizes = []
-        compilation_config.max_cudagraph_capture_size = 0
+
         assert compilation_config.cudagraph_mode == CUDAGraphMode.NONE, (
             "CUDA graph mode should be NONE on XPU"
         )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The error is detected with vLLM-omni project when running v0.16.0 on XPU
https://github.com/vllm-project/vllm-omni/pull/1416

Two issues are detected:
1. Due to xpu does not support `cudagraph` yet. vLLM main repo set `max_cudagraph_capture_size=None`.
This leads to a crash in 
And the value compare of `max_batch_size` to `max_cudagraph_capture_size` will crash at [qwen3_omni_moe_talker - init](https://github.com/vllm-project/vllm-omni/blob/main/vllm_omni/model_executor/models/qwen3_omni/qwen3_omni_moe_talker.py#L132-L134)
codes quoted here:
```
132        max_batch_size = max(
133            vllm_config.scheduler_config.max_num_seqs, vllm_config.compilation_config.max_cudagraph_capture_size
134        )
```

2. RuntimeError: k must be contiguous issue when calling vllm/model_executor/layers/attention/mm_encoder_attention.py from Qwen3_omni. Same issue also happens to Bagel txt2img encoding.

--

Solution:

- hard-config max_cudagraph_capture_size=0
- add k.contiguous()  => was doing so in previous IPEX flash_attn_varlen_func call, assume no significant perf impact


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

