### PR TITLE
[Bugfix][CPUOffloadingManager] Prevent eviction of already-stored blocks in LRU/ARC `prepare_store()`

### DIFF
--- a/tests/v1/kv_offload/test_cpu_manager.py
+++ b/tests/v1/kv_offload/test_cpu_manager.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 import numpy as np
+import pytest
 
 from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.kv_offload.abstract import (
@@ -76,6 +77,54 @@ def verify_events(
 
     assert tuple(evictions) == to_hash_sets(expected_evictions)
     assert tuple(stores) == to_hash_sets(expected_stores)
+
+
+@pytest.mark.parametrize("manager_class", [LRUOffloadingManager, ARCOffloadingManager])
+def test_already_stored_block_not_evicted_during_prepare_store(manager_class):
+    """
+    Regression test: a block that is already stored must not be evicted
+    by prepare_store() when it needs to make room for new blocks.
+    Applies to both LRUOffloadingManager and ARCOffloadingManager.
+
+    Scenario:
+        - Store blocks [1, 2] and complete.
+        - touch([1]) makes block 2 the LRU candidate.
+        - prepare_store([2, 3, 4, 5]):
+            * block 2 is filtered out as "already stored"
+            * but without the fix, block 2 would be evicted as the LRU
+              candidate to make room for [3, 4, 5]
+        - After complete_store([2, 3, 4, 5]), block 2 must still be present.
+    """
+    block_size = 256
+    cpu_backend = CPUBackend(block_size=block_size, num_blocks=4)
+    manager = manager_class(cpu_backend, enable_events=True)
+
+    # store [1, 2] and complete
+    manager.prepare_store(to_hashes([1, 2]))
+    manager.complete_store(to_hashes([1, 2]))
+
+    # touch [1] to make block 2 the LRU candidate
+    manager.touch(to_hashes([1]))
+
+    # prepare_store([2, 3, 4, 5]):
+    #   - block 2 is already stored → filtered out of block_hashes_to_store
+    #   - block 2 must NOT be evicted even though it is the LRU candidate
+    #   - block 1 (ID 0) is evicted instead; new blocks [3,4,5] get IDs 2,3,0
+    prepare_store_output = manager.prepare_store(to_hashes([2, 3, 4, 5]))
+    verify_store_output(
+        prepare_store_output,
+        ExpectedPrepareStoreOutput(
+            block_hashes_to_store=[3, 4, 5],
+            store_block_ids=[2, 3, 0],
+            block_hashes_evicted=[1],  # block 1 evicted, not block 2
+        ),
+    )
+
+    # complete_store must not silently drop block 2
+    manager.complete_store(to_hashes([2, 3, 4, 5]))
+
+    # block 2 must still be present in the cache
+    assert manager.lookup(to_hashes([2])) == 1
 
 
 def test_cpu_manager():

--- a/vllm/v1/kv_offload/arc_manager.py
+++ b/vllm/v1/kv_offload/arc_manager.py
@@ -123,8 +123,10 @@ class ARCOffloadingManager(OffloadingManager):
     def prepare_store(
         self, block_hashes: Iterable[BlockHash]
     ) -> PrepareStoreOutput | None:
+        block_hashes_list = list(block_hashes)
+
         block_hashes_to_store = []
-        for block_hash in block_hashes:
+        for block_hash in block_hashes_list:
             if block_hash not in self.t1 and block_hash not in self.t2:
                 block_hashes_to_store.append(block_hash)
 
@@ -139,13 +141,16 @@ class ARCOffloadingManager(OffloadingManager):
             len(block_hashes_to_store) - self.backend.get_num_free_blocks()
         )
 
+        # Blocks from the original input are excluded from eviction candidates:
+        # a block that was already stored must remain in the cache after this call.
+        protected = set(block_hashes_list)
         to_evict = []
         while num_blocks_to_evict > 0:
             block_to_evict = None
             if len(self.t1) >= int(self.target_t1_size):
                 # try to evict the least recently used (oldest) block from T1
                 for block_hash, block in self.t1.items():
-                    if block.ref_cnt == 0:
+                    if block.ref_cnt == 0 and block_hash not in protected:
                         block_to_evict = (block_hash, block)
                         eviction_t = self.t1
                         eviction_b = self.b1
@@ -153,7 +158,7 @@ class ARCOffloadingManager(OffloadingManager):
             if not block_to_evict:
                 # try to evict the least recently used (oldest) block from T2
                 for block_hash, block in self.t2.items():
-                    if block.ref_cnt == 0:
+                    if block.ref_cnt == 0 and block_hash not in protected:
                         block_to_evict = (block_hash, block)
                         eviction_t = self.t2
                         eviction_b = self.b2

--- a/vllm/v1/kv_offload/arc_manager.py
+++ b/vllm/v1/kv_offload/arc_manager.py
@@ -141,10 +141,11 @@ class ARCOffloadingManager(OffloadingManager):
             len(block_hashes_to_store) - self.backend.get_num_free_blocks()
         )
 
-        # Blocks from the original input are excluded from eviction candidates:
-        # a block that was already stored must remain in the cache after this call.
-        protected = set(block_hashes_list)
         to_evict = []
+        if num_blocks_to_evict > 0:
+            # Blocks from the original input are excluded from eviction candidates:
+            # a block that was already stored must remain in the cache after this call.
+            protected = set(block_hashes_list)
         while num_blocks_to_evict > 0:
             block_to_evict = None
             if len(self.t1) >= int(self.target_t1_size):

--- a/vllm/v1/kv_offload/lru_manager.py
+++ b/vllm/v1/kv_offload/lru_manager.py
@@ -57,9 +57,13 @@ class LRUOffloadingManager(OffloadingManager):
     def prepare_store(
         self, block_hashes: Iterable[BlockHash]
     ) -> PrepareStoreOutput | None:
+        block_hashes_list = list(block_hashes)
+
         # filter out blocks that are already stored
         block_hashes_to_store = [
-            block_hash for block_hash in block_hashes if block_hash not in self.blocks
+            block_hash
+            for block_hash in block_hashes_list
+            if block_hash not in self.blocks
         ]
 
         num_blocks_to_evict = (
@@ -67,10 +71,13 @@ class LRUOffloadingManager(OffloadingManager):
         )
 
         # build list of blocks to evict
+        # Blocks from the original input are excluded from eviction candidates:
+        # a block that was already stored must remain in the cache after this call.
+        protected = set(block_hashes_list)
         to_evict = []
         if num_blocks_to_evict > 0:
             for block_hash, block in self.blocks.items():
-                if block.ref_cnt == 0:
+                if block.ref_cnt == 0 and block_hash not in protected:
                     to_evict.append(block_hash)
                     num_blocks_to_evict -= 1
                     if num_blocks_to_evict == 0:

--- a/vllm/v1/kv_offload/lru_manager.py
+++ b/vllm/v1/kv_offload/lru_manager.py
@@ -71,11 +71,11 @@ class LRUOffloadingManager(OffloadingManager):
         )
 
         # build list of blocks to evict
-        # Blocks from the original input are excluded from eviction candidates:
-        # a block that was already stored must remain in the cache after this call.
-        protected = set(block_hashes_list)
         to_evict = []
         if num_blocks_to_evict > 0:
+            # Blocks from the original input are excluded from eviction candidates:
+            # a block that was already stored must remain in the cache after this call.
+            protected = set(block_hashes_list)
             for block_hash, block in self.blocks.items():
                 if block.ref_cnt == 0 and block_hash not in protected:
                     to_evict.append(block_hash)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes a bug in the CPU offloading manager where blocks could be accidentally deleted from the cache.

**The Bug:**
When you call `prepare_store([2, 3, 4, 5])` and block 2 is already in the cache:
1. Block 2 is skipped (already stored)
2. The manager needs space for blocks 3, 4, and 5
3. **Problem:** Block 2 can be picked for deletion to make room
4. Block 2 disappears from the cache without any error
5. Data is lost silently

**Why it happened:** The code that picks blocks to delete didn't check if those blocks were in the input list.

**The Fix:** Before deleting any blocks, we now mark all input blocks as "protected" so they can't be deleted.

**Files changed:**
- [`vllm/v1/kv_offload/lru_manager.py`](vllm/v1/kv_offload/lru_manager.py:57) - Fixed LRU manager
- [`vllm/v1/kv_offload/arc_manager.py`](vllm/v1/kv_offload/arc_manager.py:123) - Fixed ARC manager
- [`tests/v1/kv_offload/test_cpu_manager.py`](tests/v1/kv_offload/test_cpu_manager.py:81) - Added test to prevent this bug from happening again

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

