### PR TITLE
[Bugfix] Fix check_interleaved_audio_video false positive for batched non-interleaved requests

### DIFF
--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -150,18 +150,12 @@ def check_interleaved_audio_video(
     # Density check: for true use_audio_in_video interleaving every position
     # in the combined span is a video or audio token.  Batched non-interleaved
     # requests have text/image tokens between the per-request V and A blocks.
+    # combined_start/end encompass all V/A tokens, so num_video + num_audio
+    # equals the number of V/A tokens in range; compare directly to span size.
     combined_start = min(video_pos[0].item(), audio_pos[0].item())
     combined_end = max(video_pos[-1].item(), audio_pos[-1].item())
     total_in_range = combined_end - combined_start + 1
-    va_in_range = (
-        (
-            is_video[combined_start : combined_end + 1]
-            | is_audio[combined_start : combined_end + 1]
-        )
-        .sum()
-        .item()
-    )
-    return va_in_range == total_in_range
+    return (num_video + num_audio) == total_in_range
 
 
 def merge_interleaved_embeddings(


### PR DESCRIPTION
Fixes #35394.

## Problem

`check_interleaved_audio_video` used a simple range-overlap check to detect the `use_audio_in_video=True` case. This produces a false positive when multiple non-interleaved requests are batched together: audio tokens from request N fall between video tokens of request N and request N+1, making global position ranges overlap even though each individual request is non-interleaved.

The false positive caused `embed_input_ids` to route to `merge_interleaved_embeddings`, which then crashed with a shape mismatch because `mm_embeds` were assembled for the non-interleaved path.

## Fix

Add a density check: for true `use_audio_in_video` interleaving, every position in the combined V/A span is a video or audio token (no gaps). Batched non-interleaved requests have text/image tokens at batch boundaries that create gaps.

Both Qwen2.5-Omni and Qwen3-Omni are covered since `qwen3_omni_moe_thinker.py` imports `check_interleaved_audio_video` from `qwen2_5_omni_thinker.py`.

## Test

Added `test_batched_non_interleaved_no_false_positive` to the existing test file, which batches 5 identical non-interleaved mixed-modality requests and asserts the function correctly returns `False`.