### PR TITLE
[Perf] Optimize `sampled_token_ids` using numpy and remove `tolist`, 0.9% E2E throughput improvement

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1322,6 +1322,7 @@ class Scheduler(SchedulerInterface):
 
             req_index = model_runner_output.req_id_to_index[req_id]
             if sampled_token_ids_np is not None:
+                assert num_generated_tokens is not None
                 num_generated = int(num_generated_tokens[req_index])
                 generated_token_ids = (
                     sampled_token_ids_np[req_index, :num_generated]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1263,6 +1263,11 @@ class Scheduler(SchedulerInterface):
         sampled_token_ids = model_runner_output.sampled_token_ids
         sampled_token_ids_np = model_runner_output.sampled_token_ids_np
         num_generated_tokens = model_runner_output.num_generated_tokens
+        if sampled_token_ids_np is not None and num_generated_tokens is None:
+            raise ValueError(
+                "num_generated_tokens cannot be None when "
+                "sampled_token_ids_np is not None."
+            )
         logprobs = model_runner_output.logprobs
         prompt_logprobs_dict = model_runner_output.prompt_logprobs_dict
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
@@ -1317,11 +1322,7 @@ class Scheduler(SchedulerInterface):
 
             req_index = model_runner_output.req_id_to_index[req_id]
             if sampled_token_ids_np is not None:
-                num_generated = (
-                    int(num_generated_tokens[req_index])
-                    if num_generated_tokens is not None
-                    else sampled_token_ids_np.shape[1]
-                )
+                num_generated = int(num_generated_tokens[req_index])
                 generated_token_ids = (
                     sampled_token_ids_np[req_index, :num_generated]
                     if num_generated > 0

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -163,11 +163,13 @@ class ModelRunnerOutput:
     # req_id -> index
     req_id_to_index: dict[str, int]
 
-    # num_reqs x num_generated_tokens
-    # num_generated_tokens is the number of tokens
-    # generated in the current step. It can be different for
-    # each request due to speculative/jump decoding.
-    sampled_token_ids: list[list[int]] = field(default_factory=list)
+    # [num_reqs, <=max_num_generated_tokens] and [num_reqs]
+    sampled_token_ids_np: np.ndarray | None = None
+    num_generated_tokens: np.ndarray | None = None
+
+    # backward-compatible path for callers that still materialize Python lists.
+    # TODO(wentao): this is expensive and should be removed in the future.
+    sampled_token_ids: list[list[int]] | None = field(default_factory=list)
 
     # [num_reqs, max_num_logprobs + 1]
     # [num_reqs, max_num_logprobs + 1]

--- a/vllm/v1/worker/gpu/async_utils.py
+++ b/vllm/v1/worker/gpu/async_utils.py
@@ -49,15 +49,9 @@ class AsyncOutput(AsyncModelRunnerOutput):
     def get_output(self) -> ModelRunnerOutput:
         self.copy_event.synchronize()
 
-        # NOTE(woosuk): The following code is to ensure compatibility with
-        # the existing model runner.
-        # Going forward, we should keep the data structures as NumPy arrays
-        # rather than Python lists.
-        sampled_token_ids: list[list[int]] = self.sampled_token_ids.tolist()
-        num_sampled_tokens: list[int] = self.num_sampled_tokens_np.tolist()
-        for token_ids, num_tokens in zip(sampled_token_ids, num_sampled_tokens):
-            del token_ids[num_tokens:]
-        self.model_runner_output.sampled_token_ids = sampled_token_ids
+        self.model_runner_output.sampled_token_ids_np = self.sampled_token_ids
+        self.model_runner_output.num_generated_tokens = self.num_sampled_tokens_np
+        self.model_runner_output.sampled_token_ids = None
 
         if self.num_nans is not None:
             self.model_runner_output.num_nans_in_logits = dict(


### PR DESCRIPTION
## Purpose

Part of https://github.com/vllm-project/vllm/issues/35335

Works for both V1 and V2

## Test

```bash
export MODEL="Qwen/Qwen3-30B-A3B-Thinking-2507-FP8"
export VLLM_USE_V2_MODEL_RUNNER=1
vllm serve $MODEL --port 9256 --enable-expert-parallel --enforce_eager
```

### Acc

```bash
lm_eval --model local-completions --model_args "base_url=http://127.0.0.1:9256/v1/completions,model=$MODEL,num_concurrent=1024" --tasks gsm8k
# now
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6687|±  |0.0130|
|     |       |strict-match    |     5|exact_match|↑  |0.7862|±  |0.0113|
# main
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.6679|±  |0.0130|
|     |       |strict-match    |     5|exact_match|↑  |0.7862|±  |0.0113|
```

### Perf

```bash
vllm bench serve   --model $MODEL   --dataset-name random   --host 127.0.0.1 --port 9256   --random-input-len 1   --random-output-len 1024   --num-prompts 2048   --max-concurrency 512   --num-warmups 64   --request-rate inf   --temperature 0
# now
============ Serving Benchmark Result ============
Successful requests:                     2048      
Failed requests:                         0         
Maximum request concurrency:             512       
Benchmark duration (s):                  195.94    
Total input tokens:                      2048      
Total generated tokens:                  2097152   
Request throughput (req/s):              10.45     
Output token throughput (tok/s):         10703.14  
Peak output token throughput (tok/s):    11264.00  
Peak concurrent requests:                1024.00   
Total token throughput (tok/s):          10713.59  
---------------Time to First Token----------------
Mean TTFT (ms):                          346.37    
Median TTFT (ms):                        340.98    
P99 TTFT (ms):                           482.70    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          47.50     
Median TPOT (ms):                        47.58     
P99 TPOT (ms):                           47.67     
---------------Inter-token Latency----------------
Mean ITL (ms):                           47.50     
Median ITL (ms):                         47.13     
P99 ITL (ms):                            65.86     
==================================================
# main
============ Serving Benchmark Result ============
Successful requests:                     2048      
Failed requests:                         0         
Maximum request concurrency:             512       
Benchmark duration (s):                  197.68    
Total input tokens:                      2048      
Total generated tokens:                  2097152   
Request throughput (req/s):              10.36     
Output token throughput (tok/s):         10608.68  
Peak output token throughput (tok/s):    11190.00  
Peak concurrent requests:                1024.00   
Total token throughput (tok/s):          10619.04  
---------------Time to First Token----------------
Mean TTFT (ms):                          371.33    
Median TTFT (ms):                        357.19    
P99 TTFT (ms):                           535.79    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          47.90     
Median TPOT (ms):                        47.97     
P99 TPOT (ms):                           48.05     
---------------Inter-token Latency----------------
Mean ITL (ms):                           47.90     
Median ITL (ms):                         47.55     
P99 ITL (ms):                            63.11     
==================================================
```

CC: @WoosukKwon 