### PR TITLE
[CI/Build] Allow mounting AWS credentials for sccache S3 auth

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -262,7 +262,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Build the vLLM wheel
 # if USE_SCCACHE is set, use sccache to speed up compilation
+# AWS credentials mounted at ~/.aws/credentials for sccache S3 auth (optional)
 RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=secret,id=aws-credentials,target=/root/.aws/credentials,required=false \
     if [ "$USE_SCCACHE" = "1" ]; then \
         echo "Installing sccache..." \
         && case "${TARGETPLATFORM}" in \


### PR DESCRIPTION
Add an optional secret mount for AWS credentials in the sccache build step. This allows CI systems using S3-backed sccache with IAM/Pod Identity to pass credentials into the Docker build.

The mount is required=false so it's a no-op when not provided, fully backwards compatible with existing builds.