### PR TITLE
[Bugfix] Fix RoutedExpertsCapturer for pipeline parallelism (PP > 1)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -219,10 +219,10 @@ class RoutedExpertsCapturer:
 
         with _file_lock(self._lock_file):
             if self._owned_layers is not None:
-                for layer_idx in sorted(self._owned_layers):
-                    self._host_buffer_view[indices, layer_idx, :] = data[
-                        :, layer_idx, :
-                    ]
+                owned_layers_list = sorted(list(self._owned_layers))
+                self._host_buffer_view[indices, owned_layers_list, :] = data[
+                    :, owned_layers_list, :
+                ]
             else:
                 self._host_buffer_view[indices, :, :] = data
 


### PR DESCRIPTION
When PP > 1, each pipeline rank only processes a subset of model layers. execute_model() returns IntermediateTensors early on non-last PP ranks, before save_captured_experts() is called — so routing decisions from earlier pipeline stages are silently lost.

Additionally, the last rank's save_captured_experts() overwrites ALL layers in shared memory (including zeros for layers it didn't process), clobbering any data that other ranks might have written.

Fix:
- Record which MoE layers each PP rank owns at bind time (_owned_layers), so save_captured_experts() writes only those layers instead of a bulk overwrite. This avoids the CUDA-graph pitfall of tracking layers dynamically inside capture() (Python side-effects don't replay).
- Call save_captured_experts() before the early return for non-last PP ranks so their routing decisions are persisted to shared memory.
- Fall back to the original bulk write when _owned_layers is None (PP = 1), keeping the common path unchanged.

(Summary is generated by cursor but I checked the changes and the issue and it's legitimate)

<!-- markdownlint-disable -->

## Purpose

Fix routed experts capture with PP=2, where consecutive ranks override the previous ranks decisions

## Test Plan

Can provide tests later, for now we've tested E2E on prime-rl
<img width="428" height="201" alt="image" src="https://github.com/user-attachments/assets/91910e2c-add2-4fdb-84c4-e24565b7c8fa" />
Image shows that the first experts are set to 0.


## Test Result

<img width="468" height="334" alt="image" src="https://github.com/user-attachments/assets/336c1e35-27d7-4cae-bde2-4c83a130cb60" />

This is a kl-mismatch plot from our wandb runs, the after-patch is not visible as it's too low (1e-3-ish)
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

