### PR TITLE
[Bugfix] fix kv cache fp8 crash on sm<89

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -474,6 +474,12 @@ class CudaPlatformBase(Platform):
         return cls.has_device_capability(89)
 
     @classmethod
+    def fp8_dtype(cls) -> torch.dtype:
+        if not cls.has_device_capability(89):
+            return torch.float8_e5m2
+        return torch.float8_e4m3fn
+
+    @classmethod
     def use_custom_allreduce(cls) -> bool:
         return True
 


### PR DESCRIPTION

## Purpose

Setting `--kv-cache-dtype fp8` causes a crash on CUDA devices with compute capability below 8.9. This PR resolves the issue.

## Test Plan

Based on v0.16.0 with this patch applied, it now responds correctly on NVIDIA V100.

## Test Result

### Before
```
user@user-DGX-Station:~$ sudo docker run \
    -i -t --rm \
    -v ~/.cache:/root/.cache \
    --gpus=all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 \
    -p 8000:8000 \
    vllm/vllm-openai:v0.16.0 \
    --model unsloth/Meta-Llama-3.1-8B-Instruct \
    --max-model-len 4096 \
    --kv-cache-dtype fp8
WARNING 03-02 07:01:27 [argparse_utils.py:195] With `vllm serve`, you should provide the model as a positional argument or in a config file instead of via the `--model` option. The `--model` option will be removed in v0.13.
(APIServer pid=1) INFO 03-02 07:01:27 [utils.py:287]
(APIServer pid=1) INFO 03-02 07:01:27 [utils.py:287]        █     █     █▄   ▄█
(APIServer pid=1) INFO 03-02 07:01:27 [utils.py:287]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.16.0
(APIServer pid=1) INFO 03-02 07:01:27 [utils.py:287]   █▄█▀ █     █     █     █  model   unsloth/Meta-Llama-3.1-8B-Instruct
(APIServer pid=1) INFO 03-02 07:01:27 [utils.py:287]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=1) INFO 03-02 07:01:27 [utils.py:287]
(APIServer pid=1) INFO 03-02 07:01:27 [utils.py:223] non-default args: {'model_tag': 'unsloth/Meta-Llama-3.1-8B-Instruct', 'api_server_count': 1, 'model': 'unsloth/Meta-Llama-3.1-8B-Instruct', 'max_model_len': 4096, 'kv_cache_dtype': 'fp8'}
(APIServer pid=1) INFO 03-02 07:01:29 [model.py:529] Resolved architecture: LlamaForCausalLM
(APIServer pid=1) WARNING 03-02 07:01:29 [model.py:1821] Your device 'Tesla V100-DGXS-32GB' (with compute capability 7.0) doesn't support torch.bfloat16. Falling back to torch.float16 for compatibility.
(APIServer pid=1) WARNING 03-02 07:01:29 [model.py:1874] Casting torch.bfloat16 to torch.float16.
(APIServer pid=1) INFO 03-02 07:01:29 [model.py:1549] Using max model len 4096
(APIServer pid=1) INFO 03-02 07:01:29 [cache.py:214] Using fp8 data type to store kv cache. It reduces the GPU memory footprint and boosts the performance. Meanwhile, it may cause accuracy drop without a proper scaling factor.
(APIServer pid=1) INFO 03-02 07:01:29 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=2048.
(APIServer pid=1) INFO 03-02 07:01:29 [vllm.py:689] Asynchronous scheduling is enabled.
(EngineCore_DP0 pid=93) INFO 03-02 07:01:39 [core.py:97] Initializing a V1 LLM engine (v0.16.0) with config: model='unsloth/Meta-Llama-3.1-8B-Instruct', speculative_config=None, tokenizer='unsloth/Meta-Llama-3.1-8B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=fp8, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=unsloth/Meta-Llama-3.1-8B-Instruct, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=93) INFO 03-02 07:01:40 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.17.0.6:55053 backend=nccl
(EngineCore_DP0 pid=93) INFO 03-02 07:01:40 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A
(EngineCore_DP0 pid=93) INFO 03-02 07:01:40 [gpu_model_runner.py:4124] Starting to load model unsloth/Meta-Llama-3.1-8B-Instruct...
(EngineCore_DP0 pid=93) ERROR 03-02 07:01:41 [fa_utils.py:104] Cannot use FA version 2 is not supported due to FA2 is only supported on devices with compute capability >= 8
(EngineCore_DP0 pid=93) ERROR 03-02 07:01:41 [fa_utils.py:104] Cannot use FA version 2 is not supported due to FA2 is only supported on devices with compute capability >= 8
(EngineCore_DP0 pid=93) INFO 03-02 07:01:41 [cuda.py:367] Using TRITON_ATTN attention backend out of potential backends: ['TRITON_ATTN'].
Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:01<00:03,  1.17s/it]
Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:02<00:02,  1.30s/it]
Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:03<00:01,  1.33s/it]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:04<00:00,  1.05it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:04<00:00,  1.08s/it]
(EngineCore_DP0 pid=93)
(EngineCore_DP0 pid=93) INFO 03-02 07:01:47 [default_loader.py:293] Loading weights took 4.33 seconds
(EngineCore_DP0 pid=93) INFO 03-02 07:01:48 [gpu_model_runner.py:4221] Model loading took 14.99 GiB memory and 6.718394 seconds
(EngineCore_DP0 pid=93) INFO 03-02 07:01:57 [backends.py:916] Using cache directory: /root/.cache/vllm/torch_compile_cache/4af4c6b044/rank_0_0/backbone for vLLM's torch.compile
(EngineCore_DP0 pid=93) INFO 03-02 07:01:57 [backends.py:976] Dynamo bytecode transform time: 8.83 s
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780] Triton compilation failed: Placeholder.DESCRIPTIVE_NAME
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780] def triton_(in_ptr0, in_ptr1, in_ptr2, in_ptr3, out_ptr1, xnumel, XBLOCK : tl.constexpr):
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     xoffset = tl.program_id(0) * XBLOCK
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     xindex = xoffset + tl.arange(0, XBLOCK)[:]
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     xmask = tl.full([XBLOCK], True, tl.int1)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     x0 = (xindex % 128)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     x1 = ((xindex // 128) % 32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     x2 = xindex // 4096
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     x3 = xindex
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp40 = tl.load(in_ptr3 + (0))
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp41 = tl.broadcast_to(tmp40, [XBLOCK])
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp0 = x0
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp1 = tl.full([1], 0, tl.int64)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp2 = tmp0 >= tmp1
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp3 = tl.full([1], 64, tl.int64)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp4 = tmp0 < tmp3
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp5 = tl.load(in_ptr0 + (128*x1 + 6144*x2 + (x0)), tmp4, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp6 = tl.load(in_ptr1 + (x2), tmp4, eviction_policy='evict_last', other=0.0)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp7 = tl.full([XBLOCK], 131072, tl.int32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp8 = tmp6 + tmp7
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp9 = tmp6 < 0
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp10 = tl.where(tmp9, tmp8, tmp6)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tl.device_assert(((0 <= tl.broadcast_to(tmp10, [XBLOCK])) & (tl.broadcast_to(tmp10, [XBLOCK]) < 131072)) | ~(tmp4), "index out of bounds: 0 <= tl.broadcast_to(tmp10, [XBLOCK]) < 131072")
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp12 = tl.load(in_ptr2 + (128*tmp10 + (x0)), tmp4, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp13 = tmp5 * tmp12
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp14 = tl.load(in_ptr0 + (64 + 128*x1 + 6144*x2 + (x0)), tmp4, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp15 = tl.load(in_ptr2 + (64 + 128*tmp10 + (x0)), tmp4, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp16 = tmp14 * tmp15
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp17 = tmp13 - tmp16
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp18 = tl.full(tmp17.shape, 0.0, tmp17.dtype)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp19 = tl.where(tmp4, tmp17, tmp18)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp20 = tmp0 >= tmp3
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp21 = tl.full([1], 128, tl.int64)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp22 = tmp0 < tmp21
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp23 = tl.load(in_ptr0 + (64 + 128*x1 + 6144*x2 + ((-64) + x0)), tmp20, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp24 = tl.load(in_ptr1 + (x2), tmp20, eviction_policy='evict_last', other=0.0)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp25 = tl.full([XBLOCK], 131072, tl.int32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp26 = tmp24 + tmp25
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp27 = tmp24 < 0
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp28 = tl.where(tmp27, tmp26, tmp24)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tl.device_assert(((0 <= tl.broadcast_to(tmp28, [XBLOCK])) & (tl.broadcast_to(tmp28, [XBLOCK]) < 131072)) | ~(tmp20), "index out of bounds: 0 <= tl.broadcast_to(tmp28, [XBLOCK]) < 131072")
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp30 = tl.load(in_ptr2 + (128*tmp28 + ((-64) + x0)), tmp20, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp31 = tmp23 * tmp30
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp32 = tl.load(in_ptr0 + (128*x1 + 6144*x2 + ((-64) + x0)), tmp20, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp33 = tl.load(in_ptr2 + (64 + 128*tmp28 + ((-64) + x0)), tmp20, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp34 = tmp32 * tmp33
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp35 = tmp31 + tmp34
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp36 = tl.full(tmp35.shape, 0.0, tmp35.dtype)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp37 = tl.where(tmp20, tmp35, tmp36)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp38 = tl.where(tmp4, tmp19, tmp37)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp39 = tmp38.to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp42 = tl.full([1], 1, tl.int32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp43 = (tmp42 / tmp41)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp44 = tmp39 * tmp43
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp45 = -448.0
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp46 = triton_helpers.maximum(tmp44, tmp45)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp47 = 448.0
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp48 = triton_helpers.minimum(tmp46, tmp47)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp49 = tmp48.to(tl.float8e4nv)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tl.store(out_ptr1 + (x3), tmp49, None)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780] metadata: {'signature': {'in_ptr0': '*fp16', 'in_ptr1': '*i64', 'in_ptr2': '*fp16', 'in_ptr3': '*fp32', 'out_ptr1': '*fp8e4nv', 'xnumel': 'i32', 'XBLOCK': 'constexpr'}, 'device': 0, 'constants': {'XBLOCK': 1024}, 'configs': [{(0,): [['tt.divisibility', 16]], (1,): [['tt.divisibility', 16]], (2,): [['tt.divisibility', 16]], (3,): [['tt.divisibility', 16]], (4,): [['tt.divisibility', 16]], (5,): [['tt.divisibility', 16]]}], 'device_type': 'cuda', 'num_warps': 4, 'num_stages': 1, 'debug': True, 'cc': 70}
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780] Traceback (most recent call last):
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/runtime/triton_heuristics.py", line 778, in _precompile_config
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     binary = triton.compile(*compile_args, **compile_kwargs)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]   File "/usr/local/lib/python3.12/dist-packages/triton/compiler/compiler.py", line 300, in compile
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     module = src.make_ir(target, options, codegen_fns, module_map, context)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]   File "/usr/local/lib/python3.12/dist-packages/triton/compiler/compiler.py", line 80, in make_ir
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]     return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780] triton.compiler.errors.CompilationError: at 1:0:
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780] def triton_(in_ptr0, in_ptr1, in_ptr2, in_ptr3, out_ptr1, xnumel, XBLOCK : tl.constexpr):
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780] ^
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.240000 93 torch/_inductor/runtime/triton_heuristics.py:780] ValueError("type fp8e4nv not supported in this architecture. The supported fp8 dtypes are ('fp8e4b15', 'fp8e5')")
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780] Triton compilation failed: triton_poi_fused__to_copy_add_cat_clamp_index_select_mul_reciprocal_split_split_with_sizes_sub_unsqueeze_view_2
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780] def triton_poi_fused__to_copy_add_cat_clamp_index_select_mul_reciprocal_split_split_with_sizes_sub_unsqueeze_view_2(in_ptr0, in_ptr1, in_ptr2, in_ptr3, out_ptr1, xnumel, XBLOCK : tl.constexpr):
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     xoffset = tl.program_id(0) * XBLOCK
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     xindex = xoffset + tl.arange(0, XBLOCK)[:]
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     xmask = tl.full([XBLOCK], True, tl.int1)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     x0 = (xindex % 128)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     x1 = ((xindex // 128) % 32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     x2 = xindex // 4096
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     x3 = xindex
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp40 = tl.load(in_ptr3 + (0))
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp41 = tl.broadcast_to(tmp40, [XBLOCK])
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp0 = x0
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp1 = tl.full([1], 0, tl.int64)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp2 = tmp0 >= tmp1
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp3 = tl.full([1], 64, tl.int64)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp4 = tmp0 < tmp3
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp5 = tl.load(in_ptr0 + (128*x1 + 6144*x2 + (x0)), tmp4, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp6 = tl.load(in_ptr1 + (x2), tmp4, eviction_policy='evict_last', other=0.0)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp7 = tl.full([XBLOCK], 131072, tl.int32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp8 = tmp6 + tmp7
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp9 = tmp6 < 0
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp10 = tl.where(tmp9, tmp8, tmp6)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tl.device_assert(((0 <= tl.broadcast_to(tmp10, [XBLOCK])) & (tl.broadcast_to(tmp10, [XBLOCK]) < 131072)) | ~(tmp4), "index out of bounds: 0 <= tl.broadcast_to(tmp10, [XBLOCK]) < 131072")
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp12 = tl.load(in_ptr2 + (128*tmp10 + (x0)), tmp4, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp13 = tmp5 * tmp12
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp14 = tl.load(in_ptr0 + (64 + 128*x1 + 6144*x2 + (x0)), tmp4, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp15 = tl.load(in_ptr2 + (64 + 128*tmp10 + (x0)), tmp4, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp16 = tmp14 * tmp15
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp17 = tmp13 - tmp16
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp18 = tl.full(tmp17.shape, 0.0, tmp17.dtype)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp19 = tl.where(tmp4, tmp17, tmp18)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp20 = tmp0 >= tmp3
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp21 = tl.full([1], 128, tl.int64)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp22 = tmp0 < tmp21
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp23 = tl.load(in_ptr0 + (64 + 128*x1 + 6144*x2 + ((-64) + x0)), tmp20, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp24 = tl.load(in_ptr1 + (x2), tmp20, eviction_policy='evict_last', other=0.0)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp25 = tl.full([XBLOCK], 131072, tl.int32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp26 = tmp24 + tmp25
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp27 = tmp24 < 0
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp28 = tl.where(tmp27, tmp26, tmp24)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tl.device_assert(((0 <= tl.broadcast_to(tmp28, [XBLOCK])) & (tl.broadcast_to(tmp28, [XBLOCK]) < 131072)) | ~(tmp20), "index out of bounds: 0 <= tl.broadcast_to(tmp28, [XBLOCK]) < 131072")
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp30 = tl.load(in_ptr2 + (128*tmp28 + ((-64) + x0)), tmp20, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp31 = tmp23 * tmp30
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp32 = tl.load(in_ptr0 + (128*x1 + 6144*x2 + ((-64) + x0)), tmp20, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp33 = tl.load(in_ptr2 + (64 + 128*tmp28 + ((-64) + x0)), tmp20, eviction_policy='evict_last', other=0.0).to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp34 = tmp32 * tmp33
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp35 = tmp31 + tmp34
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp36 = tl.full(tmp35.shape, 0.0, tmp35.dtype)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp37 = tl.where(tmp20, tmp35, tmp36)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp38 = tl.where(tmp4, tmp19, tmp37)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp39 = tmp38.to(tl.float32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp42 = tl.full([1], 1, tl.int32)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp43 = (tmp42 / tmp41)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp44 = tmp39 * tmp43
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp45 = -448.0
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp46 = triton_helpers.maximum(tmp44, tmp45)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp47 = 448.0
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp48 = triton_helpers.minimum(tmp46, tmp47)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tmp49 = tmp48.to(tl.float8e4nv)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     tl.store(out_ptr1 + (x3), tmp49, None)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780] metadata: {'signature': {'in_ptr0': '*fp16', 'in_ptr1': '*i64', 'in_ptr2': '*fp16', 'in_ptr3': '*fp32', 'out_ptr1': '*fp8e4nv', 'xnumel': 'i32', 'XBLOCK': 'constexpr'}, 'device': 0, 'constants': {'XBLOCK': 1024}, 'configs': [{(0,): [['tt.divisibility', 16]], (1,): [['tt.divisibility', 16]], (2,): [['tt.divisibility', 16]], (3,): [['tt.divisibility', 16]], (4,): [['tt.divisibility', 16]], (5,): [['tt.divisibility', 16]]}], 'device_type': 'cuda', 'num_warps': 4, 'num_stages': 1, 'debug': True, 'cc': 70}
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780] Traceback (most recent call last):
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/runtime/triton_heuristics.py", line 778, in _precompile_config
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     binary = triton.compile(*compile_args, **compile_kwargs)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]   File "/usr/local/lib/python3.12/dist-packages/triton/compiler/compiler.py", line 300, in compile
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     module = src.make_ir(target, options, codegen_fns, module_map, context)
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]   File "/usr/local/lib/python3.12/dist-packages/triton/compiler/compiler.py", line 80, in make_ir
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]     return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780] triton.compiler.errors.CompilationError: at 1:0:
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780] def triton_poi_fused__to_copy_add_cat_clamp_index_select_mul_reciprocal_split_split_with_sizes_sub_unsqueeze_view_2(in_ptr0, in_ptr1, in_ptr2, in_ptr3, out_ptr1, xnumel, XBLOCK : tl.constexpr):
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780] ^
(EngineCore_DP0 pid=93) [rank0]:E0302 07:02:06.918000 93 torch/_inductor/runtime/triton_heuristics.py:780] ValueError("type fp8e4nv not supported in this architecture. The supported fp8 dtypes are ('fp8e4b15', 'fp8e5')")
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006] EngineCore failed to start.
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006] Traceback (most recent call last):
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 996, in run_engine_core
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 740, in __init__
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     super().__init__(
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 113, in __init__
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     num_gpu_blocks, num_cpu_blocks, kv_cache_config = self._initialize_kv_caches(
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/engine/core.py", line 248, in _initialize_kv_caches
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     available_gpu_memory = self.model_executor.determine_available_memory()
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/abstract.py", line 128, in determine_available_memory
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     return self.collective_rpc("determine_available_memory")
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/executor/uniproc_executor.py", line 75, in collective_rpc
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     result = run_method(self.driver_worker, method, args, kwargs)
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/serial_utils.py", line 459, in run_method
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     return func(*args, **kwargs)
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     return func(*args, **kwargs)
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_worker.py", line 339, in determine_available_memory
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     self.model_runner.profile_run()
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 5168, in profile_run
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     hidden_states, last_hidden_states = self._dummy_run(
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]                                         ^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     return func(*args, **kwargs)
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 4866, in _dummy_run
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     outputs = self.model(
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]               ^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/cuda_graph.py", line 222, in __call__
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     return self.runnable(*args, **kwargs)
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     return self._call_impl(*args, **kwargs)
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     return forward_call(*args, **kwargs)
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/llama.py", line 589, in forward
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     model_output = self.model(
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]                    ^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/decorators.py", line 559, in __call__
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     output = TorchCompileWithNoGuardsWrapper.__call__(self, *args, **kwargs)  # type: ignore[arg-type]
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/wrapper.py", line 220, in __call__
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     return self._call_with_optional_nvtx_range(
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/vllm/compilation/wrapper.py", line 119, in _call_with_optional_nvtx_range
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     return callable_fn(*args, **kwargs)
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 845, in compile_wrapper
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     raise e.remove_dynamo_frames() from None  # see TORCHDYNAMO_VERBOSE=1
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 990, in _compile_fx_inner
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     raise InductorError(e, currentframe()).with_traceback(
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 974, in _compile_fx_inner
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     mb_compiled_graph = fx_codegen_and_compile(
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]                         ^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 1695, in fx_codegen_and_compile
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     return scheme.codegen_and_compile(gm, example_inputs, inputs_to_check, graph_kwargs)
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/compile_fx.py", line 1505, in codegen_and_compile
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     compiled_module = graph.compile_to_module()
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]                       ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/graph.py", line 2319, in compile_to_module
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     return self._compile_to_module()
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/graph.py", line 2325, in _compile_to_module
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     self.codegen_with_cpp_wrapper() if self.cpp_wrapper else self.codegen()
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]                                                              ^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/graph.py", line 2271, in codegen
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     result = self.wrapper_code.generate(self.is_inference)
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/codegen/wrapper.py", line 1552, in generate
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     return self._generate(is_inference)
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/codegen/wrapper.py", line 1615, in _generate
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     self.generate_and_run_autotune_block()
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/codegen/wrapper.py", line 1695, in generate_and_run_autotune_block
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006]     raise RuntimeError(f"Failed to run autotuning code block: {e}") from e
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006] torch._inductor.exc.InductorError: RuntimeError: Failed to run autotuning code block: at 1:0:
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006] def triton_poi_fused__to_copy_add_cat_clamp_index_select_mul_reciprocal_split_split_with_sizes_sub_unsqueeze_view_2(in_ptr0, in_ptr1, in_ptr2, in_ptr3, out_ptr1, xnumel, XBLOCK : tl.constexpr):
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006] ^
(EngineCore_DP0 pid=93) ERROR 03-02 07:02:06 [core.py:1006] ValueError("type fp8e4nv not supported in this architecture. The supported fp8 dtypes are ('fp8e4b15', 'fp8e5')")

...
truncated: PR length cannot exceed 65,535 characters.
...

```

### After
```
vllm serve --model unsloth/Meta-Llama-3.1-8B-Instruct \
    --max-model-len 4096 \
    --kv-cache-dtype fp8
WARNING 03-02 07:14:32 [argparse_utils.py:195] With `vllm serve`, you should provide the model as a positional argument or in a config file instead of via the `--model` option. The `--model` option will be removed in v0.13.
(APIServer pid=485) INFO 03-02 07:14:32 [utils.py:287]
(APIServer pid=485) INFO 03-02 07:14:32 [utils.py:287]        █     █     █▄   ▄█
(APIServer pid=485) INFO 03-02 07:14:32 [utils.py:287]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.16.0
(APIServer pid=485) INFO 03-02 07:14:32 [utils.py:287]   █▄█▀ █     █     █     █  model   unsloth/Meta-Llama-3.1-8B-Instruct
(APIServer pid=485) INFO 03-02 07:14:32 [utils.py:287]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=485) INFO 03-02 07:14:32 [utils.py:287]
(APIServer pid=485) INFO 03-02 07:14:32 [utils.py:223] non-default args: {'model_tag': 'unsloth/Meta-Llama-3.1-8B-Instruct', 'api_server_count': 1, 'model': 'unsloth/Meta-Llama-3.1-8B-Instruct', 'max_model_len': 4096, 'kv_cache_dtype': 'fp8'}
(APIServer pid=485) INFO 03-02 07:14:34 [model.py:529] Resolved architecture: LlamaForCausalLM
(APIServer pid=485) WARNING 03-02 07:14:34 [model.py:1821] Your device 'Tesla V100-DGXS-32GB' (with compute capability 7.0) doesn't support torch.bfloat16. Falling back to torch.float16 for compatibility.
(APIServer pid=485) WARNING 03-02 07:14:34 [model.py:1874] Casting torch.bfloat16 to torch.float16.
(APIServer pid=485) INFO 03-02 07:14:34 [model.py:1549] Using max model len 4096
(APIServer pid=485) INFO 03-02 07:14:34 [cache.py:214] Using fp8 data type to store kv cache. It reduces the GPU memory footprint and boosts the performance. Meanwhile, it may cause accuracy drop without a proper scaling factor.
(APIServer pid=485) INFO 03-02 07:14:34 [scheduler.py:224] Chunked prefill is enabled with max_num_batched_tokens=2048.
(APIServer pid=485) INFO 03-02 07:14:34 [vllm.py:689] Asynchronous scheduling is enabled.
(EngineCore_DP0 pid=572) INFO 03-02 07:14:44 [core.py:97] Initializing a V1 LLM engine (v0.16.0) with config: model='unsloth/Meta-Llama-3.1-8B-Instruct', speculative_config=None, tokenizer='unsloth/Meta-Llama-3.1-8B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=fp8, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=unsloth/Meta-Llama-3.1-8B-Instruct, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore_DP0 pid=572) INFO 03-02 07:14:45 [parallel_state.py:1234] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.17.0.6:33437 backend=nccl
(EngineCore_DP0 pid=572) INFO 03-02 07:14:45 [parallel_state.py:1445] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A
(EngineCore_DP0 pid=572) INFO 03-02 07:14:46 [gpu_model_runner.py:4124] Starting to load model unsloth/Meta-Llama-3.1-8B-Instruct...
(EngineCore_DP0 pid=572) ERROR 03-02 07:14:46 [fa_utils.py:104] Cannot use FA version 2 is not supported due to FA2 is only supported on devices with compute capability >= 8
(EngineCore_DP0 pid=572) ERROR 03-02 07:14:46 [fa_utils.py:104] Cannot use FA version 2 is not supported due to FA2 is only supported on devices with compute capability >= 8
(EngineCore_DP0 pid=572) INFO 03-02 07:14:46 [cuda.py:367] Using TRITON_ATTN attention backend out of potential backends: ['TRITON_ATTN'].
Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:01<00:03,  1.11s/it]
Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:02<00:02,  1.16s/it]
Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:03<00:01,  1.20s/it]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:03<00:00,  1.14it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:03<00:00,  1.02it/s]
(EngineCore_DP0 pid=572)
(EngineCore_DP0 pid=572) INFO 03-02 07:14:52 [default_loader.py:293] Loading weights took 3.95 seconds
(EngineCore_DP0 pid=572) INFO 03-02 07:14:53 [gpu_model_runner.py:4221] Model loading took 14.99 GiB memory and 6.329136 seconds
(EngineCore_DP0 pid=572) INFO 03-02 07:15:02 [backends.py:916] Using cache directory: /root/.cache/vllm/torch_compile_cache/4af4c6b044/rank_0_0/backbone for vLLM's torch.compile
(EngineCore_DP0 pid=572) INFO 03-02 07:15:02 [backends.py:976] Dynamo bytecode transform time: 8.89 s
(EngineCore_DP0 pid=572) INFO 03-02 07:15:13 [backends.py:351] Cache the graph of compile range (1, 2048) for later use
(EngineCore_DP0 pid=572) INFO 03-02 07:15:18 [backends.py:368] Compiling a graph for compile range (1, 2048) takes 9.67 s
(EngineCore_DP0 pid=572) INFO 03-02 07:15:18 [monitor.py:34] torch.compile takes 18.56 s in total
(EngineCore_DP0 pid=572) INFO 03-02 07:15:19 [gpu_worker.py:373] Available KV cache memory: 12.35 GiB
(EngineCore_DP0 pid=572) INFO 03-02 07:15:19 [kv_cache_utils.py:1307] GPU KV cache size: 202,288 tokens
(EngineCore_DP0 pid=572) INFO 03-02 07:15:19 [kv_cache_utils.py:1312] Maximum concurrency for 4,096 tokens per request: 49.39x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████████████████████████████████████████████████████████████████████████████| 51/51 [00:05<00:00,  9.18it/s]
Capturing CUDA graphs (decode, FULL): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 35/35 [00:09<00:00,  3.52it/s]
(EngineCore_DP0 pid=572) INFO 03-02 07:15:35 [gpu_model_runner.py:5246] Graph capturing finished in 16 secs, took 0.53 GiB
(EngineCore_DP0 pid=572) INFO 03-02 07:15:35 [core.py:278] init engine (profile, create kv cache, warmup model) took 42.35 seconds
(EngineCore_DP0 pid=572) INFO 03-02 07:15:37 [vllm.py:689] Asynchronous scheduling is enabled.
(APIServer pid=485) INFO 03-02 07:15:37 [api_server.py:481] Supported tasks: ['generate']
(APIServer pid=485) WARNING 03-02 07:15:38 [model.py:1350] Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'temperature': 0.6, 'top_p': 0.9}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(APIServer pid=485) INFO 03-02 07:15:38 [serving.py:188] Warming up chat template processing...
(APIServer pid=485) INFO 03-02 07:15:41 [hf.py:318] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=485) INFO 03-02 07:15:41 [serving.py:213] Chat template warmup completed in 2707.3ms
(APIServer pid=485) INFO 03-02 07:15:41 [api_server.py:486] Starting vLLM API server 0 on http://0.0.0.0:8000
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:38] Available routes are:
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /openapi.json, Methods: HEAD, GET
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /docs, Methods: HEAD, GET
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /docs/oauth2-redirect, Methods: HEAD, GET
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /redoc, Methods: HEAD, GET
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /load, Methods: GET
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /version, Methods: GET
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /tokenize, Methods: POST
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /detokenize, Methods: POST
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /inference/v1/generate, Methods: POST
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /metrics, Methods: GET
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /health, Methods: GET
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /v1/models, Methods: GET
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /ping, Methods: GET
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /ping, Methods: POST
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /invocations, Methods: POST
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /v1/chat/completions, Methods: POST
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /v1/responses, Methods: POST
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /v1/completions, Methods: POST
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /v1/completions/render, Methods: POST
(APIServer pid=485) INFO 03-02 07:15:41 [launcher.py:47] Route: /v1/messages, Methods: POST
(APIServer pid=485) INFO:     Started server process [485]
(APIServer pid=485) INFO:     Waiting for application startup.
(APIServer pid=485) INFO:     Application startup complete.

curl --location 'http://localhost:8000/v1/chat/completions' \
--header 'Content-Type: application/json' \
--data '{
    "model": "",
    "messages": [{"role": "user", "content": "hi"}]
}'

{
    "id": "chatcmpl-93f036b921f9505d",
    "object": "chat.completion",
    "created": 1772436146,
    "model": "unsloth/Meta-Llama-3.1-8B-Instruct",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": "How can I assist you today?",
                "refusal": null,
                "annotations": null,
                "audio": null,
                "function_call": null,
                "tool_calls": [],
                "reasoning": null
            },
            "logprobs": null,
            "finish_reason": "stop",
            "stop_reason": null,
            "token_ids": null
        }
    ],
    "service_tier": null,
    "system_fingerprint": null,
    "usage": {
        "prompt_tokens": 36,
        "total_tokens": 44,
        "completion_tokens": 8,
        "prompt_tokens_details": null
    },
    "prompt_logprobs": null,
    "prompt_token_ids": null,
    "kv_transfer_params": null
}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

