### PR TITLE
feat: batch-aware expert pruning (XShare) for MoE models

### DIFF
--- a/tests/test_xshare_pruning.py
+++ b/tests/test_xshare_pruning.py
@@ -1,0 +1,418 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for MoE batch-aware expert pruning (XShare)."""
+
+import pytest
+import torch
+
+from vllm.config.moe import MoEConfig, MoEPruningConfig
+from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (
+    _fused_prune_experts,
+    _get_moe_pruning_config,
+    _prune_experts,
+    set_moe_config,
+)
+
+
+def _cfg(**kwargs):
+    defaults = dict(
+        enable=True,
+        expert_budget=None,
+        budget_alpha=0.5,
+        top_per_token=0,
+        group_budget=0,
+        group_size=0,
+        min_batch=0,
+        max_batch=0,
+    )
+    defaults.update(kwargs)
+    return MoEConfig(pruning=MoEPruningConfig(**defaults))
+
+
+@pytest.fixture(autouse=True)
+def _reset_config():
+    set_moe_config(None)
+    yield
+    set_moe_config(None)
+
+
+MASK_VAL_F32 = torch.finfo(torch.float32).min
+
+
+def _unmasked(result):
+    return (result > torch.finfo(result.dtype).min).sum(dim=1)
+
+
+def _unmasked_cols(result):
+    return (result > torch.finfo(result.dtype).min).any(dim=0).sum().item()
+
+
+# ── Disabled / no-op ──
+
+
+@pytest.mark.parametrize(
+    "config,label",
+    [
+        (None, "no config"),
+        (MoEConfig(pruning=MoEPruningConfig(enable=False)), "disabled"),
+        (
+            MoEConfig(
+                pruning=MoEPruningConfig(
+                    enable=True,
+                    expert_budget=None,
+                    budget_alpha=0.0,
+                    top_per_token=0,
+                    group_budget=0,
+                )
+            ),
+            "no knobs",
+        ),
+    ],
+)
+def test_pruning_disabled(config, label):
+    set_moe_config(config)
+    gating = torch.randn(8, 128)
+    assert torch.equal(_prune_experts(gating), gating), label
+
+
+# ── Expert budget (greedy total) ──
+
+
+def test_greedy_total_masks_experts():
+    set_moe_config(_cfg(expert_budget=4))
+    result = _prune_experts(torch.randn(4, 8))
+    assert (_unmasked(result) == 4).all()
+
+
+def test_greedy_total_preserves_top():
+    set_moe_config(_cfg(expert_budget=2))
+    gating = torch.zeros(4, 8)
+    gating[:, 0], gating[:, 1] = 10.0, 8.0
+    gating[:, 2] = 1.0
+    result = _prune_experts(gating)
+    assert (result[:, 0] == 10.0).all()
+    assert (result[:, 1] == 8.0).all()
+    assert (result[:, 2] == MASK_VAL_F32).all()
+
+
+@pytest.mark.parametrize("budget", [8, 200])
+def test_greedy_total_ge_num_experts(budget):
+    set_moe_config(_cfg(expert_budget=budget))
+    gating = torch.randn(4, 8)
+    assert torch.equal(_prune_experts(gating), gating)
+
+
+def test_batch_size_one():
+    set_moe_config(_cfg(expert_budget=4))
+    assert _unmasked(_prune_experts(torch.randn(1, 8))).item() == 4
+
+
+# ── Top per token ──
+
+
+def test_top_per_token_preserves_best():
+    set_moe_config(_cfg(top_per_token=1))
+    gating = torch.tensor(
+        [
+            [1.0, 5.0, 3.0, 2.0],
+            [4.0, 1.0, 2.0, 3.0],
+            [2.0, 3.0, 6.0, 1.0],
+        ]
+    )
+    result = _prune_experts(gating)
+    assert result[0, 1] == 5.0 and result[1, 0] == 4.0 and result[2, 2] == 6.0
+
+
+def test_top_per_token_with_greedy_total():
+    set_moe_config(_cfg(expert_budget=2, top_per_token=1))
+    gating = torch.tensor(
+        [
+            [1.0, 5.0, 3.0, 2.0, 0.1, 0.1, 0.1, 0.1],
+            [4.0, 1.0, 2.0, 3.0, 0.1, 0.1, 0.1, 0.1],
+        ]
+    )
+    result = _prune_experts(gating)
+    assert result[0, 1] == 5.0 and result[1, 0] == 4.0
+    assert (result[:, 4:] == MASK_VAL_F32).all()
+
+
+# ── Per-group (GPR) ──
+
+
+def test_per_group_routes_correctly():
+    set_moe_config(_cfg(group_budget=2, group_size=4))
+    gating = torch.zeros(8, 8)
+    gating[0:4, 0], gating[0:4, 1] = 5.0, 4.0
+    gating[4:8, 6], gating[4:8, 7] = 5.0, 4.0
+    result = _prune_experts(gating)
+    assert (result[0:4, 0] == 5.0).all() and (result[4:8, 6] == 5.0).all()
+
+
+def test_remainder_tokens_not_fully_masked():
+    set_moe_config(_cfg(group_budget=2, group_size=4, budget_alpha=0.0))
+    result = _prune_experts(torch.randn(6, 8))
+    assert (_unmasked(result)[4:] > 0).all()
+
+
+def test_batch_smaller_than_group_returns_original():
+    set_moe_config(_cfg(group_budget=2, group_size=4, budget_alpha=0.0))
+    gating = torch.randn(1, 8)
+    assert torch.equal(_prune_experts(gating), gating)
+
+
+# ── Batch guards ──
+
+
+@pytest.mark.parametrize(
+    "M,cfg_kwargs",
+    [
+        (4, dict(expert_budget=4, min_batch=8)),
+        (8, dict(expert_budget=4, max_batch=4)),
+    ],
+)
+def test_batch_guard_skips(M, cfg_kwargs):
+    set_moe_config(_cfg(**cfg_kwargs))
+    gating = torch.randn(M, 16)
+    assert torch.equal(_prune_experts(gating), gating)
+
+
+# ── Topk guarantee ──
+
+
+def test_topk_guarantee():
+    set_moe_config(_cfg(expert_budget=2))
+    result = _prune_experts(torch.randn(8, 16), topk=6)
+    assert (_unmasked(result) >= 6).all()
+
+
+def test_topk_zero_no_guarantee():
+    set_moe_config(_cfg(expert_budget=2))
+    result = _prune_experts(torch.randn(4, 8), topk=0)
+    assert (_unmasked(result) == 2).all()
+
+
+def test_topk_selective_not_all():
+    set_moe_config(_cfg(expert_budget=4))
+    result = _prune_experts(torch.randn(8, 16), topk=6)
+    u = _unmasked(result)
+    assert (u >= 6).all() and (u <= 10).all()
+
+
+# ── Budget alpha ──
+
+
+def test_budget_alpha():
+    set_moe_config(_cfg(budget_alpha=0.25))  # E=16 -> 4
+    result = _prune_experts(torch.randn(8, 16), topk=2)
+    assert _unmasked_cols(result) <= 4
+
+
+def test_expert_budget_overrides_alpha():
+    set_moe_config(_cfg(expert_budget=8, budget_alpha=0.1))
+    result = _prune_experts(torch.randn(8, 16), topk=2)
+    cols = _unmasked_cols(result)
+    assert 2 < cols <= 8
+
+
+# ── Non-contiguous input ──
+
+
+def test_non_contiguous():
+    set_moe_config(_cfg(expert_budget=4))
+    gating = torch.randn(16, 8)[::2]
+    assert not gating.is_contiguous()
+    assert (_unmasked(_prune_experts(gating)) == 4).all()
+
+
+# ── Route-level behavior ──
+
+
+def test_pruning_reduces_active_experts():
+    set_moe_config(_cfg(expert_budget=4))
+    torch.manual_seed(42)
+    gating = torch.randn(8, 16)
+    pruned = _prune_experts(gating, topk=2)
+    pruned_experts = set(torch.topk(pruned, 2, dim=-1).indices.flatten().tolist())
+    assert len(pruned_experts) <= 4
+
+
+# ── CUDA tests ──
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_cuda_basic():
+    set_moe_config(_cfg(expert_budget=4))
+    result = _prune_experts(torch.randn(8, 16, device="cuda"), topk=6)
+    assert (_unmasked(result) >= 6).all() and result.device.type == "cuda"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_cuda_graph_capture():
+    set_moe_config(_cfg(expert_budget=4))
+    M, E, topk = 8, 16, 6
+    _get_moe_pruning_config.cache_clear()
+    _get_moe_pruning_config()
+    gating = torch.randn(M, E, device="cuda")
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(3):
+            _prune_experts(gating, topk=topk)
+    torch.cuda.current_stream().wait_stream(s)
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        result = _prune_experts(gating, topk=topk)
+    gating.copy_(torch.randn(M, E, device="cuda"))
+    g.replay()
+    assert (_unmasked(result) >= topk).all()
+
+
+# ── Fused path ──
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("budget,topk", [(4, 2), (None, 4)])
+def test_fused_matches_python(budget, topk):
+    cfg = _cfg(expert_budget=budget, budget_alpha=0.25 if budget is None else 0.5)
+    set_moe_config(cfg)
+    gating = torch.randn(16, 32, device="cuda")
+    python_result = _prune_experts(gating.clone(), topk=topk)
+    fused_result = _fused_prune_experts(gating.clone(), topk=topk)
+    assert torch.allclose(python_result, fused_result)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "cfg_kwargs",
+    [
+        dict(expert_budget=4, top_per_token=1),
+        dict(expert_budget=4, group_budget=2, group_size=4),
+    ],
+)
+def test_fused_fallback(cfg_kwargs):
+    set_moe_config(_cfg(**cfg_kwargs))
+    result = _fused_prune_experts(torch.randn(8, 16, device="cuda"), topk=2)
+    assert (_unmasked(result) >= 2).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_fused_disabled():
+    gating = torch.randn(8, 16, device="cuda")
+    assert torch.equal(_fused_prune_experts(gating), gating)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_fused_cuda_graph():
+    set_moe_config(_cfg(expert_budget=4))
+    M, E, topk = 8, 16, 2
+    _get_moe_pruning_config.cache_clear()
+    _get_moe_pruning_config()
+    gating = torch.randn(M, E, device="cuda")
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(3):
+            _fused_prune_experts(gating, topk=topk)
+    torch.cuda.current_stream().wait_stream(s)
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        result = _fused_prune_experts(gating, topk=topk)
+    gating.copy_(torch.randn(M, E, device="cuda"))
+    g.replay()
+    assert (_unmasked(result) >= topk).all()
+    assert _unmasked_cols(result) <= 4
+
+
+# --- Integration tests ---
+
+
+def test_create_moe_config_from_dict():
+    from vllm.engine.arg_utils import EngineArgs
+
+    args = EngineArgs.__new__(EngineArgs)
+    args.moe_config = {"pruning": {"enable": True, "expert_budget": 24}}
+    cfg = args._create_moe_config()
+    assert cfg is not None
+    assert cfg.pruning.enable is True
+    assert cfg.pruning.expert_budget == 24
+
+
+def test_create_moe_config_none():
+    from vllm.engine.arg_utils import EngineArgs
+
+    args = EngineArgs.__new__(EngineArgs)
+    args.moe_config = None
+    assert args._create_moe_config() is None
+
+
+def test_create_moe_config_empty_pruning():
+    from vllm.engine.arg_utils import EngineArgs
+
+    args = EngineArgs.__new__(EngineArgs)
+    args.moe_config = {}
+    cfg = args._create_moe_config()
+    assert cfg is not None
+    assert cfg.pruning is None
+
+
+def test_create_moe_config_invalid_type():
+    from vllm.engine.arg_utils import EngineArgs
+
+    args = EngineArgs.__new__(EngineArgs)
+    args.moe_config = [1, 2, 3]
+    with pytest.raises((AttributeError, TypeError)):
+        args._create_moe_config()
+
+
+def test_context_manager_restores_config():
+    from vllm.config.moe import MoEConfig, MoEPruningConfig
+
+    cfg_with = MoEConfig(pruning=MoEPruningConfig(enable=True, expert_budget=4))
+    set_moe_config(cfg_with)
+    _get_moe_pruning_config.cache_clear()
+    assert _get_moe_pruning_config() is not None
+
+    set_moe_config(None)
+    _get_moe_pruning_config.cache_clear()
+    assert _get_moe_pruning_config() is None
+
+    gating = torch.randn(8, 16)
+    assert torch.equal(_prune_experts(gating), gating)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize(
+    "expert_budget,topk,E",
+    [
+        (4, 2, 16),
+        (8, 4, 32),
+        (2, 6, 16),
+        (24, 4, 128),
+    ],
+)
+def test_fused_matches_python_extended(expert_budget, topk, E):
+    set_moe_config(_cfg(expert_budget=expert_budget))
+    torch.manual_seed(42)
+    gating = torch.randn(16, E, device="cuda")
+    fused = _fused_prune_experts(gating, topk=topk)
+    python = _prune_experts(gating, topk=topk)
+    assert torch.allclose(fused, python)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_fused_with_ties():
+    set_moe_config(_cfg(expert_budget=4))
+    gating = torch.ones(8, 16, device="cuda", dtype=torch.bfloat16)
+    gating[:, :4] = 10.0
+    result = _fused_prune_experts(gating, topk=2)
+    mask_val = torch.finfo(gating.dtype).min
+    assert (result[:, :4] > mask_val).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_fused_dtype(dtype):
+    set_moe_config(_cfg(expert_budget=4))
+    gating = torch.randn(8, 16, device="cuda", dtype=dtype)
+    result = _fused_prune_experts(gating, topk=2)
+    assert _unmasked_cols(result) <= 4

--- a/vllm/config/__init__.py
+++ b/vllm/config/__init__.py
@@ -22,6 +22,7 @@ from vllm.config.model import (
     str_dtype_to_torch_dtype,
     try_match_architecture_defaults,
 )
+from vllm.config.moe import MoEConfig, MoEPruningConfig
 from vllm.config.multimodal import MultiModalConfig
 from vllm.config.observability import ObservabilityConfig
 from vllm.config.offload import (
@@ -126,5 +127,8 @@ __all__ = [
     "get_current_vllm_config_or_none",
     "set_current_vllm_config",
     "get_layers_from_vllm_config",
+    # From vllm.config.moe
+    "MoEConfig",
+    "MoEPruningConfig",
     "WeightTransferConfig",
 ]

--- a/vllm/config/moe.py
+++ b/vllm/config/moe.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Configuration for Mixture of Experts optimizations."""
+
+from vllm.config.utils import config
+
+
+@config
+class MoEPruningConfig:
+    """Batch-aware expert pruning configuration (XShare method)."""
+
+    enable: bool = False
+    """Master switch -- must be True for any pruning to happen."""
+
+    expert_budget: int | None = None
+    """Absolute number of experts to keep (overrides budget_alpha)."""
+
+    budget_alpha: float = 0.5
+    """Fraction of experts to keep when expert_budget is not set."""
+
+    top_per_token: int = 0
+    """Per-token top-k pre-selection (0 = disabled)."""
+
+    group_budget: int = 0
+    """Per-group expert budget."""
+
+    group_size: int = 0
+    """Tokens per group for per-group pruning."""
+
+    min_batch: int = 0
+    """Skip pruning when batch size is below this threshold."""
+
+    max_batch: int = 0
+    """Skip pruning when batch size is above this threshold (0 = no limit)."""
+
+
+@config
+class MoEConfig:
+    """Configuration for Mixture of Experts optimizations.
+
+    Consolidates MoE-related settings under one namespace.
+    Currently supports expert pruning; routing, parallelism,
+    and kernel selection are planned for future releases.
+
+    Example usage::
+
+        vllm serve model --moe-config '{"pruning":
+            {"enable": true, "expert_budget": 24}}'
+    """
+
+    pruning: MoEPruningConfig | None = None
+    """Expert pruning configuration. None means pruning is disabled."""
+    # Future sub-configs (stubs):
+    # routing: MoERoutingConfig | None = None
+    # parallelism: MoEParallelismConfig | None = None
+    # kernel: MoEKernelConfig | None = None
+
+    def compute_hash(self) -> str:
+        from vllm.config.utils import get_hash_factors, hash_factors
+        factors = get_hash_factors(self)
+        return hash_factors(factors)

--- a/vllm/config/moe.py
+++ b/vllm/config/moe.py
@@ -30,8 +30,13 @@ class MoEPruningConfig:
     min_batch: int = 0
     """Skip pruning when batch size is below this threshold."""
 
-    max_batch: int = 0
-    """Skip pruning when batch size is above this threshold (0 = no limit)."""
+    max_batch: int = 48
+    """Skip pruning when batch size exceeds this threshold.
+
+    Defaults to 48 to restrict pruning to the decode phase. During prefill,
+    M = prompt length (>> 48), so pruning is skipped, avoiding KV cache
+    corruption. During decode, M = number of concurrent sequences (≤ 48),
+    so pruning fires as intended. Set to 0 to disable this gating."""
 
 
 @config

--- a/vllm/config/moe.py
+++ b/vllm/config/moe.py
@@ -62,5 +62,6 @@ class MoEConfig:
 
     def compute_hash(self) -> str:
         from vllm.config.utils import get_hash_factors, hash_factors
-        factors = get_hash_factors(self)
+
+        factors = get_hash_factors(self, set())
         return hash_factors(factors)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -36,6 +36,7 @@ from .kv_transfer import KVTransferConfig
 from .load import LoadConfig
 from .lora import LoRAConfig
 from .model import ModelConfig
+from .moe import MoEConfig
 from .observability import ObservabilityConfig
 from .offload import OffloadConfig
 from .parallel import ParallelConfig
@@ -327,6 +328,9 @@ class VllmConfig:
     weight_transfer_config: WeightTransferConfig | None = None
     """The configurations for weight transfer during RL training."""
 
+    moe_config: MoEConfig | None = None
+    """Configuration for Mixture of Experts optimizations."""
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,
@@ -411,6 +415,10 @@ class VllmConfig:
             vllm_factors.append("None")
         if self.ec_transfer_config:
             vllm_factors.append(self.ec_transfer_config.compute_hash())
+        else:
+            vllm_factors.append("None")
+        if self.moe_config:
+            vllm_factors.append(self.moe_config.compute_hash())
         else:
             vllm_factors.append("None")
         if self.additional_config:
@@ -1701,6 +1709,12 @@ def set_current_vllm_config(
     global _current_vllm_config, _current_prefix
     old_vllm_config = _current_vllm_config
     old_prefix = _current_prefix
+    # Save the actual _moe_config value (not derived from old_vllm_config)
+    # so we restore correctly even when _moe_config was set externally
+    # (e.g. persisted in gpu_worker.load_model after the context exits).
+    from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (
+        _moe_config as _saved_moe_config,
+    )
     from vllm.compilation.counter import compilation_counter
 
     num_models_seen = compilation_counter.num_models_seen
@@ -1712,6 +1726,15 @@ def set_current_vllm_config(
 
         _current_vllm_config = vllm_config
         _current_prefix = prefix
+
+        # Propagate MoE config to the pruning module (always call, even with
+        # None, so config is cleared when context manager is re-entered)
+        from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (
+            set_moe_config,
+        )
+
+        set_moe_config(vllm_config.moe_config if vllm_config is not None else None)
+
         yield
     except Exception:
         raise
@@ -1740,6 +1763,11 @@ def set_current_vllm_config(
         _current_prefix = old_prefix
         # Clear the compilation config cache when context changes
         get_cached_compilation_config.cache_clear()
+        # Restore MoE config to what it was before entering this context.
+        # We restore the saved value (not derived from old_vllm_config) so
+        # that externally-set _moe_config persists across context manager
+        # entries/exits (e.g. during initialize_from_config after load_model).
+        set_moe_config(_saved_moe_config)
 
 
 @lru_cache(maxsize=1)

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1712,10 +1712,10 @@ def set_current_vllm_config(
     # Save the actual _moe_config value (not derived from old_vllm_config)
     # so we restore correctly even when _moe_config was set externally
     # (e.g. persisted in gpu_worker.load_model after the context exits).
+    from vllm.compilation.counter import compilation_counter
     from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (
         _moe_config as _saved_moe_config,
     )
-    from vllm.compilation.counter import compilation_counter
 
     num_models_seen = compilation_counter.num_models_seen
     try:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -586,6 +586,8 @@ class EngineArgs:
 
     additional_config: dict[str, Any] = get_field(VllmConfig, "additional_config")
 
+    moe_config: dict[str, Any] | None = None
+
     use_tqdm_on_load: bool = LoadConfig.use_tqdm_on_load
     pt_load_map_location: str | dict[str, str] = LoadConfig.pt_load_map_location
 
@@ -1276,6 +1278,16 @@ class EngineArgs:
             "--additional-config", **vllm_kwargs["additional_config"]
         )
         vllm_group.add_argument(
+            "--moe-config",
+            type=json.loads,
+            default=None,
+            help=(
+                "JSON dict for MoE configuration. "
+                'Example: \'{"pruning": {"enable": true, '
+                '"expert_budget": 24}}\''
+            ),
+        )
+        vllm_group.add_argument(
             "--structured-outputs-config", **vllm_kwargs["structured_outputs_config"]
         )
         vllm_group.add_argument("--profiler-config", **vllm_kwargs["profiler_config"])
@@ -1916,9 +1928,24 @@ class EngineArgs:
             optimization_level=self.optimization_level,
             performance_mode=self.performance_mode,
             weight_transfer_config=self.weight_transfer_config,
+            moe_config=self._create_moe_config(),
         )
 
         return config
+
+    def _create_moe_config(self):
+        if self.moe_config is None:
+            return None
+        from vllm.config import MoEConfig, MoEPruningConfig
+
+        raw = self.moe_config
+        if not isinstance(raw, dict):
+            raise TypeError(
+                f"--moe-config must be a JSON object, got {type(raw).__name__}"
+            )
+        pruning_dict = raw.get("pruning", {})
+        pruning = MoEPruningConfig(**pruning_dict) if pruning_dict else None
+        return MoEConfig(pruning=pruning)
 
     def _check_feature_supported(self):
         """Raise an error if the feature is not supported."""

--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+from functools import lru_cache
+
 import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
@@ -105,6 +107,46 @@ def pack_bitmatrix(
         tl.store(bitmatrix_ptrs, y, mask=offsets_m[:, None] < n_rows)
 
 
+@triton.jit
+def _xshare_apply_mask_kernel(
+    gating_ptr,  # [M, E] input logits
+    output_ptr,  # [M, E] output masked logits
+    global_experts_ptr,  # [GT] selected expert indices (int64)
+    M,
+    E: tl.constexpr,
+    GT: tl.constexpr,
+    TOPK: tl.constexpr,  # per-row topk guarantee (0 = disabled)
+    mask_val,
+):
+    """Fused mask: global expert selection + per-row topk in one launch."""
+    row = tl.program_id(0)
+    if row >= M:
+        return
+
+    e_idx = tl.arange(0, E)
+    row_off = row * E
+    logits = tl.load(gating_ptr + row_off + e_idx, mask=e_idx < E, other=mask_val)
+
+    # Build keep mask from global expert selection
+    keep = tl.zeros([E], dtype=tl.int1)
+    for g in tl.static_range(GT):
+        sel = tl.load(global_experts_ptr + g)
+        keep = keep | (e_idx == sel)
+
+    # Per-row top-TOPK guarantee via iterative argmax on original logits
+    if TOPK > 0:
+        temp = logits
+        for _k in tl.static_range(TOPK):
+            max_val = tl.max(temp, axis=0)
+            is_max = temp == max_val
+            max_idx = tl.min(tl.where(is_max, e_idx, E), axis=0)
+            keep = keep | (e_idx == max_idx)
+            temp = tl.where(e_idx == max_idx, mask_val, temp)
+
+    output = tl.where(keep, logits, mask_val)
+    tl.store(output_ptr + row_off + e_idx, output, mask=e_idx < E)
+
+
 def legacy_routing_from_bitmatrix(
     bitmatrix: "Bitmatrix",
     expt_scal: torch.Tensor,
@@ -167,6 +209,144 @@ def legacy_routing(
     )
 
 
+_moe_config = None
+
+
+def set_moe_config(config) -> None:
+    """Set the global MoEConfig. Called from set_current_vllm_config."""
+    global _moe_config
+    _moe_config = config
+    _get_moe_pruning_config.cache_clear()
+
+
+@lru_cache(maxsize=1)
+def _get_moe_pruning_config():
+    """Return the active MoEPruningConfig, or None if pruning is disabled."""
+    if (
+        _moe_config is not None
+        and _moe_config.pruning is not None
+        and _moe_config.pruning.enable
+    ):
+        return _moe_config.pruning
+    return None
+
+
+def _prune_experts(gating_output: "torch.Tensor", topk: int = 0) -> "torch.Tensor":
+    """Apply XShare batch-aware expert pruning to router logits."""
+    cfg = _get_moe_pruning_config()
+    if cfg is None:
+        return gating_output
+    M, E = gating_output.shape
+    if cfg.min_batch > 0 and cfg.min_batch > M:
+        return gating_output
+    if cfg.max_batch > 0 and cfg.max_batch < M:
+        return gating_output
+    k0 = max(0, min(cfg.top_per_token, E))
+    mr = max(0, min(cfg.group_budget, E))
+    ml = (
+        max(1, int(cfg.budget_alpha * E))
+        if (cfg.expert_budget or 0) == 0 and cfg.budget_alpha > 0
+        else max(0, min(cfg.expert_budget or 0, E))
+    )
+    if mr > 0 and cfg.group_size == 0:
+        logger.warning_once(
+            "MoEPruningConfig.group_budget=%d but group_size=0; "
+            "per-group pruning disabled",
+            mr,
+        )
+    if k0 == 0 and mr == 0 and ml == 0:
+        return gating_output
+    if ml >= E:
+        return gating_output
+    group_size = cfg.group_size
+    num_groups = M // group_size if group_size > 0 else 0
+    gpr_can_select = mr > 0 and group_size > 0 and group_size <= M
+    if k0 == 0 and not gpr_can_select and ml == 0:
+        return gating_output
+    gpr_has_remainder = (
+        mr > 0 and group_size > 0 and num_groups > 0 and num_groups * group_size < M
+    )
+    global_sums = None
+    if ml > 0 or gpr_has_remainder:
+        global_sums = gating_output.sum(dim=0)
+    keep_mask = torch.zeros(M, E, dtype=torch.bool, device=gating_output.device)
+    if k0 > 0:
+        top_indices = torch.topk(gating_output, k0, dim=-1, sorted=False).indices
+        keep_mask.scatter_(1, top_indices, True)
+    if mr > 0 and group_size > 0 and num_groups > 0:
+        n_tokens = num_groups * group_size
+        grouped = gating_output[:n_tokens].reshape(num_groups, group_size, E)
+        group_sums = grouped.sum(dim=1)
+        group_experts = torch.topk(group_sums, min(mr, E), dim=-1, sorted=False).indices
+        exp_idx = group_experts.unsqueeze(1).expand(-1, group_size, -1)
+        keep_mask[:n_tokens].scatter_(1, exp_idx.reshape(n_tokens, -1), True)
+        if n_tokens < M:
+            assert global_sums is not None
+            remainder_experts = torch.topk(
+                global_sums, min(mr, E), dim=-1, sorted=False
+            ).indices
+            keep_mask[n_tokens:].scatter_(
+                1, remainder_experts.unsqueeze(0).expand(M - n_tokens, -1), True
+            )
+    if ml > 0:
+        assert global_sums is not None
+        global_experts = torch.topk(global_sums, ml, dim=-1, sorted=False).indices
+        keep_mask.scatter_(1, global_experts.unsqueeze(0).expand(M, -1), True)
+    if topk > 0 and ml < topk:
+        topk_indices = torch.topk(
+            gating_output, min(topk, E), dim=-1, sorted=False
+        ).indices
+        keep_mask.scatter_(1, topk_indices, True)
+    return gating_output.masked_fill(~keep_mask, torch.finfo(gating_output.dtype).min)
+
+
+def _fused_prune_experts(
+    gating_output: "torch.Tensor", topk: int = 0
+) -> "torch.Tensor":
+    """Fused XShare pruning; falls back to _prune_experts for k0/GPR."""
+    cfg = _get_moe_pruning_config()
+    if cfg is None:
+        return gating_output
+    M, E = gating_output.shape
+    if cfg.min_batch > 0 and cfg.min_batch > M:
+        return gating_output
+    if cfg.max_batch > 0 and cfg.max_batch < M:
+        return gating_output
+    k0 = max(0, min(cfg.top_per_token, E))
+    mr = max(0, min(cfg.group_budget, E))
+    ml = (
+        max(1, int(cfg.budget_alpha * E))
+        if (cfg.expert_budget or 0) == 0 and cfg.budget_alpha > 0
+        else max(0, min(cfg.expert_budget or 0, E))
+    )
+    if k0 == 0 and mr == 0 and ml == 0:
+        return gating_output
+    if ml >= E:
+        return gating_output
+    group_size = cfg.group_size
+    num_groups = M // group_size if group_size > 0 else 0
+    if k0 > 0 or (mr > 0 and group_size > 0 and num_groups > 0):
+        return _prune_experts(gating_output, topk=topk)
+    global_sums = gating_output.sum(dim=0)
+    global_experts = torch.topk(global_sums, ml, dim=-1, sorted=False).indices.to(
+        torch.int64
+    )
+    output = torch.empty_like(gating_output)
+    mask_val = torch.finfo(gating_output.dtype).min
+    effective_topk = min(topk, E) if topk > 0 and ml < topk else 0
+    _xshare_apply_mask_kernel[(M,)](
+        gating_output,
+        output,
+        global_experts,
+        M,
+        E=E,
+        GT=ml,
+        TOPK=effective_topk,
+        mask_val=mask_val,
+    )
+    return output
+
+
 def triton_kernel_moe_forward(
     hidden_states: torch.Tensor,
     w1,  # Tensor or triton_kernels.Tensor
@@ -184,6 +364,9 @@ def triton_kernel_moe_forward(
     unpadded_N_w2=None,
     unpadded_K_w2=None,
 ) -> torch.Tensor:
+    
+    gating_output = _fused_prune_experts(gating_output, topk=topk)
+
     if (
         quant_config is not None
         and quant_config.use_mxfp4_w4a8
@@ -242,7 +425,7 @@ def triton_kernel_moe_forward(
         )
         effective_expert_map = expert_map
         effective_global_num_experts = global_num_experts
-
+    
     output = torch.empty_like(hidden_states)
     effective_quant_config = (
         quant_config if quant_config is not None else FUSED_MOE_UNQUANTIZED_CONFIG

--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -364,7 +364,6 @@ def triton_kernel_moe_forward(
     unpadded_N_w2=None,
     unpadded_K_w2=None,
 ) -> torch.Tensor:
-    
     gating_output = _fused_prune_experts(gating_output, topk=topk)
 
     if (
@@ -425,7 +424,7 @@ def triton_kernel_moe_forward(
         )
         effective_expert_map = expert_map
         effective_global_num_experts = global_num_experts
-    
+
     output = torch.empty_like(hidden_states)
     effective_quant_config = (
         quant_config if quant_config is not None else FUSED_MOE_UNQUANTIZED_CONFIG

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -344,10 +344,11 @@ class Worker(WorkerBase):
         # remains active during inference (set_current_vllm_config
         # resets it to None on exit).
         if self.vllm_config.moe_config is not None:
-            from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (
-                set_moe_config,
+            from vllm.model_executor.layers.fused_moe import (
+                gpt_oss_triton_kernels_moe as moe_kernels,
             )
-            set_moe_config(self.vllm_config.moe_config)
+
+            moe_kernels.set_moe_config(self.vllm_config.moe_config)
 
     def update_config(self, overrides: dict[str, Any]) -> None:
         self.model_runner.update_config(overrides)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -340,6 +340,15 @@ class Worker(WorkerBase):
             )
             self.model_runner.eep_eplb_suppressed = True
 
+        # Persist MoE config beyond the context manager so pruning
+        # remains active during inference (set_current_vllm_config
+        # resets it to None on exit).
+        if self.vllm_config.moe_config is not None:
+            from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (
+                set_moe_config,
+            )
+            set_moe_config(self.vllm_config.moe_config)
+
     def update_config(self, overrides: dict[str, Any]) -> None:
         self.model_runner.update_config(overrides)
 


### PR DESCRIPTION
## Summary

Implements batch-aware expert pruning ([XShare](https://arxiv.org/abs/2602.07265)) for MoE models. Before top-k routing, aggregates expert demand across the batch and masks low-demand experts so the fused MoE kernel skips loading their weights from HBM.

- Adds `--moe-config` CLI flag with `MoEConfig` / `MoEPruningConfig` dataclasses
- Fused Triton kernel for global expert selection + per-row topk masking
- Config persistence through vLLM's `set_current_vllm_config` context manager
- **Decode-only gating** (`max_batch=48`): pruning is skipped during prefill to preserve KV cache quality

RFC: https://github.com/vllm-project/vllm/issues/35550

## Benchmark results

### 128-expert model (1x H200, gpt-oss-120b)

Setup: `vllm bench serve`, 200 prompts, random in=128 out=256, rate=inf, `expert_budget=24`

| Concurrency | Baseline (tok/s) | XShare (tok/s) | Throughput | TPOT Reduction |
|:-:|:-:|:-:|:-:|:-:|
| 4 | 530 | 559 | +5.4% | -5.2% |
| 8 | 866 | 1,006 | +16.2% | -13.9% |
| 16 | 1,342 | 1,835 | +36.8% | -26.9% |
| 32 | 1,996 | 3,054 | +53.0% | -34.6% |

### 32-expert model (1x H200, gpt-oss-20b)

Setup: `expert_budget=12`, 64 prompts, random in=128 out=256, rate=inf

| Concurrency | Baseline (tok/s) | XShare (tok/s) | Throughput | TPOT Reduction |
|:-:|:-:|:-:|:-:|:-:|
| 4 | 869 | 857 | -1.5% | +1.8% |
| 8 | 1,503 | 1,660 | +10.4% | -9.5% |
| 16 | 2,719 | 3,122 | +14.8% | -13.5% |
| 32 | 4,464 | 5,273 | +18.1% | -15.8% |

### Rate-limited online serving (1x H200, gpt-oss-120b, rate=8 req/s)

| Workload | Baseline (tok/s) | XShare budget=24 (tok/s) | Improvement |
|---|:-:|:-:|:-:|
| Short (in=128, out=128) | 780 | 824 | +5.7% |
| Medium (in=512, out=256) | 1,162 | 1,321 | +13.6% |
| Long (in=1024, out=512) | 1,508 | 1,850 | +22.7% |

## Quality validation (lm-eval-harness)

Setup: 8x H200 (p5e.48xlarge), TP=8, max-model-len=32768, max-num-seqs=64, `num_concurrent=50`.
All pruning configs use decode-only gating (`max_batch=48`).

**MMLU-Pro (5-shot):**

| Config | expert_budget | top_per_token (k0) | Score | Delta vs baseline |
|---|:-:|:-:|:-:|:-:|
| Baseline (no pruning) | n/a | n/a | 0.5132 | n/a |
| budget=24, k0=1 | 24 | 1 | 0.5157 | +0.25% |
| budget=12, k0=1 | 12 | 1 | 0.5147 | +0.15% |
| budget=12, k0=2 | 12 | 2 | 0.5147 | +0.15% |
| budget=32, k0=1 | 32 | 1 | 0.5150 | +0.18% |

**GSM-8K (5-shot, exact_match strict):**

| Config | expert_budget | top_per_token (k0) | Score | Delta vs baseline |
|---|:-:|:-:|:-:|:-:|
| Baseline (no pruning) | n/a | n/a | 0.2699 | n/a |
| budget=24, k0=1 | 24 | 1 | 0.2813 | +1.14% |
| budget=12, k0=1 | 12 | 1 | 0.2745 | +0.46% |
| budget=12, k0=2 | 12 | 2 | 0.2782 | +0.83% |
| budget=32, k0=1 | 32 | 1 | 0.2623 | -0.76% |

All configs within noise of baseline. **Caveat:** with `num_concurrent=50` and `max_batch=48`, pruning fires intermittently during eval (decode batch sizes often approach or exceed 48). These results confirm pruning does not degrade quality when active, but do not stress-test sustained pruning at high intensity. Lower-concurrency eval or phase-based gating would provide stronger validation.

**Key finding:** `max_batch` gating is essential. Without it, pruning during prefill causes catastrophic quality loss (MMLU-Pro 51.3% to 26.9%). Prefill pruning corrupts the KV cache by routing prompt tokens through an incomplete expert set.

## Decode-only pruning: why and how

Pruning must be restricted to the decode phase. During prefill, all prompt tokens build the KV cache n/a routing them through a pruned expert set produces corrupted representations that cascade through the sequence.


Current gating: `max_batch=48` heuristic. During prefill M = prompt length (>> 48), so pruning is skipped. During decode M = concurrent sequences (typically ≤ 48), so pruning fires. This is empirical n/a phase-based gating via `max_query_len` in `CommonAttentionMetadata` is a planned improvement.

## Configuration

```python
@config
class MoEPruningConfig:
    enable: bool = False
    expert_budget: int | None = None  # absolute budget (overrides alpha)
    budget_alpha: float = 0.5         # fraction of experts to keep
    top_per_token: int = 0            # per-token top-k pre-selection (k0)
    group_budget: int = 0             # per-group expert budget (future)
    group_size: int = 0               # tokens per group (future)
    min_batch: int = 0                # skip pruning below this batch size
    max_batch: int = 48               # skip pruning above this (decode-only gating)
```

```bash
# Enable with absolute budget
vllm serve model --moe-config '{"pruning": {"enable": true, "expert_budget": 24}}'

# Enable with fractional budget
vllm serve model --moe-config '{"pruning": {"enable": true, "budget_alpha": 0.5}}'
```

## How to reproduce

```bash
# Baseline server
vllm serve openai/gpt-oss-120b \
    --tensor-parallel-size 1 --max-model-len 4096 --max-num-seqs 64 --port 8000

# XShare server
vllm serve openai/gpt-oss-120b \
    --tensor-parallel-size 1 --max-model-len 4096 --max-num-seqs 64 \
    --moe-config '{"pruning": {"enable": true, "expert_budget": 24}}' --port 8000

# Benchmark
vllm bench serve --backend openai --model openai/gpt-oss-120b \
    --dataset-name random --random-input-len 128 --random-output-len 256 \
    --num-prompts 200 --request-rate inf --max-concurrency 16

# Quality eval (TP=8 for speed)
vllm serve openai/gpt-oss-120b \
    --tensor-parallel-size 8 --max-model-len 32768 --max-num-seqs 64 \
    --moe-config '{"pruning": {"enable": true, "expert_budget": 24, "top_per_token": 1}}' \
    --port 8000

lm_eval --model local-completions \
    --model_args "model=openai/gpt-oss-120b,base_url=http://localhost:8000/v1/completions,num_concurrent=50,tokenized_requests=False" \
    --tasks mmlu_pro --num_fewshot 5 --output_path ./eval_results/mmlu_pro
```

## Test plan

- [x] Unit tests (`tests/test_xshare_pruning.py`)
- [x] Serving benchmarks on H200 (gpt-oss-120b 128E, gpt-oss-20b 32E)
- [x] CUDA graph compatibility verified
- [x] lm-eval quality validation (MMLU-Pro, GSM-8K n/a all configs within noise of baseline)
- [x] Tensor parallelism verified (TP=8, router replicated, identical pruning across ranks)
- [ ] Expert parallelism testing
- [ ] Lower-concurrency quality eval (ensure sustained pruning)
- [ ] Phase-based gating (replace max_batch heuristic)

Paper: [XShare: Batch-Aware Expert Selection for MoE Inference](https://arxiv.org/abs/2602.07265)