### PR TITLE
[MoE][Perf] Wrap DSV3 QKVAProj GEMM in custom op for torch.compile

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -75,6 +75,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.model_executor.models.utils import sequence_parallel_chunk
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
+from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV32IndexerBackend,
@@ -717,6 +718,39 @@ class Indexer(nn.Module):
         return self.indexer_op(hidden_states, q_fp8, k, weights)
 
 
+def _deepseek_v2_fused_qkv_a_proj_impl(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    num_tokens = input_.shape[0]
+    if 0 < num_tokens <= 16:
+        output = torch.empty(
+            num_tokens,
+            weight.shape[0],
+            dtype=torch.bfloat16,
+            device=input_.device,
+        )
+        ops.dsv3_fused_a_gemm(output, input_, weight.T)
+        return output
+    else:
+        return torch.nn.functional.linear(input_, weight)
+
+
+def _deepseek_v2_fused_qkv_a_proj_fake(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    return input_.new_empty(input_.shape[0], weight.shape[0])
+
+
+direct_register_custom_op(
+    op_name="deepseek_v2_fused_qkv_a_proj",
+    op_func=_deepseek_v2_fused_qkv_a_proj_impl,
+    mutates_args=[],
+    fake_impl=_deepseek_v2_fused_qkv_a_proj_fake,
+)
+
+
 class DeepSeekV2FusedQkvAProj(MergedColumnParallelLinear):
     def __init__(
         self,
@@ -752,19 +786,8 @@ class DeepSeekV2FusedQkvAProj(MergedColumnParallelLinear):
         self,
         input_,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.nn.Parameter | None]:
-        num_tokens = input_.shape[0]
-        if self._use_min_latency_gemm and (0 < num_tokens <= 16):
-            output = torch.empty(
-                num_tokens,
-                2112,
-                dtype=torch.bfloat16,
-                device=input_.device,
-            )
-            ops.dsv3_fused_a_gemm(
-                output,
-                input_,
-                self.weight.T,
-            )
+        if self._use_min_latency_gemm:
+            output = torch.ops.vllm.deepseek_v2_fused_qkv_a_proj(input_, self.weight)
             if not self.return_bias:
                 return output
             output_bias = self.bias if self.skip_bias_add else None

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -724,7 +724,8 @@ def _min_latency_fused_qkv_a_proj_impl(
 ) -> torch.Tensor:
     """
     Dynamically run min-latency gemm if num_tokens <= 16.
-    This must be wrapped in a custom op because torch.compile.
+    This must be wrapped in a custom op because our torch.compile integration
+    does not support runtime dispatching on num_tokens.
     """
     num_tokens = input_.shape[0]
     if 0 < num_tokens <= 16:

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -718,10 +718,14 @@ class Indexer(nn.Module):
         return self.indexer_op(hidden_states, q_fp8, k, weights)
 
 
-def _deepseek_v2_fused_qkv_a_proj_impl(
+def _min_latency_fused_qkv_a_proj_impl(
     input_: torch.Tensor,
     weight: torch.Tensor,
 ) -> torch.Tensor:
+    """
+    Dynamically run min-latency gemm if num_tokens <= 16.
+    This must be wrapped in a custom op because torch.compile.
+    """
     num_tokens = input_.shape[0]
     if 0 < num_tokens <= 16:
         output = torch.empty(
@@ -736,7 +740,7 @@ def _deepseek_v2_fused_qkv_a_proj_impl(
         return torch.nn.functional.linear(input_, weight)
 
 
-def _deepseek_v2_fused_qkv_a_proj_fake(
+def _min_latency_fused_qkv_a_proj_fake(
     input_: torch.Tensor,
     weight: torch.Tensor,
 ) -> torch.Tensor:
@@ -744,10 +748,10 @@ def _deepseek_v2_fused_qkv_a_proj_fake(
 
 
 direct_register_custom_op(
-    op_name="deepseek_v2_fused_qkv_a_proj",
-    op_func=_deepseek_v2_fused_qkv_a_proj_impl,
+    op_name="min_latency_fused_qkv_a_proj",
+    op_func=_min_latency_fused_qkv_a_proj_impl,
     mutates_args=[],
-    fake_impl=_deepseek_v2_fused_qkv_a_proj_fake,
+    fake_impl=_min_latency_fused_qkv_a_proj_fake,
 )
 
 

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -791,7 +791,7 @@ class DeepSeekV2FusedQkvAProj(MergedColumnParallelLinear):
         input_,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.nn.Parameter | None]:
         if self._use_min_latency_gemm:
-            output = torch.ops.vllm.deepseek_v2_fused_qkv_a_proj(input_, self.weight)
+            output = torch.ops.vllm.min_latency_fused_qkv_a_proj(input_, self.weight)
             if not self.return_bias:
                 return output
             output_bias = self.bias if self.skip_bias_add else None


### PR DESCRIPTION
## Summary

- `DeepSeekV2FusedQkvAProj.forward` had a data-dependent conditional `0 < num_tokens <= 16` that breaks `torch.compile` because it creates control flow that depends on tensor shape at trace time
- Wraps the kernel dispatch (`dsv3_fused_a_gemm` vs `F.linear`) in a `direct_register_custom_op`, making it opaque to the compiler
- The fake impl returns the correct output shape `(num_tokens, weight.shape[0])` for tracing
- The static `_use_min_latency_gemm` bool (fixed at init time) remains as a compile-time specialization guard outside the custom op

## Test plan

- [x] Verify DeepSeek V3 decoding still works with `torch.compile` enabled
- [x] Verify correctness: outputs match between compiled and eager mode
- [x] Verify the `_use_min_latency_gemm=False` path (non-SM90/SM100 or non-bf16) still falls through to `super().forward()`

<img width="514" height="131" alt="image" src="https://github.com/user-attachments/assets/c19fffc9-473f-46d8-b670-7631ae9413c9" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)