### PR TITLE
[Bigfix] Fix padding in FULL_DECODE path when MTP is enabled for DP case

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4858,6 +4858,10 @@ class GPUModelRunner(
 
                 cum_num_tokens, _ = self._get_cumsum_and_arange(num_scheduled_tokens)
                 self.query_start_loc.np[1 : num_reqs + 1] = cum_num_tokens
+                # Pad query_start_loc beyond num_reqs to be non-decreasing,
+                # matching execute_model behavior. Required when
+                # num_reqs_padded > num_reqs (e.g. FULL cudagraphs with DP).
+                self.query_start_loc.np[num_reqs + 1 :].fill(cum_num_tokens[-1])
                 self.query_start_loc.copy_to_gpu()
 
                 pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -773,7 +773,9 @@ class Worker(WorkerBase):
             self.profiler.stop()
 
     def execute_dummy_batch(self) -> None:
-        self.model_runner._dummy_run(1, uniform_decode=True)
+        self.model_runner._dummy_run(
+            self.model_runner.uniform_decode_query_len, uniform_decode=True
+        )
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         return self.model_runner.add_lora(lora_request)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fixing dsv32 dp + mtp crash
```bash
vllm serve deepseek-ai/DeepSeek-V3.2 \
  --tokenizer-mode deepseek_v32 \
  -dp 8 -ep \
  --block-size 256 \
  --gpu-memory-utilization 0.8 \
  --max-model-len auto \
  --reasoning-parser deepseek_v3 \
  --no-enable-prefix-caching \
  --kv-cache-dtype fp8 \
  --speculative-config.method deepseek_mtp \
  --speculative-config.num_speculative_tokens 1
```

Crash with message
```
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080] EngineCore encountered a fatal error.
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080] Traceback (most recent call last):
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/vllm/v1/engine/core.py", line 1071, in run_engine_core
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     engine_core.run_busy_loop()
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/vllm/v1/engine/core.py", line 1589, in run_busy_loop
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     self.execute_dummy_batch()
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/vllm/v1/engine/core.py", line 698, in execute_dummy_batch
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     self.model_executor.execute_dummy_batch()
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/vllm/v1/executor/abstract.py", line 231, in execute_dummy_batch
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     self.collective_rpc("execute_dummy_batch")
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/vllm/v1/executor/uniproc_executor.py", line 75, in collective_rpc
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     result = run_method(self.driver_worker, method, args, kwargs)
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/vllm/v1/serial_utils.py", line 459, in run_method
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     return func(*args, **kwargs)
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/vllm/v1/worker/gpu_worker.py", line 776, in execute_dummy_batch
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     self.model_runner._dummy_run(1, uniform_decode=True)
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     return func(*args, **kwargs)
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/vllm/v1/worker/gpu_model_runner.py", line 4864, in _dummy_run
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     attn_metadata, _ = self._build_attention_metadata(
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/vllm/v1/worker/gpu_model_runner.py", line 1944, in _build_attention_metadata
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     _build_attn_group_metadata(kv_cache_gid, attn_gid, cm)
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/vllm/v1/worker/gpu_model_runner.py", line 1895, in _build_attn_group_metadata
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     attn_metadata_i = builder.build(
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]                       ^^^^^^^^^^^^^^
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/vllm/v1/attention/backends/mla/flashmla_sparse.py", line 511, in build
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     fp8_extra_metadata = self._build_fp8_separate_prefill_decode(cm)
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/vllm/v1/attention/backends/mla/flashmla_sparse.py", line 341, in _build_fp8_separate_prefill_decode
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     split_decodes_and_prefills(
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]   File "/mnt/data/yongye/vllm/vllm/v1/attention/backends/utils.py", line 531, in split_decodes_and_prefills
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]     assert num_reqs * query_lens[0] == num_tokens, "tokens not padded correctly"
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP6 pid=447258) ERROR 03-02 01:03:49 [core.py:1080] AssertionError: tokens not padded correctly
```


When speculative decoding is enabled with data parallelism, execute_dummy_batch() calls _dummy_run(1, uniform_decode=True). With spec decode, uniform_decode_query_len = 1 + num_spec_tokens (e.g., 5), so max_query_len = 5. However, only 1 token is allocated. When DP coordination or FULL CUDAGraph mode pads the batch (e.g., num_tokens_padded = 10, num_reqs_padded = 2), the query_start_loc still reflects just 1 token for 1 request. The assertion num_reqs * query_lens[0] == num_tokens fails because 2 * 1 != 10.

## Test Plan
gsm8k score for dsv 32

## Test Result
gsm8k score for dep=8 without mtp
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9575|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9575|±  |0.0056|
```

with mtp
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9568|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9575|±  |0.0056|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

