### PR TITLE
[PaddleOCR-VL] improve image_processor size compatibility for Transformers v5.0

### DIFF
--- a/vllm/model_executor/models/paddleocr_vl.py
+++ b/vllm/model_executor/models/paddleocr_vl.py
@@ -162,8 +162,8 @@ class PaddleOCRVLProcessingInfo(BaseProcessingInfo):
             height=image_height,
             width=image_width,
             factor=patch_size * merge_size,
-            min_pixels=size["min_pixels"],
-            max_pixels=size["max_pixels"],
+            min_pixels=size.get("shortest_edge") or size.get("min_pixels"),
+            max_pixels=size.get("longest_edge") or size.get("max_pixels"),
         )
         preprocessed_size = ImageSize(width=resized_width, height=resized_height)
 


### PR DESCRIPTION
In Transformers v5.0, the keys in `PaddleOCRVLImageProcessor.size` have been updated from `min_pixels`/`max_pixels` to `shortest_edge`/`longest_edge`.

This PR enhances the compatibility of the `size` parameter to ensure a smooth transition to v5.0 while maintaining backward compatibility.