### PR TITLE
[Bugfix] Fix placeholder detection when tokenizer merges boundary tokens (#29863)

### DIFF
--- a/tests/models/multimodal/processing/test_qwen3_vl_boundary_merge.py
+++ b/tests/models/multimodal/processing/test_qwen3_vl_boundary_merge.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Regression test for https://github.com/vllm-project/vllm/issues/29863
+
+When a Qwen3-VL prompt ends with punctuation (e.g., `.` or `:`) immediately
+before a video placeholder, the HF processor expands the placeholder into
+timestamp markers like `<0.3 seconds><|vision_start|>...`.  The `<` in the
+timestamp text merges with the preceding punctuation (e.g., `.<` becomes a
+single token), breaking exact token matching in `_find_mm_placeholders`.
+
+This test exercises `_find_mm_placeholders` directly with token IDs that
+contain the boundary merge, verifying the Qwen3VL-specific override
+correctly splits merged tokens before matching.
+"""
+
+import pytest
+
+from vllm.config import ModelConfig
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.processing.processor import (
+    BaseMultiModalProcessor,
+    PromptUpdateDetails,
+    ResolvedPromptUpdate,
+    UpdateMode,
+)
+
+MODEL = "Qwen/Qwen3-VL-8B-Instruct"
+NUM_PADS = 4
+
+pytestmark = pytest.mark.cpu_test
+
+
+# ── fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def processor():
+    model_config = ModelConfig(
+        model=MODEL,
+        limit_mm_per_prompt={"video": 1},
+    )
+    return MULTIMODAL_REGISTRY.create_processor(model_config)
+
+
+@pytest.fixture(scope="module")
+def tokenizer(processor):
+    return processor.info.get_tokenizer()
+
+
+@pytest.fixture(scope="module")
+def vision_ids(processor):
+    """Return (vision_start_id, video_pad_id, vision_end_id)."""
+    cfg = processor.info.get_hf_config()
+    return cfg.vision_start_token_id, cfg.video_token_id, cfg.vision_end_token_id
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _make_video_update(tokenizer, vision_ids):
+    """Build video replacement tokens and the corresponding prompt update."""
+    vision_start_id, video_pad_id, vision_end_id = vision_ids
+    timestamp_tokens = tokenizer.encode("<0.0 seconds>", add_special_tokens=False)
+    video_replacement = (
+        timestamp_tokens
+        + [vision_start_id]
+        + [video_pad_id] * NUM_PADS
+        + [vision_end_id]
+    )
+    content = PromptUpdateDetails.select_token_id(video_replacement, video_pad_id)
+    update = ResolvedPromptUpdate(
+        modality="video",
+        item_idx=0,
+        mode=UpdateMode.REPLACE,
+        target="<|vision_start|><|video_pad|><|vision_end|>",
+        content=content,
+    )
+    return timestamp_tokens, video_replacement, {"video": [[update]]}
+
+
+# ── tests ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("merge_pattern", [".<", ":<"], ids=["dot", "colon"])
+def test_boundary_merge(processor, tokenizer, vision_ids, merge_pattern):
+    """
+    When punctuation merges with `<` (e.g. `.<` or `:<` become one token),
+    the Qwen3VL override should still find the video placeholder.
+    """
+    vision_start_id, video_pad_id, vision_end_id = vision_ids
+
+    # Verify the merge actually happens with this tokenizer
+    merged_ids = tokenizer.encode(merge_pattern, add_special_tokens=False)
+    assert len(merged_ids) == 1, (
+        f"Expected '{merge_pattern}' to merge into 1 token, got {len(merged_ids)}"
+    )
+    merged_token = merged_ids[0]
+
+    timestamp_tokens, video_replacement, mm_prompt_updates = _make_video_update(
+        tokenizer, vision_ids
+    )
+
+    # Simulate HF processor output: "details" + merged_token + rest of
+    # timestamp + vision_start + pad*N + vision_end
+    prompt_ids = (
+        tokenizer.encode("details", add_special_tokens=False)
+        + [merged_token]
+        + timestamp_tokens[1:]
+        + [vision_start_id]
+        + [video_pad_id] * NUM_PADS
+        + [vision_end_id]
+    )
+
+    # Qwen3VL override should find the placeholder
+    result = processor._find_mm_placeholders(prompt_ids, mm_prompt_updates)
+    assert "video" in result
+    assert len(result["video"]) == 1
+    ph = result["video"][0]
+    assert ph.item_idx == 0
+    assert ph.modality == "video"
+    assert len(ph.tokens) == len(video_replacement)
+
+    # Base class should fail — proves the override is needed
+    base_result = BaseMultiModalProcessor._find_mm_placeholders(
+        processor, prompt_ids, mm_prompt_updates
+    )
+    assert base_result.get("video", []) == [], (
+        "Base _find_mm_placeholders should NOT find the merged placeholder"
+    )
+
+
+def test_no_merge(processor, tokenizer, vision_ids):
+    """When there's no merge (e.g., newline before `<`), should still work."""
+    vision_start_id, video_pad_id, vision_end_id = vision_ids
+
+    timestamp_tokens, _, mm_prompt_updates = _make_video_update(tokenizer, vision_ids)
+
+    # No merge: newline before '<' keeps it as a separate token
+    prompt_ids = (
+        tokenizer.encode("details\n", add_special_tokens=False)
+        + timestamp_tokens
+        + [vision_start_id]
+        + [video_pad_id] * NUM_PADS
+        + [vision_end_id]
+    )
+
+    result = processor._find_mm_placeholders(prompt_ids, mm_prompt_updates)
+    assert "video" in result
+    assert len(result["video"]) == 1
+    ph = result["video"][0]
+    assert ph.item_idx == 0
+    assert ph.modality == "video"

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1046,8 +1046,9 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
         tokenizer = self.info.get_tokenizer()
         merged_lt_splits = _get_merged_lt_splits(tokenizer)
 
-        # Fast path: no merged tokens in this tokenizer's vocab.
-        if not merged_lt_splits:
+        # Fast path: skip split loop when no tokens in the prompt need
+        # splitting (covers both empty vocab map and no-merge prompts).
+        if not merged_lt_splits or merged_lt_splits.keys().isdisjoint(new_token_ids):
             return super()._find_mm_placeholders(new_token_ids, mm_prompt_updates)
 
         repl_token_ids = list[int]()

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -928,12 +928,12 @@ class Qwen3VLDummyInputsBuilder(BaseDummyInputsBuilder[Qwen3VLProcessingInfo]):
 def _get_merged_lt_splits(
     tokenizer: PreTrainedTokenizerBase,
 ) -> dict[int, list[int]]:
-    """Pre-compute split mappings for vocab tokens that end with ``<``.
+    """Pre-compute split mappings for vocab tokens that end with `<`.
 
-    The Qwen3-VL tokenizer may merge preceding punctuation with ``<``
-    (e.g. ``.<`` → single token 15757).  This function scans the vocab
+    The Qwen3-VL tokenizer may merge preceding punctuation with `<`
+    (e.g. `.<` → single token 15757).  This function scans the vocab
     once and returns a dict mapping each such merged token ID to its
-    split form ``[*prefix_ids, lt_id]``.
+    split form `[*prefix_ids, lt_id]`.
     """
     vocab = tokenizer.get_vocab()
     lt_id = vocab["<"]


### PR DESCRIPTION
## Purpose

Fixes #29863.

When a Qwen3-VL prompt ends with punctuation (e.g., `.` or `:`) immediately before a video placeholder, the HF processor expands the placeholder into timestamp markers like `<0.3 seconds><|vision_start|>...`. The `<` in the timestamp text merges with the preceding punctuation (e.g., `.<` becomes a single token), breaking exact token matching in `_find_mm_placeholders`.

## Approach

Add a `_find_mm_placeholders` override in `Qwen3VLMultiModalProcessor` following the same pattern as Gemma3 (`gemma3_mm.py`).

A cached helper `_get_merged_lt_splits(tokenizer)` scans the vocab once and pre-computes a `dict[int, list[int]]` mapping each merged `*<` token to its split form (`prefix_ids + [lt_id]`). At runtime, the override does a simple `dict.get()` per token — no per-token `decode()` calls. If no merged tokens exist in the vocab (e.g. future Qwen models with a different tokenizer), it falls back directly to the base implementation with zero overhead.

### Changes

- **`vllm/model_executor/models/qwen3_vl.py`**:
  - `_get_merged_lt_splits()`: `@lru_cache`d function that pre-computes the split mapping for all vocab tokens ending with `<`.
  - `_find_mm_placeholders()`: Override that splits merged tokens via the pre-computed dict, runs base class matching on the normalized sequence, and remaps `start_idx` back. Fast-paths to `super()` when no merged tokens exist.
- **`tests/models/multimodal/processing/test_qwen3_vl_boundary_merge.py`**: Regression test exercising `_find_mm_placeholders` directly with merged token IDs. Parametrized over `.<` and `:<` merge patterns, plus a no-merge baseline.

## Test Plan

```
$ python -m pytest tests/models/multimodal/processing/test_qwen3_vl_boundary_merge.py -xvs

test_boundary_merge[dot] PASSED
test_boundary_merge[colon] PASSED
test_no_merge PASSED
```

The tests also verify that the base class `_find_mm_placeholders` **fails** to find the placeholder with merged tokens, proving the override is necessary.