### PR TITLE
[ROCm][Quantization] Enable compressed-tensors WNA16 test on ROCm

### DIFF
--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -280,7 +280,8 @@ def test_compressed_tensors_w8a8_dynamic_per_token(
     ],
 )
 @pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="The tests are skipped on non-CUDA platform."
+    not current_platform.is_cuda_alike(),
+    reason="The tests are skipped on non-CUDA/ROCm platform.",
 )
 def test_compressed_tensors_wNa16(vllm_runner, wNa16_args):
     model, strategy, group, pack_factor, symmetric, has_g_idx = wNa16_args


### PR DESCRIPTION
`test_compressed_tensors_wNa16` is skipped on ROCm because the skip condition is `not current_platform.is_cuda()`. On ROCm, `is_cuda()` returns `False` (it only returns `True` for NVIDIA), so the test never runs.

But the kernel it exercises — `ExllamaLinearKernel` — already works on ROCm. Its `can_implement()` in `exllama.py` checks `current_platform.is_cuda_alike()` (line 29), which returns `True` for both CUDA and ROCm. The underlying C++ ops (`gptq_gemm`, `gptq_shuffle` in `csrc/quantization/gptq/q_gemm.cu`) have full ROCm support with hipBLAS paths gated on `USE_ROCM`. And in `vllm/model_executor/kernels/linear/__init__.py`, `ExllamaLinearKernel` is already in the `_POSSIBLE_KERNELS[PlatformEnum.ROCM]` list (line 139).

The fix is just changing the skip condition from `is_cuda()` to `is_cuda_alike()` so the test runs on ROCm too. The two test models are `nm-testing/tinyllama-oneshot-w4a16-channel-v2` (channelwise, symmetric) and `nm-testing/TinyLlama-1.1B-Chat-v1.0-W4A16-G128-Asym-Updated-ActOrder` (group 128, asymmetric, act-order).