### PR TITLE
[XPU] special handle for pooler models w8a16 gemm

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -43,6 +43,10 @@ class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
     ) -> torch.Tensor:
         weight = layer.weight
         weight_scale = layer.weight_scale
+        # In case of pooler models, pooled_data may change to head_dtype like float
+        # which fp8_gemm_w8a16 doesn't support
+        if x.dtype == torch.float:
+            x = x.to(torch.bfloat16)
         return torch.ops._xpu_C.fp8_gemm_w8a16(x, weight, weight_scale, bias)
 
     def apply_scaled_mm(


### PR DESCRIPTION

## Purpose
In case of pooler models, pooled_data may change to head_dtype like float which fp8_gemm_w8a16 doesn't support, so we make a force convert in this PR.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

