### PR TITLE
[Bugfix] Fix Fabric/RDMA attribute queries poisoning global error_code in cumem allocator

### DIFF
--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -100,6 +100,7 @@ void create_and_map(unsigned long long device, ssize_t size, CUdeviceptr d_mem,
                     unsigned long long* chunk_sizes, size_t num_chunks) {
 #endif
   ensure_context(device);
+  error_code = no_error;  // Clear any stale error from prior operations
   // Define memory allocation properties
   CUmemAllocationProp prop = {};
   prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
@@ -109,15 +110,21 @@ void create_and_map(unsigned long long device, ssize_t size, CUdeviceptr d_mem,
 
 #ifndef USE_ROCM
   int flag = 0;
-  CUDA_CHECK(cuDeviceGetAttribute(
+  CUresult rdma_ret = cuDeviceGetAttribute(
       &flag, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED,
-      device));
+      device);
+  if (rdma_ret != CUDA_SUCCESS) {
+    flag = 0;  // Attribute not recognized; assume no RDMA support
+  }
   if (flag) {  // support GPUDirect RDMA if possible
     prop.allocFlags.gpuDirectRDMACapable = 1;
   }
   int fab_flag = 0;
-  CUDA_CHECK(cuDeviceGetAttribute(
-      &fab_flag, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, device));
+  CUresult fab_ret = cuDeviceGetAttribute(
+      &fab_flag, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, device);
+  if (fab_ret != CUDA_SUCCESS) {
+    fab_flag = 0;  // Attribute not recognized; assume no Fabric support
+  }
   if (fab_flag) {  // support fabric handle if possible
     prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
   }


### PR DESCRIPTION
## Purpose

Fix #35463.

When upgrading from vllm 0.15.0 to 0.16.0, users encounter `CUDA Error: invalid argument at cumem_allocator.cpp:119` followed by OOM errors during `allocator.sleep()`.

**Root cause:** Commit 528e9b149 (PR #33540) added Fabric handle detection in `create_and_map()` using the `CUDA_CHECK` macro to query `CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED`. On GPUs/drivers that don't recognize this attribute, `cuDeviceGetAttribute()` returns `CUDA_ERROR_INVALID_VALUE`, which `CUDA_CHECK` writes into the global `error_code` variable. The subsequent guard `if (error_code != 0) { return; }` then causes an early exit — memory is created via `cuMemCreate` but never mapped via `cuMemMap`, corrupting allocator state.

**Fix:** Replace `CUDA_CHECK` with direct return value checks for both the Fabric and RDMA capability queries (same pattern bug), treating query failures as "attribute not supported" rather than fatal errors. Also reset `error_code` at the start of `create_and_map()` as defense-in-depth against stale errors leaking across calls.

## Test Plan

## Test Result