### PR TITLE
[Docs] Update `CacheConfig` block_size docstring to remove inaccurate limit when using CUDA

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -40,8 +40,7 @@ class CacheConfig:
     """Configuration for the KV cache."""
 
     block_size: SkipValidation[BlockSize] = None  # type: ignore[assignment]
-    """Size of a contiguous cache block in number of tokens. On CUDA devices,
-    only block sizes up to 32 are supported.
+    """Size of a contiguous cache block in number of tokens.
 
     This config has no static default. If left unspecified by the user, it will
     be set in `Platform.check_and_update_config()` based on the current


### PR DESCRIPTION
## Purpose
Correct `CacheConfig` docstring for `block_size` to remove a reference to an outdated limit of 32 tokens.

For example, with CUTLASS MLA and CUDA, seems we set block_size to 128:
https://github.com/vllm-project/vllm/blob/e3eb146f7ad4bc920e11e98cf88cee3839cf5f89/vllm/platforms/cuda.py#L251

## Test Plan
Confirm behavior with reviewers.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

