### PR TITLE
[Feature]: Support for multiple embedding types in a single inference call

### DIFF
--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -17,6 +17,7 @@ from vllm.renderers import BaseRenderer
 from vllm.tokenizers.detokenizer_utils import convert_ids_list_to_tokens
 
 from .types import (
+    EMBED_TASKS,
     SparseEmbeddingCompletionRequestMixin,
     SparseEmbeddingResponse,
     SparseEmbeddingResponseData,
@@ -59,11 +60,22 @@ class BgeM3SparseEmbeddingsProcessor(
         if params is None:
             params = PoolingParams()
         # refer to PoolingCompletionRequest.to_pooling_params
-        params.task = "embed&token_classify"
         # set and verify pooling params
         params.skip_reading_prefix_cache = True
 
         raw_embed_request = self.embed_request_queue.pop(0)
+        if raw_embed_request.task not in EMBED_TASKS:
+            raise ValueError(
+                f"Unsupported task {raw_embed_request}, "
+                f"Supported tasks are {EMBED_TASKS}"
+            )
+        if raw_embed_request.task == "dense":
+            params.task = "embed"
+            params.skip_reading_prefix_cache = False
+        elif raw_embed_request.task == "sparse":
+            params.task = "token_classify"
+        else:
+            params.task = "embed&token_classify"
         params.use_activation = raw_embed_request.use_activation
         params.dimensions = raw_embed_request.dimensions
 
@@ -154,32 +166,42 @@ class BgeM3SparseEmbeddingsProcessor(
         num_prompt_tokens = 0
         response_data = []
         raw_request = self._get_sparse_embedding_request(request_id)
-        embed_dimensions = (
-            self.embed_dimensions
-            if raw_request.dimensions is None
-            else raw_request.dimensions
-        )
+        has_dense_embed = raw_request.task in ["dense", "dense&sparse"]
+        has_sparse_embed = raw_request.task in ["sparse", "dense&sparse"]
+        embed_dimensions = 0
+        if has_dense_embed:
+            embed_dimensions = (
+                self.embed_dimensions
+                if raw_request.dimensions is None
+                else raw_request.dimensions
+            )
         for idx in range(len(model_output)):
             mo = model_output[idx]
-            sparse_embedding: dict[int, float] = {}
+            sparse_embedding_dict: dict[int, float] = {}
             num_prompt_tokens += len(mo.prompt_token_ids)
-            dense_embedding = mo.outputs.data[:embed_dimensions].tolist()
-            sparse_weights = mo.outputs.data[embed_dimensions:].tolist()
-            if len(mo.prompt_token_ids) != len(sparse_weights):
-                # this is the case that add_special_tokens is True,
-                # which means first token and last token are special tokens
-                mo.prompt_token_ids = mo.prompt_token_ids[1:]
-            for token_id, weight in zip(mo.prompt_token_ids, sparse_weights):
-                sparse_embedding[token_id] = max(
-                    weight, sparse_embedding.get(token_id, 0.0)
+            dense_embedding: list[float] | None = None
+            sparse_embedding: list[SparseEmbeddingTokenWeight] | None = None
+            if has_dense_embed:
+                dense_embedding = mo.outputs.data[:embed_dimensions].tolist()
+            if has_sparse_embed:
+                sparse_weights = mo.outputs.data[embed_dimensions:].tolist()
+                if len(mo.prompt_token_ids) != len(sparse_weights):
+                    # this is the case that add_special_tokens is True,
+                    # which means first token and last token are special tokens
+                    mo.prompt_token_ids = mo.prompt_token_ids[1:]
+                for token_id, weight in zip(mo.prompt_token_ids, sparse_weights):
+                    sparse_embedding_dict[token_id] = max(
+                        weight, sparse_embedding_dict.get(token_id, 0.0)
+                    )
+                sparse_embedding = self._build_sparse_embedding_token_weights(
+                    sparse_embedding_dict,
+                    raw_request.return_tokens,
                 )
+
             response_data.append(
                 SparseEmbeddingResponseData(
                     index=idx,
-                    sparse_embedding=self._build_sparse_embedding_token_weights(
-                        sparse_embedding,
-                        raw_request.return_tokens,
-                    ),
+                    sparse_embedding=sparse_embedding,
                     dense_embedding=dense_embedding,
                 )
             )

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -24,6 +24,8 @@ from .types import (
 
 logger = init_logger(__name__)
 
+_BGE_M3_EMBED_DIM = 1024
+
 
 class BgeM3SparseEmbeddingsProcessor(
     IOProcessor[SparseEmbeddingCompletionRequestMixin, SparseEmbeddingResponse]
@@ -105,8 +107,8 @@ class BgeM3SparseEmbeddingsProcessor(
             mo = model_output[idx]
             sparse_embedding: dict[int, float] = {}
             num_prompt_tokens += len(mo.prompt_token_ids)
-            dense_embedding = mo.outputs.data[:1024].tolist()
-            sparse_weights = mo.outputs.data[1024:].tolist()
+            dense_embedding = mo.outputs.data[:_BGE_M3_EMBED_DIM].tolist()
+            sparse_weights = mo.outputs.data[_BGE_M3_EMBED_DIM:].tolist()
             if len(mo.prompt_token_ids) != len(sparse_weights):
                 # this is the case that add_special_tokens is True,
                 # which means first token and last token are special tokens

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 
 from vllm.config import ModelConfig, PoolerConfig, VllmConfig
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
+from vllm.entrypoints.pooling.base.protocol import EmbedRequestMixin
 from vllm.inputs.data import PromptType
 from vllm.logger import init_logger
 from vllm.outputs import PoolingRequestOutput
@@ -40,7 +41,8 @@ class BgeM3SparseEmbeddingsProcessor(
                 if getattr(pooler_config, param, None) is None:
                     continue
                 self.default_pooling_params[param] = getattr(pooler_config, param)
-        self.embed_dimensions = vllm_config.model_config.get_hidden_size()
+        self.embed_dimensions = vllm_config.model_config.embedding_size()
+        self.embed_request_queue: list[EmbedRequestMixin] = []
         logger.info(self)
 
     def __repr__(self) -> str:
@@ -60,6 +62,10 @@ class BgeM3SparseEmbeddingsProcessor(
         params.task = "embed&token_classify"
         # set and verify pooling params
         params.skip_reading_prefix_cache = True
+
+        raw_embed_request = self.embed_request_queue.pop(0)
+        params.use_activation = raw_embed_request.use_activation
+        params.dimensions = raw_embed_request.dimensions
 
         model_config: ModelConfig = self.vllm_config.model_config
         for param in self.default_pooling_params:
@@ -108,12 +114,13 @@ class BgeM3SparseEmbeddingsProcessor(
             self.online_requests[request_id] = prompt
         else:
             self.offline_requests.append(prompt)
+        self.embed_request_queue.extend(prompt.to_embed_requests())
         return prompt.input
 
     def _get_sparse_embedding_request(self, request_id: str | None = None):
         if request_id:
             return self.online_requests.pop(request_id, None)
-        return self.offline_requests.pop()
+        return self.offline_requests.pop(0)
 
     def _build_sparse_embedding_token_weights(
         self,
@@ -145,13 +152,18 @@ class BgeM3SparseEmbeddingsProcessor(
     ) -> SparseEmbeddingResponse:
         num_prompt_tokens = 0
         response_data = []
-        return_tokens = self._get_sparse_embedding_request(request_id).return_tokens
+        raw_request = self._get_sparse_embedding_request(request_id)
+        embed_dimensions = (
+            self.embed_dimensions
+            if raw_request.dimensions is None
+            else raw_request.dimensions
+        )
         for idx in range(len(model_output)):
             mo = model_output[idx]
             sparse_embedding: dict[int, float] = {}
             num_prompt_tokens += len(mo.prompt_token_ids)
-            dense_embedding = mo.outputs.data[: self.embed_dimensions].tolist()
-            sparse_weights = mo.outputs.data[self.embed_dimensions :].tolist()
+            dense_embedding = mo.outputs.data[:embed_dimensions].tolist()
+            sparse_weights = mo.outputs.data[embed_dimensions:].tolist()
             if len(mo.prompt_token_ids) != len(sparse_weights):
                 # this is the case that add_special_tokens is True,
                 # which means first token and last token are special tokens
@@ -165,7 +177,7 @@ class BgeM3SparseEmbeddingsProcessor(
                     index=idx,
                     sparse_embedding=self._build_sparse_embedding_token_weights(
                         sparse_embedding,
-                        return_tokens,
+                        raw_request.return_tokens,
                     ),
                     dense_embedding=dense_embedding,
                 )

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -41,7 +41,7 @@ class BgeM3SparseEmbeddingsProcessor(
         if params is None:
             params = PoolingParams()
         # refer to PoolingCompletionRequest.to_pooling_params
-        params.task = "token_classify"
+        params.task = "embed&token_classify"
         return params
 
     def parse_request(
@@ -105,11 +105,13 @@ class BgeM3SparseEmbeddingsProcessor(
             mo = model_output[idx]
             sparse_embedding: dict[int, float] = {}
             num_prompt_tokens += len(mo.prompt_token_ids)
-            if len(mo.prompt_token_ids) != len(mo.outputs.data):
+            dense_embedding = mo.outputs.data[:1024].tolist()
+            sparse_weights = mo.outputs.data[1024:].tolist()
+            if len(mo.prompt_token_ids) != len(sparse_weights):
                 # this is the case that add_special_tokens is True,
                 # which means first token and last token are special tokens
                 mo.prompt_token_ids = mo.prompt_token_ids[1:]
-            for token_id, weight in zip(mo.prompt_token_ids, mo.outputs.data.tolist()):
+            for token_id, weight in zip(mo.prompt_token_ids, sparse_weights):
                 sparse_embedding[token_id] = max(
                     weight, sparse_embedding.get(token_id, 0.0)
                 )
@@ -120,6 +122,7 @@ class BgeM3SparseEmbeddingsProcessor(
                         sparse_embedding,
                         return_tokens,
                     ),
+                    dense_embedding=dense_embedding,
                 )
             )
 

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -41,7 +41,7 @@ class BgeM3SparseEmbeddingsProcessor(
                 if getattr(pooler_config, param, None) is None:
                     continue
                 self.default_pooling_params[param] = getattr(pooler_config, param)
-        self.embed_dimensions = vllm_config.model_config.embedding_size()
+        self.embed_dimensions = vllm_config.model_config.embedding_size
         self.embed_request_queue: list[EmbedRequestMixin] = []
         logger.info(self)
 

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -207,6 +207,7 @@ class BgeM3SparseEmbeddingsProcessor(
             response_data.append(
                 SparseEmbeddingResponseData(
                     index=idx,
+                    object=raw_request.embed_task,
                     sparse_embedding=sparse_embedding,
                     dense_embedding=dense_embedding,
                 )

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -24,8 +24,6 @@ from .types import (
 
 logger = init_logger(__name__)
 
-_BGE_M3_EMBED_DIM = 1024
-
 
 class BgeM3SparseEmbeddingsProcessor(
     IOProcessor[SparseEmbeddingCompletionRequestMixin, SparseEmbeddingResponse]
@@ -42,7 +40,7 @@ class BgeM3SparseEmbeddingsProcessor(
                 if getattr(pooler_config, param, None) is None:
                     continue
                 self.default_pooling_params[param] = getattr(pooler_config, param)
-        self.embed_dimensions = vllm_config.get("hidden_size", _BGE_M3_EMBED_DIM)
+        self.embed_dimensions = vllm_config.model_config.get_hidden_size()
 
     def merge_pooling_params(
         self,

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -82,7 +82,7 @@ class BgeM3SparseEmbeddingsProcessor(
         if params.use_activation is None:
             params.use_activation = True
         if not has_dense_embed:
-            params.dimension = None
+            params.dimensions = None
             return params
 
         params.dimensions = raw_embed_request.dimensions

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -64,19 +64,27 @@ class BgeM3SparseEmbeddingsProcessor(
         params.skip_reading_prefix_cache = True
 
         raw_embed_request = self.embed_request_queue.pop(0)
-        if raw_embed_request.task not in EMBED_TASKS:
+        if raw_embed_request.embed_task not in EMBED_TASKS:
             raise ValueError(
                 f"Unsupported task {raw_embed_request}, "
                 f"Supported tasks are {EMBED_TASKS}"
             )
-        if raw_embed_request.task == "dense":
+        has_dense_embed = True
+        if raw_embed_request.embed_task == "dense":
             params.task = "embed"
             params.skip_reading_prefix_cache = False
-        elif raw_embed_request.task == "sparse":
+        elif raw_embed_request.embed_task == "sparse":
             params.task = "token_classify"
+            has_dense_embed = False
         else:
             params.task = "embed&token_classify"
         params.use_activation = raw_embed_request.use_activation
+        if params.use_activation is None:
+            params.use_activation = True
+        if not has_dense_embed:
+            params.dimension = None
+            return params
+
         params.dimensions = raw_embed_request.dimensions
 
         model_config: ModelConfig = self.vllm_config.model_config
@@ -84,8 +92,6 @@ class BgeM3SparseEmbeddingsProcessor(
             if getattr(params, param, None) is None:
                 setattr(params, param, self.default_pooling_params[param])
 
-        if params.use_activation is None:
-            params.use_activation = True
         if params.dimensions is not None:
             if not model_config.is_matryoshka:
                 raise ValueError(
@@ -166,8 +172,8 @@ class BgeM3SparseEmbeddingsProcessor(
         num_prompt_tokens = 0
         response_data = []
         raw_request = self._get_sparse_embedding_request(request_id)
-        has_dense_embed = raw_request.task in ["dense", "dense&sparse"]
-        has_sparse_embed = raw_request.task in ["sparse", "dense&sparse"]
+        has_dense_embed = raw_request.embed_task in ["dense", "dense&sparse"]
+        has_sparse_embed = raw_request.embed_task in ["sparse", "dense&sparse"]
         embed_dimensions = 0
         if has_dense_embed:
             embed_dimensions = (

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -41,6 +41,14 @@ class BgeM3SparseEmbeddingsProcessor(
                     continue
                 self.default_pooling_params[param] = getattr(pooler_config, param)
         self.embed_dimensions = vllm_config.model_config.get_hidden_size()
+        logger.info(self)
+
+    def __repr__(self) -> str:
+        return (
+            f"BgeM3SparseEmbeddingsProcessor("
+            f"embed_dimensions={self.embed_dimensions}, "
+            f"default_pooling_params={self.default_pooling_params})"
+        )
 
     def merge_pooling_params(
         self,

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -112,9 +112,10 @@ class BgeM3SparseEmbeddingsProcessor(
         if request_id is not None:
             assert request_id not in self.online_requests, "request_id duplicated"
             self.online_requests[request_id] = prompt
+            self.embed_request_queue.extend(prompt.to_embed_requests_online())
         else:
             self.offline_requests.append(prompt)
-        self.embed_request_queue.extend(prompt.to_embed_requests())
+            self.embed_request_queue.extend(prompt.to_embed_requests_offline())
         return prompt.input
 
     def _get_sparse_embedding_request(self, request_id: str | None = None):

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -3,7 +3,7 @@
 
 from collections.abc import Sequence
 
-from vllm.config import ModelConfig, PoolerConfig, VllmConfig, get_current_vllm_config
+from vllm.config import ModelConfig, PoolerConfig, VllmConfig
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
 from vllm.inputs.data import PromptType
 from vllm.logger import init_logger
@@ -35,6 +35,14 @@ class BgeM3SparseEmbeddingsProcessor(
         self.offline_requests: list[SparseEmbeddingCompletionRequestMixin] = []
         self.online_requests: dict[str, SparseEmbeddingCompletionRequestMixin] = {}
         self.renderer: BaseRenderer = renderer
+        self.default_pooling_params = {}
+        pooler_config: PoolerConfig = vllm_config.model_config.pooler_config
+        if pooler_config is not None:
+            for param in ["use_activation", "dimensions"]:
+                if getattr(pooler_config, param, None) is None:
+                    continue
+                self.default_pooling_params[param] = getattr(pooler_config, param)
+        self.embed_dimensions = vllm_config.get("hidden_size", _BGE_M3_EMBED_DIM)
 
     def merge_pooling_params(
         self,
@@ -47,15 +55,10 @@ class BgeM3SparseEmbeddingsProcessor(
         # set and verify pooling params
         params.skip_reading_prefix_cache = True
 
-        model_config: ModelConfig = get_current_vllm_config().model_config
-        pooler_config: PoolerConfig = model_config.pooler_config
-        if pooler_config is not None:
-            for param in ["use_activation", "dimensions"]:
-                if getattr(pooler_config, param, None) is None:
-                    continue
-
-                if getattr(params, param, None) is None:
-                    setattr(params, param, getattr(pooler_config, param))
+        model_config: ModelConfig = self.vllm_config.model_config
+        for param in self.default_pooling_params:
+            if getattr(params, param, None) is None:
+                setattr(params, param, self.default_pooling_params[param])
 
         if params.use_activation is None:
             params.use_activation = True
@@ -141,8 +144,8 @@ class BgeM3SparseEmbeddingsProcessor(
             mo = model_output[idx]
             sparse_embedding: dict[int, float] = {}
             num_prompt_tokens += len(mo.prompt_token_ids)
-            dense_embedding = mo.outputs.data[:_BGE_M3_EMBED_DIM].tolist()
-            sparse_weights = mo.outputs.data[_BGE_M3_EMBED_DIM:].tolist()
+            dense_embedding = mo.outputs.data[: self.embed_dimensions].tolist()
+            sparse_weights = mo.outputs.data[self.embed_dimensions :].tolist()
             if len(mo.prompt_token_ids) != len(sparse_weights):
                 # this is the case that add_special_tokens is True,
                 # which means first token and last token are special tokens

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -3,7 +3,7 @@
 
 from collections.abc import Sequence
 
-from vllm.config import VllmConfig
+from vllm.config import ModelConfig, PoolerConfig, VllmConfig, get_current_vllm_config
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
 from vllm.inputs.data import PromptType
 from vllm.logger import init_logger
@@ -44,6 +44,40 @@ class BgeM3SparseEmbeddingsProcessor(
             params = PoolingParams()
         # refer to PoolingCompletionRequest.to_pooling_params
         params.task = "embed&token_classify"
+        # set and verify pooling params
+        params.skip_reading_prefix_cache = True
+
+        model_config: ModelConfig = get_current_vllm_config().model_config
+        pooler_config: PoolerConfig = model_config.pooler_config
+        if pooler_config is not None:
+            for param in ["use_activation", "dimensions"]:
+                if getattr(pooler_config, param, None) is None:
+                    continue
+
+                if getattr(params, param, None) is None:
+                    setattr(params, param, getattr(pooler_config, param))
+
+        if params.use_activation is None:
+            params.use_activation = True
+        if params.dimensions is not None:
+            if not model_config.is_matryoshka:
+                raise ValueError(
+                    f'Model "{model_config.served_model_name}" does not '
+                    f"support matryoshka representation, "
+                    f"changing output dimensions will lead to poor results."
+                )
+
+            mds = model_config.matryoshka_dimensions
+            if mds is not None:
+                if params.dimensions not in mds:
+                    raise ValueError(
+                        f"Model {model_config.served_model_name!r} "
+                        f"only supports {str(mds)} matryoshka dimensions, "
+                        f"use other output dimensions will "
+                        f"lead to poor results."
+                    )
+            elif params.dimensions < 1:
+                raise ValueError("Dimensions must be greater than 0")
         return params
 
     def parse_request(

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/sparse_embeddings_processor.py
@@ -7,7 +7,6 @@ from vllm.config import ModelConfig, PoolerConfig, VllmConfig
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
 from vllm.entrypoints.pooling.base.protocol import EmbedRequestMixin
 from vllm.inputs.data import PromptType
-from vllm.logger import init_logger
 from vllm.outputs import PoolingRequestOutput
 from vllm.plugins.io_processors.interface import (
     IOProcessor,
@@ -23,8 +22,6 @@ from .types import (
     SparseEmbeddingResponseData,
     SparseEmbeddingTokenWeight,
 )
-
-logger = init_logger(__name__)
 
 
 class BgeM3SparseEmbeddingsProcessor(
@@ -44,7 +41,6 @@ class BgeM3SparseEmbeddingsProcessor(
                 self.default_pooling_params[param] = getattr(pooler_config, param)
         self.embed_dimensions = vllm_config.model_config.embedding_size
         self.embed_request_queue: list[EmbedRequestMixin] = []
-        logger.info(self)
 
     def __repr__(self) -> str:
         return (

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/types.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/types.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import Literal, get_args
+
 from pydantic import BaseModel, Field
 
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
@@ -9,12 +11,25 @@ from vllm.entrypoints.pooling.base.protocol import (
     EmbedRequestMixin,
 )
 
+EmbedTask = Literal[
+    "sparse",
+    "dense",
+    "dense&sparse",
+]
+
+EMBED_TASKS: tuple[EmbedTask, ...] = get_args(EmbedTask)
+
 
 class SparseEmbeddingCompletionRequestMixin(CompletionRequestMixin, EmbedRequestMixin):
     return_tokens: bool | None = Field(
         default=None,
         description="Whether to return dict shows the mapping of token_id to text."
         "`None` or False means not return.",
+    )
+    embed_task: EmbedTask = Field(
+        default="dense&sparse",
+        description="embed task, can be one of 'sparse', 'dense' , 'dense&sparse', "
+        "default to 'dense&sparse'",
     )
 
     def to_embed_requests_offline(self) -> list[EmbedRequestMixin]:
@@ -35,8 +50,8 @@ class SparseEmbeddingTokenWeight(BaseModel):
 class SparseEmbeddingResponseData(BaseModel):
     index: int
     object: str = "sparse&dense"
-    sparse_embedding: list[SparseEmbeddingTokenWeight]
-    dense_embedding: list[float]
+    sparse_embedding: list[SparseEmbeddingTokenWeight] | None
+    dense_embedding: list[float] | None
 
 
 class SparseEmbeddingResponse(BaseModel):

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/types.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/types.py
@@ -23,8 +23,9 @@ class SparseEmbeddingTokenWeight(BaseModel):
 
 class SparseEmbeddingResponseData(BaseModel):
     index: int
-    object: str = "sparse-embedding"
+    object: str = "sparse&dense"
     sparse_embedding: list[SparseEmbeddingTokenWeight]
+    dense_embedding: list[float]
 
 
 class SparseEmbeddingResponse(BaseModel):

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/types.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/types.py
@@ -49,7 +49,7 @@ class SparseEmbeddingTokenWeight(BaseModel):
 
 class SparseEmbeddingResponseData(BaseModel):
     index: int
-    object: str = "sparse&dense"
+    object: str = "dense&sparse"
     sparse_embedding: list[SparseEmbeddingTokenWeight] | None
     dense_embedding: list[float] | None
 

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/types.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/types.py
@@ -4,15 +4,23 @@
 from pydantic import BaseModel, Field
 
 from vllm.entrypoints.openai.engine.protocol import UsageInfo
-from vllm.entrypoints.pooling.base.protocol import CompletionRequestMixin
+from vllm.entrypoints.pooling.base.protocol import (
+    CompletionRequestMixin,
+    EmbedRequestMixin,
+)
 
 
-class SparseEmbeddingCompletionRequestMixin(CompletionRequestMixin):
+class SparseEmbeddingCompletionRequestMixin(CompletionRequestMixin, EmbedRequestMixin):
     return_tokens: bool | None = Field(
         default=None,
         description="Whether to return dict shows the mapping of token_id to text."
         "`None` or False means not return.",
     )
+
+    def to_embed_requests(self) -> list[EmbedRequestMixin]:
+        if isinstance(self.input, list):
+            return [self] * len(self.input)
+        return [self]
 
 
 class SparseEmbeddingTokenWeight(BaseModel):

--- a/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/types.py
+++ b/tests/plugins/bge_m3_sparse_plugin/bge_m3_sparse_processor/types.py
@@ -17,9 +17,12 @@ class SparseEmbeddingCompletionRequestMixin(CompletionRequestMixin, EmbedRequest
         "`None` or False means not return.",
     )
 
-    def to_embed_requests(self) -> list[EmbedRequestMixin]:
+    def to_embed_requests_offline(self) -> list[EmbedRequestMixin]:
         if isinstance(self.input, list):
             return [self] * len(self.input)
+        return [self]
+
+    def to_embed_requests_online(self) -> list[EmbedRequestMixin]:
         return [self]
 
 

--- a/tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py
+++ b/tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py
@@ -19,6 +19,12 @@ model_config = {
     ),
 }
 
+dense_embedding_sum = [
+    -0.7214539647102356,  # "What is the capital of France?"
+    -0.6926871538162231,  # "What is the capital of Germany?"
+    -0.7129564881324768,  # "What is the capital of Spain?"
+]
+
 
 def _float_close(expected: object, result: object):
     assert isinstance(expected, float) and isinstance(result, float), (
@@ -31,6 +37,12 @@ def _get_attr_or_val(obj: object | dict, key: str):
     if isinstance(obj, dict) and key in obj:
         return obj[key]
     return getattr(obj, key, None)
+
+
+def _check_dense_embedding(data, index=0):
+    assert _float_close(sum(data), dense_embedding_sum[index]), (
+        "dense-embedding result not match"
+    )
 
 
 def _check_sparse_embedding(data, check_tokens=False):
@@ -109,13 +121,18 @@ async def test_bge_m3_sparse_plugin_online(
     assert len(_get_attr_or_val(parsed_response, "data")) > 0
 
     data_entry = _get_attr_or_val(parsed_response, "data")[0]
-    assert _get_attr_or_val(data_entry, "object") == "sparse-embedding"
+    assert _get_attr_or_val(data_entry, "object") == "sparse&dense"
     assert _get_attr_or_val(data_entry, "sparse_embedding")
 
     # Verify sparse embedding format
     sparse_embedding = _get_attr_or_val(data_entry, "sparse_embedding")
     assert isinstance(sparse_embedding, list)
     _check_sparse_embedding(sparse_embedding, return_tokens)
+
+    # Verify dense embedding format
+    dense_embedding = _get_attr_or_val(data_entry, "dense_embedding")
+    assert isinstance(dense_embedding, list)
+    _check_dense_embedding(dense_embedding)
 
     # Verify usage information
     usage = _get_attr_or_val(parsed_response, "usage")
@@ -164,6 +181,9 @@ def test_bge_m3_sparse_plugin_offline(vllm_runner, return_tokens: bool):
         sparse_embedding = output.sparse_embedding
         assert isinstance(sparse_embedding, list)
         _check_sparse_embedding(sparse_embedding, return_tokens)
+        dense_embedding = output.dense_embedding
+        assert isinstance(dense_embedding, list)
+        _check_dense_embedding(dense_embedding)
 
     # Verify usage
     assert response.usage.prompt_tokens > 0
@@ -206,6 +226,9 @@ def test_bge_m3_sparse_plugin_offline_multiple_inputs(vllm_runner):
         # Each output should have sparse embeddings
         sparse_embedding = output.sparse_embedding
         assert isinstance(sparse_embedding, list)
+        dense_embedding = output.dense_embedding
+        assert isinstance(dense_embedding, list)
+        _check_dense_embedding(dense_embedding, i)
 
     # Verify usage
     assert response.usage.prompt_tokens > 0

--- a/tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py
+++ b/tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py
@@ -121,7 +121,7 @@ async def test_bge_m3_sparse_plugin_online(
     assert len(_get_attr_or_val(parsed_response, "data")) > 0
 
     data_entry = _get_attr_or_val(parsed_response, "data")[0]
-    assert _get_attr_or_val(data_entry, "object") == "sparse&dense"
+    assert _get_attr_or_val(data_entry, "object") == "dense&sparse"
     assert _get_attr_or_val(data_entry, "sparse_embedding")
 
     # Verify sparse embedding format

--- a/vllm/model_executor/layers/pooler/special.py
+++ b/vllm/model_executor/layers/pooler/special.py
@@ -170,4 +170,42 @@ class BOSEOSFilter(Pooler):
         return pooled_outputs
 
 
-__all__ = ["BOSEOSFilter", "DispatchPooler", "IdentityPooler"]
+class BgeM3Pooler(Pooler):
+    def __init__(self, token_classify_pooler: Pooler, embed_pooler: Pooler) -> None:
+        super().__init__()
+        self.token_classify_pooler = token_classify_pooler
+        self.embed_pooler = embed_pooler
+
+    def forward(
+        self, hidden_states: torch.Tensor, pooling_metadata: PoolingMetadata
+    ) -> PoolerOutput:
+        embed_outputs = self.embed_pooler(hidden_states, pooling_metadata)
+        token_classify_outputs = self.token_classify_pooler(
+            hidden_states, pooling_metadata
+        )
+        pooler_outputs: list[torch.Tensor] = []
+        for embed_output, token_classify_output in zip(
+            embed_outputs, token_classify_outputs
+        ):
+            pooler_outputs.append(
+                torch.cat(
+                    [embed_output.view(-1), token_classify_output.view(-1)], dim=-1
+                )
+            )
+
+        return pooler_outputs
+
+    def get_supported_tasks(self) -> Set[PoolingTask]:
+        return {"embed&token_classify"}
+
+    def get_pooling_updates(self, task: PoolingTask) -> PoolingParamsUpdate:
+        return self.embed_pooler.get_pooling_updates(
+            "embed"
+        ) | self.token_classify_pooler.get_pooling_updates("token_classify")
+
+    def extra_repr(self) -> str:
+        s = f"supported_task={self.get_supported_tasks()}"
+        return s
+
+
+__all__ = ["BOSEOSFilter", "DispatchPooler", "IdentityPooler", "BgeM3Pooler"]

--- a/vllm/model_executor/models/roberta.py
+++ b/vllm/model_executor/models/roberta.py
@@ -10,6 +10,7 @@ from transformers import RobertaConfig
 
 from vllm.config import ModelConfig, PoolerConfig, VllmConfig
 from vllm.model_executor.layers.pooler import (
+    BgeM3Pooler,
     BOSEOSFilter,
     DispatchPooler,
     Pooler,
@@ -216,24 +217,29 @@ class BgeM3EmbeddingModel(RobertaEmbeddingModel):
         self.colbert_linear = nn.Linear(
             self.hidden_size, self.hidden_size, dtype=self.head_dtype
         )
+        embed_pooler = pooler_for_embed(pooler_config)
+        token_classify_pooler = BOSEOSFilter(
+            pooler_for_token_classify(
+                pooler_config,
+                pooling=AllPool(),
+                classifier=self.sparse_linear,
+                act_fn=torch.relu,
+            ),
+            self.bos_token_id,
+            self.eos_token_id,
+        )
 
         return DispatchPooler(
             {
-                "embed": pooler_for_embed(pooler_config),
+                "embed": embed_pooler,
                 "token_embed": BOSEOSFilter(
                     pooler_for_token_embed(pooler_config, self.colbert_linear),
                     self.bos_token_id,
                     # for some reason m3 only filters the bos for colbert vectors
                 ),
-                "token_classify": BOSEOSFilter(
-                    pooler_for_token_classify(
-                        pooler_config,
-                        pooling=AllPool(),
-                        classifier=self.sparse_linear,
-                        act_fn=torch.relu,
-                    ),
-                    self.bos_token_id,
-                    self.eos_token_id,
+                "token_classify": token_classify_pooler,
+                "embed&token_classify": BgeM3Pooler(
+                    token_classify_pooler, embed_pooler
                 ),
             }
         )

--- a/vllm/pooling_params.py
+++ b/vllm/pooling_params.py
@@ -82,7 +82,6 @@ class PoolingParams(
             "score": ["use_activation"],
             "token_embed": ["dimensions", "use_activation"],
             "token_classify": ["use_activation"],
-            "embed&token_classify": ["dimensions", "use_activation"],
         }
 
     def clone(self) -> "PoolingParams":
@@ -95,6 +94,10 @@ class PoolingParams(
         if self.task == "plugin":
             if self.skip_reading_prefix_cache is None:
                 self.skip_reading_prefix_cache = True
+            return
+
+        # skipping verify, let plugins configure and validate pooling params
+        if self.task not in self.valid_parameters:
             return
 
         # NOTE: Task validation needs to done against the model instance,
@@ -123,7 +126,7 @@ class PoolingParams(
             # If prefix caching is enabled,
             # the output of all pooling may less than n_prompt_tokens,
             # we need to skip reading cache at this request.
-            if self.task in ["token_embed", "token_classify", "embed&token_classify"]:
+            if self.task in ["token_embed", "token_classify"]:
                 self.skip_reading_prefix_cache = True
             else:
                 self.skip_reading_prefix_cache = False
@@ -157,7 +160,7 @@ class PoolingParams(
                     setattr(self, k, getattr(pooler_config, k))
 
     def _set_default_parameters(self, model_config: ModelConfig):
-        if self.task in ["embed", "token_embed", "embed&token_classify"]:
+        if self.task in ["embed", "token_embed"]:
             if self.use_activation is None:
                 self.use_activation = True
 
@@ -181,7 +184,7 @@ class PoolingParams(
                 elif self.dimensions < 1:
                     raise ValueError("Dimensions must be greater than 0")
 
-        elif self.task in ["classify", "score", "token_classify"]:
+        elif self.task in ["classify", "score"]:
             if self.use_activation is None:
                 self.use_activation = True
         else:

--- a/vllm/pooling_params.py
+++ b/vllm/pooling_params.py
@@ -184,7 +184,7 @@ class PoolingParams(
                 elif self.dimensions < 1:
                     raise ValueError("Dimensions must be greater than 0")
 
-        elif self.task in ["classify", "score"]:
+        elif self.task in ["classify", "score", "token_classify"]:
             if self.use_activation is None:
                 self.use_activation = True
         else:

--- a/vllm/pooling_params.py
+++ b/vllm/pooling_params.py
@@ -82,6 +82,7 @@ class PoolingParams(
             "score": ["use_activation"],
             "token_embed": ["dimensions", "use_activation"],
             "token_classify": ["use_activation"],
+            "embed&token_classify": ["dimensions", "use_activation"],
         }
 
     def clone(self) -> "PoolingParams":
@@ -122,7 +123,7 @@ class PoolingParams(
             # If prefix caching is enabled,
             # the output of all pooling may less than n_prompt_tokens,
             # we need to skip reading cache at this request.
-            if self.task in ["token_embed", "token_classify"]:
+            if self.task in ["token_embed", "token_classify", "embed&token_classify"]:
                 self.skip_reading_prefix_cache = True
             else:
                 self.skip_reading_prefix_cache = False
@@ -156,7 +157,7 @@ class PoolingParams(
                     setattr(self, k, getattr(pooler_config, k))
 
     def _set_default_parameters(self, model_config: ModelConfig):
-        if self.task in ["embed", "token_embed"]:
+        if self.task in ["embed", "token_embed", "embed&token_classify"]:
             if self.use_activation is None:
                 self.use_activation = True
 

--- a/vllm/tasks.py
+++ b/vllm/tasks.py
@@ -6,7 +6,13 @@ GenerationTask = Literal["generate", "transcription", "realtime"]
 GENERATION_TASKS: tuple[GenerationTask, ...] = get_args(GenerationTask)
 
 PoolingTask = Literal[
-    "embed", "classify", "score", "token_embed", "token_classify", "plugin"
+    "embed",
+    "classify",
+    "score",
+    "token_embed",
+    "token_classify",
+    "plugin",
+    "embed&token_classify",
 ]
 POOLING_TASKS: tuple[PoolingTask, ...] = get_args(PoolingTask)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
As issue #35190 proposed,  support both sparse&dense embedding in a single inference call. 

## Test Plan
./tests/plugins_tests/test_bge_m3_sparse_io_processor_plugins.py
## Test Result
All test cases passed. Both sparse&dense embedding is ok. 

<img width="2846" height="596" alt="image" src="https://github.com/user-attachments/assets/31147b86-ebb3-4a55-b396-327aa3c6f4c1" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

