### PR TITLE
Fix Qwen3ReasoningParser misclassifying truncated reasoning as content

### DIFF
--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -35,14 +35,10 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
     it is stripped before extraction (non-streaming) or skipped (streaming).
     """
 
-    def __init__(
-        self, tokenizer: PreTrainedTokenizerBase, *args, **kwargs
-    ):
+    def __init__(self, tokenizer: PreTrainedTokenizerBase, *args, **kwargs):
         super().__init__(tokenizer, *args, **kwargs)
         chat_kwargs = kwargs.get("chat_template_kwargs", {}) or {}
-        self._thinking_enabled = bool(
-            chat_kwargs.get("enable_thinking", True)
-        )
+        self._thinking_enabled = bool(chat_kwargs.get("enable_thinking", True))
 
     @property
     def start_token(self) -> str:


### PR DESCRIPTION
## Purpose

Fixes #35221.

When `max_completion_tokens` cuts output before `</think>` is generated, `extract_reasoning()` assumes thinking is disabled and returns all tokens as `content`. This is incorrect — the model was reasoning, it just got truncated.

The fix reads `enable_thinking` from `chat_template_kwargs` (mirroring the approach used by `DeepSeekV3ReasoningParser`) and uses it to determine behavior when `</think>` is absent:

- **`enable_thinking=True` (default):** truncated output → `reasoning_content`, no `content`
- **`enable_thinking=False`:** all output → `content` (thinking was explicitly disabled)

The streaming path (`extract_reasoning_streaming`) is already correct — it checks `previous_token_ids` for the end token and defaults to reasoning when absent. Only the non-streaming `extract_reasoning` path needed fixing.

## Test Plan

Reproduced with the script from #35221:

```shell
vllm serve Qwen/Qwen3-4B-Thinking-2507 --reasoning-parser qwen3

curl -s http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"messages":[{"role":"user","content":"Hello"}],"max_completion_tokens":5,"stream":false}' \
  | jq ".choices[0]"
```

**Before:** reasoning tokens appear in `message.content`, `reasoning_content` is null.
**After:** reasoning tokens correctly appear in `message.reasoning_content`, `content` is null.

## Test Result

Existing tests pass. The change is minimal (one new `__init__` + branching in the no-end-token path) and only affects the Qwen3 parser.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update.
</details>