### PR TITLE
[Bugfix] Fix loading Music Flamingo

### DIFF
--- a/vllm/model_executor/models/audioflamingo3.py
+++ b/vllm/model_executor/models/audioflamingo3.py
@@ -128,12 +128,6 @@ class AudioFlamingo3Encoder(Qwen2AudioEncoder):
         super().__init__(config)
         self.avg_pooler = nn.AvgPool1d(kernel_size=2, stride=2)
         # self.layer_norm is already initialized in super().__init__
-        # Keep a dummy freqs parameter for MusicFlamingo checkpoints.
-        self.pos_emb = nn.Module()
-        freqs = torch.empty(getattr(config, "num_mel_bins", 128))
-        self.pos_emb.register_parameter(
-            "freqs", nn.Parameter(freqs, requires_grad=False)
-        )
 
     def forward(
         self,

--- a/vllm/model_executor/models/musicflamingo.py
+++ b/vllm/model_executor/models/musicflamingo.py
@@ -21,6 +21,7 @@ from vllm.multimodal.processing import BaseProcessingInfo
 from .audioflamingo3 import (
     AudioFlamingo3DummyInputsBuilder,
     AudioFlamingo3ForConditionalGeneration,
+    AudioFlamingo3MultiModalDataParser,
     AudioFlamingo3MultiModalProcessor,
 )
 
@@ -53,8 +54,16 @@ class MusicFlamingoProcessingInfo(BaseProcessingInfo):
         hf_processor = self.get_hf_processor(**kwargs)
         return hf_processor.feature_extractor
 
+    def get_data_parser(self):
+        feature_extractor = self.get_feature_extractor()
+
+        return AudioFlamingo3MultiModalDataParser(
+            target_sr=feature_extractor.sampling_rate,
+            expected_hidden_size=self._get_expected_hidden_size(),
+        )
+
     def get_supported_mm_limits(self) -> Mapping[str, int | None]:
-        return {"audio": None}
+        return {"audio": 1}
 
 
 class MusicFlamingoDummyInputsBuilder(AudioFlamingo3DummyInputsBuilder):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes https://github.com/vllm-project/vllm/issues/35522

## Test Plan

```
uv pip install "transformers @ git+https://github.com/huggingface/transformers@pull/43538/head"

python examples/offline_inference/audio_language.py --model-type musicflamingo  --model nvidia/music-flamingo-think-2601-hf
python examples/offline_inference/audio_language.py --model-type musicflamingo  --model nvidia/music-flamingo-2601-hf
python examples/offline_inference/audio_language.py --model-type audioflamingo3 --model nvidia/music-flamingo-hf
python examples/offline_inference/audio_language.py --model-type audioflamingo3 --model nvidia/audio-flamingo-3-hf
```

## Test Result

All commands are successfully executed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

