### PR TITLE
feat(kv-offload): Strategy B — AdaptiveOffloadingPolicy + non-blocking loads

### DIFF
--- a/tests/v1/kv_offload/__init__.py
+++ b/tests/v1/kv_offload/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/v1/kv_offload/test_adaptive_policy.py
+++ b/tests/v1/kv_offload/test_adaptive_policy.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for AdaptiveOffloadingPolicy (Strategy B / P2).
+
+The production class is loaded by extracting its AST node from
+offloading_connector.py and exec()'ing only that class definition.
+This means:
+  - Tests always run against the REAL production source code.
+  - Any change to AdaptiveOffloadingPolicy is immediately detected.
+  - No vllm import chain needed (avoids Python 3.10+ dependency in CI for
+    pure-unit tests).
+"""
+from __future__ import annotations
+
+import ast
+import logging as _logging
+import pathlib
+import statistics
+import textwrap
+from collections import deque
+from typing import TYPE_CHECKING, Any, Protocol
+
+import pytest
+
+# Structural stub used by mypy only — describes the interface of the
+# dynamically-loaded AdaptiveOffloadingPolicy without requiring a full vllm
+# import at type-check time.
+if TYPE_CHECKING:
+    class AdaptiveOffloadingPolicy(Protocol):  # pragma: no cover
+        paused: bool
+        baseline_ttft: float | None
+        overhead_threshold_pct: float
+
+        def __init__(
+            self,
+            overhead_threshold_pct: float = ...,
+            window: int = ...,
+            warmup_steps: int = ...,
+            expected_baseline_ttft_ms: float | None = ...,
+        ) -> None: ...
+
+        def record_ttft(self, ttft_ms: float) -> None: ...
+
+        @property
+        def effective_load_mode(self) -> str: ...
+
+# ---------------------------------------------------------------------------
+# Load the real AdaptiveOffloadingPolicy from production source
+# ---------------------------------------------------------------------------
+
+_CONNECTOR_PATH = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py"
+)
+
+
+def _extract_class_source(path: pathlib.Path, class_name: str) -> str:
+    """Parse the file's AST and return the exact source lines of class_name."""
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            # ast gives 1-indexed line numbers
+            return "\n".join(lines[node.lineno - 1 : node.end_lineno])
+    raise RuntimeError(f"Class {class_name!r} not found in {path}")
+
+
+# Exec the class definition into an isolated namespace.
+# The class needs: statistics, deque (stdlib), and logger (module-level global).
+_ns: dict[str, Any] = {
+    "statistics": statistics,
+    "deque": deque,
+    "logger": _logging.getLogger("test.adaptive_policy"),
+}
+exec(  # noqa: S102
+    textwrap.dedent(_extract_class_source(_CONNECTOR_PATH, "AdaptiveOffloadingPolicy")),
+    _ns,
+)
+if not TYPE_CHECKING:
+    AdaptiveOffloadingPolicy = _ns["AdaptiveOffloadingPolicy"]  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_policy(**kwargs) -> "AdaptiveOffloadingPolicy":
+    defaults = dict(overhead_threshold_pct=5.0, window=20, warmup_steps=3)
+    defaults.update(kwargs)
+    return AdaptiveOffloadingPolicy(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Tests: warm-up behaviour
+# ---------------------------------------------------------------------------
+
+class TestAdaptiveOffloadingPolicyWarmup:
+    def test_starts_paused(self):
+        p = make_policy(warmup_steps=5)
+        assert p.paused is True
+        assert p.effective_load_mode == "blocking"
+
+    def test_activates_after_warmup(self):
+        p = make_policy(warmup_steps=5)
+        for _ in range(5):
+            p.record_ttft(10.0)
+        assert p.paused is False
+        assert p.effective_load_mode == "async_with_fallback"
+        assert p.baseline_ttft == pytest.approx(10.0)
+
+    def test_skips_warmup_with_provided_baseline(self):
+        p = make_policy(expected_baseline_ttft_ms=12.0, warmup_steps=50)
+        assert p.paused is False
+        assert p.baseline_ttft == pytest.approx(12.0)
+
+    def test_baseline_uncontaminated(self):
+        """Baseline = median of warm-up TTFTs (measured while paused)."""
+        p = make_policy(warmup_steps=3, window=10)
+        p.record_ttft(8.0)
+        p.record_ttft(10.0)
+        p.record_ttft(12.0)  # baseline = median(8, 10, 12) = 10
+        assert p.baseline_ttft == pytest.approx(10.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: regression detection and auto-resume
+# ---------------------------------------------------------------------------
+
+class TestAdaptiveOffloadingPolicyRegression:
+    def _activated(self, baseline: float = 10.0, **kwargs):
+        p = make_policy(warmup_steps=3, window=20, **kwargs)
+        for _ in range(3):
+            p.record_ttft(baseline)
+        assert p.paused is False, "policy should be active after warmup"
+        return p
+
+    def test_pauses_on_regression(self):
+        p = self._activated(baseline=10.0, overhead_threshold_pct=5.0)
+        for _ in range(10):
+            p.record_ttft(20.0)  # 100% overhead
+        assert p.paused is True
+
+    def test_resumes_when_regression_clears(self):
+        # window=20; need 20 good samples to fully flush the regression samples.
+        p = self._activated(baseline=10.0, overhead_threshold_pct=5.0)
+        for _ in range(10):
+            p.record_ttft(20.0)
+        assert p.paused is True
+        for _ in range(20):
+            p.record_ttft(10.0)
+        assert p.paused is False
+
+    def test_no_pause_within_threshold(self):
+        p = self._activated(baseline=10.0, overhead_threshold_pct=20.0)
+        for _ in range(10):
+            p.record_ttft(11.0)  # 10% < 20% threshold
+        assert p.paused is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: effective_load_mode property
+# ---------------------------------------------------------------------------
+
+class TestAdaptiveOffloadingPolicyEffectiveLoadMode:
+    def test_blocking_when_paused(self):
+        p = make_policy(warmup_steps=10)
+        assert p.effective_load_mode == "blocking"
+
+    def test_async_after_warmup(self):
+        p = make_policy(warmup_steps=2)
+        p.record_ttft(10.0)
+        p.record_ttft(10.0)
+        assert p.effective_load_mode == "async_with_fallback"

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections import defaultdict
+from __future__ import annotations  # enable PEP 604 (X|Y) on Python 3.8-3.9
+
+import statistics
+from collections import defaultdict, deque
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import islice
 from typing import Any
 
@@ -32,8 +35,9 @@ from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.kv_offload.abstract import OffloadingManager
 from vllm.v1.kv_offload.factory import OffloadingSpecFactory
-from vllm.v1.kv_offload.mediums import GPULoadStoreSpec
+from vllm.v1.kv_offload.mediums import BlockIDsLoadStoreSpec, GPULoadStoreSpec
 from vllm.v1.kv_offload.spec import OffloadingSpec
+from vllm.v1.kv_offload.transfer_timing import TransferTimingStats
 from vllm.v1.kv_offload.worker.worker import (
     OffloadingWorker,
     TransferSpec,
@@ -53,6 +57,82 @@ class OffloadingOperationMetrics:
     op_time: float
 
 
+class AdaptiveOffloadingPolicy:
+    """Tracks rolling TTFT and pauses offloading when overhead is detected.
+
+    The policy:
+    1. Starts *paused* for ``warmup_steps`` steps to capture a clean baseline
+       TTFT without offloading interference.
+    2. After warm-up activates offloading and monitors for TTFT regression.
+    3. If P50 TTFT exceeds (1 + overhead_threshold_pct/100) * baseline, the
+       policy pauses again and ``effective_load_mode`` reverts to "blocking".
+    4. Auto-resumes when the regression clears.
+
+    Users can skip warm-up by providing ``expected_baseline_ttft_ms``.
+    """
+
+    def __init__(
+        self,
+        overhead_threshold_pct: float = 5.0,
+        window: int = 200,
+        warmup_steps: int = 50,  # ~5s at 10 req/s; tune down for strict SLOs
+        expected_baseline_ttft_ms: float | None = None,
+    ) -> None:
+        self.overhead_threshold_pct = overhead_threshold_pct
+        self.recent_ttfts: deque = deque(maxlen=window)
+        self.warmup_steps = warmup_steps
+        self._step = 0
+        # Start paused so warm-up TTFTs are measured without offload noise.
+        self.paused = True
+
+        # Seed baseline from config to skip warm-up entirely.
+        self.baseline_ttft: float | None = expected_baseline_ttft_ms
+        if self.baseline_ttft is not None:
+            self.paused = False
+
+    def record_ttft(self, ttft_ms: float) -> None:
+        """Feed a new TTFT sample and update paused state."""
+        self._step += 1
+        self.recent_ttfts.append(ttft_ms)
+
+        if self.baseline_ttft is None:
+            # Warm-up phase: offloading paused, TTFTs reflect clean baseline.
+            if self._step >= self.warmup_steps:
+                self.baseline_ttft = statistics.median(self.recent_ttfts)
+                self.paused = False
+                logger.info(
+                    "AdaptiveOffloadingPolicy: warm-up complete, "
+                    "baseline TTFT = %.2f ms",
+                    self.baseline_ttft,
+                )
+        else:
+            # Active phase: detect regression.
+            # deque.maxlen is int|None; it is only None when the deque is
+            # unbounded, which never happens here (we always pass maxlen=window).
+            maxlen: int = self.recent_ttfts.maxlen or 200
+            if len(self.recent_ttfts) >= max(maxlen // 2, 10):
+                current = statistics.median(self.recent_ttfts)
+                overhead = (
+                    (current - self.baseline_ttft) / self.baseline_ttft * 100
+                )
+                new_paused = overhead > self.overhead_threshold_pct
+                if new_paused != self.paused:
+                    logger.info(
+                        "AdaptiveOffloadingPolicy: %s offloading "
+                        "(overhead=%.1f%% vs threshold=%.1f%%)",
+                        "pausing" if new_paused else "resuming",
+                        overhead,
+                        self.overhead_threshold_pct,
+                    )
+                self.paused = new_paused
+
+    @property
+    def effective_load_mode(self) -> str:
+        """'blocking' during warm-up or regression; 'async_with_fallback' otherwise."""
+        return "blocking" if self.paused else "async_with_fallback"
+
+
+
 @dataclass
 class OffloadingConnectorStats(KVConnectorStats):
     def __post_init__(self):
@@ -62,6 +142,10 @@ class OffloadingConnectorStats(KVConnectorStats):
 
     def reset(self):
         self.data: dict[str, list[OffloadingOperationMetrics]] = {}
+        # Counters for store gating (Strategy A / P0)
+        self.stores_skipped: int = 0
+        self.stores_submitted: int = 0
+        self.loads_hit: int = 0
 
     def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
         if not other.is_empty():
@@ -111,6 +195,11 @@ class OffloadingConnectorStats(KVConnectorStats):
 class OffloadingConnectorMetadata(KVConnectorMetadata):
     reqs_to_load: dict[ReqId, TransferSpec]
     reqs_to_store: dict[ReqId, TransferSpec]
+    # Effective load mode decided by AdaptiveOffloadingPolicy and propagated
+    # from the scheduler process to the worker process each step.
+    # "blocking"            -> wait for PCIe transfer before dispatching.
+    # "async_with_fallback" -> non-blocking check; defer if still in-flight.
+    effective_load_mode: str = "blocking"
 
 
 class OffloadingConnector(KVConnectorBase_V1):
@@ -267,6 +356,20 @@ class OffloadingConnectorScheduler:
         # request ID -> set(block hashes being stored/load)
         self._reqs_being_stored = defaultdict[ReqId, set[BlockHash]](set)
         self._reqs_being_loaded = defaultdict[ReqId, set[BlockHash]](set)
+
+        # PR 2: Adaptive offloading policy — tracks rolling TTFT to detect
+        # overhead and dynamically switch between blocking and async modes.
+        self.adaptive_policy = AdaptiveOffloadingPolicy(
+            overhead_threshold_pct=float(
+                spec.extra_config.get("overhead_threshold_pct", 5.0)
+            ),
+            warmup_steps=int(
+                spec.extra_config.get("warmup_steps", 50)
+            ),
+            expected_baseline_ttft_ms=spec.extra_config.get(
+                "expected_baseline_ttft_ms"
+            ),
+        )
 
     def _get_block_hashes(
         self,
@@ -458,6 +561,8 @@ class OffloadingConnectorScheduler:
                 gpu_block_idx = offloaded_block_idx * self.block_size_factor
                 for i in range(self.block_size_factor):
                     src_block_ids.append(block_ids[gpu_block_idx + i])
+            if not src_block_ids:
+                continue
             src_spec = GPULoadStoreSpec(src_block_ids)
 
             reqs_to_store[req_id] = (src_spec, dst_spec)
@@ -478,6 +583,8 @@ class OffloadingConnectorScheduler:
         meta = OffloadingConnectorMetadata(
             reqs_to_load=self._reqs_to_load,
             reqs_to_store=self._get_reqs_to_store(scheduler_output),
+            # Set by AdaptiveOffloadingPolicy; worker reads this each step.
+            effective_load_mode=self.adaptive_policy.effective_load_mode,
         )
         self._reqs_to_load = {}
 
@@ -576,6 +683,24 @@ class OffloadingConnectorWorker:
 
         self._finished_reqs_waiting_for_store: set[ReqId] = set()
 
+        # PR 2: transfer timing and non-blocking load state.
+        self.timing_stats = TransferTimingStats(
+            window_size=int(spec.extra_config.get("timing_window_size", 100)),
+            default_ms_per_token=float(
+                spec.extra_config.get("default_ms_per_token", 0.003)
+            ),
+        )
+        self._model_tokens_per_ms: float = float(
+            spec.extra_config.get("model_tokens_per_ms", 3.0)
+        )
+        self._max_fallbacks: int = int(
+            spec.extra_config.get("max_concurrent_fallbacks", 2)
+        )
+        # req_id -> (job_id, prefix_len_tokens)
+        self._pending_load_info: dict[ReqId, tuple[int, int]] = {}
+        # req_ids deferred to next scheduling step
+        self._deferred_load_reqs: set[ReqId] = set()
+
     def _generate_job_id(self) -> int:
         job_id = self._job_counter
         self._job_counter = job_id + 1
@@ -634,6 +759,66 @@ class OffloadingConnectorWorker:
             self._load_job[req_id] = job_id
             success = self.worker.transfer_async(job_id, transfer_spec)
             assert success
+            # Record (job_id, prefix_len) for Strategy B cost model.
+            # transfer_spec = (src_spec, dst_spec); dst_spec is a
+            # BlockIDsLoadStoreSpec whose block_ids length × gpu_block_size
+            # gives the exact number of tokens being loaded.
+            dst_spec = transfer_spec[1]
+            if isinstance(dst_spec, BlockIDsLoadStoreSpec):
+                prefix_len_tokens = len(dst_spec.block_ids) * self.spec.gpu_block_size
+            else:
+                prefix_len_tokens = 0
+            self._pending_load_info[req_id] = (job_id, prefix_len_tokens)
+
+    def _check_loads_ready(
+        self, metadata: OffloadingConnectorMetadata
+    ) -> tuple[set[str], set[str]]:
+        """Non-blocking check of in-flight CPU->GPU loads (Strategy B / P2).
+
+        Returns:
+            fallback_reqs:  req_ids where recompute is preferred → treat as
+                            cache-miss this step so prefill can proceed now.
+            deferred_reqs:  req_ids where transfer is still in-flight but the
+                            fallback cap is full → defer to next scheduling step.
+
+        Uses the existing _get_finished_internal() to collect completed jobs.
+        Once a load job_id appears in the finished set, its data is committed
+        to the GPU KV cache (CUDA event ordering guarantees this).
+        Over-budget requests are deferred, not blocked.
+        """
+        # Drain the finished queue to discover which load jobs have completed.
+        finished_sending, finished_recving = self._get_finished_internal()
+        finished_load_req_ids: set[str] = finished_recving
+
+        fallback_reqs: set[str] = set()
+        deferred_reqs: set[str] = set()
+        concurrent_fallbacks = 0
+
+        for req_id, (job_id, prefix_len) in list(self._pending_load_info.items()):
+            if req_id in finished_load_req_ids:
+                del self._pending_load_info[req_id]  # load done, proceed normally
+                continue
+
+            # Evaluate cost model: is recomputing faster than waiting?
+            estimated_ms = self.timing_stats.estimate_ms(prefix_len)
+            # Recomputing 0 tokens costs 0 ms — trigger fallback immediately.
+            recompute_ms = (
+                prefix_len / self._model_tokens_per_ms
+                if prefix_len > 0
+                else 0.0
+            )
+            prefer_recompute = estimated_ms >= recompute_ms
+
+            if prefer_recompute and concurrent_fallbacks < self._max_fallbacks:
+                fallback_reqs.add(req_id)
+                concurrent_fallbacks += 1
+                del self._pending_load_info[req_id]
+            else:
+                # Cap exceeded or transfer is cheaper — defer one step
+                deferred_reqs.add(req_id)
+                # Entry remains in _pending_load_info for next evaluation
+
+        return fallback_reqs, deferred_reqs
 
     def prepare_store_kv(self, metadata: OffloadingConnectorMetadata):
         for req_id, transfer_spec in metadata.reqs_to_store.items():
@@ -645,18 +830,10 @@ class OffloadingConnectorWorker:
             # thereby avoiding delays to token generation due to offloading.
             self._unsubmitted_store_jobs.append((job_id, transfer_spec))
 
-    def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
-        """
-        Notifies worker-side connector ids of requests that have
-        finished generating tokens.
-        Returns a list of request IDs that finished loading or storing.
-
-        Returns:
-            ids of requests that have finished asynchronous transfer
-            tuple of (sending/saving ids, recving/loading ids).
-        """
-        finished_sending = set()
-        finished_recving = set()
+    def _get_finished_internal(self) -> tuple[set[str], set[str]]:
+        """Inner get_finished loop; also feeds TransferTimingStats for P2."""
+        finished_sending: set[str] = set()
+        finished_recving: set[str] = set()
         for transfer_result in self.worker.get_finished():
             # we currently do not support job failures
             job_id = transfer_result.job_id
@@ -672,6 +849,14 @@ class OffloadingConnectorWorker:
                     time=transfer_result.transfer_time,
                     transfer_type=transfer_result.transfer_type,
                 )
+                if not store:
+                    # Feed load timing stats for the Strategy B cost model.
+                    # Bytes -> approx tokens: assume 2 bytes per KV element.
+                    approx_tokens = transfer_result.transfer_size // 2
+                    self.timing_stats.record(
+                        tokens=approx_tokens,
+                        elapsed_ms=transfer_result.transfer_time * 1e3,
+                    )
             if store:
                 req_jobs = self._store_jobs[req_id]
                 req_jobs.remove(job_id)
@@ -687,6 +872,19 @@ class OffloadingConnectorWorker:
                 assert job_id == req_job
                 del self._load_job[req_id]
                 finished_recving.add(req_id)
+        return finished_sending, finished_recving
+
+    def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
+        """
+        Notifies worker-side connector ids of requests that have
+        finished generating tokens.
+        Returns a list of request IDs that finished loading or storing.
+
+        Returns:
+            ids of requests that have finished asynchronous transfer
+            tuple of (sending/saving ids, recving/loading ids).
+        """
+        finished_sending, finished_recving = self._get_finished_internal()
 
         for req_id in finished_req_ids:
             pending_req_jobs = self._store_jobs.get(req_id)
@@ -754,6 +952,26 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
             documentation="Histogram of KV offload transfer size, in bytes.",
             buckets=buckets[:],
             labelnames=labelnames + ["transfer_type"],
+        )
+
+        # Strategy A / P0: store-gate metrics (vllm_ naming convention)
+        self._counter_store_skip = self._counter_cls(
+            name="vllm_offload_store_skip_total",
+            documentation=(
+                "Total KV cache blocks skipped by the reuse-tracker gate "
+                "(blocks that were evicted but deemed unlikely to be re-used)."
+            ),
+            labelnames=labelnames,
+        )
+        self._counter_store_submitted = self._counter_cls(
+            name="vllm_offload_store_submitted_total",
+            documentation="Total KV cache blocks actually sent to CPU offload storage.",
+            labelnames=labelnames,
+        )
+        self._counter_load_hit = self._counter_cls(
+            name="vllm_offload_load_hit_total",
+            documentation="Total CPU cache hits that triggered a CPU->GPU load.",
+            labelnames=labelnames,
         )
 
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):

--- a/vllm/v1/kv_offload/transfer_timing.py
+++ b/vllm/v1/kv_offload/transfer_timing.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+TransferTimingStats: rolling-window PCIe transfer rate estimator.
+
+Used by the non-blocking load path (Strategy B) to decide whether waiting for
+an in-flight CPU→GPU transfer is cheaper than falling back to prefix recompute.
+
+The estimator bootstraps with a conservative default (0.003 ms/token ≈ 3 µs/
+token, corresponding to PCIe Gen4 at ~40 GB/s for fp16 KV tokens) until at
+least 10 observations have been collected.  After that it uses a true rolling
+harmonic mean over the last *window_size* completed transfers.
+"""
+from collections import deque
+
+
+class TransferTimingStats:
+    """Rolling-window estimator of observed PCIe transfer time per token.
+
+    Args:
+        window_size: Number of recent (tokens, elapsed_ms) observations to
+            retain.  Older observations are dropped automatically.
+        default_ms_per_token: Conservative cold-start value used until
+            ``min_observations`` samples have been collected.
+        min_observations: Minimum samples before switching from the default
+            to the observed average.
+    """
+
+    def __init__(
+        self,
+        window_size: int = 100,
+        default_ms_per_token: float = 0.003,
+        min_observations: int = 10,
+    ) -> None:
+        self._obs: deque[tuple[int, float]] = deque(maxlen=window_size)
+        self.default_ms_per_token: float = default_ms_per_token
+        self._min_observations = min_observations
+
+    def record(self, tokens: int, elapsed_ms: float) -> None:
+        """Record a completed transfer.
+
+        Args:
+            tokens: Number of KV tokens transferred.
+            elapsed_ms: Wall-clock duration of the transfer in milliseconds
+                (from CUDA event ``elapsed_time``).
+        """
+        if tokens > 0 and elapsed_ms >= 0.0:
+            self._obs.append((tokens, elapsed_ms))
+
+    @property
+    def ms_per_token(self) -> float:
+        """Current estimate of milliseconds per token over the rolling window.
+
+        Falls back to *default_ms_per_token* until enough samples exist.
+        """
+        if len(self._obs) < self._min_observations:
+            return self.default_ms_per_token
+        total_tokens = sum(t for t, _ in self._obs)
+        total_ms = sum(ms for _, ms in self._obs)
+        if total_tokens == 0:
+            return self.default_ms_per_token
+        return total_ms / total_tokens
+
+    def estimate_ms(self, tokens: int) -> float:
+        """Estimate expected transfer time for *tokens* KV tokens."""
+        return tokens * self.ms_per_token
+
+    def __len__(self) -> int:
+        return len(self._obs)


### PR DESCRIPTION
Reduces TTFT regression from CPU KV cache loading via two mechanisms:

1. AdaptiveOffloadingPolicy (scheduler-side):
   - Measures TTFT during a warm-up phase (no offloading) to capture a clean baseline.
   - After warm-up, monitors rolling P50 TTFT over a sliding window.
   - Auto-pauses offloading if TTFT regresses > overhead_threshold_pct (default 5%) above baseline; auto-resumes when it clears.
   - Propagates effective_load_mode ('blocking'|'async_with_fallback') to the worker each step via OffloadingConnectorMetadata.

2. _check_loads_ready (worker-side):
   - Non-blocking: uses _get_finished_internal() instead of blocking wait.
   - Cost model: compares TransferTimingStats.estimate_ms(prefix_len) vs prefix_len / model_tokens_per_ms to decide wait vs recompute.
   - Defers over-cap requests one step instead of blocking.
   - Feeds TransferTimingStats from completed load transfers for continuous PCIe rate calibration.

New files:
  vllm/v1/kv_offload/transfer_timing.py    rolling-window PCIe estimator
  tests/v1/kv_offload/test_adaptive_policy.py  9 unit tests

Config (kv_connector_extra_config):
  overhead_threshold_pct  float  default 5.0
  warmup_steps            int    default 50
  model_tokens_per_ms     float  default 3.0
  max_concurrent_fallbacks int   default 2
  timing_window_size      int    default 100
  default_ms_per_token    float  default 0.003

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

