### PR TITLE
[Bugfix][Minor] Fix potential NameError in mamba backend selector and misc typos

### DIFF
--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -358,7 +358,7 @@ class KimiK25ForConditionalGeneration(
         target_dtype = next(self.vision_tower.parameters()).dtype
         pixel_values = pixel_values.to(target_dtype)
         assert isinstance(grid_thws, torch.Tensor), (
-            f"expect grid_thws to be a tensor, get {type(grid_thws)}"
+            f"expect grid_thws to be a tensor, got {type(grid_thws)}"
         )
         # In some cases (e.g. with merger), grid_thws has an extra middle dimension
         grid_thws = grid_thws.reshape(-1, grid_thws.shape[-1])

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -716,7 +716,10 @@ class FlexAttentionMetadataBuilder(AttentionMetadataBuilder[FlexAttentionMetadat
         prefix_kv_lens = None
         suffix_kv_lens = None
         if use_cascade:
-            raise NotImplementedError("Not yet my friend")
+            raise NotImplementedError(
+                "Cascade prefix attention is not yet implemented "
+                "for FlexAttention backend"
+            )
 
         block_size = self.kv_cache_spec.block_size
         max_possible_seq_len = self.model_config.max_model_len

--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -157,7 +157,7 @@ if current_platform.is_rocm():
         total_tokens: int,
     ):
         assert kv_cache_layout in ["NHD", "SHUFFLE"], (
-            "kv_cache_layout only support NHD, SHUFFLE"
+            "kv_cache_layout only supports NHD, SHUFFLE"
         )
         head_dim = key.shape[2]
         x = 16 // key_cache.element_size()

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -253,7 +253,7 @@ def make_local_attention_virtual_batches(
     #   seqlens_q_local = [2, 2, 1, 4, 4, 1, 4, 1]
     #
     # First Get batched arange. (E.g., [2, 4, 2] -> [0, 1, 0, 1, 2, 3, 0, 1])
-    #   (TODO: max a utility to share this code with _prepare_inputs)
+    #   (TODO: make a utility to share this code with _prepare_inputs)
     # arange step 1. [2, 4, 2] -> [2, 6, 8]
     cu_num_blocks = np.cumsum(local_blocks)
     virtual_batches = cu_num_blocks[-1]

--- a/vllm/v1/attention/selector.py
+++ b/vllm/v1/attention/selector.py
@@ -149,8 +149,8 @@ def _cached_get_mamba_attn_backend(
         selected_backend = MambaAttentionBackendEnum[backend_name]
     except KeyError as e:
         raise ValueError(
-            f"Invalid mamba attention backend type: '{backend_name}'. Valid "
-            f"backends are: {list(MambaAttentionBackendEnum.__members__.keys())}"
+            f"Invalid mamba attention backend type: '{mamba_type}'. Valid "
+            f"types are: {list(MAMBA_TYPE_TO_BACKEND_MAP.keys())}"
         ) from e
 
     mamba_attn_backend = selected_backend.get_class()


### PR DESCRIPTION
## Summary

Fix a potential `NameError` bug in the mamba attention backend selector and several minor typos/grammar issues across the codebase.

### Bug fix

In `_cached_get_mamba_attn_backend` (`vllm/v1/attention/selector.py`), if `MAMBA_TYPE_TO_BACKEND_MAP[mamba_type]` raises a `KeyError`, the variable `backend_name` is never assigned. The `except` handler then references `backend_name` in the error message, which would raise a `NameError` instead of the intended `ValueError`. Fixed by using `mamba_type` (which is always bound) in the error message and listing valid mamba types.

### Typo/grammar fixes

| File | Fix |
|------|-----|
| `vllm/v1/attention/backends/utils.py` | "max a utility" -> "make a utility" |
| `vllm/v1/attention/backends/flex_attention.py` | `"Not yet my friend"` -> descriptive error message |
| `vllm/v1/attention/backends/rocm_aiter_fa.py` | "only support" -> "only supports" |
| `vllm/model_executor/models/kimi_k25.py` | "get" -> "got" in assertion message |
| `vllm/model_executor/models/transformers/pooling.py` | "the the" -> "the" (duplicated article) |

## Test plan

- All changes are to error messages, comments, and exception handlers - no functional logic is altered
- The `NameError` bug fix can be verified by inspecting the code: `backend_name` is only assigned inside the `try` block on the line that can raise `KeyError`
