### PR TITLE
[Bugfix][NIXL] Compute NIXL throughput using timestamps instead of summed durations

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -1108,6 +1108,121 @@ def test_kv_connector_stats_aggregation():
     assert cli_stats["Avg number of descriptors"] == 1.5
 
 
+def test_kv_connector_stats_throughput_parallel_transfers():
+    """Test throughput for parallel transfers: 400 MB / 1.03s = 388 MB/s."""
+    stats = NixlKVConnectorStats()
+
+    bytes_per_transfer = 100 * (2**20)  # 100 MB
+    duration_seconds = 1.0
+
+    # 4 transfers ending 0.01s apart, each with 1s duration
+    mock_times = iter([1.00, 1.01, 1.02, 1.03])
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector.time.perf_counter",
+        lambda: next(mock_times),
+    ):
+        for _ in range(4):
+            telemetry = get_default_xfer_telemetry(
+                xferDurationS=duration_seconds,
+                postDurationS=0.1,
+                totalBytes=bytes_per_transfer,
+                descCount=1,
+            )
+            stats.record_transfer(telemetry)
+
+    cli_stats = stats.reduce()
+
+    assert stats.num_successful_transfers == 4
+    # span = 1.03 - 0.00 = 1.03s, throughput = 400 MB / 1.03s
+    expected_throughput = 400.0 / 1.03
+    assert abs(cli_stats["Throughput (MB/s)"] - expected_throughput) < 0.1
+
+
+def test_kv_connector_stats_throughput_sequential_transfers():
+    """Test throughput for sequential transfers: 400 MB / 4.0s = 100 MB/s."""
+    stats = NixlKVConnectorStats()
+
+    bytes_per_transfer = 100 * (2**20)  # 100 MB
+    duration_seconds = 1.0
+
+    # 4 transfers ending 1.0s apart (non-overlapping)
+    mock_times = iter([1.0, 2.0, 3.0, 4.0])
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector.time.perf_counter",
+        lambda: next(mock_times),
+    ):
+        for _ in range(4):
+            telemetry = get_default_xfer_telemetry(
+                xferDurationS=duration_seconds,
+                postDurationS=0.1,
+                totalBytes=bytes_per_transfer,
+                descCount=1,
+            )
+            stats.record_transfer(telemetry)
+
+    cli_stats = stats.reduce()
+
+    # span = 4.0 - 0.0 = 4.0s, throughput = 400 MB / 4.0s
+    expected_throughput = 400.0 / 4.0
+    assert abs(cli_stats["Throughput (MB/s)"] - expected_throughput) < 0.1
+
+
+def test_kv_connector_stats_throughput_single_transfer():
+    """Test throughput for single transfer: 500 MB / 2.0s = 250 MB/s."""
+    stats = NixlKVConnectorStats()
+
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector.time.perf_counter",
+        return_value=2.0,
+    ):
+        telemetry = get_default_xfer_telemetry(
+            xferDurationS=2.0,
+            postDurationS=0.1,
+            totalBytes=500 * (2**20),  # 500 MB
+            descCount=1,
+        )
+        stats.record_transfer(telemetry)
+
+    cli_stats = stats.reduce()
+
+    expected_throughput = 500.0 / 2.0
+    assert abs(cli_stats["Throughput (MB/s)"] - expected_throughput) < 0.1
+
+
+def test_kv_connector_stats_cross_worker_aggregation():
+    """Test aggregation with different perf_counter() bases: 400 MB / 1.5s."""
+    # Worker 1: perf_counter base ~1000s
+    worker1 = NixlKVConnectorStats()
+    worker1._transfer_starts = [999.0, 999.5]
+    worker1._transfer_ends = [1000.0, 1000.5]
+    worker1.data["transfer_duration"] = [1.0, 1.0]
+    worker1.data["post_duration"] = [0.1, 0.1]
+    worker1.data["bytes_transferred"] = [100 * 2**20, 100 * 2**20]  # 200 MB
+    worker1.data["num_descriptors"] = [1, 1]
+
+    # Worker 2: perf_counter base ~5000s (different process)
+    worker2 = NixlKVConnectorStats()
+    worker2._transfer_starts = [4999.0, 4999.5]
+    worker2._transfer_ends = [5000.0, 5000.5]
+    worker2.data["transfer_duration"] = [1.0, 1.0]
+    worker2.data["post_duration"] = [0.1, 0.1]
+    worker2.data["bytes_transferred"] = [100 * 2**20, 100 * 2**20]  # 200 MB
+    worker2.data["num_descriptors"] = [1, 1]
+
+    worker1_cloned = worker1.clone_and_reset()
+    worker2_cloned = worker2.clone_and_reset()
+
+    assert worker1_cloned._computed_span == 1.5
+    assert worker2_cloned._computed_span == 1.5
+
+    aggregated = worker1_cloned.aggregate(worker2_cloned)
+    assert aggregated._computed_span == 1.5
+
+    cli_stats = aggregated.reduce()
+    expected_throughput = 400.0 / 1.5
+    assert abs(cli_stats["Throughput (MB/s)"] - expected_throughput) < 0.1
+
+
 def test_multi_kv_connector_stats_aggregation():
     """
     Test MultiKVConnectorStats aggregation across TP ranks using

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -2557,7 +2557,10 @@ def zmq_ctx(socket_type: Any, addr: str) -> Iterator[zmq.Socket]:
 
 @dataclass
 class NixlKVConnectorStats(KVConnectorStats):
-    """Container for transfer performance metrics"""
+    """Container for transfer performance metrics.
+    Timestamps are kept separate from `data` and converted to a span before
+    aggregation because each process has a different perf_counter() base.
+    """
 
     def __post_init__(self):
         if not self.data:
@@ -2575,13 +2578,20 @@ class NixlKVConnectorStats(KVConnectorStats):
             "num_failed_notifications": [],
             "num_kv_expired_reqs": [],
         }
+        self._transfer_starts: list[float] = []
+        self._transfer_ends: list[float] = []
+        self._computed_span: float = 0.0
 
     def record_transfer(self, res: nixlXferTelemetry):
-        # Keep metrics units consistent with rest of the code: time us->s
-        self.data["transfer_duration"].append(res.xferDuration / 1e6)
+        duration_seconds = res.xferDuration / 1e6
+        self.data["transfer_duration"].append(duration_seconds)
         self.data["post_duration"].append(res.postDuration / 1e6)
         self.data["bytes_transferred"].append(res.totalBytes)
         self.data["num_descriptors"].append(res.descCount)
+        end_time = time.perf_counter()
+        start_time = end_time - duration_seconds
+        self._transfer_starts.append(start_time)
+        self._transfer_ends.append(end_time)
 
     def record_failed_transfer(self):
         """Record a failed NIXL transfer operation."""
@@ -2596,6 +2606,8 @@ class NixlKVConnectorStats(KVConnectorStats):
         self.data["num_kv_expired_reqs"].append(1)
 
     def clone_and_reset(self) -> "NixlKVConnectorStats":
+        if self._transfer_starts:
+            self._computed_span = max(self._transfer_ends) - min(self._transfer_starts)
         old = copy.copy(self)
         self.reset()
         return old
@@ -2615,6 +2627,8 @@ class NixlKVConnectorStats(KVConnectorStats):
                 accumulator = self.data[k]
                 assert isinstance(accumulator, list)
                 accumulator.extend(v)
+            assert isinstance(other, NixlKVConnectorStats)
+            self._computed_span = max(self._computed_span, other._computed_span)
         return self
 
     def reduce(self) -> dict[str, int | float]:
@@ -2644,8 +2658,12 @@ class NixlKVConnectorStats(KVConnectorStats):
         total_mb = mb.sum()
         avg_mb = total_mb / n
 
-        total_time_seconds = xfer_time.sum()
-        throughput_mb_s = total_mb / total_time_seconds
+        if self._computed_span > 0:
+            wall_clock_span = self._computed_span
+        else:
+            assert self._transfer_starts, "No timestamps for throughput calculation"
+            wall_clock_span = max(self._transfer_ends) - min(self._transfer_starts)
+        throughput_mb_s = total_mb / wall_clock_span if wall_clock_span > 0 else 0.0
 
         return {
             "Num successful transfers": n,


### PR DESCRIPTION
## Purpose

Fix incorrect throughput calculation in NIXL telemetry stats.

Resolves #33170

The throughput was calculated using the sum of individual transfer durations instead of the wall-clock span. This caused underreported throughput when transfers ran in parallel.

**Before (buggy):**
```
throughput = total_bytes / sum(durations)
```

**After (fixed):**
```
throughput = total_bytes / (max(end_times) - min(start_times))
```

The span is computed per-worker before aggregation (since `time.perf_counter()` has different bases per process), then combined using `max()` for parallel workers.

## Test Plan

```bash
python -m pytest tests/v1/kv_connector/unit/test_nixl_connector.py -k "throughput or cross_worker" -v
```

## Test Result

```
tests/v1/kv_connector/unit/test_nixl_connector.py::test_kv_connector_stats_throughput_parallel_transfers PASSED
tests/v1/kv_connector/unit/test_nixl_connector.py::test_kv_connector_stats_throughput_sequential_transfers PASSED
tests/v1/kv_connector/unit/test_nixl_connector.py::test_kv_connector_stats_throughput_single_transfer PASSED
tests/v1/kv_connector/unit/test_nixl_connector.py::test_kv_connector_stats_cross_worker_aggregation PASSED

4 passed
```

## Changes

### `vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py`

- Added `_transfer_starts`, `_transfer_ends`, `_computed_span` to `NixlKVConnectorStats`
- `record_transfer()`: Capture timestamps using `time.perf_counter()`
- `clone_and_reset()`: Compute span before cloning
- `aggregate()`: Combine spans using `max()`
- `reduce()`: Use pre-computed span for throughput calculation

### `tests/v1/kv_connector/unit/test_nixl_connector.py`

Added 4 deterministic tests with mocked timestamps:
- `test_kv_connector_stats_throughput_parallel_transfers`
- `test_kv_connector_stats_throughput_sequential_transfers`
- `test_kv_connector_stats_throughput_single_transfer`
- `test_kv_connector_stats_cross_worker_aggregation`