### PR TITLE
[Bugfix] Fix expired entries removal behavior for P2pNcclConnector proxy

### DIFF
--- a/examples/online_serving/disaggregated_serving_p2p_nccl_xpyd/disagg_proxy_p2p_nccl_xpyd.py
+++ b/examples/online_serving/disaggregated_serving_p2p_nccl_xpyd/disagg_proxy_p2p_nccl_xpyd.py
@@ -24,14 +24,12 @@ DEFAULT_PING_SECONDS = 5
 
 
 def _remove_oldest_instances(instances: dict[str, Any]) -> None:
-    oldest_key = next(iter(instances), None)
-    while oldest_key is not None:
-        value = instances[oldest_key]
-        if value[1] > time.time():
-            break
-        print(f"🔴Remove [HTTP:{oldest_key}, ZMQ:{value[0]}, stamp:{value[1]}]")
-        instances.pop(oldest_key, None)
-        oldest_key = next(iter(instances), None)
+    now = time.time()
+    expired_keys = [k for k, v in instances.items() if v[1] <= now]
+    for key in expired_keys:
+        value = instances[key]
+        print(f"🔴Remove [HTTP:{key}, ZMQ:{value[0]}, stamp:{value[1]}]")
+        instances.pop(key, None)
 
 
 def _listen_for_register(poller, router_socket):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fix a stale-instance cleanup bug in `_remove_oldest_instances`(disaggregated_serving_p2p_nccl_xpyd\disagg_proxy_p2p_nccl_xpyd.py) so expired instances are removed reliably regardless of dictionary insertion order.

## Problem

In the original implementation, `_remove_oldest_instances` only examined entries starting from the first dictionary key and stopped once it encountered a non-expired entry.

This behavior is incorrect because:

1. Python dict iteration order is insertion order, not expiry-time order. (**Since Python 3.7+, dict preserves insertion order, not “last updated” order.**  So updating an existing key within "_listen_for_register" will not update the dict order)
2. Expired entries that are not at the front can remain in the instance pool.
3. Stale instances may continue to be selected for routing, causing unexpected error/routing behavior.

## Solution

Changed `_remove_oldest_instances` to use a full-scan expiration cleanup:

- Compute `now = time.time()` once.
- Collect all keys with `expiry_ts <= now`.
- Remove each expired key from the dict.

This guarantees that all expired instances are removed on each cleanup invocation, independent of key order.

## Testing

- Code-level verification:
  - Confirmed the patch only changes `_remove_oldest_instances` logic in `disagg_proxy_p2p_nccl_xpyd.py`.
  - Confirmed no other runtime behavior paths were modified.
- Scenario validation (Launch P2P Nccl xpyd disaggregated serving, e.g., run `disagg_example_p2p_nccl_xpyd.sh`):
  - Expired instance in middle/end of dict is now removed.
  - Multiple expired entries are all removed in one pass.
  - Non-expired entries are preserved.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

