### PR TITLE
[Bugfix] Fix stream_interval > 1 for jamba tool parser

### DIFF
--- a/tests/tool_parsers/test_utils.py
+++ b/tests/tool_parsers/test_utils.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.tool_parsers.utils import compute_streamed_args_delta
+
+
+class TestComputeStreamedArgsDelta:
+    """Tests for compute_streamed_args_delta."""
+
+    def test_is_complete_flushes_remaining(self):
+        """When JSON is complete, flush everything not yet streamed."""
+        result = compute_streamed_args_delta(
+            cur_args_json='{"city": "Dallas"}',
+            prev_args_json='{"city": "Dallas"}',
+            already_streamed='{"city": "Dal',
+            is_complete=True,
+        )
+        assert result == 'las"}'
+
+    def test_is_complete_nothing_remaining(self):
+        """When JSON is complete and everything already streamed, return None."""
+        full = '{"city": "Dallas"}'
+        result = compute_streamed_args_delta(
+            cur_args_json=full,
+            prev_args_json=full,
+            already_streamed=full,
+            is_complete=True,
+        )
+        assert result is None
+
+    def test_is_complete_from_scratch(self):
+        """When JSON is complete but nothing streamed yet, flush everything."""
+        full = '{"city": "Dallas"}'
+        result = compute_streamed_args_delta(
+            cur_args_json=full,
+            prev_args_json=None,
+            already_streamed="",
+            is_complete=True,
+        )
+        assert result == full
+
+    def test_prev_none_holdback(self):
+        """First time seeing arguments (prev is None) and JSON incomplete —
+        hold back to avoid streaming auto-completed structure."""
+        result = compute_streamed_args_delta(
+            cur_args_json='{"city": "Dallas"}',
+            prev_args_json=None,
+            already_streamed="",
+            is_complete=False,
+        )
+        assert result is None
+
+    def test_no_change(self):
+        """When current and previous are identical, return None."""
+        same = '{"city": "Dal"}'
+        result = compute_streamed_args_delta(
+            cur_args_json=same,
+            prev_args_json=same,
+            already_streamed='{"city": "Dal',
+            is_complete=False,
+        )
+        assert result is None
+
+    def test_incremental_diff(self):
+        """Stream only the stable prefix diff between prev and current."""
+        result = compute_streamed_args_delta(
+            cur_args_json='{"city": "Dallas"}',
+            prev_args_json='{"city": "Dal"}',
+            already_streamed='{"city": "Dal',
+            is_complete=False,
+        )
+        # Common prefix of prev and cur is '{"city": "Dal'
+        # already_streamed is '{"city": "Dal' — so diff is empty
+        assert result is None
+
+    def test_incremental_diff_with_new_content(self):
+        """New content appears that extends past what was already streamed."""
+        result = compute_streamed_args_delta(
+            cur_args_json='{"city": "Dallas"}',
+            prev_args_json='{"city": "Dalla"}',
+            already_streamed='{"city": "Dal',
+            is_complete=False,
+        )
+        # Common prefix: '{"city": "Dalla' (5 chars of "Dalla" shared)
+        # already_streamed length is 14, prefix length is 16 → diff = "la"
+        assert result == "la"
+
+    def test_incremental_avoids_auto_completed_closing(self):
+        """The partial parser auto-completes closing chars — don't stream
+        those until JSON is truly finalized."""
+        # prev parse auto-completed to: {"city": "ap"}
+        # cur  parse auto-completed to: {"city": "apple"}
+        # The common prefix is '{"city": "ap' — the closing '"}' in prev
+        # is auto-completed and should not be streamed.
+        result = compute_streamed_args_delta(
+            cur_args_json='{"city": "apple"}',
+            prev_args_json='{"city": "ap"}',
+            already_streamed='{"city": "',
+            is_complete=False,
+        )
+        assert result == "ap"
+
+    @pytest.mark.parametrize(
+        "cur_args_json,prev_args_json,already,expected",
+        [
+            # Round 1: first real diff after holdback
+            ('{"key": "v"}', '{"ke"}', "", '{"ke'),
+            # Round 2: prefix includes the stable closing quote of "key"
+            ('{"key": "va"}', '{"key"}', '{"ke', 'y"'),
+            # Round 3: colon, space, opening quote, and start of value
+            ('{"key": "valu"}', '{"key": "v"}', '{"key"', ': "v'),
+            # Round 4: more of the value streams through
+            ('{"key": "value"}', '{"key": "valu"}', '{"key": "v', "alu"),
+        ],
+        ids=["round1", "round2", "round3", "round4"],
+    )
+    def test_progressive_streaming(
+        self, cur_args_json, prev_args_json, already, expected
+    ):
+        """Simulate multiple rounds of progressive streaming, where each
+        round's already_streamed is the accumulation of prior diffs."""
+        result = compute_streamed_args_delta(
+            cur_args_json=cur_args_json,
+            prev_args_json=prev_args_json,
+            already_streamed=already,
+            is_complete=False,
+        )
+        assert result == expected

--- a/vllm/tool_parsers/jamba_tool_parser.py
+++ b/vllm/tool_parsers/jamba_tool_parser.py
@@ -23,7 +23,7 @@ from vllm.entrypoints.openai.engine.protocol import (
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers import ToolParser
-from vllm.tool_parsers.utils import extract_intermediate_diff
+from vllm.tool_parsers.utils import compute_streamed_args_delta, is_complete_json
 from vllm.utils.mistral import is_mistral_tokenizer
 
 logger = init_logger(__name__)
@@ -139,16 +139,6 @@ class JambaToolParser(ToolParser):
         # if the tool call token ID IS in the tokens generated so far, that
         # means we're parsing as tool calls now
 
-        # handle if we detected the start of tool calls token which means
-        # the start of tool calling
-        if (
-            self.tool_calls_start_token_id in delta_token_ids
-            and len(delta_token_ids) == 1
-        ):
-            # if it's the only token, return None, so we don't send a chat
-            # completion and don't send a control token
-            return None
-
         # bit mask flags for partial JSON parsing. If the name hasn't been
         # sent yet, don't allow sending
         # an incomplete string since OpenAI only ever (as far as I have
@@ -176,42 +166,41 @@ class JambaToolParser(ToolParser):
                 tool_call_arr[self.current_tool_id] if len(tool_call_arr) > 0 else {}
             )
 
-            # case -- if no tokens have been streamed for the tool, e.g.
+            # if no tokens have been streamed for the tool, e.g.
             #   only the array brackets, stream nothing
             if len(tool_call_arr) == 0:
                 return None
 
+            delta = None
+
             # case: we are starting a new tool in the array
-            #   -> array has > 0 length AND length has moved past cursor
-            elif (
-                len(tool_call_arr) > 0 and len(tool_call_arr) > self.current_tool_id + 1
-            ):
+            #   -> array length has moved past cursor
+            if len(tool_call_arr) > self.current_tool_id + 1:
                 # if we're moving on to a new call, first make sure we
                 # haven't missed anything in the previous one that was
                 # auto-generated due to JSON completions, but wasn't
                 # streamed to the client yet.
                 if self.current_tool_id >= 0:
-                    diff: str | None = current_tool_call.get("arguments")
+                    prev_args = current_tool_call.get("arguments")
+                    if prev_args:
+                        prev_args_json = json.dumps(prev_args, ensure_ascii=False)
+                        already = self.streamed_args_for_tool[self.current_tool_id]
+                        remaining = prev_args_json[len(already) :]
+                        if remaining:
+                            delta = DeltaMessage(
+                                tool_calls=[
+                                    DeltaToolCall(
+                                        index=self.current_tool_id,
+                                        function=DeltaFunctionCall(
+                                            arguments=remaining
+                                        ).model_dump(exclude_none=True),
+                                    )
+                                ]
+                            )
+                            self.streamed_args_for_tool[self.current_tool_id] += (
+                                remaining
+                            )
 
-                    if diff:
-                        diff = json.dumps(diff, ensure_ascii=False).replace(
-                            self.streamed_args_for_tool[self.current_tool_id], ""
-                        )
-                        delta = DeltaMessage(
-                            tool_calls=[
-                                DeltaToolCall(
-                                    index=self.current_tool_id,
-                                    function=DeltaFunctionCall(
-                                        arguments=diff
-                                    ).model_dump(exclude_none=True),
-                                )
-                            ]
-                        )
-                        self.streamed_args_for_tool[self.current_tool_id] += diff
-                    else:
-                        delta = None
-                else:
-                    delta = None
                 # re-set stuff pertaining to progress in the current tool
                 self.current_tool_id = len(tool_call_arr) - 1
                 self.current_tool_name_sent = False
@@ -219,10 +208,9 @@ class JambaToolParser(ToolParser):
                 logger.debug("starting on new tool %d", self.current_tool_id)
                 return delta
 
-            # case: update an existing tool - this is handled below
+            # case: update an existing tool
 
             # if the current tool name hasn't been sent, send if available
-            # - otherwise send nothing
             if not self.current_tool_name_sent:
                 function_name = current_tool_call.get("name")
                 if function_name:
@@ -239,81 +227,48 @@ class JambaToolParser(ToolParser):
                         ]
                     )
                     self.current_tool_name_sent = True
-                else:
-                    delta = None
 
-            # now we know we're on the same tool call and we're streaming
-            # arguments
+            # streaming arguments — compare fully-parsed current vs
+            # previous arguments and emit only the stable diff.
             else:
                 prev_arguments = self.prev_tool_call_arr[self.current_tool_id].get(
                     "arguments"
                 )
                 cur_arguments = current_tool_call.get("arguments")
 
-                new_text = delta_text.replace("'", '"')
-
-                if not cur_arguments and not prev_arguments:
-                    delta = None
-                elif not cur_arguments and prev_arguments:
-                    logger.error(
-                        "INVARIANT - impossible to have arguments reset mid-arguments"
-                    )
-                    delta = None
-                elif cur_arguments and not prev_arguments:
-                    cur_arguments_json = json.dumps(cur_arguments, ensure_ascii=False)
-                    logger.debug("finding %s in %s", new_text, cur_arguments_json)
-
-                    arguments_delta = cur_arguments_json[
-                        : cur_arguments_json.index(new_text) + len(new_text)
-                    ]
-                    logger.debug(
-                        "First tokens in arguments received: %s", arguments_delta
-                    )
-                    delta = DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.current_tool_id,
-                                function=DeltaFunctionCall(
-                                    arguments=arguments_delta
-                                ).model_dump(exclude_none=True),
-                            )
-                        ]
-                    )
-                    self.streamed_args_for_tool[self.current_tool_id] += arguments_delta
-
-                elif cur_arguments and prev_arguments:
+                if cur_arguments is not None:
                     cur_args_json = json.dumps(cur_arguments, ensure_ascii=False)
-                    prev_args_json = json.dumps(prev_arguments, ensure_ascii=False)
-                    logger.debug(
-                        "Searching for diff between \n%s\n%s",
-                        cur_args_json,
-                        prev_args_json,
+                    prev_args_json = (
+                        json.dumps(prev_arguments, ensure_ascii=False)
+                        if prev_arguments is not None
+                        else None
                     )
+                    argument_diff = compute_streamed_args_delta(
+                        cur_args_json=cur_args_json,
+                        prev_args_json=prev_args_json,
+                        already_streamed=self.streamed_args_for_tool[
+                            self.current_tool_id
+                        ],
+                        is_complete=(
+                            self.tool_calls_end_token in current_text
+                            and is_complete_json(parsable_arr)
+                        ),
+                    )
+                    if argument_diff:
+                        delta = DeltaMessage(
+                            tool_calls=[
+                                DeltaToolCall(
+                                    index=self.current_tool_id,
+                                    function=DeltaFunctionCall(
+                                        arguments=argument_diff
+                                    ).model_dump(exclude_none=True),
+                                )
+                            ]
+                        )
+                        self.streamed_args_for_tool[self.current_tool_id] += (
+                            argument_diff
+                        )
 
-                    argument_diff = extract_intermediate_diff(
-                        cur_args_json, prev_args_json
-                    )
-                    logger.debug("got arguments diff: %s", argument_diff)
-                    delta = DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.current_tool_id,
-                                function=DeltaFunctionCall(
-                                    arguments=argument_diff
-                                ).model_dump(exclude_none=True),
-                            )
-                        ]
-                    )
-                    self.streamed_args_for_tool[self.current_tool_id] += argument_diff
-                else:
-                    # try parsing it with regular JSON - if it works we're
-                    # at the end, and we need to send the difference between
-                    # tokens streamed so far and the valid JSON
-                    delta = None
-
-            # check to see if the name is defined and has been sent. if so,
-            # stream the name - otherwise keep waiting
-            # finish by setting old and returning None as base case
             self.prev_tool_call_arr = tool_call_arr
             return delta
 

--- a/vllm/tool_parsers/utils.py
+++ b/vllm/tool_parsers/utils.py
@@ -93,6 +93,51 @@ def extract_intermediate_diff(curr: str, old: str) -> str:
     return diff
 
 
+def compute_streamed_args_delta(
+    cur_args_json: str,
+    prev_args_json: str | None,
+    already_streamed: str,
+    is_complete: bool,
+) -> str | None:
+    """Compute the next chunk of tool call arguments to stream to the client.
+
+    Compare fully-parsed current vs previous arguments JSON and emit only
+    the diff relative to what's already been streamed.
+
+    Args:
+        cur_args_json: Current arguments serialized as a JSON string.
+        prev_args_json: Previous arguments serialized as a JSON string,
+            or None if this is the first time arguments appear.
+        already_streamed: What has already been streamed for this tool call
+            (i.e. streamed_args_for_tool[tool_id]).
+        is_complete: Whether the tool_call_portion is complete, valid JSON.
+
+    Returns:
+        The argument diff string to stream, or None if nothing to stream yet.
+    """
+    sent = len(already_streamed)
+
+    if is_complete:
+        # JSON is finalized — everything after what we've sent is the diff
+        diff = cur_args_json[sent:]
+        return diff if diff else None
+
+    if prev_args_json is None:
+        # First time seeing arguments — nothing safe to send yet
+        # (partial JSON parser may have auto-completed structure)
+        return None
+
+    if cur_args_json == prev_args_json:
+        # No change since last call
+        return None
+
+    # Find the stable prefix between previous and current parsed arguments.
+    # This avoids streaming auto-completed closing brackets/quotes.
+    prefix = find_common_prefix(prev_args_json, cur_args_json)
+    diff = prefix[sent:]
+    return diff if diff else None
+
+
 def find_all_indices(string: str, substring: str) -> list[int]:
     """
     Find all (starting) indices of a substring in a given string. Useful for


### PR DESCRIPTION
## Purpose
When stream_interval > 1, multiple tokens arrive in a single delta_text chunk. The Jamba tool parser streaming breaks because it assumes delta_text always has length 1.

### The fix
This PR adds a helper method compute_streamed_args_delta, instead of using delta_text, it computes the diff by comparing consecutive snapshots, therefore it works no matter what the stream_interval is, the flow is like:
prev_args_json  →  cur_args_json  →  common prefix  →  prefix[already_streamed:]

**With this implementation, all tool parsers can later adopt the same method to fix the the stream_interval bug, this PR fixes it for the Jamba parser first.**

## Test Plan
Manual test:
```
vllm serve ai21labs/AI21-Jamba-1.5-Mini     
  --tensor-parallel-size 2     
  --enable-auto-tool-choice    
  --tool-call-parser jamba 
  --stream-interval 5
```
And run the below script:
```
#!/usr/bin/env python3
# SPDX-License-Identifier: Apache-2.0
# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
"""Reproduction script for testing Jamba tool call parsing"""

from openai import OpenAI

client = OpenAI(base_url="http://localhost:8000/v1", api_key="dummy")

tools = [
    {
        "type": "function",
        "function": {
            "name": "get_current_weather",
            "description": "Get the current weather in a given location",
            "parameters": {
                "type": "object",
                "properties": {
                    "city": {"type": "string"},
                    "state": {"type": "string"},
                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
                },
                "required": ["city", "state", "unit"],
            },
        },
    }
]

stream = client.chat.completions.create(
    model="ai21labs/AI21-Jamba-1.5-Mini",
    messages=[
        {"role": "user", "content": "What is the weather in Dallas, TX in celsius?"},
    ],
    tools=tools,
    tool_choice="auto",
    stream=True,
)

# Accumulate tool call deltas across chunks
tool_calls: dict[int, dict] = {}
content_parts: list[str] = []

for chunk in stream:
    delta = chunk.choices[0].delta

    if delta.content:
        content_parts.append(delta.content)

    for tc_delta in delta.tool_calls or []:
        idx = tc_delta.index
        if idx not in tool_calls:
            tool_calls[idx] = {"name": "", "arguments": ""}
        if tc_delta.function.name:
            tool_calls[idx]["name"] += tc_delta.function.name
        if tc_delta.function.arguments:
            tool_calls[idx]["arguments"] += tc_delta.function.arguments

if tool_calls:
    for tc in tool_calls.values():
        print(f"Tool: {tc['name']}, Args: {tc['arguments']!r}")
else:
    print(f"Content: {''.join(content_parts)!r}")

```

Unit test:
```
pytest tests/tool_parsers/test_jamba_tool_parser.py tests/tool_parsers/test_utils.py -v
```

## Test Result
**Before the fix:**
```
Tool: get_current_weather, Args: '{"city": "Dallas"", "state": "TX", "unit": "celsius{"city": "Dallas", "state": "TX", "unit": "celsius"}'
```
**After the PR:**
```
Tool: get_current_weather, Args: '{"city": "Dallas", "state": "TX", "unit": "celsius"}'
```