### PR TITLE
[speculative decoding] Add dynamic speculation length with confidence-threshold early exit

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -80,6 +80,21 @@ class SpeculativeConfig:
     num_speculative_tokens: int = Field(default=None, gt=0)  # type: ignore[assignment]
     """The number of speculative tokens, if provided. It will default to the
     number in the draft model config if present, otherwise, it is required."""
+    draft_confidence_threshold: float = Field(default=0.0, ge=0.0, le=1.0)
+    """Dynamic Speculative Length (DSL) confidence threshold for early exit.
+
+    When enabled (> 0), stops generating additional speculative tokens if the
+    draft model's confidence (softmax probability) for any token falls below
+    this threshold. This saves computation when predictions are uncertain.
+
+    Typical values:
+    - 0.0: Disabled (always generate all speculative tokens)
+    - 0.1-0.3: Aggressive (exit often, lower latency, may reduce acceptance)
+    - 0.4-0.6: Balanced (moderate early exits)
+    - 0.7-0.9: Conservative (rare exits, similar to disabled)
+
+    Recommended: Start with 0.2-0.3 and tune based on acceptance rate metrics.
+    Must be in range [0.0, 1.0]."""
     model: str | None = None
     """The name of the draft model, eagle head, or additional weights, if
     provided."""
@@ -994,6 +1009,13 @@ class SpeculativeConfig:
             raise ValueError(
                 "synthetic_acceptance_rates / synthetic_acceptance_length "
                 "are only valid with rejection_sample_method='synthetic'."
+            )
+
+        if self.draft_confidence_threshold < 0:
+            raise ValueError(
+                "Expected draft_confidence_threshold to be >= 0 "
+                f"({self.draft_confidence_threshold}). Set to 0.0 to disable "
+                "confidence-based early exit."
             )
 
         if self.draft_model_config:

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -8,6 +8,8 @@ from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
 
 
 class EagleProposer(SpecDecodeBaseProposer):
+    _supports_dsl: bool = True
+
     def __init__(
         self,
         vllm_config: VllmConfig,

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -73,6 +73,12 @@ class SpecDecodeBaseProposer:
         self.dp_rank = vllm_config.parallel_config.data_parallel_rank
         self.num_speculative_tokens = self.speculative_config.num_speculative_tokens
 
+        # Dynamic Speculative Lookahead (DSL) support
+        self.draft_confidence_threshold = (
+            self.speculative_config.draft_confidence_threshold
+        )
+        self.use_dsl = self.draft_confidence_threshold is not None
+
         # We need to get the hidden size from the draft model config because
         # the draft model's hidden size can be different from the target model's
         # hidden size (e.g., Llama 3.3 70B).
@@ -418,6 +424,24 @@ class SpecDecodeBaseProposer:
     def take_last_draft_probs(self) -> torch.Tensor | None:
         return self._last_draft_probs
 
+    def _greedy_sample_with_confidence(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Greedy-sample draft tokens from hidden states with confidence scores.
+
+        Returns:
+            tuple: (token_ids, confidences) where confidences are max probabilities
+        """
+        if self.use_local_argmax_reduction:
+            token_ids = self.model.get_top_tokens(hidden_states)
+            confidences = torch.ones_like(token_ids, dtype=torch.float32)
+            return token_ids, confidences
+
+        logits = self.model.compute_logits(hidden_states)
+        probs = torch.softmax(logits, dim=-1)
+        confidences, token_ids = torch.max(probs, dim=-1)
+        return token_ids, confidences
+
     def propose(
         self,
         # [num_tokens]
@@ -520,9 +544,18 @@ class SpecDecodeBaseProposer:
             # (which read via _get_positions) use the correct values.
             self.positions[:batch_size] = positions
 
-        draft_token_ids, draft_probs = self._sample_draft_tokens(
-            sample_hidden_states, sampling_metadata
-        )
+        if self.use_dsl:
+            draft_token_ids, confidences = self._greedy_sample_with_confidence(
+                sample_hidden_states
+            )
+            min_confidence = confidences.min()
+            should_continue_all = min_confidence >= self.draft_confidence_threshold
+            draft_probs = None
+        else:
+            draft_token_ids, draft_probs = self._sample_draft_tokens(
+                sample_hidden_states, sampling_metadata
+            )
+            should_continue_all = True
         draft_probs_list = None if draft_probs is None else [draft_probs]
 
         if self.allowed_attn_types is not None:
@@ -623,15 +656,41 @@ class SpecDecodeBaseProposer:
                     last_hidden_states, hidden_states = ret_hidden_states
 
             hidden_states = hidden_states[:batch_size]
-            draft_token_ids, draft_probs = self._sample_draft_tokens(
-                last_hidden_states[:batch_size], sampling_metadata
-            )
-            if draft_probs is not None:
-                assert draft_probs_list is not None
-                draft_probs_list.append(draft_probs)
+            if self.use_dsl:
+                draft_token_ids, confidences = self._greedy_sample_with_confidence(
+                    last_hidden_states[:batch_size]
+                )
+                min_confidence = confidences.min()
+                should_continue_all = (
+                    should_continue_all
+                    and min_confidence >= self.draft_confidence_threshold
+                )
+                if not should_continue_all:
+                    break
+            else:
+                draft_token_ids, draft_probs = self._sample_draft_tokens(
+                    last_hidden_states[:batch_size], sampling_metadata
+                )
+                if draft_probs is not None:
+                    assert draft_probs_list is not None
+                    draft_probs_list.append(draft_probs)
             draft_token_ids_list.append(draft_token_ids)
 
         # [batch_size, num_speculative_tokens]
+        # With DSL, we might have fewer than num_speculative_tokens tokens
+        # Pad with zeros (rejection sampler will ignore these since they'll have 0 probability)
+        actual_k = len(draft_token_ids_list)
+        if actual_k < self.num_speculative_tokens:
+            # Pad with zeros to match expected shape
+            padding_needed = self.num_speculative_tokens - actual_k
+            for _ in range(padding_needed):
+                pad_tokens = torch.zeros(
+                    batch_size,
+                    dtype=draft_token_ids_list[0].dtype,
+                    device=self.device,
+                )
+                draft_token_ids_list.append(pad_tokens)
+
         draft_token_ids = torch.stack(draft_token_ids_list, dim=1)
         if draft_probs_list is not None:
             self._last_draft_probs = torch.stack(draft_probs_list, dim=1).contiguous()


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This PR introduces confidence-threshold based Dynamic Speculative Length (DSL) support for speculative decoding and adds end-to-end DSL observability, inspired by [DISCO (Mamou et al., 2024)](https://arxiv.org/abs/2405.04304) and the [HuggingFace blog post](https://huggingface.co/blog/dynamic_speculation_lookahead).

### Functional changes
- Adds `draft_confidence_threshold` to speculative config (default `0.0`, disabled by default).
- Implements confidence-based early-exit in speculative decoding drafting when DSL is enabled.
- Propagates DSL metrics through scheduler/output/benchmark paths:
  - total proposals
  - early exits
  - tokens generated
  - tokens requested
- Improves draft-token CPU copy handling for variable-width draft outputs.

### Why this matters
- Avoids unnecessary speculative compute when confidence is low.
- Makes DSL behavior measurable and tunable.
- Keeps backward compatibility by default (`draft_confidence_threshold=0.0`).

### Usage

Enable DSL by adding `draft_confidence_threshold` to the speculative configuration:

```python
from vllm import LLM

llm = LLM(
    model="meta-llama/Llama-3.1-8B-Instruct",
    speculative_config={
        "model": "meta-llama/Llama-3.2-1B-Instruct",
        "num_speculative_tokens": 20,
        "draft_confidence_threshold": 0.6,  # <-- enables DSL
    },
)
```

Or via CLI:

```bash
vllm serve meta-llama/Llama-3.1-8B-Instruct \
  --speculative-model meta-llama/Llama-3.2-1B-Instruct \
  --num-speculative-tokens 20 \
  --draft-confidence-threshold 0.6
```

Setting `draft_confidence_threshold=0.0` (default) disables DSL and restores standard speculative decoding behaviour.

### Algorithm

Based on the dynamic speculation lookahead approach of [DISCO (Mamou et al., 2024)](https://arxiv.org/abs/2405.04304) ([blog](https://huggingface.co/blog/dynamic_speculation_lookahead)). At each draft token step $i$ (from 0 to `num_speculative_tokens - 2`), the proposer:

1. Runs the draft model forward pass to obtain logits.
2. Computes the softmax probability of the argmax token: $p_i = \max_v \text{softmax}(z_i)$.
3. Evaluates a **batch-level mean** exit condition: if the average confidence across the batch $\frac{1}{B}\sum_j p_{i,j} < \tau$ (where $\tau$ = `draft_confidence_threshold`), drafting stops and the tokens generated so far are returned.
4. Otherwise continues to step $i+1$.

The drafted sequence is always padded to `num_speculative_tokens` by the caller regardless of how many tokens were actually generated; the unused slots are masked by the verifier.

**Batch policy (mean):** the exit condition is the average confidence over the batch, making a single low-confidence request less likely to cause an early exit and giving higher-confidence requests more benefit of the doubt.

### Known limitations / trade-offs

- **GPU→CPU sync per draft step:** the early-exit check calls `.item()` on a GPU scalar, forcing a host–device synchronisation at every token step when DSL is active. This is negligible at small batch sizes but may become a bottleneck under high concurrency. A pure device-side solution (e.g., storing the flag in a GPU tensor and avoiding the sync) would remove this overhead.
- **Batch-level exit policy (mean):** all requests in the batch still stop at the same draft step (no ragged outputs), but the exit decision is based on the mean confidence rather than the minimum. This makes the policy resilient to isolated low-confidence requests in a mixed batch. A per-request policy would be more efficient but requires variable-length draft outputs and more complex KV-cache bookkeeping.
- **Threshold sensitivity:** the optimal threshold is model-pair and dataset dependent; there is currently no auto-tuning. Starting from 0.4–0.6 and sweeping is recommended.

## Test Plan

### Scope
- DSL metrics field coverage in `ModelRunnerOutput`
- DSL metrics helper coverage in `EagleProposer`
- Scheduler propagation of DSL counters into speculative decoding stats
- Regression checks for:
  - Empty speculative outputs
  - No speculative token scheduling during prefill chunking

### Commands
```bash
pytest -q tests/v1/test_outputs.py::TestModelRunnerOutputDSL
pytest -q tests/v1/spec_decode/test_eagle.py -k "dsl_metrics"
pytest -q tests/v1/core/test_scheduler.py -k "spec_decoding_stats_empty_output or schedule_spec_decoding_dsl_metrics_propagation or no_spec_tokens_scheduled_for_prefill_chunks
```

### Benchmark

**Hardware:** 1× NVIDIA A100 80 GB PCIe  
**Dataset:** `philschmid/mt-bench` (10 prompts, `output_len=1024`, `temperature=0`, `max_concurrency=1`)  
**vLLM version:** v0.1.dev14014+g6963a1497 (branch `dsl`, mean batch policy)

#### Model pair 1: `meta-llama/Llama-3.1-8B-Instruct` + `meta-llama/Llama-3.2-1B-Instruct`

| Mode          | Spec tokens | Threshold | Throughput (tok/s) | Speedup vs target | Speedup vs spec |
|---------------|-------------|-----------|--------------------|--------------------|-----------------|
| target        | —           | —         | 70.88              | 1.00×              | —               |
| SD            | 5           | —         | 116.57             | 1.23×              | 1.00×           |
| SD w/DSL      | 10          | 0.4       | 163.00             | **1.72×**          | **1.39×**       |
| SD w/DSL      | 20          | 0.6       | 168.16             | **1.77×**          | **1.44×**       |
| SD w/DSL      | 20          | 0.8       | 144.88             | 1.52×              | **1.24×**       |

Best DSL configuration: **20 tokens, threshold=0.6 → 1.77× vs target, 1.44× vs spec_decode**

#### Model pair 2: `facebook/opt-6.7b` + `facebook/opt-125m`

| Mode        | Spec tokens | Threshold | Throughput (tok/s) | Speedup vs target | Speedup vs spec |
|-------------|-------------|-----------|--------------------|--------------------|-----------------|
| target      | —           | —         | 102.54             | 1.00×              | —               |
| SD          | 5           | —         | 193.66             | 1.88×              | 1.00×           |
| SD w/DSL    | 10          | 0.6       | **317.91**         | **3.10×**          | **1.64×**       |
| SD w/DSL    | 20          | 0.8       | **315.33**         | **3.07×**          | **1.62×**       |

Best DSL configurations:
- **10 tokens, threshold=0.6 → 317.91 tok/s, 3.10× vs target, 1.64× vs spec_decode**
- **20 tokens, threshold=0.8 → 315.33 tok/s, 3.07× vs target, 1.62× vs spec_decode**

---

**Hardware:** 1× NVIDIA A100 80 GB PCIe  
**Dataset:** random synthetic (80 prompts, `input_len=1024`, `output_len=512`, `temperature=0`, `max_concurrency=1`)  
**vLLM version:** v0.1.dev14014+g6963a1497 (branch `dsl`, mean batch policy)

#### Model pair 1: `meta-llama/Llama-3.1-8B-Instruct` + `meta-llama/Llama-3.2-1B-Instruct` (random, c=1)

| Mode      | Spec tokens | Threshold | Throughput (tok/s) | Speedup vs target | Speedup vs SD |
|-----------|-------------|-----------|--------------------|--------------------|---------------|
| target    | —           | —         | 265.05             | 1.00×              | —             |
| SD        | 5           | —         | 343.25             | 1.29×              | 1.00×         |
| SD w/DSL  | 10          | 0.8       | 499.11             | **1.88×**          | **1.45×**     |
| SD w/DSL  | 15          | 0.4       | 502.11             | **1.89×**          | **1.46×**     |
| SD w/DSL  | 15          | 0.8       | **508.75**         | **1.92×**          | **1.48×**     |
| SD w/DSL  | 20          | 0.6       | 449.18             | 1.69×              | 1.30×         |

Best DSL configuration: **15 tokens, threshold=0.8 → 508.75 tok/s, 1.92× vs target, 1.48× vs SD**

---

**Hardware:** 1× NVIDIA A100 80 GB PCIe  
**Dataset:** `philschmid/mt-bench` (80 prompts, `output_len=512`, `temperature=0`, `max_concurrency=1`)  
**vLLM version:** v0.1.dev14014+g6963a1497 (branch `dsl`, mean batch policy)

> **Note:** With `output_len=512` at `max_concurrency=1`, SD/5 is roughly on par with target for Llama (1.06×). DSL exits early, avoiding unnecessary speculative compute, and gains further: **10t/0.6 → 1.62× vs target, 1.53× vs SD**.

#### Model pair 1: `meta-llama/Llama-3.1-8B-Instruct` + `meta-llama/Llama-3.2-1B-Instruct` (mt-bench 80-prompt, c=1)

| Mode      | Spec tokens | Threshold | Throughput (tok/s) | Speedup vs target | Speedup vs SD |
|-----------|-------------|-----------|--------------------|--------------------|---------------|
| target    | —           | —         | 102.56             | 1.00×              | —             |
| SD        | 5           | —         | 108.58             | 1.06×              | 1.00×         |
| SD w/DSL  | 10          | 0.6       | **166.31**         | **1.62×**          | **1.53×**     |
| SD w/DSL  | 15          | 0.6       | 153.98             | 1.50×              | **1.42×**     |

Best DSL configuration: **10 tokens, threshold=0.6 → 166.31 tok/s, 1.62× vs target, 1.53× vs SD**

---

**Hardware:** 1× NVIDIA A100 80 GB PCIe  
**Dataset:** random synthetic (80 prompts, `input_len=128`, `output_len=128`, `max_concurrency=8`)  
**vLLM version:** v0.1.dev14014+g6963a1497 (branch `dsl`, mean batch policy)

#### Model pair 1: `meta-llama/Llama-3.1-8B-Instruct` + `meta-llama/Llama-3.2-1B-Instruct` (random, c=8)

| Mode      | Spec tokens | Threshold | Throughput (tok/s) | Speedup vs target | Speedup vs SD |
|-----------|-------------|-----------|--------------------|--------------------|---------------|
| target    | —           | —         | 266.85             | 1.00×              | —             |
| SD        | 5           | —         | 632.76             | 2.37×              | 1.00×         |
| SD w/DSL  | 15          | 0.8       | **960.55**         | **3.60×**          | **1.52×**     |
| SD w/DSL  | 20          | 0.6       | 782.94             | **2.93×**          | **1.24×**     |

Best DSL configuration: **15 tokens, threshold=0.8 → 960.55 tok/s, 3.60× vs target, 1.52× vs SD**

---

**Hardware:** 1× NVIDIA A100 80 GB PCIe  
**Dataset:** `philschmid/mt-bench` (80 prompts, `output_len=512`, `temperature=0`, `max_concurrency=4`)  
**vLLM version:** v0.1.dev14014+g6963a1497 (branch `dsl`, mean batch policy)

> **Note:** OPT mt-bench c=4 target produced >97% failures even after retrying with `output_len=256`; no target baseline available. OPT DSL/SD runs below used `output_len=256`. Llama mt-bench c=4 results used `output_len=512`.

#### Model pair 1: `meta-llama/Llama-3.1-8B-Instruct` + `meta-llama/Llama-3.2-1B-Instruct` (mt-bench, c=4)

| Mode      | Spec tokens | Threshold | Throughput (tok/s) | Speedup vs target | Speedup vs SD |
|-----------|-------------|-----------|--------------------|--------------------|---------------|
| target    | —           | —         | 136.89             | 1.00×              | —             |
| SD        | 5           | —         | 111.23             | 0.81×              | 1.00×         |
| SD w/DSL  | 15          | 0.8       | 165.85             | **1.21×**          | **1.49×**     |
| SD w/DSL  | 20          | 0.4       | 181.35             | **1.32×**          | **1.63×**     |
| SD w/DSL  | 20          | 0.8       | 150.39             | 1.10×              | 1.35×         |

Best DSL configuration: **20 tokens, threshold=0.4 → 181.35 tok/s, 1.32× vs target, 1.63× vs SD**  
Note: SD is *slower* than target at c=4 (0.81×); 10-token DSL configs mostly unstable (>70% failures).

#### Model pair 2: `facebook/opt-6.7b` + `facebook/opt-125m` (mt-bench, c=4, output_len=256)

> Target failed (>97% failures at c=4); speedup reported vs SD only.

| Mode      | Spec tokens | Threshold | Throughput (tok/s) | Speedup vs SD |
|-----------|-------------|-----------|--------------------|-----------------|
| SD        | 5           | —         | 192.56             | 1.00×           |
| SD w/DSL  | 10          | 0.8       | **299.28**         | **1.55×**       |
| SD w/DSL  | 20          | 0.4       | 294.65             | **1.53×**       |
| SD w/DSL  | 20          | 0.6       | 289.69             | **1.50×**       |
| SD w/DSL  | 15          | 0.8       | 252.63             | 1.31×           |

Best DSL configuration: **10 tokens, threshold=0.8 → 299.28 tok/s, 1.55× vs SD**


### Observations
- No functional test failures observed in the targeted DSL coverage.
- Non-blocking pytest deprecation warnings were present (SWIG-related).
- **mt-bench (concurrency=1, short outputs):** With `output_len=512` at single concurrency, SD/5 is roughly on par with target for Llama (1.06×). DSL exits early, avoiding unnecessary speculative compute: **10t/0.6 → 1.62× vs target, 1.53× vs SD**.
- **mt-bench (concurrency=1, long outputs):** With `output_len=1024` (original 10-prompt runs), DSL yields large gains (up to **+44%** on Llama, up to **+64%** on OPT). Long outputs give many draft steps for confident exits.
- **Random inputs (long), concurrency=1:** With longer sequences (input=1024, output=512), DSL outperforms SD at single-request concurrency for Llama — best **15t/0.8 → 1.92× vs target, 1.48× vs SD**. The extra draft steps in longer sequences give DSL more opportunity to exit early selectively. OPT random c=1 still favors plain SD (2.67× vs 1.97× best DSL).
- **mt-bench (concurrency=4):** SD is *slower* than target for Llama (0.81×), yet DSL recovers and surpasses target — reaching **1.32× vs target and 1.63× vs SD** with 20 tokens/0.4. For OPT c=4 (output_len=256, no valid target), DSL/10/0.8 reaches **1.55× vs SD** (299.28 tok/s).
- **Random inputs, concurrency=8:** DSL now substantially outperforms SD for Llama (up to **+52%** with 15 tokens, threshold=0.8: 3.60× vs target vs SD's 2.37×). The mean batch policy is key here — with 8 concurrent requests sharing the drafting step, a confident batch can consistently use more draft tokens, amplifying DSL's benefit.
- **Mean batch policy:** the policy change from `any` to `mean` matters most at concurrency > 1. A single uncertain request no longer short-circuits drafting for the whole batch.
- **Threshold sensitivity:** optimal values differ across model pairs and datasets. For mt-bench the sweet spot is 0.4–0.6 at c=4; for random inputs at c=4, threshold=0.4–0.8 with 20 tokens gives best results.

---

### References

```bibtex
@article{mamou2024accelerating,
  title={Accelerating Speculative Decoding using Dynamic Speculation Length},
  author={Mamou, Jonathan and Pereg, Oren and Korat, Daniel and Berchansky, Moshe and Timor, Nadav and Wasserblat, Moshe and Schwartz, Roy},
  journal={arXiv preprint arXiv:2405.04304},
  year={2024},
  url={https://arxiv.org/abs/2405.04304}
}

@misc{mamou2024disco_blog,
  author={Mamou, Jonathan and Pereg, Oren and Gante, Joao and Tunstall, Lewis and Korat, Daniel},
  title={Faster Assisted Generation with Dynamic Speculation},
  year={2024},
  howpublished={Hugging Face Blog},
  url={https://huggingface.co/blog/dynamic_speculation_lookahead}
}
```

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

cc: @orenpereg @keyboardAnt 