### PR TITLE
[Feature] Add num_steps and delay_steps parameters to /start_profile endpoint

### DIFF
--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -121,8 +121,21 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
-    async def start_profile(self) -> None:
-        """Start profiling the engine"""
+    async def start_profile(
+        self,
+        profile_prefix: str | None = None,
+        num_steps: int | None = None,
+        delay_steps: int | None = None,
+    ) -> None:
+        """Start profiling the engine.
+
+        Args:
+            profile_prefix: If provided, used as a prefix for the trace name.
+            num_steps: If provided, overrides max_iterations for this session.
+                0 means unlimited.
+            delay_steps: If provided, overrides delay_iterations for this
+                session.
+        """
         ...
 
     @abstractmethod

--- a/vllm/profiler/wrapper.py
+++ b/vllm/profiler/wrapper.py
@@ -68,14 +68,32 @@ class WorkerProfiler(ABC):
             logger.warning("Failed to stop profiler: %s", e)
         self._running = False  # Always mark as not running, assume stop worked
 
-    def start(self) -> None:
-        """Attempt to start the profiler, accounting for delayed starts."""
+    def start(
+        self,
+        num_steps: int | None = None,
+        delay_steps: int | None = None,
+    ) -> None:
+        """Attempt to start the profiler, accounting for delayed starts.
+
+        Args:
+            num_steps: If provided, overrides max_iterations for this
+                profiling session. 0 means unlimited.
+            delay_steps: If provided, overrides delay_iterations for this
+                profiling session.
+        """
         if self._active:
             logger.debug(
                 "start_profile received when profiler is already active. "
                 "Ignoring request."
             )
             return
+
+        # Apply runtime overrides if provided
+        if num_steps is not None:
+            self._max_iters = num_steps
+        if delay_steps is not None:
+            self._delay_iters = delay_steps
+
         self._active = True
         if self._delay_iters == 0:
             self._call_start()

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -876,8 +876,15 @@ class AsyncLLM(EngineClient):
         if self.errored:
             raise self.dead_error
 
-    async def start_profile(self, profile_prefix: str | None = None) -> None:
-        coros = [self.engine_core.profile_async(True, profile_prefix)]
+    async def start_profile(
+        self,
+        profile_prefix: str | None = None,
+        num_steps: int | None = None,
+        delay_steps: int | None = None,
+    ) -> None:
+        coros = [
+            self.engine_core.profile_async(True, profile_prefix, num_steps, delay_steps)
+        ]
         if self.profiler is not None:
             coros.append(asyncio.to_thread(self.profiler.start))
         await asyncio.gather(*coros)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -551,8 +551,14 @@ class EngineCore:
         if self.scheduler:
             self.scheduler.shutdown()
 
-    def profile(self, is_start: bool = True, profile_prefix: str | None = None):
-        self.model_executor.profile(is_start, profile_prefix)
+    def profile(
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        num_steps: int | None = None,
+        delay_steps: int | None = None,
+    ):
+        self.model_executor.profile(is_start, profile_prefix, num_steps, delay_steps)
 
     def reset_mm_cache(self):
         # NOTE: Since this is mainly for debugging, we don't attempt to

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -215,7 +215,11 @@ class EngineCoreClient(ABC):
         raise NotImplementedError
 
     async def profile_async(
-        self, is_start: bool = True, profile_prefix: str | None = None
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        num_steps: int | None = None,
+        delay_steps: int | None = None,
     ) -> None:
         raise NotImplementedError
 
@@ -301,8 +305,14 @@ class InprocClient(EngineCoreClient):
     def shutdown(self, timeout: float | None = None) -> None:
         self.engine_core.shutdown()
 
-    def profile(self, is_start: bool = True, profile_prefix: str | None = None) -> None:
-        self.engine_core.profile(is_start, profile_prefix)
+    def profile(
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        num_steps: int | None = None,
+        delay_steps: int | None = None,
+    ) -> None:
+        self.engine_core.profile(is_start, profile_prefix, num_steps, delay_steps)
 
     def reset_mm_cache(self) -> None:
         self.engine_core.reset_mm_cache()
@@ -1050,9 +1060,15 @@ class AsyncMPClient(MPClient):
         return await self.call_utility_async("is_scheduler_paused")
 
     async def profile_async(
-        self, is_start: bool = True, profile_prefix: str | None = None
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        num_steps: int | None = None,
+        delay_steps: int | None = None,
     ) -> None:
-        await self.call_utility_async("profile", is_start, profile_prefix)
+        await self.call_utility_async(
+            "profile", is_start, profile_prefix, num_steps, delay_steps
+        )
 
     async def reset_mm_cache_async(self) -> None:
         await self.call_utility_async("reset_mm_cache")

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -246,8 +246,16 @@ class Executor(ABC):
     def max_concurrent_batches(self) -> int:
         return 1
 
-    def profile(self, is_start: bool = True, profile_prefix: str | None = None):
-        self.collective_rpc("profile", args=(is_start, profile_prefix))
+    def profile(
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        num_steps: int | None = None,
+        delay_steps: int | None = None,
+    ):
+        self.collective_rpc(
+            "profile", args=(is_start, profile_prefix, num_steps, delay_steps)
+        )
 
     def save_sharded_state(
         self,

--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -230,10 +230,16 @@ class CPUWorker(Worker):
         )
         return ",".join([str(x.id) for x in logical_cpu_list])
 
-    def profile(self, is_start: bool = True, profile_prefix: str | None = None):
+    def profile(
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        num_steps: int | None = None,
+        delay_steps: int | None = None,
+    ):
         if self.profiler is None:
             raise RuntimeError("Profiler is not enabled.")
         if is_start:
-            self.profiler.start()
+            self.profiler.start(num_steps=num_steps, delay_steps=delay_steps)
         else:
             self.profiler.stop()

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -851,7 +851,13 @@ class Worker(WorkerBase):
     def take_draft_token_ids(self) -> DraftTokenIds | None:
         return self.model_runner.take_draft_token_ids()
 
-    def profile(self, is_start: bool = True, profile_prefix: str | None = None):
+    def profile(
+        self,
+        is_start: bool = True,
+        profile_prefix: str | None = None,
+        num_steps: int | None = None,
+        delay_steps: int | None = None,
+    ):
         # Check if profiling is enabled
         if self.profiler_config is None or self.profiler_config.profiler is None:
             raise RuntimeError(
@@ -897,7 +903,7 @@ class Worker(WorkerBase):
 
             # If profiler already initialized, restart profiling but keep
             # the original trace name from the first initialization.
-            self.profiler.start()
+            self.profiler.start(num_steps=num_steps, delay_steps=delay_steps)
         else:
             if self.profiler is None:
                 logger.warning("Profiler was not started, nothing to stop.")


### PR DESCRIPTION
## Purpose

Adds runtime-configurable `num_steps` and `delay_steps` parameters to the `/start_profile` API endpoint, allowing users to override the server's `max_iterations` and `delay_iterations` profiler config on a per-session basis without restarting the server.

Closes https://github.com/vllm-project/vllm/issues/35332

## Test Plan

```bash
pytest tests/v1/worker/test_gpu_profiler.py -v

## Test Result
tests/v1/worker/test_gpu_profiler.py::test_immediate_start_stop PASSED
tests/v1/worker/test_gpu_profiler.py::test_delayed_start PASSED
tests/v1/worker/test_gpu_profiler.py::test_max_iterations PASSED
tests/v1/worker/test_gpu_profiler.py::test_delayed_start_and_max_iters PASSED
tests/v1/worker/test_gpu_profiler.py::test_idempotency PASSED
tests/v1/worker/test_gpu_profiler.py::test_step_inactive PASSED
tests/v1/worker/test_gpu_profiler.py::test_start_failure PASSED
tests/v1/worker/test_gpu_profiler.py::test_shutdown PASSED
tests/v1/worker/test_gpu_profiler.py::test_mixed_delay_and_stop PASSED
tests/v1/worker/test_gpu_profiler.py::test_runtime_num_steps_override PASSED
tests/v1/worker/test_gpu_profiler.py::test_runtime_delay_steps_override PASSED
tests/v1/worker/test_gpu_profiler.py::test_runtime_combined_overrides PASSED
tests/v1/worker/test_gpu_profiler.py::test_runtime_override_preserves_config_defaults PASSED
tests/v1/worker/test_gpu_profiler.py::test_runtime_override_on_restart PASSED
tests/v1/worker/test_gpu_profiler.py::TestIsUriPath::test_is_uri_path[...] PASSED (x16)
```
## New tests cover

- num_steps override auto-stops profiler after N steps
- delay_steps override delays profiler start
- Combined overrides are working together
- None values preserve server config defaults
- Overrides apply independently on each start() call
