### PR TITLE
[CI] Fix mypy for vllm/config

### DIFF
--- a/tools/pre_commit/mypy.py
+++ b/tools/pre_commit/mypy.py
@@ -40,7 +40,6 @@ EXCLUDE = [
     "vllm/v1/attention/ops",
     # TODO: Remove these entries after fixing mypy errors.
     "vllm/benchmarks",
-    "vllm/config",
 ]
 
 

--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -56,7 +56,7 @@ class AttentionConfig:
         """
         from vllm.config.utils import get_hash_factors, hash_factors
 
-        ignored_factors: list[str] = []
+        ignored_factors: set[str] = set()
         factors = get_hash_factors(self, ignored_factors)
         return hash_factors(factors)
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -116,29 +116,29 @@ class PassConfig:
     """
 
     # New flags
-    fuse_norm_quant: bool = Field(default=None)
+    fuse_norm_quant: bool | None = Field(default=None)
     """Fuse the custom RMSNorm + quant ops."""
-    fuse_act_quant: bool = Field(default=None)
+    fuse_act_quant: bool | None = Field(default=None)
     """Fuse the custom SiluMul + quant ops."""
-    fuse_attn_quant: bool = Field(default=None)
+    fuse_attn_quant: bool | None = Field(default=None)
     """Fuse the custom attention + quant ops."""
     eliminate_noops: bool = Field(default=True)
     """Eliminate no-op ops."""
-    enable_sp: bool = Field(default=None)
+    enable_sp: bool | None = Field(default=None)
     """Enable sequence parallelism. Requires TP>1. Automatically disabled
     if the model's hidden_size is too small for SP to be beneficial
     (threshold is device-capability dependent)."""
-    fuse_gemm_comms: bool = Field(default=None)
+    fuse_gemm_comms: bool | None = Field(default=None)
     """Enable async TP."""
-    fuse_allreduce_rms: bool = Field(default=None)
+    fuse_allreduce_rms: bool | None = Field(default=None)
     """Enable flashinfer allreduce fusion."""
     enable_qk_norm_rope_fusion: bool = False
     """Enable fused Q/K RMSNorm + RoPE pass."""
 
     # ROCm/AITER specific fusions
-    fuse_act_padding: bool = Field(default=None)
+    fuse_act_padding: bool | None = Field(default=None)
     """Fuse the custom RMSNorm + padding ops."""
-    fuse_rope_kvcache: bool = Field(default=None)
+    fuse_rope_kvcache: bool | None = Field(default=None)
     """Fuse the QK rope + KV cache ops."""
 
     rope_kvcache_fusion_max_token_num: int = 256
@@ -405,7 +405,7 @@ class CompilationConfig:
     """
 
     # Top-level Compilation control
-    mode: CompilationMode = Field(default=None)
+    mode: CompilationMode | None = Field(default=None)
     """The compilation approach used for torch.compile-based compilation of the
     model.
 
@@ -523,7 +523,7 @@ class CompilationConfig:
     constructor, e.g. `CompilationConfig(inductor_passes={"a": func})`."""
 
     # CudaGraph compilation
-    cudagraph_mode: CUDAGraphMode = Field(default=None)
+    cudagraph_mode: CUDAGraphMode = Field(default=None)  # type: ignore[assignment]
     """
     The mode of the cudagraph:
 
@@ -585,7 +585,7 @@ class CompilationConfig:
     When `enable_lora` is False, this option has no effect.
     """
 
-    use_inductor_graph_partition: bool = Field(default=None)
+    use_inductor_graph_partition: bool = Field(default=False)
     """Use inductor graph partition to split the graph at cudagraph_unsafe ops.
     This partition happens at inductor codegen time after all passes and fusions
     are finished. It generates a single `call` function which wraps
@@ -728,7 +728,7 @@ class CompilationConfig:
         return hash_factors(factors)
 
     def __repr__(self) -> str:
-        exclude = {
+        exclude: dict[str, bool | dict[str, bool]] = {
             "static_forward_context": True,
             "enabled_custom_ops": True,
             "disabled_custom_ops": True,
@@ -740,7 +740,7 @@ class CompilationConfig:
         }
 
         # exclude default attr in pass_config
-        pass_config_exclude = {}
+        pass_config_exclude: dict[str, bool] = {}
         for attr, default_val in vars(PassConfig()).items():
             if getattr(self.pass_config, attr) == default_val:
                 pass_config_exclude[attr] = True

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -198,9 +198,10 @@ class PassConfig:
 
         if not current_platform.is_cuda():
             return {}
-        return FI_ALLREDUCE_FUSION_MAX_SIZE_MB.get(
-            current_platform.get_device_capability().to_int(), {}
-        )
+        capability = current_platform.get_device_capability()
+        if capability is None:
+            return {}
+        return FI_ALLREDUCE_FUSION_MAX_SIZE_MB.get(capability.to_int(), {})
 
     def compute_hash(self) -> str:
         """
@@ -350,7 +351,7 @@ class DynamicShapesConfig:
 
         from vllm.config.utils import get_hash_factors, hash_factors
 
-        factors = get_hash_factors(self, {})
+        factors = get_hash_factors(self, set())
         return hash_factors(factors)
 
 
@@ -607,7 +608,7 @@ class CompilationConfig:
     pass_config: PassConfig = field(default_factory=PassConfig)
     """Custom inductor passes, see PassConfig for more details"""
 
-    max_cudagraph_capture_size: int = field(default=None)
+    max_cudagraph_capture_size: int | None = field(default=None)
     """The maximum cudagraph capture size.
 
     If cudagraph_capture_sizes is specified, this will be set to the largest
@@ -953,7 +954,7 @@ class CompilationConfig:
         - initialize compile_sizes
         """
 
-        computed_compile_sizes = []
+        computed_compile_sizes: list[int] = []
         if self.compile_sizes is not None:
             # de-duplicate the sizes provided by the config
             self.compile_sizes = list(set(self.compile_sizes))
@@ -963,6 +964,10 @@ class CompilationConfig:
                         "Unrecognized size type in compile_sizes, "
                         f"expect 'cudagraph_capture_sizes', got {x}"
                     )
+                    assert self.cudagraph_capture_sizes is not None, (
+                        "cudagraph_capture_sizes must be set when referenced in "
+                        "compile_sizes"
+                    )
                     computed_compile_sizes.extend(self.cudagraph_capture_sizes)
                 else:
                     assert isinstance(x, int)
@@ -970,6 +975,7 @@ class CompilationConfig:
         self.compile_sizes = computed_compile_sizes  # type: ignore
 
         # make sure the sizes are in ascending order
+        assert self.cudagraph_capture_sizes is not None
         self.cudagraph_capture_sizes.sort()
         if self.cudagraph_capture_sizes:
             assert self.cudagraph_capture_sizes[-1] == self.max_cudagraph_capture_size

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -26,7 +26,7 @@ MoEBackend = Literal[
 class KernelConfig:
     """Configuration for kernel selection and warmup behavior."""
 
-    enable_flashinfer_autotune: bool = Field(default=None)
+    enable_flashinfer_autotune: bool | None = Field(default=None)
     """If True, run FlashInfer autotuning during kernel warmup."""
 
     moe_backend: MoEBackend = "auto"

--- a/vllm/config/kv_events.py
+++ b/vllm/config/kv_events.py
@@ -18,7 +18,7 @@ class KVEventsConfig:
     Events can be published externally by zmq using the event publisher config.
     """
 
-    publisher: Literal["null", "zmq"] = Field(default=None)
+    publisher: Literal["null", "zmq"] = Field(default="null")
     """The publisher to use for publishing kv events. Can be "null", "zmq".
     """
 
@@ -50,5 +50,5 @@ class KVEventsConfig:
     """
 
     def __post_init__(self):
-        if self.publisher is None:
-            self.publisher = "zmq" if self.enable_kv_cache_events else "null"
+        if self.publisher == "null":
+            self.publisher = "zmq"

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -140,7 +140,7 @@ class ModelConfig:
     """Convert the model using adapters defined in
     [vllm.model_executor.models.adapters][]. The most common use case is to
     adapt a text generation model to be used for pooling tasks."""
-    tokenizer: str = Field(default=None)
+    tokenizer: str = Field(default=None)  # type: ignore[assignment]
     """Name or path of the Hugging Face tokenizer to use. If unspecified, model
     name or path will be used."""
     tokenizer_mode: TokenizerMode | str = "auto"
@@ -196,7 +196,7 @@ class ModelConfig:
     """The specific revision to use for the tokenizer on the Hugging Face Hub.
     It can be a branch name, a tag name, or a commit id. If unspecified, will
     use the default version."""
-    max_model_len: int = Field(default=None, ge=-1)
+    max_model_len: int = Field(default=None, ge=-1)  # type: ignore[assignment]
     """Model context length (prompt and output). If unspecified, will be
     automatically derived from the model config.
 

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -5,7 +5,7 @@ import warnings
 from collections.abc import Callable
 from dataclasses import InitVar, field
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal, cast, get_args
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast, get_args
 
 import torch
 from pydantic import ConfigDict, Field, field_validator, model_validator
@@ -14,7 +14,12 @@ import vllm.envs as envs
 from vllm.config.model_arch import (
     ModelArchitectureConfig,
 )
-from vllm.config.multimodal import MMCacheType, MMEncoderTPMode, MultiModalConfig
+from vllm.config.multimodal import (
+    MMCacheType,
+    MMDummyOptions,
+    MMEncoderTPMode,
+    MultiModalConfig,
+)
 from vllm.config.pooler import PoolerConfig
 from vllm.config.scheduler import RunnerType
 from vllm.config.utils import config, getattr_iter
@@ -75,7 +80,7 @@ else:
 logger = init_logger(__name__)
 
 RunnerOption = Literal["auto", RunnerType]
-ConvertType = Literal["none", "embed", "classify"]
+ConvertType = Literal["none", "embed", "classify", "reward"]
 ConvertOption = Literal["auto", ConvertType]
 TokenizerMode = Literal["auto", "hf", "slow", "mistral", "deepseek_v32"]
 ModelDType = Literal["auto", "half", "float16", "bfloat16", "float", "float32"]
@@ -95,6 +100,25 @@ _RUNNER_CONVERTS: dict[RunnerType, list[ConvertType]] = {
 AttnTypeStr = Literal[
     "decoder", "encoder", "encoder_only", "encoder_decoder", "attention_free", "hybrid"
 ]
+
+
+class _MMConfigKwargs(TypedDict, total=False):
+    """Typed kwargs for constructing MultiModalConfig in ModelConfig.__post_init__."""
+
+    language_model_only: bool
+    limit_per_prompt: MMDummyOptions
+    enable_mm_embeds: bool
+    media_io_kwargs: dict[str, dict[str, Any]]
+    mm_processor_kwargs: dict[str, object] | None
+    mm_processor_cache_gb: float
+    mm_processor_cache_type: MMCacheType
+    mm_shm_cache_max_object_size_mb: int
+    mm_encoder_only: bool
+    mm_encoder_tp_mode: MMEncoderTPMode
+    mm_encoder_attn_backend: AttentionBackendEnum | None
+    interleave_mm_strings: bool
+    skip_mm_profiling: bool
+    video_pruning_rate: float | None
 
 
 @config(config=ConfigDict(arbitrary_types_allowed=True))
@@ -242,7 +266,7 @@ class ModelConfig:
     that this name(s) will also be used in `model_name` tag content of
     prometheus metrics, if multiple names provided, metrics tag will take the
     first one."""
-    config_format: str | ConfigFormat = "auto"
+    config_format: ConfigFormat = "auto"
     """The format of the model config to load:\n
     - "auto" will try to load the config in hf format if available after trying
     to load in mistral format.\n
@@ -447,7 +471,7 @@ class ModelConfig:
             self.hf_config_path = maybe_model_redirect(self.hf_config_path)
 
         if callable(self.hf_overrides):
-            hf_overrides_kw = {}
+            hf_overrides_kw: dict[str, Any] = {}
             hf_overrides_fn = self.hf_overrides
             dict_overrides: dict[str, Any] = {}
         else:
@@ -595,26 +619,43 @@ class ModelConfig:
                 )
                 mm_encoder_tp_mode = "weights"
 
-            mm_config_kwargs = dict(
-                language_model_only=language_model_only,
-                limit_per_prompt=limit_mm_per_prompt,
-                enable_mm_embeds=enable_mm_embeds,
-                media_io_kwargs=media_io_kwargs,
-                mm_processor_kwargs=mm_processor_kwargs,
-                mm_processor_cache_gb=mm_processor_cache_gb,
-                mm_processor_cache_type=mm_processor_cache_type,
-                mm_shm_cache_max_object_size_mb=mm_shm_cache_max_object_size_mb,
-                mm_encoder_only=mm_encoder_only,
-                mm_encoder_tp_mode=mm_encoder_tp_mode,
-                mm_encoder_attn_backend=mm_encoder_attn_backend,
-                interleave_mm_strings=interleave_mm_strings,
-                skip_mm_profiling=skip_mm_profiling,
-                video_pruning_rate=video_pruning_rate,
-            )
-
-            mm_config_kwargs = {
-                k: v for k, v in mm_config_kwargs.items() if v is not None
+            # Fields that accept None as a valid value are always included.
+            # Fields typed as non-optional in MultiModalConfig are only included
+            # when not None so that MultiModalConfig uses its declared defaults.
+            # cast() is used for the two fields whose pydantic mode="before"
+            # validators accept wider input types than the field annotation.
+            mm_config_kwargs: _MMConfigKwargs = {
+                "language_model_only": language_model_only,
+                "mm_processor_kwargs": mm_processor_kwargs,
+                "mm_encoder_attn_backend": cast(
+                    AttentionBackendEnum | None, mm_encoder_attn_backend
+                ),
+                "video_pruning_rate": video_pruning_rate,
             }
+            if limit_mm_per_prompt is not None:
+                mm_config_kwargs["limit_per_prompt"] = cast(
+                    MMDummyOptions, limit_mm_per_prompt
+                )
+            if enable_mm_embeds is not None:
+                mm_config_kwargs["enable_mm_embeds"] = enable_mm_embeds
+            if media_io_kwargs is not None:
+                mm_config_kwargs["media_io_kwargs"] = media_io_kwargs
+            if mm_processor_cache_gb is not None:
+                mm_config_kwargs["mm_processor_cache_gb"] = mm_processor_cache_gb
+            if mm_processor_cache_type is not None:
+                mm_config_kwargs["mm_processor_cache_type"] = mm_processor_cache_type
+            if mm_shm_cache_max_object_size_mb is not None:
+                mm_config_kwargs["mm_shm_cache_max_object_size_mb"] = (
+                    mm_shm_cache_max_object_size_mb
+                )
+            if mm_encoder_only is not None:
+                mm_config_kwargs["mm_encoder_only"] = mm_encoder_only
+            if mm_encoder_tp_mode is not None:
+                mm_config_kwargs["mm_encoder_tp_mode"] = mm_encoder_tp_mode
+            if interleave_mm_strings is not None:
+                mm_config_kwargs["interleave_mm_strings"] = interleave_mm_strings
+            if skip_mm_profiling is not None:
+                mm_config_kwargs["skip_mm_profiling"] = skip_mm_profiling
 
             self.multimodal_config = MultiModalConfig(**mm_config_kwargs)
 
@@ -722,7 +763,11 @@ class ModelConfig:
 
     @property
     def architectures(self) -> list[str]:
-        return self.model_arch_config.architectures
+        archs = self.model_arch_config.architectures
+        assert archs is not None, (
+            "architectures must be set before accessing ModelConfig.architectures"
+        )
+        return archs
 
     @property
     def architecture(self) -> str:
@@ -992,10 +1037,11 @@ class ModelConfig:
         # TODO Remove this when bitsandbytes supports.
         """
         is_bitsandbytes = self.quantization == "bitsandbytes"
-        has_quantization_config = self.model_arch_config.quantization_config is not None
+        quant_config = self.model_arch_config.quantization_config
+        has_quantization_config = quant_config is not None
         is_8bit = (
-            self.model_arch_config.quantization_config.get("load_in_8bit", False)
-            if has_quantization_config
+            quant_config.get("load_in_8bit", False)
+            if quant_config is not None
             else False
         )
         if all(
@@ -1256,16 +1302,11 @@ class ModelConfig:
                 else:
                     return sum(t == block_type for t in layer_types_value[start:end])
 
-            if (
-                layers_block_type_value is None
-                and attn_type_list is None
-                and layer_types_value is None
-            ):
-                raise ValueError(
-                    "The model is an hybrid without a layers_block_type or an "
-                    "attn_type_list, or a layer_types in the hf_config, "
-                    f"cannot determine the num of {block_type} layers"
-                )
+            raise ValueError(
+                "The model is an hybrid without a layers_block_type or an "
+                "attn_type_list, or a layer_types in the hf_config, "
+                f"cannot determine the num of {block_type} layers"
+            )
 
     def get_mamba_chunk_size(self) -> int | None:
         """
@@ -1955,6 +1996,7 @@ def _get_and_verify_max_len(
     encoder_config: dict[str, Any] | None = None,
 ) -> int:
     """Get and verify the model's maximum length."""
+    assert model_arch_config.derived_max_model_len_and_key is not None
     (derived_max_model_len, max_len_key) = (
         model_arch_config.derived_max_model_len_and_key
     )
@@ -2072,4 +2114,5 @@ def _get_and_verify_max_len(
                     f"{msg} To allow overriding this maximum, set "
                     f"the env var VLLM_ALLOW_LONG_MAX_MODEL_LEN=1. {warning}"
                 )
+    assert max_model_len is not None
     return int(max_model_len)

--- a/vllm/config/model_arch.py
+++ b/vllm/config/model_arch.py
@@ -3,55 +3,55 @@
 from typing import Any
 
 from pydantic import ConfigDict
-from pydantic.dataclasses import dataclass
 
+from vllm.config.utils import config
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
 
-@dataclass(config=ConfigDict(arbitrary_types_allowed=True))
+@config(config=ConfigDict(arbitrary_types_allowed=True))
 class ModelArchitectureConfig:
     """
     Configuration for model architecture that required by vLLM runtime
     """
 
-    architectures: list[str] | None
+    architectures: list[str] | None = None
     """List of model architecture class names (e.g., ['LlamaForCausalLM']).
        It can be None upon calling `vllm_config.with_hf_config(config.text_config)`"""
 
-    model_type: str
+    model_type: str = ""
     """Model type identifier (e.g., 'llama', 'gpt_oss')."""
 
-    text_model_type: str | None
+    text_model_type: str | None = None
     """Text model type identifier (e.g., 'llama4_text')."""
 
-    hidden_size: int
+    hidden_size: int = 0
     """Hidden size of the model."""
 
-    total_num_hidden_layers: int
+    total_num_hidden_layers: int = 0
     """Number of hidden layers in the model."""
 
-    total_num_attention_heads: int
+    total_num_attention_heads: int = 0
     """Number of attention heads in the model."""
 
-    head_size: int
+    head_size: int = 0
     """Head dimension of the model."""
 
-    vocab_size: int
+    vocab_size: int = 0
     """Vocabulary size of the model."""
 
-    total_num_kv_heads: int
+    total_num_kv_heads: int = 0
     """Number of key value heads in the model."""
 
-    num_experts: int
+    num_experts: int = 0
     """Number of experts in the model."""
 
-    quantization_config: dict[str, Any] | None
+    quantization_config: dict[str, Any] | None = None
     """Quantization configuration dictionary containing quantization parameters."""
 
-    is_deepseek_mla: bool
+    is_deepseek_mla: bool = False
     """Whether the model is a DeepSeek MLA model."""
 
-    derived_max_model_len_and_key: tuple[float, str | None]
+    derived_max_model_len_and_key: tuple[float, str | None] | None = None
     """Derived maximum model length and key from the hf config."""

--- a/vllm/config/pooler.py
+++ b/vllm/config/pooler.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import Any, Literal, get_args
+from typing import Any, Literal, cast, get_args
 
 from vllm.config.utils import config
 from vllm.logger import init_logger
@@ -108,14 +108,14 @@ class PoolerConfig:
                     pooling_type,
                     pooling_type,
                 )
-                self.seq_pooling_type = pooling_type
+                self.seq_pooling_type = cast(SequencePoolingType, pooling_type)
             elif pooling_type in TOK_POOLING_TYPES:
                 logger.debug(
                     "Resolved `pooling_type=%r` to `tok_pooling_type=%r`.",
                     pooling_type,
                     pooling_type,
                 )
-                self.tok_pooling_type = pooling_type
+                self.tok_pooling_type = cast(TokenPoolingType, pooling_type)
             else:
                 raise NotImplementedError(pooling_type)
 

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -173,7 +173,7 @@ class SchedulerConfig:
         logger.warning_once(
             "Using custom scheduler class %s. This scheduler interface is "
             "not public and compatibility may not be maintained.",
-            self.scheduler_cls,
+            str(self.scheduler_cls),
         )
         if not isinstance(self.scheduler_cls, str):
             return cast(type["SchedulerInterface"], self.scheduler_cls)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -70,7 +70,7 @@ class SpeculativeConfig:
     enforce_eager: bool | None = None
     """Override the default enforce_eager from model_config"""
     # General speculative decoding control
-    num_speculative_tokens: int = Field(default=None, gt=0)
+    num_speculative_tokens: int = Field(default=None, gt=0)  # type: ignore[assignment]
     """The number of speculative tokens, if provided. It will default to the
     number in the draft model config if present, otherwise, it is required."""
     model: str | None = None
@@ -92,7 +92,7 @@ class SpeculativeConfig:
     warn users when they mistakenly provide the wrong argument."""
 
     # Draft model configuration
-    quantization: me_quant.QuantizationMethods | None = None
+    quantization: me_quant.QuantizationMethods | str | None = None
     """Quantization method that was used to quantize the draft model weights.
     If `None`, we assume the model weights are not quantized. Note that it only
     takes effect when using the draft model-based speculative method."""

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -11,13 +11,13 @@ import os
 import pathlib
 import textwrap
 from collections.abc import Callable, Mapping, Sequence, Set
-from dataclasses import MISSING, field, fields, is_dataclass
+from dataclasses import MISSING, dataclass, field, fields, is_dataclass
 from itertools import pairwise
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast, overload
 
 import torch
 from pydantic import ConfigDict
-from pydantic.dataclasses import dataclass
+from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pydantic.fields import Field as PydanticField
 from pydantic.fields import FieldInfo
 from typing_extensions import dataclass_transform, runtime_checkable
@@ -34,6 +34,25 @@ else:
 
 ConfigType = type[DataclassInstance]
 ConfigT = TypeVar("ConfigT", bound=DataclassInstance)
+_ReplaceT = TypeVar("_ReplaceT")
+
+
+@overload
+def config(
+    cls: type[ConfigT],
+    *,
+    config: ConfigDict | None = ...,
+    **kwargs: Any,
+) -> type[ConfigT]: ...
+
+
+@overload
+def config(
+    cls: None = ...,
+    *,
+    config: ConfigDict | None = ...,
+    **kwargs: Any,
+) -> Callable[[type[ConfigT]], type[ConfigT]]: ...
 
 
 @dataclass_transform(field_specifiers=(PydanticField,))
@@ -59,7 +78,7 @@ def config(
         merged_config.update(config)
 
     def decorator(cls):
-        return dataclass(cls, config=merged_config, **kwargs)
+        return pydantic_dataclass(cls, config=merged_config, **kwargs)
 
     # Called with arguments: @config(config=...)
     if cls is None:
@@ -68,7 +87,7 @@ def config(
     return decorator(cls)
 
 
-def get_field(cls: ConfigType, name: str) -> Any:
+def get_field(cls: type[Any], name: str) -> Any:
     """Get the default factory field of a dataclass by name. Used for getting
     default factory fields in `EngineArgs`."""
     if not is_dataclass(cls):
@@ -93,18 +112,22 @@ def get_field(cls: ConfigType, name: str) -> Any:
         else:
             default = default.default
 
-    if default is MISSING and default_factory is MISSING:
+    if default_factory is not MISSING:
+        return field(default_factory=default_factory, init=init)
+    elif default is not MISSING:
+        return field(default=default, init=init)
+    else:
         logger.warning_once(
             "%s.%s has no default or default factory.", cls.__name__, name
         )
-    return field(default=default, default_factory=default_factory, init=init)
+        return field(init=init)
 
 
-def is_init_field(cls: ConfigType, name: str) -> bool:
+def is_init_field(cls: type[Any], name: str) -> bool:
     return get_field(cls, name).init
 
 
-def replace(dataclass_instance: ConfigT, /, **kwargs) -> ConfigT:
+def replace(dataclass_instance: _ReplaceT, /, **kwargs) -> _ReplaceT:
     """Like [`dataclasses.replace`](https://docs.python.org/3/library/dataclasses.html#dataclasses.replace),
     but compatible with Pydantic dataclasses which use `pydantic.fields.Field` instead
     of `dataclasses.field`"""

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from enum import IntEnum
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, get_args
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, get_args
 
 import torch
 from pydantic import ConfigDict, Field, model_validator
@@ -870,7 +870,7 @@ class VllmConfig:
 
                     tp_size = self.parallel_config.tensor_parallel_size
                     hidden_size = self.model_config.get_hidden_size()
-                    element_size = self.model_config.dtype.itemsize
+                    element_size = cast(torch.dtype, self.model_config.dtype).itemsize
                     pass_config.sp_min_token_num = get_sequence_parallelism_threshold(
                         hidden_size, tp_size, element_size
                     )
@@ -1046,7 +1046,7 @@ class VllmConfig:
 
             is_fullgraph = (
                 self.compilation_config.use_inductor_graph_partition
-                or len(self.compilation_config.splitting_ops) == 0
+                or not self.compilation_config.splitting_ops
             )
             if self.parallel_config.pipeline_parallel_size > 1 or not is_fullgraph:
                 if "-rms_norm" not in self.compilation_config.custom_ops:
@@ -1200,23 +1200,6 @@ class VllmConfig:
                     env_path,
                 )
             self.compilation_config.debug_dump_path = env_path
-
-        def has_blocked_weights():
-            if self.quant_config is not None:
-                if hasattr(self.quant_config, "weight_block_size"):
-                    return self.quant_config.weight_block_size is not None
-                elif hasattr(self.quant_config, "has_blocked_weights"):
-                    return self.quant_config.has_blocked_weights()
-            return False
-
-        # Enable quant_fp8 CUDA ops (TODO disable in follow up)
-        # On H100 the CUDA kernel is faster than
-        # native implementation
-        # https://github.com/vllm-project/vllm/issues/25094
-        if has_blocked_weights():
-            custom_ops = self.compilation_config.custom_ops
-            if "-quant_fp8" not in custom_ops:
-                custom_ops.append("+quant_fp8")
 
         # Handle the KV connector configs
         self._post_init_kv_transfer_config()
@@ -1459,7 +1442,7 @@ class VllmConfig:
             if max_size is not None:
                 max_token_num = max_size // (
                     self.model_config.get_hidden_size()
-                    * self.model_config.dtype.itemsize
+                    * cast(torch.dtype, self.model_config.dtype).itemsize
                 )
                 if compile_range_end is not None and max_token_num < compile_range_end:
                     computed_compile_ranges_endpoints.append(max_token_num)
@@ -1482,7 +1465,7 @@ class VllmConfig:
 
                 tp_size = self.parallel_config.tensor_parallel_size
                 hidden_size = self.model_config.get_hidden_size()
-                element_size = self.model_config.dtype.itemsize
+                element_size = cast(torch.dtype, self.model_config.dtype).itemsize
                 pass_config.sp_min_token_num = get_sequence_parallelism_threshold(
                     hidden_size, tp_size, element_size
                 )

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -251,7 +251,7 @@ class VllmConfig:
 
     # TODO: use default_factory once default constructing ModelConfig doesn't
     # try to download a model
-    model_config: ModelConfig = Field(default=None)
+    model_config: ModelConfig = Field(default=None)  # type: ignore[assignment]
     """Model configuration."""
     cache_config: CacheConfig = Field(default_factory=CacheConfig)
     """Cache configuration."""

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -48,6 +48,7 @@ from vllm.config import (
     ModelConfig,
     MultiModalConfig,
     ObservabilityConfig,
+    OffloadBackend,
     OffloadConfig,
     ParallelConfig,
     PoolerConfig,
@@ -447,7 +448,7 @@ class EngineArgs:
     )
     disable_sliding_window: bool = ModelConfig.disable_sliding_window
     disable_cascade_attn: bool = ModelConfig.disable_cascade_attn
-    offload_backend: str = OffloadConfig.offload_backend
+    offload_backend: OffloadBackend = OffloadConfig.offload_backend
     cpu_offload_gb: float = UVAOffloadConfig.cpu_offload_gb
     cpu_offload_params: set[str] = get_field(UVAOffloadConfig, "cpu_offload_params")
     offload_group_size: int = PrefetchOffloadConfig.offload_group_size

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -72,6 +72,7 @@ from vllm.config.device import Device
 from vllm.config.kernel import MoEBackend
 from vllm.config.lora import MaxLoRARanks
 from vllm.config.model import (
+    ConfigFormat,
     ConvertOption,
     HfOverrides,
     LogprobsMode,
@@ -379,7 +380,7 @@ class EngineArgs:
     download_dir: str | None = LoadConfig.download_dir
     safetensors_load_strategy: str = LoadConfig.safetensors_load_strategy
     load_format: str | LoadFormats = LoadConfig.load_format
-    config_format: str = ModelConfig.config_format
+    config_format: ConfigFormat = ModelConfig.config_format
     dtype: ModelDType = ModelConfig.dtype
     kv_cache_dtype: CacheDType = CacheConfig.cache_dtype
     seed: int = ModelConfig.seed

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -71,6 +71,9 @@ class CudagraphDispatcher:
     def _compute_bs_to_padded_graph_size(self) -> None:
         """Pre-compute the mapping from batch size to padded graph size."""
         max_size = self.compilation_config.max_cudagraph_capture_size
+        assert max_size is not None, (
+            "max_cudagraph_capture_size must be set when cudagraphs are enabled."
+        )
         capture_sizes = self.compilation_config.cudagraph_capture_sizes
         assert capture_sizes is not None, (
             "Cudagraph capture sizes must be set when cudagraphs are enabled."
@@ -94,7 +97,7 @@ class CudagraphDispatcher:
         ):
             for size in self.compilation_config.compile_sizes:
                 size = int(size)
-                if size <= self.compilation_config.max_cudagraph_capture_size:
+                if size <= max_size:
                     padded = self._bs_to_padded_graph_size[size]
                     if padded != size:
                         raise ValueError(
@@ -266,10 +269,12 @@ class CudagraphDispatcher:
             f"invalid_modes={invalid_modes}"
         )
 
+        max_capture_size = self.compilation_config.max_cudagraph_capture_size
         if (
             not self.keys_initialized
             or self.cudagraph_mode == CUDAGraphMode.NONE
-            or num_tokens > self.compilation_config.max_cudagraph_capture_size
+            or max_capture_size is None
+            or num_tokens > max_capture_size
             or allowed_modes <= {CUDAGraphMode.NONE}
         ):
             return CUDAGraphMode.NONE, BatchDescriptor(num_tokens)


### PR DESCRIPTION
## Purpose

Part of https://github.com/vllm-project/vllm/issues/26533

Fixed following errors:

```bash
Run mypy locally for lowest supported Python version................................................Failed
- hook id: mypy-local
- exit code: 1

$ mypy --python-version 3.10 --follow-imports skip 

vllm/config/utils.py:100: error: No overload variant of "field" matches argument types "Any | Literal[_MISSING_TYPE.MISSING]", "_DefaultFactory[Any] | Literal[_MISSING_TYPE.MISSING]", "bool"  [call-overload]
vllm/config/utils.py:100: note: Possible overload variants:
vllm/config/utils.py:100: note:     def [_T] field(*, default: _T, init: bool = ..., repr: bool = ..., hash: bool | None = ..., compare: bool = ..., metadata: Mapping[Any, Any] | None = ..., kw_only: bool = ...) -> _T
vllm/config/utils.py:100: note:     def [_T] field(*, default_factory: Callable[[], _T], init: bool = ..., repr: bool = ..., hash: bool | None = ..., compare: bool = ..., metadata: Mapping[Any, Any] | None = ..., kw_only: bool = ...) -> _T
vllm/config/utils.py:100: note:     def field(*, init: bool = ..., repr: bool = ..., hash: bool | None = ..., compare: bool = ..., metadata: Mapping[Any, Any] | None = ..., kw_only: bool = ...) -> Any
vllm/config/scheduler.py:176: error: Argument 2 to "warning_once" of "_VllmLogger" has incompatible type "str | type[object]"; expected "Hashable"  [arg-type]
vllm/config/pooler.py:111: error: Incompatible types in assignment (expression has type "Literal['CLS', 'LAST', 'MEAN', 'ALL', 'STEP']", variable has type "Literal['CLS', 'LAST', 'MEAN'] | None")  [assignment]
vllm/config/pooler.py:118: error: Incompatible types in assignment (expression has type "Literal['CLS', 'LAST', 'MEAN', 'ALL', 'STEP']", variable has type "Literal['ALL', 'STEP'] | None")  [assignment]
vllm/config/lora.py:28: error: Argument 1 has incompatible type "type[LoRAConfig]"; expected "type[Never]"  [arg-type]
vllm/config/lora.py:29: error: Cannot instantiate type "Type[Never]"  [misc]
vllm/config/device.py:16: error: Argument 1 has incompatible type "type[DeviceConfig]"; expected "type[Never]"  [arg-type]
vllm/config/device.py:17: error: Cannot instantiate type "Type[Never]"  [misc]
vllm/config/attention.py:60: error: Argument 2 to "get_hash_factors" has incompatible type "list[str]"; expected "set[str]"  [arg-type]
vllm/transformers_utils/model_arch_config_convertor.py:304: error: Unexpected keyword argument "architectures" for "ModelArchitectureConfig"  [call-arg]
vllm/transformers_utils/model_arch_config_convertor.py:304: error: Unexpected keyword argument "model_type" for "ModelArchitectureConfig"  [call-arg]
vllm/transformers_utils/model_arch_config_convertor.py:304: error: Unexpected keyword argument "text_model_type" for "ModelArchitectureConfig"  [call-arg]
vllm/transformers_utils/model_arch_config_convertor.py:304: error: Unexpected keyword argument "hidden_size" for "ModelArchitectureConfig"  [call-arg]
vllm/transformers_utils/model_arch_config_convertor.py:304: error: Unexpected keyword argument "total_num_hidden_layers" for "ModelArchitectureConfig"  [call-arg]
vllm/transformers_utils/model_arch_config_convertor.py:304: error: Unexpected keyword argument "total_num_attention_heads" for "ModelArchitectureConfig"  [call-arg]
vllm/transformers_utils/model_arch_config_convertor.py:304: error: Unexpected keyword argument "head_size" for "ModelArchitectureConfig"  [call-arg]
vllm/transformers_utils/model_arch_config_convertor.py:304: error: Unexpected keyword argument "vocab_size" for "ModelArchitectureConfig"  [call-arg]
vllm/transformers_utils/model_arch_config_convertor.py:304: error: Unexpected keyword argument "total_num_kv_heads" for "ModelArchitectureConfig"  [call-arg]
vllm/transformers_utils/model_arch_config_convertor.py:304: error: Unexpected keyword argument "num_experts" for "ModelArchitectureConfig"  [call-arg]
vllm/transformers_utils/model_arch_config_convertor.py:304: error: Unexpected keyword argument "quantization_config" for "ModelArchitectureConfig"  [call-arg]
vllm/transformers_utils/model_arch_config_convertor.py:304: error: Unexpected keyword argument "is_deepseek_mla" for "ModelArchitectureConfig"  [call-arg]
vllm/transformers_utils/model_arch_config_convertor.py:304: error: Unexpected keyword argument "derived_max_model_len_and_key" for "ModelArchitectureConfig"  [call-arg]
vllm/config/model.py:90: error: List item 2 has incompatible type "Literal['reward']"; expected "Literal['none', 'embed', 'classify']"  [list-item]
vllm/config/model.py:99: error: Argument 1 has incompatible type "type[ModelConfig]"; expected "type[Never]"  [arg-type]
vllm/config/model.py:100: error: Cannot instantiate type "Type[Never]"  [misc]
vllm/config/model.py:447: error: Need type annotation for "hf_overrides_kw" (hint: "hf_overrides_kw: dict[<type>, <type>] = ...")  [var-annotated]
vllm/config/model.py:557: error: Argument "config_format" to "_get_and_verify_dtype" has incompatible type "str"; expected "Literal['auto', 'hf', 'mistral']"  [arg-type]
vllm/config/model.py:600: error: Argument 1 to "MultiModalConfig" has incompatible type "**dict[str, dict[str, int | dict[str, int]] | dict[str, dict[str, Any]] | dict[str, Any] | float | int | AttentionBackendEnum | str | None]"; expected "bool"  [arg-type]
vllm/config/model.py:600: error: Argument 1 to "MultiModalConfig" has incompatible type "**dict[str, dict[str, int | dict[str, int]] | dict[str, dict[str, Any]] | dict[str, Any] | float | int | AttentionBackendEnum | str | None]"; expected "dict[str, BaseDummyOptions]"  [arg-type]
vllm/config/model.py:600: error: Argument 1 to "MultiModalConfig" has incompatible type "**dict[str, dict[str, int | dict[str, int]] | dict[str, dict[str, Any]] | dict[str, Any] | float | int | AttentionBackendEnum | str | None]"; expected "dict[str, dict[str, Any]]"  [arg-type]
vllm/config/model.py:600: error: Argument 1 to "MultiModalConfig" has incompatible type "**dict[str, dict[str, int | dict[str, int]] | dict[str, dict[str, Any]] | dict[str, Any] | float | int | AttentionBackendEnum | str | None]"; expected "dict[str, object] | None"  [arg-type]
vllm/config/model.py:600: note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
vllm/config/model.py:600: note: Consider using "Mapping" instead, which is covariant in the value type
vllm/config/model.py:600: error: Argument 1 to "MultiModalConfig" has incompatible type "**dict[str, dict[str, int | dict[str, int]] | dict[str, dict[str, Any]] | dict[str, Any] | float | int | AttentionBackendEnum | str | None]"; expected "float"  [arg-type]
vllm/config/model.py:600: error: Argument 1 to "MultiModalConfig" has incompatible type "**dict[str, dict[str, int | dict[str, int]] | dict[str, dict[str, Any]] | dict[str, Any] | float | int | AttentionBackendEnum | str | None]"; expected "Literal['shm', 'lru']"  [arg-type]
vllm/config/model.py:600: error: Argument 1 to "MultiModalConfig" has incompatible type "**dict[str, dict[str, int | dict[str, int]] | dict[str, dict[str, Any]] | dict[str, Any] | float | int | AttentionBackendEnum | str | None]"; expected "int"  [arg-type]
vllm/config/model.py:600: error: Argument 1 to "MultiModalConfig" has incompatible type "**dict[str, dict[str, int | dict[str, int]] | dict[str, dict[str, Any]] | dict[str, Any] | float | int | AttentionBackendEnum | str | None]"; expected "Literal['weights', 'data']"  [arg-type]
vllm/config/model.py:600: error: Argument 1 to "MultiModalConfig" has incompatible type "**dict[str, dict[str, int | dict[str, int]] | dict[str, dict[str, Any]] | dict[str, Any] | float | int | AttentionBackendEnum | str | None]"; expected "AttentionBackendEnum | None"  [arg-type]
vllm/config/model.py:600: error: Argument 1 to "MultiModalConfig" has incompatible type "**dict[str, dict[str, int | dict[str, int]] | dict[str, dict[str, Any]] | dict[str, Any] | float | int | AttentionBackendEnum | str | None]"; expected "float | None"  [arg-type]
vllm/config/model.py:706: error: Incompatible return value type (got "list[str] | None", expected "list[str]")  [return-value]
vllm/config/model.py:978: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
vllm/config/model.py:1181: error: Missing return statement  [return]
vllm/config/compilation.py:199: error: Item "None" of "DeviceCapability | None" has no attribute "to_int"  [union-attr]
vllm/config/compilation.py:332: error: Argument 2 to "get_hash_factors" has incompatible type "dict[Never, Never]"; expected "set[str]"  [arg-type]
vllm/config/compilation.py:595: error: Incompatible types in assignment (expression has type "None", variable has type "int")  [assignment]
vllm/config/compilation.py:951: error: Need type annotation for "computed_compile_sizes" (hint: "computed_compile_sizes: list[<type>] = ...")  [var-annotated]
vllm/config/compilation.py:961: error: Argument 1 to "extend" of "list" has incompatible type "list[int] | None"; expected "Iterable[Any]"  [arg-type]
vllm/config/compilation.py:968: error: Item "None" of "list[int] | None" has no attribute "sort"  [union-attr]
vllm/config/compilation.py:1199: error: Unexpected keyword argument "start" for "Range"  [call-arg]
vllm/config/compilation.py:1199: error: Unexpected keyword argument "end" for "Range"  [call-arg]
vllm/config/vllm.py:246: error: Argument 1 has incompatible type "type[VllmConfig]"; expected "type[Never]"  [arg-type]
vllm/config/vllm.py:247: error: Cannot instantiate type "Type[Never]"  [misc]
vllm/config/vllm.py:872: error: Item "str" of "Literal['auto', 'half', 'float16', 'bfloat16', 'float', 'float32'] | Any" has no attribute "itemsize"  [union-attr]
vllm/config/vllm.py:1074: error: Argument 1 to "len" has incompatible type "list[str] | None"; expected "Sized"  [arg-type]
vllm/config/vllm.py:1249: error: Name "has_blocked_weights" already defined on line 798  [no-redef]
vllm/config/vllm.py:1504: error: Item "str" of "Literal['auto', 'half', 'float16', 'bfloat16', 'float', 'float32'] | Any" has no attribute "itemsize"  [union-attr]
vllm/config/vllm.py:1527: error: Item "str" of "Literal['auto', 'half', 'float16', 'bfloat16', 'float', 'float32'] | Any" has no attribute "itemsize"  [union-attr]
vllm/compilation/backends.py:198: error: Unexpected keyword argument "start" for "Range"  [call-arg]
vllm/compilation/backends.py:198: error: Unexpected keyword argument "end" for "Range"  [call-arg]
vllm/compilation/piecewise_backend.py:95: error: Unexpected keyword argument "start" for "Range"  [call-arg]
vllm/compilation/piecewise_backend.py:95: error: Unexpected keyword argument "end" for "Range"  [call-arg]
vllm/compilation/piecewise_backend.py:127: error: Unexpected keyword argument "start" for "Range"  [call-arg]
vllm/compilation/piecewise_backend.py:127: error: Unexpected keyword argument "end" for "Range"  [call-arg]
vllm/compilation/piecewise_backend.py:327: error: Unexpected keyword argument "start" for "Range"  [call-arg]
vllm/compilation/piecewise_backend.py:327: error: Unexpected keyword argument "end" for "Range"  [call-arg]
vllm/entrypoints/openai/chat_completion/protocol.py:477: error: Value of type variable "ConfigT" of "replace" cannot be "StructuredOutputsParams"  [type-var]
vllm/entrypoints/openai/completion/protocol.py:289: error: Value of type variable "ConfigT" of "replace" cannot be "StructuredOutputsParams"  [type-var]
vllm/entrypoints/openai/responses/serving.py:489: error: Value of type variable "ConfigT" of "replace" cannot be "StructuredOutputsParams"  [type-var]
Found 66 errors in 15 files (checked 706 source files)
```

Fix mypy errors from CI gate

```bash
$ pre-commit run -a --hook-stage manual mypy-3.10
Run mypy for Python 3.10.................................................Failed
- hook id: mypy-3.10
- exit code: 1

$ mypy --python-version 3.10
vllm/config/kv_events.py:21: error: Argument "default" to "Field" has incompatible type "None"; expected "Literal['null', 'zmq']"  [arg-type]
vllm/config/kernel.py:29: error: Incompatible types in assignment (expression has type "None", variable has type "bool")  [assignment]
vllm/config/model.py:143: error: Incompatible types in assignment (expression has type "None", variable has type "str")  [assignment]
vllm/config/model.py:199: error: Incompatible types in assignment (expression has type "None", variable has type "int")  [assignment]
vllm/config/compilation.py:119: error: Incompatible types in assignment (expression has type "None", variable has type "bool")  [assignment]
vllm/config/compilation.py:121: error: Incompatible types in assignment (expression has type "None", variable has type "bool")  [assignment]
vllm/config/compilation.py:123: error: Incompatible types in assignment (expression has type "None", variable has type "bool")  [assignment]
vllm/config/compilation.py:127: error: Incompatible types in assignment (expression has type "None", variable has type "bool")  [assignment]
vllm/config/compilation.py:131: error: Incompatible types in assignment (expression has type "None", variable has type "bool")  [assignment]
vllm/config/compilation.py:133: error: Incompatible types in assignment (expression has type "None", variable has type "bool")  [assignment]
vllm/config/compilation.py:139: error: Incompatible types in assignment (expression has type "None", variable has type "bool")  [assignment]
vllm/config/compilation.py:141: error: Incompatible types in assignment (expression has type "None", variable has type "bool")  [assignment]
vllm/config/compilation.py:408: error: Incompatible types in assignment (expression has type "None", variable has type "CompilationMode")  [assignment]
vllm/config/compilation.py:526: error: Incompatible types in assignment (expression has type "None", variable has type "CUDAGraphMode")  [assignment]
vllm/config/compilation.py:588: error: Incompatible types in assignment (expression has type "None", variable has type "bool")  [assignment]
vllm/config/compilation.py:751: error: Argument "exclude" to "dump_python" of "TypeAdapter" has incompatible type "dict[str, object]"; expected "set[int] | set[str] | Mapping[int, IncEx | bool] | Mapping[str, IncEx | bool] | None"  [arg-type]
vllm/config/vllm.py:254: error: Incompatible types in assignment (expression has type "None", variable has type "ModelConfig")  [assignment]
vllm/config/speculative.py:69: error: Incompatible types in assignment (expression has type "None", variable has type "int")  [assignment]
vllm/config/speculative.py:366: error: Incompatible types in assignment (expression has type "str | None", variable has type "Literal['awq', 'fp8', 'ptpc_fp8', 'fbgemm_fp8', 'fp_quant', 'modelopt', 'modelopt_fp4', 'modelopt_mxfp8', 'modelopt_mixed', 'gguf', 'gptq_marlin', 'awq_marlin', 'gptq', 'compressed-tensors', 'bitsandbytes', 'experts_int8', 'quark', 'moe_wna16', 'torchao', 'inc', 'mxfp4', 'petit_nvfp4', 'cpu_awq'] | None")  [assignment]
Found 19 errors in 6 files (checked 761 source files)
```

There was also an additional error caused by the fixes to the errors abovee:
`vllm/engine/arg_utils.py:1884: error: Argument "offload_backend" to "OffloadConfig" has incompatible type "str"; expected "Literal['auto', 'uva', 'prefetch']"  [arg-type]`

**Note:**
Some errors were disabled because of the side affects it would have to the overall code if the particular error was resolved.  An example was `assignment` errors like `vllm/config/model.py:143: error: Incompatible types in assignment (expression has type "None", variable has type "str")  [assignment]`. The code uses `None` to check if it is set or not but afterwards when using it, it doen't account for `None`. This would mean lots of changes across the code to corect the logic.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

