### PR TITLE
[Frontend] Add metrics-only uvicorn access log flag

### DIFF
--- a/tests/entrypoints/openai/test_cli_args.py
+++ b/tests/entrypoints/openai/test_cli_args.py
@@ -255,6 +255,15 @@ def test_default_chat_template_kwargs_invalid_json(serve_parser):
         )
 
 
+def test_disable_uvicorn_metrics_access_log(serve_parser):
+    """Ensure metrics-only access log flag is parsed correctly."""
+    args = serve_parser.parse_args(args=[])
+    assert args.disable_uvicorn_metrics_access_log is False
+
+    args = serve_parser.parse_args(args=["--disable-uvicorn-metrics-access-log"])
+    assert args.disable_uvicorn_metrics_access_log is True
+
+
 @pytest.mark.parametrize(
     "args, raises",
     [

--- a/tests/entrypoints/openai/test_server_utils.py
+++ b/tests/entrypoints/openai/test_server_utils.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from argparse import Namespace
+
+from vllm.entrypoints.openai.server_utils import get_uvicorn_log_config
+
+
+def test_get_uvicorn_log_config_with_metrics_flag():
+    args = Namespace(
+        log_config_file=None,
+        disable_access_log_for_endpoints=None,
+        disable_uvicorn_metrics_access_log=True,
+        uvicorn_log_level="info",
+    )
+
+    log_config = get_uvicorn_log_config(args)
+    assert log_config is not None
+    assert log_config["filters"]["access_log_filter"]["excluded_paths"] == ["/metrics"]
+
+
+def test_get_uvicorn_log_config_combines_and_deduplicates_paths():
+    args = Namespace(
+        log_config_file=None,
+        disable_access_log_for_endpoints="/health,/metrics,/ping",
+        disable_uvicorn_metrics_access_log=True,
+        uvicorn_log_level="info",
+    )
+
+    log_config = get_uvicorn_log_config(args)
+    assert log_config is not None
+    assert log_config["filters"]["access_log_filter"]["excluded_paths"] == [
+        "/health",
+        "/metrics",
+        "/ping",
+    ]
+
+
+def test_get_uvicorn_log_config_prefers_log_config_file(tmp_path):
+    expected = {"version": 1, "disable_existing_loggers": False}
+    log_config_file = tmp_path / "uvicorn.json"
+    log_config_file.write_text(json.dumps(expected))
+
+    args = Namespace(
+        log_config_file=str(log_config_file),
+        disable_access_log_for_endpoints="/health",
+        disable_uvicorn_metrics_access_log=True,
+        uvicorn_log_level="info",
+    )
+
+    assert get_uvicorn_log_config(args) == expected

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -224,6 +224,8 @@ class FrontendArgs(BaseFrontendArgs):
     """Log level for uvicorn."""
     disable_uvicorn_access_log: bool = False
     """Disable uvicorn access log."""
+    disable_uvicorn_metrics_access_log: bool = False
+    """Disable uvicorn access logs only for the `/metrics` endpoint."""
     disable_access_log_for_endpoints: str | None = None
     """Comma-separated list of endpoint paths to exclude from uvicorn access
     logs. This is useful to reduce log noise from high-frequency endpoints


### PR DESCRIPTION
## Summary
- Add a new `--disable-uvicorn-metrics-access-log` CLI flag to suppress access logs only for `/metrics`.
- Merge this flag with existing `--disable-access-log-for-endpoints` handling and deduplicate excluded paths.
- Add tests for CLI parsing and `get_uvicorn_log_config` behavior, including `log_config_file` precedence.

## Test plan
- [x] `python3 -m py_compile vllm/entrypoints/openai/cli_args.py vllm/entrypoints/openai/server_utils.py tests/entrypoints/openai/test_cli_args.py tests/entrypoints/openai/test_server_utils.py`
- [ ] `pytest tests/entrypoints/openai/test_cli_args.py tests/entrypoints/openai/test_server_utils.py` (not run locally due to missing full test dependencies)

Closes #29023.