### PR TITLE
[ROCm][CI] Fix backslash-continuation in pytest marker re-quoting and treat exit code 5 as success

### DIFF
--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -99,6 +99,15 @@ is_multi_node() {
   return 1
 }
 
+handle_pytest_exit() {
+  local exit_code=$1
+  if [ "$exit_code" -eq 5 ]; then
+    echo "Pytest exit code 5 (no tests collected) - treating as success."
+    exit 0
+  fi
+  exit "$exit_code"
+}
+
 ###############################################################################
 # Pytest marker/keyword re-quoting
 #
@@ -462,12 +471,7 @@ if is_multi_node "$commands"; then
     /bin/bash -c "${composite_command}"
     exit_code=$?
     cleanup_network
-    # Pytest exit code 5 means no tests were collected - treat as success
-    if [ "$exit_code" -eq 5 ]; then
-      echo "Pytest exit code 5 (no tests collected) - treating as success."
-      exit 0
-    fi
-    exit "$exit_code"
+    handle_pytest_exit "$exit_code"
   else
     echo "Multi-node job detected but failed to parse bracket command syntax."
     echo "Expected format: prefix ; [node0_cmd1, node0_cmd2] && [node1_cmd1, node1_cmd2]"
@@ -496,10 +500,5 @@ else
     /bin/bash -c "${commands}"
 
   exit_code=$?
-  # Pytest exit code 5 means no tests were collected - treat as success
-  if [ "$exit_code" -eq 5 ]; then
-    echo "Pytest exit code 5 (no tests collected) - treating as success."
-    exit 0
-  fi
-  exit "$exit_code"
+  handle_pytest_exit "$exit_code"
 fi

--- a/.buildkite/scripts/hardware_ci/run-amd-test.sh
+++ b/.buildkite/scripts/hardware_ci/run-amd-test.sh
@@ -135,8 +135,9 @@ re_quote_pytest_markers() {
   local collecting=false
   local marker_buf=""
 
-  # Flatten newlines for consistent tokenization
-  local flat="${input//$'\n'/ }"
+  # Strip backslash-newline continuations, then flatten remaining newlines
+  local flat="${input//$'\\\n'/ }"
+  flat="${flat//$'\n'/ }"
 
   # Disable globbing to prevent *.py etc. from expanding during read -ra
   local restore_glob
@@ -164,6 +165,9 @@ re_quote_pytest_markers() {
 
       local is_boundary=false
       case "$word" in
+        # Line-continuation artifact
+        "\\")
+          is_boundary=true ;;
         # Command separators
         "&&"|"||"|";"|"|")
           is_boundary=true ;;
@@ -204,6 +208,9 @@ re_quote_pytest_markers() {
         if [[ "$word" == "-m" || "$word" == "-k" ]]; then
           output+="${word} "
           collecting=true
+        # Drop stray backslash tokens silently
+        elif [[ "$word" == "\\" ]]; then
+          :
         else
           output+="${word} "
         fi
@@ -453,7 +460,14 @@ if is_multi_node "$commands"; then
     done
 
     /bin/bash -c "${composite_command}"
+    exit_code=$?
     cleanup_network
+    # Pytest exit code 5 means no tests were collected - treat as success
+    if [ "$exit_code" -eq 5 ]; then
+      echo "Pytest exit code 5 (no tests collected) - treating as success."
+      exit 0
+    fi
+    exit "$exit_code"
   else
     echo "Multi-node job detected but failed to parse bracket command syntax."
     echo "Expected format: prefix ; [node0_cmd1, node0_cmd2] && [node1_cmd1, node1_cmd2]"
@@ -480,4 +494,12 @@ else
     --name "${container_name}" \
     "${image_name}" \
     /bin/bash -c "${commands}"
+
+  exit_code=$?
+  # Pytest exit code 5 means no tests were collected - treat as success
+  if [ "$exit_code" -eq 5 ]; then
+    echo "Pytest exit code 5 (no tests collected) - treating as success."
+    exit 0
+  fi
+  exit "$exit_code"
 fi


### PR DESCRIPTION
Follow-up on: 
- https://github.com/vllm-project/vllm/pull/35170

Two issues with `run-amd-test.sh`:

1. Backslash line-continuations break `-m` marker re-quoting. Commands like:
```
   pytest -v -s models/language/generation \
     -m hybrid_model \
     --num-shards=2
```
   get flattened to tokens where `\` survives as a standalone word. The `re_quote_pytest_markers` function doesn't recognize `\` as a boundary, so it gets swept into the marker buffer, producing `-m 'hybrid_model \'`, which pytest rejects with:
```
   ERROR: Wrong expression passed to '-m': hybrid_model \: expected end of input
```

2. Pytest exit code 5 (no tests collected) fails the build.  In sharded CI runs a shard can legitimately end up with zero matching tests. Exit code 5 should not be treated as a failure.

cc @kenroche @mawong-amd 