### PR TITLE
[Bugfix] Fix GLM-OCR text_config model_type handling

### DIFF
--- a/vllm/transformers_utils/configs/glm_ocr.py
+++ b/vllm/transformers_utils/configs/glm_ocr.py
@@ -74,12 +74,13 @@ class GlmOcrConfig(PretrainedConfig):
         if isinstance(text_config, dict):
             from transformers import AutoConfig
 
-            model_type = text_config.get("model_type", "chatglm")
+            text_config = dict(text_config)
+            model_type = text_config.pop("model_type", "glm_ocr_text")
             self.text_config = AutoConfig.for_model(model_type, **text_config)
         elif text_config is None:
             from transformers import AutoConfig
 
-            self.text_config = AutoConfig.for_model("chatglm")
+            self.text_config = AutoConfig.for_model("glm_ocr_text")
         else:
             self.text_config = text_config
 


### PR DESCRIPTION
## Summary

Fix two issues in `GlmOcrConfig` text_config initialization:

1. **Duplicate keyword argument**: `text_config.get("model_type", ...)` leaves `model_type` in the dict, which then gets passed again via `**text_config` to `AutoConfig.for_model()`, causing a `TypeError`. Fixed by using `pop()` instead.

2. **Wrong default model_type**: The fallback was `"chatglm"` but GLM-OCR uses `"glm_ocr_text"` as its text sub-config type, matching the HuggingFace transformers implementation.

## Test Plan

This is a config initialization fix. The changes align with the upstream transformers implementation of `GlmOcrConfig`.

Fixes #35464