### PR TITLE
[Bug] FA2 is not supported for NVIDIA Blackwell architecture

### DIFF
--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -168,6 +168,9 @@ class FlashAttentionBackend(AttentionBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
+        # FA2 is not supported on SM12x (Blackwell GB10/GB200)
+        if capability.major >= 12:
+            return False
         return capability >= DeviceCapability(8, 0)
 
     @classmethod


### PR DESCRIPTION
## Purpose
At the moment FA2 support in Blackwell is broken: 
```
Cannot use FA version 2 is not supported due to FA2 is unavaible due to: SM 12.x not supported by flash-attn FA2
Cannot use FA version 2 is not supported due to FA2 is unavaible due to: SM 12.x not supported by flash-attn FA2
Cannot use FA version 2 is not supported due to FA2 is unavaible due to: SM 12.x not supported by flash-attn FA2
Cannot use FA version 2 is not supported due to FA2 is unavaible due to: SM 12.x not supported by flash-attn FA2
....
File "/home/olka/Software/vllm/vllm/v1/attention/ops/vit_attn_wrappers.py", line 51, in flash_attn_maxseqlen_wrapper
(EngineCore_DP0 pid=310405)     output = flash_attn_varlen_func(
(EngineCore_DP0 pid=310405)              ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=310405)   File "/home/olka/Software/vllm/vllm/vllm_flash_attn/flash_attn_interface.py", line 267, in flash_attn_varlen_func
(EngineCore_DP0 pid=310405)     out, softmax_lse = torch.ops._vllm_fa2_C.varlen_fwd(
(EngineCore_DP0 pid=310405)                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=310405)   File "/home/olka/Software/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1319, in __getattr__
(EngineCore_DP0 pid=310405)     raise AttributeError(
(EngineCore_DP0 pid=310405) AttributeError: '_OpNamespace' '_vllm_fa2_C' object has no attribute 'varlen_fwd'
```
Reason:  varlen is not properly implemented for Blackwell
Bug: https://github.com/Dao-AILab/flash-attention/issues/2220

## Test results

vLLM starts as it should without FA2 errors
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>