### PR TITLE
[Bugfix][Hardware][AMD] Fix startup hang on ROCm gfx1151 in MinTokensLogitsProcessor

### DIFF
--- a/vllm/v1/sample/logits_processor/builtin.py
+++ b/vllm/v1/sample/logits_processor/builtin.py
@@ -179,8 +179,8 @@ class MinTokensLogitsProcessor(LogitsProcessor):
         )
 
         self.neg_inf_tensor = torch.tensor(
-            -float("inf"), dtype=torch.float32, device=self.device
-        )
+            -float("inf"), dtype=torch.float32, device="cpu", pin_memory=self.pin_memory
+        ).to(device=self.device, non_blocking=True)
 
     def is_argmax_invariant(self) -> bool:
         """By censoring stop tokens, min-tokens can change the outcome


### PR DESCRIPTION
## Summary

Fixes an indefinite hang during vLLM startup on AMD Ryzen AI MAX+ 395 (gfx1151) by creating `neg_inf_tensor` on CPU first and transferring to device with `non_blocking=True`.

In `MinTokensLogitsProcessor.__init__()`, the `neg_inf_tensor` scalar is created directly on the ROCm device via `torch.tensor(..., device=self.device)`. On gfx1151/gfx1150, this triggers HIP kernel compilation that hangs indefinitely — confirmed by py-spy traces showing 100% CPU time stuck at this line.

The fix follows the same CPU-first transfer pattern already used in the same class:
- `_device_tensor()` helper (line 228): creates on CPU with `pin_memory`, then `.to(device=..., non_blocking=True)`
- `AllowedTokenIdsLogitsProcessor.__init__()` (line 155-158): same pattern

Fixes #34113

## Test plan

- Verified the fix matches the existing `_device_tensor()` and `AllowedTokenIdsLogitsProcessor` patterns in the same file
- No behavioral change for existing platforms — `non_blocking=True` transfer is functionally equivalent
- The `pin_memory` parameter is already tracked by `self.pin_memory` and used in all other tensor creations in this class