### PR TITLE
[Perf][Benchmark] Add uniform top-k scalar fast path and profiling co…

### DIFF
--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -40,5 +40,9 @@ class SamplingMetadata:
     # Loaded logits processors
     logitsprocs: LogitsProcessors
 
+    # Uniform top-k across the whole batch, if available.
+    # This allows a faster top-k-only path that avoids full vocab sorting.
+    top_k_scalar: int | None = None
+
     # Speculative token ids
     spec_token_ids: list[list[int]] | None = None

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -189,6 +189,7 @@ class Sampler(nn.Module):
             sampling_metadata.generators,
             sampling_metadata.top_k,
             sampling_metadata.top_p,
+            sampling_metadata.top_k_scalar,
         )
 
         if greedy_sampled is None:

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -783,6 +783,12 @@ class InputBatch:
             copy_slice(self.top_p_cpu_tensor, self.top_p, num_reqs)
         if not self.no_top_k:
             copy_slice(self.top_k_cpu_tensor, self.top_k, num_reqs)
+        top_k_scalar: int | None = None
+        if not self.no_top_k and num_reqs > 0:
+            top_k_values = self.top_k_cpu[:num_reqs]
+            first_top_k = int(top_k_values[0])
+            if np.all(top_k_values == first_top_k):
+                top_k_scalar = first_top_k
 
         if not self.no_penalties:
             # Since syncing these tensors is expensive only copy them
@@ -853,6 +859,7 @@ class InputBatch:
             allowed_token_ids_mask=allowed_token_ids_mask,
             bad_words_token_ids=self.bad_words_token_ids,
             logitsprocs=self.logitsprocs,
+            top_k_scalar=top_k_scalar,
         )
 
     def get_pooling_params(self) -> list[PoolingParams]:


### PR DESCRIPTION


## Purpose
Part of #32455 

This PR speeds up top-k sampling for a common case and adds better benchmark reporting. It uses a new `top_k_scalar` path when top-p is off and batch top-k is uniform, while keeping outputs the same. 
## Test Plan

Run:
```bash
Commit-to-commit microbenchmark validation
python /content/bench_topk_commit_compare.py


```
## Test Result


```
=== testing 675ec59aa ===

=== commit 675ec59aa ===
k=1 has_k_scalar=False baseline=20.741ms hint=20.741ms speedup=1.00x equal=True
k=16 has_k_scalar=False baseline=20.817ms hint=20.817ms speedup=1.00x equal=True
=== testing 5ae60f297 ===

=== commit 5ae60f297 ===
k=1 has_k_scalar=True baseline=20.839ms hint=4.349ms speedup=4.79x equal=True
k=16 has_k_scalar=True baseline=21.008ms hint=4.403ms speedup=4.77x equal=True
```
