### PR TITLE
Fix unclean shutdown from ctrl-c with AR Fusion

### DIFF
--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import atexit
 
 import torch
 import torch.distributed as dist
@@ -84,6 +85,10 @@ def initialize_fi_ar_workspace(
         hidden_dim,
         dtype,
     )
+    # Register cleanup to avoid unclean shutdown during Python interpreter
+    # finalization. The atexit handler runs before sys.meta_path is cleared,
+    # preventing ImportError in AllReduceFusionWorkspace.__del__.
+    atexit.register(destroy_fi_ar_workspace)
 
 
 def initialize_fi_ar_quant_workspace(

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -30,6 +30,8 @@ _fi_ar_workspace = None
 # Extra workspace for quant fusion patterns (only supported by trtllm backend)
 # Only created if primary workspace is not already trtllm
 _fi_ar_quant_workspace = None
+# Track whether atexit handler has been registered to avoid double registration
+_fi_ar_atexit_registered = False
 
 
 def get_fi_ar_workspace():
@@ -60,6 +62,7 @@ def initialize_fi_ar_workspace(
     create the workspace.
     """
     global _fi_ar_workspace
+    global _fi_ar_atexit_registered
     if _fi_ar_workspace is not None:
         return
 
@@ -88,7 +91,11 @@ def initialize_fi_ar_workspace(
     # Register cleanup to avoid unclean shutdown during Python interpreter
     # finalization. The atexit handler runs before sys.meta_path is cleared,
     # preventing ImportError in AllReduceFusionWorkspace.__del__.
-    atexit.register(destroy_fi_ar_workspace)
+    # Guard registration with a module-level flag to avoid double-registration
+    # if workspace is destroyed and re-initialized.
+    if not _fi_ar_atexit_registered:
+        atexit.register(destroy_fi_ar_workspace)
+        _fi_ar_atexit_registered = True
 
 
 def initialize_fi_ar_quant_workspace(
@@ -140,6 +147,7 @@ def initialize_fi_ar_quant_workspace(
 def destroy_fi_ar_workspace():
     global _fi_ar_workspace
     global _fi_ar_quant_workspace
+    global _fi_ar_atexit_registered
     if (
         _fi_ar_quant_workspace is not None
         and _fi_ar_quant_workspace is not _fi_ar_workspace
@@ -149,6 +157,7 @@ def destroy_fi_ar_workspace():
     if _fi_ar_workspace is not None:
         _fi_ar_workspace.destroy()
         _fi_ar_workspace = None
+    _fi_ar_atexit_registered = False
 
 
 class FlashInferAllReduce:


### PR DESCRIPTION
## Summary

This PR fixes the unclean shutdown issue reported in #35686, where pressing Ctrl-C during vLLM execution with AR Fusion enabled produces an unsightly stack trace from AllReduceFusionWorkspace.__del__.

## Problem

When AR Fusion is enabled (default on B200), the FlashInfer AllReduceFusionWorkspace objects are cleaned up during Python interpreter finalization. At this stage, sys.meta_path has already been set to None, causing the workspace's __del__ method to raise ImportError: sys.meta_path is None, Python is likely shutting down.

## Solution

Register destroy_fi_ar_workspace() with the atexit module during workspace initialization. The atexit handlers execute during the interpreter shutdown phase but before the import system is torn down, ensuring clean workspace destruction without ImportError noise.

## Changes

- Added atexit import to flashinfer_all_reduce.py
- Registered destroy_fi_ar_workspace as an atexit handler in initialize_fi_ar_workspace()

## Verification

The fix follows the same pattern used elsewhere in vLLM (e.g., pynccl_allocator.py) for handling cleanup of resources with external dependencies during interpreter shutdown.

Fixes #35686

---

Contributed with appreciation for the vLLM maintainers' dedication to clean, performant inference infrastructure.