### PR TITLE
[torch.compile] Add AsyncTP fusion on Blackwell using FlashInfer bmm_fp8 and symm_mem impl

### DIFF
--- a/tests/compile/fusions_e2e/test_tp2_async_tp.py
+++ b/tests/compile/fusions_e2e/test_tp2_async_tp.py
@@ -13,7 +13,6 @@ from .common import (
     AttentionBackendCase,
     Matches,
     custom_ops_combos,
-    is_blackwell,
 )
 from .models import (
     FLASHINFER_ATTN,
@@ -46,13 +45,8 @@ def test_tp2_async_tp_fp8_fusions(
     custom_ops: str,
     inductor_graph_partition: bool,
     run_e2e_fusion_test,
-    monkeypatch,
 ):
     matches = matches_fn(n_layers)
-
-    if is_blackwell():
-        # Disable FlashInfer scaled_mm FP8 as it's not supported in async tp patterns
-        monkeypatch.setenv("VLLM_DISABLED_KERNELS", "FlashInferFP8ScaledMMLinearKernel")
 
     # Reduce size of model and skip weight loading time
     model_kwargs["hf_overrides"] = hf_overrides(n_layers)
@@ -171,13 +165,8 @@ def test_tp2_sp_ar_rms_fp8_fusions(
     custom_ops: str,
     inductor_graph_partition: bool,
     run_e2e_fusion_test,
-    monkeypatch,
 ):
     matches = matches_fn(n_layers)
-
-    if is_blackwell():
-        # Disable FlashInfer scaled_mm FP8 as it's not supported in async tp patterns
-        monkeypatch.setenv("VLLM_DISABLED_KERNELS", "FlashInferFP8ScaledMMLinearKernel")
 
     # Reduce size of model and skip weight loading time
     model_kwargs["hf_overrides"] = hf_overrides(n_layers)

--- a/tests/compile/passes/distributed/test_async_tp.py
+++ b/tests/compile/passes/distributed/test_async_tp.py
@@ -224,6 +224,63 @@ class TestAGCutlassScaledMMModel(_BaseScaledMMModel):
         return [torch.ops.symm_mem.fused_all_gather_scaled_matmul.default]
 
 
+class _BaseFlashInferBMMFP8Model(torch.nn.Module):
+    """Base for FlashInfer bmm_fp8 test models (per-tensor scalar scales)."""
+
+    def __init__(self, hidden_size=16, dtype=torch.float16):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.dtype = dtype
+        # Non-transposed weight [K, N] — FlashInfer uses [K, N] not [N, K].T
+        self.weight = torch.empty([hidden_size, hidden_size], dtype=FP8_DTYPE)
+        # Per-tensor scalar scales
+        self.scale_a = torch.tensor(1.0, dtype=torch.float32)
+        self.scale_b = torch.tensor(1.0, dtype=torch.float32)
+
+
+class TestFlashInferBMMFP8RSModel(_BaseFlashInferBMMFP8Model):
+    def forward(self, input: torch.Tensor):
+        """bmm_fp8 + reduce_scatter — matches FlashInfer's traced pattern."""
+        fp8_input = input.to(FP8_DTYPE)
+        output = torch.ops.vllm.bmm_fp8(
+            fp8_input.unsqueeze(0),
+            self.weight.unsqueeze(0),
+            self.scale_a,
+            self.scale_b,
+            self.dtype,
+            "auto",
+        ).view(fp8_input.shape[0], self.weight.shape[1])
+        return tensor_model_parallel_reduce_scatter(output, dim=0)
+
+    def ops_in_model_before(self):
+        return [torch.ops.vllm.reduce_scatter.default]
+
+    def ops_in_model_after(self):
+        return [torch.ops.vllm.fused_flashinfer_scaled_matmul_reduce_scatter.default]
+
+
+class TestAGFlashInferBMMFP8Model(_BaseFlashInferBMMFP8Model):
+    def forward(self, input: torch.Tensor):
+        """all_gather + bmm_fp8 — matches FlashInfer's traced pattern."""
+        fp8_input = input.to(FP8_DTYPE)
+        all_gather = tensor_model_parallel_all_gather(fp8_input, dim=0)
+        output = torch.ops.vllm.bmm_fp8(
+            all_gather.unsqueeze(0),
+            self.weight.unsqueeze(0),
+            self.scale_a,
+            self.scale_b,
+            self.dtype,
+            "auto",
+        ).view(all_gather.shape[0], self.weight.shape[1])
+        return output
+
+    def ops_in_model_before(self):
+        return [torch.ops.vllm.all_gather.default]
+
+    def ops_in_model_after(self):
+        return [torch.ops.vllm.fused_all_gather_flashinfer_scaled_matmul.default]
+
+
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize(
     "test_model",
@@ -234,6 +291,8 @@ class TestAGCutlassScaledMMModel(_BaseScaledMMModel):
         TestAGScaledMMModel,
         TestCutlassScaledMMRSModel,
         TestAGCutlassScaledMMModel,
+        TestFlashInferBMMFP8RSModel,
+        TestAGFlashInferBMMFP8Model,
     ],
 )
 @pytest.mark.parametrize("batch_size", [8])
@@ -264,6 +323,12 @@ def test_async_tp_pass_replace(
             "Only bf16 high precision output types are supported for "
             "per-token (row-wise) scaling"
         )
+
+    if test_model in (TestFlashInferBMMFP8RSModel, TestAGFlashInferBMMFP8Model):
+        if not hasattr(torch.ops.vllm, "bmm_fp8"):
+            pytest.skip("FlashInfer bmm_fp8 not available")
+        if dtype == torch.float16:
+            pytest.skip("FlashInfer FP8 async TP fusion requires bf16 output")
 
     num_processes = 2
 

--- a/vllm/compilation/passes/fusion/collective_fusion.py
+++ b/vllm/compilation/passes/fusion/collective_fusion.py
@@ -371,6 +371,119 @@ class AllGatherCutlassScaledMMPattern(BasePattern):
         )
 
 
+class FlashInferBMMFP8ReduceScatterPattern(BasePattern):
+    """Matches unsqueeze → unsqueeze → bmm_fp8 → view → reduce_scatter
+    and replaces with fused_flashinfer_scaled_matmul_reduce_scatter."""
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        input = torch.empty([16, 16], device=self.device, dtype=FP8_DTYPE)
+        weight = torch.empty([16, 16], device=self.device, dtype=FP8_DTYPE)
+        scale_a = torch.tensor(1.0, device=self.device, dtype=torch.float32)
+        scale_b = torch.tensor(1.0, device=self.device, dtype=torch.float32)
+        return [input, weight, scale_a, scale_b]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            input_3d = input.unsqueeze(0)
+            weight_3d = weight.unsqueeze(0)
+            bmm_result = torch.ops.vllm.bmm_fp8.default(
+                input_3d, weight_3d, scale_a, scale_b, self.dtype, "auto"
+            )
+            mm_result = bmm_result.view(input.shape[0], weight.shape[1])
+            reduce_scatter = torch.ops.vllm.reduce_scatter.default(
+                mm_result,
+                dim=0,
+                world_size=self.tp_size,
+                group_name=self.tp.unique_name,
+            )
+            return reduce_scatter
+
+        def replacement(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            output_shape = [*input.shape[:-1], weight.shape[1]]
+            scatter_dim = 0
+            return torch.ops.vllm.fused_flashinfer_scaled_matmul_reduce_scatter(
+                input,
+                weight,
+                scale_a,
+                scale_b,
+                "sum",
+                scatter_dim,
+                scatter_dim,
+                self.tp.device_group.group_name,
+                output_shape,
+                self.dtype,
+            )
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
+class AllGatherFlashInferBMMFP8Pattern(BasePattern):
+    """Matches all_gather → unsqueeze → unsqueeze → bmm_fp8 → view
+    and replaces with fused_all_gather_flashinfer_scaled_matmul."""
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        x = torch.empty([8, 16], device=self.device, dtype=FP8_DTYPE)
+        weight = torch.empty([16, 16], device=self.device, dtype=FP8_DTYPE)
+        scale_a = torch.tensor(1.0, device=self.device, dtype=torch.float32)
+        scale_b = torch.tensor(1.0, device=self.device, dtype=torch.float32)
+        return [x, weight, scale_a, scale_b]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            all_gather = torch.ops.vllm.all_gather.default(
+                x,
+                dim=0,
+                world_size=self.tp_size,
+                group_name=self.tp.unique_name,
+            )
+            ag_3d = all_gather.unsqueeze(0)
+            weight_3d = weight.unsqueeze(0)
+            bmm_result = torch.ops.vllm.bmm_fp8.default(
+                ag_3d, weight_3d, scale_a, scale_b, self.dtype, "auto"
+            )
+            return bmm_result.view(all_gather.shape[0], weight.shape[1])
+
+        def replacement(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            scale_a: torch.Tensor,
+            scale_b: torch.Tensor,
+        ) -> torch.Tensor:
+            ag_output, mm_output = (
+                torch.ops.vllm.fused_all_gather_flashinfer_scaled_matmul(
+                    x,
+                    weight,
+                    scale_a,
+                    scale_b,
+                    0,  # gather_dim
+                    self.tp.device_group.group_name,
+                    self.dtype,
+                )
+            )
+            return mm_output
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
 class AsyncTPPass(VllmPatternMatcherPass):
     @enable_fake_mode
     def __init__(self, config: VllmConfig) -> None:
@@ -402,6 +515,15 @@ class AsyncTPPass(VllmPatternMatcherPass):
             AllGatherCutlassScaledMMPattern(self.model_dtype, self.device).register(
                 self.patterns
             )
+
+            # FlashInfer bmm_fp8 patterns (SM >= 100 / Blackwell)
+            if hasattr(torch.ops.vllm, "bmm_fp8"):
+                FlashInferBMMFP8ReduceScatterPattern(
+                    self.model_dtype, self.device
+                ).register(self.patterns)
+                AllGatherFlashInferBMMFP8Pattern(
+                    self.model_dtype, self.device
+                ).register(self.patterns)
 
         self.dump_patterns(config, self.patterns)
 

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -284,6 +284,160 @@ direct_register_custom_op(
 )
 
 
+# --- FlashInfer bmm_fp8 fused ops for AsyncTP on Blackwell (SM >= 100) ---
+
+
+def _flashinfer_scaled_mm_out(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    *,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+    out_dtype: torch.dtype | None = None,
+    out: torch.Tensor,
+    **_kwargs: Any,
+) -> torch.Tensor:
+    """Adapter: wraps FlashInfer bmm_fp8 to match mm_out_op(A, B, ..., out=)
+    interface expected by PyTorch's _fused_*_impl helpers."""
+    result = torch.ops.vllm.bmm_fp8(
+        A.unsqueeze(0),
+        B.unsqueeze(0),
+        scale_a,
+        scale_b,
+        out_dtype or out.dtype,
+        "auto",
+    ).squeeze(0)
+    out.copy_(result)
+    return out
+
+
+def fused_flashinfer_scaled_matmul_reduce_scatter(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    A_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    reduce_op: str,
+    orig_scatter_dim: int,
+    scatter_dim_after_maybe_reshape: int,
+    group_name: str,
+    output_shape: list[int],
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    from torch.distributed._symmetric_memory import (
+        _fused_scaled_matmul_reduce_scatter_impl,
+    )
+
+    return _fused_scaled_matmul_reduce_scatter_impl(
+        mm_out_op=_flashinfer_scaled_mm_out,
+        A=A,
+        B=B,
+        A_scale=A_scale,
+        kwargs={"scale_b": B_scale, "out_dtype": out_dtype},
+        out_dtype=out_dtype,
+        reduce_op=reduce_op,
+        orig_scatter_dim=orig_scatter_dim,
+        scatter_dim_after_maybe_reshape=scatter_dim_after_maybe_reshape,
+        group_name=group_name,
+        output_shape=output_shape,
+    )
+
+
+def fused_flashinfer_scaled_matmul_reduce_scatter_fake(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    A_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    reduce_op: str,
+    orig_scatter_dim: int,
+    scatter_dim_after_maybe_reshape: int,
+    group_name: str,
+    output_shape: list[int],
+    out_dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    out_dtype = out_dtype or A.dtype
+    C = torch.ops.vllm.bmm_fp8(
+        A.flatten(0, -2).contiguous().unsqueeze(0),
+        B.unsqueeze(0),
+        A_scale,
+        B_scale,
+        out_dtype,
+        "auto",
+    ).squeeze(0)
+    C = C.view(*output_shape[:-1], B.shape[1])
+    res = funcol.reduce_scatter_tensor(
+        C,
+        reduce_op,
+        orig_scatter_dim,
+        group_name,
+    )
+    res = funcol.wait_tensor(res)
+    return res
+
+
+direct_register_custom_op(
+    op_name="fused_flashinfer_scaled_matmul_reduce_scatter",
+    op_func=fused_flashinfer_scaled_matmul_reduce_scatter,
+    fake_impl=fused_flashinfer_scaled_matmul_reduce_scatter_fake,
+)
+
+
+def fused_all_gather_flashinfer_scaled_matmul(
+    A_shard: torch.Tensor,
+    B: torch.Tensor,
+    A_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    gather_dim: int,
+    group_name: str,
+    out_dtype: torch.dtype | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from torch.distributed._symmetric_memory import (
+        _fused_all_gather_matmul_impl,
+    )
+
+    A, res_list = _fused_all_gather_matmul_impl(
+        mm_out_op=_flashinfer_scaled_mm_out,
+        A_shard=A_shard,
+        Bs=[B],
+        A_scale=A_scale,
+        kwargs_list=[{"scale_b": B_scale, "out_dtype": out_dtype}],
+        out_dtypes=[out_dtype],
+        gather_dim=gather_dim,
+        group_name=group_name,
+        return_A=True,
+    )
+    return A, res_list[0]
+
+
+def fused_all_gather_flashinfer_scaled_matmul_fake(
+    A_shard: torch.Tensor,
+    B: torch.Tensor,
+    A_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    gather_dim: int,
+    group_name: str,
+    out_dtype: torch.dtype | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    out_dtype = out_dtype or A_shard.dtype
+    A = funcol.all_gather_tensor(A_shard, gather_dim, group_name)
+    A = funcol.wait_tensor(A)
+    mm_out = torch.ops.vllm.bmm_fp8(
+        A.unsqueeze(0),
+        B.unsqueeze(0),
+        A_scale,
+        B_scale,
+        out_dtype,
+        "auto",
+    ).squeeze(0)
+    return A, mm_out
+
+
+direct_register_custom_op(
+    op_name="fused_all_gather_flashinfer_scaled_matmul",
+    op_func=fused_all_gather_flashinfer_scaled_matmul,
+    fake_impl=fused_all_gather_flashinfer_scaled_matmul_fake,
+)
+
+
 class GroupCoordinator:
     """
     PyTorch ProcessGroup wrapper for a group of processes.


### PR DESCRIPTION
## Summary
- On Blackwell GPUs (SM >= 100), vLLM selects FlashInfer's `bmm_fp8` as the FP8 GEMM kernel, but the AsyncTP compile pass only had patterns for `aten._scaled_mm` and `cutlass_scaled_mm` — so FlashInfer's GEMM couldn't be fused with collective ops, meaning **no async TP fusion for FP8 on Blackwell**
- Adds an adapter wrapping `bmm_fp8` to match PyTorch's `mm_out_op` interface, two fused custom ops delegating to `_fused_scaled_matmul_reduce_scatter_impl` / `_fused_all_gather_matmul_impl`, and two pattern classes for the FX pattern matcher
- Removes the workaround in E2E tests that disabled FlashInfer on Blackwell entirely

Fixes #27893

## Test plan
- [ ] Unit test: `pytest tests/compile/passes/distributed/test_async_tp.py -k "FlashInfer"` (2 GPUs + FlashInfer required)
- [ ] E2E test: `pytest tests/compile/fusions_e2e/test_tp2_async_tp.py::test_tp2_async_tp_fp8_fusions` on Blackwell without workaround
- [ ] Verify FX graph pattern matching accuracy (unsqueeze/bmm_fp8/view structure matches traced FlashInfer path)
- [ ] Benchmark AsyncTP throughput on Blackwell with and without the fix

