### PR TITLE
[ROCm][Quantization] Enable moe_wna16 on ROCm via Triton fallback

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1217,6 +1217,7 @@ def should_moe_wna16_use_cuda(
 ):
     return (
         current_platform.is_cuda()
+        and not current_platform.is_rocm()
         and bit == 4
         and group_size in [32, 64, 128]
         and num_valid_tokens / num_experts <= 6

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -336,6 +336,7 @@ class RocmPlatform(Platform):
         "petit_nvfp4",
         "torchao",
         "bitsandbytes",
+        "moe_wna16",
     ]
 
     @classmethod


### PR DESCRIPTION
`moe_wna16` (W4A16/W8A16 MoE quantization, used by GPTQ/AWQ-quantized Mixtral, DeepSeek, etc.) is blocked on ROCm by two issues:

1. Not in `RocmPlatform.supported_quantization` — platform verification rejects it outright.

2. Even if you bypass that, `should_moe_wna16_use_cuda()` in `fused_moe.py` returns `True` on ROCm because it checks `current_platform.is_cuda()`, which returns `True` for ROCm under the current platform model. This routes into `invoke_fused_moe_wna16_cuda_kernel` → `ops.moe_wna16_gemm`, a CUDA-only C++ op that isn't registered on ROCm builds. The Triton fallback path (`invoke_fused_moe_wna16_triton_kernel`) would work fine but never gets reached.

The fix is two lines:

- Add `"moe_wna16"` to `supported_quantization` in `vllm/platforms/rocm.py`
- Add `and not current_platform.is_rocm()` to `should_moe_wna16_use_cuda()` in `vllm/model_executor/layers/fused_moe/fused_moe.py` so the Triton kernel is used instead

The linear layers within `moe_wna16` models already handle ROCm correctly — `check_marlin_supports_layer()` in `marlin_utils.py` returns `False` on ROCm (line 213-214), so `MoeWNA16Config.get_quant_method()` falls through to the non-Marlin AWQ/GPTQ paths which have working ROCm support via Exllama/Conch.

The Triton WNA16 MoE kernel is the same one used on CUDA when `should_moe_wna16_use_cuda()` returns false (W8A16 case, or large batch sizes), so it's well-exercised in existing CI.