### PR TITLE
[Docs] Fix typos in comments and docstrings

### DIFF
--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -175,7 +175,7 @@ class DPMetadata:
     # Get the cumulative tokens across sequence parallel ranks.
     # In this case the input to the MoEs will be distributed w.r.t both
     # DP and TP rank.
-    # When sp_size==1, this is just the cummulative num tokens across DP.
+    # When sp_size==1, this is just the cumulative num tokens across DP.
     def cu_tokens_across_sp(self, sp_size: int) -> torch.Tensor:
         num_tokens_across_sp_cpu = (
             self.num_tokens_across_dp_cpu - 1 + sp_size

--- a/vllm/model_executor/models/isaac.py
+++ b/vllm/model_executor/models/isaac.py
@@ -646,7 +646,7 @@ class IsaacImageProcessor:
         return_tensors: str | TensorType | None,
         **kwargs: Unpack[IsaacImageProcessorKwargs],
     ) -> BatchFeature:
-        """Preprocess images into format compatibile with vLLM input processing."""
+        """Preprocess images into format compatible with vLLM input processing."""
 
         all_pixel_values: list[torch.Tensor] = []
         all_image_grids: list[torch.Tensor] = []

--- a/vllm/model_executor/models/transformers/pooling.py
+++ b/vllm/model_executor/models/transformers/pooling.py
@@ -57,7 +57,7 @@ class SequenceClassificationMixin(SupportsCrossEncoding, VllmModelForPooling):
         pooler_config = vllm_config.model_config.pooler_config
         assert pooler_config is not None
 
-        # Certain information about the the model and classifier can only be
+        # Certain information about the model and classifier can only be
         # inferred from the `ForSequenceClassification` class. Therefore, we
         # instantiate it on the "meta" device to avoid allocating GPU memory.
         with torch.device("meta"):

--- a/vllm/v1/kv_offload/worker/cpu_gpu.py
+++ b/vllm/v1/kv_offload/worker/cpu_gpu.py
@@ -197,7 +197,7 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
             transfer = self._transfers.popleft()
             transfer_time = (
                 transfer.start_event.elapsed_time(transfer.end_event) * 1e-3
-            )  # elapsed_time is in miliseconds
+            )  # elapsed_time is in milliseconds
             result = TransferResult(
                 job_id=transfer.job_id,
                 success=True,


### PR DESCRIPTION
## Summary

Fix several typos found across the codebase in comments and docstrings:

- **`vllm/v1/kv_offload/worker/cpu_gpu.py`**: "miliseconds" → "milliseconds"
- **`vllm/model_executor/models/isaac.py`**: "compatibile" → "compatible"
- **`vllm/model_executor/models/transformers/pooling.py`**: "the the" → "the" (duplicate word removed)
- **`vllm/forward_context.py`**: "cummulative" → "cumulative"

These are comment/docstring-only changes with no functional impact.

## Test plan

- No functional changes, only typo fixes in comments and docstrings.
- No tests required.