### PR TITLE
Replace bare Exception with ValueError for invalid argument values

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -356,7 +356,7 @@ def marlin_zero_points(
     elif num_bits == 8:
         interleave = numpy.array([0, 2, 1, 3])
     else:
-        raise Exception("num_bits must be 4 or 8, got {}".format(num_bits))
+        raise ValueError("num_bits must be 4 or 8, got {}".format(num_bits))
 
     if not is_a_8bit:
         zp = zp.reshape((-1, len(interleave)))[:, interleave].ravel()
@@ -385,7 +385,7 @@ def awq_to_marlin_zero_points(
     elif num_bits == 8:
         undo_interleave = numpy.argsort(numpy.array([0, 2, 1, 3]))
     else:
-        raise Exception("num_bits must be 4 or 8, got {}".format(num_bits))
+        raise ValueError("num_bits must be 4 or 8, got {}".format(num_bits))
 
     q_zp = q_zp.reshape((-1, len(undo_interleave)))[:, undo_interleave].ravel()
     q_zp = q_zp.reshape((-1, size_n)).contiguous()

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -772,7 +772,7 @@ def awq_pack(
     elif num_bits == 8:
         interleave = numpy.array([0, 2, 1, 3])
     else:
-        raise Exception("num_bits must be 4 or 8, got {}".format(num_bits))
+        raise ValueError("num_bits must be 4 or 8, got {}".format(num_bits))
 
     q_w = q_w.reshape((-1, len(interleave)))[:, interleave].ravel()
     q_w = q_w.reshape((-1, size_n)).contiguous()

--- a/vllm/tool_parsers/granite_tool_parser.py
+++ b/vllm/tool_parsers/granite_tool_parser.py
@@ -67,9 +67,7 @@ class GraniteToolParser(ToolParser):
         try:
             raw_function_calls = json.loads(stripped)
             if not isinstance(raw_function_calls, list):
-                raise ValueError(
-                    f"Expected list, got {type(raw_function_calls)}"
-                )
+                raise ValueError(f"Expected list, got {type(raw_function_calls)}")
 
             logger.debug("Extracted %d tool calls", len(raw_function_calls))
             tool_calls = [

--- a/vllm/tool_parsers/granite_tool_parser.py
+++ b/vllm/tool_parsers/granite_tool_parser.py
@@ -68,7 +68,7 @@ class GraniteToolParser(ToolParser):
             raw_function_calls = json.loads(stripped)
             if not isinstance(raw_function_calls, list):
                 raise ValueError(
-                    f"Expected dict or list, got {type(raw_function_calls)}"
+                    f"Expected list, got {type(raw_function_calls)}"
                 )
 
             logger.debug("Extracted %d tool calls", len(raw_function_calls))

--- a/vllm/tool_parsers/granite_tool_parser.py
+++ b/vllm/tool_parsers/granite_tool_parser.py
@@ -67,7 +67,7 @@ class GraniteToolParser(ToolParser):
         try:
             raw_function_calls = json.loads(stripped)
             if not isinstance(raw_function_calls, list):
-                raise Exception(
+                raise ValueError(
                     f"Expected dict or list, got {type(raw_function_calls)}"
                 )
 


### PR DESCRIPTION
## Summary

In several places throughout the codebase, `raise Exception(...)` is used when the error is caused by an **invalid argument value**. Python best practices recommend using `ValueError` for such cases.

This PR replaces `raise Exception` with `raise ValueError` in the following locations:

| File | Context |
|------|---------|
| `vllm/model_executor/layers/quantization/utils/marlin_utils.py` (×2) | `num_bits must be 4 or 8, got {}` |
| `vllm/model_executor/layers/quantization/utils/quant_utils.py` | `num_bits must be 4 or 8, got {}` |
| `vllm/tool_parsers/granite_tool_parser.py` | `Expected dict or list, got {type(...)}` |

All four sites are cases where a caller passes an unsupported value, making `ValueError` the semantically correct exception type.

## Test Plan

- No logic change; existing unit tests cover these code paths.
- Callers catching `Exception` will still catch `ValueError` (it is a subclass).
