### PR TITLE
[Perf] Eliminate duplicate bitmatrix metadata computation in gpt oss …

### DIFF
--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -159,12 +159,6 @@ def legacy_routing(
         logits = torch.softmax(logits, dim=-1)
     sparse_logits = topk(logits, n_expts_act, apply_softmax=not sm_first)
     n_expts_tot = logits.shape[-1]
-    if use_legacy_triton_kernels:
-        from triton_kernels.routing import routing_from_bitmatrix
-
-        return routing_from_bitmatrix(
-            sparse_logits.mask, sparse_logits.vals, sparse_logits.indx, n_expts_tot, n_expts_act
-        )
     dispatch_indx = sparse_logits.mask_metadata.row_sorted_indx
     combine_indx = sparse_logits.mask_metadata.col_sorted_indx
     ragged_batch_metadata = make_ragged_tensor_metadata(
@@ -182,6 +176,7 @@ def legacy_routing(
     gather_idx = GatherIndx(combine_indx, dispatch_indx)
     scatter_idx = ScatterIndx(dispatch_indx, combine_indx)
     return routing_data, gather_idx, scatter_idx
+
 
 def triton_kernel_moe_forward(
     hidden_states: torch.Tensor,

--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -158,14 +158,30 @@ def legacy_routing(
     if sm_first:
         logits = torch.softmax(logits, dim=-1)
     sparse_logits = topk(logits, n_expts_act, apply_softmax=not sm_first)
-    return legacy_routing_from_bitmatrix(
-        sparse_logits.mask,
-        sparse_logits.vals,
-        sparse_logits.indx,
-        logits.shape[-1],
-        n_expts_act,
-    )
+    n_expts_tot = logits.shape[-1]
+    if use_legacy_triton_kernels:
+        from triton_kernels.routing import routing_from_bitmatrix
 
+        return routing_from_bitmatrix(
+            sparse_logits.mask, sparse_logits.vals, sparse_logits.indx, n_expts_tot, n_expts_act
+        )
+    dispatch_indx = sparse_logits.mask_metadata.row_sorted_indx
+    combine_indx = sparse_logits.mask_metadata.col_sorted_indx
+    ragged_batch_metadata = make_ragged_tensor_metadata(
+        sparse_logits.mask_metadata.col_sum,
+        dispatch_indx.shape[0],
+    )
+    gate_scal = sparse_logits.vals.flatten()[combine_indx]
+    routing_data = RoutingData(
+        gate_scal,
+        ragged_batch_metadata.block_sizes,
+        n_expts_tot,
+        n_expts_act,
+        ragged_batch_metadata,
+    )
+    gather_idx = GatherIndx(combine_indx, dispatch_indx)
+    scatter_idx = ScatterIndx(dispatch_indx, combine_indx)
+    return routing_data, gather_idx, scatter_idx
 
 def triton_kernel_moe_forward(
     hidden_states: torch.Tensor,


### PR DESCRIPTION
…MoE routing


This PR removes redundant computation of the SparseMatrix in the legacy_routing function by inlining legacy_routing_from_bitmatrix into legacy_routing. This function is used in the GPT OSS routing.

## Purpose
This PR is one of the PRs that will solve this issue: https://github.com/vllm-project/vllm/issues/28986, i.e, fuse the kernel for the GPT OSS router. It seems there have been a few changes since the issue was created. So, the kernel is not exactly the same that was before. 


## Test Plan

Before Kernels:

<img width="1129" height="193" alt="image" src="https://github.com/user-attachments/assets/217a2339-9c53-4b2b-9b05-827557f6613e" />


After Kernels:

<img width="1386" height="217" alt="image" src="https://github.com/user-attachments/assets/c906c57d-e98d-48ee-bac1-73f2ec5ffb22" />

You can see the kernels are reduced from 14 to 10.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

