### PR TITLE
[Bugfix] Update TritonExperts to reflect support for none-gated ReLU^2

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1944,7 +1944,7 @@ class TritonExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:
-        return False
+        return True
 
     @staticmethod
     def _supports_quant_scheme(
@@ -1983,6 +1983,7 @@ class TritonExperts(mk.FusedMoEExpertsModular):
             MoEActivation.GELU,
             MoEActivation.SWIGLUOAI,
             MoEActivation.SWIGLUSTEP,
+            MoEActivation.RELU2_NO_MUL,
         ]
 
     @staticmethod


### PR DESCRIPTION
## Purpose

The Triton MoE functionally supports non-gated ReLU^2 MoEs. Seems a recent regression was introduced and prevents Triton MoEs for being a candidate for Nemotron 3 models (e.g. [Nano v3](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16)). This PR makes the required 2-line fix to reenable the Triton MoEs for Nemotrons. 

On current main, this does not cause a regression where Marlin kernels are supported, but we want to maximize the fallbacks we have and the Triton kernels have a great support matrix for Nemotron3s to benefit from. 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

