### PR TITLE
[Rocm][CI] Fix ROCm LM Eval Large Models (8 Card)

### DIFF
--- a/.buildkite/lm-eval-harness/configs/models-large-rocm.txt
+++ b/.buildkite/lm-eval-harness/configs/models-large-rocm.txt
@@ -1,2 +1,1 @@
 Meta-Llama-4-Maverick-17B-128E-Instruct-FP8.yaml
-Qwen3-235B-A22B-Instruct-2507-FP8.yaml


### PR DESCRIPTION
Qwen3-235B-A22B-Instruct-2507-FP8 can not be run in tp8.