### PR TITLE
[Responses API] Sanitize leaked Harmony control tokens in tool names and recipients

### DIFF
--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -8,10 +8,12 @@ from tests.entrypoints.openai.utils import verify_harmony_messages
 from vllm.entrypoints.openai.parser.harmony_utils import (
     auto_drop_analysis_messages,
     get_encoding,
+    get_streamable_parser_for_assistant,
     get_system_message,
     has_custom_tools,
     parse_chat_input_to_harmony_message,
     parse_chat_output,
+    sanitize_harmony_name,
 )
 from vllm.entrypoints.openai.responses.harmony import (
     response_previous_input_to_harmony,
@@ -841,3 +843,119 @@ class TestGetSystemMessage:
                 assert channel in valid_channels, (
                     f"{channel} missing when with_custom_tools={with_tools}"
                 )
+
+
+class TestSanitizeHarmonyName:
+    """Tests for sanitize_harmony_name()."""
+
+    def test_clean_name_unchanged(self) -> None:
+        assert sanitize_harmony_name("get_weather") == "get_weather"
+
+    def test_strip_channel_token(self) -> None:
+        assert (
+            sanitize_harmony_name("manage_cart<|channel|>commentary") == "manage_cart"
+        )
+
+    def test_strip_constrain_token(self) -> None:
+        assert sanitize_harmony_name("<|constrain|>json") == ""
+
+    def test_pure_control_token_returns_empty(self) -> None:
+        assert sanitize_harmony_name("<|start|>") == ""
+
+    def test_multiple_tokens_earliest_wins(self) -> None:
+        assert (
+            sanitize_harmony_name("foo<|channel|>bar<|constrain|>baz") == "foo"
+        )
+
+    def test_empty_string(self) -> None:
+        assert sanitize_harmony_name("") == ""
+
+    def test_trailing_whitespace_stripped(self) -> None:
+        assert sanitize_harmony_name("tool_name  <|end|>") == "tool_name"
+
+
+class TestResilientStreamableParser:
+    """Tests for ResilientStreamableParser error recovery."""
+
+    def test_normal_sequence_unchanged(self) -> None:
+        """Normal token sequence should produce same results as raw parser."""
+        encoding = get_encoding()
+        harmony_str = "<|channel|>final<|message|>Hello world<|end|>"
+        token_ids = encoding.encode(harmony_str, allowed_special="all")
+
+        parser = get_streamable_parser_for_assistant()
+        for tok in token_ids:
+            parser.process(tok)
+
+        assert len(parser.messages) == 1
+        assert parser.messages[0].content[0].text == "Hello world"
+        assert parser.messages[0].channel == "final"
+
+    def test_missing_start_recovery(self) -> None:
+        """Parser should recover when <|start|> is missing between messages."""
+        encoding = get_encoding()
+        # First message completes normally, second is missing <|start|>
+        first_msg = "<|channel|>final<|message|>First.<|end|>"
+        second_msg = "<|channel|>final<|message|>Second.<|end|>"
+        first_tokens = encoding.encode(first_msg, allowed_special="all")
+        second_tokens = encoding.encode(second_msg, allowed_special="all")
+
+        parser = get_streamable_parser_for_assistant()
+        for tok in first_tokens:
+            parser.process(tok)
+        # Feed second message tokens directly (missing <|start|>assistant)
+        for tok in second_tokens:
+            parser.process(tok)
+
+        assert len(parser.messages) == 2
+        assert parser.messages[0].content[0].text == "First."
+        assert parser.messages[1].content[0].text == "Second."
+
+    def test_constrain_in_header_skipped(self) -> None:
+        """<|constrain|> in HEADER state should be skipped gracefully."""
+        encoding = get_encoding()
+        # First, complete a normal message so parser goes to EXPECT_START
+        first_msg = "<|channel|>final<|message|>First.<|end|>"
+        first_tokens = encoding.encode(first_msg, allowed_special="all")
+
+        # Build a second message where <|constrain|> appears in the header
+        # after <|start|>assistant, before <|channel|>
+        start_tok = encoding.encode("<|start|>", allowed_special="all")
+        role_toks = encoding.encode("assistant", allowed_special="all")
+        constrain_tok = encoding.encode("<|constrain|>", allowed_special="all")
+        # Garbage tokens that should be skipped
+        json_toks = encoding.encode("json", allowed_special="all")
+        message_tok = encoding.encode("<|message|>", allowed_special="all")
+        text_toks = encoding.encode("Second.", allowed_special="all")
+        end_tok = encoding.encode("<|end|>", allowed_special="all")
+
+        parser = get_streamable_parser_for_assistant()
+        # Complete first message
+        for tok in first_tokens:
+            parser.process(tok)
+        assert len(parser.messages) == 1
+
+        # Feed: <|start|>assistant → puts parser in HEADER state
+        for tok in start_tok:
+            parser.process(tok)
+        for tok in role_toks:
+            parser.process(tok)
+        # Feed: <|constrain|> → should enter skip mode
+        for tok in constrain_tok:
+            parser.process(tok)
+        # Feed: json tokens → should be discarded in skip mode
+        for tok in json_toks:
+            parser.process(tok)
+        # Feed: <|message|> → should exit skip mode and resume
+        for tok in message_tok:
+            parser.process(tok)
+        # Feed: text + <|end|>
+        for tok in text_toks:
+            parser.process(tok)
+        for tok in end_tok:
+            parser.process(tok)
+
+        # Should have produced two messages despite the malformed sequence
+        assert len(parser.messages) == 2
+        assert parser.messages[0].content[0].text == "First."
+

--- a/tests/entrypoints/openai/responses/test_harmony_utils.py
+++ b/tests/entrypoints/openai/responses/test_harmony_utils.py
@@ -461,3 +461,40 @@ def test_parser_state_to_response_output_analysis_channel() -> None:
     assert len(builtin_items) == 1
     assert not isinstance(builtin_items[0], McpCall)
     assert builtin_items[0].type == "reasoning"
+
+
+class TestHarmonyOutputSanitization:
+    """Tests that leaked Harmony control tokens are sanitized in output."""
+
+    def test_constrain_recipient_treated_as_no_recipient(self):
+        """<|constrain|>json as recipient should be sanitized to empty,
+        falling through to _parse_message_no_recipient (produces message)."""
+        message = Message.from_role_and_content(
+            Role.ASSISTANT, "Some output text"
+        )
+        message = message.with_channel("commentary")
+        message = message.with_recipient("<|constrain|>json")
+
+        output_items = harmony_to_response_output(message)
+
+        # Should produce a message (preamble), not an MCP call
+        assert len(output_items) == 1
+        assert isinstance(output_items[0], ResponseOutputMessage)
+        assert output_items[0].type == "message"
+
+    def test_contaminated_tool_name_cleaned_in_function_call(self):
+        """Function name with leaked <|channel|> should be sanitized."""
+        message = Message.from_role_and_content(
+            Role.ASSISTANT, '{"location": "SF"}'
+        )
+        message = message.with_channel("commentary")
+        message = message.with_recipient(
+            "functions.get_weather<|channel|>commentary"
+        )
+
+        output_items = harmony_to_response_output(message)
+
+        assert len(output_items) == 1
+        assert isinstance(output_items[0], ResponseFunctionToolCall)
+        assert output_items[0].name == "get_weather"
+        assert "<|" not in output_items[0].name

--- a/vllm/entrypoints/openai/chat_completion/stream_harmony.py
+++ b/vllm/entrypoints/openai/chat_completion/stream_harmony.py
@@ -12,6 +12,7 @@ from typing import NamedTuple
 from openai_harmony import StreamableParser
 
 from vllm.entrypoints.chat_utils import make_tool_call_id
+from vllm.entrypoints.openai.parser.harmony_utils import sanitize_harmony_name
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaFunctionCall,
     DeltaMessage,
@@ -109,7 +110,9 @@ def extract_harmony_streaming_delta(
             opened_new_call = False
             if prev_recipient != group.recipient:
                 # New tool call - emit the opening message
-                tool_name = group.recipient.split("functions.", 1)[1]
+                tool_name = sanitize_harmony_name(
+                    group.recipient.split("functions.", 1)[1]
+                )
                 tool_messages.append(
                     DeltaToolCall(
                         id=make_tool_call_id(),

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -15,6 +15,7 @@ from openai_harmony import (
     ReasoningEffort,
     Role,
     StreamableParser,
+    StreamState,
     SystemContent,
     TextContent,
     ToolDescription,
@@ -26,6 +27,126 @@ from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionTools
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+# Harmony special token strings that may leak into tool names or recipients
+# during generation by GPT-OSS models.
+_HARMONY_SPECIAL_TOKEN_STRS = (
+    "<|channel|>",
+    "<|constrain|>",
+    "<|start|>",
+    "<|end|>",
+    "<|message|>",
+    "<|call|>",
+)
+
+# Harmony special token IDs (GPT-OSS encoding)
+_TOK_CONSTRAIN = 200003
+_TOK_CHANNEL = 200005
+_TOK_START = 200006
+_TOK_END = 200007
+_TOK_MESSAGE = 200008
+
+
+def sanitize_harmony_name(name: str) -> str:
+    """Strip leaked Harmony control tokens from a tool/recipient name.
+
+    Finds the earliest Harmony control token string in *name* and returns
+    only the text before it.  Returns the original string unchanged when
+    no control tokens are present.
+    """
+    earliest = len(name)
+    for tok in _HARMONY_SPECIAL_TOKEN_STRS:
+        idx = name.find(tok)
+        if idx != -1 and idx < earliest:
+            earliest = idx
+    return name[:earliest].rstrip()
+
+
+class ResilientStreamableParser:
+    """Wrapper around ``StreamableParser`` that recovers from two common
+    malformed-output patterns produced by GPT-OSS models:
+
+    1. **Missing ``<|start|>`` recovery** – When the parser expects a
+       ``<|start|>`` token but receives ``<|channel|>`` instead, inject the
+       missing ``<|start|>`` + assistant role token before forwarding.
+
+    2. **Malformed ``<|constrain|>`` in headers** – When the parser is in
+       ``HEADER`` state and receives ``<|constrain|>``, enter skip mode and
+       discard tokens until ``<|message|>`` or ``<|end|>`` is seen.
+
+    All public properties are delegated to the underlying parser.  The
+    ``current_recipient`` getter additionally sanitizes leaked tokens.
+    """
+
+    def __init__(self, inner: StreamableParser, encoding):
+        self._inner = inner
+        self._encoding = encoding
+        self._skip_until_message_or_end = False
+
+    # --- error-recovering process() -----------------------------------
+
+    def process(self, token_id: int) -> None:
+        # Pattern 2: skip mode – discard until <|message|> or <|end|>
+        if self._skip_until_message_or_end:
+            if token_id in (_TOK_MESSAGE, _TOK_END):
+                self._skip_until_message_or_end = False
+                self._inner.process(token_id)
+            # else: silently discard the token
+            return
+
+        state = self._inner.state
+
+        # Pattern 1: missing <|start|> before <|channel|>
+        if state == StreamState.EXPECT_START and token_id == _TOK_CHANNEL:
+            # Inject <|start|> + assistant role token
+            self._inner.process(_TOK_START)
+            role_tokens = self._encoding.encode("assistant", allowed_special="all")
+            for rt in role_tokens:
+                self._inner.process(rt)
+            self._inner.process(token_id)
+            return
+
+        # Pattern 2: <|constrain|> during HEADER → enter skip mode
+        if state == StreamState.HEADER and token_id == _TOK_CONSTRAIN:
+            self._skip_until_message_or_end = True
+            return
+
+        self._inner.process(token_id)
+
+    # --- delegated properties -----------------------------------------
+
+    @property
+    def messages(self):
+        return self._inner.messages
+
+    @property
+    def current_content(self):
+        return self._inner.current_content
+
+    @property
+    def current_channel(self):
+        return self._inner.current_channel
+
+    @property
+    def current_recipient(self):
+        raw = self._inner.current_recipient
+        if raw is not None:
+            sanitized = sanitize_harmony_name(raw)
+            return sanitized if sanitized else None
+        return raw
+
+    @property
+    def current_role(self):
+        return self._inner.current_role
+
+    @property
+    def state(self):
+        return self._inner.state
+
+    @property
+    def last_content_delta(self):
+        return self._inner.last_content_delta
+
 
 REASONING_EFFORT = {
     "high": ReasoningEffort.HIGH,
@@ -256,7 +377,7 @@ def parse_chat_input_to_harmony_message(
 
         for call in tool_calls:
             func = call.get("function", {})
-            name = func.get("name", "")
+            name = sanitize_harmony_name(func.get("name", ""))
             arguments = func.get("arguments", "") or ""
             msg = Message.from_role_and_content(Role.ASSISTANT, arguments)
             msg = msg.with_channel("commentary")
@@ -328,8 +449,10 @@ def get_stop_tokens_for_assistant_actions() -> list[int]:
     return get_encoding().stop_tokens_for_assistant_actions()
 
 
-def get_streamable_parser_for_assistant() -> StreamableParser:
-    return StreamableParser(get_encoding(), role=Role.ASSISTANT)
+def get_streamable_parser_for_assistant() -> ResilientStreamableParser:
+    encoding = get_encoding()
+    inner = StreamableParser(encoding, role=Role.ASSISTANT)
+    return ResilientStreamableParser(inner, encoding)
 
 
 def parse_output_into_messages(token_ids: Iterable[int]) -> StreamableParser:

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -31,6 +31,7 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     get_encoding,
     get_streamable_parser_for_assistant,
     render_for_completion,
+    sanitize_harmony_name,
 )
 from vllm.entrypoints.openai.parser.responses_parser import (
     get_responses_parser_for_simple_context,
@@ -669,7 +670,9 @@ class HarmonyContext(ConversationContext):
     def need_builtin_tool_call(self) -> bool:
         last_msg = self.messages[-1]
         recipient = last_msg.recipient
-        if recipient is None:
+        if recipient is not None:
+            recipient = sanitize_harmony_name(recipient)
+        if not recipient:
             return False
         if recipient.startswith("browser."):
             return "browser" in self.available_tools
@@ -685,6 +688,8 @@ class HarmonyContext(ConversationContext):
         last_msg = self.messages[-1]
         recipient = last_msg.recipient
         if recipient is not None:
+            recipient = sanitize_harmony_name(recipient)
+        if recipient:
             if recipient.startswith("browser."):
                 return await self.call_search_tool(
                     self._tool_sessions["browser"], last_msg
@@ -708,7 +713,7 @@ class HarmonyContext(ConversationContext):
         self.called_tools.add("browser")
         if isinstance(tool_session, Tool):
             return await tool_session.get_result(self)
-        tool_name = last_msg.recipient.split(".")[1]
+        tool_name = sanitize_harmony_name(last_msg.recipient.split(".")[1])
         if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
             try:
                 args = json.loads(last_msg.content[0].text)
@@ -795,7 +800,9 @@ class HarmonyContext(ConversationContext):
         self.called_tools.add("container")
         if isinstance(tool_session, Tool):
             return await tool_session.get_result(self)
-        tool_name = last_msg.recipient.split(".")[1].split(" ")[0]
+        tool_name = sanitize_harmony_name(
+            last_msg.recipient.split(".")[1].split(" ")[0]
+        )
         if envs.VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY:
             try:
                 args = json.loads(last_msg.content[0].text)

--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -32,6 +32,7 @@ from openai_harmony import Author, Message, Role, StreamableParser, TextContent
 from vllm.entrypoints.openai.parser.harmony_utils import (
     BUILTIN_TOOL_TO_MCP_SERVER_LABEL,
     flatten_chat_text_content,
+    sanitize_harmony_name,
 )
 from vllm.entrypoints.openai.responses.protocol import (
     ResponseInputOutputItem,
@@ -93,7 +94,7 @@ def _parse_chat_format_message(chat_msg: dict) -> list[Message]:
         msgs: list[Message] = []
         for call in tool_calls:
             func = call.get("function", {})
-            name = func.get("name", "")
+            name = sanitize_harmony_name(func.get("name", ""))
             arguments = func.get("arguments", "") or ""
             msg = Message.from_role_and_content(Role.ASSISTANT, arguments)
             msg = msg.with_channel("commentary")
@@ -178,7 +179,8 @@ def response_input_to_harmony(
     elif response_msg["type"] == "function_call":
         msg = Message.from_role_and_content(Role.ASSISTANT, response_msg["arguments"])
         msg = msg.with_channel("commentary")
-        msg = msg.with_recipient(f"functions.{response_msg['name']}")
+        sanitized_name = sanitize_harmony_name(response_msg["name"])
+        msg = msg.with_recipient(f"functions.{sanitized_name}")
         msg = msg.with_content_type("json")
     else:
         raise ValueError(f"Unknown input type: {response_msg['type']}")
@@ -284,7 +286,7 @@ def _parse_browser_tool_call(message: Message, recipient: str) -> ResponseOutput
 
 def _parse_function_call(message: Message, recipient: str) -> list[ResponseOutputItem]:
     """Parse function calls into function tool call items."""
-    function_name = recipient.split(".")[-1]
+    function_name = sanitize_harmony_name(recipient.split(".")[-1])
     output_items = []
     for content in message.content:
         random_id = random_uuid()
@@ -413,6 +415,10 @@ def harmony_to_response_output(message: Message) -> list[ResponseOutputItem]:
 
     output_items: list[ResponseOutputItem] = []
     recipient = message.recipient
+    if recipient is not None:
+        recipient = sanitize_harmony_name(recipient)
+        if not recipient:
+            recipient = None
 
     if recipient is not None:
         # Browser tool calls (browser.search, browser.open, browser.find)
@@ -451,6 +457,10 @@ def parser_state_to_response_output(
     if parser.current_role != Role.ASSISTANT:
         return []
     current_recipient = parser.current_recipient
+    if current_recipient is not None:
+        current_recipient = sanitize_harmony_name(current_recipient)
+        if not current_recipient:
+            current_recipient = None
     if current_recipient is not None and current_recipient.startswith("browser."):
         return []
 


### PR DESCRIPTION
> _Recreated from #35881, which was closed when the fork was temporarily made private._

## Summary

GPT-OSS models leak Harmony protocol control tokens (`<|channel|>`, `<|constrain|>`, `<|start|>`, `<|end|>`, `<|message|>`) into tool names and recipient fields during generation. This causes:

- **Tool name contamination** — e.g. `manage_cart<|channel|>commentary` instead of `manage_cart`, corrupting function call routing and causing infinite tool-call loops
- **`<|constrain|>` as recipient** — e.g. `<|constrain|>json` matches no routing pattern, falls through to MCP handler or raises errors
- **Missing `<|start|>` between channels** — model omits start token between consecutive outputs, causing `StreamableParser` to throw `HarmonyError`
- **Malformed `<|constrain|>` in headers** — produces garbage in recipient or content_type fields

### Three layers of defense

1. **`sanitize_harmony_name()`** — Pure string function that finds the earliest Harmony control token in a name and returns only the text before it. Applied at all input parsing, output dispatching, tool routing, and streaming delta extraction sites.

2. **`ResilientStreamableParser`** — Drop-in wrapper around `StreamableParser` that intercepts two malformed token patterns:
   - Missing `<|start|>` recovery: when parser expects `<|start|>` but gets `<|channel|>`, inject the missing tokens
   - Malformed `<|constrain|>` in headers: skip tokens until `<|message|>` or `<|end|>`

3. **Routing-level fallback** — After sanitization, if a recipient becomes empty string, treat it as `None` so it falls through to `_parse_message_no_recipient()` (produces a user-visible message instead of a misrouted MCP call).

## Related Issues & PRs

| # | Title | Relation |
|---|-------|----------|
| #32587 | Special tokens leak into tool names | Primary bug report for tool name contamination |
| #30372 | Distorted tool names + infinite tool-call loop | Consequence of tool name contamination |
| #23567 | HarmonyError: unexpected tokens in message header | Parser crash from malformed sequences |
| #28262 | Incorrect input/output handling in Responses API | Channel metadata loss causing `<\|constrain\|>` misrouting |
| #31677 | Sanitize malformed tool call recipients (stale PR) | Strips `<\|channel\|>` from recipients |
| #32633 | Fix token leaks in tool names and streaming (stale PR) | Defines sanitize + strip functions |
| #28303 | Parse gpt-oss refusals w/ non-strict mode (stale PR) | Different approach via openai-harmony library |
| #29236 | Fix gpt oss tool parser v2 (stale PR) | Also addresses tag sanitization |
| #34857 | Responses API & Tool Calling H1 2026 roadmap | Lists "guided decode and structured outputs" as focus area |

## Decisions to debate

1. **Wrapper vs. monkey-patch for `StreamableParser`**: We chose a wrapper class (`ResilientStreamableParser`) that delegates all properties to the inner parser, rather than monkey-patching or subclassing. This means `get_streamable_parser_for_assistant()` returns our wrapper instead of a raw `StreamableParser`. All existing consumers work unchanged, but `isinstance(parser, StreamableParser)` checks would fail — we haven't found any such checks in the codebase, but reviewers should flag if they know of one.

2. **String-level vs. token-level sanitization**: `sanitize_harmony_name()` operates on strings, not token IDs. This is intentional — by the time we have a `message.recipient` or `function_name`, it's already a string. Token-level recovery is handled separately by `ResilientStreamableParser.process()`. The two layers are complementary, not redundant.

3. **Hardcoded token IDs (200003, 200005–200008)**: The `ResilientStreamableParser` references specific GPT-OSS encoding token IDs. These are stable across the `harmony-gpt-oss` encoding but would break if a different encoding were used. We could look these up dynamically from the encoding, but the IDs are well-established constants and dynamic lookup adds complexity for no current benefit.

4. **Sanitization applied broadly (defense in depth)**: We sanitize at input parsing, output dispatch, tool routing, AND streaming — even though the `ResilientStreamableParser` should catch most issues at the token level. This is intentional defense-in-depth: if a code path bypasses the resilient parser (e.g. direct `Message` construction in tests or from `previous_input_messages`), the string-level sanitization still catches leaked tokens.

5. **Empty-after-sanitization → `None` fallback**: When sanitizing a recipient produces an empty string, we convert it to `None` rather than raising an error. This causes the message to be treated as a "no-recipient" message (preamble), which is the safest fallback — the user sees the text content rather than getting a routing error. This is a design choice that could mask other bugs; an alternative would be to log a warning.

## Files changed

| File | Change |
|------|--------|
| `vllm/entrypoints/openai/parser/harmony_utils.py` | Add `sanitize_harmony_name()`, `ResilientStreamableParser`, wrap `get_streamable_parser_for_assistant()`, sanitize input parsing |
| `vllm/entrypoints/openai/responses/harmony.py` | Sanitize recipients in output dispatch + input parsing functions |
| `vllm/entrypoints/openai/responses/context.py` | Sanitize recipients in tool routing |
| `vllm/entrypoints/openai/chat_completion/stream_harmony.py` | Sanitize tool names in streaming delta extraction |
| `tests/entrypoints/openai/parser/test_harmony_utils.py` | Unit tests for `sanitize_harmony_name` + `ResilientStreamableParser` |
| `tests/entrypoints/openai/responses/test_harmony_utils.py` | Unit tests for output sanitization (contaminated recipients + tool names) |

## Test plan

- [x] `TestSanitizeHarmonyName` — 7 cases: clean passthrough, `<|channel|>` stripping, `<|constrain|>` stripping, pure token → empty, multiple tokens → earliest wins, empty input, trailing whitespace
- [x] `TestResilientStreamableParser` — 3 cases: normal sequence unchanged, missing `<|start|>` recovery, `<|constrain|>` in header skip
- [x] `TestHarmonyOutputSanitization` — 2 cases: `<|constrain|>json` recipient → message output, contaminated function name → cleaned
- [x] All existing parser and responses unit tests pass (90 total, 0 regressions)
- [ ] Integration test with live GPT-OSS model (needs model access)