### PR TITLE
[ROCm][CI] Fix TP size issue for `test_gpt_oss`

### DIFF
--- a/tests/models/quantization/test_gpt_oss.py
+++ b/tests/models/quantization/test_gpt_oss.py
@@ -21,6 +21,8 @@ import lm_eval
 import pytest
 from packaging import version
 
+from vllm.utils.torch_utils import cuda_device_count_stateless
+
 MODEL_ACCURACIES = {
     # Full quantization: attention linears and MoE linears
     "amd/gpt-oss-20b-WFP8-AFP8-KVFP8": 0.89,
@@ -83,6 +85,9 @@ class EvaluationConfig:
 def test_gpt_oss_attention_quantization(
     model_name: str, tp_size: int, expected_accuracy: float
 ):
+    if tp_size > cuda_device_count_stateless():
+        pytest.skip("Not enough GPUs to run this test case")
+
     model_args = EvaluationConfig(model_name).get_model_args(tp_size)
 
     extra_run_kwargs = {


### PR DESCRIPTION
<!-- markdownlint-disable -->
`Quantized Models Test` is allocated to a 1 GPU agent pool in CI, but tries to run multi-GPU tests (example: https://buildkite.com/vllm/amd-ci/builds/5699/steps/canvas?sid=019cb28b-7107-44a7-adde-1af22fb4f7b7&tab=output#019cb28b-71fb-4bda-bc58-43ef57384abc/L1654)

This PR skips the multi-GPU test cases if there are not enough GPUs available.