### PR TITLE
[Misc] Bound NIXL upper bound version

### DIFF
--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -1,3 +1,3 @@
 lmcache >= 0.3.9
-nixl >= 0.7.1 # Required for disaggregated prefill
+nixl >= 0.7.1, < 0.10.0 # Required for disaggregated prefill
 mooncake-transfer-engine >= 0.3.8


### PR DESCRIPTION
Temporarily bounding NIXL to <0.10.0 after some internal reports of agent disconnection (nixlRemoteDisconnectError) by @ZhanqiuHu. 

All in all, we should still have a bit more control over deps and add an upper version bound.
