### PR TITLE
[ROCm][Quantization] Enable experts_int8 on ROCm

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -336,6 +336,7 @@ class RocmPlatform(Platform):
         "petit_nvfp4",
         "torchao",
         "bitsandbytes",
+        "experts_int8",
     ]
 
     @classmethod


### PR DESCRIPTION
`experts_int8` quantization (INT8-quantized MoE expert weights) is not in `RocmPlatform.supported_quantization`, so loading any model that uses it on ROCm fails at platform verification with something like:

```
ValueError: ... experts_int8 quantization is currently not supported in ROCm ...
```

The actual compute path is fine though. `ExpertsInt8MoEMethod.apply()` calls `fused_experts()` with `int8_w8a16_moe_quant_config`, which ends up in the Triton fused MoE kernel — nothing CUDA-specific in that path. The missing piece is just the string in the platform's supported list.

This adds `"experts_int8"` to `RocmPlatform.supported_quantization` in `vllm/platforms/rocm.py`. The existing test in `tests/quantization/test_experts_int8.py` gates itself with `is_quant_method_supported("experts_int8")`, so it should pick this up automatically on ROCm CI.