### PR TITLE
[Bugfix][RoCM] GPT-OSS + Expert Parallel

### DIFF
--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -71,6 +71,8 @@ if has_triton_kernels():
 @triton.jit
 def pack_bitmatrix(
     bitmatrix,
+    bm_row_stride,
+    bm_col_stride,
     topk_ids,
     n_rows,  # n_rows in bitmatrix / topk_ids
     bm_cols: tl.constexpr,  # n int32_t bitpacks in bitmatrix
@@ -92,6 +94,7 @@ def pack_bitmatrix(
     div = indices // 32
     rem = indices % 32
     one = tl.cast(1, tl.uint32)
+    zero = tl.cast(0, tl.uint32) 
 
     # Iterate through all the relevant bitmatrix columns.
     for i in range(bm_cols):
@@ -99,12 +102,11 @@ def pack_bitmatrix(
         offs = tl.arange(0, BLOCK_SIZE_K // 32) + i * (BLOCK_SIZE_K // 32)
         # All topks that need to go into this column has the correct bit set.
         # Other bits are 0. x is a 2D tensor.
-        x = tl.where(
-            div[:, :, None] == offs[None, None, :], (one << rem)[:, :, None], 0
-        )
+        is_valid_expert = (div[:, :, None] == offs[None, None, :]) & (indices[:, :, None] >= 0)
+        x = tl.where(is_valid_expert, (one << rem)[:, :, None], zero)
         # Reduce x to get a single int32_t bitpack.
         y = tl.reduce_or(x, axis=1)
-        bitmatrix_ptrs = bitmatrix + offsets_m[:, None] * bm_cols + offs[None, :]
+        bitmatrix_ptrs = bitmatrix + offsets_m[:, None] * bm_row_stride + offs[None, :] * bm_col_stride
         tl.store(bitmatrix_ptrs, y, mask=offsets_m[:, None] < n_rows)
 
 
@@ -506,14 +508,15 @@ def make_routing_data(
     BLOCK_SIZE_M = 512
     BLOCK_SIZE_K = 32
 
-    bm_cols = triton.cdiv(num_local_experts, BLOCK_SIZE_K)  # n_bitpacks
-    bitmatrix = torch.zeros(
-        (n_rows, bm_cols), dtype=torch.uint32, device=topk_ids.device
-    )
+    bm_cols = triton.cdiv(num_local_experts, 32)  # n_bitpacks
+    bitmatrix = torch.zeros((bm_cols, triton.cdiv(n_rows, 32) * 32), dtype=torch.uint32, device=topk_ids.device)
+    bitmatrix = torch.transpose(bitmatrix, 0, 1)[:n_rows]
 
     grid = (triton.cdiv(n_rows, BLOCK_SIZE_M),)
     pack_bitmatrix[grid](
         bitmatrix,
+        bitmatrix.stride(0),
+        bitmatrix.stride(1),
         topk_ids,
         n_rows,
         bm_cols,
@@ -525,9 +528,7 @@ def make_routing_data(
     bitmatrix_shape = [n_rows, bm_cols * 32]
     bitmatrix_shape_max = [n_rows, None]
     bitmatrix = (
-        Bitmatrix(
-            bitmatrix, dtype=BIT, shape=bitmatrix_shape, shape_max=bitmatrix_shape_max
-        )
+        Bitmatrix(bitmatrix, dtype=BIT, shape=bitmatrix_shape)
         if not use_legacy_triton_kernels
         else Bitmatrix(
             bitmatrix,

--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -94,7 +94,7 @@ def pack_bitmatrix(
     div = indices // 32
     rem = indices % 32
     one = tl.cast(1, tl.uint32)
-    zero = tl.cast(0, tl.uint32) 
+    zero = tl.cast(0, tl.uint32)
 
     # Iterate through all the relevant bitmatrix columns.
     for i in range(bm_cols):
@@ -102,11 +102,17 @@ def pack_bitmatrix(
         offs = tl.arange(0, BLOCK_SIZE_K // 32) + i * (BLOCK_SIZE_K // 32)
         # All topks that need to go into this column has the correct bit set.
         # Other bits are 0. x is a 2D tensor.
-        is_valid_expert = (div[:, :, None] == offs[None, None, :]) & (indices[:, :, None] >= 0)
+        is_valid_expert = (div[:, :, None] == offs[None, None, :]) & (
+            indices[:, :, None] >= 0
+        )
         x = tl.where(is_valid_expert, (one << rem)[:, :, None], zero)
         # Reduce x to get a single int32_t bitpack.
         y = tl.reduce_or(x, axis=1)
-        bitmatrix_ptrs = bitmatrix + offsets_m[:, None] * bm_row_stride + offs[None, :] * bm_col_stride
+        bitmatrix_ptrs = (
+            bitmatrix
+            + offsets_m[:, None] * bm_row_stride
+            + offs[None, :] * bm_col_stride
+        )
         tl.store(bitmatrix_ptrs, y, mask=offsets_m[:, None] < n_rows)
 
 
@@ -509,7 +515,11 @@ def make_routing_data(
     BLOCK_SIZE_K = 32
 
     bm_cols = triton.cdiv(num_local_experts, 32)  # n_bitpacks
-    bitmatrix = torch.zeros((bm_cols, triton.cdiv(n_rows, 32) * 32), dtype=torch.uint32, device=topk_ids.device)
+    bitmatrix = torch.zeros(
+        (bm_cols, triton.cdiv(n_rows, 32) * 32),
+        dtype=torch.uint32,
+        device=topk_ids.device,
+    )
     bitmatrix = torch.transpose(bitmatrix, 0, 1)[:n_rows]
 
     grid = (triton.cdiv(n_rows, BLOCK_SIZE_M),)


### PR DESCRIPTION
## Purpose
On local source-build using `python setup.py develop` on RoCM, gpt-oss + expert-parallel segfault

Repro command: `vllm serve openai/gpt-oss-120b --data-parallel-size 2 --enable-expert-parallel`

Why: When using expert-parallel, the invalid topk-ids are marked as `-1`. The bitmatrix construction kernel is supposed to ignore this. This is achieved by comparing `topk_id // 32` with `offs` (which are all >= 0) into the bitmatrix at https://github.com/vllm-project/vllm/blob/2a9e3347e9fbefc4bf991b60dc45a8c156d8696f/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py#L100 . 
The current code has the assumption that `-1 // 32` will evaluate to `-1` and the comparison will fail. However, I see that this may not be the case always. On RoCM, I see `-1 // 32` evaluates to `0` and results in setting the expert `-1 % 32 = 31`st expert.  This is incorrect. 

Fix: The fix is to robustify the `invalid_expert` check by including the topk-ids directly in the masking operation. 

Note: 
1. I haven't tested this on Nvidia GPUs but I don't remember seeing this behaviour. 
2. This PR also transposes the bitmatrix tensor for efficient access by the downstream OpenAI Triton kernels (Based on references in OpenAI triton_kernels)

## Test Plan
`vllm serve openai/gpt-oss-120b --data-parallel-size 2 --enable-expert-parallel` 

eval : `OPENAI_API_KEY=empty python -m gpt_oss.evals --model openai/gpt-oss-120b --eval gpqa --n-threads 512 --reasoning-effort low --base-url http://localhost:8000/v1 `

## Test Result
`vllm serve openai/gpt-oss-120b --data-parallel-size 2 --enable-expert-parallel` starts up fine. i.e. no segfault

eval : `[{'eval_name': 'gpqa', 'model_name': 'openai__gpt-oss-120b-low_temp1.0_20260302_192828', 'metric': 0.6527777777777778}]`
