### PR TITLE
[Scheduler] Fix KV-cache head-of-line blocking (#31731)

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -4037,3 +4037,174 @@ def test_eagle3_mm_encoder_cache_with_shift():
         f"shifted_end={scheduled_end_with_shift}) overlapping MM at "
         f"{start_pos}. The fix must schedule encoder inputs."
     )
+
+
+# ---- Tests for KV-cache HOL blocking fix (issue #31731) ----
+
+
+def test_kv_heavy_running_request_does_not_block_others():
+    """When a running request can't allocate KV blocks and exhausts all
+    preemption options, the remaining running requests should still be
+    scheduled rather than being blocked by the failing request.
+
+    Regression test for: https://github.com/vllm-project/vllm/issues/31731
+    """
+    # 20 usable blocks (21 total, block 0 reserved as null).
+    # block_size=16, so each block holds 16 tokens.
+    scheduler = create_scheduler(
+        max_num_batched_tokens=512,
+        block_size=16,
+        num_blocks=21,
+        enable_prefix_caching=False,
+    )
+
+    # R_heavy: 160 tokens = 10 blocks (uses half the cache)
+    heavy_reqs = create_requests(
+        num_requests=1,
+        num_tokens=160,
+        block_size=16,
+        req_ids=["heavy"],
+    )
+    # R_light1, R_light2: 80 tokens = 5 blocks each (10 blocks total)
+    light_reqs = create_requests(
+        num_requests=2,
+        num_tokens=80,
+        block_size=16,
+        req_ids=["light1", "light2"],
+    )
+
+    # Add all three requests. They use 10+5+5=20 blocks = all available.
+    for req in heavy_reqs + light_reqs:
+        scheduler.add_request(req)
+    output0 = scheduler.schedule()
+    assert len(output0.num_scheduled_tokens) == 3
+
+    # Simulate output for all three so they each generate 1 output token.
+    model_output0 = ModelRunnerOutput(
+        req_ids=["heavy", "light1", "light2"],
+        req_id_to_index={"heavy": 0, "light1": 1, "light2": 2},
+        sampled_token_ids=[[0], [0], [0]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output0, model_output0)
+
+    # Now all 20 blocks are used, 0 free.
+    # R_heavy needs 1 new block (161 tokens -> 11 blocks, has 10).
+    # R_light1 needs 0 new blocks (81 tokens -> 6 blocks, has 5... needs 1).
+    # R_light2 needs 0 new blocks (same).
+    # Actually all three need 1 new block, but only 0 free.
+    # The preemption loop will preempt some to make room.
+    # Key assertion: even if R_heavy can't be served, the schedule
+    # step should NOT completely stall — other requests should still run.
+    output1 = scheduler.schedule()
+
+    # At least one request should be scheduled (not a total stall).
+    assert len(output1.num_scheduled_tokens) >= 1, (
+        "KV-heavy request blocked all other running requests"
+    )
+
+
+def test_waiting_requests_admitted_after_preemption():
+    """Waiting requests should still be considered for scheduling even
+    when preemption occurred during the running-request phase.
+
+    Regression test for: https://github.com/vllm-project/vllm/issues/31731
+    """
+    # 10 usable blocks.
+    scheduler = create_scheduler(
+        max_num_batched_tokens=512,
+        block_size=16,
+        num_blocks=11,
+        enable_prefix_caching=False,
+    )
+
+    # R1: 80 tokens = 5 blocks. R2: 80 tokens = 5 blocks. Total = 10.
+    requests = create_requests(
+        num_requests=2,
+        num_tokens=80,
+        block_size=16,
+        req_ids=["r1", "r2"],
+    )
+    scheduler.add_request(requests[0])
+    scheduler.add_request(requests[1])
+    output0 = scheduler.schedule()
+    assert len(output0.num_scheduled_tokens) == 2
+
+    # Simulate output so R1 generates a token (needs 1 new block).
+    model_output0 = ModelRunnerOutput(
+        req_ids=["r1", "r2"],
+        req_id_to_index={"r1": 0, "r2": 1},
+        sampled_token_ids=[[0], [0]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output0, model_output0)
+
+    # Add a small waiting request (16 tokens = 1 block).
+    small_req = create_requests(
+        num_requests=1,
+        num_tokens=16,
+        block_size=16,
+        req_ids=["small"],
+    )
+    scheduler.add_request(small_req[0])
+
+    # Schedule: cache is full, preemption will happen for running requests.
+    # The small waiting request should still be admitted after preemption
+    # frees blocks (not blocked by `if not preempted_reqs`).
+    output1 = scheduler.schedule()
+    assert "small" in output1.num_scheduled_tokens, (
+        "Waiting request was not admitted despite available capacity after preemption"
+    )
+
+
+def test_skip_kv_blocked_waiting_request_allows_light_request():
+    """A KV-heavy request at the head of the waiting queue should not
+    block lighter requests behind it from being scheduled.
+
+    Regression test for: https://github.com/vllm-project/vllm/issues/31731
+    """
+    # 5 usable blocks (6 total, block 0 reserved).
+    scheduler = create_scheduler(
+        max_num_batched_tokens=512,
+        block_size=16,
+        num_blocks=6,
+        enable_prefix_caching=False,
+    )
+
+    # Heavy request: 160 tokens = 10 blocks. Won't fit in 5 usable blocks.
+    heavy_req = create_requests(
+        num_requests=1,
+        num_tokens=160,
+        block_size=16,
+        req_ids=["heavy"],
+    )
+    # Light request: 16 tokens = 1 block. Easily fits.
+    light_req = create_requests(
+        num_requests=1,
+        num_tokens=16,
+        block_size=16,
+        req_ids=["light"],
+    )
+
+    # Add heavy first (it's at the head of the queue).
+    scheduler.add_request(heavy_req[0])
+    scheduler.add_request(light_req[0])
+
+    output = scheduler.schedule()
+
+    # The light request should be scheduled even though the heavy request
+    # at the head of the queue can't fit.
+    assert "light" in output.num_scheduled_tokens, (
+        "Light request was blocked by KV-heavy request at head of waiting queue"
+    )
+
+    # The heavy request should NOT be scheduled (not enough blocks).
+    assert "heavy" not in output.num_scheduled_tokens
+
+    # The heavy request should still be in the waiting queue (not dropped).
+    waiting_ids = [r.request_id for r in scheduler.waiting]
+    assert "heavy" in waiting_ids, "Heavy request was dropped instead of being retried"

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -462,8 +462,6 @@ class Scheduler(SchedulerInterface):
                                 preempted_req_id, None
                             )
                             if preempted_encoder_inputs:
-                                # Restore encoder compute budget if the preempted
-                                # request had encoder inputs scheduled in this step.
                                 num_embeds_to_restore = sum(
                                     preempted_req.get_num_encoder_embeds(i)
                                     for i in preempted_encoder_inputs
@@ -476,12 +474,15 @@ class Scheduler(SchedulerInterface):
                     self._preempt_request(preempted_req, scheduled_timestamp)
                     preempted_reqs.append(preempted_req)
                     if preempted_req == request:
-                        # No more request to preempt. Cannot schedule this request.
+                        # No more request to preempt.
                         break
 
             if new_blocks is None:
-                # Cannot schedule this request.
-                break
+                # This request could not be scheduled even after preempting
+                # others. Instead of stopping the entire loop, continue
+                # scheduling the remaining running requests. This prevents
+                # a single KV-heavy request from blocking all others.
+                continue
 
             # Schedule the request.
             scheduled_running_reqs.append(request)
@@ -533,7 +534,11 @@ class Scheduler(SchedulerInterface):
             assert len(scheduled_loras) <= self.lora_config.max_loras
 
         # Next, schedule the WAITING requests.
-        if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
+        # NOTE: We allow scheduling waiting requests even when preemptions
+        # occurred. Preempting a KV-heavy running request frees blocks that
+        # can be used by waiting requests, so skipping this phase would
+        # waste available capacity.
+        if self._pause_state == PauseState.UNPAUSED:
             # Use a temporary RequestQueue to collect requests that need to be
             # skipped and put back at the head of the waiting queue later
             skipped_waiting_requests = create_request_queue(self.policy)
@@ -735,13 +740,15 @@ class Scheduler(SchedulerInterface):
                 )
 
                 if new_blocks is None:
-                    # The request cannot be scheduled.
-
-                    # NOTE: we need to untouch the request from the encode cache
-                    # manager
+                    # The request cannot be scheduled due to KV cache
+                    # pressure. Skip it and try the next waiting request,
+                    # to avoid head-of-line blocking where a KV-heavy
+                    # request prevents lighter requests from being admitted.
                     if request.has_encoder_inputs:
                         self.encoder_cache_manager.free(request)
-                    break
+                    self.waiting.pop_request()
+                    skipped_waiting_requests.add_request(request)
+                    continue
 
                 # KVTransfer: the connector uses this info to determine
                 # if a load is needed. Note that


### PR DESCRIPTION
## Purpose

Fix KV-cache head-of-line (HOL) blocking in the V1 scheduler (#31731).

When KV cache is under pressure, the scheduler `break`s out of scheduling loops on the first allocation failure, blocking all subsequent requests — including lightweight ones that would easily fit. This causes small, fast requests to wait behind large KV-heavy requests unnecessarily.

This PR makes three targeted changes to `vllm/v1/core/sched/scheduler.py`:

1. **RUNNING phase**: replace `break` with `continue` when a running request fails allocation after exhausting preemption options, so remaining running requests are still scheduled.
2. **WAITING phase guard**: remove the `not preempted_reqs` condition that skipped the entire waiting-request phase whenever preemption occurred, wasting freed capacity.
3. **WAITING phase allocation**: replace `break` with skip-and-continue when a waiting request cannot allocate, allowing lighter requests behind it to be admitted.

All three changes follow the existing precedent set by the `num_new_tokens == 0` continue-path (lines 416-432 in the scheduler), which explicitly relaxes strict FCFS ordering to improve throughput.

Fixes: #31731

## Test Plan

3 new regression tests added to `tests/v1/core/test_scheduler.py`:

- `test_kv_heavy_running_request_does_not_block_others` — verifies running requests are still scheduled when one fails allocation
- `test_waiting_requests_admitted_after_preemption` — verifies waiting requests are admitted even after preemption occurred
- `test_skip_kv_blocked_waiting_request_allows_light_request` — verifies a KV-heavy waiting request does not block lighter ones behind it


### E2E benchmark: Qwen/Qwen2.5-7B on H100 80GB

**Setup:** `--gpu-memory-utilization 0.22` to constrain KV cache to ~2 GiB, `--max-num-seqs 64`, `--enforce-eager`. 20 heavy requests (~3000 input tokens) + 15 light requests (~30 input tokens), all sent concurrently with unique prompts (to defeat prefix caching).

#### Light request latency (the requests being HOL-blocked)

| Metric | Baseline | Fixed | Change |
|--------|----------|-------|--------|
| min | 2.083 s | 1.049 s | **−49.6%** |
| p50 | 2.245 s | 1.558 s | **−30.6%** |
| p99 | 2.254 s | 1.568 s | **−30.4%** |
| max | 2.254 s | 1.568 s | **−30.4%** |

#### Heavy request latency (no regression)

| Metric | Baseline | Fixed | Change |
|--------|----------|-------|--------|
| min | 1.193 s | 1.217 s | +2.0% |
| p50 | 1.619 s | 1.587 s | −2.0% |
| max | 2.258 s | 2.265 s | +0.3% |

#### Overall throughput

| Metric | Baseline | Fixed | Change |
|--------|----------|-------|--------|
| Total wall time | 2.285 s | 2.284 s | −0.0% |

In the baseline, all 15 light requests finish last (2.08–2.25 s), stuck behind the heavy requests. With the fix, light requests interleave and complete 30–50% faster, with zero impact on heavy request throughput or total wall time.


@DarkLight1337 