### PR TITLE
[Harmony] Fix analysis-channel tool calls and preserve reasoning across turns

### DIFF
--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
-from openai_harmony import Message, Role
+from openai_harmony import Author, Message, Role
 
 from tests.entrypoints.openai.utils import verify_harmony_messages
 from vllm.entrypoints.openai.parser.harmony_utils import (
@@ -12,6 +12,7 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     has_custom_tools,
     parse_chat_input_to_harmony_message,
     parse_chat_output,
+    render_for_completion,
 )
 from vllm.entrypoints.openai.responses.harmony import (
     response_previous_input_to_harmony,
@@ -841,3 +842,50 @@ class TestGetSystemMessage:
                 assert channel in valid_channels, (
                     f"{channel} missing when with_custom_tools={with_tools}"
                 )
+
+
+class TestRenderForCompletion:
+    def test_preserves_analysis(self):
+        """render_for_completion must not strip analysis messages —
+        vLLM handles that via auto_drop_analysis_messages()."""
+        messages = [
+            get_system_message(),
+            Message.from_role_and_content(Role.USER, "What is 2+2?"),
+            Message.from_role_and_content(Role.ASSISTANT, "Let me think.").with_channel(
+                "analysis"
+            ),
+            Message.from_role_and_content(
+                Role.ASSISTANT, "The answer is 4."
+            ).with_channel("final"),
+        ]
+        token_ids = render_for_completion(messages)
+        decoded = get_encoding().decode(token_ids)
+        assert "Let me think." in decoded
+
+    def test_preserves_reasoning_across_tool_turns(self):
+        """Reasoning before a tool call must survive rendering even when
+        the conversation ends with a final message (which triggers the
+        encoder's auto_drop_analysis)."""
+        messages = [
+            get_system_message(),
+            Message.from_role_and_content(Role.USER, "What's the weather?"),
+            Message.from_role_and_content(
+                Role.ASSISTANT, "I should call the weather API."
+            ).with_channel("analysis"),
+            Message.from_role_and_content(Role.ASSISTANT, '{"location": "SF"}')
+            .with_channel("commentary")
+            .with_recipient("functions.get_weather")
+            .with_content_type("json"),
+            Message.from_author_and_content(
+                Author.new(Role.TOOL, "functions.get_weather"), "72F, sunny"
+            )
+            .with_channel("commentary")
+            .with_recipient("assistant"),
+            # Final message triggers the encoder's auto_drop_analysis
+            Message.from_role_and_content(
+                Role.ASSISTANT, "It is 72F and sunny in SF."
+            ).with_channel("final"),
+        ]
+        token_ids = render_for_completion(messages)
+        decoded = get_encoding().decode(token_ids)
+        assert "I should call the weather API." in decoded

--- a/tests/entrypoints/openai/responses/test_harmony_utils.py
+++ b/tests/entrypoints/openai/responses/test_harmony_utils.py
@@ -254,6 +254,19 @@ class TestHarmonyToResponseOutput:
         assert output_items[0].name == "custom_tool"
         assert output_items[0].server_label == "custom_tool"
 
+    def test_analysis_with_function_recipient_creates_function_call(self):
+        """GPT-OSS models sometimes emit tool calls on analysis channel.
+        Should produce function call, not MCP call."""
+        message = Message.from_role_and_content(Role.ASSISTANT, '{"location": "SF"}')
+        message = message.with_channel("analysis")
+        message = message.with_recipient("functions.get_weather")
+
+        output_items = harmony_to_response_output(message)
+
+        assert len(output_items) == 1
+        assert isinstance(output_items[0], ResponseFunctionToolCall)
+        assert output_items[0].name == "get_weather"
+
     def test_analysis_channel_creates_reasoning(self):
         """Test that analysis channel creates reasoning items."""
         message = Message.from_role_and_content(

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -13,6 +13,7 @@ from openai_harmony import (
     HarmonyEncodingName,
     Message,
     ReasoningEffort,
+    RenderConversationConfig,
     Role,
     StreamableParser,
     SystemContent,
@@ -318,8 +319,13 @@ def parse_chat_input_to_harmony_message(
 
 def render_for_completion(messages: list[Message]) -> list[int]:
     conversation = Conversation.from_messages(messages)
+    # Disable auto_drop_analysis: vLLM handles analysis filtering via
+    # auto_drop_analysis_messages(). Letting the encoder also drop causes
+    # double-filtering that strips reasoning the model needs between
+    # tool-calling turns.
+    config = RenderConversationConfig(auto_drop_analysis=False)
     token_ids = get_encoding().render_conversation_for_completion(
-        conversation, Role.ASSISTANT
+        conversation, Role.ASSISTANT, config=config
     )
     return token_ids
 

--- a/vllm/entrypoints/openai/responses/harmony.py
+++ b/vllm/entrypoints/openai/responses/harmony.py
@@ -419,8 +419,11 @@ def harmony_to_response_output(message: Message) -> list[ResponseOutputItem]:
         if recipient.startswith("browser."):
             output_items.append(_parse_browser_tool_call(message, recipient))
 
-        # Function calls (should only happen on commentary channel)
-        elif message.channel == "commentary" and recipient.startswith("functions."):
+        # Function calls (commentary or analysis channel — GPT-OSS models
+        # sometimes emit tool calls on analysis channel)
+        elif message.channel in ("commentary", "analysis") and recipient.startswith(
+            "functions."
+        ):
             output_items.extend(_parse_function_call(message, recipient))
 
         # Built-in MCP tools (python, browser, container)


### PR DESCRIPTION
> _Recreated from #35884, which was closed when the fork was temporarily made private._

## Motivation

GPT-OSS Harmony models exhibit two behaviors that stock vLLM handles incorrectly, causing silent misrouting of tool calls and loss of reasoning context in multi-turn tool-calling conversations.

### Bug 1: Tool calls on the analysis channel are silently misrouted

GPT-OSS models sometimes emit function calls on the `analysis` channel instead of `commentary`. The completed-message parser (`harmony_to_response_output`) only accepted function calls on `commentary`, so analysis-channel function calls fell through to `_parse_mcp_call()`, producing incorrect MCP call output items instead of function tool calls.

This was an inconsistency: `parser_state_to_response_output()` (streaming) and the in-progress parser already accepted function calls on both channels. Only the completed-message path was missing.

### Bug 2: Reasoning lost between tool-calling turns

The `openai_harmony` library defaults to `auto_drop_analysis=True` when rendering conversations for completion, stripping **all** analysis messages. vLLM already has its own `auto_drop_analysis_messages()` that selectively drops prior-turn analysis while preserving current-turn reasoning. The encoder's blanket drop on top of vLLM's selective drop caused double-filtering that destroyed the model's reasoning context between tool-calling turns.

## Changes

### Fix 1: Accept function calls on analysis channel (`harmony.py`)

Widened the channel check in `harmony_to_response_output()` from `== "commentary"` to `in ("commentary", "analysis")`, making the completed-message parser consistent with the streaming and in-progress paths.

### Fix 2: Disable encoder-side analysis dropping (`harmony_utils.py`)

Pass `RenderConversationConfig(auto_drop_analysis=False)` to the `openai_harmony` encoder in `render_for_completion()`. This prevents the encoder from double-dropping analysis messages that vLLM already selectively filters via `auto_drop_analysis_messages()`.

### Tests

- `test_analysis_with_function_recipient_creates_function_call` — verifies analysis-channel function calls produce `ResponseFunctionToolCall`, not `McpCall`
- `test_preserves_analysis` — verifies `render_for_completion` doesn't strip analysis messages
- `test_preserves_reasoning_across_tool_turns` — verifies reasoning before a tool call survives rendering through a tool turn

## Related Issues / PRs

| # | Title | Relation |
|---|-------|----------|
| #35779 | Harmony models incorrectly drops prior-turn analysis channel | Primary bug for reasoning loss — this PR fixes the encoder-side half |
| #35826 | Fix: preserve prior-turn analysis messages | Fixes vLLM-side `auto_drop_analysis_messages()` algorithm; complementary to our encoder-side fix |
| #27653 | [RFC] Include past-reasoning for harmony formatting | Proposes preserving reasoning in multi-turn; our fix implements the rendering half |
| #28262 | Responses API incorrect input/output handling | Channel metadata loss in round-trips |
| #35540 | Fix empty channel/recipient in harmony for /v1/responses | Fixes channel/recipient preservation on input; complementary |
| #32713 | [RFC] Unified Parser for reasoning, tool calling | Long-term architecture; these fixes are consistent with it |

## Design Decisions

1. **Why widen the channel check instead of fixing the model?** The model's behavior of emitting tool calls on `analysis` is valid per the Harmony protocol — the streaming and in-progress parsers already handle it. The completed-message parser was the only inconsistent path.

2. **Why disable `auto_drop_analysis` at the encoder instead of removing `auto_drop_analysis_messages()`?** vLLM's `auto_drop_analysis_messages()` implements the correct selective dropping policy (only prior-turn analysis before a `final` message). The encoder's blanket `auto_drop_analysis=True` is redundant and destructive. Disabling it at the encoder preserves vLLM's intentional filtering while preventing double-drops.

3. **Complementary to #35826:** That PR fixes the `auto_drop_analysis_messages()` algorithm itself. This PR fixes the encoder-side double-drop. Both are needed for correct behavior — they address different layers of the same problem.

## Test Plan

- [x] `pytest tests/entrypoints/openai/parser/test_harmony_utils.py -v` — 59 passed
- [x] `pytest tests/entrypoints/openai/responses/test_harmony_utils.py -v` — 22 passed
- [x] All 81 tests pass with no regressions
- [x] Pre-commit checks pass