### PR TITLE
[Bugfix] Fix crash with EPLB + NVFP4

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -217,7 +217,7 @@ def select_nvfp4_moe_backend(
                     )
                 if supported:
                     logger.info_once(_make_log_backend(backend), scope="local")
-                    return backend, None
+                    return backend, k_cls
                 else:
                     logger.debug_once(
                         _make_log_unsupported(backend, reason), scope="local"

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -511,8 +511,8 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
     # For some FI kernels, the input scales are shared by all experts.
     if is_global_sf_supported_for_nvfp4_backend(backend):
         num_experts = w13.shape[0]
-        a13_scale = a13_scale.max().to(torch.float32).expand(num_experts)
-        a2_scale = a2_scale.max().to(torch.float32).expand(num_experts)
+        a13_scale = a13_scale.max().to(torch.float32).expand(num_experts).contiguous()
+        a2_scale = a2_scale.max().to(torch.float32).expand(num_experts).contiguous()
     else:
         a13_scale = a13_scale.max(dim=1).values.to(torch.float32)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

 ### Bug 1: `expand()` creates non-contiguous input scale tensors, breaking EPLB

  In `prepare_nvfp4_moe_layer_for_fi_or_cutlass` (`flashinfer_fp4_moe.py:514-515`), input scales are broadcast via `expand()`:

  ```python
  a13_scale = a13_scale.max().to(torch.float32).expand(num_experts)
  a2_scale = a2_scale.max().to(torch.float32).expand(num_experts)
```
  expand() creates stride-0 non-contiguous views. These are stored as layer parameters via replace_parameter(), which causes EPLB's get_expert_weights() contiguity assertion to fail. The _maybe_make_contiguous helper only
   handles 3D weight_scale tensors and doesn't cover these 1D expanded tensors.

### Bug 2: `select_nvfp4_moe_backend` returns `None` for `experts_cls` on fallback                                                                                                                                         
                              
  When `VLLM_USE_FLASHINFER_MOE_FP4=1` is set without `VLLM_FLASHINFER_MOE_BACKEND`, the auto-select loop in `select_nvfp4_moe_backend` (`nvfp4.py:200-224`) iterates through flashinfer backends.

  This only triggers when TRTLLM is rejected (e.g. due to `VLLM_MOE_ROUTING_SIMULATION_STRATEGY=uniform_random` setting `RoutingMethodType.Simulated`, which TRTLLM doesn't support) and a fallback like CUTEDSL or CUTLASS
  is selected.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

