### PR TITLE
[Bugfix][Hardware][AMD] Gate FP4 ops on gfx950 to prevent MI300X crash

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -999,12 +999,16 @@ class rocm_aiter_ops:
     @classmethod
     @if_aiter_supported
     def is_fp4bmm_enabled(cls) -> bool:
-        return cls._AITER_ENABLED and cls._FP4BMM_ENABLED
+        from vllm.platforms.rocm import on_gfx950
+
+        return cls._AITER_ENABLED and cls._FP4BMM_ENABLED and on_gfx950()
 
     @classmethod
     @if_aiter_supported
     def is_asm_fp4_gemm_dynamic_quant_enabled(cls) -> bool:
-        return cls._AITER_ENABLED and cls._FP4_GEMM_DYNAMIC_QUANT_ASM
+        from vllm.platforms.rocm import on_gfx950
+
+        return cls._AITER_ENABLED and cls._FP4_GEMM_DYNAMIC_QUANT_ASM and on_gfx950()
 
     @classmethod
     @if_aiter_supported


### PR DESCRIPTION
## Summary

FP4 BMM and FP4 ASM GEMM use CDNA4-only instructions available only on gfx950. Without a hardware check, enabling `VLLM_ROCM_USE_AITER_FP4BMM` or `VLLM_ROCM_USE_AITER_FP4_ASM_GEMM` on MI300X (gfx942) would crash with illegal instruction errors.

- Add `on_gfx950()` gate to `is_fp4bmm_enabled()` and `is_asm_fp4_gemm_dynamic_quant_enabled()` in `rocm_aiter_ops`
- Consistent with how other gfx950-only features are gated (e.g., `mxfp4_utils.py:46`, `layers/utils.py:173`)

## Test plan

- [ ] Verify `is_fp4bmm_enabled()` returns `False` on gfx942 even when env var is set
- [ ] Verify `is_asm_fp4_gemm_dynamic_quant_enabled()` returns `False` on gfx942 even when env var is set
- [ ] AMD CI passes (same gating pattern as existing `on_gfx950()` checks)