### PR TITLE
[misc] cleanup one level of error stack when nixl fails to initialize

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -2506,6 +2506,9 @@ class NixlConnectorWorker:
 
     def shutdown(self):
         """Shutdown the connector worker."""
+        if not hasattr(self, "_handshake_initiation_executor"):
+            # error happens during init, no need to shutdown
+            return
         self._handshake_initiation_executor.shutdown(wait=False)
         for handles in self._recving_transfers.values():
             for handle in handles:


### PR DESCRIPTION
## Purpose

When NIXL fails to init, the shutdown function will raise a confusing error, see https://github.com/vllm-project/vllm/issues/32222 for example, while the actual error is "RuntimeError: NIXL is not available".

## Test Plan

Run NIXL example without NIXL installed, and the shutdown log can be clean.

## Test Result

Run NIXL example without NIXL installed, and the shutdown log does not contain "AttributeError: 'NixlConnectorWorker' object has no attribute '_handshake_initiation_executor'"

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

