### PR TITLE
[Bugfix][Hardware][AMD] Support all MoE activations in WNA16 quantization on ROCm

### DIFF
--- a/vllm/model_executor/layers/quantization/moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/moe_wna16.py
@@ -6,7 +6,6 @@ from typing import Any
 import torch
 
 from vllm.distributed import get_tensor_model_parallel_rank, get_tp_group
-from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     int4_w4a16_moe_quant_config,
@@ -372,10 +371,6 @@ class MoeWNA16Method(FusedMoEMethodBase):
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         from vllm.model_executor.layers.fused_moe import fused_experts
 
-        assert layer.activation == MoEActivation.SILU, (
-            f"Only SiLU activation is supported, not {layer.activation}."
-        )
-
         return fused_experts(
             x,
             layer.w13_qweight,
@@ -383,6 +378,7 @@ class MoeWNA16Method(FusedMoEMethodBase):
             topk_weights=topk_weights,
             topk_ids=topk_ids,
             inplace=not self.moe.disable_inplace,
+            activation=layer.activation,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             global_num_experts=layer.global_num_experts,
             expert_map=layer.expert_map,


### PR DESCRIPTION
## Summary

Removes the SiLU-only assertion in `MoeWNA16Method.apply()` and passes `layer.activation` through to `fused_experts()`, enabling GPTQ INT4 MoE models with non-SiLU activations (e.g., SWIGLUSTEP) to run on ROCm.

On ROCm, Marlin MoE is disabled (`check_moe_marlin_supports_layer` returns `False`), so all GPTQ INT4 MoE models go through the WNA16 path. The WNA16 path had a hardcoded `assert layer.activation == MoEActivation.SILU` that blocked models using other activations, even though the underlying `fused_experts()` → `apply_moe_activation()` pipeline already supports all activation types (SILU, GELU, SWIGLUSTEP, RELU2, SWIGLUOAI, etc.).

This caused `QuixiAI/Step-3.5-Flash-int4-AutoRound` (which uses SWIGLUSTEP for certain MoE layers) to crash with:
```
AssertionError: Only SiLU activation is supported, not MoEActivation.SWIGLUSTEP.
```

Fixes #34118

## Test plan

- Verified `fused_experts()` accepts `activation` parameter (defaults to `MoEActivation.SILU`)
- Verified `apply_moe_activation()` handles all activation types including `SWIGLUSTEP` via `swiglustep_and_mul_triton()`
- No other code in `moe_wna16.py` assumes SiLU activation
- The change is a 4-line removal + 1-line addition with no behavioral change for existing SiLU models