### PR TITLE
[Torch 2.11] Migrate torch._C._cpu calls to public   torch.cpu API

### DIFF
--- a/benchmarks/kernels/cpu/benchmark_cpu_attn.py
+++ b/benchmarks/kernels/cpu/benchmark_cpu_attn.py
@@ -27,7 +27,7 @@ def get_attn_isa(
     else:
         if current_platform.get_cpu_architecture() == CpuArchEnum.ARM:
             return "neon"
-        elif torch._C._cpu._is_amx_tile_supported():
+        elif hasattr(torch._C._cpu, '_is_amx_tile_supported') and torch._C._cpu._is_amx_tile_supported():
             return "amx"
         else:
             return "vec"

--- a/benchmarks/kernels/cpu/benchmark_cpu_attn.py
+++ b/benchmarks/kernels/cpu/benchmark_cpu_attn.py
@@ -27,7 +27,7 @@ def get_attn_isa(
     else:
         if current_platform.get_cpu_architecture() == CpuArchEnum.ARM:
             return "neon"
-        elif hasattr(torch._C._cpu, '_is_amx_tile_supported') and torch._C._cpu._is_amx_tile_supported():
+        elif current_platform.is_amx_tile_supported():
             return "amx"
         else:
             return "vec"

--- a/benchmarks/kernels/cpu/benchmark_cpu_attn.py
+++ b/benchmarks/kernels/cpu/benchmark_cpu_attn.py
@@ -27,7 +27,7 @@ def get_attn_isa(
     else:
         if current_platform.get_cpu_architecture() == CpuArchEnum.ARM:
             return "neon"
-        elif current_platform.is_amx_tile_supported():
+        elif torch.cpu._is_amx_tile_supported():
             return "amx"
         else:
             return "vec"

--- a/benchmarks/kernels/cpu/benchmark_cpu_fused_moe.py
+++ b/benchmarks/kernels/cpu/benchmark_cpu_fused_moe.py
@@ -24,7 +24,7 @@ except (ImportError, AttributeError) as e:
     sys.exit(1)
 
 # ISA selection following test_cpu_fused_moe.py pattern
-ISA_CHOICES = ["amx", "vec"] if torch._C._cpu._is_amx_tile_supported() else ["vec"]
+ISA_CHOICES = ["amx", "vec"] if hasattr(torch._C._cpu, '_is_amx_tile_supported') and torch._C._cpu._is_amx_tile_supported() else ["vec"]
 
 
 @torch.inference_mode()

--- a/benchmarks/kernels/cpu/benchmark_cpu_fused_moe.py
+++ b/benchmarks/kernels/cpu/benchmark_cpu_fused_moe.py
@@ -24,7 +24,9 @@ except (ImportError, AttributeError) as e:
     sys.exit(1)
 
 # ISA selection following test_cpu_fused_moe.py pattern
-ISA_CHOICES = ["amx", "vec"] if hasattr(torch._C._cpu, '_is_amx_tile_supported') and torch._C._cpu._is_amx_tile_supported() else ["vec"]
+from vllm.platforms import current_platform
+
+ISA_CHOICES = ["amx", "vec"] if current_platform.is_amx_tile_supported() else ["vec"]
 
 
 @torch.inference_mode()

--- a/benchmarks/kernels/cpu/benchmark_cpu_fused_moe.py
+++ b/benchmarks/kernels/cpu/benchmark_cpu_fused_moe.py
@@ -7,6 +7,7 @@ import time
 import numpy as np
 import torch
 
+from vllm.platforms import current_platform
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.torch_utils import set_random_seed
 
@@ -24,8 +25,6 @@ except (ImportError, AttributeError) as e:
     sys.exit(1)
 
 # ISA selection following test_cpu_fused_moe.py pattern
-from vllm.platforms import current_platform
-
 ISA_CHOICES = ["amx", "vec"] if current_platform.is_amx_tile_supported() else ["vec"]
 
 

--- a/benchmarks/kernels/cpu/benchmark_cpu_fused_moe.py
+++ b/benchmarks/kernels/cpu/benchmark_cpu_fused_moe.py
@@ -7,7 +7,6 @@ import time
 import numpy as np
 import torch
 
-from vllm.platforms import current_platform
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.torch_utils import set_random_seed
 
@@ -25,7 +24,7 @@ except (ImportError, AttributeError) as e:
     sys.exit(1)
 
 # ISA selection following test_cpu_fused_moe.py pattern
-ISA_CHOICES = ["amx", "vec"] if current_platform.is_amx_tile_supported() else ["vec"]
+ISA_CHOICES = ["amx", "vec"] if torch.cpu._is_amx_tile_supported() else ["vec"]
 
 
 @torch.inference_mode()

--- a/tests/kernels/attention/test_cpu_attn.py
+++ b/tests/kernels/attention/test_cpu_attn.py
@@ -48,7 +48,7 @@ def get_attn_isa(
     else:
         if current_platform.get_cpu_architecture() == CpuArchEnum.ARM:
             return "neon"
-        elif hasattr(torch._C._cpu, '_is_amx_tile_supported') and torch._C._cpu._is_amx_tile_supported():
+        elif current_platform.is_amx_tile_supported():
             return "amx"
         else:
             return "vec"
@@ -401,7 +401,7 @@ def test_varlen_with_paged_kv_normal_vec(
 @pytest.mark.parametrize("use_sink", [False])
 @pytest.mark.parametrize("isa", ["amx"])
 @pytest.mark.skipif(
-    not (hasattr(torch._C._cpu, '_is_amx_tile_supported') and torch._C._cpu._is_amx_tile_supported()), reason="no AMX support."
+    not current_platform.is_amx_tile_supported(), reason="no AMX support."
 )
 def test_varlen_with_paged_kv_normal_amx(
     seq_lens: list[tuple[int, int]],

--- a/tests/kernels/attention/test_cpu_attn.py
+++ b/tests/kernels/attention/test_cpu_attn.py
@@ -48,7 +48,7 @@ def get_attn_isa(
     else:
         if current_platform.get_cpu_architecture() == CpuArchEnum.ARM:
             return "neon"
-        elif torch._C._cpu._is_amx_tile_supported():
+        elif hasattr(torch._C._cpu, '_is_amx_tile_supported') and torch._C._cpu._is_amx_tile_supported():
             return "amx"
         else:
             return "vec"
@@ -401,7 +401,7 @@ def test_varlen_with_paged_kv_normal_vec(
 @pytest.mark.parametrize("use_sink", [False])
 @pytest.mark.parametrize("isa", ["amx"])
 @pytest.mark.skipif(
-    not torch._C._cpu._is_amx_tile_supported(), reason="no AMX support."
+    not (hasattr(torch._C._cpu, '_is_amx_tile_supported') and torch._C._cpu._is_amx_tile_supported()), reason="no AMX support."
 )
 def test_varlen_with_paged_kv_normal_amx(
     seq_lens: list[tuple[int, int]],

--- a/tests/kernels/attention/test_cpu_attn.py
+++ b/tests/kernels/attention/test_cpu_attn.py
@@ -400,9 +400,7 @@ def test_varlen_with_paged_kv_normal_vec(
 @pytest.mark.parametrize("use_alibi", [False])
 @pytest.mark.parametrize("use_sink", [False])
 @pytest.mark.parametrize("isa", ["amx"])
-@pytest.mark.skipif(
-    not torch.cpu._is_amx_tile_supported(), reason="no AMX support."
-)
+@pytest.mark.skipif(not torch.cpu._is_amx_tile_supported(), reason="no AMX support.")
 def test_varlen_with_paged_kv_normal_amx(
     seq_lens: list[tuple[int, int]],
     num_heads: tuple[int, int],

--- a/tests/kernels/attention/test_cpu_attn.py
+++ b/tests/kernels/attention/test_cpu_attn.py
@@ -48,7 +48,7 @@ def get_attn_isa(
     else:
         if current_platform.get_cpu_architecture() == CpuArchEnum.ARM:
             return "neon"
-        elif current_platform.is_amx_tile_supported():
+        elif torch.cpu._is_amx_tile_supported():
             return "amx"
         else:
             return "vec"
@@ -401,7 +401,7 @@ def test_varlen_with_paged_kv_normal_vec(
 @pytest.mark.parametrize("use_sink", [False])
 @pytest.mark.parametrize("isa", ["amx"])
 @pytest.mark.skipif(
-    not current_platform.is_amx_tile_supported(), reason="no AMX support."
+    not torch.cpu._is_amx_tile_supported(), reason="no AMX support."
 )
 def test_varlen_with_paged_kv_normal_amx(
     seq_lens: list[tuple[int, int]],

--- a/tests/kernels/moe/test_cpu_fused_moe.py
+++ b/tests/kernels/moe/test_cpu_fused_moe.py
@@ -22,7 +22,7 @@ INTERMEDIATE_DIM = [128, 2880]
 BATCH_SIZE = [1, 64, 256]
 ACT = [MoEActivation.SILU, MoEActivation.SWIGLUOAI]
 USE_BIAS = [True, False]
-ISA = ["amx", "vec"] if hasattr(torch._C._cpu, '_is_amx_tile_supported') and torch._C._cpu._is_amx_tile_supported() else ["vec"]
+ISA = ["amx", "vec"] if current_platform.is_amx_tile_supported() else ["vec"]
 DTYPE = [torch.bfloat16]
 
 

--- a/tests/kernels/moe/test_cpu_fused_moe.py
+++ b/tests/kernels/moe/test_cpu_fused_moe.py
@@ -22,7 +22,7 @@ INTERMEDIATE_DIM = [128, 2880]
 BATCH_SIZE = [1, 64, 256]
 ACT = [MoEActivation.SILU, MoEActivation.SWIGLUOAI]
 USE_BIAS = [True, False]
-ISA = ["amx", "vec"] if torch._C._cpu._is_amx_tile_supported() else ["vec"]
+ISA = ["amx", "vec"] if hasattr(torch._C._cpu, '_is_amx_tile_supported') and torch._C._cpu._is_amx_tile_supported() else ["vec"]
 DTYPE = [torch.bfloat16]
 
 

--- a/tests/kernels/moe/test_cpu_fused_moe.py
+++ b/tests/kernels/moe/test_cpu_fused_moe.py
@@ -22,7 +22,7 @@ INTERMEDIATE_DIM = [128, 2880]
 BATCH_SIZE = [1, 64, 256]
 ACT = [MoEActivation.SILU, MoEActivation.SWIGLUOAI]
 USE_BIAS = [True, False]
-ISA = ["amx", "vec"] if current_platform.is_amx_tile_supported() else ["vec"]
+ISA = ["amx", "vec"] if torch.cpu._is_amx_tile_supported() else ["vec"]
 DTYPE = [torch.bfloat16]
 
 

--- a/vllm/model_executor/kernels/linear/mixed_precision/cpu.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/cpu.py
@@ -119,10 +119,7 @@ class CPUWNA16LinearKernel(MPLinearKernel):
 
 
 def _get_isa_hint(dtype: torch.dtype) -> str:
-    if hasattr(torch._C._cpu, "_is_amx_tile_supported"):
-        supports_amx = torch._C._cpu._is_amx_tile_supported()
-    else:
-        supports_amx = False
+    supports_amx = current_platform.is_amx_tile_supported()
     if supports_amx and dtype in (torch.bfloat16,):
         return "amx"
     else:

--- a/vllm/model_executor/kernels/linear/mixed_precision/cpu.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/cpu.py
@@ -119,7 +119,10 @@ class CPUWNA16LinearKernel(MPLinearKernel):
 
 
 def _get_isa_hint(dtype: torch.dtype) -> str:
-    supports_amx = torch._C._cpu._is_amx_tile_supported()
+    if hasattr(torch._C._cpu, "_is_amx_tile_supported"):
+        supports_amx = torch._C._cpu._is_amx_tile_supported()
+    else:
+        supports_amx = False
     if supports_amx and dtype in (torch.bfloat16,):
         return "amx"
     else:

--- a/vllm/model_executor/kernels/linear/mixed_precision/cpu.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/cpu.py
@@ -119,7 +119,7 @@ class CPUWNA16LinearKernel(MPLinearKernel):
 
 
 def _get_isa_hint(dtype: torch.dtype) -> str:
-    supports_amx = current_platform.is_amx_tile_supported()
+    supports_amx = torch.cpu._is_amx_tile_supported()
     if supports_amx and dtype in (torch.bfloat16,):
         return "amx"
     else:

--- a/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
@@ -7,6 +7,7 @@ import torch
 from torch.nn import functional as F
 
 from vllm import _custom_ops as ops
+from vllm.platforms import current_platform
 from vllm._custom_ops import cpu_fused_moe, cpu_prepack_moe_weight
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
@@ -280,10 +281,7 @@ class CPUFusedMOE:
         if not (w13_output_size % 32 == 0 and w2_output_size % 32 == 0):
             return False, "none"
 
-        if hasattr(torch._C._cpu, "_is_amx_tile_supported"):
-            supports_amx = torch._C._cpu._is_amx_tile_supported()
-        else:
-            supports_amx = False
+        supports_amx = current_platform.is_amx_tile_supported()
 
         if (
             supports_amx

--- a/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
@@ -7,11 +7,11 @@ import torch
 from torch.nn import functional as F
 
 from vllm import _custom_ops as ops
-from vllm.platforms import current_platform
 from vllm._custom_ops import cpu_fused_moe, cpu_prepack_moe_weight
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.quantization.utils.layer_utils import replace_parameter
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
 
 _CPU_MOE_LAYER_CACHE = {}

--- a/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
@@ -280,7 +280,10 @@ class CPUFusedMOE:
         if not (w13_output_size % 32 == 0 and w2_output_size % 32 == 0):
             return False, "none"
 
-        supports_amx = torch._C._cpu._is_amx_tile_supported()
+        if hasattr(torch._C._cpu, "_is_amx_tile_supported"):
+            supports_amx = torch._C._cpu._is_amx_tile_supported()
+        else:
+            supports_amx = False
 
         if (
             supports_amx

--- a/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py
@@ -11,7 +11,6 @@ from vllm._custom_ops import cpu_fused_moe, cpu_prepack_moe_weight
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.quantization.utils.layer_utils import replace_parameter
-from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
 
 _CPU_MOE_LAYER_CACHE = {}
@@ -281,7 +280,7 @@ class CPUFusedMOE:
         if not (w13_output_size % 32 == 0 and w2_output_size % 32 == 0):
             return False, "none"
 
-        supports_amx = current_platform.is_amx_tile_supported()
+        supports_amx = torch.cpu._is_amx_tile_supported()
 
         if (
             supports_amx

--- a/vllm/model_executor/layers/quantization/cpu_wna16.py
+++ b/vllm/model_executor/layers/quantization/cpu_wna16.py
@@ -292,7 +292,10 @@ class CPUAWQLinearMethod(LinearMethodBase):
 
 
 def _get_isa_hint(dtype: torch.dtype) -> str:
-    supports_amx = torch._C._cpu._is_amx_tile_supported()
+    if hasattr(torch._C._cpu, "_is_amx_tile_supported"):
+        supports_amx = torch._C._cpu._is_amx_tile_supported()
+    else:
+        supports_amx = False
     if supports_amx and dtype in (torch.bfloat16,):
         return "amx"
     else:

--- a/vllm/model_executor/layers/quantization/cpu_wna16.py
+++ b/vllm/model_executor/layers/quantization/cpu_wna16.py
@@ -292,10 +292,7 @@ class CPUAWQLinearMethod(LinearMethodBase):
 
 
 def _get_isa_hint(dtype: torch.dtype) -> str:
-    if hasattr(torch._C._cpu, "_is_amx_tile_supported"):
-        supports_amx = torch._C._cpu._is_amx_tile_supported()
-    else:
-        supports_amx = False
+    supports_amx = current_platform.is_amx_tile_supported()
     if supports_amx and dtype in (torch.bfloat16,):
         return "amx"
     else:

--- a/vllm/model_executor/layers/quantization/cpu_wna16.py
+++ b/vllm/model_executor/layers/quantization/cpu_wna16.py
@@ -292,7 +292,7 @@ class CPUAWQLinearMethod(LinearMethodBase):
 
 
 def _get_isa_hint(dtype: torch.dtype) -> str:
-    supports_amx = current_platform.is_amx_tile_supported()
+    supports_amx = torch.cpu._is_amx_tile_supported()
     if supports_amx and dtype in (torch.bfloat16,):
         return "amx"
     else:

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -212,7 +212,8 @@ direct_register_custom_op(
 
 def check_cpu_sgl_kernel(n: int, k: int, dtype: torch.dtype) -> bool:
     return (
-        torch._C._cpu._is_amx_tile_supported()
+        hasattr(torch._C._cpu, '_is_amx_tile_supported')
+        and torch._C._cpu._is_amx_tile_supported()
         and (dtype in (torch.bfloat16, torch.int8))
         and k % 32 == 0
         and n % 16 == 0

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -212,7 +212,7 @@ direct_register_custom_op(
 
 def check_cpu_sgl_kernel(n: int, k: int, dtype: torch.dtype) -> bool:
     return (
-        current_platform.is_amx_tile_supported()
+        torch.cpu._is_amx_tile_supported()
         and (dtype in (torch.bfloat16, torch.int8))
         and k % 32 == 0
         and n % 16 == 0

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -212,8 +212,7 @@ direct_register_custom_op(
 
 def check_cpu_sgl_kernel(n: int, k: int, dtype: torch.dtype) -> bool:
     return (
-        hasattr(torch._C._cpu, '_is_amx_tile_supported')
-        and torch._C._cpu._is_amx_tile_supported()
+        current_platform.is_amx_tile_supported()
         and (dtype in (torch.bfloat16, torch.int8))
         and k % 32 == 0
         and n % 16 == 0

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -471,10 +471,11 @@ class CpuPlatform(Platform):
 
     @classmethod
     def is_avx512_supported(cls) -> bool:
-        return (
-            hasattr(torch._C._cpu, "_is_avx512_supported")
-            and torch._C._cpu._is_avx512_supported()
-        )
+        if hasattr(torch._C._cpu, "_is_avx512_supported"):
+            return torch._C._cpu._is_avx512_supported()
+        elif hasattr(torch.cpu, "_is_avx512_supported"):
+            return torch.cpu._is_avx512_supported()
+        return False
 
     @classmethod
     def is_avx512_bf16_supported(cls) -> bool:
@@ -483,10 +484,11 @@ class CpuPlatform(Platform):
 
     @classmethod
     def is_amx_tile_supported(cls) -> bool:
-        return (
-            hasattr(torch._C._cpu, "_is_amx_tile_supported")
-            and torch._C._cpu._is_amx_tile_supported()
-        )
+        if hasattr(torch._C._cpu, "_is_amx_tile_supported"):
+            return torch._C._cpu._is_amx_tile_supported()
+        elif hasattr(torch.cpu, "_is_amx_tile_supported"):
+            return torch.cpu._is_amx_tile_supported()
+        return False
 
     @classmethod
     def import_kernels(cls) -> None:

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -470,27 +470,6 @@ class CpuPlatform(Platform):
         return True
 
     @classmethod
-    def is_avx512_supported(cls) -> bool:
-        if hasattr(torch._C._cpu, "_is_avx512_supported"):
-            return torch._C._cpu._is_avx512_supported()
-        elif hasattr(torch.cpu, "_is_avx512_supported"):
-            return torch.cpu._is_avx512_supported()
-        return False
-
-    @classmethod
-    def is_avx512_bf16_supported(cls) -> bool:
-        return hasattr(torch._C._cpu, '_is_avx512_bf16_supported') \
-            and torch._C._cpu._is_avx512_bf16_supported()
-
-    @classmethod
-    def is_amx_tile_supported(cls) -> bool:
-        if hasattr(torch._C._cpu, "_is_amx_tile_supported"):
-            return torch._C._cpu._is_amx_tile_supported()
-        elif hasattr(torch.cpu, "_is_amx_tile_supported"):
-            return torch.cpu._is_amx_tile_supported()
-        return False
-
-    @classmethod
     def import_kernels(cls) -> None:
         if Platform.get_cpu_architecture() in (CpuArchEnum.X86,):
             # Note: The lib name is _C_AVX2/AVX512, but the module name is _C.
@@ -499,8 +478,8 @@ class CpuPlatform(Platform):
             # successfully. So ignore the exception for now, until we find
             # a solution.
             ignored_msg = "dynamic module does not define module export function"
-            if cls.is_avx512_supported():
-                if cls.is_avx512_bf16_supported():
+            if torch.cpu._is_avx512_supported():
+                if torch.cpu._is_avx512_bf16_supported():
                     try:
                         import vllm._C  # noqa: F401
                     except ImportError as e:

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -478,8 +478,10 @@ class CpuPlatform(Platform):
             # successfully. So ignore the exception for now, until we find
             # a solution.
             ignored_msg = "dynamic module does not define module export function"
-            if torch.cpu._is_avx512_supported():
-                if torch.cpu._is_avx512_bf16_supported():
+            if hasattr(torch._C._cpu, '_is_avx512_supported') \
+                    and torch.cpu._is_avx512_supported():
+                if hasattr(torch._C._cpu, '_is_avx512_bf16_supported') \
+                        and torch.cpu._is_avx512_bf16_supported():
                     try:
                         import vllm._C  # noqa: F401
                     except ImportError as e:

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -470,6 +470,21 @@ class CpuPlatform(Platform):
         return True
 
     @classmethod
+    def is_avx512_supported(cls) -> bool:
+        return hasattr(torch._C._cpu, '_is_avx512_supported') \
+            and torch._C._cpu._is_avx512_supported()
+
+    @classmethod
+    def is_avx512_bf16_supported(cls) -> bool:
+        return hasattr(torch._C._cpu, '_is_avx512_bf16_supported') \
+            and torch._C._cpu._is_avx512_bf16_supported()
+
+    @classmethod
+    def is_amx_tile_supported(cls) -> bool:
+        return hasattr(torch._C._cpu, '_is_amx_tile_supported') \
+            and torch._C._cpu._is_amx_tile_supported()
+
+    @classmethod
     def import_kernels(cls) -> None:
         if Platform.get_cpu_architecture() in (CpuArchEnum.X86,):
             # Note: The lib name is _C_AVX2/AVX512, but the module name is _C.
@@ -478,10 +493,8 @@ class CpuPlatform(Platform):
             # successfully. So ignore the exception for now, until we find
             # a solution.
             ignored_msg = "dynamic module does not define module export function"
-            if hasattr(torch._C._cpu, '_is_avx512_supported') \
-                    and torch.cpu._is_avx512_supported():
-                if hasattr(torch._C._cpu, '_is_avx512_bf16_supported') \
-                        and torch.cpu._is_avx512_bf16_supported():
+            if cls.is_avx512_supported():
+                if cls.is_avx512_bf16_supported():
                     try:
                         import vllm._C  # noqa: F401
                     except ImportError as e:

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -471,8 +471,10 @@ class CpuPlatform(Platform):
 
     @classmethod
     def is_avx512_supported(cls) -> bool:
-        return hasattr(torch._C._cpu, '_is_avx512_supported') \
+        return (
+            hasattr(torch._C._cpu, "_is_avx512_supported")
             and torch._C._cpu._is_avx512_supported()
+        )
 
     @classmethod
     def is_avx512_bf16_supported(cls) -> bool:
@@ -481,8 +483,10 @@ class CpuPlatform(Platform):
 
     @classmethod
     def is_amx_tile_supported(cls) -> bool:
-        return hasattr(torch._C._cpu, '_is_amx_tile_supported') \
+        return (
+            hasattr(torch._C._cpu, "_is_amx_tile_supported")
             and torch._C._cpu._is_amx_tile_supported()
+        )
 
     @classmethod
     def import_kernels(cls) -> None:

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -482,7 +482,7 @@ def _get_attn_isa(
 ) -> str:
     if head_size is not None and head_size % 32 != 0 and head_size % 16 == 0:
         return "vec16"
-    supports_amx = current_platform.is_amx_tile_supported()
+    supports_amx = torch.cpu._is_amx_tile_supported()
     supports_arm = current_platform.get_cpu_architecture() == CpuArchEnum.ARM
     supports_vxe = current_platform.get_cpu_architecture() == CpuArchEnum.S390X
     if supports_amx and dtype in (torch.bfloat16,) and block_size % 32 == 0:

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -482,10 +482,7 @@ def _get_attn_isa(
 ) -> str:
     if head_size is not None and head_size % 32 != 0 and head_size % 16 == 0:
         return "vec16"
-    if hasattr(torch._C._cpu, "_is_amx_tile_supported"):
-        supports_amx = torch._C._cpu._is_amx_tile_supported()
-    else:
-        supports_amx = False
+    supports_amx = current_platform.is_amx_tile_supported()
     supports_arm = current_platform.get_cpu_architecture() == CpuArchEnum.ARM
     supports_vxe = current_platform.get_cpu_architecture() == CpuArchEnum.S390X
     if supports_amx and dtype in (torch.bfloat16,) and block_size % 32 == 0:

--- a/vllm/v1/attention/backends/cpu_attn.py
+++ b/vllm/v1/attention/backends/cpu_attn.py
@@ -482,7 +482,10 @@ def _get_attn_isa(
 ) -> str:
     if head_size is not None and head_size % 32 != 0 and head_size % 16 == 0:
         return "vec16"
-    supports_amx = torch._C._cpu._is_amx_tile_supported()
+    if hasattr(torch._C._cpu, "_is_amx_tile_supported"):
+        supports_amx = torch._C._cpu._is_amx_tile_supported()
+    else:
+        supports_amx = False
     supports_arm = current_platform.get_cpu_architecture() == CpuArchEnum.ARM
     supports_vxe = current_platform.get_cpu_architecture() == CpuArchEnum.S390X
     if supports_amx and dtype in (torch.bfloat16,) and block_size % 32 == 0:


### PR DESCRIPTION
## Summary

  - Migrate all torch._C._cpu._is_amx_tile_supported() calls to
   the public API torch.cpu._is_amx_tile_supported()
  - PyTorch 2.11 removed/renamed these private CPU
  introspection attributes (see
  https://github.com/pytorch/pytorch/pull/173433), causing
  AttributeError crashes

  After: https://github.com/pytorch/pytorch/pull/173433
  Similar change on torchao:
  https://github.com/pytorch/ao/pull/3845/

  ## Failures on torch 2.11

  Async Engine, Inputs, Utils, Worker, Config (CPU):
  https://buildkite.com/vllm/ci/builds/53398#019c9ab8-230b-4cd5
  -9bc5-7ae9831ca300/L7150
  AttributeError: module 'torch._C._cpu' has no attribute
  '_is_amx_tile_supported'

##  Details

  The private torch._C._cpu._is_amx_tile_supported attribute
  was removed in PyTorch 2.11. The public equivalent
  torch.cpu._is_amx_tile_supported() exists in both old and new
   PyTorch versions.

  This PR replaces all 9 call sites across the codebase
  (benchmarks, tests, and vllm source) to use the public
  torch.cpu API instead of the private torch._C._cpu API.

##  Test plan

  - Existing CPU tests should continue to pass on PyTorch <=
  2.10 (public API also works there)
  - On PyTorch 2.11+, the public API is the correct path and
  avoids the crash