### PR TITLE
[Bug] Fix missing <think> tag after tool call in MiniMax 2.1

### DIFF
--- a/vllm/reasoning/minimax_m2_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m2_reasoning_parser.py
@@ -87,10 +87,15 @@ class MiniMaxM2AppendThinkReasoningParser(ReasoningParser):
     def __init__(self, tokenizer: TokenizerLike, *args, **kwargs):
         super().__init__(tokenizer, *args, **kwargs)
         self.end_token_id = self.vocab.get("</think>")
+        self.start_token_id = self.vocab.get("<think>")
 
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         end_token_id = self.end_token_id
-        return any(input_id == end_token_id for input_id in reversed(input_ids))
+        start_token_id = self.start_token_id
+        for input_id in reversed(input_ids):
+            if input_id in (end_token_id, start_token_id):
+                return input_ids == end_token_id
+        return True
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         return input_ids

--- a/vllm/reasoning/minimax_m2_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m2_reasoning_parser.py
@@ -95,7 +95,7 @@ class MiniMaxM2AppendThinkReasoningParser(ReasoningParser):
         for input_id in reversed(input_ids):
             if input_id in (end_token_id, start_token_id):
                 return input_id == end_token_id
-        return True
+        return False
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
         return input_ids

--- a/vllm/reasoning/minimax_m2_reasoning_parser.py
+++ b/vllm/reasoning/minimax_m2_reasoning_parser.py
@@ -94,7 +94,7 @@ class MiniMaxM2AppendThinkReasoningParser(ReasoningParser):
         start_token_id = self.start_token_id
         for input_id in reversed(input_ids):
             if input_id in (end_token_id, start_token_id):
-                return input_ids == end_token_id
+                return input_id == end_token_id
         return True
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:


### PR DESCRIPTION
Fix: #35349
## Purpose
This PR improves the reasoning end detection logic in MiniMaxM2AppendThinkReasoningParser.is_reasoning_end.  
After a successful tool call, the following line incorrectly evaluates to `True`, which causes the subsequent `<think>` tag to be missing.

https://github.com/vllm-project/vllm/blob/86c3b5a808506e325fd7e59d86d83170fc98c93c/vllm/entrypoints/openai/chat_completion/serving.py#L816

## Test Plan
```shell
CUDA_VISIBLE_DEVICES=3,4,5,6 python3 -m vllm.entrypoints.openai.api_server \
  --model MiniMax/MiniMax-M2.1 \
  --trust-remote-code \
  --tensor-parallel-size 4 \
  --enable-auto-tool-choice \
  --tool-call-parser minimax_m2 \
  --max-model-len 100000 \
  --reasoning-parser minimax_m2_append_think
```

```python
from openai import OpenAI
client = OpenAI(
    base_url="http://localhost:8000/v1",
    api_key="<KEY>"
)
resp = client.chat.completions.create(
    model="MiniMax/MiniMax-M2.1",
    messages=[
        {'role': 'system', 'name': 'system', 'content': [{'type': 'text', 'text': "You're a helpful assistant named Friday."}]},
        {'role': 'user', 'name': 'user', 'content': [{'type': 'text', 'text': 'Check what files are in the current folder.'}]},
        {
            'role': 'assistant',
            'name': 'Friday', 'content': [{'type': 'text', 'text': '<think>The user wants to see what files are in the current folder. I can use shell commands to list the files in the current directory.\n</think>\n\n\n'}],
            'tool_calls': [
                {'id': 'call_a62dc7eb4a984cb1b1a65d95', 'type': 'function', 'function': {'name': 'execute_shell_command', 'arguments': '{"command": "ls -la"}'}}
            ]
        },
        {'role': 'tool', 'tool_call_id': 'call_a62dc7eb4a984cb1b1a65d95', 'content': '<returncode>0</returncode><stdout>total 648\ndrwxr-xr-x  7 zcy  staff     224 Feb 24 16:34 .\ndrwxr-xr-x  8 zcy  staff     256 Feb 12 16:12 ..\n-rw-r--r--  1 zcy  staff    8205 Feb 24 16:34 1.py\n-rw-r--r--  1 zcy  staff    3136 Feb 12 16:34 2.py\ndrwxr-xr-x  3 zcy  staff      96 Feb 12 16:12 sample_skill\n-rw-r--r--  1 zcy  staff    6953 Feb 12 15:58 test_msg_class.py\n-rw-r--r--@ 1 zcy  staff  306217 Feb 24 16:03 vllm.log\n</stdout><stderr></stderr>', 'name': 'execute_shell_command'},
    ],
    stream=True,
)

for chunk in resp:
    # if hasattr(chunk.choices[0].delta, "reasoning"):
    #     print(chunk.choices[0].delta.reasoning, end="", flush=True)
    if chunk.choices[0].delta.content:
        print(chunk.choices[0].delta.content, end="", flush=True)
```
## Test Result
Before
```
The command executed successfully and listed the files in the current directory. Let me present this information in a more readable format for the user.
</think>

Here are the files in the current folder:

| File/Folder | Size | Last Modified |
|-------------|------|---------------|
| `1.py` | 8.2 KB | Feb 24 16:34 |
| `2.py` | 3.1 KB | Feb 12 16:34 |
| `sample_skill/` | 96 B | Feb 12 16:12 |
| `test_msg_class.py` | 6.9 KB | Feb 12 15:58 |
| `vllm.log` | 299 KB | Feb 24 16:03 |

**Total:** 5 items (4 files, 1 folder)
```

After
```
<think>The command executed successfully and listed the files in the current directory. Let me present this information in a more readable format for the user.
</think>

Here are the files and folders in the current directory:

| Name | Size | Last Modified |
|------|------|---------------|
| `1.py` | 8.2 KB | Feb 24 16:34 |
| `2.py` | 3.1 KB | Feb 24 16:34 |
| `sample_skill/` | 96 B | Feb 12 16:12 |
| `test_msg_class.py` | 6.9 KB | Feb 12 15:58 |
| `vllm.log` | 299 KB | Feb 24 16:03 |

**Folders:**
- `sample_skill/` - a directory

**Files:**
- Python scripts: `1.py`, `2.py`, `test_msg_class.py`
- Log file: `vllm.log`
Process finished with exit code 0
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

