### PR TITLE
[Core] Add chunking for audio over 30s on offline inference,

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1,17 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import copy
 import itertools
 import warnings
-from collections.abc import Callable, Iterable, Sequence
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, cast
 
 import cloudpickle
-import copy
 import torch.nn as nn
 from pydantic import ValidationError
 from tqdm.auto import tqdm
-from typing import cast, Any, Mapping
 from typing_extensions import TypeVar, overload
 
 from vllm.beam_search import (
@@ -78,10 +77,10 @@ from vllm.platforms import current_platform
 from vllm.pooling_params import PoolingParams
 from vllm.renderers import ChatParams, merge_kwargs
 from vllm.renderers.inputs.preprocess import (
+    chunk_audio_data,
     conversation_to_seq,
     parse_model_prompt,
     prompt_to_seq,
-    chunk_audio_data,
 )
 from vllm.sampling_params import BeamSearchParams, RequestOutputKind, SamplingParams
 from vllm.tasks import PoolingTask

--- a/vllm/renderers/inputs/preprocess.py
+++ b/vllm/renderers/inputs/preprocess.py
@@ -4,10 +4,12 @@ Schemas and utilites for preprocessing inputs.
 
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import math
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, NamedTuple, TypeAlias, TypedDict, overload
+
 import numpy as np
-import math
+
 from vllm.inputs import (
     EmbedsPrompt,
     ExplicitEncoderDecoderPrompt,
@@ -17,9 +19,10 @@ from vllm.inputs import (
     TextPrompt,
     TokensPrompt,
 )
+from vllm.transformers_utils.processor import get_feature_extractor
 from vllm.utils import length_from_prompt_token_ids_or_embeds
 from vllm.utils.collection_utils import is_list_of
-from vllm.transformers_utils.processor import get_feature_extractor
+
 if TYPE_CHECKING:
     import torch
 


### PR DESCRIPTION
<!-- markdownlint-disable -->


## Purpose

Currently, vLLM supports ASR (Automatic Speech Recognition) inference for audio segments exceeding 30 seconds, but this is not yet supported for offline inference.

https://github.com/vllm-project/vllm/issues/25750#issuecomment-3886442288

I have been working on a PR to address this (see my comment here: [link]), but in the meantime, another PR ([#34628](https://github.com/vllm-project/vllm/pull/34628)) covering similar ground was merged.

That PR introduces a slightly different approach by automating audio chunking. Because of this overlap, I have converted my PR to a draft for now.

If this contribution is redundant or if you feel the implementation is unstable, please let me know and I will close the PR.


## Test Plan



## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

