### PR TITLE
Fix: DBO + DSA shape mismatch

### DIFF
--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -232,7 +232,8 @@ def sparse_attn_indexer(
                 topk_indices.reshape(batch_size, -1, topk_indices.shape[-1]),
                 decode_lens,
             )
-            topk_indices_buffer[:num_decode_tokens, : topk_indices.shape[-1]] = (
+            actual_num_decode_tokens = topk_indices.shape[0]
+            topk_indices_buffer[:actual_num_decode_tokens, : topk_indices.shape[-1]] = (
                 topk_indices
             )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Tries to fix #35796 - when DBO is used together with sparse attention, we get a mismatch in shapes that is probably caused by `num_decode_tokens` coming from the global attention and `topk_indices_buffer` being from the local minibatch. 

## Test Plan

## Test Result

Tested locally on a previously failing deploy and it doesn't fail right now

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

