### PR TITLE
[Test] Add PD disagg + SD acceptance tests

### DIFF
--- a/.buildkite/test_areas/distributed.yaml
+++ b/.buildkite/test_areas/distributed.yaml
@@ -271,6 +271,32 @@ steps:
     - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
     - bash v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh
 
+- label: NixlConnector PD + Spec Decode acceptance - Qwen3-8B EAGLE3 (2 GPUs)
+  timeout_in_minutes: 30
+  device: a100
+  working_dir: "/vllm-workspace/tests"
+  num_devices: 2
+  source_file_dependencies:
+    - vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+    - vllm/v1/worker/kv_connector_model_runner_mixin.py
+    - tests/v1/kv_connector/nixl_integration/
+  commands:
+    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
+    - TEST_CONFIG=qwen3-8b-eagle3 MODEL_NAME=Qwen/Qwen3-8B SD_MODEL=RedHatAI/Qwen3-8B-speculator.eagle3 KV_BUFFER_DEVICES=cuda bash v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh
+
+- label: NixlConnector PD + Spec Decode acceptance - GPT-OSS-20B EAGLE3 (2 GPUs)
+  timeout_in_minutes: 30
+  device: a100
+  working_dir: "/vllm-workspace/tests"
+  num_devices: 2
+  source_file_dependencies:
+    - vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+    - vllm/v1/worker/kv_connector_model_runner_mixin.py
+    - tests/v1/kv_connector/nixl_integration/
+  commands:
+    - uv pip install --system -r /vllm-workspace/requirements/kv_connectors.txt
+    - TEST_CONFIG=gpt-oss-20b-eagle3 MODEL_NAME=openai/gpt-oss-20b SD_MODEL=RedHatAI/gpt-oss-20b-speculator.eagle3 ATTENTION_BACKEND=TRITON_ATTN KV_BUFFER_DEVICES=cuda bash v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh
+
 - label: Pipeline + Context Parallelism (4 GPUs)
   timeout_in_minutes: 60
   working_dir: "/vllm-workspace/tests"

--- a/docs/features/nixl_connector_usage.md
+++ b/docs/features/nixl_connector_usage.md
@@ -222,6 +222,52 @@ To enable this feature:
 --kv-transfer-config '{..., "kv_connector_extra_config": {"enable_cross_layers_blocks": "True"}}'
 ```
 
+### Speculative Decoding (EAGLE3)
+
+Disaggregated prefilling works with EAGLE3 speculative decoding. Both prefill and decode instances need `--speculative-config`, but with different `num_speculative_tokens`:
+
+- **Prefill**: set `num_speculative_tokens=1` (drafter runs minimally to populate its KV cache for transfer)
+- **Decode**: set `num_speculative_tokens=N` (full speculative decoding)
+
+```bash
+# Prefill instance
+CUDA_VISIBLE_DEVICES=0 \
+VLLM_KV_CACHE_LAYOUT=HND \
+UCX_NET_DEVICES=all \
+VLLM_NIXL_SIDE_CHANNEL_PORT=5559 \
+vllm serve meta-llama/Llama-3.1-8B-Instruct \
+  --port 8100 \
+  --enforce-eager \
+  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
+  --speculative-config '{"method":"eagle3","model":"RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3","num_speculative_tokens":1,"max_model_len":16384}'
+
+# Decode instance
+CUDA_VISIBLE_DEVICES=1 \
+VLLM_KV_CACHE_LAYOUT=HND \
+UCX_NET_DEVICES=all \
+VLLM_NIXL_SIDE_CHANNEL_PORT=5659 \
+vllm serve meta-llama/Llama-3.1-8B-Instruct \
+  --port 8200 \
+  --enforce-eager \
+  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
+  --speculative-config '{"method":"eagle3","model":"RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3","num_speculative_tokens":3,"max_model_len":16384}'
+```
+
+!!! note
+    `VLLM_KV_CACHE_LAYOUT=HND` is required for both instances when using speculative decoding with NixlConnector.
+
+#### Verified Configurations
+
+Tested on H100 with MT-Bench (80 prompts, 256 output tokens, temperature=0), `kv_buffer_device=cuda`:
+
+| Model | Drafter | Attn Backend | Acceptance Length |
+| --- | --- | --- | --- |
+| meta-llama/Llama-3.1-8B-Instruct | RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3 | FLASH_ATTN | 2.56 |
+| Qwen/Qwen3-8B | RedHatAI/Qwen3-8B-speculator.eagle3 | FLASH_ATTN | 2.25 |
+| openai/gpt-oss-20b | RedHatAI/gpt-oss-20b-speculator.eagle3 | TRITON_ATTN | 2.54 |
+
+See [spec_decode_acceptance_test.sh](../../tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh) for the full test script.
+
 ## Example Scripts/Code
 
 Refer to these example scripts in the vLLM repository:

--- a/tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh
+++ b/tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh
@@ -14,6 +14,7 @@
 #   CUDA_VISIBLE_DEVICES=0,1 bash tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh
 #
 # Environment variables:
+#   TEST_CONFIG         - config id passed to pytest (e.g. "llama3-8b-eagle3")
 #   KV_BUFFER_DEVICES   - space-separated list of devices to test
 #                         (default: "cuda cpu")
 #   SD_METHOD           - spec decode method (default: eagle3)
@@ -30,6 +31,7 @@ set -x
 
 # ── Model & spec decode config ──────────────────────────────────────────
 
+TEST_CONFIG="${TEST_CONFIG:-}"
 MODEL_NAME="${MODEL_NAME:-meta-llama/Llama-3.1-8B-Instruct}"
 SD_METHOD="${SD_METHOD:-eagle3}"
 SD_MODEL="${SD_MODEL:-RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3}"
@@ -149,6 +151,7 @@ run_test_for_device() {
   echo "================================================================"
   echo "NixlConnector PD + Spec Decode Acceptance Test (kv_buffer_device=${kv_device})"
   echo "================================================================"
+  echo "Config:             ${TEST_CONFIG:-'(auto)'}"
   echo "Model:              ${MODEL_NAME}"
   echo "SD method:          ${SD_METHOD}"
   echo "SD model:           ${SD_MODEL}"
@@ -192,7 +195,7 @@ run_test_for_device() {
       --tensor-parallel-size $PREFILLER_TP_SIZE \
       --kv-transfer-config "$kv_config" \
       --speculative-config "$PREFILL_SPEC_CONFIG" \
-      --attention-backend $ATTENTION_BACKEND &
+      --attention-backend "$ATTENTION_BACKEND" &
 
     PREFILL_HOSTS+=("localhost")
     PREFILL_PORTS+=("$PORT")
@@ -225,7 +228,7 @@ run_test_for_device() {
       --tensor-parallel-size $DECODER_TP_SIZE \
       --kv-transfer-config "$kv_config" \
       --speculative-config "$DECODE_SPEC_CONFIG" \
-      --attention-backend $ATTENTION_BACKEND &
+      --attention-backend "$ATTENTION_BACKEND" &
 
     DECODE_HOSTS+=("localhost")
     DECODE_PORTS+=("$PORT")
@@ -253,8 +256,10 @@ run_test_for_device() {
 
   # Run test
   echo "Running spec decode acceptance test (kv_buffer_device=${kv_device}, backend=${ATTENTION_BACKEND})..."
-  DECODE_PORT=${DECODE_PORTS[0]} \
-  TEST_MODEL=$MODEL_NAME \
+  TEST_CONFIG="$TEST_CONFIG" \
+  TEST_MODEL="$MODEL_NAME" \
+  DECODE_PORT="${DECODE_PORTS[0]}" \
+  PROXY_PORT="$PROXY_PORT" \
   python3 -m pytest -s -x "${GIT_ROOT}/tests/v1/kv_connector/nixl_integration/test_spec_decode_acceptance.py"
 
   # Tear down before next iteration

--- a/tests/v1/kv_connector/nixl_integration/test_spec_decode_acceptance.py
+++ b/tests/v1/kv_connector/nixl_integration/test_spec_decode_acceptance.py
@@ -12,8 +12,10 @@ Baselines from tests/v1/spec_decode/test_acceptance_length.py
 PD disaggregation via NixlConnector should match within tolerance.
 
 Environment variables (set by spec_decode_acceptance_test.sh):
-    TEST_MODEL   - target model name
+    TEST_CONFIG  - config id (e.g. "llama3-8b-eagle3")
+    TEST_MODEL   - target model name (fallback if TEST_CONFIG not set)
     DECODE_PORT  - port of the decode vLLM server (for /metrics)
+    PROXY_PORT   - port of the proxy server (default: 8192)
 """
 
 import os
@@ -27,9 +29,11 @@ from transformers import AutoTokenizer
 
 from vllm.benchmarks.datasets import get_samples
 
-PROXY_BASE_URL = "http://localhost:8192/v1"
-DECODE_PORT = os.environ.get("DECODE_PORT", "8200")
+TEST_CONFIG = os.environ.get("TEST_CONFIG", "")
 MODEL_NAME = os.environ.get("TEST_MODEL", "meta-llama/Llama-3.1-8B-Instruct")
+DECODE_PORT = os.environ.get("DECODE_PORT", "8200")
+PROXY_PORT = os.environ.get("PROXY_PORT", "8192")
+PROXY_BASE_URL = f"http://localhost:{PROXY_PORT}/v1"
 
 
 @dataclass
@@ -40,17 +44,35 @@ class Eagle3ModelConfig:
     expected_acceptance_lengths_per_pos: list[float] = field(default_factory=list)
     id: str = ""
     rtol: float | None = None
+    attention_backend: str = "FLASH_ATTN"
+    max_model_len: int = 16384
+    num_spec_tokens: int = 3
 
 
 # Standalone EAGLE3 baselines (MT-Bench, 80 prompts, 256 tokens, temp=0).
 # Source: tests/v1/spec_decode/test_acceptance_length.py
 EAGLE3_MODEL_CONFIGS = [
     Eagle3ModelConfig(
+        id="llama3-8b-eagle3",
         verifier="meta-llama/Llama-3.1-8B-Instruct",
         drafter="RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3",
         expected_acceptance_length=2.60,
         expected_acceptance_lengths_per_pos=[0.7296, 0.5208, 0.3545],
-        id="llama3-8b-eagle3",
+    ),
+    Eagle3ModelConfig(
+        id="qwen3-8b-eagle3",
+        verifier="Qwen/Qwen3-8B",
+        drafter="RedHatAI/Qwen3-8B-speculator.eagle3",
+        expected_acceptance_length=2.26,
+        expected_acceptance_lengths_per_pos=[0.6541, 0.3993, 0.2020],
+    ),
+    Eagle3ModelConfig(
+        id="gpt-oss-20b-eagle3",
+        verifier="openai/gpt-oss-20b",
+        drafter="RedHatAI/gpt-oss-20b-speculator.eagle3",
+        expected_acceptance_length=2.56,
+        expected_acceptance_lengths_per_pos=[0.7165, 0.5120, 0.3337],
+        attention_backend="TRITON_ATTN",
     ),
 ]
 
@@ -60,13 +82,14 @@ DEFAULT_RTOL = 0.05
 
 
 def _get_model_config() -> Eagle3ModelConfig:
-    """Get the model config matching MODEL_NAME."""
+    """Get the model config matching TEST_CONFIG or TEST_MODEL."""
     for config in EAGLE3_MODEL_CONFIGS:
-        if config.verifier == MODEL_NAME:
+        if config.id == TEST_CONFIG or config.verifier == MODEL_NAME:
             return config
     raise ValueError(
-        f"No Eagle3ModelConfig found for model {MODEL_NAME}. "
-        f"Available: {[c.verifier for c in EAGLE3_MODEL_CONFIGS]}"
+        f"No Eagle3ModelConfig for TEST_CONFIG={TEST_CONFIG!r}, "
+        f"TEST_MODEL={MODEL_NAME!r}. "
+        f"Available: {[c.id for c in EAGLE3_MODEL_CONFIGS]}"
     )
 
 


### PR DESCRIPTION
## Summary
Follow-up of #35158. 
Add integration tests for **PD disaggregation + speculative decoding** via `NixlConnector`. 

Currently covers two configs: **Qwen3-8B + EAGLE3** (FLASH_ATTN, acceptance length 2.245 vs 2.260 expected) and **GPT-OSS-20B + EAGLE3** (TRITON_ATTN, 2.549 vs 2.560 expected), both validated on H100. 

Not wired into default CI — run manually with `bash tests/v1/kv_connector/nixl_integration/pd_spec_decode_eagle3_test.sh --all`. Future work includes attention backend sweeps and MTP model configs once #35158 merges.

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

