### PR TITLE
[Model Runner V2] Fix inputs_embeds=None bug for MM models

### DIFF
--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -907,9 +907,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             )
 
         inputs_embeds = None
-        if self.supports_mm_inputs and self.is_first_pp_rank and not dummy_run:
+        if self.supports_mm_inputs and self.is_first_pp_rank:
             # Run MM encoder (if needed) and get multimodal embeddings.
             # Only first PP rank prepares multimodal embeddings.
+            # NOTE(woosuk): We must call get_mm_embeddings even during dummy runs
+            # to obtain inputs_embeds, because the compiled model expects this input.
             inputs_embeds = self.model_state.get_mm_embeddings(
                 scheduler_output.scheduled_encoder_inputs,
                 input_batch,


### PR DESCRIPTION
This PR fixes a bug that VLMs see blank images when CUDA graph is enabled (while the model works fine with eager mode). The bug is actually caused by incorrect compilation; We didn't provide `inputs_embeds` for the initial run.