### PR TITLE
[Bugfix] Fix coord_socket assertion in DPEngineCoreProc for offline DP mode

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1571,7 +1571,11 @@ class DPEngineCoreProc(EngineCoreProc):
 
     def resume_scheduler(self):
         super().resume_scheduler()
-        if not self.engines_running and self.scheduler.has_unfinished_requests():
+        if (
+            self.has_coordinator
+            and not self.engines_running
+            and self.scheduler.has_unfinished_requests()
+        ):
             # Wake up other DP engines.
             self.output_queue.put_nowait(
                 (-1, EngineCoreOutputs(start_wave=self.current_wave))


### PR DESCRIPTION
 ## Purpose

  Fix assertion failure `assert coord_socket is not None` in `process_output_sockets()` when running with data parallelism in offline SPMD mode (e.g., standalone benchmarks with DP > 1).

  **The bug:** `DPEngineCoreProc.resume_scheduler()` unconditionally sends coordinator messages (`client_index=-1`) without checking whether a coordinator exists. In offline mode, no coordinator is started, so `coord_socket` is `None`, causing an assertion crash.

  **Fix 1:** Guard `resume_scheduler()` with `has_coordinator` check — this is the root cause fix. The method should not attempt to wake other DP engines via the coordinator when there is no coordinator.

  **Fix 2:** Replace the hard `assert` in `process_output_sockets()` with graceful error logging as a safety net. If a coordinator message somehow reaches the output processing without a coordinator socket, log an error and drop the message instead of crashing.

  ## Test Plan

  Ran standalone MoE model benchmarks on 8x GPUs (DP=8, TP=1, EP=8):

  ```bash
  python benchmarks/benchmark_latency.py \
      --model <moe-model> \
      --tensor-parallel-size 1 \
      --data-parallel-size 8 \
      --trust-remote-code
```

##  Test Result

  All DP offline benchmarks pass (decode and prefill). Previously all crashed with AssertionError on coord_socket.



cc @njhill @houseroad @zhuohan123 @hao-aaron 