### PR TITLE
[WIP][Bugfix] Fix CUDA OOM in sparse_attn_indexer prefill with high concurrency

### DIFF
--- a/tests/v1/attention/test_sparse_mla_backends.py
+++ b/tests/v1/attention/test_sparse_mla_backends.py
@@ -42,6 +42,7 @@ from vllm.v1.attention.backends.mla.flashmla_sparse import (
     FlashMLASparseBackend,
     triton_convert_req_index_to_global_index,
 )
+from vllm.v1.attention.backends.mla.indexer import split_indexer_prefill_chunks
 from vllm.v1.attention.backends.utils import split_prefill_chunks
 from vllm.v1.attention.ops import flashmla
 
@@ -706,6 +707,68 @@ def test_triton_convert_req_index_to_global_index_with_prefill_workspace(block_s
 )
 def test_split_prefill_chunks(seq_lens, max_buf, expected):
     out = split_prefill_chunks(seq_lens, max_buf)
+    assert out == expected
+
+
+@pytest.mark.parametrize(
+    "seq_lens,query_lens,workspace,max_logits_bytes,expected",
+    [
+        # All fit in one chunk (both constraints satisfied)
+        (
+            torch.tensor([100, 200, 300]),
+            torch.tensor([10, 20, 30]),
+            10000,
+            600 * 60 * 4,  # M*N = 60*600 = 36000, budget = 36000
+            [(0, 3)],
+        ),
+        # Logits constraint splits: M*N too large for all together
+        (
+            torch.tensor([1000, 1000]),
+            torch.tensor([500, 500]),
+            10000,  # workspace is fine
+            500 * 1000 * 4,  # budget allows M=500, N=1000 only
+            [(0, 1), (1, 2)],
+        ),
+        # Workspace constraint splits (same as split_prefill_chunks)
+        (
+            torch.tensor([2, 3, 4, 2]),
+            torch.tensor([1, 1, 1, 1]),
+            5,
+            10000000,  # logits budget is very large
+            [(0, 2), (2, 3), (3, 4)],
+        ),
+        # Single request exceeding both constraints (forced into its own chunk)
+        (
+            torch.tensor([50000]),
+            torch.tensor([1000]),
+            10000,  # workspace exceeded
+            100 * 4,  # logits budget exceeded
+            [(0, 1)],
+        ),
+        # request_offset shifts indices
+        (
+            torch.tensor([100, 200]),
+            torch.tensor([10, 20]),
+            10000,
+            10000000,
+            [(5, 7)],  # offset=5 applied
+        ),
+    ],
+    ids=[
+        "all_fit",
+        "logits_split",
+        "workspace_split",
+        "single_oversized",
+        "with_offset",
+    ],
+)
+def test_split_indexer_prefill_chunks(
+    seq_lens, query_lens, workspace, max_logits_bytes, expected
+):
+    offset = 5 if expected == [(5, 7)] else 0
+    out = split_indexer_prefill_chunks(
+        seq_lens, query_lens, workspace, max_logits_bytes, request_offset=offset
+    )
     assert out == expected
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     VLLM_ZENTORCH_WEIGHT_PREPACK: bool = True
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
+    VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: int = 512
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: Literal["auto", "nccl", "shm"] = "auto"
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
     VLLM_USE_RAY_WRAPPED_PP_COMM: bool = True
@@ -834,6 +835,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Enable SPMD mode for TPU backend.
     "VLLM_XLA_USE_SPMD": lambda: bool(int(os.getenv("VLLM_XLA_USE_SPMD", "0"))),
+    # Maximum size (in MB) for logits tensor in sparse MLA indexer prefill
+    # chunks. Bounds the [M, N] float32 logits tensor to prevent CUDA OOM.
+    # Default: 512 MB
+    "VLLM_SPARSE_INDEXER_MAX_LOGITS_MB": lambda: int(
+        os.getenv("VLLM_SPARSE_INDEXER_MAX_LOGITS_MB", "512")
+    ),
     # If set, the OpenAI API server will stay alive even after the underlying
     # AsyncLLMEngine errors and stops serving requests
     "VLLM_KEEP_ALIVE_ON_ENGINE_DEATH": lambda: bool(

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -4,6 +4,7 @@
 
 import torch
 
+import vllm.envs as envs
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
@@ -29,6 +30,13 @@ elif current_platform.is_xpu():
     from vllm._xpu_ops import xpu_ops as ops
 
 logger = init_logger(__name__)
+
+# Maximum logits tensor size for the sparse attention indexer prefill path.
+# When the full-chunk [M, N] logits would exceed this budget, we sub-chunk
+# the query dimension to keep each sub-chunk's logits within budget.
+# See: https://github.com/vllm-project/vllm/issues/34553
+_MAX_LOGITS_BYTES = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
+_MAX_LOGITS_ELEMS = _MAX_LOGITS_BYTES // 4  # float32
 
 
 def sparse_attn_indexer(
@@ -113,60 +121,62 @@ def sparse_attn_indexer(
                 chunk.block_table,
                 chunk.cu_seq_lens,
             )
-            if is_deep_gemm_supported():
-                logits = fp8_mqa_logits(
-                    q_fp8[chunk.token_start : chunk.token_end],
-                    (k_fp8, k_scale.view(torch.float32).flatten()),
-                    weights[chunk.token_start : chunk.token_end],
-                    chunk.cu_seqlen_ks,
-                    chunk.cu_seqlen_ke,
-                    clean_logits=False,
-                )
-            else:
-                logits = fp8_mqa_logits_torch(
-                    q_fp8[chunk.token_start : chunk.token_end],
-                    (k_fp8, k_scale.view(torch.float32).flatten()),
-                    weights[chunk.token_start : chunk.token_end],
-                    chunk.cu_seqlen_ks,
-                    chunk.cu_seqlen_ke,
-                )
-            num_rows = logits.shape[0]
+            chunk_m = chunk.token_end - chunk.token_start
+            chunk_n = chunk.total_seq_lens
+            kv = (k_fp8, k_scale.view(torch.float32).flatten())
 
-            topk_indices = topk_indices_buffer[
-                chunk.token_start : chunk.token_end, :topk_tokens
-            ]
-
-            if current_platform.is_xpu():
-                ops.top_k_per_row_prefill(
-                    logits,
-                    chunk.cu_seqlen_ks,
-                    chunk.cu_seqlen_ke,
-                    topk_indices,
-                    num_rows,
-                    logits.stride(0),
-                    logits.stride(1),
-                    topk_tokens,
-                )
-            else:
-                torch.ops._C.top_k_per_row_prefill(
-                    logits,
-                    chunk.cu_seqlen_ks,
-                    chunk.cu_seqlen_ke,
-                    topk_indices,
-                    num_rows,
-                    logits.stride(0),
-                    logits.stride(1),
-                    topk_tokens,
-                )
-
-            # Compute lengths from row spans
-            # lengths = (chunk.cu_seqlen_ke - chunk.cu_seqlen_ks).to(torch.int32)
-            # torch.ops._C.large_context_topk(
-            #    logits,
-            #    topk_indices,
-            #    lengths,
-            #    chunk.cu_seqlen_ks,  # row_starts
-            # )
+            # Sub-chunk the query dimension when the [M, N] logits
+            # tensor would exceed the memory budget. When it fits,
+            # max_q == chunk_m so this loop runs exactly once.
+            # See: https://github.com/vllm-project/vllm/issues/34553
+            max_q = (
+                max(1, _MAX_LOGITS_ELEMS // chunk_n)
+                if chunk_m * chunk_n > _MAX_LOGITS_ELEMS
+                else chunk_m
+            )
+            for sub_s in range(0, chunk_m, max_q):
+                sub_e = min(sub_s + max_q, chunk_m)
+                g_s = chunk.token_start + sub_s
+                g_e = chunk.token_start + sub_e
+                if is_deep_gemm_supported():
+                    logits = fp8_mqa_logits(
+                        q_fp8[g_s:g_e],
+                        kv,
+                        weights[g_s:g_e],
+                        chunk.cu_seqlen_ks[sub_s:sub_e],
+                        chunk.cu_seqlen_ke[sub_s:sub_e],
+                        clean_logits=False,
+                    )
+                else:
+                    logits = fp8_mqa_logits_torch(
+                        q_fp8[g_s:g_e],
+                        kv,
+                        weights[g_s:g_e],
+                        chunk.cu_seqlen_ks[sub_s:sub_e],
+                        chunk.cu_seqlen_ke[sub_s:sub_e],
+                    )
+                if current_platform.is_xpu():
+                    ops.top_k_per_row_prefill(
+                        logits,
+                        chunk.cu_seqlen_ks[sub_s:sub_e],
+                        chunk.cu_seqlen_ke[sub_s:sub_e],
+                        topk_indices_buffer[g_s:g_e, :topk_tokens],
+                        logits.shape[0],
+                        logits.stride(0),
+                        logits.stride(1),
+                        topk_tokens,
+                    )
+                else:
+                    torch.ops._C.top_k_per_row_prefill(
+                        logits,
+                        chunk.cu_seqlen_ks[sub_s:sub_e],
+                        chunk.cu_seqlen_ke[sub_s:sub_e],
+                        topk_indices_buffer[g_s:g_e, :topk_tokens],
+                        logits.shape[0],
+                        logits.stride(0),
+                        logits.stride(1),
+                        topk_tokens,
+                    )
 
     if has_decode:
         decode_metadata = attn_metadata.decode

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import torch
 
+import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -22,12 +23,42 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
-    split_prefill_chunks,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.worker.cp_utils import get_total_cp_world_size
 
 logger = init_logger(__name__)
+
+
+def split_indexer_prefill_chunks(
+    seq_lens_cpu: torch.Tensor,
+    query_lens_cpu: torch.Tensor,
+    workspace_size: int,
+    max_logits_bytes: int,
+    request_offset: int = 0,
+) -> list[tuple[int, int]]:
+    """Split prefill requests into chunks for the sparse indexer, respecting:
+    - N constraint: total_seq_lens <= workspace_size (existing O(N) workspace)
+    - Logits constraint: M * N * 4 <= max_logits_bytes
+    """
+    chunk_bounds: list[tuple[int, int]] = []
+    n = len(seq_lens_cpu)
+    max_logits_elems = max_logits_bytes // 4
+    start, chunk_m, chunk_n = 0, 0, 0
+
+    for i in range(n):
+        q, s = query_lens_cpu[i].item(), seq_lens_cpu[i].item()
+        new_m, new_n = chunk_m + q, chunk_n + s
+        if chunk_m > 0 and (new_n > workspace_size or new_m * new_n > max_logits_elems):
+            chunk_bounds.append((start + request_offset, i + request_offset))
+            start, chunk_m, chunk_n = i, q, s
+        else:
+            chunk_m, chunk_n = new_m, new_n
+
+    if n > 0:
+        chunk_bounds.append((start + request_offset, n + request_offset))
+
+    return chunk_bounds
 
 
 class DeepseekV32IndexerBackend(AttentionBackend):
@@ -339,9 +370,15 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
 
         prefill_metadata = None
         if num_prefills > 0:
-            chunk_seq_ids = split_prefill_chunks(
+            prefill_query_lens_cpu = torch.diff(
+                query_start_loc_cpu[num_decodes : num_decodes + num_prefills + 1]
+            )
+            max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
+            chunk_seq_ids = split_indexer_prefill_chunks(
                 common_attn_metadata.seq_lens_cpu[num_decodes:],
+                prefill_query_lens_cpu,
                 self.max_prefill_buffer_size,
+                max_logits_bytes,
                 request_offset=num_decodes,
             )
             chunks = [


### PR DESCRIPTION
## Purpose

Fix CUDA OOM in `sparse_attn_indexer` during prefill with high concurrency (e.g., 48–64 concurrent requests with ISL=10240 on 8×H200 serving GLM-5-FP8).

Fixes: https://github.com/vllm-project/vllm/issues/34553

## Root Cause

`fp8_mqa_logits` allocates a `[M, N]` float32 logits tensor where M = total query tokens and N = total KV seq lengths. The existing `split_prefill_chunks` only bounds N (workspace size) but not the M×N product (logits size). At high concurrency, N grows to ~300K+ while M stays ~8192, causing a ~9.89 GiB allocation that OOMs.

A secondary issue: per-request KV slicing in a naive fix breaks TMA (Tensor Memory Access) alignment required by DeepGEMM's `cuTensorMapEncodeTiled`, causing sporadic `CUDA_ERROR_INVALID_VALUE`.

## Solution

**Metadata-level chunk splitting** (inspired by #36178): Add `split_indexer_prefill_chunks()` in the metadata builder that considers **both** the workspace (N) and logits (M×N×4) constraints when splitting prefill requests into chunks. This prevents the logits tensor from ever exceeding the memory budget.

**Query-only sub-chunking safety net**: For single-request overflow (one request's M×N exceeds budget), sub-chunk only the query dimension while keeping the full KV buffer intact. This avoids per-request KV slicing and preserves TMA alignment.

### Key changes:

1. **`vllm/envs.py`**: Register `VLLM_SPARSE_INDEXER_MAX_LOGITS_MB` (default 512 MB) environment variable
2. **`vllm/v1/attention/backends/mla/indexer.py`**: Add `split_indexer_prefill_chunks()` that respects both N and M×N constraints; update `build()` to use it
3. **`vllm/model_executor/layers/sparse_attn_indexer.py`**: Add helper functions for prefill logits computation with query sub-chunking fallback; use `vllm.envs` instead of `os.environ`
4. **`tests/v1/attention/test_sparse_mla_backends.py`**: Add parametrized tests for `split_indexer_prefill_chunks`

## Test Plan

- [x] `python -m pytest tests/v1/attention/test_sparse_mla_backends.py::test_split_indexer_prefill_chunks -x -v` — 5/5 pass
- [x] `python -m pytest tests/v1/attention/test_sparse_mla_backends.py::test_split_prefill_chunks -x -v` — existing tests still pass
- [ ] Full validation on SM90+ hardware: serve GLM-5-FP8 with high concurrency and confirm no OOM or CUDA errors