### PR TITLE
[ROCm][Quantization] Simplify activation scale passing for triton mxfp4 w4afp8

### DIFF
--- a/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/gpt_oss_triton_kernels_moe.py
@@ -415,17 +415,15 @@ def triton_kernel_fused_mxfp4_w4a8_experts(
         "w2_precision in quant config can't be None"
     )
 
-    hidden_states = downcast_to_static_fp8(
-        hidden_states, quant_config.w1_precision.flex_ctx.lhs_data.scale
-    )
+    hidden_states = downcast_to_static_fp8(hidden_states, quant_config.a1_scale)
 
     intermediate_cache1 = moe_gemm_a8w4(
         hidden_states,
         w1.storage.data,
         None,
         quant_config.w1_precision.weight_scale.storage.data,
-        quant_config.w1_precision.flex_ctx.lhs_data.scale,
-        quant_config.w2_precision.flex_ctx.lhs_data.scale,
+        quant_config.a1_scale,
+        quant_config.a2_scale,
         quant_config.w1_bias,
         routing_data,
         gather_indx=gather_indx,
@@ -444,7 +442,7 @@ def triton_kernel_fused_mxfp4_w4a8_experts(
         w2.storage.data,
         None,
         quant_config.w2_precision.weight_scale.storage.data,
-        quant_config.w2_precision.flex_ctx.lhs_data.scale,
+        quant_config.a2_scale,
         None,
         quant_config.w2_bias,
         routing_data,

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -1111,19 +1111,14 @@ class QuarkOCP_MX_MoEMethod_OSS(QuarkOCP_MX_MoEMethod):
                 layer.w2_input_scale.max().to(torch.float32), requires_grad=False
             )
 
-            from triton_kernels.numerics import InFlexData
-
-            lhs_data13 = InFlexData(scale=layer.w13_input_scale)
-            lhs_data2 = InFlexData(scale=layer.w2_input_scale)
-
             self.w13_precision_config = PrecisionConfig(
                 weight_scale=w13_scale,
-                flex_ctx=FlexCtx(rhs_data=w13_flex, lhs_data=lhs_data13),
+                flex_ctx=FlexCtx(rhs_data=w13_flex),
             )
 
             self.w2_precision_config = PrecisionConfig(
                 weight_scale=w2_scale,
-                flex_ctx=FlexCtx(rhs_data=w2_flex, lhs_data=lhs_data2),
+                flex_ctx=FlexCtx(rhs_data=w2_flex),
             )
 
     def get_fused_moe_quant_config(


### PR DESCRIPTION
For simplicity, use `a1_scale` and `a2_scale` from `FusedMoEQuantConfig` for activation scales.