### PR TITLE
[Core] Use pybase64 consistently in AudioMediaIO

### DIFF
--- a/vllm/multimodal/media/audio.py
+++ b/vllm/multimodal/media/audio.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import base64
 from io import BytesIO
 from pathlib import Path
 
@@ -43,7 +42,7 @@ class AudioMediaIO(MediaIO[tuple[npt.NDArray, float]]):
         media_type: str,
         data: str,
     ) -> tuple[npt.NDArray, float]:
-        return self.load_bytes(base64.b64decode(data))
+        return self.load_bytes(pybase64.b64decode(data))
 
     def load_file(self, filepath: Path) -> tuple[npt.NDArray, float]:
         return librosa.load(filepath, sr=None)
@@ -60,7 +59,7 @@ class AudioMediaIO(MediaIO[tuple[npt.NDArray, float]]):
             soundfile.write(buffer, audio, sr, format=audio_format)
             data = buffer.getvalue()
 
-        return base64.b64encode(data).decode("utf-8")
+        return pybase64.b64encode(data).decode("utf-8")
 
 
 class AudioEmbeddingMediaIO(MediaIO[torch.Tensor]):


### PR DESCRIPTION
`AudioMediaIO.load_base64` and `encode_base64` still used stdlib `base64`
while the same file already imports and uses `pybase64` in
`AudioEmbeddingMediaIO`. This unifies on `pybase64` which provides
SIMD-accelerated base64 encoding/decoding via libbase64.

The `import base64` is removed since it is no longer used in this file.

Note: `validate=True` is intentionally NOT used for `b64decode` to match
the original stdlib behavior which accepts whitespace in input.

**Benchmark** (1MB payload, 500 iterations):
```
Decode: stdlib 3.4032 ms  pybase64 0.6940 ms  speedup 4.9x
Encode: stdlib 6.1315 ms  pybase64 1.3787 ms  speedup 4.4x
```