### PR TITLE
[Bugfix] Replace assert with ValueError for response_format validatio…

### DIFF
--- a/tests/entrypoints/openai/test_chat_error.py
+++ b/tests/entrypoints/openai/test_chat_error.py
@@ -153,6 +153,19 @@ async def test_chat_error_non_stream():
     assert response.error.code == HTTPStatus.INTERNAL_SERVER_ERROR
 
 
+def test_json_schema_response_format_missing_schema():
+    """When response_format type is 'json_schema' but the json_schema field
+    is not provided, request construction should raise a validation error
+    so the API returns 400 instead of 500."""
+    with pytest.raises(Exception, match="json_schema.*must be provided"):
+        ChatCompletionRequest(
+            model=MODEL_NAME,
+            prompt="Test prompt",
+            max_tokens=10,
+            response_format={"type": "json_schema"},
+        )
+
+
 @pytest.mark.asyncio
 async def test_chat_error_stream():
     """test finish_reason='error' returns 500 InternalServerError (streaming)"""


### PR DESCRIPTION

## Purpose

When the /v1/chat/completions endpoint receives a request with `response_format` type `json_schema` but without the required json_schema field, the server crashes with an AssertionError, resulting in a **500 Internal Server Error**.

Fixes https://github.com/vllm-project/vllm/issues/35438

This is the same class of issue addressed in https://github.com/vllm-project/vllm/pull/35456 for the `/v1/completions` endpoint

## Test Plan

```
pytest tests/entrypoints/openai/test_chat_error.py -v
```

## Test Result

```
Testing started at 14:58 ...
Launching pytest with arguments test_chat_error.py::test_json_schema_response_format_missing_schema --no-header --no-summary -q in /Users/santonov/github/vllm/tests/entrypoints/openai

============================= test session starts ==============================
collecting ... collected 1 item

test_chat_error.py::test_json_schema_response_format_missing_schema PASSED [100%]
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

