### PR TITLE
[BugFix] Fix MoE g_idx params causing ValueError with actorder=null AWQ models

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
@@ -131,49 +131,11 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         layer.register_parameter("w13_weight_shape", w13_weight_shape)
         set_weight_attrs(w13_weight_shape, extra_weight_attrs)
 
-        w13_g_idx = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                hidden_size,
-                dtype=torch.int32,
-            ),
-            requires_grad=False,
-        )
-        layer.register_parameter("w13_weight_g_idx", w13_g_idx)
-        set_weight_attrs(w13_g_idx, extra_weight_attrs)
-
-        w2_g_idx = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                intermediate_size_per_partition,
-                dtype=torch.int32,
-            ),
-            requires_grad=False,
-        )
-        layer.register_parameter("w2_weight_g_idx", w2_g_idx)
-        set_weight_attrs(w2_g_idx, extra_weight_attrs)
-
-        w13_g_idx_sort_indices = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                hidden_size,
-                dtype=torch.int32,
-            ),
-            requires_grad=False,
-        )
-        layer.register_parameter("w13_g_idx_sort_indices", w13_g_idx_sort_indices)
-        set_weight_attrs(w13_g_idx_sort_indices, extra_weight_attrs)
-
-        w2_g_idx_sort_indices = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                intermediate_size_per_partition,
-                dtype=torch.int32,
-            ),
-            requires_grad=False,
-        )
-        layer.register_parameter("w2_g_idx_sort_indices", w2_g_idx_sort_indices)
-        set_weight_attrs(w2_g_idx_sort_indices, extra_weight_attrs)
+        # No g_idx parameters registered here: this class asserts
+        # actorder != "group" above, so activation ordering is never used
+        # and the checkpoint contains no g_idx tensors.  Registering them
+        # unconditionally would trip track_weights_loading()'s
+        # uninitialized-weights check.
 
         layer.a13_scale = None
         layer.a2_scale = None

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_marlin.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_marlin.py
@@ -273,57 +273,66 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
         layer.register_parameter("w13_weight_shape", w13_weight_shape)
         set_weight_attrs(w13_weight_shape, extra_weight_attrs)
 
-        w13_g_idx = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                hidden_size,
-                dtype=torch.int32,
-            ),
-            requires_grad=False,
-        )
-        layer.register_parameter("w13_weight_g_idx", w13_g_idx)
-        set_weight_attrs(w13_g_idx, extra_weight_attrs)
+        # Only register g_idx parameters when actorder is set (e.g.
+        # "group"), since the checkpoint only contains these tensors when
+        # activation ordering was used during quantization.  When actorder
+        # is null the checkpoint has no g_idx tensors, and registering them
+        # as Parameters causes track_weights_loading() to raise ValueError
+        # for uninitialized weights.
+        if self.actorder:
+            w13_g_idx = torch.nn.Parameter(
+                torch.empty(
+                    num_experts,
+                    hidden_size,
+                    dtype=torch.int32,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter("w13_weight_g_idx", w13_g_idx)
+            set_weight_attrs(w13_g_idx, extra_weight_attrs)
 
-        w2_g_idx = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                intermediate_size_per_partition,
-                dtype=torch.int32,
-            ),
-            requires_grad=False,
-        )
-        layer.register_parameter("w2_weight_g_idx", w2_g_idx)
-        set_weight_attrs(w2_g_idx, extra_weight_attrs)
+            w2_g_idx = torch.nn.Parameter(
+                torch.empty(
+                    num_experts,
+                    intermediate_size_per_partition,
+                    dtype=torch.int32,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter("w2_weight_g_idx", w2_g_idx)
+            set_weight_attrs(w2_g_idx, extra_weight_attrs)
 
-        w13_g_idx_sort_indices = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                hidden_size,
-                dtype=torch.int32,
-            ),
-            requires_grad=False,
-        )
-        layer.register_parameter("w13_g_idx_sort_indices", w13_g_idx_sort_indices)
-        set_weight_attrs(w13_g_idx_sort_indices, extra_weight_attrs)
+            w13_g_idx_sort_indices = torch.nn.Parameter(
+                torch.empty(
+                    num_experts,
+                    hidden_size,
+                    dtype=torch.int32,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter("w13_g_idx_sort_indices", w13_g_idx_sort_indices)
+            set_weight_attrs(w13_g_idx_sort_indices, extra_weight_attrs)
 
-        w2_g_idx_sort_indices = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                intermediate_size_per_partition,
-                dtype=torch.int32,
-            ),
-            requires_grad=False,
-        )
-        layer.register_parameter("w2_g_idx_sort_indices", w2_g_idx_sort_indices)
-        set_weight_attrs(w2_g_idx_sort_indices, extra_weight_attrs)
+            w2_g_idx_sort_indices = torch.nn.Parameter(
+                torch.empty(
+                    num_experts,
+                    intermediate_size_per_partition,
+                    dtype=torch.int32,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter("w2_g_idx_sort_indices", w2_g_idx_sort_indices)
+            set_weight_attrs(w2_g_idx_sort_indices, extra_weight_attrs)
 
         layer.a13_scale = None
         layer.a2_scale = None
         layer.marlin_state = GPTQMarlinState.REPACK
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        num_experts = layer.w13_weight_g_idx.shape[0]
-        device = layer.w13_weight_g_idx.device
+        # Use w13_weight_packed (always registered) rather than
+        # w13_weight_g_idx, which is only registered when actorder is set.
+        num_experts = layer.w13_weight_packed.shape[0]
+        device = layer.w13_weight_packed.device
         if self.kernel_backend == "Flashinfer":
             dict_weights_mxint4 = prepare_static_weights_for_trtllm_mxint4_moe(
                 layer.w13_weight_packed,
@@ -383,21 +392,21 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
             replace_parameter(layer, "w2_g_idx_sort_indices", w2_g_idx_sort_indices)
 
         else:
-            layer.w13_weight_g_idx = torch.nn.Parameter(
-                torch.empty((num_experts, 0), dtype=torch.int32, device=device),
-                requires_grad=False,
+            # No actorder — set empty tensors as plain attributes (not
+            # nn.Parameter) since they were not registered for checkpoint
+            # loading and only need to exist for the Marlin repack calls
+            # below.
+            layer.w13_weight_g_idx = torch.empty(
+                (num_experts, 0), dtype=torch.int32, device=device
             )
-            layer.w2_weight_g_idx = torch.nn.Parameter(
-                torch.empty((num_experts, 0), dtype=torch.int32, device=device),
-                requires_grad=False,
+            layer.w2_weight_g_idx = torch.empty(
+                (num_experts, 0), dtype=torch.int32, device=device
             )
-            layer.w13_g_idx_sort_indices = torch.nn.Parameter(
-                torch.empty((num_experts, 0), dtype=torch.int32, device=device),
-                requires_grad=False,
+            layer.w13_g_idx_sort_indices = torch.empty(
+                (num_experts, 0), dtype=torch.int32, device=device
             )
-            layer.w2_g_idx_sort_indices = torch.nn.Parameter(
-                torch.empty((num_experts, 0), dtype=torch.int32, device=device),
-                requires_grad=False,
+            layer.w2_g_idx_sort_indices = torch.empty(
+                (num_experts, 0), dtype=torch.int32, device=device
             )
 
         marlin_w13_qweight = ops.gptq_marlin_moe_repack(


### PR DESCRIPTION
## Summary

- Fix `CompressedTensorsWNA16MarlinMoEMethod.create_weights()` to only register `g_idx` parameters when `self.actorder` is set, preventing `ValueError` from `track_weights_loading()` when loading compressed-tensors AWQ MoE models with `actorder=null`
- Fix `CompressedTensorsWNA16MoEMethod.create_weights()` to remove unreachable `g_idx` registration (class asserts `actorder != "group"`)
- Fix `process_weights_after_loading()` to derive `num_experts`/`device` from `w13_weight_packed` instead of `w13_weight_g_idx`

Fixes #35303

## Motivation

`CompressedTensorsWNA16MarlinMoEMethod.create_weights()` unconditionally registers `w13_weight_g_idx`, `w2_weight_g_idx`, `w13_g_idx_sort_indices`, and `w2_g_idx_sort_indices` as `nn.Parameter`. When `actorder` is `null` (no activation ordering), the checkpoint does not contain these tensors. The strict weight validation in `DefaultModelLoader.track_weights_loading()` then raises:

```
ValueError: Following weights were not initialized from checkpoint: {
  'language_model.model.layers.0.mlp.experts.w13_weight_g_idx',
  'language_model.model.layers.0.mlp.experts.w2_weight_g_idx',
  ... (all MoE layers)
}
```

This affects any compressed-tensors AWQ MoE model with `actorder=null`, such as `cpatonn/Qwen3-VL-30B-A3B-Instruct-AWQ-4bit`. These models load successfully on v0.15.1 but crash on the v0.16.0 nightlies.

The `process_weights_after_loading()` method already handles `actorder != "group"` by replacing these with empty tensors — but validation runs *before* that method, so the error fires first.

A similar bug was previously fixed for non-MoE models (Issue #5088 / PR #5108 for GPTQ Marlin `g_idx_sort_indices`), but the MoE code path was not covered.

## Changes

### `CompressedTensorsWNA16MarlinMoEMethod` (Marlin backend)

1. **`create_weights()`**: Wrap the four `g_idx` `register_parameter()` calls in `if self.actorder:` so they are only registered when the checkpoint actually contains them.

2. **`process_weights_after_loading()`**:
   - Get `num_experts`/`device` from `layer.w13_weight_packed` (always present) instead of `layer.w13_weight_g_idx` (absent when actorder is null).
   - In the `else` branch (no actorder), use plain `torch.empty()` tensors instead of `nn.Parameter` for the empty g_idx placeholders, since they don't need gradient tracking or checkpoint loading.

### `CompressedTensorsWNA16MoEMethod` (non-Marlin backend)

3. **`create_weights()`**: Remove g_idx parameter registration entirely. This class asserts `weight_quant.actorder != "group"` in `__init__`, so g_idx tensors are never present in the checkpoint and should never be registered.

## Test plan

- [x] Verified fix loads and runs `cpatonn/Qwen3-VL-30B-A3B-Instruct-AWQ-4bit` successfully on v0.16.0rc2.dev472 (CUDA 13.0, RTX 5090)
- [ ] Existing compressed-tensors MoE tests should still pass (actorder=group path unchanged)
- [ ] Models with `actorder="group"` should still correctly load g_idx from checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)