### PR TITLE
Fix: Suppress spurious cuDeviceGetAttribute errors in cumem_allocator

### DIFF
--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -136,6 +136,9 @@ void create_and_map(unsigned long long device, ssize_t size, CUdeviceptr d_mem,
   CUresult rdma_result = cuDeviceGetAttribute(
       &flag, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED,
       device);
+  if (rdma_result != CUDA_SUCCESS && rdma_result != CUDA_ERROR_INVALID_VALUE) {
+    CUDA_CHECK(rdma_result);
+  }
   if (rdma_result == CUDA_SUCCESS &&
       flag) {  // support GPUDirect RDMA if possible
     prop.allocFlags.gpuDirectRDMACapable = 1;
@@ -143,6 +146,9 @@ void create_and_map(unsigned long long device, ssize_t size, CUdeviceptr d_mem,
   int fab_flag = 0;
   CUresult fab_result = cuDeviceGetAttribute(
       &fab_flag, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, device);
+  if (fab_result != CUDA_SUCCESS && fab_result != CUDA_ERROR_INVALID_VALUE) {
+    CUDA_CHECK(fab_result);
+  }
   if (fab_result == CUDA_SUCCESS &&
       fab_flag) {  // support fabric handle if possible
     prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;


### PR DESCRIPTION
## What this PR does / why we need it
This PR removes the `CUDA_CHECK` macro wrappers around `cuDeviceGetAttribute` calls for `GPU_DIRECT_RDMA` and `HANDLE_TYPE_FABRIC` in `csrc/cumem_allocator.cpp`. 

Wrapping non-modifying attribute queries in `CUDA_CHECK` causes spurious "invalid argument" CUDA errors to be printed to the log when evaluating optional feature flags (specifically during sleep mode or on setups where these attributes are unsupported). 

By removing the assertive wrapper and allowing the query to fail gracefully, the code accurately defaults the feature flags to 0 without flooding the logs with false-positive runtime errors.

## Related Issue
Fixes #35612