### PR TITLE
[CI] Add nsys profiling support with NVTX tracing

### DIFF
--- a/vllm/config/observability.py
+++ b/vllm/config/observability.py
@@ -150,3 +150,11 @@ class ObservabilityConfig:
                 "collect_detailed_traces requires `--otlp-traces-endpoint` to be set."
             )
         return self
+
+    @model_validator(mode="after")
+    def _apply_env_layerwise_nvtx_override(self):
+        from vllm import envs
+
+        if envs.VLLM_ENABLE_LAYERWISE_NVTX_TRACING:
+            self.enable_layerwise_nvtx_tracing = True
+        return self

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -216,6 +216,7 @@ if TYPE_CHECKING:
     VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY: bool = False
     VLLM_CUSTOM_SCOPES_FOR_PROFILING: bool = False
     VLLM_NVTX_SCOPES_FOR_PROFILING: bool = False
+    VLLM_ENABLE_LAYERWISE_NVTX_TRACING: bool = False
     VLLM_KV_EVENTS_USE_INT_BLOCK_HASHES: bool = True
     VLLM_OBJECT_STORAGE_SHM_BUFFER_NAME: str = "VLLM_OBJECT_STORAGE_SHM_BUFFER"
     VLLM_DEEPEP_BUFFER_SIZE_MB: int = 1024
@@ -1505,6 +1506,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Add optional nvtx scopes for profiling, disable to avoid overheads
     "VLLM_NVTX_SCOPES_FOR_PROFILING": lambda: bool(
         int(os.getenv("VLLM_NVTX_SCOPES_FOR_PROFILING", "0"))
+    ),
+    # Enable layerwise NVTX tracing via env var, disable to avoid overheads
+    "VLLM_ENABLE_LAYERWISE_NVTX_TRACING": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_LAYERWISE_NVTX_TRACING", "0"))
     ),
     # Represent block hashes in KV cache events as 64-bit integers instead of
     # raw bytes. Defaults to True for backward compatibility.


### PR DESCRIPTION
## Purpose
Add a way to enable layerwise NVTX tracing via an environment variable, without requiring the --enable-layerwise-nvtx-tracing CLI flag.

## Behavior
- Layerwise NVTX tracing adds range markers around each layer/module with metadata (e.g. input/output shapes). 
- Many potential use cases (e.g. profiling, debugging, custom tooling)

This introduces:
- `VLLM_ENABLE_LAYERWISE_NVTX_TRACING` environment variable in `vllm/envs.py` to enable layerwise NVTX tracing
- A model validator in `ObservabilityConfig` that automatically applies the env var override