### PR TITLE
[Bugfix] Fix broken online quantization due to weights loading tracking

### DIFF
--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -304,8 +304,10 @@ class DefaultModelLoader(BaseModelLoader):
         if loaded_weights is not None:
             for name, module in model.named_modules():
                 quant_method = getattr(module, "quant_method", None)
-                # ignore kv_cache scale, which can be missing in checkpoints
-                if isinstance(quant_method, BaseKVCacheMethod):
+                has_online_quant = getattr(quant_method, "uses_meta_device", False)
+                # ignore kv_cache scale and online quant scale,
+                # which can be missing in checkpoints
+                if isinstance(quant_method, BaseKVCacheMethod) or has_online_quant:
                     for param_name, _ in module.named_parameters():
                         full_name = f"{name}.{param_name}" if name else param_name
                         loaded_weights.add(full_name)


### PR DESCRIPTION

## Purpose
- Fix https://github.com/vllm-project/vllm/pull/35074#issuecomment-3957466170
- Also checking if there're other breakpoints not covered by default CI run.

## Test Plan
```
python3 examples/offline_inference/basic/generate.py --model /mnt/data0/LLM/Qwen3-0.6B --quantization fp8
```

## Test Result
Model runs fine.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

