### PR TITLE
[Bugfix] Fix CompressedTensors MoE g_idx registration when actorder is null

### DIFF
--- a/tests/quantization/test_compressed_tensors_moe_actorder_null.py
+++ b/tests/quantization/test_compressed_tensors_moe_actorder_null.py
@@ -142,6 +142,13 @@ class TestCompressedTensorsMoEActorderNull(unittest.TestCase):
         self.assertEqual(layer.w13_weight_g_idx.shape[1], 0)
         self.assertEqual(layer.w2_weight_g_idx.shape[1], 0)
 
+        # Verify g_idx are NOT registered as nn.Parameters
+        param_names = {name for name, _ in layer.named_parameters()}
+        self.assertNotIn("w13_weight_g_idx", param_names)
+        self.assertNotIn("w2_weight_g_idx", param_names)
+        self.assertNotIn("w13_g_idx_sort_indices", param_names)
+        self.assertNotIn("w2_g_idx_sort_indices", param_names)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/quantization/test_compressed_tensors_moe_actorder_null.py
+++ b/tests/quantization/test_compressed_tensors_moe_actorder_null.py
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
 Test that CompressedTensorsWNA16MarlinMoEMethod does not register g_idx
 parameters when actorder is null. Regression test for #35303.
@@ -30,14 +34,17 @@ class TestCompressedTensorsMoEActorderNull(unittest.TestCase):
         moe = MagicMock()
         moe.is_act_and_mul = True
 
-        with patch(
-            "vllm.model_executor.layers.quantization.compressed_tensors."
-            "compressed_tensors_moe.get_marlin_input_dtype",
-            return_value=None,
-        ), patch(
-            "vllm.model_executor.layers.quantization.compressed_tensors."
-            "compressed_tensors_moe.is_flashinfer_mxint4_moe_available",
-            return_value=False,
+        with (
+            patch(
+                "vllm.model_executor.layers.quantization.compressed_tensors."
+                "compressed_tensors_moe.get_marlin_input_dtype",
+                return_value=None,
+            ),
+            patch(
+                "vllm.model_executor.layers.quantization.compressed_tensors."
+                "compressed_tensors_moe.is_flashinfer_mxint4_moe_available",
+                return_value=False,
+            ),
         ):
             method = CompressedTensorsWNA16MarlinMoEMethod(
                 moe=moe,
@@ -110,17 +117,21 @@ class TestCompressedTensorsMoEActorderNull(unittest.TestCase):
 
         # After process_weights, g_idx should be set as plain attributes
         # (empty tensors), not nn.Parameters
-        with patch(
-            "vllm.model_executor.layers.quantization.compressed_tensors."
-            "compressed_tensors_moe.ops"
-        ) as mock_ops, patch(
-            "vllm.model_executor.layers.quantization.compressed_tensors."
-            "compressed_tensors_moe.marlin_moe_permute_scales",
-            side_effect=lambda s, **kw: s,
-        ), patch(
-            "vllm.model_executor.layers.quantization.compressed_tensors."
-            "compressed_tensors_moe.marlin_make_workspace_new",
-            return_value=torch.empty(0),
+        with (
+            patch(
+                "vllm.model_executor.layers.quantization.compressed_tensors."
+                "compressed_tensors_moe.ops"
+            ) as mock_ops,
+            patch(
+                "vllm.model_executor.layers.quantization.compressed_tensors."
+                "compressed_tensors_moe.marlin_moe_permute_scales",
+                side_effect=lambda s, **kw: s,
+            ),
+            patch(
+                "vllm.model_executor.layers.quantization.compressed_tensors."
+                "compressed_tensors_moe.marlin_make_workspace_new",
+                return_value=torch.empty(0),
+            ),
         ):
             mock_ops.gptq_marlin_moe_repack.side_effect = lambda w, *a, **kw: w
             method.process_weights_after_loading(layer)

--- a/tests/quantization/test_compressed_tensors_moe_actorder_null.py
+++ b/tests/quantization/test_compressed_tensors_moe_actorder_null.py
@@ -1,0 +1,136 @@
+"""
+Test that CompressedTensorsWNA16MarlinMoEMethod does not register g_idx
+parameters when actorder is null. Regression test for #35303.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+import torch.nn as nn
+
+
+class TestCompressedTensorsMoEActorderNull(unittest.TestCase):
+    """Verify g_idx params are conditionally registered based on actorder."""
+
+    def _make_method(self, actorder=None):
+        """Create a CompressedTensorsWNA16MarlinMoEMethod with mocked deps."""
+        from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (  # noqa: E501
+            CompressedTensorsWNA16MarlinMoEMethod,
+        )
+
+        weight_quant = MagicMock()
+        weight_quant.symmetric = True
+        weight_quant.num_bits = 4
+        weight_quant.strategy = "group"
+        weight_quant.group_size = 32
+        weight_quant.actorder = actorder
+
+        input_quant = None
+        moe = MagicMock()
+        moe.is_act_and_mul = True
+
+        with patch(
+            "vllm.model_executor.layers.quantization.compressed_tensors."
+            "compressed_tensors_moe.get_marlin_input_dtype",
+            return_value=None,
+        ), patch(
+            "vllm.model_executor.layers.quantization.compressed_tensors."
+            "compressed_tensors_moe.is_flashinfer_mxint4_moe_available",
+            return_value=False,
+        ):
+            method = CompressedTensorsWNA16MarlinMoEMethod(
+                moe=moe,
+                weight_quant=weight_quant,
+                input_quant=input_quant,
+            )
+        return method
+
+    def _create_weights_on_layer(self, method):
+        """Call create_weights and return the layer module."""
+        layer = nn.Module()
+        num_experts = 4
+        hidden_size = 64
+        intermediate_size = 32
+
+        method.create_weights(
+            layer=layer,
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size_per_partition=intermediate_size,
+            params_dtype=torch.float16,
+            intermediate_size_full=intermediate_size,
+        )
+        return layer
+
+    def test_actorder_null_no_g_idx_params(self):
+        """When actorder is null, g_idx should NOT be registered as params."""
+        method = self._make_method(actorder=None)
+        layer = self._create_weights_on_layer(method)
+
+        param_names = {name for name, _ in layer.named_parameters()}
+        g_idx_names = {
+            "w13_weight_g_idx",
+            "w2_weight_g_idx",
+            "w13_g_idx_sort_indices",
+            "w2_g_idx_sort_indices",
+        }
+        registered_g_idx = param_names & g_idx_names
+        self.assertEqual(
+            registered_g_idx,
+            set(),
+            f"g_idx params should not be registered when actorder=null, "
+            f"but found: {registered_g_idx}",
+        )
+
+    def test_actorder_group_has_g_idx_params(self):
+        """When actorder='group', g_idx SHOULD be registered as params."""
+        method = self._make_method(actorder="group")
+        layer = self._create_weights_on_layer(method)
+
+        param_names = {name for name, _ in layer.named_parameters()}
+        g_idx_names = {
+            "w13_weight_g_idx",
+            "w2_weight_g_idx",
+            "w13_g_idx_sort_indices",
+            "w2_g_idx_sort_indices",
+        }
+        missing = g_idx_names - param_names
+        self.assertEqual(
+            missing,
+            set(),
+            f"g_idx params should be registered when actorder='group', "
+            f"but missing: {missing}",
+        )
+
+    def test_process_weights_actorder_null(self):
+        """process_weights_after_loading should work when actorder is null."""
+        method = self._make_method(actorder=None)
+        layer = self._create_weights_on_layer(method)
+
+        # After process_weights, g_idx should be set as plain attributes
+        # (empty tensors), not nn.Parameters
+        with patch(
+            "vllm.model_executor.layers.quantization.compressed_tensors."
+            "compressed_tensors_moe.ops"
+        ) as mock_ops, patch(
+            "vllm.model_executor.layers.quantization.compressed_tensors."
+            "compressed_tensors_moe.marlin_moe_permute_scales",
+            side_effect=lambda s, **kw: s,
+        ), patch(
+            "vllm.model_executor.layers.quantization.compressed_tensors."
+            "compressed_tensors_moe.marlin_make_workspace_new",
+            return_value=torch.empty(0),
+        ):
+            mock_ops.gptq_marlin_moe_repack.side_effect = lambda w, *a, **kw: w
+            method.process_weights_after_loading(layer)
+
+        # g_idx attrs should exist as empty tensors
+        self.assertTrue(hasattr(layer, "w13_weight_g_idx"))
+        self.assertTrue(hasattr(layer, "w2_weight_g_idx"))
+        self.assertEqual(layer.w13_weight_g_idx.shape[1], 0)
+        self.assertEqual(layer.w2_weight_g_idx.shape[1], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -1570,21 +1570,19 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
             replace_parameter(layer, "w2_g_idx_sort_indices", w2_g_idx_sort_indices)
 
         else:
-            layer.w13_weight_g_idx = torch.nn.Parameter(
-                torch.empty((num_experts, 0), dtype=torch.int32, device=device),
-                requires_grad=False,
+            # When actorder is null, assign g_idx as plain tensors (not
+            # nn.Parameter) since they are not real model weights.
+            layer.w13_weight_g_idx = torch.empty(
+                (num_experts, 0), dtype=torch.int32, device=device
             )
-            layer.w2_weight_g_idx = torch.nn.Parameter(
-                torch.empty((num_experts, 0), dtype=torch.int32, device=device),
-                requires_grad=False,
+            layer.w2_weight_g_idx = torch.empty(
+                (num_experts, 0), dtype=torch.int32, device=device
             )
-            layer.w13_g_idx_sort_indices = torch.nn.Parameter(
-                torch.empty((num_experts, 0), dtype=torch.int32, device=device),
-                requires_grad=False,
+            layer.w13_g_idx_sort_indices = torch.empty(
+                (num_experts, 0), dtype=torch.int32, device=device
             )
-            layer.w2_g_idx_sort_indices = torch.nn.Parameter(
-                torch.empty((num_experts, 0), dtype=torch.int32, device=device),
-                requires_grad=False,
+            layer.w2_g_idx_sort_indices = torch.empty(
+                (num_experts, 0), dtype=torch.int32, device=device
             )
 
         marlin_w13_qweight = ops.gptq_marlin_moe_repack(

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -1452,57 +1452,69 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
         layer.register_parameter("w13_weight_shape", w13_weight_shape)
         set_weight_attrs(w13_weight_shape, extra_weight_attrs)
 
-        w13_g_idx = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                hidden_size,
-                dtype=torch.int32,
-            ),
-            requires_grad=False,
-        )
-        layer.register_parameter("w13_weight_g_idx", w13_g_idx)
-        set_weight_attrs(w13_g_idx, extra_weight_attrs)
+        # Only register g_idx parameters when actorder is enabled.
+        # When actorder is null/falsy, the checkpoint does not contain these
+        # tensors, and registering them as nn.Parameter causes
+        # DefaultModelLoader.track_weights_loading() to raise ValueError
+        # for uninitialized weights. See #35303.
+        if self.actorder:
+            w13_g_idx = torch.nn.Parameter(
+                torch.empty(
+                    num_experts,
+                    hidden_size,
+                    dtype=torch.int32,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter("w13_weight_g_idx", w13_g_idx)
+            set_weight_attrs(w13_g_idx, extra_weight_attrs)
 
-        w2_g_idx = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                intermediate_size_per_partition,
-                dtype=torch.int32,
-            ),
-            requires_grad=False,
-        )
-        layer.register_parameter("w2_weight_g_idx", w2_g_idx)
-        set_weight_attrs(w2_g_idx, extra_weight_attrs)
+            w2_g_idx = torch.nn.Parameter(
+                torch.empty(
+                    num_experts,
+                    intermediate_size_per_partition,
+                    dtype=torch.int32,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter("w2_weight_g_idx", w2_g_idx)
+            set_weight_attrs(w2_g_idx, extra_weight_attrs)
 
-        w13_g_idx_sort_indices = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                hidden_size,
-                dtype=torch.int32,
-            ),
-            requires_grad=False,
-        )
-        layer.register_parameter("w13_g_idx_sort_indices", w13_g_idx_sort_indices)
-        set_weight_attrs(w13_g_idx_sort_indices, extra_weight_attrs)
+            w13_g_idx_sort_indices = torch.nn.Parameter(
+                torch.empty(
+                    num_experts,
+                    hidden_size,
+                    dtype=torch.int32,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter(
+                "w13_g_idx_sort_indices", w13_g_idx_sort_indices
+            )
+            set_weight_attrs(w13_g_idx_sort_indices, extra_weight_attrs)
 
-        w2_g_idx_sort_indices = torch.nn.Parameter(
-            torch.empty(
-                num_experts,
-                intermediate_size_per_partition,
-                dtype=torch.int32,
-            ),
-            requires_grad=False,
-        )
-        layer.register_parameter("w2_g_idx_sort_indices", w2_g_idx_sort_indices)
-        set_weight_attrs(w2_g_idx_sort_indices, extra_weight_attrs)
+            w2_g_idx_sort_indices = torch.nn.Parameter(
+                torch.empty(
+                    num_experts,
+                    intermediate_size_per_partition,
+                    dtype=torch.int32,
+                ),
+                requires_grad=False,
+            )
+            layer.register_parameter(
+                "w2_g_idx_sort_indices", w2_g_idx_sort_indices
+            )
+            set_weight_attrs(w2_g_idx_sort_indices, extra_weight_attrs)
 
         layer.a13_scale = None
         layer.a2_scale = None
         layer.marlin_state = GPTQMarlinState.REPACK
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        num_experts = layer.w13_weight_g_idx.shape[0]
-        device = layer.w13_weight_g_idx.device
+        # Use w13_weight_packed (always present) instead of w13_weight_g_idx
+        # which may not exist when actorder is null. See #35303.
+        num_experts = layer.w13_weight_packed.shape[0]
+        device = layer.w13_weight_packed.device
         if self.kernel_backend == "Flashinfer":
             dict_weights_mxint4 = prepare_static_weights_for_trtllm_mxint4_moe(
                 layer.w13_weight_packed,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -1488,9 +1488,7 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
                 ),
                 requires_grad=False,
             )
-            layer.register_parameter(
-                "w13_g_idx_sort_indices", w13_g_idx_sort_indices
-            )
+            layer.register_parameter("w13_g_idx_sort_indices", w13_g_idx_sort_indices)
             set_weight_attrs(w13_g_idx_sort_indices, extra_weight_attrs)
 
             w2_g_idx_sort_indices = torch.nn.Parameter(
@@ -1501,9 +1499,7 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
                 ),
                 requires_grad=False,
             )
-            layer.register_parameter(
-                "w2_g_idx_sort_indices", w2_g_idx_sort_indices
-            )
+            layer.register_parameter("w2_g_idx_sort_indices", w2_g_idx_sort_indices)
             set_weight_attrs(w2_g_idx_sort_indices, extra_weight_attrs)
 
         layer.a13_scale = None


### PR DESCRIPTION
## Summary

Fixes `DefaultModelLoader` `ValueError` when loading AWQ 4-bit MoE models (e.g. Qwen3-VL-30B-A3B) on v0.16.

Fixes #35303

## Root Cause

`CompressedTensorsWNA16MarlinMoEMethod.create_weights()` unconditionally registers `g_idx` and `sort_indices` parameters even when `actorder` is `None`. The stricter weight validation in `DefaultModelLoader` (introduced in v0.16) then raises `ValueError` because these parameters are never loaded from the checkpoint.

## Fix

- Wrap `g_idx`/`sort_indices` parameter registration in `if self.actorder` guard
- Derive `num_experts` and `device` from `w13_weight_packed` in `process_weights_after_loading()` instead of `g_idx` (which may not exist)

## Test Plan

Added 3 regression tests in `tests/quantization/test_compressed_tensors_moe_actorder_null.py`:
- `test_create_weights_no_g_idx_when_actorder_null` — verifies g_idx params are not registered
- `test_create_weights_g_idx_present_when_actorder_group` — verifies g_idx params are registered when actorder is enabled  
- `test_process_weights_derives_from_w13` — verifies num_experts/device derivation from w13_weight_packed

Signed-off-by: sxu75374 <imshuaixu@gmail.com>