### PR TITLE
[Benchmark] Avoid unnecessary video download in MMVU

### DIFF
--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2695,7 +2695,9 @@ class MMVUDataset(HuggingFaceDataset):
         if parser_fn is None:
             raise ValueError(f"Unsupported dataset path: {self.hf_name}")
 
-        remote_path = f"https://huggingface.co/datasets/{self.hf_name}/resolve/main"
+        remote_path_root = (
+            f"https://huggingface.co/datasets/{self.hf_name}/resolve/main"
+        )
         local_path_root = snapshot_download(self.hf_name, repo_type="dataset")
 
         output_len = output_len if output_len is not None else self.DEFAULT_OUTPUT_LEN
@@ -2707,7 +2709,7 @@ class MMVUDataset(HuggingFaceDataset):
 
             prompt = parser_fn(item)
             mm_content = process_video(
-                item["video"].replace(remote_path, local_path_root)
+                item["video"].replace(remote_path_root, local_path_root)
             )
             prompt_len = len(tokenizer.encode(prompt))
             if enable_multimodal_chat:

--- a/vllm/benchmarks/datasets.py
+++ b/vllm/benchmarks/datasets.py
@@ -2681,6 +2681,14 @@ class MMVUDataset(HuggingFaceDataset):
         + (" ".join(f"{k}.{v}" for k, v in x["choices"].items())),
     }
 
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        self._remote_path_root = (
+            f"https://huggingface.co/datasets/{self.hf_name}/resolve/main"
+        )
+        self._local_path_root = snapshot_download(self.hf_name, repo_type="dataset")
+
     def sample(
         self,
         tokenizer: TokenizerLike,
@@ -2695,11 +2703,6 @@ class MMVUDataset(HuggingFaceDataset):
         if parser_fn is None:
             raise ValueError(f"Unsupported dataset path: {self.hf_name}")
 
-        remote_path_root = (
-            f"https://huggingface.co/datasets/{self.hf_name}/resolve/main"
-        )
-        local_path_root = snapshot_download(self.hf_name, repo_type="dataset")
-
         output_len = output_len if output_len is not None else self.DEFAULT_OUTPUT_LEN
 
         sampled_requests = []
@@ -2709,7 +2712,7 @@ class MMVUDataset(HuggingFaceDataset):
 
             prompt = parser_fn(item)
             mm_content = process_video(
-                item["video"].replace(remote_path_root, local_path_root)
+                item["video"].replace(self._remote_path_root, self._local_path_root)
             )
             prompt_len = len(tokenizer.encode(prompt))
             if enable_multimodal_chat:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The videos in https://huggingface.co/datasets/yale-nlp/MMVU are linked to the online HF repo, which causes unnecessary downloads when running the benchmark. This PR solves it by replacing the remote paths with local paths.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

