### PR TITLE
Make DeepSeek V2/V3/R1 RMSNorm consistent with DeepSeek impl

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -446,7 +446,7 @@ class DeepseekV2Attention(nn.Module):
                 quant_config=quant_config,
                 prefix=f"{prefix}.q_a_proj",
             )
-            self.q_a_layernorm = RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
+            self.q_a_layernorm = RMSNorm(self.q_lora_rank)
             self.q_b_proj = ColumnParallelLinear(
                 q_lora_rank,
                 self.num_heads * self.qk_head_dim,
@@ -470,7 +470,7 @@ class DeepseekV2Attention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.kv_a_proj_with_mqa",
         )
-        self.kv_a_layernorm = RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
+        self.kv_a_layernorm = RMSNorm(self.kv_lora_rank)
         self.kv_b_proj = ColumnParallelLinear(
             self.kv_lora_rank,
             self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),


### PR DESCRIPTION
In the remote code (and the upstreamed Trannsformers implementation) `eps` is not passed to to the RMSNorm ops inside the Attention module. As you can see from https://huggingface.co/deepseek-ai/DeepSeek-V3/blob/main/modeling_deepseek.py#L664-L674

In vLLM we were passing `eps` to these ops so if a config specified a value of `rms_norm_eps` that wasn't the same as the default value for the `RMSNorm` op, they would see inconsistent behaviour between Transformers and vLLM.

This PR updates the vLLM implementation to match the other two.