### PR TITLE
[Misc] Replace bare AssertionError with specific exception types

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1710,7 +1710,7 @@ def get_cached_compilation_config():
 
 def get_current_vllm_config() -> VllmConfig:
     if _current_vllm_config is None:
-        raise AssertionError(
+        raise RuntimeError(
             "Current vLLM config is not set. This typically means "
             "get_current_vllm_config() was called outside of a "
             "set_current_vllm_config() context, or a CustomOp was instantiated "

--- a/vllm/model_executor/layers/fused_moe/runner/default_moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/default_moe_runner.py
@@ -46,7 +46,7 @@ def get_layer_from_name(layer_name: str) -> torch.nn.Module:
         assert all_moe_layers is not None
         moe_layer_index = forward_context.moe_layer_index
         if moe_layer_index >= len(all_moe_layers):
-            raise AssertionError(
+            raise RuntimeError(
                 "We expected the number of MOE layers in `all_moe_layers` "
                 "to be equal to the number of "
                 "{vllm.moe_forward, vllm.moe_forward_shared} calls."

--- a/vllm/model_executor/models/minimax_text_01.py
+++ b/vllm/model_executor/models/minimax_text_01.py
@@ -866,7 +866,7 @@ class MiniMaxText01ForCausalLM(nn.Module, HasInnerState, IsHybrid):
                 elif "down_proj" in name:
                     weight_loader(param, loaded_weight)
                 else:
-                    raise AssertionError("MLP weight not in [gate_up_proj, down_proj]")
+                    raise ValueError("MLP weight not in [gate_up_proj, down_proj]")
             loaded_params.add(name)
             return
 

--- a/vllm/transformers_utils/repo_utils.py
+++ b/vllm/transformers_utils/repo_utils.py
@@ -50,7 +50,7 @@ def with_retry(
             time.sleep(retry_delay)
             retry_delay *= 2
 
-    raise AssertionError("Should not be reached")
+    raise RuntimeError("Should not be reached")
 
 
 # @cache doesn't cache exceptions

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -314,7 +314,7 @@ class PlaceholderModule(_PlaceholderBase):
 
             raise exc
 
-        raise AssertionError(
+        raise RuntimeError(
             "PlaceholderModule should not be used "
             "when the original module can be imported"
         )
@@ -334,7 +334,7 @@ class _PlaceholderModuleAttr(_PlaceholderBase):
     def __getattr__(self, key: str) -> Never:
         getattr(self.__module, f"{self.__attr_path}.{key}")
 
-        raise AssertionError(
+        raise RuntimeError(
             "PlaceholderModule should not be used "
             "when the original module can be imported"
         )

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -123,7 +123,7 @@ class BlockHashToBlockMap:
         return len(self._cache)
 
     def _unexpected_blocks_type(self, blocks: Any) -> None:
-        raise AssertionError(f"Invalid KV cache block type {type(blocks)}")
+        raise TypeError(f"Invalid KV cache block type {type(blocks)}")
 
 
 class BlockPool:

--- a/vllm/v1/metrics/reader.py
+++ b/vllm/v1/metrics/reader.py
@@ -138,7 +138,7 @@ def get_metrics_snapshot() -> list[Metric]:
                     )
                 )
         else:
-            raise AssertionError(f"Unknown metric type {metric.type}")
+            raise ValueError(f"Unknown metric type {metric.type}")
 
     return collected
 

--- a/vllm/v1/worker/workspace.py
+++ b/vllm/v1/worker/workspace.py
@@ -152,7 +152,7 @@ class WorkspaceManager:
                 return "unknown"
 
             if self._locked:
-                raise AssertionError(
+                raise RuntimeError(
                     f"Workspace is locked but allocation from '{get_caller_info()}' "
                     f"requires {required_bytes / _MB:.2f} MB, current size is "
                     f"{current_size / _MB:.2f} MB. "


### PR DESCRIPTION
Replace explicit `raise AssertionError(...)` with more semantically
appropriate exception types across 8 files.

## Changes

| File | Old | New | Reason |
|------|-----|-----|--------|
| `vllm/v1/core/block_pool.py` | `AssertionError` | `TypeError` | Invalid type argument |
| `vllm/v1/metrics/reader.py` | `AssertionError` | `ValueError` | Unknown/invalid value |
| `vllm/model_executor/models/minimax_text_01.py` | `AssertionError` | `ValueError` | Unexpected weight name |
| `vllm/v1/worker/workspace.py` | `AssertionError` | `RuntimeError` | Runtime state violation |
| `vllm/config/vllm.py` | `AssertionError` | `RuntimeError` | Runtime state (config not set) |
| `vllm/transformers_utils/repo_utils.py` | `AssertionError` | `RuntimeError` | Unreachable code path |
| `vllm/utils/import_utils.py` (×2) | `AssertionError` | `RuntimeError` | PlaceholderModule state error |
| `vllm/model_executor/layers/fused_moe/runner/default_moe_runner.py` | `AssertionError` | `RuntimeError` | MoE layer count mismatch at runtime |

`AssertionError` is semantically reserved for `assert`-statement failures and programmer logic errors in tests; using specific exception types improves error handling granularity and debuggability.

cc @yewentao256