### PR TITLE
[Bugfix] Fix MM processor test for Qwen3.5

### DIFF
--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -127,6 +127,8 @@ MM_DATA_PATCHES = {
     "glmasr": glmasr_patch_mm_data,
     "interns1_pro": qwen3_vl_patch_mm_data,
     "molmo2": qwen3_vl_patch_mm_data,
+    "qwen3_5": qwen3_vl_patch_mm_data,
+    "qwen3_5_moe": qwen3_vl_patch_mm_data,
     "qwen3_vl": qwen3_vl_patch_mm_data,
     "qwen3_vl_moe": qwen3_vl_patch_mm_data,
 }


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
#35763 added Qwen3.5 to CI but did not register it for patching video metadata, which breaks the mm processor test. This PR fixes it.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

