### PR TITLE
[Bugfix] Qwen3Coder streaming tool call JSON missing opening brace in arguments

### DIFF
--- a/tests/tool_parsers/test_qwen3coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3coder_tool_parser.py
@@ -1017,18 +1017,38 @@ def test_streaming_opening_brace_always_emitted_first_issue_35266(
         tools=[bash_tool],
     )
 
-    # Reproduce the exact trigger: function header and first <parameter=>
-    # arrive together in the same delta (the condition that skipped '{').
-    # Split </function> and </tool_call> into separate chunks so the parser
-    # gets distinct calls to (a) process the parameter after emitting '{',
-    # and (b) emit '}' once all parameters are done.  This reflects realistic
-    # token-boundary behaviour and is the minimal sequence needed to exercise
-    # the full state machine transition.
+    # To trigger the pre-fix bug we need the opening-brace logic to fire on
+    # a delta whose text contains '<parameter='.  The state machine works as
+    # follows:
+    #
+    #   chunk 1 '<tool_call>'          -> sees tool_call_start_token, sets
+    #                                     is_tool_call_started=True, returns None
+    #   chunk 2 '<function=bash>'      -> accumulates to full header in tool_text,
+    #                                     emits header DeltaMessage, sets
+    #                                     in_function=True, json_started=False
+    #   chunk 3 '<parameter=...>'      -> delta_text contains '<parameter=',
+    #                                     json_started=False  **<-- bug trigger**
+    #                                     old code: gate `parameter_prefix not in
+    #                                     delta_text` → False → skip '{', but
+    #                                     still set json_started=True via fallback
+    #                                     fixed code: unconditionally emit '{'
+    #   chunk 4 '</function>'          -> '{' already emitted; processes parameter,
+    #                                     appends '}' inline (function closed)
+    #   chunk 5 '</tool_call>'         -> state cleanup, returns None
+    #
+    # If '<tool_call>' and '<function=bash>' arrive in the same chunk (as in
+    # the original 4-chunk split), the parser returns None on that chunk
+    # (tool_call_start_token triggers an early return before the header logic),
+    # and the header is only emitted on the *next* chunk whose delta_text is
+    # '<parameter=...>'. The following chunk is then '</function>', which does
+    # NOT contain '<parameter=' -- so the old gate would have passed and the
+    # bug would not have been triggered, making the test a false negative.
     chunks = [
-        "<tool_call><function=bash>",  # header
-        "<parameter=command>echo hi</parameter>",  # first param in same step as header
-        "</function>",  # triggers param emission (not '}' yet)
-        "</tool_call>",  # triggers '}'
+        "<tool_call>",
+        "<function=bash>",
+        "<parameter=command>echo hi</parameter>",  # bug trigger: <parameter= in delta
+        "</function>",
+        "</tool_call>",
     ]
 
     prev = ""

--- a/tests/tool_parsers/test_qwen3coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3coder_tool_parser.py
@@ -976,3 +976,107 @@ fahrenheit
     assert args["city"] == "Dallas"
     assert args["state"] == "TX"
     assert args["unit"] == "fahrenheit"
+
+
+def test_streaming_opening_brace_always_emitted_first_issue_35266(
+    qwen3_tool_parser,
+):
+    """Regression test for #35266.
+
+    When the first <parameter=> tag arrives in the same streaming delta as
+    the function header (i.e. chunk boundary falls inside the function tag),
+    the parser MUST emit '{' as the very first arguments fragment.
+
+    Root cause: the original code gated '{' emission on
+    `self.parameter_prefix not in delta_text`, then unconditionally set
+    json_started=True via a separate fallback even when '{' was never emitted.
+    This caused the first parameter fragment (e.g. '"command": "..."') to be
+    streamed WITHOUT a preceding '{', producing invalid JSON.
+
+    This test calls extract_tool_calls_streaming directly with hand-crafted
+    chunk boundaries (bypassing the tokenizer) to pin the exact failure mode.
+    """
+    bash_tool = ChatCompletionToolsParam(
+        type="function",
+        function={
+            "name": "bash",
+            "description": "Run a bash command",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string"},
+                    "description": {"type": "string"},
+                },
+                "required": ["command"],
+            },
+        },
+    )
+    request = ChatCompletionRequest(
+        model=MODEL,
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[bash_tool],
+    )
+
+    # Reproduce the exact trigger: function header and first <parameter=>
+    # arrive together in the same delta (the condition that skipped '{').
+    # Split </function> and </tool_call> into separate chunks so the parser
+    # gets distinct calls to (a) process the parameter after emitting '{',
+    # and (b) emit '}' once all parameters are done.  This reflects realistic
+    # token-boundary behaviour and is the minimal sequence needed to exercise
+    # the full state machine transition.
+    chunks = [
+        "<tool_call><function=bash>",  # header
+        "<parameter=command>echo hi</parameter>",  # first param in same step as header
+        "</function>",  # triggers param emission (not '}' yet)
+        "</tool_call>",  # triggers '}'
+    ]
+
+    prev = ""
+    all_arg_fragments: list[str] = []
+
+    for chunk in chunks:
+        current = prev + chunk
+        dm = qwen3_tool_parser.extract_tool_calls_streaming(
+            previous_text=prev,
+            current_text=current,
+            delta_text=chunk,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=request,
+        )
+        if (
+            dm
+            and dm.tool_calls
+            and dm.tool_calls[0].function
+            and dm.tool_calls[0].function.arguments is not None
+        ):
+            frag = dm.tool_calls[0].function.arguments
+            if frag:  # skip empty-string header sentinel
+                all_arg_fragments.append(frag)
+        prev = current
+
+    assert all_arg_fragments, "No arguments fragments were emitted at all"
+
+    # Core invariant: '{' must be the very first arguments fragment emitted.
+    assert all_arg_fragments[0] == "{", (
+        f"First arguments fragment must be '{{' but got {all_arg_fragments[0]!r}. "
+        f"Full fragment list: {all_arg_fragments}. "
+        "This means the opening brace was skipped, breaking JSON validity."
+    )
+
+    # The concatenated stream must be parseable as valid JSON.
+    concatenated = "".join(all_arg_fragments)
+    try:
+        parsed = json.loads(concatenated)
+    except json.JSONDecodeError as exc:
+        pytest.fail(
+            f"Concatenated arguments are not valid JSON: {exc!r}\n"
+            f"Value: {concatenated!r}\n"
+            f"Fragments: {all_arg_fragments}"
+        )
+
+    # The parsed result must contain the actual parameter value.
+    assert parsed.get("command") == "echo hi", (
+        f"Expected arguments to contain command='echo hi', got: {parsed}"
+    )

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -511,8 +511,15 @@ class Qwen3CoderToolParser(ToolParser):
 
         # We've sent header, now handle function body
         if self.in_function:
-            # Send opening brace if not sent yet
-            if not self.json_started and self.parameter_prefix not in delta_text:
+            # Always emit the opening brace exactly once, before any parameter
+            # fragments, regardless of what else is in delta_text.
+            # Previously this was gated on `self.parameter_prefix not in
+            # delta_text`, which caused `{` to be skipped when the first
+            # parameter arrived in the same delta as the function header.
+            # A separate fallback then set json_started=True without emitting
+            # `{`, producing invalid JSON (missing opening brace). Fix: make
+            # emission unconditional and remove the fallback. See #35266.
+            if not self.json_started:
                 self.json_started = True
                 return DeltaMessage(
                     tool_calls=[
@@ -523,12 +530,29 @@ class Qwen3CoderToolParser(ToolParser):
                     ]
                 )
 
-            # Make sure json_started is set if we're processing parameters
-            if not self.json_started:
-                self.json_started = True
+            # Look for parameters.
+            # IMPORTANT: parameter extraction must happen BEFORE the
+            # function_end_token check so that parameters accumulated in
+            # tool_text are never skipped when `</function>` arrives in
+            # the same delta as the last parameter.  The closing `}`
+            # is only emitted once every pending parameter has been
+            # streamed out.  See #35266.
+            param_starts = []
+            idx = 0
+            while True:
+                idx = tool_text.find(self.parameter_prefix, idx)
+                if idx == -1:
+                    break
+                param_starts.append(idx)
+                idx += len(self.parameter_prefix)
 
-            # Check for function end in accumulated text
-            if not self.json_closed and self.function_end_token in tool_text:
+            # Check for function end in accumulated text, but only after
+            # all parameters have been emitted as streaming deltas.
+            if (
+                not self.json_closed
+                and self.function_end_token in tool_text
+                and self.param_count >= len(param_starts)
+            ):
                 # Close JSON
                 self.json_closed = True
 
@@ -575,17 +599,6 @@ class Qwen3CoderToolParser(ToolParser):
                 self.accumulated_params = {}
 
                 return result
-
-            # Look for parameters
-            # Find all parameter starts
-            param_starts = []
-            idx = 0
-            while True:
-                idx = tool_text.find(self.parameter_prefix, idx)
-                if idx == -1:
-                    break
-                param_starts.append(idx)
-                idx += len(self.parameter_prefix)
 
             # Check if we should start a new parameter
             if (
@@ -675,6 +688,55 @@ class Qwen3CoderToolParser(ToolParser):
                             )
 
                         self.param_count += 1
+
+                        # If the function is already closed in the accumulated
+                        # text AND this was the last parameter, append `}` now
+                        # so the stream is never left open.  Without this, the
+                        # closing brace would require an additional streaming
+                        # call that may never arrive (e.g. when `</function>`
+                        # and `</tool_call>` arrive in the same final delta or
+                        # when `</tool_call>` is the last token).  See #35266.
+                        if (
+                            self.function_end_token in tool_text
+                            and self.param_count >= len(param_starts)
+                            and not self.json_closed
+                        ):
+                            json_fragment += "}"
+                            self.json_closed = True
+                            # Update prev_tool_call_arr with final arguments
+                            func_start_pos = tool_text.find(
+                                self.tool_call_prefix
+                            ) + len(self.tool_call_prefix)
+                            func_content_end = tool_text.find(
+                                self.function_end_token, func_start_pos
+                            )
+                            if func_content_end != -1:
+                                func_content = tool_text[
+                                    func_start_pos:func_content_end
+                                ]
+                                try:
+                                    parsed_tool = self._parse_xml_function_call(
+                                        func_content,
+                                        self.streaming_request.tools
+                                        if self.streaming_request
+                                        else None,
+                                    )
+                                    if parsed_tool:
+                                        for i, tool in enumerate(
+                                            self.prev_tool_call_arr
+                                        ):
+                                            if (
+                                                tool.get("name")
+                                                == parsed_tool.function.name
+                                            ):
+                                                self.prev_tool_call_arr[i][
+                                                    "arguments"
+                                                ] = parsed_tool.function.arguments
+                                                break
+                                except Exception:
+                                    pass
+                            self.in_function = False
+                            self.accumulated_params = {}
 
                         return DeltaMessage(
                             tool_calls=[

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -239,6 +239,37 @@ class Qwen3CoderToolParser(ToolParser):
                 )
             return param_value
 
+    def _update_final_tool_arguments(self, tool_text: str) -> None:
+        """Parse the fully accumulated tool_text and update prev_tool_call_arr
+        with the final, correctly-typed arguments. Called once when the
+        function body is closed during streaming.
+        """
+        func_start_pos = tool_text.find(self.tool_call_prefix) + len(
+            self.tool_call_prefix
+        )
+        func_content_end = tool_text.find(self.function_end_token, func_start_pos)
+        if func_content_end == -1:
+            return
+        func_content = tool_text[func_start_pos:func_content_end]
+        try:
+            parsed_tool = self._parse_xml_function_call(
+                func_content,
+                self.streaming_request.tools if self.streaming_request else None,
+            )
+            if not parsed_tool:
+                return
+            for i, tool in enumerate(self.prev_tool_call_arr):
+                if tool.get("name") == parsed_tool.function.name:
+                    self.prev_tool_call_arr[i]["arguments"] = (
+                        parsed_tool.function.arguments
+                    )
+                    break
+        except Exception:
+            logger.warning(
+                "Failed to parse and update final arguments during streaming.",
+                exc_info=True,
+            )
+
     def _parse_xml_function_call(
         self, function_call_str: str, tools: list[ChatCompletionToolsParam] | None
     ) -> ToolCall | None:
@@ -556,33 +587,7 @@ class Qwen3CoderToolParser(ToolParser):
                 # Close JSON
                 self.json_closed = True
 
-                # Extract complete tool call to update
-                # prev_tool_call_arr with final arguments
-                # Find the function content
-                func_start = tool_text.find(self.tool_call_prefix) + len(
-                    self.tool_call_prefix
-                )
-                func_content_end = tool_text.find(self.function_end_token, func_start)
-                if func_content_end != -1:
-                    func_content = tool_text[func_start:func_content_end]
-                    # Parse to get the complete arguments
-                    try:
-                        parsed_tool = self._parse_xml_function_call(
-                            func_content,
-                            self.streaming_request.tools
-                            if self.streaming_request
-                            else None,
-                        )
-                        if parsed_tool:
-                            # Update existing entry in
-                            # prev_tool_call_arr with complete args
-                            for i, tool in enumerate(self.prev_tool_call_arr):
-                                if tool.get("name") == parsed_tool.function.name:
-                                    args = parsed_tool.function.arguments
-                                    self.prev_tool_call_arr[i]["arguments"] = args
-                                    break
-                    except Exception:
-                        pass  # Ignore parsing errors during streaming
+                self._update_final_tool_arguments(tool_text)
 
                 result = DeltaMessage(
                     tool_calls=[
@@ -703,38 +708,7 @@ class Qwen3CoderToolParser(ToolParser):
                         ):
                             json_fragment += "}"
                             self.json_closed = True
-                            # Update prev_tool_call_arr with final arguments
-                            func_start_pos = tool_text.find(
-                                self.tool_call_prefix
-                            ) + len(self.tool_call_prefix)
-                            func_content_end = tool_text.find(
-                                self.function_end_token, func_start_pos
-                            )
-                            if func_content_end != -1:
-                                func_content = tool_text[
-                                    func_start_pos:func_content_end
-                                ]
-                                try:
-                                    parsed_tool = self._parse_xml_function_call(
-                                        func_content,
-                                        self.streaming_request.tools
-                                        if self.streaming_request
-                                        else None,
-                                    )
-                                    if parsed_tool:
-                                        for i, tool in enumerate(
-                                            self.prev_tool_call_arr
-                                        ):
-                                            if (
-                                                tool.get("name")
-                                                == parsed_tool.function.name
-                                            ):
-                                                self.prev_tool_call_arr[i][
-                                                    "arguments"
-                                                ] = parsed_tool.function.arguments
-                                                break
-                                except Exception:
-                                    pass
+                            self._update_final_tool_arguments(tool_text)
                             self.in_function = False
                             self.accumulated_params = {}
 


### PR DESCRIPTION
Fixes #35266

## Problem

When streaming tool calls with `Qwen3CoderToolParser`, the `function.arguments` field was sometimes missing the opening `{`, producing invalid JSON like:
"command": "echo hi"}
instead of:
{"command": "echo hi"}

This caused `json.loads(arguments)` to fail in any client that parses arguments on completion (opencode, claudecode, etc.).

## Root Cause

Two bugs in `extract_tool_calls_streaming`:

1. `{` emission was gated on `self.parameter_prefix not in delta_text`, so when the first `<parameter=>` tag arrived in the same delta as the function header (a valid chunk boundary), the opening brace was silently skipped.
2. A separate fallback immediately after set `json_started = True` regardless, so the state machine believed JSON had started even though `{` was never emitted.
3. When `</function>` arrived after a parameter was processed, the closing `}` had no subsequent call to live in, leaving the stream permanently unclosed.

## Fix

- Remove the `parameter_prefix not in delta_text` gate `{` is now always emitted once, unconditionally, on first entry into function body.
- Remove the premature `json_started = True` fallback.
- When the last parameter is processed and `</function>` is already present in `tool_text`, append `}` to the same delta fragment instead of deferring it to a call that may never come.

## Testing

Added a regression test in `tests/tool_parsers/test_qwen3coder_tool_parser.py` that directly calls `extract_tool_calls_streaming` with hand-crafted chunk boundaries reproducing the exact failure mode (function header and first `<parameter=>` in the same delta). No GPU or model download required.

Verified locally with a mock-tokenizer script against the fixed parser, both the bug-trigger split and normal split produce valid JSON.