### PR TITLE
[Bugfix] Fix EC connector unit tests after has_cache_item API change

### DIFF
--- a/tests/v1/ec_connector/unit/test_ec_example_connector.py
+++ b/tests/v1/ec_connector/unit/test_ec_example_connector.py
@@ -175,7 +175,7 @@ class TestCacheExistence:
     def test_has_cache_item_none_exist(
         self, mock_vllm_config_producer, mock_request_with_3_mm
     ):
-        """Test has_caches returns False when no caches exist."""
+        """Test has_cache_item returns False when no caches exist."""
         connector = ECExampleConnector(
             vllm_config=mock_vllm_config_producer,
             role=ECConnectorRole.SCHEDULER,
@@ -194,7 +194,7 @@ class TestCacheExistence:
     def test_has_cache_item_partial_exist(
         self, mock_vllm_config_producer, mock_request_with_3_mm
     ):
-        """Test has_caches with some caches existing (1 of 3)."""
+        """Test has_cache_item with some caches existing (1 of 3)."""
         connector = ECExampleConnector(
             vllm_config=mock_vllm_config_producer,
             role=ECConnectorRole.SCHEDULER,
@@ -607,17 +607,3 @@ class TestEdgeCases:
         # Should raise FileNotFoundError
         with pytest.raises(FileNotFoundError):
             connector.start_load_caches(encoder_cache=encoder_cache)
-
-    def test_has_caches_empty_request(self, mock_vllm_config_producer):
-        """Test has_caches with request that has no MM data."""
-        connector = ECExampleConnector(
-            vllm_config=mock_vllm_config_producer,
-            role=ECConnectorRole.SCHEDULER,
-        )
-
-        mock_request = MockRequest("req_empty", [], [])
-
-        result = connector.has_caches(mock_request)
-
-        assert len(result) == 0
-        assert result == []


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Remove a stale unit test path that still calls the removed `has_caches` API, keeping EC connector tests aligned with the current `has_cache_item` API.

## Problem

PR #32585 changed the EC connector API from `has_caches(request) -> list[bool]` to `has_cache_item(identifier) -> bool`

One test in `tests/v1/ec_connector/unit/test_ec_example_connector.py` still used the old API (`has_caches`), which causes unit tests to fail with `AttributeError`.

Note: CI currently does not cover `tests/v1/ec_connector/unit`, which allowed this mismatch to pass CI.

## Solution

This PR removes that stale old-API test path and keeps tests aligned with the current API.

`test_has_caches_empty_request` is safe to remove because it only checks behavior of the removed API (batch request check returning `[]` for empty request). Current `has_cache_item` behavior is already covered by existing tests (`all exist`, `none exist`, `partial exist`).

## Test Plan

```bash
python -m pytest -q tests/v1/ec_connector/unit/test_ec_example_connector.py
```

## Test Result

Before:
```
FAILED tests/v1/ec_connector/unit/test_ec_example_connector.py::TestEdgeCases::test_has_caches_empty_request - AttributeError: 'ECExampleConnector' object has no attribute 'has_caches'. Did you mean: 'save_caches'?
1 failed, 24 passed
```
After:
```
24 passed
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
