### PR TITLE
Revert "[CI/Build] Enable Qwen3.5 tests on CI" (#35763)

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1008,20 +1008,24 @@ _MULTIMODAL_EXAMPLE_MODELS = {
         min_transformers_version="4.57",
     ),
     "Qwen3_5ForConditionalGeneration": _HfExamplesInfo(
-        "Qwen/Qwen3.5-0.8B",
+        "Qwen/Qwen3.5-9B-Instruct",
         max_model_len=4096,
+        min_transformers_version="5.1.0",
     ),
     "Qwen3_5MoeForConditionalGeneration": _HfExamplesInfo(
-        "Qwen/Qwen3.5-35B-A3B",
+        "Qwen/Qwen3.5-35B-A3B-Instruct",
         max_model_len=4096,
+        min_transformers_version="5.1.0",
     ),
     "Qwen3_5MTP": _HfExamplesInfo(
-        "Qwen/Qwen3.5-0.8B",
-        speculative_model="Qwen/Qwen3.5-0.8B",
+        "Qwen/Qwen3.5-9B-Instruct",
+        speculative_model="Qwen/Qwen3.5-9B-Instruct",
+        min_transformers_version="5.1.0",
     ),
     "Qwen3_5MoeMTP": _HfExamplesInfo(
-        "Qwen/Qwen3.5-35B-A3B",
-        speculative_model="Qwen/Qwen3.5-35B-A3B",
+        "Qwen/Qwen3.5-35B-A3B-Instruct",
+        speculative_model="Qwen/Qwen3.5-35B-A3B-Instruct",
+        min_transformers_version="5.1.0",
     ),
     "Qwen3OmniMoeForConditionalGeneration": _HfExamplesInfo(
         "Qwen/Qwen3-Omni-30B-A3B-Instruct",


### PR DESCRIPTION
## Revert of #35763

This reverts commit cc0d565f40814b7406ac7a420725c54ce6ebd116 (merge commit of PR #35763).

**Original PR:** https://github.com/vllm-project/vllm/pull/35763
**Failure count:** 2 new CI failures linked to this PR
**Build:** https://buildkite.com/vllm/ci/builds/54051

### Failing tests
- **Multi-Modal Processor** — Qwen3.5 models fail with `ValueError: Video metadata is required but not found in mm input`
- **Multi-Modal Processor Test (CPU)** — Same Qwen3.5 video metadata error

### Root cause
PR #35763 enabled Qwen3.5 model tests in `tests/models/registry.py`. The Qwen3.5 models inherit from Qwen2-VL video parsing which requires video metadata, but the test harness does not provide it for these models, causing all Qwen3.5-related multimodal processor test cases to fail.

---
*Auto-generated by CI failure analyzer*