### PR TITLE
[Bugfix] Fix uint32 overflow in Mamba selective scan state pointer arithmetic

### DIFF
--- a/csrc/mamba/mamba_ssm/selective_scan.h
+++ b/csrc/mamba/mamba_ssm/selective_scan.h
@@ -15,7 +15,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 struct SSMParamsBase {
-    using index_t = uint32_t;
+    using index_t = size_t;
 
     int batch, dim, seqlen, dstate, n_groups, n_chunks;
     int dim_ngroups_ratio;


### PR DESCRIPTION
## Purpose
Fixed SSM state corruption for Mamba models under high concurrency.

`SSMParamsBase::index_t` was `uint32_t`, causing `cache_index * ssm_states_batch_stride` to overflow for large cache indices.
This made the kernel write SSM state to wrong memory addresses, leaving the intended slots zeroed. Subsequent decode steps read stale/zero state, producing garbage/incorrect output.

The fix changes `index_t` from `uint32_t` to `size_t` (64-bit).
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
