### PR TITLE
Fix typo: implictly -> implicitly in isaac.py docstring

### DIFF
--- a/vllm/model_executor/models/isaac.py
+++ b/vllm/model_executor/models/isaac.py
@@ -551,7 +551,7 @@ def process_vision_for_patches(
             `(num_images, height, width, channels)` for a batch. Channels are
             expected to be RGB.
         patch_size (`int`):
-            Edge length of square patches; implictly controls resize grid granularity.
+            Edge length of square patches; implicitly controls resize grid granularity.
         max_num_patches (`int`):
             Maximum number of patches allowed after resizing.
         min_num_patches (`int`, *optional*):


### PR DESCRIPTION
## Summary

Fixes a minor typo in the docstring of `vllm/model_executor/models/isaac.py`:

```
- Edge length of square patches; implictly controls resize grid granularity.
+ Edge length of square patches; implicitly controls resize grid granularity.
```

## Test Plan

Docstring-only change, no functional impact.
