### PR TITLE
[Kernel] Add FP8 block-quantized MoE config for E=256,N=512 on H100

### DIFF
--- a/vllm/model_executor/layers/fused_moe/configs/E=256,N=512,device_name=NVIDIA_H100_80GB_HBM3,dtype=fp8_w8a8,block_shape=[128,128].json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=256,N=512,device_name=NVIDIA_H100_80GB_HBM3,dtype=fp8_w8a8,block_shape=[128,128].json
@@ -1,0 +1,83 @@
+{
+  "triton_version": "3.6.0",
+  "1": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 4
+  },
+  "2": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 3
+  },
+  "4": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "8": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "16": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "32": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "64": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "128": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "256": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "512": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 256,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  }
+}


### PR DESCRIPTION
## Summary

Adds a tuned Triton fused MoE kernel configuration for the following combination that was previously missing:

- **Experts:** E=256, N=512 (e.g., Qwen3.5-35B-A3B-FP8 at TP=1)
- **GPU:** NVIDIA H100 80GB HBM3
- **Dtype:** fp8_w8a8
- **Block shape:** [128, 128]
- **Triton version:** 3.6.0

The non-quantized variant (`E=256,N=512,device_name=NVIDIA_H100_80GB_HBM3.json`) already exists, but the FP8 block-quantized version was missing, producing the warning:

```
Using default MoE config. Performance might be sub-optimal!
Config file not found at .../E=256,N=512,device_name=NVIDIA_H100_80GB_HBM3,dtype=fp8_w8a8,block_shape=[128,128].json
```

## Methodology

Generated using `benchmarks/kernels/benchmark_moe.py --tune` on a single H100 80GB, sweeping across batch sizes 1, 2, 4, 8, 16, 32, 64, 128, 256, 512.

Note: `get_model_params()` in the benchmark script needed a minor patch to handle Qwen3.5's config structure (`num_experts` instead of `num_local_experts`, `moe_intermediate_size` instead of `intermediate_size`, nested under `text_config`).

## Test plan

- [x] Config generated successfully with `benchmark_moe.py --tune`
- [x] Deployed with `VLLM_TUNED_CONFIG_FOLDER` pointing to this config
- [x] Startup warning eliminated
- [x] Verified inference performance on H100 with Qwen3.5-35B-A3B-FP8