### PR TITLE
[Bugfix] Enable stats logging with multiple API servers (DP>1)

### DIFF
--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1261,17 +1261,14 @@ class StatLoggerManager:
             stat_logger_factories.extend(custom_stat_loggers)
         if enable_default_loggers and logger.isEnabledFor(logging.INFO):
             if client_count > 1:
-                logger.warning(
-                    "AsyncLLM created with api_server_count more than 1; "
-                    "disabling stats logging to avoid incomplete stats."
-                )
+                default_logger_factory = AggregatedLoggingStatLogger
             else:
                 default_logger_factory = (
                     AggregatedLoggingStatLogger
                     if aggregate_engine_logging
                     else LoggingStatLogger
                 )
-                stat_logger_factories.append(default_logger_factory)
+            stat_logger_factories.append(default_logger_factory)
         custom_prometheus_logger: bool = False
         for stat_logger_factory in stat_logger_factories:
             if isinstance(stat_logger_factory, type) and issubclass(


### PR DESCRIPTION
## Summary

  When `data_parallel_size > 1`, `api_server_count` defaults to `data_parallel_size`, causing `client_count > 1`. Previously this disabled **all** stats logging with a
  warning:

  > "AsyncLLM created with api_server_count more than 1; disabling stats logging to avoid incomplete stats."

  This means prefix cache hit rate, speculative decoding metrics (acceptance rate, mean acceptance length), and throughput stats are completely invisible in DP>1 deployments.

  ## Fix

  Use `AggregatedLoggingStatLogger` (which already exists for aggregating multi-engine stats) instead of disabling logging entirely when `client_count > 1`.

  ## Test

  Verified on a dual-node DP=2 deployment (GLM-5, TP=8, MTP spec decoding):
  - Before: No stats logging output
  - After: Stats correctly aggregated and logged:
    - `2 Engines Aggregated: ... Prefix cache hit rate: 0.0%`
    - `SpecDecoding metrics: Mean acceptance length: 2.25, ... Avg Draft acceptance rate: 41.7%`
  - Performance: No degradation (throughput 96.74 vs baseline 96.84 tok/s)
