### PR TITLE
[Feature] Add basic metrics for /realtime endpoint

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -264,12 +264,13 @@ def build_app(
     # Add scaling middleware to check for scaling state
     app.add_middleware(ScalingMiddleware)
 
-    # Add WebSocket metrics middleware
-    from vllm.entrypoints.openai.realtime.metrics import (
-        WebSocketMetricsMiddleware,
-    )
+    if "realtime" in supported_tasks:
+        # Add WebSocket metrics middleware
+        from vllm.entrypoints.openai.realtime.metrics import (
+            WebSocketMetricsMiddleware,
+        )
 
-    app.add_middleware(WebSocketMetricsMiddleware)
+        app.add_middleware(WebSocketMetricsMiddleware)
 
     if envs.VLLM_DEBUG_LOG_API_SERVER_RESPONSE:
         logger.warning(

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -264,6 +264,13 @@ def build_app(
     # Add scaling middleware to check for scaling state
     app.add_middleware(ScalingMiddleware)
 
+    # Add WebSocket metrics middleware
+    from vllm.entrypoints.openai.realtime.metrics import (
+        WebSocketMetricsMiddleware,
+    )
+
+    app.add_middleware(WebSocketMetricsMiddleware)
+
     if envs.VLLM_DEBUG_LOG_API_SERVER_RESPONSE:
         logger.warning(
             "CAUTION: Enabling log response in the API Server. "

--- a/vllm/entrypoints/openai/realtime/metrics.py
+++ b/vllm/entrypoints/openai/realtime/metrics.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""ASGI middleware for WebSocket Prometheus metrics.
+
+Modeled after prometheus-fastapi-instrumentator, this middleware
+transparently instruments WebSocket endpoints with standard metrics
+without requiring changes to handler code.
+
+NOTE: This module intentionally has zero vllm imports so that it can
+be extracted into a standalone package (similar to
+prometheus-fastapi-instrumentator) in the future. Please keep it that way.
+"""
+
+import time
+from collections.abc import Awaitable
+
+from prometheus_client import Counter, Gauge, Histogram
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+# Standard WebSocket metric names (not vllm-specific, following
+# the same convention as prometheus-fastapi-instrumentator).
+_active_sessions = Gauge(
+    name="vllm:websocket_connections_active",
+    documentation="Number of currently active WebSocket connections.",
+    multiprocess_mode="livesum",
+)
+
+_total_sessions = Counter(
+    name="vllm:websocket_connections_total",
+    documentation="Total number of WebSocket connections.",
+)
+
+_session_duration = Histogram(
+    name="vllm:websocket_connection_duration_seconds",
+    documentation="Duration of WebSocket connections in seconds.",
+    buckets=[0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600, 1800],
+)
+
+
+class WebSocketMetricsMiddleware:
+    """Pure ASGI middleware that instruments WebSocket connections.
+
+    Tracks active connections (gauge), total connections (counter),
+    and connection duration (histogram) for all WebSocket endpoints.
+
+    Usage::
+
+        app.add_middleware(WebSocketMetricsMiddleware)
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    def __call__(
+        self, scope: Scope, receive: Receive, send: Send
+    ) -> Awaitable[None]:
+        if scope["type"] != "websocket":
+            return self.app(scope, receive, send)
+
+        return self._handle_websocket(scope, receive, send)
+
+    async def _handle_websocket(
+        self, scope: Scope, receive: Receive, send: Send
+    ) -> None:
+        start_time: float | None = None
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal start_time
+            if message["type"] == "websocket.accept":
+                start_time = time.monotonic()
+                _active_sessions.inc()
+                _total_sessions.inc()
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            if start_time is not None:
+                _active_sessions.dec()
+                _session_duration.observe(time.monotonic() - start_time)

--- a/vllm/entrypoints/openai/realtime/metrics.py
+++ b/vllm/entrypoints/openai/realtime/metrics.py
@@ -51,9 +51,7 @@ class WebSocketMetricsMiddleware:
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
-    def __call__(
-        self, scope: Scope, receive: Receive, send: Send
-    ) -> Awaitable[None]:
+    def __call__(self, scope: Scope, receive: Receive, send: Send) -> Awaitable[None]:
         if scope["type"] != "websocket":
             return self.app(scope, receive, send)
 


### PR DESCRIPTION
## Purpose

The purpose of this PR is to lay the foundation for /realtime mettrics since we have none at the moment: https://github.com/vllm-project/vllm/issues/35004

We're implementing these metrics as a pure middleware, with no internal references to vllm from the implementation such that we can turn this into a separate project down the line (similar to prometheus-fastapi-instrumentator).

Metrics exposed:
- vllm:websocket_connections_active (Gauge)
- vllm:websocket_connections_total (Counter)
- vllm:websocket_connection_duration_seconds (Histogram)

## Test Plan

```
  python -m vllm.entrypoints.openai.api_server \
      --model mistralai/Voxtral-Mini-3B-Realtime-2602 \
      --gpu-memory-utilization 0.8 \
      --enforce-eager \
      --max-model-len 4096

  Test script pseudocode:

  - Open 10 WebSocket connections to /v1/realtime with random lifetimes (20-60s)
  - Each session sends random PCM16 audio chunks over its lifetime
  - Stagger session starts over ~10s
  - Every 5s, scrape GET /metrics and print vllm:websocket_* lines
  - Verify: active gauge ramps up to 10, decreases as sessions close, returns to 0
  - Verify: total counter reaches 10 and stays
  - Verify: duration histogram buckets fill correctly (≤30s and ≤60s)
```

## Test Result

```
  t+0s — fresh server, no connections yet:
  vllm:websocket_connections_active                             0.0
  vllm:websocket_connections_total                              0.0
  vllm:websocket_connection_duration_seconds_count              0.0

  t+10s — all 10 sessions connected:
  vllm:websocket_connections_active                             10.0
  vllm:websocket_connections_total                              10.0
  vllm:websocket_connection_duration_seconds_count              0.0

  t+45s — 5 sessions closed, 5 still active:
  vllm:websocket_connections_active                             5.0
  vllm:websocket_connections_total                              10.0
  vllm:websocket_connection_duration_seconds_count              5.0
  vllm:websocket_connection_duration_seconds_bucket{le="30.0"}  2.0
  vllm:websocket_connection_duration_seconds_bucket{le="60.0"}  5.0

  t+62s — all sessions closed:
  vllm:websocket_connections_active                             0.0
  vllm:websocket_connections_total                              10.0
  vllm:websocket_connection_duration_seconds_count              10.0
  vllm:websocket_connection_duration_seconds_sum                401.74
  vllm:websocket_connection_duration_seconds_bucket{le="30.0"}  2.0
  vllm:websocket_connection_duration_seconds_bucket{le="60.0"}  10.0
  vllm:websocket_connection_duration_seconds_bucket{le="+Inf"}  10.0
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ x The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

