### PR TITLE
[Bugfix] Fix Qwen3Coder tool call streaming with speculative decoding

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1265,9 +1265,7 @@ class OpenAIServingChat(OpenAIServing):
                             if isinstance(args, str):
                                 expected_call = args
                             else:
-                                expected_call = json.dumps(
-                                    args, ensure_ascii=False
-                                )
+                                expected_call = json.dumps(args, ensure_ascii=False)
 
                             # get what we've streamed so far for arguments
                             # for the current tool

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1249,13 +1249,25 @@ class OpenAIServingChat(OpenAIServing):
                                 )
 
                             # get the expected call based on partial JSON
-                            # parsing which "autocompletes" the JSON
-                            expected_call = json.dumps(
-                                tool_parser.prev_tool_call_arr[index].get(
-                                    "arguments", {}
-                                ),
-                                ensure_ascii=False,
+                            # parsing which "autocompletes" the JSON.
+                            # Tool parsers (e.g. Qwen3Coder) store
+                            # arguments as a JSON string in
+                            # prev_tool_call_arr. Calling json.dumps()
+                            # on an already-serialized string would
+                            # double-serialize it (e.g. '{"k":1}' becomes
+                            # '"{\\"k\\":1}"'), which then causes the
+                            # replace() below to fail and append the
+                            # entire double-serialized string as a
+                            # spurious final delta.
+                            args = tool_parser.prev_tool_call_arr[index].get(
+                                "arguments", {}
                             )
+                            if isinstance(args, str):
+                                expected_call = args
+                            else:
+                                expected_call = json.dumps(
+                                    args, ensure_ascii=False
+                                )
 
                             # get what we've streamed so far for arguments
                             # for the current tool

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -567,8 +567,7 @@ class Qwen3CoderToolParser(ToolParser):
                                     break
                     except Exception:
                         logger.debug(
-                            "Failed to parse tool call during "
-                            "streaming: %s",
+                            "Failed to parse tool call during streaming: %s",
                             tool_text,
                             exc_info=True,
                         )
@@ -576,16 +575,11 @@ class Qwen3CoderToolParser(ToolParser):
                 # Send closing brace; the serving layer autocomplete
                 # will fill in any missing arguments based on
                 # prev_tool_call_arr vs streamed_args_for_tool.
-                if self.current_tool_index < len(
-                    self.streamed_args_for_tool
-                ):
-                    self.streamed_args_for_tool[
-                        self.current_tool_index
-                    ] += "}"
+                if self.current_tool_index < len(self.streamed_args_for_tool):
+                    self.streamed_args_for_tool[self.current_tool_index] += "}"
                 else:
                     logger.warning(
-                        "streamed_args_for_tool out of sync: "
-                        "index=%d len=%d",
+                        "streamed_args_for_tool out of sync: index=%d len=%d",
                         self.current_tool_index,
                         len(self.streamed_args_for_tool),
                     )
@@ -708,16 +702,13 @@ class Qwen3CoderToolParser(ToolParser):
 
                         # Track what we've streamed so the serving
                         # layer can compute remaining args at the end.
-                        if self.current_tool_index < len(
-                            self.streamed_args_for_tool
-                        ):
-                            self.streamed_args_for_tool[
-                                self.current_tool_index
-                            ] += json_fragment
+                        if self.current_tool_index < len(self.streamed_args_for_tool):
+                            self.streamed_args_for_tool[self.current_tool_index] += (
+                                json_fragment
+                            )
                         else:
                             logger.warning(
-                                "streamed_args_for_tool out of sync: "
-                                "index=%d len=%d",
+                                "streamed_args_for_tool out of sync: index=%d len=%d",
                                 self.current_tool_index,
                                 len(self.streamed_args_for_tool),
                             )

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -566,7 +566,12 @@ class Qwen3CoderToolParser(ToolParser):
                                     self.prev_tool_call_arr[i]["arguments"] = args
                                     break
                     except Exception:
-                        pass
+                        logger.debug(
+                            "Failed to parse tool call during "
+                            "streaming: %s",
+                            tool_text,
+                            exc_info=True,
+                        )
 
                 # Send closing brace; the serving layer autocomplete
                 # will fill in any missing arguments based on
@@ -577,6 +582,13 @@ class Qwen3CoderToolParser(ToolParser):
                     self.streamed_args_for_tool[
                         self.current_tool_index
                     ] += "}"
+                else:
+                    logger.warning(
+                        "streamed_args_for_tool out of sync: "
+                        "index=%d len=%d",
+                        self.current_tool_index,
+                        len(self.streamed_args_for_tool),
+                    )
 
                 result = DeltaMessage(
                     tool_calls=[
@@ -702,6 +714,13 @@ class Qwen3CoderToolParser(ToolParser):
                             self.streamed_args_for_tool[
                                 self.current_tool_index
                             ] += json_fragment
+                        else:
+                            logger.warning(
+                                "streamed_args_for_tool out of sync: "
+                                "index=%d len=%d",
+                                self.current_tool_index,
+                                len(self.streamed_args_for_tool),
+                            )
 
                         return DeltaMessage(
                             tool_calls=[


### PR DESCRIPTION
## Summary

Fixes broken tool call JSON when using `Qwen3CoderToolParser` (`--tool-call-parser qwen3_coder`) with speculative decoding (`--num-speculative-tokens N` where N >= 2).

PR #35347 partially addressed this for `num_speculative_tokens: 2` by adding `Qwen35CoderToolParser`, but the fix **still fails for `num_speculative_tokens: 3, 4, 5`** because the root cause is in the serving layer and in missing `streamed_args_for_tool` tracking in the base `Qwen3CoderToolParser`. This PR fixes the actual root causes directly in `Qwen3CoderToolParser`, so no separate parser class is needed.

## Root Cause Analysis

Three bugs interact to produce malformed tool call JSON:

### Bug 1: Double-serialization in `serving.py` (the primary cause)

`prev_tool_call_arr[index]["arguments"]` is already a JSON **string** (e.g. `'{"city": "Prague"}'`), but the serving layer calls `json.dumps()` on it again:

```python
# BEFORE (broken):
expected_call = json.dumps(
    tool_parser.prev_tool_call_arr[index].get("arguments", {}),
    ensure_ascii=False,
)
# Result: '"{\\"city\\": \\"Prague\\"}"' (double-serialized!)
```

This causes `expected_call.replace(actual_call, "", 1)` to fail (the format doesn't match), so `remaining_call` equals the entire double-serialized string, which gets appended as a spurious final delta. The client then assembles:

```
{"city": "Prague""{\"city\": \"Prague\"}"
```

### Bug 2: Missing `streamed_args_for_tool` tracking in `Qwen3CoderToolParser`

The parser never populates `self.streamed_args_for_tool`, but the serving layer reads it at stream end (`streamed_args_for_tool[index]`), causing `IndexError: list index out of range`.

### Bug 3: Conditional `{` sending can be skipped

The original condition `if not self.json_started and self.parameter_prefix not in delta_text` skips sending `{` when the delta contains parameter data (common with speculative decoding where multiple tokens arrive at once). But `json_started` is then set to `True` anyway, desyncing the tracked state from what was actually streamed.

## Changes

- **`serving.py`**: Check if `arguments` is already a string before calling `json.dumps()`, preventing double-serialization.
- **`qwen3coder_tool_parser.py`**: 
  - Add `streamed_args_for_tool` tracking at all argument emission points (header, `{`, parameters, `}`).
  - Always send `{` first regardless of delta content, removing the `parameter_prefix not in delta_text` condition.
  - Remove dead code (`if not self.json_started: self.json_started = True` was unreachable after the fix).

## How to Reproduce

```bash
# Start vLLM with speculative decoding and Qwen3Coder tool parser
vllm serve <model> \
  --tool-call-parser qwen3_coder \
  --speculative-model <draft_model> \
  --num-speculative-tokens 5

# Send a multi-turn tool call conversation. On the second turn
# (when the assistant's tool_call response is sent back), the
# server crashes with either:
#   - json.JSONDecodeError: Expecting ',' delimiter
#   - IndexError: list index out of range (streamed_args_for_tool)
```

With `num_speculative_tokens: 1` it works. With `:2` it may work (depending on token boundaries). With `:3` and above it consistently fails.

## Test Plan

- [x] Tested with `num_speculative_tokens: 1, 2, 3, 4, 5` — all work after the fix
- [x] Tested with multi-parameter tool calls (arrays, strings, integers)
- [x] Verified no regression for non-speculative-decoding tool calls
- [ ] Unit tests for `streamed_args_for_tool` population