### PR TITLE
[Bugfix] Fix misleading cancel error message and noisy CancelledError log

### DIFF
--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1305,7 +1305,7 @@ class OpenAIServingResponses(OpenAIServing):
             if prev_status not in ("queued", "in_progress"):
                 return self.create_error_response(
                     err_type="invalid_request_error",
-                    message="Cannot cancel a synchronous response.",
+                    message=f"Cannot cancel response with status '{prev_status}'.",
                     param="response_id",
                 )
 
@@ -1318,7 +1318,7 @@ class OpenAIServingResponses(OpenAIServing):
             try:
                 await task
             except asyncio.CancelledError:
-                logger.exception("Background task for %s was cancelled", response_id)
+                logger.debug("Background task for %s was cancelled", response_id)
         return response
 
     def _make_not_found_error(self, response_id: str) -> ErrorResponse:


### PR DESCRIPTION
## Summary

Two small fixes in `cancel_responses`:

### 1. Misleading error message
When cancelling a response that is already `completed`, `failed`, or `cancelled`, the error message says *"Cannot cancel a synchronous response"* — but the response may not be synchronous at all. It was simply already finished.

**Before:**
```
Cannot cancel a synchronous response.
```

**After:**
```
Cannot cancel response with status 'completed'.
```

### 2. Noisy CancelledError log
When a background task is successfully cancelled (expected behavior), it logs at `exception` level with a full stack trace:

**Before:**
```
ERROR    vllm.entrypoints.openai.responses.serving: Background task for resp_xxx was cancelled
Traceback (most recent call last):
  ...
asyncio.CancelledError
```

**After:**
```
DEBUG    vllm.entrypoints.openai.responses.serving: Background task for resp_xxx was cancelled
```

`CancelledError` after an explicit `task.cancel()` is the expected outcome, not an error. Logging it at `debug` level keeps the information available without polluting production logs.