### PR TITLE
fix(mxfp4): return is_monolithic=False when LoRA is enabled for Triton backend

### DIFF
--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -1001,6 +1001,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
     @property
     def is_monolithic(self) -> bool:
+        if self.moe.is_lora_enabled:
+            return False
         return (
             self.mxfp4_backend == Mxfp4Backend.SM100_FI_MXFP4_MXFP8_TRTLLM
             or self.mxfp4_backend == Mxfp4Backend.SM100_FI_MXFP4_BF16


### PR DESCRIPTION
When LoRA is enabled with MXFP4 quantization and the Triton backend is selected (via VLLM_MXFP4_USE_MARLIN=0), the LoRA injection in FusedMoELoRALayer._inject_lora_into_fused_moe() wraps the quant method with FusedMoEModularMethod, which asserts not is_monolithic. However, is_monolithic unconditionally returns True for the Triton backend, causing an AssertionError.

---

## Purpose

Fix `AssertionError` when using MXFP4 quantization with LoRA adapters on the Triton backend (e.g., Hopper GPUs with `VLLM_MXFP4_USE_MARLIN=0`).

There is an inconsistency in `Mxfp4MoEMethod`:

1. `get_mxfp4_backend_with_lora()` explicitly returns `Mxfp4Backend.TRITON` as a valid LoRA-compatible backend (line 95-97).
2. `select_gemm_impl()` returns `UnfusedOAITritonExperts` when LoRA is enabled with the Triton backend (line 875-877), which is designed for the modular kernel path.
3. However, `is_monolithic` unconditionally returns `True` for the Triton backend (line 884-890), which causes `FusedMoEModularMethod.__init__` to fail at the assertion `assert not self.old_quant_method.is_monolithic` (`fused_moe_modular_method.py:40`).

The fix returns `False` from `is_monolithic` when `self.moe.is_lora_enabled` is `True`, so the modular kernel path is used with `UnfusedOAITritonExperts` as intended.

Crash traceback:
```
File "vllm/lora/layers/fused_moe.py", line 341, in _inject_lora_into_fused_moe
    self.base_layer.quant_method = FusedMoEModularMethod(...)
File "vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py", line 40
    assert not self.old_quant_method.is_monolithic
AssertionError
```

## Test Plan

```bash
export VLLM_MXFP4_USE_MARLIN=0
vllm serve openai/gpt-oss-20b \
  --enable-lora \
  --lora-modules my_adapter=./path/to/adapter \
  --max-loras 3 \
  --max-lora-rank 16
```

- [x] Server starts without `AssertionError`
- [x] `/v1/models` lists both the base model and LoRA adapters
- [x] Inference works with both base model and LoRA adapters

## Test Result

Tested on NVIDIA H100 NVL (SM90), driver 550.90.07, vllm 0.16.0, torch 2.9.1+cu128.

Before fix:
```
AssertionError  (at fused_moe_modular_method.py:40)
```

After fix:
```
INFO [mxfp4.py:96] [get_mxfp4_backend_with_lora] Using Triton backend
INFO [default_loader.py:293] Loading weights took 3.35 seconds
INFO Application startup complete.
```

Server successfully loaded `openai/gpt-oss-20b` (MXFP4) with LoRA adapters and served requests via the OpenAI-compatible API.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

