### PR TITLE
[Core] Use np.empty instead of np.full for dummy video profiling data

### DIFF
--- a/vllm/multimodal/profiling.py
+++ b/vllm/multimodal/profiling.py
@@ -130,7 +130,7 @@ class BaseDummyInputsBuilder(ABC, Generic[_I]):
     ) -> list[npt.NDArray]:
         if num_videos == 0:
             return []
-        video = np.full((num_frames, width, height, 3), 255)
+        video = np.empty((num_frames, width, height, 3), dtype=np.uint8)
         return [video] * num_videos
 
 


### PR DESCRIPTION
## Summary

The dummy video data in `_get_dummy_videos` (used for memory profiling) is never read for actual pixel values — it only needs to occupy the right amount of memory. Replace `np.full((num_frames, width, height, 3), 255)` with `np.empty((num_frames, width, height, 3), dtype=np.uint8)` to skip unnecessary memory initialization.

Also explicitly sets `dtype=np.uint8` to match the actual video frame dtype, reducing memory from float64 (default) to uint8.

## Benchmark

| Variant | Time | Speedup |
|---------|------|---------|
| np.full (original) | 6.97 ms | — |
| np.empty (optimized) | 0.03 ms | ~225x |

Shape: (32, 224, 224, 3)

<details>
<summary>Benchmark code</summary>

\`\`\`python
import numpy as np, time

shape = (32, 224, 224, 3)
ITERS = 200

def timeit(fn):
    fn()
    t0 = time.perf_counter()
    for _ in range(ITERS): fn()
    return (time.perf_counter() - t0) / ITERS

t_orig = timeit(lambda: np.full(shape, 255))
t_opt  = timeit(lambda: np.empty(shape, dtype=np.uint8))

a = np.full(shape, 255)
b = np.empty(shape, dtype=np.uint8)
assert a.shape == b.shape
assert b.dtype == np.uint8

print(f"np.full:  {t_orig*1000:.3f} ms")
print(f"np.empty: {t_opt*1000:.3f} ms")
print(f"Speedup:  {t_orig/t_opt:.1f}x")
\`\`\`

</details>