### PR TITLE
[Spec Decode] implement online hidden state extraction

### DIFF
--- a/tests/v1/kv_connector/unit/test_capturing_proposer.py
+++ b/tests/v1/kv_connector/unit/test_capturing_proposer.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for CapturingEagleProposer and capture_hidden_states."""
+import os
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.distributed.kv_transfer.kv_connector.online.online_hidden_states_connector import OnlineHiddenStatesConnector
+
+
+def _make_connector(tmp_path):
+    with patch.object(OnlineHiddenStatesConnector, "__init__",
+                      lambda self, *a, **k: None):
+        connector = OnlineHiddenStatesConnector.__new__(
+            OnlineHiddenStatesConnector)
+    connector._block_size, connector._storage_path = 16, str(tmp_path)
+    connector._vllm_config = connector._kv_transfer_config = MagicMock()
+    connector._active_requests, connector._req_blocks = {}, {}
+    connector._request_filenames = {}
+    connector.cache_layers, connector.num_hidden_states = [], 3
+    connector.use_compression, connector.compression_level = False, 3
+    connector.percentile_tracker = None
+    connector.decode_filenames, connector.request_filenames = {}, {}
+    connector.prev_step_info, connector.acceptance_lengths = {}, {}
+    connector.total_captured = connector.total_skipped = 0
+    connector.writer = None
+    return connector
+
+
+def _flush_and_shutdown(connector):
+    """Flush accumulated buffers via get_finished and shut down writer."""
+    req_ids = set(connector.decode_filenames.keys())
+    connector.get_finished(req_ids)
+    writer = connector.writer
+    if writer is not None:
+        writer.flush(timeout=5.0)
+        writer.shutdown()
+
+
+class TestCaptureHiddenStates:
+    def test_splits_per_request(self, tmp_path):
+        connector = _make_connector(tmp_path)
+        hidden_states = torch.randn(40, 4096)
+        token_ids = torch.arange(40, dtype=torch.long)
+        query_start_loc = torch.tensor([0, 10, 25, 40], dtype=torch.int32)
+
+        connector.capture_hidden_states(
+            hidden_states, token_ids, query_start_loc,
+            req_ids=["r1", "r2", "r3"],
+            lora_mapping=np.array([0, 0, 0]),
+            lora_lookup={})
+
+        _flush_and_shutdown(connector)
+
+        import safetensors.torch
+        for req_id, expected_len in [("r1", 10), ("r2", 15), ("r3", 15)]:
+            filepath = str(tmp_path / "base" / f"{req_id}.safetensors")
+            assert os.path.exists(filepath), f"Missing {filepath}"
+            loaded = safetensors.torch.load_file(filepath)
+            assert loaded["hidden_states"].shape[0] == expected_len
+            assert loaded["token_ids"].shape[0] == expected_len
+
+    def test_accumulates_across_steps(self, tmp_path):
+        connector = _make_connector(tmp_path)
+        mapping = np.array([0])
+        # Step 1: 4 tokens
+        connector.capture_hidden_states(
+            torch.randn(4, 256), torch.tensor([1, 2, 3, 4]),
+            torch.tensor([0, 4], dtype=torch.int32),
+            req_ids=["r1"], lora_mapping=mapping, lora_lookup={})
+        # Step 2: 4 more tokens
+        connector.capture_hidden_states(
+            torch.randn(4, 256), torch.tensor([5, 6, 7, 8]),
+            torch.tensor([0, 4], dtype=torch.int32),
+            req_ids=["r1"], lora_mapping=mapping, lora_lookup={})
+
+        _flush_and_shutdown(connector)
+
+        import safetensors.torch
+        loaded = safetensors.torch.load_file(
+            str(tmp_path / "base" / "r1.safetensors"))
+        assert loaded["hidden_states"].shape[0] == 8
+        assert loaded["token_ids"].shape[0] == 8
+        assert torch.equal(loaded["token_ids"],
+                           torch.tensor([1, 2, 3, 4, 5, 6, 7, 8]))
+
+    def test_lora_subdirs(self, tmp_path):
+        connector = _make_connector(tmp_path)
+        mock_lora = MagicMock()
+        mock_lora.lora_name = "my-adapter"
+
+        connector.capture_hidden_states(
+            torch.randn(30, 256), torch.arange(30, dtype=torch.long),
+            torch.tensor([0, 10, 20, 30], dtype=torch.int32),
+            req_ids=["r1", "r2", "r3"],
+            lora_mapping=np.array([0, 5, 5]),
+            lora_lookup={5: mock_lora})
+
+        _flush_and_shutdown(connector)
+
+        assert os.path.exists(str(tmp_path / "base" / "r1.safetensors"))
+        assert os.path.exists(
+            str(tmp_path / "my-adapter" / "r2.safetensors"))
+        assert os.path.exists(
+            str(tmp_path / "my-adapter" / "r3.safetensors"))
+
+    def test_skips_empty_requests(self, tmp_path):
+        connector = _make_connector(tmp_path)
+        connector.capture_hidden_states(
+            torch.randn(10, 256), torch.arange(10, dtype=torch.long),
+            torch.tensor([0, 0, 10], dtype=torch.int32),
+            req_ids=["r1", "r2"],
+            lora_mapping=np.array([0, 0]),
+            lora_lookup={})
+
+        _flush_and_shutdown(connector)
+
+        assert not os.path.exists(str(tmp_path / "base" / "r1.safetensors"))
+        assert os.path.exists(str(tmp_path / "base" / "r2.safetensors"))
+
+    def test_data_integrity(self, tmp_path):
+        connector = _make_connector(tmp_path)
+        hidden_states = torch.arange(20, dtype=torch.float32).reshape(4, 5)
+        token_ids = torch.tensor([10, 20, 30, 40], dtype=torch.long)
+
+        connector.capture_hidden_states(
+            hidden_states, token_ids,
+            torch.tensor([0, 2, 4], dtype=torch.int32),
+            req_ids=["r1", "r2"],
+            lora_mapping=np.array([0, 0]),
+            lora_lookup={})
+
+        _flush_and_shutdown(connector)
+
+        import safetensors.torch
+        r1 = safetensors.torch.load_file(
+            str(tmp_path / "base" / "r1.safetensors"))
+        assert torch.equal(r1["hidden_states"], hidden_states[:2])
+        assert torch.equal(r1["token_ids"], token_ids[:2])
+
+        r2 = safetensors.torch.load_file(
+            str(tmp_path / "base" / "r2.safetensors"))
+        assert torch.equal(r2["hidden_states"], hidden_states[2:4])
+        assert torch.equal(r2["token_ids"], token_ids[2:4])
+
+    def test_no_files_before_flush(self, tmp_path):
+        """Data is only written to disk after get_finished flushes."""
+        connector = _make_connector(tmp_path)
+        connector.capture_hidden_states(
+            torch.randn(10, 256), torch.arange(10, dtype=torch.long),
+            torch.tensor([0, 10], dtype=torch.int32),
+            req_ids=["r1"],
+            lora_mapping=np.array([0]),
+            lora_lookup={})
+
+        # Before flush: no files on disk
+        assert not os.path.exists(str(tmp_path / "base" / "r1.safetensors"))
+
+        _flush_and_shutdown(connector)
+
+        # After flush: file exists
+        assert os.path.exists(str(tmp_path / "base" / "r1.safetensors"))
+
+    def test_discard_drops_accumulated(self, tmp_path):
+        """Discarding a request drops accumulated buffers without writing."""
+        connector = _make_connector(tmp_path)
+        connector.capture_hidden_states(
+            torch.randn(10, 256), torch.arange(10, dtype=torch.long),
+            torch.tensor([0, 10], dtype=torch.int32),
+            req_ids=["r1"],
+            lora_mapping=np.array([0]),
+            lora_lookup={})
+
+        # Manually discard instead of flushing
+        writer = connector.get_writer()
+        writer.discard_request("r1")
+        connector.decode_filenames.pop("r1", None)
+        writer.flush(timeout=5.0)
+        writer.shutdown()
+
+        assert not os.path.exists(str(tmp_path / "base" / "r1.safetensors"))

--- a/tests/v1/kv_connector/unit/test_online_connector.py
+++ b/tests/v1/kv_connector/unit/test_online_connector.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for OnlineHiddenStatesConnector."""
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm.distributed.kv_transfer.kv_connector.online.hidden_states_writer import HiddenStatesWriter
+from vllm.distributed.kv_transfer.kv_connector.online.online_hidden_states_connector import OnlineHiddenStatesConnector
+from vllm.distributed.kv_transfer.kv_connector.online.percentile_tracker import PercentileTracker
+
+
+@pytest.fixture
+def writer(tmp_path):
+    w = HiddenStatesWriter(str(tmp_path), use_compression=False)
+    yield w
+    w.shutdown()
+
+
+def _make_connector(tmp_path, capture_percentile=0.0):
+    with patch.object(OnlineHiddenStatesConnector, "__init__",
+                      lambda self, *a, **k: None):
+        c = OnlineHiddenStatesConnector.__new__(OnlineHiddenStatesConnector)
+    c._block_size, c._storage_path = 16, str(tmp_path)
+    c._vllm_config = c._kv_transfer_config = MagicMock()
+    c._active_requests, c._req_blocks, c._request_filenames = {}, {}, {}
+    c.cache_layers, c.num_hidden_states = [], 3
+    c.use_compression, c.compression_level = False, 3
+    c.percentile_tracker, c.writer = None, None
+    c.decode_filenames, c.request_filenames = {}, {}
+    c.prev_step_info, c.acceptance_lengths = {}, {}
+    c.total_captured = c.total_skipped = 0
+    if capture_percentile > 0:
+        c.percentile_tracker = PercentileTracker(
+            percentile=capture_percentile, window_size=1000, min_samples=5)
+    return c
+
+
+@pytest.fixture
+def connector(tmp_path):
+    return _make_connector(tmp_path)
+
+
+def _mock_request(req_id):
+    mock = MagicMock()
+    mock.request_id = req_id
+    return mock
+
+
+def _setup_request(connector, tmp_path, req_id, lora=None):
+    subdir = lora or "base"
+    prefill_path = str(tmp_path / subdir / f"{req_id}.safetensors")
+    decode_path = str(tmp_path / subdir / f"{req_id}_decode.safetensors")
+    connector.request_filenames[req_id] = (prefill_path, decode_path)
+    connector._active_requests[req_id] = "mock"
+    return prefill_path, decode_path
+
+
+def _mock_scheduler_output(reqs):
+    output = MagicMock()
+    output.scheduled_new_reqs = reqs
+    output.scheduled_spec_decode_tokens = {}
+    output.num_scheduled_tokens = {r.req_id: 1 for r in reqs}
+    cached = MagicMock()
+    cached.req_ids, cached.num_computed_tokens, cached.new_block_ids = [], [], []
+    output.scheduled_cached_reqs = cached
+    return output
+
+
+def _mock_new_request(req_id, lora=None):
+    req = MagicMock()
+    req.req_id = req_id
+    req.prompt_token_ids = [1, 2, 3]
+    req.block_ids = ([0, 1],)
+    req.num_computed_tokens = 0
+    req.lora_request = None
+    if lora:
+        req.lora_request = MagicMock()
+        req.lora_request.lora_name = lora
+    return req
+
+
+class TestPercentileTracker:
+    def test_warmup_captures_everything(self):
+        t = PercentileTracker(percentile=10.0, window_size=100, min_samples=50)
+        for _ in range(49):
+            assert t.should_capture(100.0) is True
+            t.observe(100.0)
+
+    def test_filtering_after_warmup(self):
+        t = PercentileTracker(percentile=10.0, window_size=1000, min_samples=100)
+        for i in range(200):
+            t.observe(float(i + 1))
+        assert t.should_capture(1.0) is True
+        assert t.should_capture(100.0) is False
+
+    def test_observe_and_check_atomic(self):
+        t = PercentileTracker(percentile=50.0, window_size=100, min_samples=10)
+        for i in range(20):
+            t.observe(float(i))
+        n = t.get_stats()["num_samples"]
+        t.observe_and_check(5.0)
+        assert t.get_stats()["num_samples"] == n + 1
+
+    def test_sliding_window_eviction(self):
+        t = PercentileTracker(percentile=50.0, window_size=10, min_samples=5)
+        for _ in range(10):
+            t.observe(1.0)
+        for _ in range(10):
+            t.observe(100.0)
+        assert t.get_stats()["min_acceptance"] == 100.0
+
+    def test_uniform_distribution_filters(self):
+        """When all values are identical, should_capture respects percentile."""
+        t = PercentileTracker(percentile=5.0, window_size=1000, min_samples=10)
+        for _ in range(200):
+            t.observe(2.0)
+        # All values are 2.0, threshold is 2.0, fraction_at_threshold ~ 0.05
+        # Run many trials to check statistical behavior
+        import random
+        random.seed(42)
+        captured = sum(t.should_capture(2.0) for _ in range(1000))
+        # With p5, expect ~5% capture rate (50 out of 1000)
+        assert 10 < captured < 120, f"Expected ~50 captures, got {captured}"
+
+    def test_get_stats(self):
+        assert PercentileTracker().get_stats()["num_samples"] == 0
+        t = PercentileTracker(percentile=25.0, min_samples=5)
+        for v in range(1, 11):
+            t.observe(float(v))
+        assert t.get_stats()["mean_acceptance"] == pytest.approx(5.5)
+
+
+class TestHiddenStatesWriter:
+    def test_write_and_read(self, writer, tmp_path):
+        hs = torch.randn(10, 4, 256)
+        tids = torch.arange(10, dtype=torch.long)
+        f = str(tmp_path / "test.safetensors")
+        writer.write_async(hs, tids, f)
+        writer.flush(timeout=5.0)
+        import safetensors.torch
+        loaded = safetensors.torch.load_file(f)
+        assert loaded["hidden_states"].shape == hs.shape
+        assert torch.equal(loaded["token_ids"], tids)
+
+    def test_compression(self, tmp_path):
+        pytest.importorskip("zstandard")
+        w = HiddenStatesWriter(str(tmp_path), use_compression=True)
+        f = str(tmp_path / "c.safetensors")
+        w.write_async(torch.randn(20, 4, 128), torch.arange(20, dtype=torch.long), f)
+        w.flush(timeout=5.0)
+        assert os.path.exists(f + ".zst")
+        w.shutdown()
+
+    def test_data_integrity(self, writer, tmp_path):
+        hs = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+        tids = torch.tensor([100, 200], dtype=torch.long)
+        f = str(tmp_path / "int.safetensors")
+        writer.write_async(hs, tids, f)
+        writer.flush(timeout=5.0)
+        import safetensors.torch
+        assert torch.equal(safetensors.torch.load_file(f)["hidden_states"], hs)
+
+    def test_creates_subdirs(self, writer, tmp_path):
+        hs, tids = torch.randn(4, 3, 64), torch.arange(4, dtype=torch.long)
+        writer.write_async(hs, tids, str(tmp_path / "base" / "r1.safetensors"))
+        writer.write_async(hs, tids, str(tmp_path / "lora" / "r2.safetensors"))
+        writer.flush(timeout=5.0)
+        assert (tmp_path / "base" / "r1.safetensors").exists()
+        assert (tmp_path / "lora" / "r2.safetensors").exists()
+
+
+class TestWriterAccumulate:
+    def test_accumulate_and_flush(self, writer, tmp_path):
+        for i in range(3):
+            writer.accumulate_async("r1", torch.randn(1, 3, 256),
+                                    torch.tensor([i], dtype=torch.long))
+        f = str(tmp_path / "base" / "r1_decode.safetensors")
+        writer.flush_request("r1", f)
+        writer.flush(timeout=5.0)
+        import safetensors.torch
+        assert safetensors.torch.load_file(f)["hidden_states"].shape == (3, 3, 256)
+
+    def test_flush_empty_is_noop(self, writer, tmp_path):
+        f = str(tmp_path / "empty.safetensors")
+        writer.flush_request("nonexistent", f)
+        writer.flush(timeout=5.0)
+        assert not os.path.exists(f)
+
+    def test_discard_cleans_buffers(self, writer):
+        writer.accumulate_async("r1", torch.randn(1, 3, 64),
+                                torch.tensor([1], dtype=torch.long))
+        writer.discard_request("r1")
+        assert "r1" not in writer.decode_hidden_states
+
+    def test_shutdown_clears_and_joins(self, tmp_path):
+        w = HiddenStatesWriter(str(tmp_path), use_compression=False)
+        w.accumulate_async("r1", torch.randn(1, 3, 64),
+                           torch.tensor([1], dtype=torch.long))
+        w.shutdown()
+        assert len(w.decode_hidden_states) == 0
+        assert not w.writer_thread.is_alive()
+
+
+class TestGetFinished:
+    def test_flushes_decode(self, connector, tmp_path):
+        w = connector.get_writer()
+        for i in range(3):
+            w.accumulate_async("r1", torch.randn(1, 3, 256),
+                               torch.tensor([i], dtype=torch.long))
+        connector.decode_filenames["r1"] = str(tmp_path / "base" / "r1_decode.safetensors")
+        connector.get_finished({"r1"})
+        w.flush(timeout=5.0)
+        assert os.path.exists(str(tmp_path / "base" / "r1_decode.safetensors"))
+        w.shutdown()
+
+    def test_no_decode_no_file(self, connector, tmp_path):
+        connector.decode_filenames["r1"] = str(tmp_path / "base" / "r1_decode.safetensors")
+        connector.get_finished({"r1"})
+        assert not os.path.exists(str(tmp_path / "base" / "r1_decode.safetensors"))
+
+    def test_cleans_state(self, connector):
+        connector.decode_filenames.update({"r1": "/tmp/x", "r2": "/tmp/y"})
+        connector.get_finished({"r1", "r2"})
+        assert len(connector.decode_filenames) == 0
+
+
+class TestRequestFinished:
+    def test_returns_both_paths(self, connector, tmp_path):
+        prefill_path, decode_path = _setup_request(connector, tmp_path, "r1")
+        _, params = connector.request_finished(_mock_request("r1"), [])
+        assert params["hidden_states_prefill"] == prefill_path
+        assert params["hidden_states_decode"] == decode_path
+
+    def test_cleans_all_state(self, connector, tmp_path):
+        _setup_request(connector, tmp_path, "r1")
+        connector.prev_step_info["r1"] = (10, 2)
+        connector.acceptance_lengths["r1"] = [1.5]
+        connector.request_finished(_mock_request("r1"), [])
+        for d in (connector.request_filenames, connector._active_requests,
+                  connector.prev_step_info, connector.acceptance_lengths):
+            assert "r1" not in d
+
+    def test_missing_req(self, connector):
+        assert connector.request_finished(_mock_request("nope"), [])[1]["hidden_states_prefill"] is None
+
+    def test_isolates_requests(self, connector, tmp_path):
+        _setup_request(connector, tmp_path, "a")
+        _setup_request(connector, tmp_path, "b")
+        connector.request_finished(_mock_request("a"), [])
+        assert "a" not in connector.request_filenames and "b" in connector.request_filenames
+
+    def test_shutdown_flushes(self, connector, tmp_path):
+        w = connector.get_writer()
+        w.write_async(torch.randn(4, 3, 64), torch.arange(4, dtype=torch.long),
+                      str(tmp_path / "base" / "t.safetensors"))
+        connector.shutdown()
+        assert os.path.exists(str(tmp_path / "base" / "t.safetensors"))
+
+
+class TestPercentileFiltering:
+    def test_bad_acceptance_keeps(self, tmp_path):
+        c = _make_connector(tmp_path, capture_percentile=10.0)
+        for _ in range(20):
+            c.percentile_tracker.observe(5.0)
+        prefill_path, _ = _setup_request(c, tmp_path, "bad")
+        c.acceptance_lengths["bad"] = [1.0, 1.0]
+        assert c.request_finished(_mock_request("bad"), [])[1]["hidden_states_prefill"] == prefill_path
+
+    def test_good_acceptance_deletes(self, tmp_path):
+        c = _make_connector(tmp_path, capture_percentile=10.0)
+        for _ in range(20):
+            c.percentile_tracker.observe(1.5)
+        prefill_path, decode_path = _setup_request(c, tmp_path, "good")
+        os.makedirs(os.path.dirname(prefill_path), exist_ok=True)
+        for path in (prefill_path, decode_path):
+            open(path, "wb").write(b"x")
+        c.acceptance_lengths["good"] = [5.0, 5.0]
+        assert c.request_finished(_mock_request("good"), [])[1]["hidden_states_prefill"] is None
+        assert not os.path.exists(prefill_path) and not os.path.exists(decode_path)
+
+    def test_no_acceptance_keeps(self, tmp_path):
+        c = _make_connector(tmp_path, capture_percentile=10.0)
+        _setup_request(c, tmp_path, "p")
+        assert c.request_finished(_mock_request("p"), [])[1]["hidden_states_prefill"] is not None
+
+    def test_disabled_always_keeps(self, connector, tmp_path):
+        _setup_request(connector, tmp_path, "r")
+        assert connector.request_finished(_mock_request("r"), [])[1]["hidden_states_prefill"] is not None
+
+
+class TestLoraLayout:
+    def test_base_subdir(self, connector):
+        connector.build_connector_meta(_mock_scheduler_output([_mock_new_request("r1")]))
+        prefill_path, decode_path = connector.request_filenames["r1"]
+        assert "/base/" in prefill_path and prefill_path.endswith("r1.safetensors")
+        assert decode_path.endswith("r1_decode.safetensors")
+
+    def test_lora_subdir(self, connector):
+        connector.build_connector_meta(_mock_scheduler_output([_mock_new_request("r1", "my-lora")]))
+        assert "/my-lora/" in connector.request_filenames["r1"][0]
+
+    def test_multiple_adapters(self, connector):
+        connector.build_connector_meta(
+            _mock_scheduler_output([_mock_new_request("r1"), _mock_new_request("r2", "a"), _mock_new_request("r3", "b")]))
+        assert "/base/" in connector.request_filenames["r1"][0]
+        assert "/a/" in connector.request_filenames["r2"][0]
+        assert "/b/" in connector.request_filenames["r3"][0]

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -156,6 +156,12 @@ KVConnectorFactory.register_connector(
 )
 
 KVConnectorFactory.register_connector(
+    "OnlineHiddenStatesConnector",
+    "vllm.distributed.kv_transfer.kv_connector.online.online_hidden_states_connector",
+    "OnlineHiddenStatesConnector",
+)
+
+KVConnectorFactory.register_connector(
     "P2pNcclConnector",
     "vllm.distributed.kv_transfer.kv_connector.v1.p2p.p2p_nccl_connector",
     "P2pNcclConnector",

--- a/vllm/distributed/kv_transfer/kv_connector/online/__init__.py
+++ b/vllm/distributed/kv_transfer/kv_connector/online/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/distributed/kv_transfer/kv_connector/online/hidden_states_writer.py
+++ b/vllm/distributed/kv_transfer/kv_connector/online/hidden_states_writer.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+import queue
+import tempfile
+import threading
+import time
+from collections import deque
+
+import safetensors.torch
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+try:
+    import zstandard as zstd
+    ZSTD_AVAILABLE = True
+except ImportError:
+    ZSTD_AVAILABLE = False
+
+
+class PinnedBufferPool:
+    """Reusable pinned-memory tensors keyed by (shape, dtype)."""
+
+    def __init__(self, max_per_key: int = 8):
+        self.max_per_key = max_per_key
+        self.pool: dict[tuple, deque[torch.Tensor]] = {}
+
+    def get(self, shape: tuple, dtype: torch.dtype) -> torch.Tensor:
+        key = (shape, dtype)
+        if buffers := self.pool.get(key):
+            return buffers.popleft()
+        return torch.empty(shape, dtype=dtype, pin_memory=True)
+
+    def put(self, tensor: torch.Tensor) -> None:
+        key = (tuple(tensor.shape), tensor.dtype)
+        buffers = self.pool.setdefault(key, deque())
+        if len(buffers) < self.max_per_key:
+            buffers.append(tensor)
+
+
+class HiddenStatesWriter:
+    """Non-blocking safetensors writer with async GPU→pinned transfer."""
+
+    def __init__(
+        self,
+        storage_path: str = "/tmp",
+        use_compression: bool = True,
+        compression_level: int = 3,
+    ):
+        self.storage_path = storage_path
+        self.compression_enabled = use_compression and ZSTD_AVAILABLE
+        self.compression_level = compression_level
+        os.makedirs(storage_path, exist_ok=True)
+
+        if use_compression and not ZSTD_AVAILABLE:
+            logger.warning(
+                "Compression requested but zstandard not installed."
+            )
+
+        self.transfer_stream: torch.cuda.Stream | None = None
+        self.write_queue: queue.Queue = queue.Queue(maxsize=1000)
+        self.is_shutdown = False
+        self.pinned_pool = PinnedBufferPool()
+        self.compressor = None
+        if self.compression_enabled:
+            self.compressor = zstd.ZstdCompressor(level=compression_level)
+
+        # Per-request decode accumulation buffers (pinned CPU tensors)
+        self.decode_hidden_states: dict[str, list[torch.Tensor]] = {}
+        self.decode_token_ids: dict[str, list[torch.Tensor]] = {}
+        self.decode_events: dict[str, list[torch.cuda.Event]] = {}
+
+        self.total_writes = 0
+        self.total_bytes = 0
+
+        self.writer_thread = threading.Thread(
+            target=self.writer_loop, daemon=True, name="hs-writer",
+        )
+        self.writer_thread.start()
+        logger.info(
+            "HiddenStatesWriter initialized: path=%s, compression=%s",
+            storage_path, self.compression_enabled,
+        )
+
+    def copy_to_pinned(
+        self, hidden_states: torch.Tensor, token_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.cuda.Event | None]:
+        """Copy GPU tensors to pinned memory on the transfer stream."""
+        device = hidden_states.device
+        if device.type == "cuda":
+            if self.transfer_stream is None:
+                self.transfer_stream = torch.cuda.Stream(device=device)
+            stream = self.transfer_stream
+            hs_pinned = self.pinned_pool.get(
+                tuple(hidden_states.shape), hidden_states.dtype,
+            )
+            tids_pinned = self.pinned_pool.get(
+                tuple(token_ids.shape), token_ids.dtype,
+            )
+            with torch.cuda.stream(stream):
+                stream.wait_stream(torch.cuda.default_stream(device))
+                hs_pinned.copy_(hidden_states, non_blocking=True)
+                tids_pinned.copy_(token_ids, non_blocking=True)
+                event = torch.cuda.Event()
+                event.record()
+            return hs_pinned, tids_pinned, event
+        else:
+            return hidden_states.clone(), token_ids.clone(), None
+
+    def write_async(
+        self,
+        hidden_states: torch.Tensor,
+        token_ids: torch.Tensor,
+        filename: str,
+    ) -> None:
+        """Copy to pinned memory and queue for immediate write."""
+        hs_pinned, tids_pinned, event = self.copy_to_pinned(
+            hidden_states, token_ids,
+        )
+        try:
+            self.write_queue.put_nowait({
+                "hidden_states": hs_pinned,
+                "token_ids": tids_pinned,
+                "filename": filename,
+                "event": event,
+            })
+        except queue.Full:
+            # Return pinned buffers to pool to avoid leak
+            if hs_pinned.is_pinned():
+                self.pinned_pool.put(hs_pinned)
+            if tids_pinned.is_pinned():
+                self.pinned_pool.put(tids_pinned)
+            logger.warning("Write queue full, dropping %s", filename)
+
+    def accumulate_async(
+        self,
+        req_id: str,
+        hidden_states: torch.Tensor,
+        token_ids: torch.Tensor,
+    ) -> None:
+        """Copy decode token to pinned memory and accumulate per-request."""
+        hs_pinned, tids_pinned, event = self.copy_to_pinned(
+            hidden_states, token_ids,
+        )
+        if req_id not in self.decode_hidden_states:
+            self.decode_hidden_states[req_id] = []
+            self.decode_token_ids[req_id] = []
+            self.decode_events[req_id] = []
+        self.decode_hidden_states[req_id].append(hs_pinned)
+        self.decode_token_ids[req_id].append(tids_pinned)
+        if event is not None:
+            self.decode_events[req_id].append(event)
+
+    def flush_request(self, req_id: str, filename: str) -> None:
+        """Concatenate accumulated decode buffers and queue for write."""
+        hs_chunks = self.decode_hidden_states.pop(req_id, None)
+        tids_chunks = self.decode_token_ids.pop(req_id, None)
+        events = self.decode_events.pop(req_id, None)
+
+        if not hs_chunks:
+            return
+
+        if events:
+            for e in events:
+                e.synchronize()
+
+        hs_concat = torch.cat(hs_chunks, dim=0)
+        tids_concat = torch.cat(tids_chunks, dim=0)
+
+        for buf in hs_chunks:
+            if buf.is_pinned():
+                self.pinned_pool.put(buf)
+        for buf in tids_chunks:
+            if buf.is_pinned():
+                self.pinned_pool.put(buf)
+
+        try:
+            self.write_queue.put_nowait({
+                "hidden_states": hs_concat,
+                "token_ids": tids_concat,
+                "filename": filename,
+                "event": None,
+            })
+        except queue.Full:
+            logger.warning("Write queue full, dropping decode %s", filename)
+
+    def discard_request(self, req_id: str) -> None:
+        """Discard accumulated decode buffers without writing."""
+        hs_chunks = self.decode_hidden_states.pop(req_id, None)
+        tids_chunks = self.decode_token_ids.pop(req_id, None)
+        self.decode_events.pop(req_id, None)
+        if hs_chunks:
+            for buf in hs_chunks:
+                if buf.is_pinned():
+                    self.pinned_pool.put(buf)
+        if tids_chunks:
+            for buf in tids_chunks:
+                if buf.is_pinned():
+                    self.pinned_pool.put(buf)
+
+    def writer_loop(self) -> None:
+        while not self.is_shutdown:
+            try:
+                item = self.write_queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            try:
+                event = item.get("event")
+                if event is not None:
+                    event.synchronize()
+
+                tensors = {
+                    "hidden_states": item["hidden_states"],
+                    "token_ids": item["token_ids"],
+                }
+                filepath = item["filename"]
+                os.makedirs(os.path.dirname(filepath), exist_ok=True)
+
+                if self.compression_enabled:
+                    filepath += ".zst"
+                    self.write_compressed(tensors, filepath)
+                else:
+                    safetensors.torch.save_file(tensors, filepath)
+
+                self.total_writes += 1
+                self.total_bytes += os.path.getsize(filepath)
+
+                for key in ("hidden_states", "token_ids"):
+                    t = item[key]
+                    if t.is_pinned():
+                        self.pinned_pool.put(t)
+            except Exception as e:
+                logger.error("Error writing %s: %s",
+                             item.get("filename", "?"), e)
+
+    def write_compressed(
+        self, tensors: dict[str, torch.Tensor], filepath: str,
+    ) -> None:
+        raw_bytes = safetensors.torch.save(tensors)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=os.path.dirname(filepath), prefix="tmp_hs_",
+        )
+        try:
+            compressed = self.compressor.compress(raw_bytes)
+            os.write(fd, compressed)
+            os.close(fd)
+            fd = -1
+            os.replace(tmp_path, filepath)
+        except Exception:
+            if fd >= 0:
+                os.close(fd)
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            raise
+
+    def flush(self, timeout: float = 10.0) -> None:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.write_queue.empty():
+                return
+            time.sleep(0.01)
+        logger.warning("Flush timed out after %.1fs", timeout)
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        # Discard any remaining decode buffers to free pinned memory
+        for req_id in list(self.decode_hidden_states.keys()):
+            self.discard_request(req_id)
+        # Drain the write queue
+        self.flush(timeout=timeout)
+        logger.info(
+            "HiddenStatesWriter shutting down. "
+            "Writes: %d, Bytes: %.1f MB",
+            self.total_writes, self.total_bytes / 1024 / 1024,
+        )
+        self.is_shutdown = True
+        self.writer_thread.join(timeout=timeout)

--- a/vllm/distributed/kv_transfer/kv_connector/online/online_hidden_states_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/online/online_hidden_states_connector.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+from typing import TYPE_CHECKING
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.example_hidden_states_connector import (  # noqa: E501
+    ExampleHiddenStatesConnector,
+    ExampleHiddenStatesConnectorMetadata,
+    extract_from_kv_cache,
+)
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+
+logger = init_logger(__name__)
+
+
+class OnlineHiddenStatesConnector(ExampleHiddenStatesConnector):
+    """Async two-file hidden states capture for EAGLE drafter training.
+
+    Scheduler and worker run as separate instances in the same process.
+    Percentile filtering decisions are communicated via the class-level
+    ``discard_req_ids`` set: the scheduler adds IDs in request_finished,
+    and the worker checks them in get_finished.
+    """
+
+    # Shared between scheduler and worker instances (same process)
+    discard_req_ids: set[str] = set()
+
+    def __init__(self, vllm_config, role, kv_cache_config=None):
+        super().__init__(vllm_config=vllm_config, role=role,
+                         kv_cache_config=kv_cache_config)
+        kv = self._kv_transfer_config.get_from_extra_config
+        self.use_compression = kv("use_compression", False)
+        self.compression_level = kv("compression_level", 3)
+        self.percentile_tracker = self.create_percentile_tracker(kv)
+        self.decode_filenames: dict[str, str] = {}
+        self.request_filenames: dict[str, tuple[str, str]] = {}
+        self.prev_step_info: dict[str, tuple[int, int]] = {}
+        self.acceptance_lengths: dict[str, list[float]] = {}
+        self.total_captured = 0
+        self.total_skipped = 0
+        self.writer = None
+
+    def create_percentile_tracker(self, kv):
+        pct = kv("capture_percentile", 0.0)
+        if pct <= 0:
+            return None
+        from vllm.distributed.kv_transfer.kv_connector.online.percentile_tracker import PercentileTracker  # noqa: E501
+        return PercentileTracker(percentile=pct,
+                                 window_size=kv("capture_window_size", 1000),
+                                 min_samples=kv("capture_min_samples", 100))
+
+    def get_writer(self):
+        if self.writer is None:
+            from vllm.distributed.kv_transfer.kv_connector.online.hidden_states_writer import HiddenStatesWriter  # noqa: E501
+            self.writer = HiddenStatesWriter(self._storage_path,
+                                             use_compression=self.use_compression,
+                                             compression_level=self.compression_level)
+        return self.writer
+
+    # ==============================
+    # Worker-side methods
+    # ==============================
+
+    def wait_for_save(self):
+        if self.writer is not None:
+            self.writer.flush(timeout=10.0)
+
+    def register_kv_caches(self, kv_caches):
+        """Override parent to handle both extract_hidden_states and live EAGLE.
+
+        With extract_hidden_states: finds CacheOnlyAttentionLayer (parent behavior).
+        With live EAGLE: no CacheOnlyAttentionLayer exists, so skip the assertion.
+        In live mode, capture happens via capture_hidden_states() from the proposer.
+        """
+        from vllm.model_executor.models.extract_hidden_states import (
+            CacheOnlyAttentionLayer,
+        )
+        from vllm.config import get_layers_from_vllm_config
+        layers = get_layers_from_vllm_config(
+            self._vllm_config, CacheOnlyAttentionLayer,
+            list(kv_caches.keys()),
+        )
+        self.cache_layers = list(layers.keys())
+
+    def save_kv_layer(self, layer_name, kv_layer, attn_metadata, **kwargs):
+        if layer_name not in self.cache_layers:
+            return
+        from vllm.model_executor.models.extract_hidden_states import CacheOnlyAttentionMetadata  # noqa: E501
+        assert isinstance(attn_metadata, CacheOnlyAttentionMetadata)
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, ExampleHiddenStatesConnectorMetadata)
+        writer = self.get_writer()
+        for request in metadata.requests:
+            hs = extract_from_kv_cache(kv_layer, request.slot_mapping,
+                                       request.token_ids.shape[0])
+            if request.new_req:
+                self.write_prefill(writer, request, hs)
+            else:
+                writer.accumulate_async(request.req_id, hs, request.token_ids)
+
+    def write_prefill(self, writer, request, hidden_states):
+        os.makedirs(os.path.dirname(request.filename), exist_ok=True)
+        writer.write_async(hidden_states, request.token_ids, request.filename)
+        self.decode_filenames[request.req_id] = request.filename.replace(
+            ".safetensors", "_decode.safetensors")
+
+    def get_finished(self, finished_req_ids):
+        for req_id in finished_req_ids:
+            fn = self.decode_filenames.pop(req_id, None)
+            if self.writer is None:
+                continue
+            # Check if scheduler marked this request for discard
+            if req_id in OnlineHiddenStatesConnector.discard_req_ids:
+                OnlineHiddenStatesConnector.discard_req_ids.discard(req_id)
+                self.writer.discard_request(req_id)
+            elif fn is not None:
+                self.writer.flush_request(req_id, fn)
+            else:
+                self.writer.discard_request(req_id)
+        return None, None
+
+    # ==============================
+    # Scheduler-side methods
+    # ==============================
+
+    def build_connector_meta(self, scheduler_output):
+        meta = ExampleHiddenStatesConnectorMetadata()
+        cached = scheduler_output.scheduled_cached_reqs
+        self.track_acceptance(cached)
+        self.record_step_info(scheduler_output, cached)
+        self.register_new_requests(meta, scheduler_output)
+        return meta
+
+    def track_acceptance(self, cached_reqs):
+        if self.percentile_tracker is None:
+            return
+        for i, req_id in enumerate(cached_reqs.req_ids):
+            prev = self.prev_step_info.get(req_id)
+            if prev is None or prev[1] <= 0:
+                continue
+            actual = cached_reqs.num_computed_tokens[i]
+            accepted = max(0, actual - prev[0] + prev[1])
+            self.acceptance_lengths.setdefault(req_id, []).append(
+                1.0 + accepted / prev[1])
+
+    def record_step_info(self, sched_out, cached_reqs):
+        self.prev_step_info.clear()
+        spec = sched_out.scheduled_spec_decode_tokens
+        computed = {cid: cached_reqs.num_computed_tokens[j]
+                    for j, cid in enumerate(cached_reqs.req_ids)}
+        for r in sched_out.scheduled_new_reqs:
+            computed[r.req_id] = r.num_computed_tokens
+        for rid, n in sched_out.num_scheduled_tokens.items():
+            c = computed.get(rid)
+            if c is not None:
+                self.prev_step_info[rid] = (c + n, len(spec.get(rid, [])))
+
+    def register_new_requests(self, meta, sched_out):
+        for r in sched_out.scheduled_new_reqs:
+            tids = r.prompt_token_ids or []
+            sub = r.lora_request.lora_name if r.lora_request else "base"
+            pfn = os.path.join(self._storage_path, sub, f"{r.req_id}.safetensors")
+            dfn = os.path.join(self._storage_path, sub, f"{r.req_id}_decode.safetensors")
+            meta.add_request(r.req_id, filename=pfn, token_ids=tids,
+                             block_ids=r.block_ids[0], block_size=self._block_size)
+            self.request_filenames[r.req_id] = (pfn, dfn)
+            self._active_requests[r.req_id] = r
+
+    # ==============================
+    # Request completion
+    # ==============================
+
+    def request_finished(self, request, block_ids):
+        rid = request.request_id
+        fns = self.request_filenames.pop(rid, None)
+        self._active_requests.pop(rid, None)
+        self.prev_step_info.pop(rid, None)
+        acc = self.acceptance_lengths.pop(rid, None)
+
+        empty = False, {"hidden_states_prefill": None, "hidden_states_decode": None}
+        if fns is None:
+            return empty
+        pfn, dfn = fns
+        if self.should_discard(acc):
+            # Mark for discard — worker's get_finished will skip writing.
+            # Also delete any prefill file that was already written to disk.
+            OnlineHiddenStatesConnector.discard_req_ids.add(rid)
+            self.delete_captured_files(pfn, dfn)
+            self.total_skipped += 1
+            return empty
+        self.total_captured += 1
+        return False, {"hidden_states_prefill": pfn, "hidden_states_decode": dfn}
+
+    def should_discard(self, acc):
+        if self.percentile_tracker is None or not acc:
+            return False
+        return not self.percentile_tracker.observe_and_check(sum(acc) / len(acc))
+
+    @staticmethod
+    def delete_captured_files(*paths):
+        for p in paths:
+            for c in (p, p + ".zst"):
+                try:
+                    os.remove(c)
+                except FileNotFoundError:
+                    pass
+
+    # ==============================
+    # Lifecycle
+    # ==============================
+
+    def shutdown(self):
+        if self.writer is not None:
+            self.writer.flush(timeout=10.0)
+            self.writer.shutdown(timeout=5.0)
+
+    # ==============================
+    # Live EAGLE capture
+    # ==============================
+
+    def capture_hidden_states(self, hidden_states, token_ids,
+                              query_start_loc, req_ids,
+                              lora_mapping, lora_lookup):
+        """Accumulate per-request hidden states during live EAGLE serving.
+
+        Data is buffered in pinned CPU memory and written to disk only when
+        the request finishes (via get_finished), enabling percentile filtering.
+        """
+        writer = self.get_writer()
+        for i, req_id in enumerate(req_ids):
+            start = query_start_loc[i].item()
+            end = query_start_loc[i + 1].item()
+            if start == end:
+                continue
+
+            lora_id = int(lora_mapping[i])
+            if lora_id != 0 and lora_id in lora_lookup:
+                subdir = lora_lookup[lora_id].lora_name
+            else:
+                subdir = "base"
+
+            # Track filename for flush at request completion
+            if req_id not in self.decode_filenames:
+                self.decode_filenames[req_id] = os.path.join(
+                    self._storage_path, subdir,
+                    f"{req_id}.safetensors")
+
+            writer.accumulate_async(
+                req_id, hidden_states[start:end], token_ids[start:end])

--- a/vllm/distributed/kv_transfer/kv_connector/online/percentile_tracker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/online/percentile_tracker.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import random
+from collections import deque
+
+import numpy as np
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class PercentileTracker:
+    """Track acceptance lengths and filter by worst percentile.
+
+    Uses a two-tier check: values strictly below the threshold are always
+    captured, values exactly at the threshold are randomly captured to
+    approximate the target percentile. This handles uniform distributions
+    where all values cluster at the same level.
+
+    Args:
+        percentile: Capture drafts in the worst X% (0-100).
+        window_size: Sliding window of recent observations.
+        min_samples: Minimum observations before filtering kicks in.
+            During warmup, all requests are captured.
+    """
+
+    def __init__(
+        self,
+        percentile: float = 10.0,
+        window_size: int = 1000,
+        min_samples: int = 100,
+    ):
+        self.percentile = percentile
+        self.window_size = window_size
+        self.min_samples = min_samples
+
+        self._window: deque[float] = deque(maxlen=window_size)
+        self._cached_threshold: float | None = None
+        self._fraction_at_threshold: float = 0.0
+        self._cache_valid = False
+
+    def observe(self, acceptance_length: float) -> None:
+        """Record an acceptance length observation."""
+        self._window.append(acceptance_length)
+        if len(self._window) % 10 == 0:
+            self._cache_valid = False
+
+    def should_capture(self, acceptance_length: float) -> bool:
+        """Check if this acceptance length is in the worst percentile.
+
+        Returns True if the value should be captured (i.e. it's bad enough
+        to be useful for distillation training).
+        """
+        if len(self._window) < self.min_samples:
+            return True
+
+        if not self._cache_valid:
+            self.update_threshold()
+
+        assert self._cached_threshold is not None
+
+        if acceptance_length < self._cached_threshold:
+            return True
+        if acceptance_length > self._cached_threshold:
+            return False
+        # At the threshold: randomly capture to hit target percentage
+        return random.random() < self._fraction_at_threshold
+
+    def observe_and_check(self, acceptance_length: float) -> bool:
+        """Atomically observe and check whether to capture."""
+        should = self.should_capture(acceptance_length)
+        self.observe(acceptance_length)
+        return should
+
+    def update_threshold(self) -> None:
+        """Recompute the cached percentile threshold and boundary fraction.
+
+        The fraction_at_threshold handles the case where many values equal
+        the threshold. For example, if percentile=5 and all values are 2.0,
+        the threshold is 2.0, fraction_below is 0%, so we need to randomly
+        capture 5% of the at-threshold values.
+        """
+        if len(self._window) == 0:
+            self._cached_threshold = float("inf")
+            self._fraction_at_threshold = 0.0
+            return
+        arr = np.array(self._window)
+        self._cached_threshold = float(np.percentile(arr, self.percentile))
+        fraction_below = float(np.mean(arr < self._cached_threshold))
+        fraction_at = float(np.mean(arr == self._cached_threshold))
+        target = self.percentile / 100.0
+        if fraction_at > 0:
+            self._fraction_at_threshold = max(
+                0.0, min(1.0, (target - fraction_below) / fraction_at))
+        else:
+            self._fraction_at_threshold = 0.0
+        self._cache_valid = True
+
+    def get_stats(self) -> dict:
+        """Return current tracker statistics."""
+        if len(self._window) == 0:
+            return {
+                "num_samples": 0,
+                "percentile_threshold": None,
+                "mean_acceptance": None,
+            }
+        if not self._cache_valid:
+            self.update_threshold()
+        arr = np.array(self._window)
+        return {
+            "num_samples": len(self._window),
+            "percentile_threshold": self._cached_threshold,
+            "fraction_at_threshold": self._fraction_at_threshold,
+            "mean_acceptance": float(np.mean(arr)),
+            "min_acceptance": float(np.min(arr)),
+            "max_acceptance": float(np.max(arr)),
+        }

--- a/vllm/v1/spec_decode/capturing_eagle.py
+++ b/vllm/v1/spec_decode/capturing_eagle.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+
+from vllm.v1.spec_decode.eagle import EagleProposer
+
+
+class CapturingEagleProposer(EagleProposer):
+    """EagleProposer that captures target hidden states per-request.
+
+    When a KV transfer connector with ``capture_hidden_states`` is active,
+    this proposer intercepts the target hidden states before each draft
+    round and forwards them to the connector for async disk write.
+    """
+
+    def __init__(self, vllm_config, device: torch.device, runner=None):
+        super().__init__(vllm_config, device, runner)
+        self._connector = None
+        self._connector_resolved = False
+
+    def _resolve_connector(self):
+        """Lazily resolve the KV transfer connector (once)."""
+        if self._connector_resolved:
+            return self._connector
+        self._connector_resolved = True
+        from vllm.distributed.kv_transfer.kv_transfer_state import (
+            get_kv_transfer_group,
+            has_kv_transfer_group,
+        )
+        if has_kv_transfer_group():
+            connector = get_kv_transfer_group()
+            if hasattr(connector, "capture_hidden_states"):
+                self._connector = connector
+        return self._connector
+
+    def propose(
+        self,
+        *,
+        target_hidden_states: torch.Tensor,
+        target_token_ids: torch.Tensor,
+        common_attn_metadata,
+        **kwargs,
+    ) -> torch.Tensor:
+        connector = self._resolve_connector()
+        if connector is not None:
+            batch = self.runner.input_batch
+            num_reqs = len(batch.req_ids)
+            connector.capture_hidden_states(
+                hidden_states=target_hidden_states,
+                token_ids=target_token_ids,
+                query_start_loc=common_attn_metadata.query_start_loc_cpu,
+                req_ids=batch.req_ids[:num_reqs],
+                lora_mapping=batch.request_lora_mapping,
+                lora_lookup=batch.lora_id_to_lora_request,
+            )
+        return super().propose(
+            target_hidden_states=target_hidden_states,
+            target_token_ids=target_token_ids,
+            common_attn_metadata=common_attn_metadata,
+            **kwargs,
+        )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -540,7 +540,14 @@ class GPUModelRunner(
             elif self.speculative_config.method == "suffix":
                 self.drafter = SuffixDecodingProposer(self.vllm_config)
             elif self.speculative_config.use_eagle():
-                self.drafter = EagleProposer(self.vllm_config, self.device, self)
+                eagle_cls = EagleProposer
+                if self.vllm_config.kv_transfer_config is not None:
+                    from vllm.v1.spec_decode.capturing_eagle import (
+                        CapturingEagleProposer,
+                    )
+
+                    eagle_cls = CapturingEagleProposer
+                self.drafter = eagle_cls(self.vllm_config, self.device, self)
                 if self.speculative_config.method == "eagle3":
                     self.use_aux_hidden_state_outputs = (
                         self.drafter.eagle3_use_aux_hidden_state


### PR DESCRIPTION
Updated PR description:

---

## Purpose

Based on RFC #33118 and all the changes are in commit `a278418`

Add `OnlineHiddenStatesConnector` — a drop-in replacement for `ExampleHiddenStatesConnector` (from #33736) that captures hidden states from live serving traffic without blocking the forward pass.

This enables a continuous improvement loop for Eagle3 speculative decoding: **serve → capture discrepancies → fine-tune LoRA drafter head → redeploy → repeat**.

Key features:
- **Async I/O**: GPU→pinned-memory copy on a dedicated CUDA stream + background writer thread keeps disk I/O off the forward-pass critical path
- **zstd compression**: enabled by default, reduces output size ~21%
- **Deferred percentile-based capture filtering**: acceptance lengths are accumulated per request during decode; at request completion, only requests whose average acceptance falls in the worst X% keep their captured file — focusing data collection on cases where the drafter struggles
- **LoRA-aware output layout**: files organized into `base/` and `<lora_name>/` subdirectories
- **Write-once strategy**: hidden states written at prefill only (prompt hidden states don't change during decode)

Configuration via `kv_connector_extra_config`:
- `shared_storage_path`, `use_compression`, `compression_level`
- `capture_percentile`, `capture_window_size`, `capture_min_samples`

Implementation:
- Reusable pinned buffer pool (avoids repeated `cudaHostAlloc`/`cudaFreeHost`)
- In-memory serialization for compression (no intermediate temp files for uncompressed data)
- O(1) request lookup in `build_connector_meta`
- File deletion at `request_finished` for filtered-out requests

Files added:
- `vllm/distributed/kv_transfer/kv_connector/online/` — connector, writer, percentile tracker
- `examples/offline_inference/extract_hidden_states_online*.py` — 3 examples (basic, eagle3, eagle3+LoRA)
- `tests/v1/kv_connector/unit/test_online_connector.py` — 28 unit tests
- `tests/v1/kv_connector/extract_hidden_states_integration/test_online_extraction.py` — 3 integration tests
- `benchmarks/benchmark_hidden_states_capture.py` — 3-way comparison benchmark

## Test Plan

```bash
# Unit tests (no GPU required)
python -m pytest tests/v1/kv_connector/unit/test_online_connector.py -v

# Integration tests (requires GPU)
CUDA_VISIBLE_DEVICES=0 python -m pytest tests/v1/kv_connector/extract_hidden_states_integration/test_online_extraction.py -v --timeout=300

# Benchmark (requires GPU + UltraChat dataset)
CUDA_VISIBLE_DEVICES=0 python benchmarks/benchmark_hidden_states_capture.py --include-sync --num-prompts 256 --data-files <path_to_ultrachat.jsonl>
```

## Test Result

28 unit tests + 3 integration tests: all passing on H200.

Benchmark (Qwen3-8B, 1xH200, 256 UltraChat prompts, avg 154 tokens, max_tokens=1, layers 1,2,3,4, CUDA graphs enabled):

```
                      baseline      online        sync
elapsed (s)               0.90        1.70        1.89
prompts/s                283.2       150.2       135.4
avg latency (ms)           3.5         6.7         7.4
output files                 0         256         256
output (MB)                0.0       980.9      1245.2

online overhead vs baseline: +88.5%
sync overhead vs baseline:  +109.1%
online vs sync: 11% faster, 21% smaller output (zstd)
```

---

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update.

