### PR TITLE
feat: add trace spans for failed API requests

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -345,7 +345,8 @@ class OpenAIServingChat(OpenAIServing):
         except RuntimeError as e:
             logger.exception("Error in reasoning parser creation.")
             await self._trace_error_request(
-                raw_request, request_start_time_ns,
+                raw_request,
+                request_start_time_ns,
                 error_type=type(e).__name__,
                 error_message=str(e),
                 span_name="chat_completion_error",
@@ -354,7 +355,8 @@ class OpenAIServingChat(OpenAIServing):
         result = await self.render_chat_request(request)
         if isinstance(result, ErrorResponse):
             await self._trace_error_request(
-                raw_request, request_start_time_ns,
+                raw_request,
+                request_start_time_ns,
                 error_type="BadRequestError",
                 error_message=result.error.message,
                 span_name="chat_completion_error",
@@ -380,7 +382,8 @@ class OpenAIServingChat(OpenAIServing):
         except (ValueError, TypeError, RuntimeError) as e:
             logger.exception("Error preparing request components")
             await self._trace_error_request(
-                raw_request, request_start_time_ns,
+                raw_request,
+                request_start_time_ns,
                 error_type=type(e).__name__,
                 error_message=str(e),
                 span_name="chat_completion_error",
@@ -497,7 +500,8 @@ class OpenAIServingChat(OpenAIServing):
             )
         except GenerationError as e:
             await self._trace_error_request(
-                raw_request, request_start_time_ns,
+                raw_request,
+                request_start_time_ns,
                 error_type="GenerationError",
                 error_message=str(e),
                 span_name="chat_completion_error",
@@ -505,7 +509,8 @@ class OpenAIServingChat(OpenAIServing):
             return self._convert_generation_error_to_response(e)
         except ValueError as e:
             await self._trace_error_request(
-                raw_request, request_start_time_ns,
+                raw_request,
+                request_start_time_ns,
                 error_type=type(e).__name__,
                 error_message=str(e),
                 span_name="chat_completion_error",

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -141,7 +141,8 @@ class OpenAIServingCompletion(OpenAIServing):
         result = await self.render_completion_request(request)
         if isinstance(result, ErrorResponse):
             await self._trace_error_request(
-                raw_request, request_start_time_ns,
+                raw_request,
+                request_start_time_ns,
                 error_type="BadRequestError",
                 error_message=result.error.message,
                 span_name="completion_error",
@@ -162,7 +163,8 @@ class OpenAIServingCompletion(OpenAIServing):
         except (ValueError, TypeError, RuntimeError) as e:
             logger.exception("Error preparing request components")
             await self._trace_error_request(
-                raw_request, request_start_time_ns,
+                raw_request,
+                request_start_time_ns,
                 error_type=type(e).__name__,
                 error_message=str(e),
                 span_name="completion_error",
@@ -287,7 +289,8 @@ class OpenAIServingCompletion(OpenAIServing):
             )
         except asyncio.CancelledError:
             await self._trace_error_request(
-                raw_request, request_start_time_ns,
+                raw_request,
+                request_start_time_ns,
                 error_type="CancelledError",
                 error_message="Client disconnected",
                 span_name="completion_error",
@@ -295,7 +298,8 @@ class OpenAIServingCompletion(OpenAIServing):
             return self.create_error_response("Client disconnected")
         except GenerationError as e:
             await self._trace_error_request(
-                raw_request, request_start_time_ns,
+                raw_request,
+                request_start_time_ns,
                 error_type="GenerationError",
                 error_message=str(e),
                 span_name="completion_error",
@@ -303,7 +307,8 @@ class OpenAIServingCompletion(OpenAIServing):
             return self._convert_generation_error_to_response(e)
         except ValueError as e:
             await self._trace_error_request(
-                raw_request, request_start_time_ns,
+                raw_request,
+                request_start_time_ns,
                 error_type=type(e).__name__,
                 error_message=str(e),
                 span_name="completion_error",

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -125,7 +125,6 @@ from vllm.tracing import (
     extract_trace_context,
     extract_trace_headers,
     instrument_manual,
-    is_tracing_available,
     log_tracing_disabled_warning,
 )
 from vllm.utils import random_uuid

--- a/vllm/tracing/__init__.py
+++ b/vllm/tracing/__init__.py
@@ -125,6 +125,7 @@ def instrument_manual(
     attributes: dict[str, Any] | None = None,
     context: Any = None,
     kind: Any = None,
+    set_status_on_error: str | None = None,
 ):
     """Manually create a span with explicit timestamps.
 
@@ -135,11 +136,14 @@ def instrument_manual(
         attributes: Optional dict of span attributes.
         context: Optional trace context (e.g., from extract_trace_context).
         kind: Optional SpanKind (e.g., SpanKind.SERVER).
+        set_status_on_error: If provided, sets the span status to ERROR with
+            this string as the description.
     """
     is_available, _, _, _, manual_instrument_fn = _REGISTERED_TRACING_BACKENDS["otel"]
     if is_available():
         return manual_instrument_fn(
-            span_name, start_time, end_time, attributes, context, kind
+            span_name, start_time, end_time, attributes, context, kind,
+            set_status_on_error,
         )
     else:
         return None

--- a/vllm/tracing/__init__.py
+++ b/vllm/tracing/__init__.py
@@ -142,7 +142,12 @@ def instrument_manual(
     is_available, _, _, _, manual_instrument_fn = _REGISTERED_TRACING_BACKENDS["otel"]
     if is_available():
         return manual_instrument_fn(
-            span_name, start_time, end_time, attributes, context, kind,
+            span_name,
+            start_time,
+            end_time,
+            attributes,
+            context,
+            kind,
             set_status_on_error,
         )
     else:

--- a/vllm/tracing/otel.py
+++ b/vllm/tracing/otel.py
@@ -187,8 +187,20 @@ def manual_instrument_otel(
     attributes: dict[str, Any] | None = None,
     context: Context | None = None,
     kind: Any = None,  # SpanKind, but typed as Any for when OTEL unavailable
+    set_status_on_error: str | None = None,
 ):
-    """Manually create and end a span with explicit timestamps."""
+    """Manually create and end a span with explicit timestamps.
+
+    Args:
+        span_name: Name of the span to create.
+        start_time: Start time in nanoseconds since epoch.
+        end_time: Optional end time in nanoseconds. If None, ends immediately.
+        attributes: Optional dict of span attributes.
+        context: Optional trace context (e.g., from extract_trace_context).
+        kind: Optional SpanKind (e.g., SpanKind.SERVER).
+        set_status_on_error: If provided, sets the span status to ERROR with
+            this string as the description.
+    """
     if not _IS_OTEL_AVAILABLE:
         return
 
@@ -207,6 +219,10 @@ def manual_instrument_otel(
     span = tracer.start_span(**span_kwargs)
     if attributes:
         span.set_attributes(attributes)
+    if set_status_on_error is not None:
+        from opentelemetry.trace import StatusCode
+
+        span.set_status(StatusCode.ERROR, set_status_on_error)
     if end_time is not None:
         span.end(end_time=end_time)
     else:

--- a/vllm/tracing/utils.py
+++ b/vllm/tracing/utils.py
@@ -44,6 +44,10 @@ class SpanAttributes:
     GEN_AI_LATENCY_TIME_IN_MODEL_DECODE = "gen_ai.latency.time_in_model_decode"
     GEN_AI_LATENCY_TIME_IN_MODEL_INFERENCE = "gen_ai.latency.time_in_model_inference"
 
+    # Error attributes for failed request tracing
+    GEN_AI_ERROR_TYPE = "gen_ai.error.type"
+    GEN_AI_ERROR_MESSAGE = "gen_ai.error.message"
+
 
 class LoadingSpanAttributes:
     """Custom attributes for code-level tracing (file, line number)."""


### PR DESCRIPTION
## Summary
about #17528 
When tracing is enabled and the incoming request carries W3C trace-context headers (traceparent/tracestate), failed requests now produce an OpenTelemetry span with ERROR status. This closes a gap where only successful requests generated trace data, making it impossible to diagnose failures via distributed tracing.

## Changes

- **`vllm/tracing/utils.py`**: Add `GEN_AI_ERROR_TYPE` and `GEN_AI_ERROR_MESSAGE` to `SpanAttributes`
- **`vllm/tracing/otel.py`**: Extend `manual_instrument_otel` to accept `set_status_on_error` for marking spans as ERROR
- **`vllm/tracing/__init__.py`**: Pass through the new `set_status_on_error` parameter in `instrument_manual`
- **`vllm/entrypoints/openai/engine/serving.py`**: Add `_trace_error_request` helper to `OpenAIServing` base class
- **`vllm/entrypoints/openai/chat_completion/serving.py`**: Instrument all error paths in `create_chat_completion`
- **`vllm/entrypoints/openai/completion/serving.py`**: Instrument all error paths in `create_completion`

## Design

- **Zero overhead on normal path**: Spans are only created when tracing is enabled AND the request carries trace headers
- **Reuses existing infrastructure**: Built on top of `instrument_manual`, `extract_trace_context`, and `_get_trace_headers`
- **Minimal footprint**: 134 lines added across 6 files

## Testing

Manual verification with OpenTelemetry collector. The change is additive and does not affect existing behavior when tracing is disabled.