### PR TITLE
[Test] Add some gsm8k configs for hybrid models.

### DIFF
--- a/tests/evals/gsm8k/configs/hybrid/Qwen3-Next-FP8-TP4-MTP-Align.yaml
+++ b/tests/evals/gsm8k/configs/hybrid/Qwen3-Next-FP8-TP4-MTP-Align.yaml
@@ -1,0 +1,9 @@
+model_name: "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8"
+accuracy_threshold: 0.85
+num_questions: 1319
+num_fewshot: 5
+server_args: >-
+  --max-model-len 4096
+  --tensor-parallel-size 4
+  --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}'
+  --enable-prefix-caching

--- a/tests/evals/gsm8k/configs/hybrid/Qwen3-Next-FP8-TP4-MTP.yaml
+++ b/tests/evals/gsm8k/configs/hybrid/Qwen3-Next-FP8-TP4-MTP.yaml
@@ -1,0 +1,8 @@
+model_name: "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8"
+accuracy_threshold: 0.85
+num_questions: 1319
+num_fewshot: 5
+server_args: >-
+  --max-model-len 4096
+  --tensor-parallel-size 4
+  --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}'

--- a/tests/evals/gsm8k/configs/hybrid/Qwen3-Next-FP8-TP4.yaml
+++ b/tests/evals/gsm8k/configs/hybrid/Qwen3-Next-FP8-TP4.yaml
@@ -1,0 +1,7 @@
+model_name: "Qwen/Qwen3-Next-80B-A3B-Instruct-FP8"
+accuracy_threshold: 0.85
+num_questions: 1319
+num_fewshot: 5
+server_args: >-
+  --max-model-len 4096
+  --tensor-parallel-size 4

--- a/tests/evals/gsm8k/configs/hybrid/models-h100.txt
+++ b/tests/evals/gsm8k/configs/hybrid/models-h100.txt
@@ -1,0 +1,3 @@
+Qwen3-Next-FP8-TP4.yaml
+Qwen3-Next-FP8-TP4-MTP.yaml
+Qwen3-Next-FP8-TP4-MTP-Align.yaml


### PR DESCRIPTION
## Purpose

This PR adds some configs to the gsm8k testing framework that are very helpful for development on the hybrid models. I found this super helpful for debugging something I'm working on right now related to MTP + prefix caching + async scheduling. 

## Test Plan

They can be run with:
```
pytest -s -v tests/evals/gsm8k/test_gsm8k_correctness.py --config-list-file=tests/evals/gsm8k/configs/hybrid/models-h100.txt -k 'Qwen3-Next-FP8-TP4-MTP-Align'
```

## Test Result

```
GSM8K Results for Qwen/Qwen3-Next-80B-A3B-Instruct-FP8:
  Measured metric: 0.8264
  Expected metric: 0.8500
  Tolerance: 0.0800
  Questions: 1319
  Invalid rate: 0.000
  Latency: 78.5s
  QPS: 16.8
✅ GSM8K test passed for Qwen/Qwen3-Next-80B-A3B-Instruct-FP8
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

