### PR TITLE
fix: correct max_loras grid size in fused_moe_lora kernels

### DIFF
--- a/vllm/lora/ops/triton_ops/fused_moe_lora_fp8_op.py
+++ b/vllm/lora/ops/triton_ops/fused_moe_lora_fp8_op.py
@@ -460,7 +460,7 @@ def _fused_moe_lora_shrink_fp8(
         top_k_num,
         lora_ids,
         adapter_enabled,
-        lora_a_stacked[0].shape[0],
+        lora_a_stacked[0].shape[0] + 1,  # +1 for base-model slot
         qcurr_hidden_states.stride(0),
         qcurr_hidden_states.stride(1),
         w1_lora_a_stacked.stride(0),
@@ -637,7 +637,7 @@ def _fused_moe_lora_expand_fp8(
         top_k_num,
         lora_ids,
         adapter_enabled,
-        lora_b_stacked[0].shape[0],
+        lora_b_stacked[0].shape[0] + 1,  # +1 for base-model slot
         a_intermediate_cache1.stride(0),
         a_intermediate_cache1.stride(1),
         w1_lora_b_stacked.stride(0),

--- a/vllm/lora/ops/triton_ops/fused_moe_lora_op.py
+++ b/vllm/lora/ops/triton_ops/fused_moe_lora_op.py
@@ -503,7 +503,7 @@ def _fused_moe_lora_shrink(
         top_k_num,
         lora_ids,
         adapter_enabled,
-        lora_a_stacked[0].shape[0],
+        lora_a_stacked[0].shape[0] + 1,  # +1 for base-model slot
         qcurr_hidden_states.stride(0),
         qcurr_hidden_states.stride(1),
         w1_lora_a_stacked.stride(0),
@@ -639,7 +639,7 @@ def _fused_moe_lora_expand(
         top_k_num,
         lora_ids,
         adapter_enabled,
-        lora_b_stacked[0].shape[0],
+        lora_b_stacked[0].shape[0] + 1,  # +1 for base-model slot
         a_intermediate_cache1.stride(0),
         a_intermediate_cache1.stride(1),
         w1_lora_b_stacked.stride(0),


### PR DESCRIPTION
## Summary

Fixes #32235

The grid size in `fused_moe_lora` kernels was using `max_loras` directly, but it should be `max_loras + 1` to account for the base-model slot (represented by `lora_id = -1`).

When the batch contains a mix of base-model tokens and LoRA tokens (e.g., `active_lora_ids = [-1, 0, 1, 2, 3]`), there are actually `max_loras + 1` distinct slots to iterate over. Using `max_loras` to construct the grid only covers `max_loras` slots, so the final slot can be skipped.

## Changes

- `vllm/lora/ops/triton_ops/fused_moe_lora_op.py`: Changed `lora_a_stacked[0].shape[0]` to `lora_a_stacked[0].shape[0] + 1` in `_fused_moe_lora_shrink`
- Same change for `lora_b_stacked[0].shape[0]` in `_fused_moe_lora_expand`

This matches the behavior of regular LoRA shrink/expand kernels where the grid is built from `lora_ids.size(0)` which equals `max_loras + 1`.