### PR TITLE
[Bugfix] Move chat completion response_format validation to Pydantic model_validator

### DIFF
--- a/tests/entrypoints/openai/test_chat_error.py
+++ b/tests/entrypoints/openai/test_chat_error.py
@@ -370,3 +370,15 @@ def test_system_message_warns_on_video(video_content):
     call_args = str(mock_logger.warning_once.call_args)
     assert "System messages should only contain text" in call_args
     assert "video_url" in call_args
+
+
+def test_json_schema_response_format_missing_schema():
+    """When response_format type is 'json_schema' but the json_schema field
+    is not provided, request construction should raise a validation error
+    so the API returns 400 instead of 500."""
+    with pytest.raises(Exception, match="json_schema.*must be provided"):
+        ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            response_format={"type": "json_schema"},
+        )

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -504,6 +504,34 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def validate_response_format(cls, data):
+        response_format = data.get("response_format")
+        if response_format is None:
+            return data
+
+        rf_type = (
+            response_format.get("type")
+            if isinstance(response_format, dict)
+            else getattr(response_format, "type", None)
+        )
+
+        if rf_type == "json_schema":
+            json_schema = (
+                response_format.get("json_schema")
+                if isinstance(response_format, dict)
+                else getattr(response_format, "json_schema", None)
+            )
+            if json_schema is None:
+                raise VLLMValidationError(
+                    "When response_format type is 'json_schema', the "
+                    "'json_schema' field must be provided.",
+                    parameter="response_format",
+                )
+
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def validate_stream_options(cls, data):
         if data.get("stream_options") and not data.get("stream"):
             raise VLLMValidationError(


### PR DESCRIPTION
## Summary

Apply the same Pydantic validation pattern from #35456 (completions endpoint, merged) to the **chat completions** endpoint.

The `/v1/chat/completions` endpoint has the same issue: when `response_format` type is `json_schema` but the `json_schema` field is missing, an `assert` fires during `to_sampling_params()`, causing a 500 Internal Server Error instead of a 400 Bad Request.

This PR adds a `@model_validator(mode="before")` to `ChatCompletionRequest` that validates `json_schema` presence at request construction time, following the approach requested by @DarkLight1337 in the review of #35456.

**Note:** #35443 addresses the same issue with an inline `ValueError` approach. This PR uses the Pydantic `model_validator` pattern instead, consistent with the reviewer feedback on #35456 and the existing validation style in the codebase.

## Changes

- **`chat_completion/protocol.py`**: Add `validate_response_format` model validator
- **`test_chat_error.py`**: Add test for missing `json_schema` field validation

## Test Plan

```bash
pytest tests/entrypoints/openai/test_chat_error.py::test_json_schema_response_format_missing_schema -v
```

Related: #35456 (completions endpoint fix, merged), #35438, #35443