### PR TITLE
[Bugfix] Fix AttributeError in SMControlContextManager

### DIFF
--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -73,7 +73,7 @@ class SMControlContextManager:
             "SM control is currently only supported on CUDA"
         )
 
-        total_sms = num_compute_units(torch.cuda.current_device().index)
+        total_sms = num_compute_units(torch.cuda.current_device())
 
         assert comm_sms < total_sms
         self.total_sms = total_sms


### PR DESCRIPTION
FIX  #35337

## Summary

Fixes `AttributeError: 'int' object has no attribute 'index'` in `SMControlContextManager.__init__()` when running with data parallel and expert parallel enabled (DBO tests).

## Root Cause

PR #35042 introduced a bug where `torch.cuda.current_device().index` is called, but `torch.cuda.current_device()` returns an `int` directly, not a device object with an `.index` attribute.

## Fix

Remove the erroneous `.index` access since `torch.cuda.current_device()` already returns the device index as an integer.

## Test Plan

- [x] Verify `torch.cuda.current_device()` returns `int`
- [ ] CI: `v1/distributed/test_dbo.py::test_dbo_dp_ep_gsm8k[deepep_low_latency]`
- [ ] CI: `v1/distributed/test_dbo.py::test_dbo_dp_ep_gsm8k[deepep_high_throughput]`