### PR TITLE
[LoRA] support loading Mistral-format LoRA weights via hf_to_vllm_mapper

### DIFF
--- a/tests/lora/test_lora_checkpoints.py
+++ b/tests/lora/test_lora_checkpoints.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import torch
 import pytest
+import torch
 
 from vllm.lora.lora_model import LoRAModel
 from vllm.lora.peft_helper import PEFTHelper
@@ -146,41 +146,37 @@ def test_mistral_lora_format_weights_mapping():
     """
     rank = 8
     hidden_size = 64
+    intermediate_size = 256
 
-    # Synthetic LoRA tensors using Mistral-format key names (no base_model prefix)
+    # Synthetic LoRA tensors using Mistral-format key names (no base_model prefix).
+    # Shapes follow the LoRA convention: lora_A=(rank, in_features),
+    # lora_B=(out_features, rank).
     mistral_format_tensors: dict[str, torch.Tensor] = {}
     mistral_keys = [
-        ("layers.0.attention.wq", hidden_size, rank),
-        ("layers.0.attention.wk", hidden_size, rank),
-        ("layers.0.attention.wv", hidden_size, rank),
-        ("layers.0.attention.wo", rank, hidden_size),
-        ("layers.0.feed_forward.w1", hidden_size, rank),
-        ("layers.0.feed_forward.w2", rank, hidden_size),
-        ("layers.0.feed_forward.w3", hidden_size, rank),
+        # (module_key, out_features, in_features)
+        ("layers.0.attention.wq", hidden_size, hidden_size),
+        ("layers.0.attention.wk", hidden_size, hidden_size),
+        ("layers.0.attention.wv", hidden_size, hidden_size),
+        ("layers.0.attention.wo", hidden_size, hidden_size),
+        ("layers.0.feed_forward.w1", intermediate_size, hidden_size),
+        ("layers.0.feed_forward.w2", hidden_size, intermediate_size),
+        ("layers.0.feed_forward.w3", intermediate_size, hidden_size),
     ]
-    for module_key, out_dim, in_dim in mistral_keys:
+    for module_key, out_features, in_features in mistral_keys:
         mistral_format_tensors[f"{module_key}.lora_A.weight"] = torch.zeros(
-            rank, in_dim
+            rank, in_features
         )
         mistral_format_tensors[f"{module_key}.lora_B.weight"] = torch.zeros(
-            out_dim, rank
+            out_features, rank
         )
 
     peft_helper = PEFTHelper.from_dict(
-        {"r": rank, "lora_alpha": rank, "target_modules": ["wq", "wk", "wv", "wo",
-                                                            "w1", "w2", "w3"]}
+        {
+            "r": rank,
+            "lora_alpha": rank,
+            "target_modules": ["wq", "wk", "wv", "wo", "w1", "w2", "w3"],
+        }
     )
-
-    # expected_lora_modules mirrors what worker_manager builds from the model's
-    # supported_lora_modules + packed_modules_mapping
-    packed_modules_mapping = MistralForCausalLM.packed_modules_mapping
-    supported = ["qkv_proj", "gate_up_proj", "o_proj", "down_proj"]
-    expected_lora_modules: set[str] = set()
-    for mod in supported:
-        if mod in packed_modules_mapping:
-            expected_lora_modules.update(packed_modules_mapping[mod])
-        else:
-            expected_lora_modules.add(mod)
 
     lora_model = LoRAModel.from_lora_tensors(
         lora_model_id=1,
@@ -201,3 +197,18 @@ def test_mistral_lora_format_weights_mapping():
         "model.layers.0.mlp.up_proj",
     }
     assert set(lora_model.loras.keys()) == expected_module_names
+
+    # Backward compat: standard PEFT-format keys (after stripping
+    # "base_model.model.") must pass through the mapper unchanged.
+    hf_format_keys = [
+        "model.layers.0.self_attn.q_proj.lora_A.weight",
+        "model.layers.0.self_attn.k_proj.lora_A.weight",
+        "model.layers.0.mlp.gate_proj.lora_A.weight",
+        "model.layers.0.mlp.down_proj.lora_A.weight",
+    ]
+    mapper = MistralForCausalLM.hf_to_vllm_mapper
+    for key in hf_format_keys:
+        assert mapper._map_name(key) == key, (
+            f"hf_to_vllm_mapper must not modify standard HF-format keys, "
+            f"but '{key}' was changed to '{mapper._map_name(key)}'"
+        )

--- a/tests/lora/test_lora_checkpoints.py
+++ b/tests/lora/test_lora_checkpoints.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import torch
 import pytest
 
 from vllm.lora.lora_model import LoRAModel
 from vllm.lora.peft_helper import PEFTHelper
 from vllm.model_executor.models.baichuan import BaiChuanBaseForCausalLM
+from vllm.model_executor.models.mistral import MistralForCausalLM
 from vllm.model_executor.models.utils import WeightsMapper
 
 lora_lst = ["baichuan7B", "baichuan7B-zero", "baichuan7B-zero-regex", "chatglm3-6b"]
@@ -128,3 +130,74 @@ def test_lora_weights_mapping(baichuan_lora_files):
     for name in lora_model.loras:
         assert name.startswith(hf_to_vllm_mapper.orig_to_new_prefix["model."])
         assert ".baichuan_layers." in name
+
+
+def test_mistral_lora_format_weights_mapping():
+    """Test that Mistral-format LoRA weight keys are correctly remapped.
+
+    Mistral consolidated checkpoints use different layer names than the
+    HuggingFace / vLLM convention, e.g.:
+      layers.7.attention.wk  ->  model.layers.7.self_attn.k_proj
+      layers.7.feed_forward.w1  ->  model.layers.7.mlp.gate_proj
+
+    MistralForCausalLM.hf_to_vllm_mapper must translate these keys so that
+    LoRA weights saved in the Mistral format can be loaded without manual
+    key renaming.
+    """
+    rank = 8
+    hidden_size = 64
+
+    # Synthetic LoRA tensors using Mistral-format key names (no base_model prefix)
+    mistral_format_tensors: dict[str, torch.Tensor] = {}
+    mistral_keys = [
+        ("layers.0.attention.wq", hidden_size, rank),
+        ("layers.0.attention.wk", hidden_size, rank),
+        ("layers.0.attention.wv", hidden_size, rank),
+        ("layers.0.attention.wo", rank, hidden_size),
+        ("layers.0.feed_forward.w1", hidden_size, rank),
+        ("layers.0.feed_forward.w2", rank, hidden_size),
+        ("layers.0.feed_forward.w3", hidden_size, rank),
+    ]
+    for module_key, out_dim, in_dim in mistral_keys:
+        mistral_format_tensors[f"{module_key}.lora_A.weight"] = torch.zeros(
+            rank, in_dim
+        )
+        mistral_format_tensors[f"{module_key}.lora_B.weight"] = torch.zeros(
+            out_dim, rank
+        )
+
+    peft_helper = PEFTHelper.from_dict(
+        {"r": rank, "lora_alpha": rank, "target_modules": ["wq", "wk", "wv", "wo",
+                                                            "w1", "w2", "w3"]}
+    )
+
+    # expected_lora_modules mirrors what worker_manager builds from the model's
+    # supported_lora_modules + packed_modules_mapping
+    packed_modules_mapping = MistralForCausalLM.packed_modules_mapping
+    supported = ["qkv_proj", "gate_up_proj", "o_proj", "down_proj"]
+    expected_lora_modules: set[str] = set()
+    for mod in supported:
+        if mod in packed_modules_mapping:
+            expected_lora_modules.update(packed_modules_mapping[mod])
+        else:
+            expected_lora_modules.add(mod)
+
+    lora_model = LoRAModel.from_lora_tensors(
+        lora_model_id=1,
+        tensors=mistral_format_tensors,
+        peft_helper=peft_helper,
+        device="cpu",
+        weights_mapper=MistralForCausalLM.hf_to_vllm_mapper,
+    )
+
+    # All loaded module names must use vLLM's naming convention
+    expected_module_names = {
+        "model.layers.0.self_attn.q_proj",
+        "model.layers.0.self_attn.k_proj",
+        "model.layers.0.self_attn.v_proj",
+        "model.layers.0.self_attn.o_proj",
+        "model.layers.0.mlp.gate_proj",
+        "model.layers.0.mlp.down_proj",
+        "model.layers.0.mlp.up_proj",
+    }
+    assert set(lora_model.loras.keys()) == expected_module_names

--- a/vllm/model_executor/models/mistral.py
+++ b/vllm/model_executor/models/mistral.py
@@ -28,6 +28,32 @@ from vllm.v1.attention.backend import AttentionType
 
 from .utils import AutoWeightsLoader, WeightsMapper
 
+# Shared mapping for consolidated Mistral format (used by mistral_mapping and
+# hf_to_vllm_mapper). Defined at module level so Ruff resolves it in class body.
+_MISTRAL_MAPPING = {
+    "layers": "model.layers",
+    "attention": "self_attn",
+    "qscale_act": "input_scale",
+    "qscale_weight": "weight_scale",
+    "kv_fake_quantizer.qscale_act": "kv_scale",
+    "q_fake_quantizer.qscale_act": "attn.q_scale",
+    "k_fake_quantizer.qscale_act": "k_scale",
+    "v_fake_quantizer.qscale_act": "v_scale",
+    "wq": "q_proj",
+    "wk": "k_proj",
+    "wv": "v_proj",
+    "wo": "o_proj",
+    "attention_norm": "input_layernorm",
+    "feed_forward": "mlp",
+    "w1": "gate_proj",
+    "w2": "down_proj",
+    "w3": "up_proj",
+    "ffn_norm": "post_attention_layernorm",
+    "tok_embeddings": "model.embed_tokens",
+    "output": "lm_head",
+    "norm": "model.norm",
+}
+
 
 class MistralMLP(nn.Module):
     def __init__(
@@ -233,32 +259,10 @@ class MistralForCausalLM(LlamaForCausalLM):
 
     # Mistral/Llama models can also be loaded with --load-format mistral
     # from consolidated.safetensors checkpoints
-    mistral_mapping = {
-        "layers": "model.layers",
-        "attention": "self_attn",
-        "qscale_act": "input_scale",
-        "qscale_weight": "weight_scale",
-        "kv_fake_quantizer.qscale_act": "kv_scale",
-        "q_fake_quantizer.qscale_act": "attn.q_scale",
-        "k_fake_quantizer.qscale_act": "k_scale",
-        "v_fake_quantizer.qscale_act": "v_scale",
-        "wq": "q_proj",
-        "wk": "k_proj",
-        "wv": "v_proj",
-        "wo": "o_proj",
-        "attention_norm": "input_layernorm",
-        "feed_forward": "mlp",
-        "w1": "gate_proj",
-        "w2": "down_proj",
-        "w3": "up_proj",
-        "ffn_norm": "post_attention_layernorm",
-        "tok_embeddings": "model.embed_tokens",
-        "output": "lm_head",
-        "norm": "model.norm",
-    }
+    mistral_mapping = _MISTRAL_MAPPING
 
     # Maps Mistral-format LoRA weight keys to vLLM's internal naming (derived
-    # from mistral_mapping to avoid duplication).
+    # from _MISTRAL_MAPPING to avoid duplication).
     _lora_substr_keys = (
         "attention_norm",
         "ffn_norm",
@@ -274,11 +278,10 @@ class MistralForCausalLM(LlamaForCausalLM):
     )
     hf_to_vllm_mapper = WeightsMapper(
         orig_to_new_prefix={
-            "layers.": f"{mistral_mapping['layers']}.",
+            "layers.": f"{_MISTRAL_MAPPING['layers']}.",
         },
         orig_to_new_substr={
-            f".{k}.": f".{mistral_mapping[k]}."
-            for k in _lora_substr_keys
+            f".{k}.": f".{_MISTRAL_MAPPING[k]}." for k in _lora_substr_keys
         },
     )
 

--- a/vllm/model_executor/models/mistral.py
+++ b/vllm/model_executor/models/mistral.py
@@ -231,29 +231,6 @@ class MistralForCausalLM(LlamaForCausalLM):
     # Mistral: We don't support LoRA on the embedding layers.
     embedding_modules: dict[str, str] = {}
 
-    # Maps Mistral-format LoRA weight keys to vLLM's internal naming.
-    # Mistral format uses e.g. `layers.N.attention.wk` while vLLM expects
-    # `model.layers.N.self_attn.k_proj`. This allows loading LoRA checkpoints
-    # saved in the Mistral consolidated format without manual key renaming.
-    hf_to_vllm_mapper = WeightsMapper(
-        orig_to_new_prefix={
-            "layers.": "model.layers.",
-        },
-        orig_to_new_substr={
-            ".attention_norm.": ".input_layernorm.",
-            ".ffn_norm.": ".post_attention_layernorm.",
-            ".attention.": ".self_attn.",
-            ".feed_forward.": ".mlp.",
-            ".wq.": ".q_proj.",
-            ".wk.": ".k_proj.",
-            ".wv.": ".v_proj.",
-            ".wo.": ".o_proj.",
-            ".w1.": ".gate_proj.",
-            ".w2.": ".down_proj.",
-            ".w3.": ".up_proj.",
-        },
-    )
-
     # Mistral/Llama models can also be loaded with --load-format mistral
     # from consolidated.safetensors checkpoints
     mistral_mapping = {
@@ -279,6 +256,31 @@ class MistralForCausalLM(LlamaForCausalLM):
         "output": "lm_head",
         "norm": "model.norm",
     }
+
+    # Maps Mistral-format LoRA weight keys to vLLM's internal naming (derived
+    # from mistral_mapping to avoid duplication).
+    _lora_substr_keys = (
+        "attention_norm",
+        "ffn_norm",
+        "attention",
+        "feed_forward",
+        "wq",
+        "wk",
+        "wv",
+        "wo",
+        "w1",
+        "w2",
+        "w3",
+    )
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "layers.": f"{mistral_mapping['layers']}.",
+        },
+        orig_to_new_substr={
+            f".{k}.": f".{mistral_mapping[k]}."
+            for k in _lora_substr_keys
+        },
+    )
 
     def __init__(
         self,

--- a/vllm/model_executor/models/mistral.py
+++ b/vllm/model_executor/models/mistral.py
@@ -26,7 +26,7 @@ from vllm.model_executor.models.llama import (
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionType
 
-from .utils import AutoWeightsLoader
+from .utils import AutoWeightsLoader, WeightsMapper
 
 
 class MistralMLP(nn.Module):
@@ -230,6 +230,29 @@ class MistralModel(LlamaModel):
 class MistralForCausalLM(LlamaForCausalLM):
     # Mistral: We don't support LoRA on the embedding layers.
     embedding_modules: dict[str, str] = {}
+
+    # Maps Mistral-format LoRA weight keys to vLLM's internal naming.
+    # Mistral format uses e.g. `layers.N.attention.wk` while vLLM expects
+    # `model.layers.N.self_attn.k_proj`. This allows loading LoRA checkpoints
+    # saved in the Mistral consolidated format without manual key renaming.
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "layers.": "model.layers.",
+        },
+        orig_to_new_substr={
+            ".attention_norm.": ".input_layernorm.",
+            ".ffn_norm.": ".post_attention_layernorm.",
+            ".attention.": ".self_attn.",
+            ".feed_forward.": ".mlp.",
+            ".wq.": ".q_proj.",
+            ".wk.": ".k_proj.",
+            ".wv.": ".v_proj.",
+            ".wo.": ".o_proj.",
+            ".w1.": ".gate_proj.",
+            ".w2.": ".down_proj.",
+            ".w3.": ".up_proj.",
+        },
+    )
 
     # Mistral/Llama models can also be loaded with --load-format mistral
     # from consolidated.safetensors checkpoints


### PR DESCRIPTION
## Purpose

Related Issues: #35730 
Fixes the inability to load LoRA checkpoints saved in the Mistral consolidated format without manually renaming keys.

Mistral-format LoRA checkpoints use different layer naming conventions than HuggingFace/vLLM:

| Mistral format | vLLM internal |
|---|---|
| `layers.N.attention.wq` | `model.layers.N.self_attn.q_proj` |
| `layers.N.attention.wk` | `model.layers.N.self_attn.k_proj` |
| `layers.N.attention.wv` | `model.layers.N.self_attn.v_proj` |
| `layers.N.attention.wo` | `model.layers.N.self_attn.o_proj` |
| `layers.N.feed_forward.w1` | `model.layers.N.mlp.gate_proj` |
| `layers.N.feed_forward.w2` | `model.layers.N.mlp.down_proj` |
| `layers.N.feed_forward.w3` | `model.layers.N.mlp.up_proj` |

This PR adds a `hf_to_vllm_mapper` class attribute to `MistralForCausalLM` using the existing `WeightsMapper` mechanism (already used by models like Qwen2VL). The `worker_manager` already reads this attribute automatically via `getattr(model, "hf_to_vllm_mapper", None)`, so no changes to the LoRA loading infrastructure were needed.

**No existing functionality is changed.** Standard PEFT-format LoRA keys (`base_model.model.model.layers.N.self_attn.*`) pass through the mapper without modification.

## Test Plan

```bash
# Unit test (CPU only, no model files required)
pytest tests/lora/test_lora_checkpoints.py::test_mistral_lora_format_weights_mapping -v
```

## Test Result

```
TBD (Waiting for GPU Server)
```
