### PR TITLE
[BugFix/CI]: Fix AttributeError: 'RMSNormGated' object has no attribute 'activation'

### DIFF
--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -510,6 +510,7 @@ class RMSNormGated(CustomOp):
         norm_before_gate: bool = False,
         device: torch.device | None = None,
         dtype: torch.dtype | None = None,
+        activation: str = "swish",
     ):
         """Initialize RMSNormGated.
 
@@ -524,10 +525,13 @@ class RMSNormGated(CustomOp):
                               If False and z is provided: out = norm(x * silu(z))
             device: Device to create parameters on
             dtype: Data type for parameters
+            activation: Activation function to use for gating ("swish"/"silu"
+                        or "sigmoid"). Defaults to "swish".
         """
         factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
         self.eps = eps
+        self.activation = activation
         self.weight = nn.Parameter(torch.empty(hidden_size, **factory_kwargs))
         self.register_parameter("bias", None)
         self.group_size = group_size


### PR DESCRIPTION
FIX #35476

## Summary

- Adds missing `activation` attribute to `RMSNormGated` class in `layernorm.py`
- This fixes a regression introduced in  PR #35102 that caused `AttributeError: 'RMSNormGated' object has no attribute 'activation'`

## Root Cause Analysis

### The Bug

The Qwen3-Next model fails during `profile_run()` with:
```
AttributeError: 'RMSNormGated' object has no attribute 'activation'
```

### What Happened

PR #35102 added support for configurable activation functions in the gated RMSNorm layer. The changes were made to two files:

1. **`vllm/model_executor/layers/fla/ops/layernorm_guard.py`** (correctly updated):
   - Added `activation: str = "swish"` parameter to `rmsnorm_fn()`
   - Added `self.activation = activation` to `RMSNormGated.__init__()` class

2. **`vllm/model_executor/layers/layernorm.py`** (incompletely updated):
   - Added `activation=self.activation` to `RMSNormGated.forward_cuda()`
   - **BUT** did not add `self.activation` to `RMSNormGated.__init__()`

There are two separate `RMSNormGated` classes:
- One in `layernorm_guard.py` (a simple `nn.Module`)
- One in `layernorm.py` (a `CustomOp` with `forward_native` and `forward_cuda` methods)

The `qwen3_next.py` model imports `RMSNormGated` from `layernorm.py` (the `CustomOp` version), which was missing the `activation` attribute.

## The Fix

Add the missing `activation` parameter and attribute to `RMSNormGated` in `layernorm.py`, matching the signature in `layernorm_guard.py`:

```python
def __init__(
    self,
    hidden_size: int,
    eps: float = 1e-5,
    group_size: int | None = None,
    norm_before_gate: bool = False,
    device: torch.device | None = None,
    dtype: torch.dtype | None = None,
    activation: str = "swish",  # Added
):
    ...
    self.activation = activation  # Added
```

