### PR TITLE
[Bugfix] Fix NVFP4 MoE scale misalignment for non-128-aligned hidden dims

### DIFF
--- a/tests/kernels/moe/test_nvfp4_moe.py
+++ b/tests/kernels/moe/test_nvfp4_moe.py
@@ -39,6 +39,9 @@ MNK_FACTORS = [
     (64, 2048, 1536),
     (224, 1024, 1024),
     (224, 1024, 1536),
+    # Non-128-aligned K: triggers swizzle_blockscale w2 padding mismatch
+    (2, 2880, 2880),
+    (64, 1024, 1600),
 ]
 
 

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -566,4 +566,11 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
 
         w2_scale = swizzle_blockscale(w2_scale)
 
+        # Pad w2 to match w2_scale. swizzle_blockscale rounds M up to
+        # a multiple of 128, and the CUTLASS kernel computes per-expert
+        # scale offsets using N = b.size(1) from the weight tensor.
+        w2_pad = w2_scale.size(1) - w2.size(1)
+        if w2_pad > 0:
+            w2 = torch.nn.functional.pad(w2, (0, 0, 0, w2_pad))
+
     return w13, w13_scale, w13_scale_2, a13_scale, w2, w2_scale, w2_scale_2, a2_scale


### PR DESCRIPTION
## Summary

- `swizzle_blockscale()` pads M to a multiple of 128 when preparing block scales for the CUTLASS FP4 MoE kernel. For the second GEMM (down projection), `w2_scale` gets padded (e.g. 2880 → 2944) but `w2` stays at the original size. The CUTLASS kernel computes per-expert scale offsets as `expert_id * N * group_k` where `N = b.size(1)` from the weight tensor, causing every expert > 0 to read scale data at the wrong offset — producing garbage output.
- Fixes by padding `w2` to match `w2_scale`, adjusting `problem_sizes2` and output workspace in `run_cutlass_moe_fp4`, slicing output back to actual hidden_dim, and ensuring workspace allocation accounts for padded K.
- Affects any NVFP4 MoE model where `hidden_dim % 128 != 0`. Models with power-of-2 hidden dims (Llama, DeepSeek, Qwen) are unaffected.

## Test plan

- [ ] New test cases with non-128-aligned K (2880, 1600) in `tests/kernels/moe/test_nvfp4_moe.py`
- [ ] All existing NVFP4 MoE tests pass (128-aligned K values unchanged)
- [ ] Verified with real MoE model inference (hidden_dim=2880, 32 experts) — coherent output after fix, garbage before