### PR TITLE
fix: preserve prior-turn analysis messages in Harmony multi-turn conversations

### DIFF
--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -703,6 +703,70 @@ class TestAutoDropAnalysisMessages:
         # Should have dropped the analysis message
         assert cleaned_messages == messages[1:]
 
+    def test_preserves_prior_turn_analysis_messages(self) -> None:
+        """Test that analysis messages from prior turns are preserved.
+
+        Regression test for https://github.com/vllm-project/vllm/issues/35779
+        """
+        messages = [
+            Message.from_role_and_content(Role.USER, "Pick a secret number."),
+            Message.from_role_and_content(
+                Role.ASSISTANT, "I will pick 742."
+            ).with_channel("analysis"),
+            Message.from_role_and_content(
+                Role.ASSISTANT, "OK, I have picked a number."
+            ).with_channel("final"),
+            Message.from_role_and_content(Role.USER, "What is the secret number?"),
+        ]
+        cleaned_messages = auto_drop_analysis_messages(messages)
+        # All messages should be preserved - prior turn analysis is needed
+        assert cleaned_messages == messages
+
+    def test_drops_current_turn_analysis_but_preserves_prior(self) -> None:
+        """Test multi-turn: prior turn analysis kept, current turn analysis dropped."""
+        messages = [
+            Message.from_role_and_content(Role.USER, "First question"),
+            Message.from_role_and_content(
+                Role.ASSISTANT, "Prior reasoning"
+            ).with_channel("analysis"),
+            Message.from_role_and_content(Role.ASSISTANT, "First answer").with_channel(
+                "final"
+            ),
+            Message.from_role_and_content(Role.USER, "Second question"),
+            Message.from_role_and_content(
+                Role.ASSISTANT, "Current reasoning"
+            ).with_channel("analysis"),
+            Message.from_role_and_content(Role.ASSISTANT, "Second answer").with_channel(
+                "final"
+            ),
+        ]
+        cleaned_messages = auto_drop_analysis_messages(messages)
+        # Prior turn analysis[1] is preserved, current turn analysis[4] is dropped
+        assert len(cleaned_messages) == 5
+        assert cleaned_messages[0].content[0].text == "First question"
+        assert cleaned_messages[1].content[0].text == "Prior reasoning"
+        assert cleaned_messages[2].content[0].text == "First answer"
+        assert cleaned_messages[3].content[0].text == "Second question"
+        assert cleaned_messages[4].content[0].text == "Second answer"
+
+    def test_preserves_analysis_when_no_final_in_current_turn(self) -> None:
+        """Current turn has analysis but no final yet - keep everything."""
+        messages = [
+            Message.from_role_and_content(Role.USER, "First question"),
+            Message.from_role_and_content(
+                Role.ASSISTANT, "Prior reasoning"
+            ).with_channel("analysis"),
+            Message.from_role_and_content(Role.ASSISTANT, "First answer").with_channel(
+                "final"
+            ),
+            Message.from_role_and_content(Role.USER, "Second question"),
+            Message.from_role_and_content(
+                Role.ASSISTANT, "Still thinking..."
+            ).with_channel("analysis"),
+        ]
+        cleaned_messages = auto_drop_analysis_messages(messages)
+        assert cleaned_messages == messages
+
 
 class TestParseChatOutput:
     def test_parse_chat_output_interrupted_first_message(self) -> None:

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -215,11 +215,14 @@ def auto_drop_analysis_messages(msgs: list[Message]) -> list[Message]:
         return msgs
 
     # Drop analysis messages in the current turn that precede the last final.
+    # Also guard against accidentally filtering non-assistant messages.
     return [
         msg
         for i, msg in enumerate(msgs)
         if not (
-            current_turn_start <= i < last_final_in_turn and msg.channel == "analysis"
+            current_turn_start <= i < last_final_in_turn
+            and msg.channel == "analysis"
+            and msg.author.role != "user"
         )
     ]
 

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -188,24 +188,40 @@ def auto_drop_analysis_messages(msgs: list[Message]) -> list[Message]:
     the conversation with multiple assistant messages to the final channel in the
     conversation.
 
-    So, we find the index of the last assistant message to the final channel and drop
-    all analysis messages that precede it, leaving only the analysis messages that
-    are relevant to the current part of the conversation.
+    We only drop analysis messages from the current turn (after the last user message)
+    that precede the last assistant final message in that turn. Analysis messages from
+    prior turns are preserved so the model can see its own prior reasoning when the
+    client explicitly provides reasoning_content.
     """
-    last_assistant_final_index = -1
+    if not msgs:
+        return msgs
+
+    # Find the start of the current turn (after the last user message).
+    current_turn_start = 0
     for i in range(len(msgs) - 1, -1, -1):
-        msg = msgs[i]
-        if msg.author.role == "assistant" and msg.channel == "final":
-            last_assistant_final_index = i
+        if msgs[i].author.role == "user":
+            current_turn_start = i + 1
             break
 
-    cleaned_msgs: list[Message] = []
-    for i, msg in enumerate(msgs):
-        if i < last_assistant_final_index and msg.channel == "analysis":
-            continue
-        cleaned_msgs.append(msg)
+    # Find the last assistant final message in the current turn.
+    last_final_in_turn = -1
+    for i in range(len(msgs) - 1, current_turn_start - 1, -1):
+        if msgs[i].author.role == "assistant" and msgs[i].channel == "final":
+            last_final_in_turn = i
+            break
 
-    return cleaned_msgs
+    if last_final_in_turn < current_turn_start:
+        # No final message in current turn, nothing to drop.
+        return msgs
+
+    # Drop analysis messages in the current turn that precede the last final.
+    return [
+        msg
+        for i, msg in enumerate(msgs)
+        if not (
+            current_turn_start <= i < last_final_in_turn and msg.channel == "analysis"
+        )
+    ]
 
 
 def flatten_chat_text_content(content: str | list | None) -> str | None:


### PR DESCRIPTION
## Summary

- Fix `auto_drop_analysis_messages` to only drop analysis messages within the **current turn** (after the last user message), preserving prior-turn reasoning context
- The old implementation dropped ALL analysis messages before the last assistant final message, which incorrectly discarded `reasoning_content` from prior conversation turns

## Root Cause

When a client sends a multi-turn conversation with `reasoning_content` on prior assistant messages:
```json
[
  {"role": "user", "content": "Pick a secret number..."},
  {"role": "assistant", "content": "OK, I picked.", "reasoning_content": "I will pick 742."},
  {"role": "user", "content": "What is the secret number?"}
]
```

The analysis message from the first turn (containing "742") was dropped because the old code dropped ALL analysis messages before the last assistant final — regardless of turn boundaries. The model could not access its own prior reasoning.

## Fix

Changed the algorithm to:
1. Find the current turn boundary (after the last user message)
2. Only drop analysis messages within the current turn that precede the last final message
3. Leave prior-turn analysis messages untouched

## Test Plan

- [x] Added `test_preserves_prior_turn_analysis_messages` — exact scenario from the issue
- [x] Added `test_drops_current_turn_analysis_but_preserves_prior` — multi-turn with both prior and current analysis
- [x] Added `test_preserves_analysis_when_no_final_in_current_turn` — ongoing reasoning not dropped
- [x] All existing `TestAutoDropAnalysisMessages` tests pass unchanged (verified via logic simulation)

Fixes #35779