### PR TITLE
[CI] Temporarily Disable Llama4 MoE Refactor Test

### DIFF
--- a/tests/evals/gsm8k/configs/moe-refactor/config-h100.txt
+++ b/tests/evals/gsm8k/configs/moe-refactor/config-h100.txt
@@ -8,8 +8,5 @@ Qwen3-30B-A3B-Fp8-CT-Block-marlin.yaml
 Qwen3-30B-A3B-Fp8-CT-Block-triton.yaml
 Qwen3-30B-A3B-Fp8-CT-Channel-marlin.yaml
 Qwen3-30B-A3B-Fp8-CT-Channel-vllm-cutlass.yaml
-Llama-4-Scout-Fp8-ModelOpt-fi-cutlass.yaml
-Llama-4-Scout-Fp8-ModelOpt-marlin.yaml
-Llama-4-Scout-Fp8-ModelOpt-triton.yaml
 Qwen3-30B-A3B-BF16-fi-cutlass.yaml
 Qwen3-30B-A3B-BF16-triton.yaml


### PR DESCRIPTION
- Removed Llama-4 Scout model configurations from the file.
- unable to reproduce locally