### PR TITLE
[Bugfix] Fix weight loading tracking for Marlin MoE quantized models

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -1484,6 +1484,9 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
         )
         layer.register_parameter("w13_g_idx_sort_indices", w13_g_idx_sort_indices)
         set_weight_attrs(w13_g_idx_sort_indices, extra_weight_attrs)
+        # sort indices are always computed in process_weights_after_loading,
+        # never loaded from checkpoint, so skip weight loading tracking
+        set_weight_attrs(w13_g_idx_sort_indices, {"skip_weight_check": True})
 
         w2_g_idx_sort_indices = torch.nn.Parameter(
             torch.empty(
@@ -1495,6 +1498,9 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
         )
         layer.register_parameter("w2_g_idx_sort_indices", w2_g_idx_sort_indices)
         set_weight_attrs(w2_g_idx_sort_indices, extra_weight_attrs)
+        # sort indices are always computed in process_weights_after_loading,
+        # never loaded from checkpoint, so skip weight loading tracking
+        set_weight_attrs(w2_g_idx_sort_indices, {"skip_weight_check": True})
 
         layer.a13_scale = None
         layer.a2_scale = None
@@ -1891,6 +1897,9 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         )
         layer.register_parameter("w13_g_idx_sort_indices", w13_g_idx_sort_indices)
         set_weight_attrs(w13_g_idx_sort_indices, extra_weight_attrs)
+        # sort indices are always computed in process_weights_after_loading,
+        # never loaded from checkpoint, so skip weight loading tracking
+        set_weight_attrs(w13_g_idx_sort_indices, {"skip_weight_check": True})
 
         w2_g_idx_sort_indices = torch.nn.Parameter(
             torch.empty(
@@ -1902,6 +1911,9 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         )
         layer.register_parameter("w2_g_idx_sort_indices", w2_g_idx_sort_indices)
         set_weight_attrs(w2_g_idx_sort_indices, extra_weight_attrs)
+        # sort indices are always computed in process_weights_after_loading,
+        # never loaded from checkpoint, so skip weight loading tracking
+        set_weight_attrs(w2_g_idx_sort_indices, {"skip_weight_check": True})
 
         layer.a13_scale = None
         layer.a2_scale = None

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -99,7 +99,11 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     normalize_e4m3fn_to_e4m3fnuz,
 )
-from vllm.model_executor.utils import replace_parameter, set_weight_attrs
+from vllm.model_executor.utils import (
+    replace_parameter,
+    set_weight_attr_computed,
+    set_weight_attrs,
+)
 from vllm.platforms import CpuArchEnum, current_platform
 
 logger = init_logger(__name__)
@@ -1484,9 +1488,7 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
         )
         layer.register_parameter("w13_g_idx_sort_indices", w13_g_idx_sort_indices)
         set_weight_attrs(w13_g_idx_sort_indices, extra_weight_attrs)
-        # sort indices are always computed in process_weights_after_loading,
-        # never loaded from checkpoint, so skip weight loading tracking
-        set_weight_attrs(w13_g_idx_sort_indices, {"skip_weight_check": True})
+        set_weight_attr_computed(w13_g_idx_sort_indices)
 
         w2_g_idx_sort_indices = torch.nn.Parameter(
             torch.empty(
@@ -1498,9 +1500,7 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
         )
         layer.register_parameter("w2_g_idx_sort_indices", w2_g_idx_sort_indices)
         set_weight_attrs(w2_g_idx_sort_indices, extra_weight_attrs)
-        # sort indices are always computed in process_weights_after_loading,
-        # never loaded from checkpoint, so skip weight loading tracking
-        set_weight_attrs(w2_g_idx_sort_indices, {"skip_weight_check": True})
+        set_weight_attr_computed(w2_g_idx_sort_indices)
 
         layer.a13_scale = None
         layer.a2_scale = None
@@ -1897,9 +1897,7 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         )
         layer.register_parameter("w13_g_idx_sort_indices", w13_g_idx_sort_indices)
         set_weight_attrs(w13_g_idx_sort_indices, extra_weight_attrs)
-        # sort indices are always computed in process_weights_after_loading,
-        # never loaded from checkpoint, so skip weight loading tracking
-        set_weight_attrs(w13_g_idx_sort_indices, {"skip_weight_check": True})
+        set_weight_attr_computed(w13_g_idx_sort_indices)
 
         w2_g_idx_sort_indices = torch.nn.Parameter(
             torch.empty(
@@ -1911,9 +1909,7 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         )
         layer.register_parameter("w2_g_idx_sort_indices", w2_g_idx_sort_indices)
         set_weight_attrs(w2_g_idx_sort_indices, extra_weight_attrs)
-        # sort indices are always computed in process_weights_after_loading,
-        # never loaded from checkpoint, so skip weight loading tracking
-        set_weight_attrs(w2_g_idx_sort_indices, {"skip_weight_check": True})
+        set_weight_attr_computed(w2_g_idx_sort_indices)
 
         layer.a13_scale = None
         layer.a2_scale = None

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -644,6 +644,9 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
         )
         layer.register_parameter("w13_g_idx_sort_indices", w13_g_idx_sort_indices)
         set_weight_attrs(w13_g_idx_sort_indices, extra_weight_attrs)
+        # sort indices are always computed in process_weights_after_loading,
+        # never loaded from checkpoint, so skip weight loading tracking
+        set_weight_attrs(w13_g_idx_sort_indices, {"skip_weight_check": True})
         w2_g_idx_sort_indices = torch.nn.Parameter(
             torch.empty(
                 num_experts,
@@ -654,6 +657,9 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
         )
         layer.register_parameter("w2_g_idx_sort_indices", w2_g_idx_sort_indices)
         set_weight_attrs(w2_g_idx_sort_indices, extra_weight_attrs)
+        # sort indices are always computed in process_weights_after_loading,
+        # never loaded from checkpoint, so skip weight loading tracking
+        set_weight_attrs(w2_g_idx_sort_indices, {"skip_weight_check": True})
 
         device = layer.w13_qweight.device
         layer.workspace = marlin_make_workspace_new(device, 4)

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -55,6 +55,7 @@ from vllm.model_executor.parameter import (
     PackedvLLMParameter,
     RowvLLMParameter,
 )
+from vllm.model_executor.utils import set_weight_attr_computed
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 from vllm.transformers_utils.config import get_safetensors_params_metadata
@@ -644,9 +645,7 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
         )
         layer.register_parameter("w13_g_idx_sort_indices", w13_g_idx_sort_indices)
         set_weight_attrs(w13_g_idx_sort_indices, extra_weight_attrs)
-        # sort indices are always computed in process_weights_after_loading,
-        # never loaded from checkpoint, so skip weight loading tracking
-        set_weight_attrs(w13_g_idx_sort_indices, {"skip_weight_check": True})
+        set_weight_attr_computed(w13_g_idx_sort_indices)
         w2_g_idx_sort_indices = torch.nn.Parameter(
             torch.empty(
                 num_experts,
@@ -657,9 +656,7 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
         )
         layer.register_parameter("w2_g_idx_sort_indices", w2_g_idx_sort_indices)
         set_weight_attrs(w2_g_idx_sort_indices, extra_weight_attrs)
-        # sort indices are always computed in process_weights_after_loading,
-        # never loaded from checkpoint, so skip weight loading tracking
-        set_weight_attrs(w2_g_idx_sort_indices, {"skip_weight_check": True})
+        set_weight_attr_computed(w2_g_idx_sort_indices)
 
         device = layer.w13_qweight.device
         layer.workspace = marlin_make_workspace_new(device, 4)

--- a/vllm/model_executor/utils.py
+++ b/vllm/model_executor/utils.py
@@ -44,6 +44,17 @@ def set_weight_attrs(
         setattr(weight, key, value)
 
 
+def set_weight_attr_computed(weight: torch.Tensor) -> None:
+    """Mark a weight parameter as computed (not loaded from checkpoint).
+
+    Parameters marked this way are excluded from weight loading validation
+    in ``DefaultModelLoader.track_weights_loading``. Use this for parameters
+    that are derived from other weights in ``process_weights_after_loading``
+    (e.g. argsort indices) and are therefore never present in checkpoints.
+    """
+    set_weight_attrs(weight, {"skip_weight_check": True})
+
+
 def replace_parameter(
     layer: torch.nn.Module, param_name: str, new_data: torch.Tensor | None
 ):


### PR DESCRIPTION
## Summary

PR #35074 introduced `track_weights_loading()` to validate all registered parameters are loaded from checkpoint. This broke loading of GPTQ/AWQ MoE models using the Marlin backend with the following error:

```
ValueError: Following weights were not initialized from checkpoint:
{'model.layers.0.mlp.experts.w13_g_idx_sort_indices',
 'model.layers.0.mlp.experts.w2_g_idx_sort_indices',
 'model.layers.0.mlp.experts.w13_weight_g_idx',
 'model.layers.0.mlp.experts.w2_weight_g_idx', ...}
```

Two categories of parameters are legitimately absent from checkpoints:

- **`g_idx_sort_indices`**: computed via `torch.argsort` in `process_weights_after_loading` (both actorder=group and non-group paths) — present in `GPTQMarlinMoEMethod`, `CompressedTensorsWNA16MarlinMoEMethod`, and `CompressedTensorsWNA16MoEMethod`
- **`weight_g_idx`** (actorder=null/none): replaced with empty `(num_experts, 0)` tensors in `process_weights_after_loading`

## Changes

1. **`base_loader.py`**: Move `track_weights_loading` call to *after* `process_weights_after_loading` in `load_model`, so computed parameters are populated before the check runs. `DefaultModelLoader.load_weights` now returns `loaded_weights` instead of calling the check directly.

2. **`gptq_marlin.py` / `compressed_tensors_moe.py`**: Mark `g_idx_sort_indices` parameters with `skip_weight_check=True` via `set_weight_attrs` — these are always computed, never present in any checkpoint.

3. **`default_loader.py`**: Extend `track_weights_loading` to skip parameters where `param.numel() == 0` (intentionally empty after processing, e.g. `weight_g_idx` for actorder=null) or `getattr(param, "skip_weight_check", False)` is set.

## Test Plan

- Manually verified loading of `cyankiwi/Qwen3-Coder-Next-AWQ-4bit` (`CompressedTensorsWNA16MarlinMoEMethod`, `actorder: null`, `group_size: 32`) which previously failed with the above error and now loads successfully
- The fix does not affect the check for models that do have all weights in their checkpoint — `skip_weight_check` is only set on the specific computed-index parameters, and the `numel() == 0` check only affects intentionally-empty tensors