### PR TITLE
[CI] Defining extended V1 e2e + engine tests

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -381,10 +381,9 @@ steps:
 
 - label: V1 Test e2e + engine # 65min
   timeout_in_minutes: 90
-  mirror_hardwares: [amdexperimental]
-  # The test uses 4 GPUs, but we schedule it on 8-GPU machines for stability.
-  # See discussion here: https://github.com/vllm-project/vllm/pull/31040
-  agent_pool: mi325_8
+  mirror_hardwares: [amdexperimental, amdproduction]
+  agent_pool: mi325_1
+  optional: true
   # grade: Blocking
   source_file_dependencies:
     - vllm/
@@ -394,6 +393,34 @@ steps:
     # VLLM_USE_FLASHINFER_SAMPLER or not on H100.
     - pytest -v -s v1/e2e
     - pytest -v -s v1/engine
+
+- label: V1 Test e2e (2 GPUs) # 65min
+  timeout_in_minutes: 90
+  mirror_hardwares: [amdexperimental, amdproduction]
+  agent_pool: mi325_2
+  optional: true
+  # grade: Blocking
+  source_file_dependencies:
+    - vllm/
+    - tests/v1
+  commands:
+    # Only run tests that need exactly 2 GPUs
+    - pytest -v -s v1/e2e/test_spec_decode.py -k "tensor_parallelism"
+
+- label: V1 Test e2e (4 GPUs) # 65min
+  timeout_in_minutes: 90
+  mirror_hardwares: [amdexperimental, amdproduction]
+  # The test uses 4 GPUs, but we schedule it on 8-GPU machines for stability.
+  # See discussion here: https://github.com/vllm-project/vllm/pull/31040
+  agent_pool: mi325_4
+  optional: true
+  # grade: Blocking
+  source_file_dependencies:
+    - vllm/
+    - tests/v1
+  commands:
+    # Only run tests that need 4 GPUs
+    - pytest -v -s v1/e2e/test_spec_decode.py -k "eagle_correctness_heavy"
 
 - label: V1 Test entrypoints # 35min
   timeout_in_minutes: 50

--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -14,7 +14,7 @@ steps:
   commands:
   - pytest -v -s engine test_sequence.py test_config.py test_logger.py test_vllm_port.py
 
-- label: V1 e2e + engine
+- label: V1 e2e + engine (1 GPU)
   timeout_in_minutes: 45
   source_file_dependencies:
     - vllm/
@@ -36,3 +36,35 @@ steps:
       commands:
       - pytest -v -s v1/e2e
       - pytest -v -s v1/engine
+
+- label: V1 e2e (2 GPUs)
+  timeout_in_minutes: 60 # TODO: Fix timeout after we have more confidence in the test stability
+  optional: true
+  num_devices: 2
+  source_file_dependencies:
+    - vllm/
+    - tests/v1/e2e
+  commands:
+    # Only run tests that need exactly 2 GPUs
+    - pytest -v -s v1/e2e/test_spec_decode.py -k "tensor_parallelism"
+  mirror:
+    amd:
+      device: mi325_2
+      depends_on:
+      - image-build-amd
+
+- label: V1 e2e (4 GPUs)
+  timeout_in_minutes: 60 # TODO: Fix timeout after we have more confidence in the test stability
+  optional: true
+  num_devices: 4
+  source_file_dependencies:
+    - vllm/
+    - tests/v1/e2e
+  commands:
+    # Only run tests that need 4 GPUs
+    - pytest -v -s v1/e2e/test_spec_decode.py -k "eagle_correctness_heavy"
+  mirror:
+    amd:
+      device: mi325_4
+      depends_on:
+      - image-build-amd

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -630,7 +630,7 @@ def test_eagle_correctness_medium(
             False,
             "auto",
             0.8,
-            marks=[*multi_gpu_marks(num_gpus=4), large_gpu_mark(min_gb=80)],
+            marks=[*multi_gpu_marks(num_gpus=4), large_gpu_mark(min_gb=40)],
             id="llama4_eagle",
         ),
         pytest.param(
@@ -644,7 +644,7 @@ def test_eagle_correctness_medium(
             True,
             "auto",
             0.8,
-            marks=[*multi_gpu_marks(num_gpus=4), large_gpu_mark(min_gb=120)],
+            marks=[*multi_gpu_marks(num_gpus=4), large_gpu_mark(min_gb=80)],
             id="llama4_eagle_mm",
         ),
     ],

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -630,7 +630,7 @@ def test_eagle_correctness_medium(
             False,
             "auto",
             0.8,
-            marks=multi_gpu_marks(num_gpus=4),
+            marks=[*multi_gpu_marks(num_gpus=4), large_gpu_mark(min_gb=47)],
             id="llama4_eagle",
         ),
         pytest.param(

--- a/tests/v1/e2e/test_spec_decode.py
+++ b/tests/v1/e2e/test_spec_decode.py
@@ -630,7 +630,7 @@ def test_eagle_correctness_medium(
             False,
             "auto",
             0.8,
-            marks=[*multi_gpu_marks(num_gpus=4), large_gpu_mark(min_gb=47)],
+            marks=[*multi_gpu_marks(num_gpus=4), large_gpu_mark(min_gb=80)],
             id="llama4_eagle",
         ),
         pytest.param(
@@ -644,7 +644,7 @@ def test_eagle_correctness_medium(
             True,
             "auto",
             0.8,
-            marks=[*multi_gpu_marks(num_gpus=4), large_gpu_mark(min_gb=80)],
+            marks=[*multi_gpu_marks(num_gpus=4), large_gpu_mark(min_gb=120)],
             id="llama4_eagle_mm",
         ),
     ],


### PR DESCRIPTION
The V1 e2e tests (including `test_spec_decode.py`) currently only run in 1-GPU pools. Tests decorated with `@multi_gpu_only(num_gpus=2)` and `@multi_gpu_marks(num_gpus=4)` silently skip because only one GPU is available. This means the following tests have no CI coverage:

- `test_draft_model_tensor_parallelism` (2 GPUs)
- `test_draft_model_engine_args_tensor_parallelism` (2 GPUs)
- `test_eagle_correctness_heavy`: Llama-4-Scout Eagle params (4 GPUs)

### Solution

Add dedicated 2-GPU and 4-GPU steps to the Engine test group, targeting the specific tests that require multi-GPU. The existing 1-GPU step continues to run the full `v1/e2e` directory (multi-GPU tests self-skip there via `skipif` decorators). This is a follow-up to: 
- https://github.com/vllm-project/vllm/pull/35265
- https://github.com/vllm-project/vllm/pull/34923

### Changes

- **V1 e2e (2 GPUs)**: Runs `test_spec_decode.py -k "tensor_parallelism"`
- **V1 e2e (4 GPUs)**: Runs `test_spec_decode.py -k "eagle_correctness_heavy"`
- No changes to existing 1-GPU step behavior

cc @kenroche