### PR TITLE
[Attention] Enable FP8 KV cache for Triton MLA backend

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -213,4 +213,4 @@ configuration.
 | `ROCM_AITER_MLA` | fp16, bf16 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | 1 | Any | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_MLA_SPARSE` | fp16, bf16 | `auto`, `bfloat16` | 1 | Any | ❌ | ✅ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_TRITON_MLA` | fp16, bf16 | `auto` | Any | Any | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
-| `TRITON_MLA` | fp16, bf16 | `auto`, `bfloat16` | Any | Any | ❌ | ❌ | ❌ | ✅ | Decoder | Any |
+| `TRITON_MLA` | fp16, bf16 | `auto`, `bfloat16`, `fp8`, `fp8_e4m3` | Any | Any | ❌ | ❌ | ❌ | ✅ | Decoder | Any |

--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -119,20 +119,25 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
         assert kv_c_and_k_pe_cache.numel() > 0
         assert attn_metadata.decode is not None
 
-        # Determine compute dtype — Triton kernels need BF16/FP16, not FP8.
-        compute_dtype = torch.bfloat16
-
-        if self.kv_cache_dtype.startswith("fp8"):
-            # Dequantize FP8 cache to BF16 before Triton kernel.
-            k_scale = layer._k_scale.float() if hasattr(layer, "_k_scale") else 1.0
-            kv_c_and_k_pe_cache = (kv_c_and_k_pe_cache.float() * k_scale).to(
-                compute_dtype
-            )
-
         if type(q) is tuple:
             q = torch.cat(q, dim=-1)
 
         assert isinstance(q, torch.Tensor)
+
+        # Determine compute dtype — Triton kernels need BF16/FP16, not FP8.
+        # Derive from q's dtype when possible; fall back to model default for
+        # FP8-quantized queries (element_size()==1 means FP8).
+        if q.dtype.is_floating_point and q.element_size() == 1:
+            compute_dtype = torch.get_default_dtype()
+        else:
+            compute_dtype = q.dtype
+
+        if self.kv_cache_dtype.startswith("fp8"):
+            # Dequantize FP8 cache before Triton kernel.
+            k_scale = layer._k_scale.float() if hasattr(layer, "_k_scale") else 1.0
+            kv_c_and_k_pe_cache = (kv_c_and_k_pe_cache.float() * k_scale).to(
+                compute_dtype
+            )
 
         # Query may have been quantized to FP8 by the caller — dequantize.
         if q.dtype.is_floating_point and q.element_size() == 1:


### PR DESCRIPTION
## Summary

- Enable `--kv-cache-dtype fp8_e4m3` for MLA models when using the Triton MLA attention backend
- Pre-dequantize FP8 KV cache and query tensors to BF16 before the Triton decode kernel
- Update attention backend documentation with new supported dtypes

## Motivation

MLA models (DeepSeek-V2/V3, GLM-4) use compressed KV cache (e.g. 576 values per token per layer vs full head dimensions). Combined with FP8 KV cache, this roughly doubles available context length on VRAM-constrained GPUs. For example, on an RTX 5080 (16 GB) serving GLM-4.7-Flash:

| KV dtype | Max blocks | Max tokens |
|----------|-----------|------------|
| BF16 | 380 | 6,080 |
| **FP8** | **733** | **11,728** |

The pre-dequantization approach trades a small amount of compute (FP8→BF16 cast) for significant memory savings. The Triton kernel itself is unchanged.

## Test plan

- [x] Verified on GLM-4.7-Flash-REAP-23B-A3B-NVFP4 with `--kv-cache-dtype fp8_e4m3` on RTX 5080
- [x] Smoke tested: factual Q&A, math, JSON output, code generation all produce correct results
- [x] Pre-commit passes (ruff, mypy, typos, attention-backend-docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)