### PR TITLE
[SP] Add opt-in ragged sequence parallelism path via VLLM_ENABLE_SP_RAGGED

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1146,7 +1146,11 @@ class CompilationConfig:
         self, uniform_decode_query_len: int, tensor_parallel_size: int
     ):
         multiple_of = uniform_decode_query_len
-        if tensor_parallel_size > 1 and self.pass_config.enable_sp:
+        if (
+            tensor_parallel_size > 1
+            and self.pass_config.enable_sp
+            and not envs.VLLM_ENABLE_SP_RAGGED
+        ):
             multiple_of = max(uniform_decode_query_len, tensor_parallel_size)
             if (
                 multiple_of % uniform_decode_query_len != 0

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1234,6 +1234,10 @@ class VllmConfig:
         self._post_init_kv_transfer_config()
 
     def update_sizes_for_sequence_parallelism(self, possible_sizes: list) -> list:
+        if envs.VLLM_ENABLE_SP_RAGGED:
+            # Ragged SP supports non-TP-multiple token counts.
+            return possible_sizes
+
         # remove the sizes that not multiple of tp_size when
         # enable sequence parallelism
         removed_sizes = [

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1235,8 +1235,22 @@ class VllmConfig:
 
     def update_sizes_for_sequence_parallelism(self, possible_sizes: list) -> list:
         if envs.VLLM_ENABLE_SP_RAGGED:
-            # Ragged SP supports non-TP-multiple token counts.
-            return possible_sizes
+            # Keep TP-divisible sizes unchanged (fast path), and lightly bucket
+            # TP-indivisible sizes to reduce graph-shape churn.
+            tp_size = self.parallel_config.tensor_parallel_size
+            bucket_size = min(4, max(1, tp_size // 2))
+            if bucket_size <= 1:
+                return possible_sizes
+
+            max_size = max(possible_sizes) if possible_sizes else 0
+            bucketed = []
+            for size in possible_sizes:
+                if size % tp_size == 0:
+                    bucketed.append(size)
+                    continue
+                rounded = ((size + bucket_size - 1) // bucket_size) * bucket_size
+                bucketed.append(size if rounded > max_size else rounded)
+            return sorted(set(bucketed))
 
         # remove the sizes that not multiple of tp_size when
         # enable sequence parallelism

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -15,17 +15,21 @@ def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
 
 
 def tensor_model_parallel_all_gather(
-    input_: torch.Tensor, dim: int = -1
+    input_: torch.Tensor,
+    dim: int = -1,
+    sizes: list[int] | None = None,
 ) -> torch.Tensor:
     """All-gather the input tensor across model parallel group."""
-    return get_tp_group().all_gather(input_, dim)
+    return get_tp_group().all_gather(input_, dim, sizes=sizes)
 
 
 def tensor_model_parallel_reduce_scatter(
-    input_: torch.Tensor, dim: int = -1
+    input_: torch.Tensor,
+    dim: int = -1,
+    sizes: list[int] | None = None,
 ) -> torch.Tensor:
     """Reduce-Scatter the input tensor across model parallel group."""
-    return get_tp_group().reduce_scatter(input_, dim)
+    return get_tp_group().reduce_scatter(input_, dim, sizes=sizes)
 
 
 def tensor_model_parallel_gather(

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -7,7 +7,6 @@ import torch
 import torch.distributed
 
 import vllm.envs as envs
-from vllm.config import get_current_vllm_config_or_none
 
 from .parallel_state import get_tp_group
 
@@ -36,6 +35,9 @@ def _infer_sp_ragged_sizes_for_all_gather(
 ) -> list[int] | None:
     if not envs.VLLM_ENABLE_SP_RAGGED or dim != 0:
         return None
+
+    # Avoid circular import at module import time.
+    from vllm.config import get_current_vllm_config_or_none
 
     config = get_current_vllm_config_or_none()
     if config is None or not config.parallel_config.use_sequence_parallel_moe:

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -6,6 +6,9 @@ from typing import Any
 import torch
 import torch.distributed
 
+import vllm.envs as envs
+from vllm.config import get_current_vllm_config_or_none
+
 from .parallel_state import get_tp_group
 
 
@@ -14,13 +17,71 @@ def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     return get_tp_group().all_reduce(input_)
 
 
+def _normalize_dim(dim: int, ndim: int) -> int:
+    if dim < 0:
+        dim += ndim
+    return dim
+
+
+def _compute_balanced_split_sizes(total: int, world_size: int) -> list[int]:
+    base = total // world_size
+    remainder = total % world_size
+    return [base + (1 if rank < remainder else 0) for rank in range(world_size)]
+
+
+def _infer_sp_ragged_sizes_for_all_gather(
+    input_: torch.Tensor,
+    dim: int,
+    tp_group: Any,
+) -> list[int] | None:
+    if not envs.VLLM_ENABLE_SP_RAGGED or dim != 0:
+        return None
+
+    config = get_current_vllm_config_or_none()
+    if config is None or not config.parallel_config.use_sequence_parallel_moe:
+        return None
+
+    world_size = tp_group.world_size
+    if world_size <= 1:
+        return None
+
+    try:
+        from vllm.forward_context import (
+            get_forward_context,
+            is_forward_context_available,
+        )
+    except Exception:
+        return None
+
+    if not is_forward_context_available():
+        return None
+
+    batch_descriptor = get_forward_context().batch_descriptor
+    if batch_descriptor is None:
+        return None
+
+    total_tokens = batch_descriptor.num_tokens
+    if total_tokens % world_size == 0:
+        return None
+
+    sizes = _compute_balanced_split_sizes(total_tokens, world_size)
+    if input_.shape[dim] != sizes[tp_group.rank_in_group]:
+        return None
+
+    return sizes
+
+
 def tensor_model_parallel_all_gather(
     input_: torch.Tensor,
     dim: int = -1,
     sizes: list[int] | None = None,
 ) -> torch.Tensor:
     """All-gather the input tensor across model parallel group."""
-    return get_tp_group().all_gather(input_, dim, sizes=sizes)
+    tp_group = get_tp_group()
+    if sizes is None:
+        normalized_dim = _normalize_dim(dim, input_.dim())
+        sizes = _infer_sp_ragged_sizes_for_all_gather(input_, normalized_dim, tp_group)
+    return tp_group.all_gather(input_, dim, sizes=sizes)
 
 
 def tensor_model_parallel_reduce_scatter(

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -133,6 +133,31 @@ def all_reduce_fake(tensor: torch.Tensor, group_name: str) -> torch.Tensor:
     return torch.empty_like(tensor)
 
 
+def _normalize_dim(dim: int, ndim: int) -> int:
+    if not -ndim <= dim < ndim:
+        raise ValueError(f"Invalid dim ({dim}) for tensor with ndim={ndim}")
+    return dim if dim >= 0 else dim + ndim
+
+
+def _compute_balanced_split_sizes(total: int, world_size: int) -> list[int]:
+    base = total // world_size
+    remainder = total % world_size
+    return [base + (1 if rank < remainder else 0) for rank in range(world_size)]
+
+
+def _all_gather_local_sizes(
+    tensor: torch.Tensor,
+    dim: int,
+    group: "GroupCoordinator",
+) -> list[int]:
+    local_size = torch.tensor(
+        [tensor.shape[dim]], dtype=torch.int64, device=tensor.device
+    )
+    gathered_sizes = [torch.empty_like(local_size) for _ in range(group.world_size)]
+    torch.distributed.all_gather(gathered_sizes, local_size, group=group.device_group)
+    return [int(x.item()) for x in gathered_sizes]
+
+
 def reduce_scatter(
     tensor: torch.Tensor, dim: int, world_size: int, group_name: str
 ) -> torch.Tensor:
@@ -140,14 +165,27 @@ def reduce_scatter(
     group = _groups[group_name]()
     if group is None:
         raise ValueError(f"Group {group_name} is destroyed.")
+    dim = _normalize_dim(dim, tensor.dim())
+    if envs.VLLM_ENABLE_SP_RAGGED and dim == 0 and tensor.shape[dim] % world_size != 0:
+        sizes = _compute_balanced_split_sizes(tensor.shape[dim], world_size)
+        return group.reduce_scatterv(tensor, dim=dim, sizes=sizes)
     return group._reduce_scatter_out_place(tensor, dim)
 
 
 def reduce_scatter_fake(
     tensor: torch.Tensor, dim: int, world_size: int, group_name: str
 ) -> torch.Tensor:
+    dim = _normalize_dim(dim, tensor.dim())
     new_shape = list(tensor.shape)
-    new_shape[dim] = tensor.shape[dim] // world_size
+    if envs.VLLM_ENABLE_SP_RAGGED and dim == 0 and tensor.shape[dim] % world_size != 0:
+        sizes = _compute_balanced_split_sizes(tensor.shape[dim], world_size)
+        rank_in_group = 0
+        group = _groups.get(group_name, lambda: None)()
+        if group is not None:
+            rank_in_group = group.rank_in_group
+        new_shape[dim] = sizes[rank_in_group]
+    else:
+        new_shape[dim] = tensor.shape[dim] // world_size
     return torch.empty(new_shape, dtype=tensor.dtype, device=tensor.device)
 
 
@@ -158,14 +196,74 @@ def all_gather(
     group = _groups[group_name]()
     if group is None:
         raise ValueError(f"Group {group_name} is destroyed.")
+    dim = _normalize_dim(dim, tensor.dim())
+    if envs.VLLM_ENABLE_SP_RAGGED and dim == 0:
+        sizes = _all_gather_local_sizes(tensor, dim, group)
+        if any(size != sizes[0] for size in sizes):
+            return group.all_gatherv(tensor, dim=dim, sizes=sizes)
     return group._all_gather_out_place(tensor, dim)
 
 
 def all_gather_fake(
     tensor: torch.Tensor, dim: int, world_size: int, group_name: str
 ) -> torch.Tensor:
+    dim = _normalize_dim(dim, tensor.dim())
     new_shape = list(tensor.shape)
     new_shape[dim] = tensor.shape[dim] * world_size
+    return torch.empty(new_shape, dtype=tensor.dtype, device=tensor.device)
+
+
+def reduce_scatterv(
+    tensor: torch.Tensor,
+    dim: int,
+    sizes: list[int],
+    group_name: str,
+) -> torch.Tensor:
+    assert group_name in _groups, f"Group {group_name} is not found."
+    group = _groups[group_name]()
+    if group is None:
+        raise ValueError(f"Group {group_name} is destroyed.")
+    return group.reduce_scatterv(tensor, dim=dim, sizes=sizes)
+
+
+def reduce_scatterv_fake(
+    tensor: torch.Tensor,
+    dim: int,
+    sizes: list[int],
+    group_name: str,
+) -> torch.Tensor:
+    dim = _normalize_dim(dim, tensor.dim())
+    rank_in_group = 0
+    group = _groups.get(group_name, lambda: None)()
+    if group is not None:
+        rank_in_group = group.rank_in_group
+    new_shape = list(tensor.shape)
+    new_shape[dim] = sizes[rank_in_group]
+    return torch.empty(new_shape, dtype=tensor.dtype, device=tensor.device)
+
+
+def all_gatherv(
+    tensor: torch.Tensor,
+    dim: int,
+    sizes: list[int],
+    group_name: str,
+) -> torch.Tensor:
+    assert group_name in _groups, f"Group {group_name} is not found."
+    group = _groups[group_name]()
+    if group is None:
+        raise ValueError(f"Group {group_name} is destroyed.")
+    return group.all_gatherv(tensor, dim=dim, sizes=sizes)
+
+
+def all_gatherv_fake(
+    tensor: torch.Tensor,
+    dim: int,
+    sizes: list[int],
+    group_name: str,
+) -> torch.Tensor:
+    dim = _normalize_dim(dim, tensor.dim())
+    new_shape = list(tensor.shape)
+    new_shape[dim] = sum(sizes)
     return torch.empty(new_shape, dtype=tensor.dtype, device=tensor.device)
 
 
@@ -269,6 +367,18 @@ direct_register_custom_op(
     op_name="all_gather",
     op_func=all_gather,
     fake_impl=all_gather_fake,
+)
+
+direct_register_custom_op(
+    op_name="reduce_scatterv",
+    op_func=reduce_scatterv,
+    fake_impl=reduce_scatterv_fake,
+)
+
+direct_register_custom_op(
+    op_name="all_gatherv",
+    op_func=all_gatherv,
+    fake_impl=all_gatherv_fake,
 )
 
 # TODO: Remove this once the pytorch fix
@@ -512,7 +622,12 @@ class GroupCoordinator:
             raise ValueError("No device communicator found")
         return self.device_communicator.all_reduce(input_)
 
-    def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
+    def all_gather(
+        self,
+        input_: torch.Tensor,
+        dim: int = -1,
+        sizes: list[int] | None = None,
+    ) -> torch.Tensor:
         world_size = self.world_size
         # Bypass the function if we are using only 1 GPU.
         if world_size == 1:
@@ -520,6 +635,10 @@ class GroupCoordinator:
         assert -input_.dim() <= dim < input_.dim(), (
             f"Invalid dim ({dim}) for input tensor with shape {input_.size()}"
         )
+        dim = _normalize_dim(dim, input_.dim())
+
+        if envs.VLLM_ENABLE_SP_RAGGED and sizes is not None:
+            return self.all_gatherv(input_, dim=dim, sizes=sizes)
 
         if self.use_custom_op_call:
             return torch.ops.vllm.all_gather(
@@ -543,7 +662,12 @@ class GroupCoordinator:
             raise ValueError("No device communicator found")
         return self.device_communicator.all_gatherv(input_, dim, sizes)
 
-    def reduce_scatter(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
+    def reduce_scatter(
+        self,
+        input_: torch.Tensor,
+        dim: int = -1,
+        sizes: list[int] | None = None,
+    ) -> torch.Tensor:
         world_size = self.world_size
         # Bypass the function if we are using only 1 GPU.
         if world_size == 1:
@@ -551,6 +675,10 @@ class GroupCoordinator:
         assert -input_.dim() <= dim < input_.dim(), (
             f"Invalid dim ({dim}) for input tensor with shape {input_.size()}"
         )
+        dim = _normalize_dim(dim, input_.dim())
+
+        if envs.VLLM_ENABLE_SP_RAGGED and sizes is not None:
+            return self.reduce_scatterv(input_, dim=dim, sizes=sizes)
 
         if self.use_custom_op_call:
             return torch.ops.vllm.reduce_scatter(

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -234,6 +234,7 @@ if TYPE_CHECKING:
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
+    VLLM_ENABLE_SP_RAGGED: bool = False
     VLLM_USE_V2_MODEL_RUNNER: bool = False
     VLLM_LOG_MODEL_INSPECTION: bool = False
     VLLM_DEBUG_MFU_METRICS: bool = False
@@ -1580,6 +1581,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_COMPILE_CACHE_SAVE_FORMAT": env_with_choices(
         "VLLM_COMPILE_CACHE_SAVE_FORMAT", "binary", ["binary", "unpacked"]
     ),
+    # Enable ragged sequence parallelism path.
+    "VLLM_ENABLE_SP_RAGGED": lambda: bool(int(os.getenv("VLLM_ENABLE_SP_RAGGED", "0"))),
     # Flag to enable v2 model runner.
     "VLLM_USE_V2_MODEL_RUNNER": lambda: bool(
         int(os.getenv("VLLM_USE_V2_MODEL_RUNNER", "0"))

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -12,6 +12,7 @@ import torch.nn as nn
 from torch.nn.modules.module import register_module_module_registration_hook
 from transformers import PretrainedConfig
 
+import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.distributed import (
     get_tensor_model_parallel_rank,
@@ -807,27 +808,48 @@ def sequence_parallel_chunk(x: torch.Tensor) -> torch.Tensor:
     return torch.ops.vllm.sequence_parallel_chunk_impl(x)
 
 
+def sequence_parallel_split_sizes(num_tokens: int) -> list[int]:
+    tp_size = get_tensor_model_parallel_world_size()
+    if not envs.VLLM_ENABLE_SP_RAGGED:
+        # Legacy behavior pads to equal chunk sizes.
+        return [cdiv(num_tokens, tp_size)] * tp_size
+
+    base = num_tokens // tp_size
+    remainder = num_tokens % tp_size
+    return [base + (1 if rank < remainder else 0) for rank in range(tp_size)]
+
+
 def sequence_parallel_chunk_impl(x: torch.Tensor) -> torch.Tensor:
     tp_size = get_tensor_model_parallel_world_size()
     tp_rank = get_tensor_model_parallel_rank()
-
-    # all_gather needs the sequence length to be divisible by tp_size
     seq_len = x.size(0)
-    remainder = seq_len % tp_size
-    if remainder != 0:
-        pad_len = tp_size - remainder
-        y = nn.functional.pad(x, (0, 0, 0, pad_len))
-    else:
-        y = x
 
-    chunk = y.shape[0] // tp_size
-    start = tp_rank * chunk
-    return torch.narrow(y, 0, start, chunk)
+    if not envs.VLLM_ENABLE_SP_RAGGED:
+        # all_gather needs the sequence length to be divisible by tp_size
+        remainder = seq_len % tp_size
+        if remainder != 0:
+            pad_len = tp_size - remainder
+            y = nn.functional.pad(x, (0, 0, 0, pad_len))
+        else:
+            y = x
+
+        chunk = y.shape[0] // tp_size
+        start = tp_rank * chunk
+        return torch.narrow(y, 0, start, chunk)
+
+    split_sizes = sequence_parallel_split_sizes(seq_len)
+    start = sum(split_sizes[:tp_rank])
+    return torch.narrow(x, 0, start, split_sizes[tp_rank])
 
 
 def sequence_parallel_chunk_impl_fake(x: torch.Tensor) -> torch.Tensor:
-    tp_size = get_tensor_model_parallel_world_size()
-    seq_len = cdiv(x.size(0), tp_size)
+    if not envs.VLLM_ENABLE_SP_RAGGED:
+        tp_size = get_tensor_model_parallel_world_size()
+        seq_len = cdiv(x.size(0), tp_size)
+    else:
+        tp_rank = get_tensor_model_parallel_rank()
+        seq_len = sequence_parallel_split_sizes(x.size(0))[tp_rank]
+
     shape = list(x.shape)
     shape[0] = seq_len
     out = torch.empty(shape, dtype=x.dtype, device=x.device)

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -5,6 +5,7 @@ import itertools
 from collections.abc import Callable, Iterable, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import Any, Literal, Protocol, overload
 
 import torch
@@ -808,15 +809,28 @@ def sequence_parallel_chunk(x: torch.Tensor) -> torch.Tensor:
     return torch.ops.vllm.sequence_parallel_chunk_impl(x)
 
 
+@lru_cache(maxsize=4096)
+def _cached_sp_split_and_offsets(
+    num_tokens: int,
+    tp_size: int,
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    base = num_tokens // tp_size
+    remainder = num_tokens % tp_size
+    split_sizes = [base + (1 if rank < remainder else 0) for rank in range(tp_size)]
+    offsets = [0]
+    for size in split_sizes[:-1]:
+        offsets.append(offsets[-1] + size)
+    return tuple(split_sizes), tuple(offsets)
+
+
 def sequence_parallel_split_sizes(num_tokens: int) -> list[int]:
     tp_size = get_tensor_model_parallel_world_size()
     if not envs.VLLM_ENABLE_SP_RAGGED:
         # Legacy behavior pads to equal chunk sizes.
         return [cdiv(num_tokens, tp_size)] * tp_size
 
-    base = num_tokens // tp_size
-    remainder = num_tokens % tp_size
-    return [base + (1 if rank < remainder else 0) for rank in range(tp_size)]
+    split_sizes, _ = _cached_sp_split_and_offsets(num_tokens, tp_size)
+    return list(split_sizes)
 
 
 def sequence_parallel_chunk_impl(x: torch.Tensor) -> torch.Tensor:
@@ -837,9 +851,8 @@ def sequence_parallel_chunk_impl(x: torch.Tensor) -> torch.Tensor:
         start = tp_rank * chunk
         return torch.narrow(y, 0, start, chunk)
 
-    split_sizes = sequence_parallel_split_sizes(seq_len)
-    start = sum(split_sizes[:tp_rank])
-    return torch.narrow(x, 0, start, split_sizes[tp_rank])
+    split_sizes, offsets = _cached_sp_split_and_offsets(seq_len, tp_size)
+    return torch.narrow(x, 0, offsets[tp_rank], split_sizes[tp_rank])
 
 
 def sequence_parallel_chunk_impl_fake(x: torch.Tensor) -> torch.Tensor:

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -3,6 +3,7 @@
 import math
 from collections import defaultdict
 from dataclasses import dataclass, field
+from functools import lru_cache
 
 import torch
 
@@ -374,6 +375,17 @@ def get_local_tokens_for_sp(
         assert num_input_tokens % tensor_parallel_size == 0
         return num_input_tokens // tensor_parallel_size
 
+    return _cached_local_tokens_for_sp(
+        num_input_tokens, tensor_parallel_size, tensor_parallel_rank
+    )
+
+
+@lru_cache(maxsize=8192)
+def _cached_local_tokens_for_sp(
+    num_input_tokens: int,
+    tensor_parallel_size: int,
+    tensor_parallel_rank: int,
+) -> int:
     base = num_input_tokens // tensor_parallel_size
     remainder = num_input_tokens % tensor_parallel_size
     return base + (1 if tensor_parallel_rank < remainder else 0)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
https://github.com/vllm-project/vllm/issues/29136#issuecomment-3965933181

## Changes
- Added env flag: `VLLM_ENABLE_SP_RAGGED` (default off).
- Wired SP to ragged collectives where needed:
  - `reduce_scatterv`
  - `all_gatherv`
- Updated SP chunking logic:
  - flag off: legacy padding + equal split
  - flag on: balanced ragged split (no forced TP-multiple)
- Integrated ragged behavior into SP fusion/runtime/config paths (including residual slicing and SP-related size handling).
Additional updates included
Added explicit ragged collective custom ops and fake implementations for compile-time shape propagation:
reduce_scatterv / all_gatherv
Extended TP group collective APIs to accept optional sizes and dispatch:
keep regular all_gather / reduce_scatter for uniform splits
use all_gatherv / reduce_scatterv only for uneven splits
Added SP helper utilities for balanced split computation and rank-local token sizing.
Updated SP fake/runtime shape handling to support ragged per-rank sequence lengths (including residual slicing correctness).
Integrated ragged-aware SP size flow in compilation/runtime config:
preserve non-TP-divisible sizes when ragged is enabled
avoid strict TP-multiple assumptions in SP-related size adjustments
Added caching for repeated split/offset computations to reduce Python-side overhead on common token counts.

## Test Plan
/tmp/bench_sp_n_n1.p：
https://paste.ubuntu.com/p/hr7NjqykdF/
 
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export VLLM_DISABLE_COMPILE_CACHE=1

# off
export VLLM_ENABLE_SP_RAGGED=0
python /tmp/bench_sp_n_n1.py --model nvidia/Qwen3-32B-NVFP4 --tp 8 --num-reqs 1024 --output-len 1 --repeats 10 --output-json /tmp/sp_off.json

# on
export VLLM_ENABLE_SP_RAGGED=1
python /tmp/bench_sp_n_n1.py --model nvidia/Qwen3-32B-NVFP4 --tp 8 --num-reqs 1024 --output-len 1 --repeats 10 --output-json /tmp/sp_on.json


```
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export VLLM_DISABLE_COMPILE_CACHE=1   # 关缓存，不关compile

for N in 128 256 384 512 768 1024 1536 2048 3072 4096; do
  VLLM_ENABLE_SP_RAGGED=0 python /tmp/bench_sp_n_n1.py \
    --model nvidia/Qwen3-32B-NVFP4 \
    --tp 8 \
    --num-reqs $N \
    --output-len 1 \
    --repeats 10 \
    --output-json /tmp/sp_off_${N}.json

  VLLM_ENABLE_SP_RAGGED=1 python /tmp/bench_sp_n_n1.py \
    --model nvidia/Qwen3-32B-NVFP4 \
    --tp 8 \
    --num-reqs $N \
    --output-len 1 \
    --repeats 10 \
    --output-json /tmp/sp_on_${N}.json
done

```
## Test Result

```
     N    off(N+1/N)    on(N+1/N)  N+1 on/off   N on/off
  1024         0.785        0.965       1.289      1.048
   128         0.997        1.006       1.006      0.997
  1536         1.135        0.917       0.901      1.115
  2048         0.803        0.913       1.092      0.960
   256         0.999        1.005       0.606      0.603
  3072         0.974        0.927       1.504      1.579
   384         1.039        1.040       1.019      1.018
  4096         0.877        0.893       0.969      0.952
   512         0.972        1.001       1.048      1.017
   768         0.517        0.510       0.890      0.902

```
Summary:
N+1 on/off median: 1.012
N+1 on/off mean  : 1.032

```
python - <<'PY'
import json
off=json.load(open("/tmp/sp_off.json"))
on=json.load(open("/tmp/sp_on.json"))
print("off ratio(N+1/N):", off["ratio_n1_over_n"])
print("on  ratio(N+1/N):", on["ratio_n1_over_n"])
print("N+1 improvement(on/off):", on["N_plus_1"]["tokens_per_sec"]/off["N_plus_1"]["tokens_per_sec"])
PY
off ratio(N+1/N): 0.5484957841908911
on  ratio(N+1/N): 0.5985702003962979
N+1 improvement(on/off): 1.166764350323683
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

