### PR TITLE
[BugFix] Validate max_model_len against num_gpu_blocks_override at init

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1607,6 +1607,28 @@ def get_kv_cache_configs(
         if len(kv_cache_config.kv_cache_groups) > 0:
             _report_kv_cache_config(vllm_config, kv_cache_config)
 
+    # When num_gpu_blocks_override is set, validate that max_model_len
+    # still fits in the actual (overridden) block count.  Without this
+    # check the scheduler will loop forever on requests that can never
+    # be allocated.
+    if (vllm_config.cache_config.num_gpu_blocks_override is not None
+            and global_kv_cache_groups):
+        block_size = global_kv_cache_groups[0].kv_cache_spec.block_size
+        # One block is reserved as the null block.
+        usable_blocks = min_num_blocks - 1
+        max_tokens = usable_blocks * block_size
+        max_model_len = vllm_config.model_config.max_model_len
+        if max_model_len > max_tokens:
+            raise ValueError(
+                f"num_gpu_blocks_override="
+                f"{vllm_config.cache_config.num_gpu_blocks_override} "
+                f"provides {usable_blocks} usable blocks "
+                f"({max_tokens} tokens with block_size={block_size}), "
+                f"which cannot serve a request of max_model_len="
+                f"{max_model_len}. Decrease max_model_len to at most "
+                f"{max_tokens}, or increase num_gpu_blocks_override to "
+                f"at least {cdiv(max_model_len, block_size) + 1}.")
+
     return kv_cache_configs
 
 


### PR DESCRIPTION


## Purpose

Fix https://github.com/vllm-project/vllm/issues/35541

When `num_gpu_blocks_override` is set low (e.g., 50, giving 49 usable blocks) and a prompt requires more blocks than exist (e.g., ~1002 tokens needing 63 blocks), `allocate_slots()` returns `None`. The scheduler breaks out of the waiting loop, but the request stays at the head of the queue (accessed via `peek_request()`, only popped on success). The next `schedule()` call retries the same request, fails again, and loops forever with zero progress.
The Fix is:

Add an init-time validation in `get_kv_cache_configs()`: after the override is applied and `min_num_blocks` is finalized, check that `max_model_len` fits in the usable blocks (`min_num_blocks - 1`). If not, raise a `ValueError` .

```
## Test Result

Before fix: Round 2 hangs indefinitely (killed after 90s+ timeout).

After fix:  request finished (case 1 in my example) or crashed (case 2/3 for small VRAM)



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

