### PR TITLE
[MIX] More accurate processing of quantization of `mlp.gate`

### DIFF
--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -118,6 +118,13 @@ QUANT_ALGOS = [
 KV_CACHE_QUANT_ALGOS = ["FP8"]
 
 
+def is_modelopt_quant_config(
+    quant_config: QuantizationConfig | None,
+) -> bool:
+    """Check if the quantization config originates from ModelOpt."""
+    return isinstance(quant_config, ModelOptQuantConfigBase)
+
+
 class ModelOptFp8KVCacheMethod(BaseKVCacheMethod):
     """
     Supports loading kv-cache scaling factors from FP8 checkpoints.

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -63,6 +63,9 @@ from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
     causal_conv1d_update,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.modelopt import (
+    is_modelopt_quant_config,
+)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -248,11 +251,15 @@ class Qwen3NextSparseMoeBlock(nn.Module):
             self.physical_expert_start + self.n_local_physical_experts
         )
 
+        # ModelOpt checkpoints never quantize mlp.gate layers
+        gate_quant_config = (
+            None if is_modelopt_quant_config(quant_config) else quant_config
+        )
         self.gate = ReplicatedLinear(
             config.hidden_size,
             config.num_experts,
             bias=False,
-            quant_config=None,
+            quant_config=gate_quant_config,
             prefix=f"{prefix}.gate",
         )
 


### PR DESCRIPTION
Addon to #35156.

Mark `mlp.gate` as non-quant for ModelOpt models only.