### PR TITLE
Fix unresolved-import errors when using Astral's ty by removing src.root

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,12 +117,10 @@ markers = [
 ]
 
 [tool.ty.src]
-root = "./vllm"
 respect-ignore-files = true
 
 [tool.ty.environment]
 python = "./.venv"
-extra-paths = ["."]
 
 [tool.typos.files]
 # these files may be written in non english words

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ respect-ignore-files = true
 
 [tool.ty.environment]
 python = "./.venv"
+extra-paths = ["."]
 
 [tool.typos.files]
 # these files may be written in non english words


### PR DESCRIPTION
Setting`[tool.ty.src] root = "./vllm"` sets the first-party module search path to `./vllm/`. This means `import vllm.config` looks for `./vllm/vllm/config/`, which doesn't exist. This causes cross-module imports using the `vllm.` prefix to fail with `unresolved-import` errors.

From talking to @hmellor `src.root` appears to be deprecated, and in my environment removing it resolves the `uresolved-import` errors