### PR TITLE
[BugFix] Repo utils debug print patch

### DIFF
--- a/vllm/transformers_utils/repo_utils.py
+++ b/vllm/transformers_utils/repo_utils.py
@@ -285,7 +285,7 @@ def get_hf_file_to_dict(
             EntryNotFoundError,
             LocalEntryNotFoundError,
         ) as e:
-            logger.debug("File or repository not found in hf_hub_download: %s", e)
+            logger.debug("File or repository not found in hf_hub_download:", exc_info=e)
             return None
         except HfHubHTTPError as e:
             logger.warning(

--- a/vllm/transformers_utils/repo_utils.py
+++ b/vllm/transformers_utils/repo_utils.py
@@ -285,7 +285,7 @@ def get_hf_file_to_dict(
             EntryNotFoundError,
             LocalEntryNotFoundError,
         ) as e:
-            logger.debug("File or repository not found in hf_hub_download", e)
+            logger.debug("File or repository not found in hf_hub_download %s", e)
             return None
         except HfHubHTTPError as e:
             logger.warning(

--- a/vllm/transformers_utils/repo_utils.py
+++ b/vllm/transformers_utils/repo_utils.py
@@ -285,7 +285,7 @@ def get_hf_file_to_dict(
             EntryNotFoundError,
             LocalEntryNotFoundError,
         ) as e:
-            logger.debug("File or repository not found in hf_hub_download %s", e)
+            logger.debug("File or repository not found in hf_hub_download: %s", e)
             return None
         except HfHubHTTPError as e:
             logger.warning(


### PR DESCRIPTION

## Purpose

Previously if file did not exist on HF hub and `VLLM_LOGGING_LEVEL=debug`, debug statement [here](https://github.com/vllm-project/vllm/blob/a1f53addb132f75704710184f4c1cc4780343329/vllm/transformers_utils/repo_utils.py#L288C1-L288C79) would error. This fixes that with a simple `%s` parameter in `logger.debug` message.

Previous error (was testing on vllm-omni):

```
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1160, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/logging_utils/formatter.py", line 71, in format
    msg = super().format(record)
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/logging/__init__.py", line 703, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/logging/__init__.py", line 392, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/workspace/vllm-omni/vllm_omni/entrypoints/cli/main.py", line 59, in <module>
    main()
  File "/workspace/vllm-omni/vllm_omni/entrypoints/cli/main.py", line 50, in main
    cmds[args.subparser].validate(args)
  File "/workspace/vllm-omni/vllm_omni/entrypoints/cli/serve.py", line 59, in validate
    if model and is_diffusion_model(model):
  File "/workspace/vllm-omni/vllm_omni/diffusion/utils/hf_utils.py", line 57, in is_diffusion_model
    config_dict = get_hf_file_to_dict("model_index.json", model_name)
  File "/opt/venv/lib/python3.12/site-packages/vllm/transformers_utils/repo_utils.py", line 288, in get_hf_file_to_dict
    logger.debug("File or repository not found in hf_hub_download", e)
Message: 'File or repository not found in hf_hub_download'
Arguments: (EntryNotFoundError('404 Client Error. (Request ID: Root=1-69a0968b-1bfa18665c666a843a4fe0f1;d2bcaef8-e4ae-49a0-9736-2fdb801e65b4)\n\nEntry Not Found for url: https://huggingface.co/Qwen/Qwen3-Omni-30B-A3B-Instruct/resolve/main/model_index.json.'),)
```

Expected output: 

```
DEBUG 02-26 18:52:59 [transfomer_utils/repo_utils.py:288] File or repository not found in hf_hub_download: EntryNotFoundError('404 Client Error. (Request ID: Root=1-69a0968b-1bfa18665c666a843a4fe0f1;d2bcaef8-e4ae-49a0-9736-2fdb801e65b4)\n\nEntry Not Found for url: https://huggingface.co/Qwen/Qwen3-Omni-30B-A3B-Instruct/resolve/main/model_index.json.')
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

