### PR TITLE
interleave mm strings via request

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1555,6 +1555,7 @@ async def parse_chat_messages_async(
     messages: list[ChatCompletionMessageParam],
     model_config: ModelConfig,
     content_format: ChatTemplateContentFormat,
+    interleave_mm_strings: bool | None = None,
 ) -> tuple[
     list[ConversationMessage],
     MultiModalDataDict | None,
@@ -1563,15 +1564,16 @@ async def parse_chat_messages_async(
     conversation: list[ConversationMessage] = []
     mm_tracker = AsyncMultiModalItemTracker(model_config)
 
+    if interleave_mm_strings is None and (cfg := model_config.multimodal_config):
+        interleave_mm_strings = cfg.interleave_mm_strings
+
     for msg in messages:
         sub_messages = _parse_chat_message_content(
             msg,
             mm_tracker,
             content_format,
-            interleave_strings=(
-                content_format == "string"
-                and model_config.multimodal_config is not None
-                and model_config.multimodal_config.interleave_mm_strings
+            interleave_strings=bool(
+                content_format == "string" and interleave_mm_strings
             ),
         )
 

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -271,6 +271,14 @@ class ChatCompletionRequest(OpenAIBaseModel):
         default=None,
         description=("Additional kwargs to pass to the HF processor."),
     )
+    interleave_mm_strings: bool | None = Field(
+        default=None,
+        description=(
+            "Request-level override for multimodal string interleaving when "
+            "chat template content format is string. If unset, the "
+            "server/model default is used."
+        ),
+    )
     structured_outputs: StructuredOutputsParams | None = Field(
         default=None,
         description="Additional kwargs for structured outputs",
@@ -355,6 +363,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                     reasoning_effort=self.reasoning_effort,
                 ),
             ),
+            interleave_mm_strings=self.interleave_mm_strings,
         )
 
     def build_tok_params(self, model_config: ModelConfig) -> TokenizeParams:

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -689,6 +689,7 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
                 tokenizer=tokenizer,
                 model_config=model_config,
             ),
+            interleave_mm_strings=params.interleave_mm_strings,
         )
 
         prompt_raw = safe_apply_chat_template(

--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -52,6 +52,9 @@ class ChatParams:
     chat_template_kwargs: dict[str, Any] = field(default_factory=dict)
     """The kwargs to pass to the chat template."""
 
+    interleave_mm_strings: bool | None = None
+    """Request-level override for multimodal string interleaving."""
+
     def with_defaults(self, default_chat_template_kwargs: dict[str, Any] | None):
         if not default_chat_template_kwargs:
             return self
@@ -63,6 +66,7 @@ class ChatParams:
                 default_chat_template_kwargs,
                 self.chat_template_kwargs,
             ),
+            interleave_mm_strings=self.interleave_mm_strings,
         )
 
     def get_apply_chat_template_kwargs(self) -> dict[str, Any]:


### PR DESCRIPTION
Allow passing a `interleave_mm_strings` via a ChatCompletionRequest body, that allows setting/overriding model config/server config defaults.

```vllm serve microsoft/Phi-3.5-vision-instruct```

```json
curl http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d @- <<JSON 
    {
        "model": "microsoft/Phi-3.5-vision-instruct", 
        "max_tokens": 2500, "temperature": 0.0, "top_k": 1,
        "messages": [{"role": "user", "content": [
            {"type": "text", "text": "Explain image 1:"},
            {"type": "image_url", "image_url": {"url": "https://images.unsplash.com/photo-1579353977828-2a4eab540b9a?q=80&w=1374&auto=format&fit=crop&ixlib=rb-4.1.0"}},
            {"type": "text", "text": "Explain image 2:"},
            {"type": "image_url", "image_url": {"url": "https://images.unsplash.com/photo-1600716051809-e997e11a5d52?q=80&w=1450&auto=format&fit=crop&ixlib=rb-4.1.0"}},
            {"type": "text", "text": "Explain image 3:"},
            {"type": "image_url", "image_url": {"url": "https://plus.unsplash.com/premium_photo-1680740103993-21639956f3f0?q=80&w=688&auto=format&fit=crop&ixlib=rb-4.1.0"}}
        ]}],
        # Add this -------> "interleave_mm_strings": true
}
JSON
```

Resulting text prompt:

Off (default):
```
<|image_1|>
<|image_2|>
<|image_3|>
Explain image 1:
Explain image 2:
Explain image 3:
```
On:
```
Explain image 1:
<|image_1|>
Explain image 2:
<|image_2|>
Explain image 3:
<|image_3|>
```


