### PR TITLE
[Bugfix] Add missing activation attr to RMSNormGated

### DIFF
--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -510,6 +510,7 @@ class RMSNormGated(CustomOp):
         norm_before_gate: bool = False,
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
+        activation: str = "swish",
     ):
         """Initialize RMSNormGated.
 
@@ -524,10 +525,12 @@ class RMSNormGated(CustomOp):
                               If False and z is provided: out = norm(x * silu(z))
             device: Device to create parameters on
             dtype: Data type for parameters
+            activation: Activation function name for gating
         """
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
         self.eps = eps
+        self.activation = activation
         self.weight = nn.Parameter(torch.empty(hidden_size, **factory_kwargs))
         self.register_parameter("bias", None)
         self.group_size = group_size


### PR DESCRIPTION
## Purpose

Fix `AttributeError: 'RMSNormGated' object has no attribute 'activation'` introduced in #35102.

#35102 added `activation=self.activation` to `RMSNormGated.forward_cuda()` in `layernorm.py` but did not add the `activation` parameter or `self.activation` attribute to `__init__()`. The sibling class in `fla/ops/layernorm_guard.py` was correctly updated.

Affects any model using `RMSNormGated` from `layernorm.py` — specifically Qwen3.5 GatedDeltaNet layers via `qwen3_next.py`.

## Changes

Add `activation: str = "swish"` parameter and `self.activation = activation` to `RMSNormGated.__init__()`, matching the implementation in `fla/ops/layernorm_guard.py`.

## Test plan

- Confirmed fix on 4x RTX PRO 6000 Blackwell serving Qwen3.5-122B-A10B (vLLM `0.16.1rc1.dev12+g111d86906`)
- Model loads and serves successfully after patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)