### PR TITLE
[CI] Bump `num_speculative_tokens` to 3 in nightly DeepSeek tests

### DIFF
--- a/tests/evals/gsm8k/configs/DeepSeek-R1-DP.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-R1-DP.yaml
@@ -8,4 +8,4 @@ server_args: >-
   --max-model-len 4096
   --data-parallel-size 8
   --enable-expert-parallel
-  --speculative-config '{"method":"mtp","num_speculative_tokens":1}'
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'

--- a/tests/evals/gsm8k/configs/DeepSeek-R1-TP.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-R1-TP.yaml
@@ -8,4 +8,4 @@ server_args: >-
   --max-model-len 4096
   --tensor-parallel-size 8
   --enable-expert-parallel
-  --speculative-config '{"method":"mtp","num_speculative_tokens":1}'
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'

--- a/tests/evals/gsm8k/configs/DeepSeek-V3.2-DP.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-V3.2-DP.yaml
@@ -8,4 +8,4 @@ server_args: >-
   --max-model-len 4096
   --data-parallel-size 8
   --enable-expert-parallel
-  --speculative-config '{"method":"mtp","num_speculative_tokens":1}'
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'

--- a/tests/evals/gsm8k/configs/DeepSeek-V3.2-TP.yaml
+++ b/tests/evals/gsm8k/configs/DeepSeek-V3.2-TP.yaml
@@ -8,4 +8,4 @@ server_args: >-
   --max-model-len 4096
   --tensor-parallel-size 8
   --enable-expert-parallel
-  --speculative-config '{"method":"mtp","num_speculative_tokens":1}'
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3}'


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Now that #34552 has landed, both standard and sparse MLA support MTP > 1. We should exercise this in CI.

## Test Plan
LM Eval Large Models (H200) should pass CI

## Test Result
TBD

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

