### PR TITLE
Fix TYPE_CHECKING stub defaults in envs.py to match actual runtime defaults

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     VLLM_USAGE_STATS_SERVER: str = "https://stats.vllm.ai"
     VLLM_NO_USAGE_STATS: bool = False
     VLLM_DO_NOT_TRACK: bool = False
-    VLLM_USAGE_SOURCE: str = ""
+    VLLM_USAGE_SOURCE: str = "production"
     VLLM_CONFIGURE_LOGGING: bool = True
     VLLM_LOGGING_LEVEL: str = "INFO"
     VLLM_LOGGING_PREFIX: str = ""
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     VLLM_USE_FLASHINFER_SAMPLER: bool | None = None
     VLLM_PP_LAYER_PARTITION: str | None = None
     VLLM_CPU_KVCACHE_SPACE: int | None = 0
-    VLLM_CPU_OMP_THREADS_BIND: str = ""
+    VLLM_CPU_OMP_THREADS_BIND: str = "auto"
     VLLM_CPU_NUM_OF_RESERVED_CPU: int | None = None
     VLLM_CPU_SGL_KERNEL: bool = False
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
@@ -89,7 +89,7 @@ if TYPE_CHECKING:
     VLLM_LORA_RESOLVER_CACHE_DIR: str | None = None
     VLLM_LORA_RESOLVER_HF_REPO_LIST: str | None = None
     VLLM_USE_AOT_COMPILE: bool = False
-    VLLM_USE_BYTECODE_HOOK: bool = False
+    VLLM_USE_BYTECODE_HOOK: bool = True
     VLLM_FORCE_AOT_LOAD: bool = False
     VLLM_USE_MEGA_AOT_ARTIFACT: bool = False
     VLLM_USE_TRITON_AWQ: bool = False


### PR DESCRIPTION
## Summary

The `TYPE_CHECKING` block in `vllm/envs.py` provides stubs used by IDE tools and static type-checkers (e.g. mypy/pyright). However, three variables had stub default values that **differed** from the actual defaults returned by their runtime lambdas in the `environment_variables` dict:

| Variable | Stub default (wrong) | Runtime lambda default (correct) |
|---|---|---|
| `VLLM_USAGE_SOURCE` | `""` | `"production"` |
| `VLLM_CPU_OMP_THREADS_BIND` | `""` | `"auto"` |
| `VLLM_USE_BYTECODE_HOOK` | `False` | `True` (from `int("1")`) |

Note: `VLLM_MAIN_CUDA_VERSION` looks inconsistent at first glance (`str = "12.9"` vs `os.getenv(..., "").lower() or "12.9"`), but the effective default is the same `"12.9"` and does not need fixing.

## Changes

Updated the three stub defaults to match the actual runtime behavior so that IDEs, type-checkers, and documentation reflect correct values.

## Test Plan

- No runtime logic changed; this is a documentation/stub fix only.
- Verify with `grep` that stub values now match lambda defaults.
