### PR TITLE
[Bugfix] [Qwen3.5]Fix Qwen3.5 FP8 quantization: tuple shard_id weight loading

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -788,6 +788,11 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             )
             current_shard_offset = 0
             use_bitsandbytes_4bit = getattr(param, "use_bitsandbytes_4bit", False)
+            if use_bitsandbytes_4bit and isinstance(loaded_shard_id, tuple):
+                raise NotImplementedError(
+                    "Shard id with multiple indices is not supported "
+                    "for BNB quantization yet."
+                )
             shard_offsets: list[tuple[int, int, int]] = []
             for i, output_size in enumerate(output_sizes):
                 shard_offsets.append((i, current_shard_offset, output_size))

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -924,7 +924,13 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             if isinstance(param, PerTensorScaleParameter):
                 param.load_merged_column_weight(loaded_weight=loaded_weight, shard_id=0)
                 return
-            elif type(param) in (RowvLLMParameter, BasevLLMParameter):
+            # For tuple shard_id (e.g. (0,1,2)), we must split and load by
+            # output_sizes; do not use load_merged_column_weight which expects
+            # a single full tensor.
+            if loaded_shard_id is None and type(param) in (
+                RowvLLMParameter,
+                BasevLLMParameter,
+            ):
                 param.load_merged_column_weight(loaded_weight=loaded_weight)
                 return
             output_sizes = (

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -577,14 +577,13 @@ class Fp8OnlineLinearMethod(Fp8LinearMethod):
                 if args
                 else kwargs.get("loaded_shard_id", kwargs.get("shard_id"))
             )
+            copy_numel_counter = CopyNumelCounter()
             if isinstance(loaded_shard_id, tuple) and hasattr(
                 layer, "weight_loader_v2"
             ):
-                copy_numel_counter = CopyNumelCounter()
                 with copy_numel_counter:
                     res = layer.weight_loader_v2(param, loaded_weight, loaded_shard_id)
             else:
-                copy_numel_counter = CopyNumelCounter()
                 with copy_numel_counter:
                     res = weight_loader(param, loaded_weight, *args, **kwargs)  # type: ignore[misc]
             layer._loaded_numel += copy_numel_counter.copied_numel

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -569,10 +569,24 @@ class Fp8OnlineLinearMethod(Fp8LinearMethod):
             # materialization
             param = layer.weight
 
-            # load the current weight chunk
-            copy_numel_counter = CopyNumelCounter()
-            with copy_numel_counter:
-                res = weight_loader(param, loaded_weight, *args, **kwargs)  # type: ignore[misc]
+            # Shard id with multiple indices (tuple) is only supported by
+            # weight_loader_v2; use it so we stay in the patched path and
+            # _loaded_numel / process_weights_after_loading still run.
+            loaded_shard_id = (
+                args[0]
+                if args
+                else kwargs.get("loaded_shard_id", kwargs.get("shard_id"))
+            )
+            if isinstance(loaded_shard_id, tuple) and hasattr(
+                layer, "weight_loader_v2"
+            ):
+                copy_numel_counter = CopyNumelCounter()
+                with copy_numel_counter:
+                    res = layer.weight_loader_v2(param, loaded_weight, loaded_shard_id)
+            else:
+                copy_numel_counter = CopyNumelCounter()
+                with copy_numel_counter:
+                    res = weight_loader(param, loaded_weight, *args, **kwargs)  # type: ignore[misc]
             layer._loaded_numel += copy_numel_counter.copied_numel
 
             # if we have loaded all of the elements, call


### PR DESCRIPTION
## Purpose
Fix #35287 
Fix online FP8 quantization (`--quantization fp8`) for Qwen3.5 models.
### Bug — Weight loading crash: `NotImplementedError` for tuple `shard_id`

Qwen3.5's GDN block uses `stacked_params_mapping` with a **tuple** `shard_id`
(e.g. `("in_proj_qkvz", "in_proj_qkv", (0, 1, 2))`), indicating that the
checkpoint weight covers multiple output shards simultaneously.

`MergedColumnParallelLinear.weight_loader` does not support tuple `shard_id`

- In `fp8.py` `patched_weight_loader`: detect when the incoming `shard_id` is
  a tuple; call `layer.weight_loader_v2(param, loaded_weight, shard_id)` instead
  of `weight_loader`. This keeps the load inside the patched path so that
  `_loaded_numel` is correctly updated and `process_weights_after_loading`
  (which quantizes the weight to FP8) is triggered after all shards are loaded.
- In `linear.py` `MergedColumnParallelLinear.weight_loader_v2`: for tuple
  `shard_id`, skip the early `load_merged_column_weight` return branch
  (which is only correct for `loaded_shard_id is None`) and instead route
  through `_load_fused_module_from_checkpoint` with the per-index `output_sizes`,
  correctly splitting and loading each sub-shard.


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

