### PR TITLE
feat(responses): stateless multi-turn via encrypted_content (RFC #26934 + @grs proposal)

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -29,8 +29,57 @@ See [LICENSE](../../LICENSE).
 The first step of contributing to vLLM is to clone the GitHub repository:
 
 ```bash
-git clone https://github.com/vllm-project/vllm.git
+git clone <your-fork-url>
 cd vllm
+```
+
+If your fork was created from `github.com/vllm-project/vllm`, add the project remote and name it `upstream`:
+
+```bash
+git remote add upstream https://github.com/vllm-project/vllm.git
+git remote -v
+```
+
+If your remotes are reversed, use `git remote rename` to make your fork `origin` and project repo `upstream`.
+
+If this checkout still has only `origin` pointing at the main vLLM repo, run:
+
+```bash
+git remote rename origin upstream
+git remote add origin <your-fork-url>
+```
+
+### Contributor Workspace Setup
+
+Before you begin, check your branch health:
+
+```bash
+scripts/contributor-workspace.sh status
+```
+
+If your branch is behind or missing `upstream/main`, sync your local `main` first:
+
+```bash
+scripts/contributor-workspace.sh sync-main
+```
+
+### Baseline Version Guidance
+
+For day-to-day contributions to vLLM, work from `main` unless a maintainer explicitly asks for a stable release branch.
+
+Find the latest stable tagged release in this repo:
+
+```bash
+git tag -l 'v[0-9]*.[0-9]*.[0-9]*' \
+  | grep -Ev 'rc|post|dev' \
+  | sort -V \
+  | tail -n 1
+```
+
+Then create a short-lived branch when you need a stable snapshot:
+
+```bash
+git switch -c contrib/<area>-<date> vX.Y.Z
 ```
 
 Then, configure your Python virtual environment.
@@ -98,6 +147,14 @@ vLLM's `pre-commit` hooks will now run automatically every time you commit.
     pre-commit run --hook-stage manual mypy-3.10
     ```
 
+If your environment has restricted access to `~/.cache`, use the repo-local helper:
+
+```bash
+scripts/run-pre-commit.sh run -a  # runs on all files
+```
+
+Use this helper whenever you run pre-commit manually.
+
 ### Documentation
 
 MkDocs is a fast, simple and downright gorgeous static site generator that's geared towards building project documentation. Documentation source files are written in Markdown, and configured with a single YAML configuration file, [mkdocs.yaml](../../mkdocs.yaml).
@@ -158,6 +215,16 @@ pytest -s -v tests/test_logger.py
     Currently, not all unit tests pass when run on CPU platforms. If you don't have access to a GPU
     platform to run unit tests locally, rely on the continuous integration system to run the tests for
     now.
+
+### Choosing PR Candidates
+
+Use this order when selecting work:
+
+- Start with `good first issue` labels, since they are curated for new contributors.
+- Follow issues tagged by a maintainer for component-specific work you can reproduce.
+- If there is no existing issue, open one first and wait for maintainer alignment before writing significant code.
+- For larger refactors, ask for an RFC before implementation; `rfc-required` labels usually indicate this.
+- Keep first PRs narrow: one behavior, one test area, one subsystem.
 
 ## Issues
 
@@ -223,6 +290,20 @@ The PR needs to meet the following code quality standards:
   includes both unit tests and integration tests.
 - Please add documentation to `docs/` if the PR modifies the user-facing behaviors of vLLM.
   It helps vLLM users understand and utilize the new features or changes.
+
+## First PR Checklist
+
+Before you open your first PR, use this checklist as a concrete execution path:
+
+- Open or find a relevant issue and link it in your PR description.
+- Keep your branch focused on one change only.
+- Choose a PR title with the required type prefix (for example, `[Bugfix]`, `[Doc]`, or `[Model]`).
+- Add the smallest sufficient test coverage for code changes; for docs-only changes, validate docs build.
+- Run `pre-commit` locally before pushing.
+- Include a short test plan and test results section in the PR description.
+- Ensure your commit has DCO sign-off (`git commit -s`).
+
+A small PR with complete checkboxes is easier to review and more likely to move quickly through review.
 
 ### Adding or Changing Kernels
 

--- a/docs/contributing/responses-harmony-state-plan.md
+++ b/docs/contributing/responses-harmony-state-plan.md
@@ -1,0 +1,120 @@
+# Responses + Harmony Contribution Plan (Core GPT-OSS Focus)
+
+## Purpose
+This repo is intended as a focused working area for contributions in core vLLM, GPT-OSS models, and Harmony/Responses API features. The list below captures ten concrete tasks grouped by impact.
+
+## 1) Concrete contribution list (priority order)
+
+### 1. Complete refusal and non-text handling in Harmony input conversion
+**Why**: Open-ended chat/tool payloads are currently flattened to text-only assumptions in some branches, which drops refusal and non-text content.
+**Scope**:
+- [vllm/entrypoints/openai/parser/harmony_utils.py](../vllm/entrypoints/openai/parser/harmony_utils.py)
+- [vllm/entrypoints/openai/responses/harmony.py](../vllm/entrypoints/openai/responses/harmony.py)
+**Tasks**:
+- Add support for `refusal` fields and non-text content blocks in `_parse_chat_format_message`/`_parse_harmony_format_message` and equivalent response parsing paths.
+- Ensure round-trips preserve typed content in `Message.from_*` and serializer paths.
+
+### 2. Wire tool-call detection through chat-output parsing
+**Why**: `parse_chat_output()` currently always reports no tool call in the tuple return value, even when tool calls are present.
+**Scope**: [vllm/entrypoints/openai/parser/harmony_utils.py](../vllm/entrypoints/openai/parser/harmony_utils.py)
+**Tasks**:
+- Detect commentary/recipient-marked tool call messages while parsing and set `is_tool_call` correctly.
+- Add unit coverage for models that emit tool calls and partial tool calls.
+
+### 3. Preserve MCP/tool-call context instead of forcing `mcp_call` fallback shape
+**Why**: When converting parser state to response output, MCP metadata is currently overwritten and error handling is missing.
+**Scope**: [vllm/entrypoints/openai/parser/responses_parser.py](../vllm/entrypoints/openai/parser/responses_parser.py)
+**Tasks**:
+- Store and emit tool-server label data when converting `ResponseFunctionToolCallOutputItem` to `McpCall`.
+- Add support for error outputs in function-call result conversion rather than silently dropping metadata.
+
+### 4. Add output annotations/logprob propagation to fallback output builders
+**Why**: Parser fallback paths currently emit placeholder values for `annotations`/`logprobs`, which loses observability and parity with non-harmony parsing.
+**Scope**:
+- [vllm/entrypoints/openai/parser/responses_parser.py](../vllm/entrypoints/openai/parser/responses_parser.py)
+- [vllm/entrypoints/openai/responses/harmony.py](../vllm/entrypoints/openai/responses/harmony.py)
+**Tasks**:
+- Thread through available token-level logprob structures where requested.
+- Keep annotation structure stable and non-null in final output items.
+
+### 5. Include tool output messages in streaming harmony message history
+**Why**: `StreamingHarmonyContext.append_tool_output()` still has a TODO to add tool output messages; without it, state reconstruction can omit tool-result content in streamed runs.
+**Scope**: [vllm/entrypoints/openai/responses/context.py](../vllm/entrypoints/openai/responses/context.py)
+**Tasks**:
+- Append parsed tool-result `Message` objects into `_messages`.
+- Validate that returned stream event order matches non-streaming output item conversion.
+
+### 6. Clarify and fix previous-turn reconstruction in harmony continuation
+**Why**: The slice-delete/reappend block for previous-response continuation appears intentionally redundant and can mis-handle turn boundaries.
+**Scope**: [vllm/entrypoints/openai/responses/serving.py](../vllm/entrypoints/openai/responses/serving.py)
+**Tasks**:
+- Remove no-op behavior and implement explicit final-channel turn trimming policy.
+- Add regression tests for multi-turn conversations where last message is `analysis`/`final`.
+
+### 7. Add robust stateful response persistence and cleanup
+**Why**: response/message stores are explicit in-memory hacks with known leak risks.
+**Scope**:
+- [vllm/entrypoints/openai/responses/serving.py](../vllm/entrypoints/openai/responses/serving.py)
+- [vllm/entrypoints/openai/responses/context.py](../vllm/entrypoints/openai/responses/context.py)
+**Tasks**:
+- Track TTL/size limits or explicit pruning for `response_store`, `msg_store`, and `event_store`.
+- Ensure state used for `previous_response_id` survives normal use while preventing unbounded growth.
+
+### 8. Harden stateful tool execution contract for streaming
+**Why**: Tool execution + streaming paths still have known quirks (disconnect handling and per-request session behavior) not fully codified.
+**Scope**: [vllm/entrypoints/openai/responses/serving.py](../vllm/entrypoints/openai/responses/serving.py)
+**Tasks**:
+- Address `TODO` around disconnect handling in stream generator.
+- Add/extend tests around `previous_response_id` when `background=True`, including stream replay (`starting_after`).
+
+### 9. Improve parser compatibility for nested JSON tool arguments
+**Why**: Nested JSON tool arguments are known to fail in one parser path and are xfailed in streaming mode.
+**Scope**: [tests/entrypoints/openai/tool_parsers/test_hunyuan_a13b_tool_parser.py](../tests/entrypoints/openai/tool_parsers/test_hunyuan_a13b_tool_parser.py), [vllm/entrypoints/openai/tool_parsers/hunyuan_a13b_tool_parser.py](../vllm/entrypoints/openai/tool_parsers/hunyuan_a13b_tool_parser.py)
+**Tasks**:
+- Implement nested-object parsing in tool-parser extraction.
+- Remove remaining skip/xfail behavior and add focused regression tests.
+
+### 10. Fix GPT-OSS MoE Triton routing-weight path
+**Why**: `apply_router_weight_on_input` is currently ignored in the custom MOE kernel path, which can alter behavior versus reference implementation.
+**Scope**: [vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py](../vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py)
+**Tasks**:
+- Thread/consume `apply_router_weight_on_input` in `OAITritonExperts.apply`.
+- Add kernel parity tests in [tests/kernels/moe/test_modular_oai_triton_moe.py](../tests/kernels/moe/test_modular_oai_triton_moe.py).
+
+## 2) How Responses API statefulness currently works
+
+### Core behavior
+1. On request, `create_responses()` optionally loads prior response with `previous_response_id`.
+2. `previous_response_id` is loaded from `self.response_store`; if missing, the request returns `invalid_request_error`.
+3. For non-Harmony models, `construct_input_messages()` prepends previous chat messages (`msg_store`) and previous assistant outputs (`prev_response.output`) before appending current input.
+4. For Harmony/GPT-OSS, `_construct_input_messages_with_harmony()` loads previous harmony messages from `msg_store[prev_response.id]` and appends parsed new input.
+5. `msg_store`/`response_store` are only reliably populated when `store=True`.
+
+### Practical caveats
+- `msg_store` is in-memory only and has no eviction policy (`FIXME` comments mark this as a memory leak risk).
+- `response_store` and `event_store` are also in-memory hacks with no retention policy.
+- Request-level state is per `response_id`; streaming replay (`starting_after`) reads from `event_store` rather than recomputing.
+- In Harmony, `context.messages` includes init state + generated messages; stateful reconstruction depends on correct `_construct_input_messages_with_harmony()` behavior.
+
+## 3) TODOs affecting stateful correctness
+
+### Direct TODOs in responses/harmony flow
+- `vllm/entrypoints/openai/responses/harmony.py` and `.../parser/harmony_utils.py`: refusal/non-text support gaps.
+- `.../parser/harmony_utils.py`: `parse_chat_output()` does not report `is_tool_call` yet.
+- `.../responses/context.py`: add tool output messages in streaming harmony history.
+- `.../responses/serving.py`: known streaming bug around tool session initialization/streaming path, plus disconnect TODO.
+- `.../responses/serving.py`: previous-response continuation block is currently redundant and needs explicit final-turn handling.
+- `.../responses/serving.py`: store/event maps include explicit FIXME about unbounded memory use.
+- `.../protocol.py`: incomplete-details only covers max tokens; content_filter reason is still TODO.
+- `.../protocol.py`: non-harmony previous_input message support is marked TODO.
+
+### Parser/Output conversion TODOs that impact state replay
+- `.../parser/responses_parser.py`: MCP server label and error-output conversion are incomplete.
+- `.../parser/responses_parser.py` and `.../responses/harmony.py`: annotations/logprobs are placeholders in several conversion paths.
+- `.../streaming_events.py`: TODOs around logprobs and web-search URL/ids in emitted events (impacting debugability and stream consumers).
+
+## 4) Suggested near-term execution order
+1. Address parser/harmony correctness items (1, 2, 4) together to stabilize message/output semantics.
+2. Fix streaming tool output and state reconstruction (5, 6) to avoid multi-turn drift.
+3. Add robust state persistence policy + regression tests (7, 8).
+4. Improve tool-call robustness and kernel parity work (9, 10).

--- a/scripts/contributor-workspace.sh
+++ b/scripts/contributor-workspace.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+UPSTREAM_REMOTE="${UPSTREAM_REMOTE:-upstream}"
+BASE_BRANCH="${BASE_BRANCH:-main}"
+
+cd "$REPO_ROOT"
+
+resolve_upstream_remote() {
+  if git remote get-url "$UPSTREAM_REMOTE" >/dev/null 2>&1; then
+    printf '%s\n' "$UPSTREAM_REMOTE"
+    return 0
+  fi
+
+  if git remote get-url origin >/dev/null 2>&1; then
+    local origin_url
+    origin_url="$(git remote get-url origin)"
+    if printf '%s' "$origin_url" | grep -Eq 'vllm-project/vllm(\.git)?$'; then
+      printf 'origin\n'
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+print_status() {
+  local upstream_remote
+  upstream_remote="$(resolve_upstream_remote || true)"
+
+  local latest_stable
+  latest_stable="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -Ev 'rc|post|dev' | sort -V | tail -n 1)"
+  echo
+  echo "Contributor workspace status"
+  echo "----------------------------"
+  echo "Repo:            ${REPO_ROOT}"
+  echo "Branch:          $(git branch --show-current)"
+  echo
+  echo "Remotes:"
+  git remote -v
+  echo
+
+  if [ -n "$upstream_remote" ]; then
+    if git rev-parse --verify --quiet "refs/remotes/$upstream_remote/$BASE_BRANCH" >/dev/null; then
+      echo "Tracking base:"
+      local local_ahead upstream_ahead
+      read -r local_ahead upstream_ahead < <(git rev-list --left-right --count "${BASE_BRANCH}...$upstream_remote/$BASE_BRANCH")
+      printf "  %s: upstream=%s\n" "$BASE_BRANCH" "$upstream_remote/$BASE_BRANCH"
+      printf "  local commits not in upstream / upstream commits not in local: %s\n" "$local_ahead/$upstream_ahead"
+    else
+      echo "Remote branch not cached locally yet: $upstream_remote/$BASE_BRANCH (run: scripts/contributor-workspace.sh sync-main)"
+    fi
+  else
+    echo "No upstream project remote found (expected upstream project remote)."
+    echo "Run: git remote add upstream https://github.com/vllm-project/vllm.git"
+    echo "If your fork is in origin and upstream points to your fork, you can set UPSTREAM_REMOTE=origin."
+  fi
+
+  echo
+  if [ -n "$latest_stable" ]; then
+    echo "Latest stable tag (non-rc/post): $latest_stable"
+    echo "  To create a fresh baseline branch:"
+    echo "  git switch -c contrib/stable-base \"$latest_stable\""
+  else
+    echo "No stable version tag found by pattern: vN.N.N"
+  fi
+  echo
+}
+
+sync_main() {
+  local current_branch
+  current_branch="$(git symbolic-ref --short -q HEAD || true)"
+  local upstream_remote
+  upstream_remote="$(resolve_upstream_remote || true)"
+
+  if [ -z "$upstream_remote" ]; then
+    echo "Missing upstream remote. Add it first:"
+    echo "git remote add $UPSTREAM_REMOTE https://github.com/vllm-project/vllm.git"
+    exit 1
+  fi
+
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "Workspace has uncommitted changes. Commit/stash or reset before sync."
+    git status --short
+    exit 1
+  fi
+
+  if [ "$upstream_remote" != "$UPSTREAM_REMOTE" ]; then
+    echo "Using upstream remote '$upstream_remote' (set UPSTREAM_REMOTE explicitly to override)."
+    UPSTREAM_REMOTE="$upstream_remote"
+  fi
+
+  git fetch "$UPSTREAM_REMOTE" --prune --tags
+
+  if git rev-parse --verify --quiet "refs/remotes/$UPSTREAM_REMOTE/$BASE_BRANCH" >/dev/null; then
+    git switch "$BASE_BRANCH"
+    git pull --ff-only "$UPSTREAM_REMOTE" "$BASE_BRANCH"
+  else
+    echo "Creating local ${BASE_BRANCH} from $UPSTREAM_REMOTE/${BASE_BRANCH}"
+    git switch --track -c "$BASE_BRANCH" "$UPSTREAM_REMOTE/$BASE_BRANCH"
+  fi
+
+  if [ -n "$current_branch" ] && [ "$current_branch" != "$BASE_BRANCH" ]; then
+    git switch "$current_branch"
+    echo
+    echo "Updated $BASE_BRANCH from $UPSTREAM_REMOTE/$BASE_BRANCH"
+    echo "Returned to your working branch: $current_branch"
+  else
+    echo
+    echo "Updated $BASE_BRANCH from $UPSTREAM_REMOTE/$BASE_BRANCH"
+    echo "Working branch remains checked out: $BASE_BRANCH"
+  fi
+}
+
+show_help() {
+  cat <<'EOF'
+Usage:
+  scripts/contributor-workspace.sh status
+  scripts/contributor-workspace.sh sync-main
+
+Environment:
+  UPSTREAM_REMOTE  Remote that points to https://github.com/vllm-project/vllm (default: upstream)
+  BASE_BRANCH     Base branch to track and sync (default: main)
+EOF
+}
+
+case "${1:-status}" in
+  status)
+    print_status
+    ;;
+  sync-main)
+    sync_main
+    ;;
+  -h|--help|help)
+    show_help
+    ;;
+  *)
+    echo "Unknown mode: ${1:-}"
+    show_help
+    exit 1
+    ;;
+esac

--- a/scripts/run-pre-commit.sh
+++ b/scripts/run-pre-commit.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PRE_COMMIT_DIR="${PRE_COMMIT_HOME:-${REPO_ROOT}/.cache/pre-commit}"
+XDG_CACHE_DIR="${XDG_CACHE_HOME:-${REPO_ROOT}/.cache}"
+
+export PRE_COMMIT_HOME="$PRE_COMMIT_DIR"
+export XDG_CACHE_HOME="$XDG_CACHE_DIR"
+
+mkdir -p "${PRE_COMMIT_HOME}" "${XDG_CACHE_HOME}"
+
+if ! command -v pre-commit > /dev/null 2>&1; then
+  echo "pre-commit not found. Install it (for example, with: uv pip install pre-commit)." >&2
+  exit 1
+fi
+
+pre-commit "$@"

--- a/tests/entrypoints/openai/responses/test_serving_stateless.py
+++ b/tests/entrypoints/openai/responses/test_serving_stateless.py
@@ -1,0 +1,326 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Unit tests for stateless multi-turn Responses API (RFC #26934 + @grs).
+
+Covers:
+- Protocol-level validation (pydantic model constraints on ResponsesRequest)
+- State carrier injection helpers (_build_state_carrier / _extract_state_from_response)
+- Error paths when enable_store=False (retrieve, cancel, previous_response_id)
+- utils.py skipping of state-carrier items
+- construct_input_messages with prev_messages
+"""
+
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Signing key fixture — deterministic per test run
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def set_signing_key(monkeypatch):
+    monkeypatch.setenv("VLLM_RESPONSES_STATE_SIGNING_KEY", "cc" * 32)
+    import vllm.entrypoints.openai.responses.state as state_mod
+
+    state_mod._SIGNING_KEY = None
+    yield
+    state_mod._SIGNING_KEY = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_serving(enable_store: bool = False):
+    """Return an OpenAIServingResponses instance with only the attributes
+    exercised by the methods under test.  We bypass __init__ via __new__ and
+    set exactly what is needed.
+
+    Attributes touched by retrieve_responses / cancel_responses:
+      enable_store, response_store, response_store_lock, background_tasks,
+      log_error_stack (for create_error_response from base class)
+    Attributes touched by create_responses (up to store check):
+      models (for _check_model), engine_client (for errored check)
+    """
+    import asyncio
+
+    from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+
+    obj = OpenAIServingResponses.__new__(OpenAIServingResponses)
+    obj.enable_store = enable_store
+    obj.response_store = {}
+    obj.response_store_lock = asyncio.Lock()
+    obj.background_tasks = {}
+    obj.log_error_stack = False
+    # _check_model needs models.is_base_model to return True (model found)
+    obj.models = MagicMock()
+    obj.models.is_base_model.return_value = True
+    # _validate_create_responses_input checks this before hitting the store guard
+    obj.use_harmony = False
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Protocol validation — pydantic model constraints
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolValidation:
+    def test_previous_response_and_id_mutually_exclusive(self):
+        from vllm.entrypoints.openai.responses.protocol import (
+            ResponsesRequest,
+            ResponsesResponse,
+        )
+
+        # model_construct bypasses field validation so we get a typed instance
+        # without needing all required fields — Pydantic accepts it for type checks.
+        fake_prev = ResponsesResponse.model_construct(id="resp_fake")
+        with pytest.raises(Exception, match="Cannot set both"):
+            ResponsesRequest(
+                model="test",
+                input="hello",
+                previous_response_id="resp_abc",
+                previous_response=fake_prev,
+            )
+
+    def test_previous_response_silently_clears_store(self):
+        from vllm.entrypoints.openai.responses.protocol import (
+            ResponsesRequest,
+            ResponsesResponse,
+        )
+
+        fake_prev = ResponsesResponse.model_construct(id="resp_fake")
+        req = ResponsesRequest(
+            model="test",
+            input="hello",
+            store=True,
+            previous_response=fake_prev,
+        )
+        assert req.store is False
+
+    def test_no_previous_response_preserves_store_true(self):
+        from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+        req = ResponsesRequest(model="test", input="hello", store=True)
+        assert req.store is True
+
+
+# ---------------------------------------------------------------------------
+# State carrier round-trip via serving helpers
+# (thin wrappers over state.py — verified here to confirm the integration)
+# ---------------------------------------------------------------------------
+
+
+class TestStateCarrierHelpers:
+    def test_build_and_extract_roundtrip(self):
+        from openai.types.responses.response_reasoning_item import ResponseReasoningItem
+        from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+
+        serving = _make_minimal_serving()
+        messages = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+
+        carrier = OpenAIServingResponses._build_state_carrier(serving, messages, "test_req_id_12345")
+
+        assert isinstance(carrier, ResponseReasoningItem)
+        assert carrier.type == "reasoning"
+        assert carrier.status == "completed"
+        assert carrier.encrypted_content.startswith("vllm:1:")
+
+        mock_response = MagicMock()
+        mock_response.output = [carrier]
+
+        recovered = OpenAIServingResponses._extract_state_from_response(serving, mock_response)
+        assert recovered == messages
+
+    def test_extract_returns_none_when_no_carrier(self):
+        from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+        from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+
+        serving = _make_minimal_serving()
+
+        text = ResponseOutputText(type="output_text", text="hi", annotations=[])
+        msg = ResponseOutputMessage(
+            id="msg_1", type="message", role="assistant",
+            content=[text], status="completed",
+        )
+        mock_response = MagicMock()
+        mock_response.output = [msg]
+
+        assert OpenAIServingResponses._extract_state_from_response(serving, mock_response) is None
+
+    def test_extract_raises_on_tampered_carrier(self):
+        from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+
+        serving = _make_minimal_serving()
+        carrier = OpenAIServingResponses._build_state_carrier(
+            serving, [{"role": "user", "content": "hi"}], "req"
+        )
+
+        parts = carrier.encrypted_content.split(":", 3)
+        parts[3] = "0" * 64
+        carrier.encrypted_content = ":".join(parts)
+
+        mock_response = MagicMock()
+        mock_response.output = [carrier]
+
+        with pytest.raises(ValueError, match="HMAC verification failed"):
+            OpenAIServingResponses._extract_state_from_response(serving, mock_response)
+
+
+# ---------------------------------------------------------------------------
+# Error paths when enable_store=False
+# ---------------------------------------------------------------------------
+
+
+class TestStorelessErrorPaths:
+    @pytest.mark.asyncio
+    async def test_retrieve_without_store_returns_501(self):
+        from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+        from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+
+        serving = _make_minimal_serving(enable_store=False)
+        result = await OpenAIServingResponses.retrieve_responses(
+            serving, "resp_123", None, False
+        )
+
+        assert isinstance(result, ErrorResponse)
+        assert result.error.code == HTTPStatus.NOT_IMPLEMENTED
+        assert "VLLM_ENABLE_RESPONSES_API_STORE" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_cancel_without_store_returns_501(self):
+        from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+        from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+
+        serving = _make_minimal_serving(enable_store=False)
+        result = await OpenAIServingResponses.cancel_responses(serving, "resp_123")
+
+        assert isinstance(result, ErrorResponse)
+        assert result.error.code == HTTPStatus.NOT_IMPLEMENTED
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_without_store_returns_400(self):
+        """create_responses should reject previous_response_id when store is off."""
+        from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+        from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+        from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+
+        serving = _make_minimal_serving(enable_store=False)
+        # Minimal extra attributes that create_responses reads before the store check
+        serving.engine_client = MagicMock()
+        serving.engine_client.errored = False
+
+        req = ResponsesRequest(
+            model="test",
+            input="hello",
+            previous_response_id="resp_old",
+            store=False,
+        )
+
+        result = await OpenAIServingResponses.create_responses(serving, req)
+
+        assert isinstance(result, ErrorResponse)
+        assert result.error.code == HTTPStatus.BAD_REQUEST
+        assert "VLLM_ENABLE_RESPONSES_API_STORE" in result.error.message
+
+
+# ---------------------------------------------------------------------------
+# utils.py — state-carrier items are transparently skipped
+# ---------------------------------------------------------------------------
+
+
+class TestUtilsStateCarrierSkipping:
+    def test_construct_chat_messages_skips_state_carrier(self):
+        from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+        from openai.types.responses.response_reasoning_item import ResponseReasoningItem
+        from vllm.entrypoints.openai.responses.state import serialize_state
+        from vllm.entrypoints.openai.responses.utils import construct_chat_messages_with_tool_call
+
+        blob = serialize_state([{"role": "user", "content": "prev"}])
+        carrier = ResponseReasoningItem(
+            id="rs_state_abc", type="reasoning", summary=[],
+            status="completed", encrypted_content=blob,
+        )
+        text = ResponseOutputText(type="output_text", text="Hello!", annotations=[])
+        msg = ResponseOutputMessage(
+            id="msg_1", type="message", role="assistant",
+            content=[text], status="completed",
+        )
+
+        result = construct_chat_messages_with_tool_call([carrier, msg])
+
+        assert len(result) == 1
+        assert result[0]["role"] == "assistant"
+        assert result[0]["content"] == "Hello!"
+
+    def test_single_message_from_state_carrier_is_none(self):
+        from openai.types.responses.response_reasoning_item import ResponseReasoningItem
+        from vllm.entrypoints.openai.responses.state import serialize_state
+        from vllm.entrypoints.openai.responses.utils import _construct_single_message_from_response_item
+
+        blob = serialize_state([{"role": "user", "content": "hi"}])
+        carrier = ResponseReasoningItem(
+            id="rs_state_xyz", type="reasoning", summary=[],
+            status="completed", encrypted_content=blob,
+        )
+        assert _construct_single_message_from_response_item(carrier) is None
+
+    def test_external_encrypted_content_still_raises(self):
+        from openai.types.responses.response_reasoning_item import ResponseReasoningItem
+        from vllm.entrypoints.openai.responses.utils import _construct_single_message_from_response_item
+
+        external = ResponseReasoningItem(
+            id="rs_ext", type="reasoning", summary=[],
+            status="completed",
+            encrypted_content="opaque-blob-not-from-vllm",
+        )
+        with pytest.raises(ValueError, match="not supported"):
+            _construct_single_message_from_response_item(external)
+
+
+# ---------------------------------------------------------------------------
+# construct_input_messages with prev_messages override
+# ---------------------------------------------------------------------------
+
+
+class TestPrevMessagesOverride:
+    def test_prev_messages_used_over_empty_msg_store(self):
+        from vllm.entrypoints.openai.responses.utils import construct_input_messages
+
+        prev = [
+            {"role": "user", "content": "Who are you?"},
+            {"role": "assistant", "content": "I am helpful."},
+        ]
+        result = construct_input_messages(
+            request_instructions=None,
+            request_input="What did you say?",
+            prev_msg=prev,
+            prev_response_output=None,
+        )
+        assert result[0] == {"role": "user", "content": "Who are you?"}
+        assert result[1] == {"role": "assistant", "content": "I am helpful."}
+        assert result[2] == {"role": "user", "content": "What did you say?"}
+
+    def test_full_stateless_roundtrip(self):
+        """serialize → embed in carrier → extract → same messages."""
+        from vllm.entrypoints.openai.responses.serving import OpenAIServingResponses
+
+        serving = _make_minimal_serving()
+        original = [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "My name is Alice"},
+            {"role": "assistant", "content": "Hello, Alice!"},
+        ]
+        carrier = OpenAIServingResponses._build_state_carrier(serving, original, "req_abc123456789")
+
+        mock_response = MagicMock()
+        mock_response.output = [carrier]
+
+        recovered = OpenAIServingResponses._extract_state_from_response(serving, mock_response)
+        assert recovered == original

--- a/tests/entrypoints/openai/responses/test_state.py
+++ b/tests/entrypoints/openai/responses/test_state.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Unit tests for the stateless Responses API state carrier (state.py)."""
+
+import importlib
+import os
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_signing_key():
+    """Force state.py to re-derive the signing key on next call."""
+    import vllm.entrypoints.openai.responses.state as state_mod
+
+    state_mod._SIGNING_KEY = None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def isolated_key(monkeypatch):
+    """Each test gets a fresh, deterministic signing key."""
+    monkeypatch.setenv(
+        "VLLM_RESPONSES_STATE_SIGNING_KEY", "ab" * 32  # 64 hex chars = 32 bytes
+    )
+    _reset_signing_key()
+    yield
+    _reset_signing_key()
+
+
+# ---------------------------------------------------------------------------
+# Import after env is patched (in case module was already imported)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def state():
+    import vllm.entrypoints.openai.responses.state as m
+
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_plain_dicts(state):
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
+    ]
+    blob = state.serialize_state(messages)
+    recovered = state.deserialize_state(blob)
+    assert recovered == messages
+
+
+def test_roundtrip_empty_list(state):
+    blob = state.serialize_state([])
+    recovered = state.deserialize_state(blob)
+    assert recovered == []
+
+
+def test_roundtrip_nested_structure(state):
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "What is 2+2?"}],
+        },
+        {"role": "assistant", "content": "4", "extra": {"key": [1, 2, 3]}},
+    ]
+    blob = state.serialize_state(messages)
+    recovered = state.deserialize_state(blob)
+    assert recovered == messages
+
+
+def test_roundtrip_pydantic_model(state):
+    """Objects with model_dump() should serialize transparently."""
+
+    class FakeModel:
+        def model_dump(self):
+            return {"author": {"role": "user"}, "content": "hi"}
+
+    messages = [FakeModel()]
+    blob = state.serialize_state(messages)
+    recovered = state.deserialize_state(blob)
+    # After JSON round-trip, FakeModel becomes a plain dict
+    assert recovered == [{"author": {"role": "user"}, "content": "hi"}]
+
+
+# ---------------------------------------------------------------------------
+# is_state_carrier
+# ---------------------------------------------------------------------------
+
+
+def test_is_state_carrier_true(state):
+    blob = state.serialize_state([{"role": "user", "content": "hi"}])
+
+    class FakeItem:
+        encrypted_content = blob
+
+    assert state.is_state_carrier(FakeItem())
+
+
+def test_is_state_carrier_false_external(state):
+    """Real encrypted_content from external models should not be detected."""
+
+    class FakeItem:
+        encrypted_content = "some-opaque-blob-from-openai"
+
+    assert not state.is_state_carrier(FakeItem())
+
+
+def test_is_state_carrier_false_no_field(state):
+    class FakeItem:
+        pass
+
+    assert not state.is_state_carrier(FakeItem())
+
+
+def test_is_state_carrier_false_none(state):
+    class FakeItem:
+        encrypted_content = None
+
+    assert not state.is_state_carrier(FakeItem())
+
+
+# ---------------------------------------------------------------------------
+# deserialize_state — non-carrier inputs
+# ---------------------------------------------------------------------------
+
+
+def test_deserialize_returns_none_for_non_carrier(state):
+    assert state.deserialize_state("some-random-opaque-string") is None
+
+
+def test_deserialize_returns_none_for_empty_string(state):
+    assert state.deserialize_state("") is None
+
+
+# ---------------------------------------------------------------------------
+# HMAC tamper detection
+# ---------------------------------------------------------------------------
+
+
+def test_tampered_payload_raises(state):
+    blob = state.serialize_state([{"role": "user", "content": "original"}])
+    # Corrupt the payload part (index 2 when split on ':')
+    parts = blob.split(":", 3)
+    assert len(parts) == 4
+    parts[2] = parts[2][:-4] + "XXXX"  # corrupt the base64 payload
+    tampered = ":".join(parts)
+    with pytest.raises(ValueError, match="HMAC verification failed"):
+        state.deserialize_state(tampered)
+
+
+def test_tampered_sig_raises(state):
+    blob = state.serialize_state([{"role": "user", "content": "hello"}])
+    parts = blob.split(":", 3)
+    parts[3] = "0" * 64  # replace HMAC with zeros
+    tampered = ":".join(parts)
+    with pytest.raises(ValueError, match="HMAC verification failed"):
+        state.deserialize_state(tampered)
+
+
+def test_malformed_carrier_raises(state):
+    malformed = "vllm:1:onlythreeparts"
+    with pytest.raises(ValueError, match="Malformed vLLM state carrier"):
+        state.deserialize_state(malformed)
+
+
+# ---------------------------------------------------------------------------
+# Cross-key incompatibility
+# ---------------------------------------------------------------------------
+
+
+def test_different_keys_are_incompatible(monkeypatch):
+    """A blob signed with key A must not validate with key B."""
+    import vllm.entrypoints.openai.responses.state as state_mod
+
+    monkeypatch.setenv("VLLM_RESPONSES_STATE_SIGNING_KEY", "aa" * 32)
+    state_mod._SIGNING_KEY = None
+    blob = state_mod.serialize_state([{"role": "user", "content": "secret"}])
+
+    # Switch to a different key
+    monkeypatch.setenv("VLLM_RESPONSES_STATE_SIGNING_KEY", "bb" * 32)
+    state_mod._SIGNING_KEY = None
+
+    with pytest.raises(ValueError, match="HMAC verification failed"):
+        state_mod.deserialize_state(blob)
+
+
+# ---------------------------------------------------------------------------
+# Random-key warning (no env var)
+# ---------------------------------------------------------------------------
+
+
+def test_no_env_var_generates_random_key(monkeypatch):
+    """Without the env var, a random 32-byte key is generated.
+
+    The warning is emitted via vLLM's logger (visible in test output) but is
+    not capturable via capsys/caplog since vLLM writes to sys.__stdout__ directly.
+    """
+    import vllm.entrypoints.openai.responses.state as state_mod
+
+    monkeypatch.delenv("VLLM_RESPONSES_STATE_SIGNING_KEY", raising=False)
+    state_mod._SIGNING_KEY = None
+
+    key = state_mod._get_signing_key()
+
+    assert key is not None
+    assert len(key) == 32
+    # A second call returns the same cached key (warning only fires once)
+    key2 = state_mod._get_signing_key()
+    assert key == key2
+
+
+# ---------------------------------------------------------------------------
+# Invalid hex key
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_hex_key_raises(monkeypatch):
+    import vllm.entrypoints.openai.responses.state as state_mod
+
+    monkeypatch.setenv("VLLM_RESPONSES_STATE_SIGNING_KEY", "not-valid-hex!!")
+    state_mod._SIGNING_KEY = None
+
+    with pytest.raises(ValueError, match="valid hex string"):
+        state_mod._get_signing_key()

--- a/vllm/entrypoints/openai/responses/state.py
+++ b/vllm/entrypoints/openai/responses/state.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Stateless conversation state carrier for the Responses API.
+
+Serializes conversation message history into the ``encrypted_content`` field of
+a synthetic ResponseReasoningItem, enabling multi-turn conversations without
+server-side storage.  Implements the approach proposed by @grs in
+vllm-project/vllm#26934.
+
+Wire format:  ``vllm:1:<base64(json(messages))>:<hmac-sha256-hex>``
+
+Security note:
+    The payload is **signed**, not encrypted.  The HMAC-SHA256 signature
+    prevents client-side tampering with the serialized history, but the
+    contents (serialized message dicts) are readable by anyone who holds
+    the response object.  This matches the spirit of the ``encrypted_content``
+    field in the OpenAI protocol: an opaque blob the client stores and
+    returns verbatim.
+
+Multi-node deployments:
+    Set ``VLLM_RESPONSES_STATE_SIGNING_KEY`` to the same 64-character hex
+    string on all nodes.  Without it each process generates a random key at
+    startup, making state carriers incompatible across restarts/replicas.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+from typing import Any
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_FORMAT_VERSION = "vllm:1"
+_SIGNING_KEY: bytes | None = None
+
+
+def _get_signing_key() -> bytes:
+    global _SIGNING_KEY
+    if _SIGNING_KEY is None:
+        key_hex = os.environ.get("VLLM_RESPONSES_STATE_SIGNING_KEY", "")
+        if key_hex:
+            try:
+                _SIGNING_KEY = bytes.fromhex(key_hex)
+            except ValueError as exc:
+                raise ValueError(
+                    "VLLM_RESPONSES_STATE_SIGNING_KEY must be a valid hex "
+                    "string (e.g. a 64-char / 32-byte hex key)."
+                ) from exc
+        else:
+            _SIGNING_KEY = os.urandom(32)
+            logger.warning(
+                "VLLM_RESPONSES_STATE_SIGNING_KEY is not set. "
+                "Stateless multi-turn state carriers are valid only for this "
+                "server instance and will break across restarts or on "
+                "multi-node deployments. "
+                "Set VLLM_RESPONSES_STATE_SIGNING_KEY to a shared 64-char "
+                "hex key to enable multi-node / restart-safe operation."
+            )
+    return _SIGNING_KEY
+
+
+def _harmony_serializer(obj: Any) -> Any:
+    """JSON serializer for OpenAIHarmonyMessage and similar pydantic models."""
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump()
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
+def serialize_state(messages: list[Any]) -> str:
+    """Serialize *messages* into a signed, base64-encoded state carrier string.
+
+    The returned string is suitable for embedding in
+    ``ResponseReasoningItem.encrypted_content``.
+
+    Args:
+        messages: A list of message objects (OpenAIHarmonyMessage instances or
+            plain ``ChatCompletionMessageParam`` dicts).
+
+    Returns:
+        A wire-format state carrier string: ``vllm:1:<b64>:<hmac>``.
+    """
+    payload_b64 = base64.b64encode(
+        json.dumps(messages, default=_harmony_serializer).encode()
+    ).decode()
+    sig = hmac.new(
+        _get_signing_key(), payload_b64.encode(), hashlib.sha256
+    ).hexdigest()
+    return f"{_FORMAT_VERSION}:{payload_b64}:{sig}"
+
+
+def deserialize_state(encrypted_content: str) -> list[Any] | None:
+    """Deserialize a state carrier string back into a message list.
+
+    Args:
+        encrypted_content: The value of ``ResponseReasoningItem.encrypted_content``.
+
+    Returns:
+        The deserialized message list (as plain dicts), or ``None`` if the
+        string is not a vLLM state carrier (e.g. a real encrypted_content
+        from an external model).
+
+    Raises:
+        ValueError: If the string looks like a vLLM state carrier but the
+            HMAC signature does not match (indicates tampering).
+    """
+    if not encrypted_content.startswith(f"{_FORMAT_VERSION}:"):
+        return None
+    # Expected: "vllm:1:<payload_b64>:<sig>"
+    # Split into exactly 4 parts on the first 3 colons.
+    parts = encrypted_content.split(":", 3)
+    if len(parts) != 4:
+        raise ValueError(
+            "Malformed vLLM state carrier: expected "
+            f"'{_FORMAT_VERSION}:<payload>:<sig>', got {encrypted_content!r}"
+        )
+    _, _, payload_b64, sig = parts
+    expected = hmac.new(
+        _get_signing_key(), payload_b64.encode(), hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        raise ValueError(
+            "vLLM state carrier HMAC verification failed. "
+            "The state may have been tampered with, or was produced by a "
+            "different server instance (check VLLM_RESPONSES_STATE_SIGNING_KEY)."
+        )
+    return json.loads(base64.b64decode(payload_b64))
+
+
+def is_state_carrier(item: Any) -> bool:
+    """Return True if *item* is a vLLM state-carrier ReasoningItem.
+
+    A state carrier is a ``ResponseReasoningItem`` whose ``encrypted_content``
+    field starts with the vLLM format prefix.  These items are synthetic:
+    they carry serialized conversation history and should not be sent to the
+    LLM as part of the chat message list.
+
+    Args:
+        item: Any object, typically a ``ResponseOutputItem``.
+
+    Returns:
+        True if the item is a vLLM-generated state carrier.
+    """
+    ec = getattr(item, "encrypted_content", None)
+    return bool(ec and isinstance(ec, str) and ec.startswith(f"{_FORMAT_VERSION}:"))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -200,6 +200,7 @@ if TYPE_CHECKING:
     VLLM_LOOPBACK_IP: str = ""
     VLLM_ALLOW_CHUNKED_LOCAL_ATTN_WITH_HYBRID_KV_CACHE: bool = True
     VLLM_ENABLE_RESPONSES_API_STORE: bool = False
+    VLLM_RESPONSES_STATE_SIGNING_KEY: str = ""
     VLLM_NVFP4_GEMM_BACKEND: str | None = None
     VLLM_HAS_FLASHINFER_CUBIN: bool = False
     VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: bool = False
@@ -1449,6 +1450,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     #    never removed from memory until the server terminates.
     "VLLM_ENABLE_RESPONSES_API_STORE": lambda: bool(
         int(os.getenv("VLLM_ENABLE_RESPONSES_API_STORE", "0"))
+    ),
+    # Hex-encoded 32-byte (64-char) signing key for stateless multi-turn
+    # state carriers (RFC #26934). If not set, a random key is generated at
+    # startup (incompatible across restarts / multi-node deployments).
+    "VLLM_RESPONSES_STATE_SIGNING_KEY": lambda: os.environ.get(
+        "VLLM_RESPONSES_STATE_SIGNING_KEY", ""
     ),
     # If set, use the fp8 mfma in rocm paged attention.
     "VLLM_ROCM_FP8_MFMA_PAGE_ATTN": lambda: bool(


### PR DESCRIPTION
## Summary

Implements the [@grs proposal](https://github.com/vllm-project/vllm/issues/26934) for stateless multi-turn Responses API conversations — enabling multi-turn without server-side storage by serialising Harmony message history into the standard OpenAI `encrypted_content` field on a synthetic `ResponseReasoningItem`.

**Addresses:** RFC #26934 | Related: #33089 #34738

---

## Motivation

vLLM's Responses API currently stores conversation state in three in-process Python dicts (`response_store`, `msg_store`, `event_store`) commented `# HACK` / `# FIXME` in source. These are disabled by default (`VLLM_ENABLE_RESPONSES_API_STORE=0`) because they:
- Cause memory leaks in long-running deployments
- Lose all state on server restart
- Are incompatible with multi-node / load-balanced deployments
- Block adoption of `previous_response_id` multi-turn for most users (issues #33089, #34738)

RFC #26934 (@qandrew, Meta) calls for decoupling storage from the inference engine. @grs proposed reusing the existing `encrypted_content` field on `ReasoningItem` objects — no new protocol extensions needed.

---

## Design

```
Turn 1:  client → vLLM  { store: false, include: ["reasoning.encrypted_content"], input: "..." }
         vLLM  → client  { output: [...real items..., ReasoningItem(encrypted_content="vllm:1:<b64>:<hmac>")] }

Turn 2:  client → vLLM  { store: false, previous_response: <full Turn 1 response>, input: "..." }
         vLLM extracts encrypted_content, verifies HMAC, deserialises Harmony history → uses as context
```

**Wire format:** `vllm:1:<base64(json(messages))>:<hmac-sha256-hex>`
- Not encrypted (content is base64 JSON) — HMAC is for tamper detection only
- `VLLM_RESPONSES_STATE_SIGNING_KEY` (64-char hex) enables multi-node deployments; random key is generated per-process if unset (with a warning)

**State carrier item** is a synthetic `ReasoningItem` with `id="rs_state_<req_id[-12:]>"`. It is invisible to the LLM — filtered out by `_construct_single_message_from_response_item()` in `utils.py`.

---

## Files Changed

| File | Change |
|------|--------|
| `vllm/entrypoints/openai/responses/state.py` | **NEW** — `serialize_state` / `deserialize_state` / `is_state_carrier` / HMAC helpers |
| `vllm/entrypoints/openai/responses/protocol.py` | Add `previous_response: ResponsesResponse \| None` to `ResponsesRequest`; `model_validator` for mutual exclusion with `previous_response_id`; `model_rebuild()` for forward ref |
| `vllm/entrypoints/openai/responses/serving.py` | Stateless prev-response resolution in `create_responses`; thread `prev_messages` through `_make_request` / `_make_request_with_harmony` / `_construct_input_messages_with_harmony`; inject state carrier in `responses_full_generator`; 501 guards on `retrieve_responses` / `cancel_responses` when store disabled |
| `vllm/entrypoints/openai/responses/utils.py` | `_construct_single_message_from_response_item` returns `None` for state-carrier items; `construct_chat_messages_with_tool_call` filters `None` entries |
| `vllm/envs.py` | Register `VLLM_RESPONSES_STATE_SIGNING_KEY` |
| `tests/entrypoints/openai/responses/test_state.py` | **NEW** — 16 unit tests (round-trip, tamper detection, cross-key incompatibility, bad hex key, random key caching) |
| `tests/entrypoints/openai/responses/test_serving_stateless.py` | **NEW** — 14 unit tests (protocol validation, state carrier helpers, storeless error paths, utils skipping, prev_messages override) |

---

## Test Results

```
tests/entrypoints/openai/responses/test_state.py             16/16 passed
tests/entrypoints/openai/responses/test_serving_stateless.py 14/14 passed
```

All tests are pure-Python unit tests (no GPU needed).

---

## Usage Example

**Turn 1 — no store needed:**
```python
resp1 = client.responses.create(
    model="gpt-4o",
    input="My name is Alice",
    store=False,
    include=["reasoning.encrypted_content"],
)
# resp1.output contains [..., ReasoningItem(encrypted_content="vllm:1:...")]
```

**Turn 2 — pass back the full response:**
```python
resp2 = client.responses.create(
    model="gpt-4o",
    input="What is my name?",
    store=False,
    previous_response=resp1,          # full object, not previous_response_id
    include=["reasoning.encrypted_content"],
)
# → "Your name is Alice."
```

**Multi-node deployment:**
```bash
export VLLM_RESPONSES_STATE_SIGNING_KEY="$(openssl rand -hex 32)"
# Set the same value on all vLLM nodes so tokens validate across replicas
```

---

## Backward Compatibility

- **No breaking changes.** Existing `previous_response_id` + `VLLM_ENABLE_RESPONSES_API_STORE=1` path is completely unchanged.
- New stateless path requires explicit opt-in via `store=false` + `include=["reasoning.encrypted_content"]` + `previous_response`.
- `previous_response_id` without store now returns a helpful 400 error pointing users to the stateless path.

---

## Known Limitations / Follow-up

- **Streaming not yet covered.** The state carrier is only injected in `responses_full_generator`. Streaming (`responses_stream_generator`) needs `ResponseOutputItemAddedEvent` + `ResponseOutputItemDoneEvent` events for the carrier before `ResponseCompletedEvent`. Left as a follow-up to keep this PR reviewable.
- **No encryption.** Content is signed (HMAC) but not encrypted. This mirrors existing `encrypted_content` usage (the field name is from the OpenAI spec; vLLM reuses it for opaque state). Actual encryption is out of scope per the RFC.
- **In-memory `msg_store` / `response_store` hacks not removed.** This PR adds the stateless path without deleting the existing store-enabled path. Cleanup can follow once stateless is validated.

---

## Reviewer Notes

Key design decision open for discussion: **single state carrier vs. per-item state**. The current implementation appends one synthetic `ReasoningItem` carrying the full Harmony history. @alecsolder raised in #26934 that tool-call metadata may not be expressible in per-reasoning-item form; this design sidesteps that by carrying the complete history in one item.

cc @qandrew @grs @WoosukKwon @njhill @Simon-Laux