### PR TITLE
[Core] Num External Cached Tokens 

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_integration/vllm_v1_adapter.py
@@ -1421,11 +1421,14 @@ class LMCacheConnectorV1Impl:
         )
         return_params = None
 
-        # NOTE: Used to stream back the first token
-        # for disagg prefill
-        if params is not None and "ret_first_tok" in params:
-            return_params = {
-                "first_tok": request._output_token_ids[0],
-            }
+        if params is not None:
+            return_params = {}
+            # NOTE: Used to stream back the first token
+            # for disagg prefill
+            if "ret_first_tok" in params:
+                return_params["first_tok"] = request._output_token_ids[0]
+            # number of tokens cached by LMCache
+            if "ret_num_cached_toks" in params:
+                return_params["num_cached_toks"] = request.num_external_cached_tokens
 
         return False, return_params

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -797,8 +797,8 @@ class Scheduler(SchedulerInterface):
                 # Count the number of prefix cached tokens.
                 if request.num_cached_tokens < 0:
                     request.num_cached_tokens = num_computed_tokens
-                if request.num_external_computed_tokens < 0:
-                    request.num_external_computed_tokens = num_external_computed_tokens
+                if request.num_external_cached_tokens < 0:
+                    request.num_external_cached_tokens = num_external_computed_tokens
                 # Encoder-related.
                 if encoder_inputs_to_schedule:
                     scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -797,6 +797,8 @@ class Scheduler(SchedulerInterface):
                 # Count the number of prefix cached tokens.
                 if request.num_cached_tokens < 0:
                     request.num_cached_tokens = num_computed_tokens
+                if request.num_external_computed_tokens < 0:
+                    request.num_external_computed_tokens = num_external_computed_tokens
                 # Encoder-related.
                 if encoder_inputs_to_schedule:
                     scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -150,6 +150,9 @@ class Request:
         # The number of tokens with prefix cache hits.
         self.num_cached_tokens = -1
 
+        # The number of tokens that have been cached remotely
+        self.num_external_cached_tokens = -1
+
         # True if this request is scheduled as a non-final prefill chunk.
         self.is_prefill_chunk = False
 


### PR DESCRIPTION
## Purpose
Add `Num External Cached Tokens` to request to helper developer of external cache system such as LMCache to track external cache usage in each request. 

## Test Plan
- Install both vllm and lmcache from source code
- Run vllm with lmcache 
- Test Completion, Chat Completion and Response API 

## Test Result
num_external_cached_tokens works as expected, only shows num of token cached by lmcache. 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

