### PR TITLE
[Bugfix] Clamp out-of-bounds token IDs in MTP models

### DIFF
--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -120,6 +120,7 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
     ) -> torch.Tensor:
         if get_pp_group().is_first_rank:
             if inputs_embeds is None:
+                input_ids = input_ids.clamp(0, self.vocab_size - 1)
                 inputs_embeds = self.embed_input_ids(input_ids)
             assert hidden_states.shape[-1] == inputs_embeds.shape[-1]
             inputs_embeds = self.pre_fc_norm_embedding(inputs_embeds)

--- a/vllm/model_executor/models/qwen3_next_mtp.py
+++ b/vllm/model_executor/models/qwen3_next_mtp.py
@@ -106,6 +106,7 @@ class Qwen3NextMultiTokenPredictor(nn.Module):
     ) -> torch.Tensor:
         if get_pp_group().is_first_rank:
             if inputs_embeds is None:
+                input_ids = input_ids.clamp(0, self.vocab_size - 1)
                 inputs_embeds = self.embed_input_ids(input_ids)
             assert hidden_states.shape[-1] == inputs_embeds.shape[-1]
             inputs_embeds = self.pre_fc_norm_embedding(inputs_embeds)


### PR DESCRIPTION
## Summary

MTP speculative decoding can produce out-of-bounds token IDs when the lm_head has a padded vocabulary size that differs from the embedding table's `vocab_size`. This causes an index-out-of-range error in the embedding lookup and can result in corrupted output (e.g., "!!!!" appearing in thinking/reasoning output).

- Add `input_ids.clamp(0, self.vocab_size - 1)` before the embedding lookup in `Qwen3_5MultiTokenPredictor.forward()` and `Qwen3NextMultiTokenPredictor.forward()` to defensively handle OOB token IDs from speculative decoding.

## Test plan

- [ ] Run Qwen3.5 MoE with MTP enabled (`num_speculative_tokens > 0`) and verify no index-out-of-range crashes
- [ ] Verify output quality is not degraded (clamped tokens are speculative and will be verified/rejected by the main model)
- [ ] Run existing MTP tests: `pytest tests/ -k "mtp"`