### PR TITLE
[BugFix][Model]Fix the garbled code in Ernie4.5-VL caused by fast_moe_cold_start

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -329,6 +329,14 @@ class SnowflakeGteNewModelConfig(VerifyAndUpdateConfig):
         }
 
 
+class Ernie4_5_VLMoeForConditionalGenerationConfig(VerifyAndUpdateConfig):
+    @staticmethod
+    def verify_and_update_config(vllm_config: "VllmConfig") -> None:
+        # Ernie4.5-VL conditionally executes text/vision MoE branches, so
+        # fast_moe_cold_start can silently produce incorrect execution order.
+        vllm_config.compilation_config.fast_moe_cold_start = True
+
+
 class GptOssForCausalLMConfig(VerifyAndUpdateConfig):
     @staticmethod
     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
@@ -661,6 +669,7 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "Qwen2ForRewardModel": Qwen2ForRewardModelConfig,
     "Qwen3ForSequenceClassification": Qwen3ForSequenceClassificationConfig,
     "Qwen3VLForSequenceClassification": Qwen3VLForSequenceClassificationConfig,
+    "Ernie4_5_VLMoeForConditionalGeneration":  Ernie4_5_VLMoeForConditionalGenerationConfig,
     "XLMRobertaModel": JinaRobertaModelConfig,
     "ColBERTJinaRobertaModel": JinaRobertaModelConfig,
     "JinaVLForRanking": JinaVLForSequenceClassificationConfig,

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -669,7 +669,7 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "Qwen2ForRewardModel": Qwen2ForRewardModelConfig,
     "Qwen3ForSequenceClassification": Qwen3ForSequenceClassificationConfig,
     "Qwen3VLForSequenceClassification": Qwen3VLForSequenceClassificationConfig,
-    "Ernie4_5_VLMoeForConditionalGeneration":  Ernie4_5_VLMoeForConditionalGenerationConfig,
+    "Ernie4_5_VLMoeForConditionalGeneration": Ernie4_5_VLMoeForConditionalGenerationConfig,  # noqa: E501
     "XLMRobertaModel": JinaRobertaModelConfig,
     "ColBERTJinaRobertaModel": JinaRobertaModelConfig,
     "JinaVLForRanking": JinaVLForSequenceClassificationConfig,

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -334,7 +334,7 @@ class Ernie4_5_VLMoeForConditionalGenerationConfig(VerifyAndUpdateConfig):
     def verify_and_update_config(vllm_config: "VllmConfig") -> None:
         # Ernie4.5-VL conditionally executes text/vision MoE branches, so
         # fast_moe_cold_start can silently produce incorrect execution order.
-        vllm_config.compilation_config.fast_moe_cold_start = True
+        vllm_config.compilation_config.fast_moe_cold_start = False
 
 
 class GptOssForCausalLMConfig(VerifyAndUpdateConfig):

--- a/vllm/model_executor/models/ernie45_vl_moe.py
+++ b/vllm/model_executor/models/ernie45_vl_moe.py
@@ -618,6 +618,10 @@ class Ernie4_5_VLMoeForCausalLM(nn.Module, SupportsPP):
         quant_config = vllm_config.quant_config
         self.config = config
         self.quant_config = quant_config
+        # Ernie45-VL conditionally executes text/vision MoE branches, which
+        # breaks fast_moe_cold_start's assumption that all MoE layers execute
+        # in initialization order during each forward pass.
+        vllm_config.compilation_config.fast_moe_cold_start = False
         self.model = Ernie4_5_VLMoeModel(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )

--- a/vllm/model_executor/models/ernie45_vl_moe.py
+++ b/vllm/model_executor/models/ernie45_vl_moe.py
@@ -618,10 +618,6 @@ class Ernie4_5_VLMoeForCausalLM(nn.Module, SupportsPP):
         quant_config = vllm_config.quant_config
         self.config = config
         self.quant_config = quant_config
-        # Ernie45-VL conditionally executes text/vision MoE branches, which
-        # breaks fast_moe_cold_start's assumption that all MoE layers execute
-        # in initialization order during each forward pass.
-        vllm_config.compilation_config.fast_moe_cold_start = False
         self.model = Ernie4_5_VLMoeModel(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )


### PR DESCRIPTION

## Purpose
Fix the garbled code in Ernie4.5-VL caused by `fast_moe_cold_start`https://github.com/vllm-project/vllm/pull/32805

Ernie45-VL conditionally executes text/vision MoE branches, which breaks `fast_moe_cold_start`  assumption that all MoE layers execute in initialization order during each forward pass.

The solution is directly set to False by default in Ernie4.5-VL

## Test Plan

```bash
vllm serve baidu/ERNIE-4.5-VL-28B-A3B-PT --port 8506 --gpu-memory-utilization 0.95 --trust-remote-code
```

## Test Result
output normal

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

