### PR TITLE
[Do not merge] FA4 hang bisect Trial 3: cmake + requirements only (main Python)

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -11,3 +11,7 @@ torchaudio==2.10.0
 torchvision==0.25.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # FlashInfer should be updated together with the Dockerfile
 flashinfer-python==0.6.4
+
+# QuACK and Cutlass DSL for FA4 (cute-DSL implementation)
+nvidia-cutlass-dsl>=4.4.0.dev1
+quack-kernels>=0.2.7

--- a/setup.py
+++ b/setup.py
@@ -976,6 +976,11 @@ if _is_cuda():
     ):
         # FA3 requires CUDA 12.3 or later
         ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa3_C"))
+    # FA4 CuteDSL - Python-only component for FA4's cute DSL support
+    # Optional since this doesn't produce a .so file, just copies Python files
+    ext_modules.append(
+        CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa4_cutedsl_C", optional=True)
+    )
     if envs.VLLM_USE_PRECOMPILED or (
         CUDA_HOME and get_nvcc_cuda_version() >= Version("12.9")
     ):


### PR DESCRIPTION
## FA4 Hang Bisection - Trial 3: cmake + requirements only

**Goal**: Isolate whether the build/cmake changes alone cause the V1 Others hang on L4.

**Changes**: ONLY build-related changes from FA4:
- `cmake/external_projects/vllm_flash_attn.cmake` (new flash-attn git tag `140c00c`, per-component install rules, cute directory cmake target)
- `requirements/cuda.txt` (add `nvidia-cutlass-dsl>=4.4.0.dev1`, `quack-kernels>=0.2.7`)
- `setup.py` (add `_vllm_fa4_cutedsl_C` optional extension)

**NOT included**: Python code changes. Uses main's cmake-generated `__init__.py` and `flash_attn_interface.py`.

**Expected outcome**:
- If V1 Others **hangs** → cmake/build changes cause it
- If V1 Others **passes** → Python changes cause it (see Trial 2)

Related: #32974

🤖 Generated with [Claude Code](https://claude.com/claude-code)