### PR TITLE
[ROCm][CI] Fix Assertion Logic For `test_gpt_oss`

### DIFF
--- a/tests/models/quantization/test_gpt_oss.py
+++ b/tests/models/quantization/test_gpt_oss.py
@@ -12,8 +12,8 @@ Config:
 Run: pytest tests/models/quantization/test_gpt_oss.py
 """
 
-import importlib
 import importlib.metadata
+import importlib.util
 from dataclasses import dataclass
 
 import huggingface_hub
@@ -104,7 +104,7 @@ def test_gpt_oss_attention_quantization(
     )
 
     rtol = 0.02
-    assert (
-        measured_accuracy - rtol < expected_accuracy
-        and measured_accuracy + rtol > expected_accuracy
-    ), f"Expected: {expected_accuracy} |  Measured: {measured_accuracy}"
+    assert measured_accuracy >= expected_accuracy - rtol, (
+        f"Accuracy {measured_accuracy:.4f} is below threshold "
+        f"{expected_accuracy - rtol:.4f} (expected >= {expected_accuracy} - {rtol})"
+    )


### PR DESCRIPTION
<!-- markdownlint-disable -->
After https://github.com/vllm-project/vllm/pull/35658 was merged, we saw `Quantized Models Test` started failing in AMD CI:
https://buildkite.com/vllm/amd-ci/builds/5661/steps/canvas?sid=019cad58-e61d-4bf9-8028-1a6a6a7ac897&tab=output

As it turns out, this test was previously skipped because quark was not installed in our CI builds. Now that it is, it exposed that this test was flaky because it doesn't allow for measured accuracy that is higher than the expected accuracy. Before this PR, tests sometimes fail with errors like `AssertionError: Expected: 0.89 |  Measured: 0.913151364764268`. (e.g. you can observe this with `pytest -v -s models/quantization/test_gpt_oss.py::test_gpt_oss_attention_quantization[amd/gpt-oss-20b-WFP8-AFP8-KVFP8-0.89-1]`). Clearly, 0.91 is a perfectly valid accuracy score, so we should accept it.
