### PR TITLE
[Bugfix] Fix missing sequence_lengths in qwen3_omni_moe_thinker

### DIFF
--- a/vllm/model_executor/models/qwen3_omni_moe_thinker.py
+++ b/vllm/model_executor/models/qwen3_omni_moe_thinker.py
@@ -648,6 +648,7 @@ class Qwen3_VisionBlock(nn.Module):
         rotary_pos_emb_cos: torch.Tensor,
         rotary_pos_emb_sin: torch.Tensor,
         max_seqlen: torch.Tensor | None,  # Only used for Flash Attention
+        sequence_lengths: torch.Tensor | None,  # Only used for FlashInfer CuDNN backend
     ) -> torch.Tensor:
         x = x + self.attn(
             self.norm1(x),
@@ -655,6 +656,7 @@ class Qwen3_VisionBlock(nn.Module):
             rotary_pos_emb_cos=rotary_pos_emb_cos,
             rotary_pos_emb_sin=rotary_pos_emb_sin,
             max_seqlen=max_seqlen,
+            sequence_lengths=sequence_lengths,
         )
 
         x = x + self.mlp(self.norm2(x))
@@ -975,6 +977,20 @@ class Qwen3Omni_VisionTransformer(nn.Module):
         rotary_pos_emb_sin = rotary_pos_emb_sin.to(hidden_states.device)
         max_seqlen = self.compute_attn_mask_seqlen(cu_seqlens)
 
+        # Recompute cu_seqlens in numpy from grid_thw to avoid GPU->CPU sync
+        grid_thw_np = grid_thw.cpu().numpy()
+        cu_seqlens_np = np.repeat(
+            grid_thw_np[:, 1] * grid_thw_np[:, 2], grid_thw_np[:, 0]
+        ).cumsum(axis=0, dtype=np.int32)
+        cu_seqlens_np = np.concatenate([np.zeros(1, dtype=np.int32), cu_seqlens_np])
+        sequence_lengths = MMEncoderAttention.maybe_compute_sequence_lengths(
+            self.attn_backend, cu_seqlens_np
+        )
+        if sequence_lengths is not None:
+            sequence_lengths = torch.from_numpy(sequence_lengths).to(
+                self.device, non_blocking=True
+            )
+
         hidden_states_list = []
         deepstack_visual_indexes = self.deepstack_visual_indexes
 
@@ -985,6 +1001,7 @@ class Qwen3Omni_VisionTransformer(nn.Module):
                 rotary_pos_emb_cos=rotary_pos_emb_cos,
                 rotary_pos_emb_sin=rotary_pos_emb_sin,
                 max_seqlen=max_seqlen,
+                sequence_lengths=sequence_lengths,
             )
             if (
                 deepstack_visual_indexes is not None


### PR DESCRIPTION
## Purpose

PR #34580 added a `sequence_lengths` parameter to
`Qwen2_5_VisionAttention.forward()` for the FlashInfer cuDNN backend and updated callers in `qwen3_vl.py` and `qwen2_5_vl.py`, but missed updating `qwen3_omni_moe_thinker.py`. This causes a TypeError crash when loading any Qwen3-Omni model:

```
TypeError: Qwen2_5_VisionAttention.forward() missing 1 required
positional argument: 'sequence_lengths'
```

Fix:
- Add `sequence_lengths` parameter to `Qwen3OmniMoeThinkerVisionBlock.forward()` and pass it through to `self.attn()`
- Compute `sequence_lengths` in the encoder loop using `MMEncoderAttention.maybe_compute_sequence_lengths()`, mirroring the pattern in `qwen3_vl.py`
- Build `cu_seqlens_np` from `grid_thw` directly in numpy to avoid a GPU->CPU sync on the CUDA `cu_seqlens` tensor

## Test Plan
e2e run

## Test Result

h100
```
[2026-03-02 01:44:49,560] [rank 0] [INFO] Evaluation results on task mmmu_thinking_v0: mmmu_accuracy: 0.73
Peak TPGS: 616.0 (adjust if server does not use all allocated GPUs)
Peak Prefill TPGS: 17036.0 (prefill tokens per GPU per second)
Ran 21/21 requests in 294.48s
Success Rate: 100.00%
Peak QPS: 0.27
Server Avg TTFT: 285359ms
Server P50 TTFT: 285359ms
Server P99 TTFT: 285359ms
Server Avg TTIT: 35ms
Server P50 TTIT: 33ms
Server P99 TTIT: 35ms
Server Output Tokens Per Second: 71
Avg Prefill Len: 18979
P50 Prefill Len: 18979
P99 Prefill Len: 19003
Avg Decode Len: 2142
P50 Decode Len: 2142
P99 Decode Len: 2786
```
gb200
```
[2026-03-02 02:56:03,531] [rank 0] [INFO] Evaluation results on task mmmu_thinking_v0: mmmu_accuracy: 0.67625
Peak TPGS: 1954.0 (adjust if server does not use all allocated GPUs)
Peak Prefill TPGS: 18314.0 (prefill tokens per GPU per second)
Ran 89/89 requests in 329.84s
Success Rate: 100.00%
Peak QPS: 0.48
Server Avg TTFT: 352ms
Server P50 TTFT: 337ms
Server P99 TTFT: 537ms
Server Avg TTIT: 16ms
Server P50 TTIT: 15ms
Server P99 TTIT: 18ms
Server Output Tokens Per Second: 963
Avg Prefill Len: 18902
P50 Prefill Len: 18902
P99 Prefill Len: 18997
Avg Decode Len: 4129
P50 Decode Len: 2961
P99 Decode Len: 7310
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

