### PR TITLE
[compile] Cleanup: Remove unnecessary +rms_norm forcing for sequence parallelism

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -857,7 +857,7 @@ class VllmConfig:
                 self.compilation_config.pass_config.fuse_gemm_comms = False
             else:
                 # Compute SP threshold early; disable if None (model too
-                # small) before +rms_norm gets forced into custom_ops.
+                # small for SP to be beneficial).
                 pass_config = self.compilation_config.pass_config
                 if pass_config.sp_min_token_num is None:
                     from vllm.compilation.passes.fusion.sequence_parallelism import (
@@ -879,14 +879,6 @@ class VllmConfig:
                     )
                     self.compilation_config.pass_config.enable_sp = False
                     self.compilation_config.pass_config.fuse_gemm_comms = False
-
-        if self.compilation_config.pass_config.enable_sp:
-            if "-rms_norm" in self.compilation_config.custom_ops:
-                logger.warning(
-                    "RMS norm force disabled, sequence parallelism might break"
-                )
-            else:
-                self.compilation_config.custom_ops.append("+rms_norm")
 
         if self.compilation_config.fast_moe_cold_start is None:
             # resolve default behavior: try to be as safe as possible


### PR DESCRIPTION
## Purpose

The SP pass no longer requires +rms_norm custom ops to be enabled. PR #27126 introduced MatcherRMSNorm which matches both custom op and native rms_norm implementations, making the forcing unnecessary.

Removing it allows native rms_norm to trace through inductor, which should improve performance. The +rms_norm forcing for PP>1 and dynamo partitioning is kept as a workaround for a separate tracing bug (#27894).

## Test Plan

CI

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

