### PR TITLE
[Feature][CI]: compare `func` & `no_func` outputs in test_functionalization.py 

### DIFF
--- a/tests/compile/passes/test_functionalization.py
+++ b/tests/compile/passes/test_functionalization.py
@@ -313,8 +313,16 @@ def test_fix_functionalization(
         model_no_func = copy.deepcopy(model_func)
         model_func = torch.compile(model_func, backend=backend_func)
         model_no_func = torch.compile(model_no_func, backend=backend_no_func)
-        model_func(*inputs_func)
-        model_no_func(*inputs_no_func)
+        outputs_func = model_func(*inputs_func)
+        outputs_no_func = model_no_func(*inputs_no_func)
+
+        if not isinstance(outputs_func, (tuple, list)):
+            outputs_func = (outputs_func,)
+        if not isinstance(outputs_no_func, (tuple, list)):
+            outputs_no_func = (outputs_no_func,)
+
+        for out_func, out_no_func in zip(outputs_func, outputs_no_func):
+            torch.testing.assert_close(out_func, out_no_func)
 
         # check if the functionalization pass is applied
         for op in model.ops_in_model(do_fusion):

--- a/tests/compile/passes/test_functionalization.py
+++ b/tests/compile/passes/test_functionalization.py
@@ -334,8 +334,3 @@ def test_fix_functionalization(
                     found[op] = True
         assert all(found[op] for op in model.ops_in_model(do_fusion))
         assert all(not found.get(op) for op in model.ops_not_in_model())
-
-        # TODO (Rohan138): compare the outputs from model_func and model_no_func
-        # currently runs into errors while comparing `TestFusedAddRMSNorm`
-        # Linked issue: https://github.com/vllm-project/vllm/issues/34996
-        # torch.testing.assert_close(outputs_func, outputs_no_func)

--- a/tests/compile/passes/test_functionalization.py
+++ b/tests/compile/passes/test_functionalization.py
@@ -316,13 +316,7 @@ def test_fix_functionalization(
         outputs_func = model_func(*inputs_func)
         outputs_no_func = model_no_func(*inputs_no_func)
 
-        if not isinstance(outputs_func, (tuple, list)):
-            outputs_func = (outputs_func,)
-        if not isinstance(outputs_no_func, (tuple, list)):
-            outputs_no_func = (outputs_no_func,)
-
-        for out_func, out_no_func in zip(outputs_func, outputs_no_func):
-            torch.testing.assert_close(out_func, out_no_func)
+        torch.testing.assert_close(outputs_func, outputs_no_func)
 
         # check if the functionalization pass is applied
         for op in model.ops_in_model(do_fusion):

--- a/tests/compile/passes/test_functionalization.py
+++ b/tests/compile/passes/test_functionalization.py
@@ -309,13 +309,12 @@ def test_fix_functionalization(
         model = model_class()
         inputs_func = model.example_inputs()
         inputs_no_func = copy.deepcopy(inputs_func)
-        model_func = model_class()
-        model_no_func = copy.deepcopy(model_func)
+        model_func = copy.deepcopy(model)
+        model_no_func = copy.deepcopy(model)
         model_func = torch.compile(model_func, backend=backend_func)
         model_no_func = torch.compile(model_no_func, backend=backend_no_func)
-        outputs_func = model_func(*inputs_func)
-        outputs_no_func = model_no_func(*inputs_no_func)
-
+        outputs_func = model_func(*copy.deepcopy(inputs_func))
+        outputs_no_func = model_no_func(*copy.deepcopy(inputs_no_func))
         torch.testing.assert_close(outputs_func, outputs_no_func)
 
         # check if the functionalization pass is applied

--- a/tests/compile/passes/test_functionalization.py
+++ b/tests/compile/passes/test_functionalization.py
@@ -313,8 +313,8 @@ def test_fix_functionalization(
         model_no_func = copy.deepcopy(model)
         model_func = torch.compile(model_func, backend=backend_func)
         model_no_func = torch.compile(model_no_func, backend=backend_no_func)
-        outputs_func = model_func(inputs_func)
-        outputs_no_func = model_no_func(inputs_no_func)
+        outputs_func = model_func(*copy.deepcopy(inputs_func))
+        outputs_no_func = model_no_func(*copy.deepcopy(inputs_no_func))
         torch.testing.assert_close(outputs_func, outputs_no_func)
 
         # check if the functionalization pass is applied

--- a/tests/compile/passes/test_functionalization.py
+++ b/tests/compile/passes/test_functionalization.py
@@ -313,8 +313,8 @@ def test_fix_functionalization(
         model_no_func = copy.deepcopy(model)
         model_func = torch.compile(model_func, backend=backend_func)
         model_no_func = torch.compile(model_no_func, backend=backend_no_func)
-        outputs_func = model_func(*copy.deepcopy(inputs_func))
-        outputs_no_func = model_no_func(*copy.deepcopy(inputs_no_func))
+        outputs_func = model_func(inputs_func)
+        outputs_no_func = model_no_func(inputs_no_func)
         torch.testing.assert_close(outputs_func, outputs_no_func)
 
         # check if the functionalization pass is applied

--- a/tests/compile/passes/test_functionalization.py
+++ b/tests/compile/passes/test_functionalization.py
@@ -313,6 +313,8 @@ def test_fix_functionalization(
         model_no_func = copy.deepcopy(model)
         model_func = torch.compile(model_func, backend=backend_func)
         model_no_func = torch.compile(model_no_func, backend=backend_no_func)
+
+        # deepcopy inputs to prevent potential in place mutation
         outputs_func = model_func(*copy.deepcopy(inputs_func))
         outputs_no_func = model_no_func(*copy.deepcopy(inputs_no_func))
         torch.testing.assert_close(outputs_func, outputs_no_func)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR Fixes #34996 
Previously `model_func` & `model_no_func` were created as new model_class instances after `model.exmaple_inputs()` had consumed the random state giving different weight, I fixed it by using `deepcopy` for both
## Test Plan

```
python -m pytest tests/compile/passes/test_functionalization.py::test_fix_functionalization[TestFusedAddRMSNorm-False-dtype0] -s
```
## Test Result
Previously failing test passed.
```
(vllm) happy@happyc:~/vllm$ python -m pytest tests/compile/passes/test_functionalization.py::test_fix_functionalization[TestFusedAddRMSNorm-False-dtype0] -s
======================================================= test session starts ========================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/happy/vllm
configfile: pyproject.toml
plugins: anyio-4.12.1
collecting ... WARNING 02-27 13:20:49 [interface.py:599] Current platform cuda does not have '__test__' attribute.
WARNING 02-27 13:20:49 [interface.py:599] Current platform cuda does not have '__bases__' attribute.
WARNING 02-27 13:20:49 [interface.py:599] Current platform cuda does not have '__test__' attribute.
collected 1 item

tests/compile/passes/test_functionalization.py INFO 02-27 13:20:50 [model.py:532] Resolved architecture: Qwen3ForCausalLM
WARNING 02-27 13:20:50 [model.py:1897] Casting torch.bfloat16 to torch.float16.
INFO 02-27 13:20:50 [model.py:1557] Using max model len 40960
INFO 02-27 13:20:50 [scheduler.py:231] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 02-27 13:20:50 [vllm.py:747] Asynchronous scheduling is enabled.
W0227 13:20:52.039000 372958 .venv/lib/python3.12/site-packages/torch/_inductor/utils.py:1679] [0/0] Not enough SMs to use max_autotune_gemm mode
.

========================================================= warnings summary =========================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv/lib/python3.12/site-packages/astor/op_util.py:92
  /home/happy/vllm/.venv/lib/python3.12/site-packages/astor/op_util.py:92: DeprecationWarning: ast.Num is deprecated and will be removed in Python 3.14; use ast.Constant instead
    precedence_data = dict((getattr(ast, x, None), z) for x, y, z in op_data)

.venv/lib/python3.12/site-packages/torch/jit/_script.py:362: 14 warnings
  /home/happy/vllm/.venv/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

<frozen importlib._bootstrap_external>:1301
  <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.

<frozen importlib._bootstrap_external>:1301
  <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================== 1 passed, 19 warnings in 5.80s ==================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

