### PR TITLE
[RL] [Weight Sync] Guard IPC update-info pickle deserialization behind insecure serialization flag

### DIFF
--- a/tests/distributed/test_weight_transfer.py
+++ b/tests/distributed/test_weight_transfer.py
@@ -488,9 +488,7 @@ class TestIPCWeightTransferUpdateInfoValidation:
                 names=[],
                 dtype_names=[],
                 shapes=[],
-                ipc_handles_pickled=base64.b64encode(pickle.dumps([])).decode(
-                    "utf-8"
-                ),
+                ipc_handles_pickled=base64.b64encode(pickle.dumps([])).decode("utf-8"),
             )
 
     def test_both_handles_and_pickled_raises(self):

--- a/tests/distributed/test_weight_transfer.py
+++ b/tests/distributed/test_weight_transfer.py
@@ -456,10 +456,12 @@ class TestIPCWeightTransferUpdateInfoValidation:
                 ipc_handles=ipc_handles,
             )
 
-    def test_valid_update_info_from_pickled(self):
+    def test_valid_update_info_from_pickled(self, monkeypatch):
         """Test creating IPCWeightTransferUpdateInfo from pickled handles."""
         if torch.cuda.device_count() < 1:
             pytest.skip("Need at least 1 GPU for this test")
+
+        monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
 
         dummy_tensor = torch.ones(10, 10, device="cuda:0")
         ipc_handle = reduce_tensor(dummy_tensor)
@@ -476,6 +478,20 @@ class TestIPCWeightTransferUpdateInfoValidation:
         )
         assert info.ipc_handles == ipc_handles
         assert info.ipc_handles_pickled is None
+
+    def test_pickled_requires_insecure_serialization_flag(self, monkeypatch):
+        """Test that pickled handles are rejected unless env flag is enabled."""
+        monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "0")
+
+        with pytest.raises(ValueError, match="VLLM_ALLOW_INSECURE_SERIALIZATION=1"):
+            IPCWeightTransferUpdateInfo(
+                names=[],
+                dtype_names=[],
+                shapes=[],
+                ipc_handles_pickled=base64.b64encode(pickle.dumps([])).decode(
+                    "utf-8"
+                ),
+            )
 
     def test_both_handles_and_pickled_raises(self):
         """Test that providing both ipc_handles and ipc_handles_pickled raises."""
@@ -556,10 +572,12 @@ class TestIPCEngineParsing:
         assert update_info.shapes == [[100, 100], [50]]
         assert len(update_info.ipc_handles) == 2
 
-    def test_parse_update_info_pickled(self):
+    def test_parse_update_info_pickled(self, monkeypatch):
         """Test parsing update info with pickled IPC handles (HTTP path)."""
         if torch.cuda.device_count() < 1:
             pytest.skip("Need at least 1 GPU for this test")
+
+        monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
 
         config = WeightTransferConfig(backend="ipc")
         parallel_config = create_mock_parallel_config()

--- a/vllm/distributed/weight_transfer/ipc_engine.py
+++ b/vllm/distributed/weight_transfer/ipc_engine.py
@@ -12,6 +12,7 @@ import requests
 import torch
 from torch.multiprocessing.reductions import reduce_tensor
 
+from vllm import envs
 from vllm.config.parallel import ParallelConfig
 from vllm.config.weight_transfer import WeightTransferConfig
 from vllm.distributed.weight_transfer.base import (
@@ -74,6 +75,13 @@ class IPCWeightTransferUpdateInfo(WeightTransferUpdateInfo):
                 raise ValueError(
                     "Cannot specify both `ipc_handles` and `ipc_handles_pickled`"
                 )
+
+            if not envs.VLLM_ALLOW_INSECURE_SERIALIZATION:
+                raise ValueError(
+                    "Refusing to deserialize `ipc_handles_pickled` without "
+                    "VLLM_ALLOW_INSECURE_SERIALIZATION=1"
+                )
+
             self.ipc_handles = pickle.loads(base64.b64decode(self.ipc_handles_pickled))
             self.ipc_handles_pickled = None
 


### PR DESCRIPTION
### Motivation
- Prevent unsafe unpickling of attacker-controlled data in the IPC weight-transfer HTTP path which could lead to remote code execution when `ipc` transport + dev-mode are enabled.

### Description
- Added an explicit gate in `IPCWeightTransferUpdateInfo.__post_init__` to refuse deserializing `ipc_handles_pickled` unless `VLLM_ALLOW_INSECURE_SERIALIZATION=1` is enabled via `vllm.envs`.
- This ensures `pickle.loads` on HTTP-provided payloads is only executed in environments that have explicitly opted into insecure serialization.
- Updated `tests/distributed/test_weight_transfer.py` to set `VLLM_ALLOW_INSECURE_SERIALIZATION=1` for existing pickled-handle tests and added a new negative test asserting pickled handles are rejected when the flag is disabled.

### Testing
- Compiled the changed modules with `python -m compileall vllm/distributed/weight_transfer/ipc_engine.py tests/distributed/test_weight_transfer.py`, which succeeded.
- Attempted to run targeted tests with `pytest -q tests/distributed/test_weight_transfer.py -k "pickled_requires_insecure_serialization_flag or valid_update_info_from_pickled or parse_update_info_pickled"`, but it failed to run in this environment due to missing test dependencies (`tblib`), so full pytest validation could not be completed here.
- Verified locally-editable behavior via quick runtime checks where the new guard raises `ValueError` when the env flag is not set and allows deserialization when `VLLM_ALLOW_INSECURE_SERIALIZATION=1` is present (limited by unavailable runtime deps in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a209caccb88329a5a086dd156ca3f6)