### PR TITLE
[MISC] Fixing a null reference by removing parallel_utils from mypy EXCLUDE

### DIFF
--- a/tools/pre_commit/mypy.py
+++ b/tools/pre_commit/mypy.py
@@ -34,7 +34,6 @@ SEPARATE_GROUPS = [
 
 # TODO(woosuk): Include the code from Megatron and HuggingFace.
 EXCLUDE = [
-    "vllm/model_executor/parallel_utils",
     "vllm/model_executor/models",
     "vllm/model_executor/layers/fla/ops",
     # Ignore triton kernels in ops.


### PR DESCRIPTION
## Purpose
This PR removes parallel_utils from the mypy EXCLUDE list since the parallel_utils folder does not exist. This is part of the ongoing effort in [26533](https://github.com/vllm-project/vllm/issues/26533) to enable mypy checking across the codebase.

## Test Plan
`pre-commit run --hook-stage manual mypy-3.10 -a`

## Test Result
`Run mypy for Python 3.10.................................................Passed`

