### PR TITLE
[Perf] [Hybrid] Copy num_accepted_tokens in non-blocking way when not using prefix caching

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1191,13 +1191,14 @@ class GPUModelRunner(
             return
 
         # Find the number of accepted tokens for each sequence.
+        num_reqs = output_token_ids.size(0)
         num_accepted_tokens = (
             (
                 torch.cat(
                     [
                         output_token_ids,
                         torch.full(
-                            (output_token_ids.size(0), 1),
+                            (num_reqs, 1),
                             -1,
                             device=output_token_ids.device,
                         ),
@@ -1208,12 +1209,11 @@ class GPUModelRunner(
             )
             .int()
             .argmax(-1)
-            .cpu()
-            .numpy()
         )
-        for i, num_tokens in enumerate(num_accepted_tokens):
-            self.input_batch.num_accepted_tokens_cpu[i] = num_tokens
         if self.cache_config.mamba_cache_mode == "align":
+            for i, num_tokens in enumerate(num_accepted_tokens.cpu().numpy()):
+                self.input_batch.num_accepted_tokens_cpu[i] = num_tokens
+
             mamba_utils.postprocess_mamba(
                 scheduler_output,
                 self.kv_cache_config,
@@ -1223,6 +1223,10 @@ class GPUModelRunner(
                 self.compilation_config.static_forward_context,
                 self.model.get_mamba_state_copy_func(),
                 self._get_mamba_copy_bufs(),
+            )
+        else:
+            self.input_batch.num_accepted_tokens_cpu_tensor[:num_reqs].copy_(
+                num_accepted_tokens, non_blocking=True
             )
 
     def _update_streaming_request(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1192,7 +1192,7 @@ class GPUModelRunner(
 
         # Find the number of accepted tokens for each sequence.
         num_reqs = output_token_ids.size(0)
-        num_accepted_tokens = (
+        self.num_accepted_tokens.gpu[:num_reqs] = (
             (
                 torch.cat(
                     [
@@ -1211,7 +1211,9 @@ class GPUModelRunner(
             .argmax(-1)
         )
         if self.cache_config.mamba_cache_mode == "align":
-            for i, num_tokens in enumerate(num_accepted_tokens.cpu().numpy()):
+            for i, num_tokens in enumerate(
+                self.num_accepted_tokens.gpu[:num_reqs].cpu().numpy()
+            ):
                 self.input_batch.num_accepted_tokens_cpu[i] = num_tokens
 
             mamba_utils.postprocess_mamba(
@@ -1226,7 +1228,7 @@ class GPUModelRunner(
             )
         else:
             self.input_batch.num_accepted_tokens_cpu_tensor[:num_reqs].copy_(
-                num_accepted_tokens, non_blocking=True
+                self.num_accepted_tokens.gpu[:num_reqs], non_blocking=True
             )
 
     def _update_streaming_request(


### PR DESCRIPTION
## Purpose

Related to issue https://github.com/vllm-project/vllm/issues/35387

I'm profiling the behaviour of `Qwen3-Next-80B-A3B-Instruct-FP8` using MTP but *without* prefix caching using:

```
vllm bench latency    \
    --model Qwen/Qwen3-Next-80B-A3B-Instruct-FP8    \
    --tensor-parallel-size 4        \
    --max-model-len 262144          \
    --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}' \
    --profile \
    --profiler-config '{"profiler": "torch", "torch_profiler_dir": "./profiling_traces"}'
```

On main I see the copying of the num_accepted_tokens tensor in function `_update_states_after_model_execute` taking more than 6ms because it causes a CPU-GPU sync. GPU profile also shows clear bubble due to this. 

<img width="752" height="577" alt="image" src="https://github.com/user-attachments/assets/850c5b3a-0085-4040-ae63-c7fc0de1b948" />


However, if we are not using prefix caching, we don't need to have the num_accepted_tokens back on the CPU immediately. It is sufficient to do a non-blocking copy. 

After the small change from this PR the same function is taking around 200us:

<img width="806" height="568" alt="image" src="https://github.com/user-attachments/assets/de0bcd32-05e3-4a5c-9185-b6ac22cc252c" />

------

Quite an easy fix, but solving it for prefix caching enabled is going to be more complicated though. 

cc @heheda12345 @peakcrosser7 @ywang96 

## Test Plan

1. Latency test:
```
vllm bench latency    \
    --model Qwen/Qwen3-Next-80B-A3B-Instruct-FP8    \
    --tensor-parallel-size 4        \
    --max-model-len 262144          \
    --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}' 
```

2. Serving benchmark with server:
```
vllm serve   \
    --model Qwen/Qwen3-Next-80B-A3B-Instruct-FP8    \
    --tensor-parallel-size 4        \
    --max-model-len 262144          \
    --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}' 
```
and client:
```
vllm bench serve \
    --dataset-name sharegpt \
    --dataset-path ./ShareGPT_V3_unfiltered_cleaned_split.json  \
    --request-rate 1 \
   --num-prompts 200 \
   --ignore_eos
```

3. Eval 

Running the gsm8k config from [this](https://github.com/vllm-project/vllm/pull/35406) PR:
```
pytest -s -v tests/evals/gsm8k/test_gsm8k_correctness.py --config-list-file=tests/evals/gsm8k/configs/hybrid/models-h100.txt -k 'Qwen3-Next-FP8-TP4-MTP'
```

## Test Result

**Latency (main)**
```
Avg latency: 1.5709037275674442 seconds
10% percentile latency: 1.5244868238456548 seconds
25% percentile latency: 1.5468210519757122 seconds
50% percentile latency: 1.5686878953129053 seconds
75% percentile latency: 1.5988200621213764 seconds
90% percentile latency: 1.6146010012365877 seconds
99% percentile latency: 1.6589137179311364 seconds
```

**Latency (PR):**
```
Avg latency: 1.2981053032291432 seconds
10% percentile latency: 1.2529189011082054 seconds
25% percentile latency: 1.2786941428203136 seconds
50% percentile latency: 1.3038783464580774 seconds
75% percentile latency: 1.3190837821457535 seconds
90% percentile latency: 1.3358878444880247 seconds
99% percentile latency: 1.3585048682801426 seconds
```

It is around 18% better.

**Serving (main):**
```
============ Serving Benchmark Result ============
Successful requests:                     200       
Failed requests:                         0         
Request rate configured (RPS):           1.00      
Benchmark duration (s):                  202.64    
Total input tokens:                      43560     
Total generated tokens:                  44697     
Request throughput (req/s):              0.99      
Output token throughput (tok/s):         220.58    
Peak output token throughput (tok/s):    395.00    
Peak concurrent requests:                8.00      
Total token throughput (tok/s):          435.54    
---------------Time to First Token----------------
Mean TTFT (ms):                          108.62    
Median TTFT (ms):                        71.31     
P99 TTFT (ms):                           217.10    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          10.30     
Median TPOT (ms):                        5.95      
P99 TPOT (ms):                           26.26     
---------------Inter-token Latency----------------
Mean ITL (ms):                           14.69     
Median ITL (ms):                         12.81     
P99 ITL (ms):                            44.22     
---------------Speculative Decoding---------------
Acceptance rate (%):                     67.23     
Acceptance length:                       2.34      
Drafts:                                  19049     
Draft tokens:                            38098     
Accepted tokens:                         25612     
Per-position acceptance (%):
  Position 0:                            77.76     
  Position 1:                            56.70     
==================================================
```

**Serving (PR):**
```
============ Serving Benchmark Result ============
Successful requests:                     200       
Failed requests:                         0         
Request rate configured (RPS):           1.00      
Benchmark duration (s):                  202.06    
Total input tokens:                      43560     
Total generated tokens:                  44697     
Request throughput (req/s):              0.99      
Output token throughput (tok/s):         221.21    
Peak output token throughput (tok/s):    431.00    
Peak concurrent requests:                8.00      
Total token throughput (tok/s):          436.79    
---------------Time to First Token----------------
Mean TTFT (ms):                          67.54     
Median TTFT (ms):                        59.33     
P99 TTFT (ms):                           160.88    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          4.86      
Median TPOT (ms):                        4.66      
P99 TPOT (ms):                           9.01      
---------------Inter-token Latency----------------
Mean ITL (ms):                           10.67     
Median ITL (ms):                         10.13     
P99 ITL (ms):                            37.50     
---------------Speculative Decoding---------------
Acceptance rate (%):                     66.96     
Acceptance length:                       2.34      
Drafts:                                  19095     
Draft tokens:                            38190     
Accepted tokens:                         25572     
Per-position acceptance (%):
  Position 0:                            77.32     
  Position 1:                            56.60     
==================================================
```

- TTFT (mean) is 41% better
- TPOT (mean) is 51% better
- ITL (mean) is 27% better

**Correctness (main)**
```
GSM8K Results for Qwen/Qwen3-Next-80B-A3B-Instruct-FP8:
  Measured metric: 0.8309
  Expected metric: 0.8500
  Tolerance: 0.0800
  Questions: 1319
  Invalid rate: 0.000
  Latency: 77.4s
  QPS: 17.1
✅ GSM8K test passed for Qwen/Qwen3-Next-80B-A3B-Instruct-FP8
```

**Correctness (PR)**
```
GSM8K Results for Qwen/Qwen3-Next-80B-A3B-Instruct-FP8:
  Measured metric: 0.8279
  Expected metric: 0.8500
  Tolerance: 0.0800
  Questions: 1319
  Invalid rate: 0.001
  Latency: 73.2s
  QPS: 18.0
✅ GSM8K test passed for Qwen/Qwen3-Next-80B-A3B-Instruct-FP8
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

