### PR TITLE
fix(docs): update broken perf.vllm.ai link to PyTorch HUD

### DIFF
--- a/.buildkite/performance-benchmarks/README.md
+++ b/.buildkite/performance-benchmarks/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 This directory contains a benchmarking suite for **developers** to run locally and gain clarity on whether their PR improves/degrades vllm's performance.
-vLLM also maintains a continuous performance benchmark under [perf.vllm.ai](https://perf.vllm.ai/), hosted under PyTorch CI HUD.
+vLLM also maintains a continuous performance benchmark under the [vLLM Performance Dashboard](https://hud.pytorch.org/benchmark/llms?repoName=vllm-project%2Fvllm), hosted under PyTorch CI HUD.
 
 ## Performance benchmark quick overview
 


### PR DESCRIPTION
Fixes #31710

The  URL referenced in  is no longer accessible and returns connection errors.

## Changes
- Updated broken  link to point to the correct vLLM Performance Dashboard: 
- Made the link text consistent with other documentation in the repository that already uses the correct PyTorch HUD URL

## Testing
Verified that the new URL is accessible and shows the vLLM performance benchmarks. This URL format is already used in other documentation files throughout the repository (docs/benchmarking/dashboard.md, docs/contributing/profiling.md, etc.).