### PR TITLE
[CI] Add explicit permissions to macOS smoke test workflow

### DIFF
--- a/.github/workflows/macos-smoke-test.yml
+++ b/.github/workflows/macos-smoke-test.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:  # Manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   macos-m1-smoke-test:
     runs-on: macos-latest


### PR DESCRIPTION
Add `permissions: contents: read` to follow the principle of least
privilege, consistent with how other workflows in the repo declare
permissions.

Not declaring explicit permissions gets flagged by GitHub's security
scans, so that's where it got flagged to me.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
