### PR TITLE
scaffold logic which ensures that conditionally imported deps exist

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -13,6 +13,7 @@ from torch.distributed.distributed_c10d import is_nccl_available
 
 import vllm.envs as envs
 from vllm.logger import init_logger
+from vllm.utils.optional_deps import validate_platform_optional_deps
 from vllm.utils.torch_utils import cuda_device_count_stateless
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
@@ -342,6 +343,10 @@ class RocmPlatform(Platform):
     def import_kernels(cls) -> None:
         """Import ROCm-specific kernels."""
         super().import_kernels()
+
+        # Fail fast if optional deps for ROCm-supported features are missing
+        # (e.g. amd-quark for mxfp4). See vllm.utils.optional_deps.
+        validate_platform_optional_deps(PlatformEnum.ROCM)
 
         import contextlib
 

--- a/vllm/utils/optional_deps.py
+++ b/vllm/utils/optional_deps.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fail-fast validation for platform optional dependencies.
+
+If a platform advertises a feature (e.g. mxfp4 on ROCm), the corresponding
+package must be importable or we raise at startup with a clear message.
+
+WIP: Draft for team review. Only ROCm + amd-quark (mxfp4/mxfp6) for now;
+other platforms can be added in the same way.
+"""
+
+from __future__ import annotations
+
+import importlib
+from importlib.metadata import version
+from typing import Any
+
+from packaging.version import Version
+
+# Platform enum -> list of (feature_name, pip_package, import_name, min_version?).
+# If supported_quantization includes the feature, we require the package.
+_PLATFORM_OPTIONAL_DEPS: dict[str, list[tuple[str, str, str, str | None]]] = {
+    "ROCM": [
+        # mxfp4/mxfp6 use quark.torch.kernel
+        ("mxfp4", "amd-quark", "quark", "0.8.99"),
+    ],
+}
+
+
+def _check_package(
+    feature_name: str,
+    pip_package: str,
+    import_name: str,
+    min_version: str | None,
+) -> None:
+    """Import package and optionally check version. Raises ImportError if missing."""
+    try:
+        importlib.import_module(import_name)
+    except ImportError as err:
+        raise ImportError(
+            f"The package `{pip_package}` is required for {feature_name} on this "
+            f"platform. Install with: pip install {pip_package}"
+        ) from err
+
+    if min_version is not None:
+        try:
+            installed = version(pip_package)
+            if Version(installed) < Version(min_version):
+                raise ImportError(
+                    f"`{pip_package}>={min_version}` required for {feature_name}; "
+                    f"found {installed}. Upgrade: pip install -U {pip_package}"
+                )
+        except Exception as e:
+            if isinstance(e, ImportError):
+                raise
+            # version() can fail for non-PyPI installs; allow through
+            pass
+
+
+def validate_platform_optional_deps(platform_enum: Any) -> None:
+    """Validate optional deps for current platform.
+
+    Call when platform is first initialized (e.g. from
+    RocmPlatform.import_kernels()). Raises ImportError if dep missing.
+
+    Args:
+        platform_enum: PlatformEnum value (e.g. ROCM). Only validates that
+            platform; others are no-ops.
+    """
+    name = getattr(platform_enum, "name", None) or str(platform_enum)
+    deps = _PLATFORM_OPTIONAL_DEPS.get(name)
+    if not deps:
+        return
+
+    for feature_name, pip_package, import_name, min_version in deps:
+        _check_package(feature_name, pip_package, import_name, min_version)


### PR DESCRIPTION
## [WIP] Fail-fast validation for platform optional deps (e.g. amd-quark on ROCm)

### Summary

Draft implementation for fail-fast validation of optional dependencies required per platform (e.g. `amd-quark` for MXFP4 on ROCm). Previously, missing deps only appeared when users loaded a model; now we fail at startup with a clear error.

### Changes

- **New:** `vllm/utils/optional_deps.py` – generic validator for per-platform optional deps. Only ROCm + amd-quark (mxfp4/mxfp6) is wired so far.
- **ROCm:** `RocmPlatform.import_kernels()` calls `validate_platform_optional_deps(PlatformEnum.ROCM)` so missing `amd-quark` fails when ROCm kernels load instead of when loading an MXFP4 model.

### Design notes

- Validation runs in `import_kernels()`, so it only runs when ROCm is the active platform (no impact on CUDA/CPU).
- Other platforms and features can be added via `_PLATFORM_OPTIONAL_DEPS`.
- Version check uses `importlib.metadata.version(pip_package)`; if it fails (e.g. non-PyPI installs), we allow it and only require the import to succeed.

### Testing

- With `amd-quark` installed: behavior unchanged.
- Without `amd-quark`: using ROCm (e.g. `vllm serve` on AMD) should raise a clear `pip install amd-quark` error.

### Related

Addresses the issue where the ROCm Docker image failed because `amd-quark` was missing from `requirements/rocm.txt` (PR #35658).