### PR TITLE
[BugFix][XPU] Fix speculative decoding on Intel XPU due to bug with `IGC_ForceOCLSIMDWidth=16`

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -201,9 +201,6 @@ class XPUPlatform(Platform):
 
         if vllm_config.lora_config is not None:
             compilation_config.mode = CompilationMode.NONE
-        # decrease triton kernel compilation scratch space for speculative decoding
-        if vllm_config.speculative_config is not None:
-            os.environ["IGC_ForceOCLSIMDWidth"] = "16"  # noqa: SIM112
         # check and update parallel config
         parallel_config = vllm_config.parallel_config
         # Only override worker_cls if it's still the default "auto"


### PR DESCRIPTION

## Purpose
The environment variable setting `IGC_ForceOCLSIMDWidth=16` was introduced in #30538 to reduce memory usage when compiling `sample_recovered_tokens_kernel`.

With the introduction of `copy_and_expand_eagle_inputs_kernel` in #32887 speculative decoding with draft model stopped working on XPU. 

Furthermore, speculative decoding with sampling (T>0) didn't work with either Eagle/draft model, and Qwen3 + SD didn't work due to the same issue of OOM in scratchpad.

It turns out that there is a bug in the IGC that makes `tl.store` not work correctly with `IGC_ForceOCLSIMDWidth=16` which was the root cause for speculative to stop working on XPU after the #32887 commit.

With the implementation for computing `sample_recovered_tokens_kernel` in tiles in #34974, the OOM issue in XPU without `IGC_ForceOCLSIMDWidth=16` was solved and so removing this environment variable entirely fixes all the issue with speculative decoding on XPU:
1. SD with draft model
2. SD with sampling
3. SD with Qwen3

## Test Plan

```bash
vllm serve RedHatAI/Qwen3-8B-quantized.w4a16 \
    --enforce-eager \
    --speculative-config {"model": "Qwen/Qwen3-0.6B", "num_speculative_tokens": 3, "method": "draft_model"}
```

```bash
vllm bench serve \
    --model RedHatAI/Qwen3-8B-quantized.w4a16 \
    --dataset-name hf \
    --dataset-path philschmid/mt-bench \
    --max-concurrency 1 \
    --num-prompts 20 \
    --hf-output-len 128 \
    --seed 42 \
    --temperature 0.6
```

## Test Result

Before PR doesn't work

After PR works


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

