### PR TITLE
[Core] Move test utility to test file

### DIFF
--- a/tests/kernels/moe/test_gpt_oss_triton_kernels.py
+++ b/tests/kernels/moe/test_gpt_oss_triton_kernels.py
@@ -28,15 +28,7 @@ from vllm.model_executor.layers.fused_moe.gpt_oss_triton_kernels_moe import (
 )
 from vllm.utils.math_utils import round_up
 
-
-def shuffle_weight(w: torch.Tensor) -> torch.Tensor:
-    """Fold weights to adjacent locations for Triton MoE kernel layout."""
-    shape = w.shape
-    n = shape[-1]
-    first = w[..., : n // 2]
-    second = w[..., n // 2 :]
-    stacked = torch.stack((first, second), dim=-1)
-    return stacked.reshape(shape)
+from .utils import shuffle_weight
 
 
 def deshuffle(w: torch.Tensor):

--- a/tests/kernels/moe/test_modular_oai_triton_moe.py
+++ b/tests/kernels/moe/test_modular_oai_triton_moe.py
@@ -36,7 +36,7 @@ from vllm.model_executor.layers.fused_moe.prepare_finalize import (
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
 
-from .utils import make_dummy_moe_config
+from .utils import make_dummy_moe_config, shuffle_weight
 
 MNK = [
     (1, 512, 384),
@@ -45,16 +45,6 @@ MNK = [
     (2, 2880, 2880),
     (16, 2880, 2880),
 ]
-
-
-def shuffle_weight(w: torch.Tensor) -> torch.Tensor:
-    """Fold weights to adjacent locations for Triton MoE kernel layout."""
-    shape = w.shape
-    n = shape[-1]
-    first = w[..., : n // 2]
-    second = w[..., n // 2 :]
-    stacked = torch.stack((first, second), dim=-1)
-    return stacked.reshape(shape)
 
 
 def unshuffle_weight(w: torch.Tensor):

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -31,27 +31,6 @@ def is_layer_moe_router_gate(prefix: str) -> bool:
     return prefix.rsplit(".", 1)[-1] in MOE_LAYER_ROUTER_GATE_SUFFIXES
 
 
-def shuffle_weight(w: torch.Tensor) -> torch.Tensor:
-    # Shuffle weight along the last dimension so that
-    # we folded the weights to adjance location
-    # Example:
-    # input:
-    #       [[1, 2, 3, 4, 5, 6],
-    #        [7, 8, 9, 10, 11, 12]]
-    # output:
-    #       [[1, 4, 2, 5, 3, 6],
-    #        [7, 10, 8, 11, 9, 12]]
-    # This will be used together with triton swiglu kernel
-    shape = w.shape
-    N = shape[-1]
-    first = w[..., : N // 2]
-    second = w[..., N // 2 :]
-
-    stacked = torch.stack((first, second), dim=-1)
-    w_shuffled = stacked.reshape(shape)
-    return w_shuffled
-
-
 def get_token_bin_counts_and_mask(
     tokens: torch.Tensor,
     vocab_size: int,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

This code was introduced about six months ago to shuffle weights into the layout expected by the Triton SwiGLU kernel. ROCm’s AITER operations have [since implemented weight shuffling](https://github.com/wjabbour/vllm/blob/jabbour-remove-dead-function/vllm/_aiter_ops.py#L1816) (e.g. rocm_aiter_ops.shuffle_weights, shuffle_weight_a16w4), and all production code paths use AITER for weight shuffling (mxfp4, quark_moe, fused_moe oracle).

This function in utils.py is not used by any production code. It has been removed from utils.py, and a local shuffle_weight helper has been added to a shared util file for unit tests.

## Test Plan

## Test Result

:heavy_check_mark: 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

