### PR TITLE
[Perf] Optimize FusedMoEModularKernel output tensor using torch.empty

### DIFF
--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1519,7 +1519,7 @@ class FusedMoEKernelModularImpl:
             assert not disable_inplace()
             output = hidden_states
         else:
-            output = torch.zeros_like(hidden_states)
+            output = torch.empty_like(hidden_states)
 
         local_num_experts = w1.size(0)
         if global_num_experts == -1:


### PR DESCRIPTION

## Purpose

I noticed `at::native::vectorized_elementwise_kernel` was launched before `fused_moe_kernel`, and found it's because output tensor is created using `torch.zeros_like` in https://github.com/vllm-project/vllm/blob/v0.16.1rc0/vllm/model_executor/layers/fused_moe/modular_kernel.py#L1363.

I found `torhc.empty_like` should be good enough because the whole output tensor will be written by downstream. There are 6 downstreams:

1) DeepEPHTPrepareAndFinalize, the whole output tensor is written by [`output.copy_(combined_x, non_blocking=True)`](https://github.com/vllm-project/vllm/blob/v0.16.1rc0/vllm/model_executor/layers/fused_moe/deepep_ht_prepare_finalize.py#L384). It's OK is use empty as output.
2) DeepEPLLPrepareAndFinalize, the whole output tensor is written in https://github.com/vllm-project/vllm/blob/v0.16.1rc0/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py#L399-L408. It's OK is use empty as output, see DeepEP unit test in https://github.com/deepseek-ai/DeepEP/blob/v1.2.1/tests/test_low_latency.py#L107
3) MoEPrepareAndFinalizeNaiveEP, the whole output tensor in https://github.com/vllm-project/vllm/blob/v0.16.1rc0/vllm/model_executor/layers/fused_moe/prepare_finalize.py#L128-L130
4) MoriPrepareAndFinalize: the whole output tensor is written in https://github.com/vllm-project/vllm/blob/v0.16.1rc0/vllm/model_executor/layers/fused_moe/mori_prepare_finalize.py#L127
5) FlashInferA2APrepareAndFinalize: the whole output tensor is written in https://github.com/vllm-project/vllm/blob/v0.16.1rc0/vllm/model_executor/layers/fused_moe/flashinfer_a2a_prepare_finalize.py#L115
6) MoEPrepareAndFinalizeNoEP, BatchedPrepareAndFinalize
  * TopKWeightAndReduceNaiveBatched: output is filled with 0 in https://github.com/vllm-project/vllm/blob/v0.16.1rc0/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py#L153
  * TopKWeightAndReduceNoOP: the whole output tensor is written in https://github.com/vllm-project/vllm/blob/v0.16.1rc0/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py#L71
  * TopKWeightAndReduceContiguous: it's OK to use torch.empty, see https://github.com/vllm-project/vllm/blob/v0.16.1rc0/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py#L106-L110

## Test Plan

```
pytest -s -v tests/kernels/moe/test_moe.py \
    tests/kernels/moe/test_batched_moe.py \
    tests/kernels/moe/test_cutedsl_moe.py \
    tests/kernels/moe/test_cutlass_moe.py \
    tests/kernels/moe/test_cutlass_moe.py \
    tests/kernels/moe/test_deepep_deepgemm_moe.py \
    tests/kernels/moe/test_deepep_moe.py \
    tests/kernels/moe/test_flashinfer_moe.py
```

## Test Result

Unit tests passed.

## Profiling

Main:

<img width="1904" height="397" alt="Screenshot 2026-03-02 at 2 30 54 PM" src="https://github.com/user-attachments/assets/54546cd8-54ea-4e53-af4a-1e08af777848" />

PR:
<img width="1901" height="399" alt="Screenshot 2026-03-02 at 2 31 27 PM" src="https://github.com/user-attachments/assets/7c155c7c-1bfa-455c-97c3-8e132643584e" />

Main: `at::native::vectorized_elementwise_kernel` was launched.

PR: No `at::native::vectorized_elementwise_kernel` launched.

## Benchmarking

```
vllm serve Qwen/Qwen3.5-35B-A3B \
    --tensor-parallel-size 1 \
    --max-num-seqs 8 \
    --no-enable-prefix-caching
```
```
vllm bench serve \
  --model Qwen/Qwen3.5-35B-A3B \
  --dataset-name sharegpt \
  --dataset-path /tmp/ShareGPT_V3_unfiltered_cleaned_split.json \
  --sharegpt-output-len 300 \
  --max-concurrency 8 \
  --num-prompts 1000 \
  --num-warmups 50 \
  --ignore-eos \
  --temperature 0
```

Main:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  389.83    
Total input tokens:                      237165    
Total generated tokens:                  300000    
Request throughput (req/s):              2.57      
Output token throughput (tok/s):         769.56    
Peak output token throughput (tok/s):    888.00    
Peak concurrent requests:                16.00     
Total token throughput (tok/s):          1377.94   
---------------Time to First Token----------------
Mean TTFT (ms):                          171.63    
Median TTFT (ms):                        155.28    
P99 TTFT (ms):                           793.95    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.86      
Median TPOT (ms):                        9.84      
P99 TPOT (ms):                           10.76     
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.86      
Median ITL (ms):                         9.86      
P99 ITL (ms):                            11.38     
==================================================
```

PR:
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  386.86    
Total input tokens:                      237165    
Total generated tokens:                  300000    
Request throughput (req/s):              2.58      
Output token throughput (tok/s):         775.47    
Peak output token throughput (tok/s):    896.00    
Peak concurrent requests:                16.00     
Total token throughput (tok/s):          1388.52   
---------------Time to First Token----------------
Mean TTFT (ms):                          164.07    
Median TTFT (ms):                        155.75    
P99 TTFT (ms):                           642.94    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          9.80      
Median TPOT (ms):                        9.79      
P99 TPOT (ms):                           10.70     
---------------Inter-token Latency----------------
Mean ITL (ms):                           9.80      
Median ITL (ms):                         9.81      
P99 ITL (ms):                            11.30     
==================================================
```
Output token throughput improves 0.7%.

## Accuracy Testing

```
python3 -m lm_eval --model local-completions \
  --model_args model=/opt/dlami/nvme/models/Qwen3.5-35B-A3B,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=8 \
  --tasks gsm8k
```

Main:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8537|±  |0.0097|
|     |       |strict-match    |     5|exact_match|↑  |0.8446|±  |0.0100|
```

PR:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8597|±  |0.0096|
|     |       |strict-match    |     5|exact_match|↑  |0.8453|±  |0.0100|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

