### PR TITLE
[XPU][QWEN3_NEXT] remove fla hardcode to cuda

### DIFF
--- a/vllm/model_executor/layers/fla/ops/chunk.py
+++ b/vllm/model_executor/layers/fla/ops/chunk.py
@@ -11,6 +11,8 @@ import warnings
 
 import torch
 
+from vllm.platforms import current_platform
+
 from .chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from .chunk_o import chunk_fwd_o
 from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
@@ -73,7 +75,7 @@ def chunk_gated_delta_rule_fwd(
 class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
     @staticmethod
     @input_guard
-    @torch.amp.custom_fwd(device_type="cuda")
+    @torch.amp.custom_fwd(device_type=current_platform.device_type)
     def forward(
         ctx,
         q: torch.Tensor,

--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -105,7 +105,7 @@ def input_guard(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
                     break
 
         if tensor is not None:
-            ctx = torch.cuda.device(tensor.device.index)
+            ctx = current_platform.device(tensor.device.index)
         else:
             ctx = contextlib.nullcontext()
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Remove Qwen3Next - fla hard-code to CUDA

## Test Plan

```
python examples/offline_inference/basic/generate.py --model /data/models/Qwen/Qwen3-Coder-Next/ --tensor-parallel-size 8 --gpu-memory-utilization 0.85 --max-model-len 4096 --dtype bfloat16 --quantization fp8 --enforce-eager --attention-backend TRITON_ATTN
```

```
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Kostas. I have a problem with one of my games. I have'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' elected every 4 years. In 2000, the president was'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' Paris. (True or False)\n\nWe are given the statement: "The capital'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' not about replacing humans but about empowering them.\n\nThe statement, **"The future'
--------------------------------------------------
```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

