### PR TITLE
[Bugfix] Remove erroneous lower bound on LoRA vocab size constraint

### DIFF
--- a/tests/lora/test_layers.py
+++ b/tests/lora/test_layers.py
@@ -469,7 +469,7 @@ def test_lm_head_logits_processor(
 
 
 @torch.inference_mode()
-@pytest.mark.parametrize("vocab_size", [512, 32000, 258049, 300000])
+@pytest.mark.parametrize("vocab_size", [258049, 300000])
 @pytest.mark.parametrize("device", DEVICES)
 def test_lm_head_logits_processor_invalid_vocab_size(
     default_vllm_config, dist_init, vocab_size, device
@@ -489,7 +489,7 @@ def test_lm_head_logits_processor_invalid_vocab_size(
         logits_processor, 1024, torch.float16, device, None
     )
 
-    with pytest.raises(ValueError, match="vocab size must be > 32000 and <= 258048"):
+    with pytest.raises(ValueError, match="vocab size must be <= 258048"):
         lora_logits_processor.create_lora_weights(max_loras, lora_config)
 
 

--- a/vllm/lora/layers/logits_processor.py
+++ b/vllm/lora/layers/logits_processor.py
@@ -88,10 +88,8 @@ class LogitsProcessorWithLoRA(BaseLayerWithLoRA):
         model_config: PretrainedConfig | None = None,
     ) -> None:
         # TODO: Verify if this condition can be further relaxed
-        if self.base_layer.vocab_size <= 32000 or self.base_layer.vocab_size > 258048:
-            raise ValueError(
-                "When using LoRA, vocab size must be > 32000 and <= 258048"
-            )
+        if self.base_layer.vocab_size > 258048:
+            raise ValueError("When using LoRA, vocab size must be <= 258048")
         self.lora_a_stacked = torch.zeros(
             (
                 max_loras,


### PR DESCRIPTION
FIX #35353

# Summary

Fixes `ValueError: When using LoRA, vocab size must be > 32000 and <= 258048` that breaks Mixtral LoRA tests.

# Root Cause

PR #34773 intended to increase the LoRA vocab size upper bound from 257024 to 258048, but accidentally introduced a lower bound check.

The original condition was:
```python
if 32000 < self.base_layer.vocab_size > 257024:
```

This is a Python chained comparison equivalent to:
```python
if (32000 < vocab_size) and (vocab_size > 257024):
```

Which simplifies to just `vocab_size > 257024` - the lower bound was never enforced.

PR #34773 changed it to:
```python
if self.base_layer.vocab_size <= 32000 or self.base_layer.vocab_size > 258048:
```

This now rejects `vocab_size <= 32000`, breaking models like Mixtral which has `vocab_size = 32000`.

# Fix

Remove the lower bound check since it was never enforced before:
```python
if self.base_layer.vocab_size > 258048:
```

## Test Plan

- [x] Update `test_lm_head_logits_processor_invalid_vocab_size` to only test upper bound violations
- [ ] CI: `lora/test_mixtral.py::test_mixtral_lora[4]`

## Related

- Regression from PR #34773
