### PR TITLE
[Bugfix][ROCm] Disable full CUDA graph capture on RDNA3/RDNA4 (gfx1x)

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -555,6 +555,16 @@ class RocmPlatform(Platform):
                     "Overriding cudagraph_mode to PIECEWISE."
                 )
                 compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+            # RDNA3/RDNA4 (gfx11xx/gfx12xx) Triton kernels are unstable
+            # inside HIP graph capture/replay, causing GPU memory faults.
+            # Downgrade to PIECEWISE which runs attention eagerly.
+            elif _ON_GFX1X:
+                logger.warning_once(
+                    "RDNA (gfx1x) detected. Full CUDA graph capture of "
+                    "Triton kernels is unsupported on this architecture. "
+                    "Overriding cudagraph_mode to PIECEWISE."
+                )
+                compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
         if cache_config and cache_config.block_size is None:
             if (


### PR DESCRIPTION
## Purpose

Fix #34154. RDNA3/RDNA4 GPUs (gfx11xx/gfx12xx) crash with `Memory access fault ... Page not present or supervisor privilege` during FULL CUDA graph capture of Triton attention kernels when running models like DeepSeek-OCR.

The default `cudagraph_mode` is `FULL_AND_PIECEWISE`, which captures the entire model forward pass (including Triton attention kernels) inside HIP graphs for uniform decode batches. On RDNA3/RDNA4 architectures, Triton-compiled kernels are unstable inside HIP graph capture/replay — a known class of issues on these GPUs (e.g., `torch.repeat_interleave` kernel crash workaround in `qwen3_omni_moe_thinker.py`). PIECEWISE mode, which runs attention eagerly outside the graph, succeeds for all batch sizes.

This PR adds a guard in `RocmPlatform.check_and_update_config()` to downgrade `cudagraph_mode` from `FULL_AND_PIECEWISE` to `PIECEWISE` on gfx1x GPUs, following the exact same pattern used for the existing DCP and PCP incompatibility downgrades.

## Test Plan

## Test Result