### PR TITLE
[Bugfix] Fix dtype mismatch in RMSNormGated.forward_native() during torch.compile

### DIFF
--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -557,6 +557,11 @@ class RMSNormGated(CustomOp):
             - norm_before_gate=True: out = norm(x) * silu(z)
             - norm_before_gate=False: out = norm(x * silu(z))
         """
+        orig_dtype = x.dtype
+        x = x.float()
+        weight = self.weight.float()
+        z = z.float() if z is not None else None
+
         # Apply gating before normalization if needed
         if z is not None and not self.norm_before_gate:
             x = x * F.silu(z)
@@ -566,7 +571,7 @@ class RMSNormGated(CustomOp):
             # Standard RMS norm across the last dimension
             variance = x.pow(2).mean(dim=-1, keepdim=True)
             x_normed = x * torch.rsqrt(variance + self.eps)
-            out = x_normed * self.weight
+            out = x_normed * weight
         else:
             # Group RMS norm
             from einops import rearrange
@@ -574,13 +579,13 @@ class RMSNormGated(CustomOp):
             x_group = rearrange(x, "... (g d) -> ... g d", d=self.group_size)
             variance = x_group.pow(2).mean(dim=-1, keepdim=True)
             x_normed = x_group * torch.rsqrt(variance + self.eps)
-            out = rearrange(x_normed, "... g d -> ... (g d)") * self.weight
+            out = rearrange(x_normed, "... g d -> ... (g d)") * weight
 
         # Apply gating after normalization if needed
         if z is not None and self.norm_before_gate:
             out = out * F.silu(z)
 
-        return out.to(x.dtype)
+        return out.to(orig_dtype)
 
     def forward_cuda(
         self, x: torch.Tensor, z: torch.Tensor | None = None


### PR DESCRIPTION
## Purpose

Fixes #35238.

When `torch.compile` is active (the default with Inductor backend), vLLM disables custom ops (`custom_ops=["none"]`). This causes `RMSNormGated` to dispatch to `forward_native` instead of `forward_cuda`. The `forward_native` implementation did not preserve input dtype — PyTorch's `mean()` on float16 tensors promotes the result to float32, which propagated through all subsequent operations (`rsqrt`, weight multiply, gating). The float32 output was then passed to `out_proj` (a `RowParallelLinear` with float16 weights), causing `mm(float32, float16)` → crash.

The fix follows the same pattern used by `RMSNorm.forward_static` and `GemmaRMSNorm._forward_static_no_residual` in the same file: explicitly upcast inputs to float32 for numerical stability, then cast back to the original dtype before returning.

## Test Plan

Added `test_rmsnorm_gated_forward_native_dtype` — 216 parametrized tests covering:
- dtype preservation (float16, bfloat16, float32)
- Numerical correctness against `rms_norm_ref`
- With/without gating (`z`)
- With/without `group_size`
- Both `norm_before_gate` modes

Also added `torch.float16` to the existing `DTYPES` list in `test_fla_layernorm_guard.py` for broader Triton kernel test coverage.

## Test Result

- 216 new tests: all passed
- 1337 existing tests (including with float16 now added): all passed