### PR TITLE
[Core] Support FP8 weight storage in unquantized linear and embedding layers

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -223,9 +223,13 @@ class UnquantizedLinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        weight = layer.weight
+        # Support FP8 weight storage: cast to compute dtype for GEMM
+        if weight.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+            weight = weight.to(x.dtype)
         if envs.VLLM_BATCH_INVARIANT and current_platform.is_cuda_alike():
-            return linear_batch_invariant(x, layer.weight, bias)
-        return dispatch_unquantized_gemm()(layer, x, layer.weight, bias)
+            return linear_batch_invariant(x, weight, bias)
+        return dispatch_unquantized_gemm()(layer, x, weight, bias)
 
 
 class LinearBase(PluggableLayer):

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -82,7 +82,7 @@ class UnquantizedEmbeddingMethod(QuantizeMethodBase):
         output = F.embedding(input_, layer.weight)
         # Support FP8 weight storage: cast to compute dtype after lookup
         if output.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
-            output = output.to(torch.bfloat16)
+            output = output.to(torch.get_default_dtype())
         return output
 
 

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -70,12 +70,20 @@ class UnquantizedEmbeddingMethod(QuantizeMethodBase):
         x: torch.Tensor,
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        weight = layer.weight
+        # Support FP8 weight storage: cast to compute dtype for GEMM
+        if weight.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+            weight = weight.to(x.dtype)
         if envs.VLLM_BATCH_INVARIANT and current_platform.is_cuda_alike():
-            return linear_batch_invariant(x, layer.weight, bias)
-        return dispatch_unquantized_gemm()(layer, x, layer.weight, bias)
+            return linear_batch_invariant(x, weight, bias)
+        return dispatch_unquantized_gemm()(layer, x, weight, bias)
 
     def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
-        return F.embedding(input_, layer.weight)
+        output = F.embedding(input_, layer.weight)
+        # Support FP8 weight storage: cast to compute dtype after lookup
+        if output.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+            output = output.to(torch.bfloat16)
+        return output
 
 
 def pad_vocab_size(vocab_size: int, pad_to: int = DEFAULT_VOCAB_PADDING_SIZE) -> int:
@@ -434,6 +442,14 @@ class VocabParallelEmbedding(PluggableLayer):
             if output_dim is not None:
                 shape[output_dim] = self.num_embeddings_per_partition
             param.materialize(tuple(shape), dtype=loaded_weight.dtype)
+
+        # If loaded weight is FP8, cast parameter to match so FP8 is
+        # preserved in memory (saves VRAM for e.g. embed_tokens).
+        if (
+            loaded_weight.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+            and param.data.dtype != loaded_weight.dtype
+        ):
+            param.data = torch.empty_like(param.data, dtype=loaded_weight.dtype)
 
         # If parameter does not have output dim, then it should
         # be copied onto all gpus (e.g. g_idx for act_order gptq).


### PR DESCRIPTION
## Summary

- Add FP8 (`float8_e4m3fn` / `float8_e5m2`) dtype handling to `UnquantizedLinearMethod` and `UnquantizedEmbeddingMethod`
- Cast FP8 weights to compute dtype before GEMM operations and after embedding lookup
- Preserve FP8 dtype in `VocabParallelEmbedding.weight_loader` instead of silently upcasting to BF16

## Motivation

This enables post-training FP8 compression of `embed_tokens` and `lm_head` layers to save VRAM without requiring a dedicated quantization scheme. For models with large vocabularies (131K+), this frees ~640 MB of VRAM that can be used for KV cache, significantly extending context length on memory-constrained GPUs.

## Test plan

- [x] Verified on GLM-4.7-Flash-REAP-23B-A3B with FP8 embed_tokens (saves 464 MB)
- [x] Verified on Devstral-24B with FP8 embed_tokens (saves 640 MB)
- [x] Pre-commit passes (ruff, mypy, typos)
- [ ] Unit tests for FP8 dtype path in both methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)