### PR TITLE
[Bugfix] Narrow kv_cache mempool context to prevent sleep mode regressions

### DIFF
--- a/tests/basic_correctness/test_cumem.py
+++ b/tests/basic_correctness/test_cumem.py
@@ -245,6 +245,36 @@ def test_deep_sleep_async():
     asyncio.run(test())
 
 
+@create_new_process_for_each_test()
+def test_flashinfer_sleep_wake():
+    """Regression test for issue #31016: FlashInfer + sleep mode.
+
+    Ensures that metadata tensors allocated during attention backend
+    initialization are not tagged as 'kv_cache', which would cause
+    them to be freed on sleep and lead to errors on wake/generate.
+    """
+    from vllm.utils.flashinfer import has_flashinfer
+
+    if not has_flashinfer():
+        pytest.skip("FlashInfer is not installed")
+
+    model = "hmellor/tiny-random-LlamaForCausalLM"
+    llm = LLM(
+        model,
+        enable_sleep_mode=True,
+        attention_config={"backend": "FLASHINFER"},
+    )
+    prompt = "How are you?"
+    sampling_params = SamplingParams(temperature=0, max_tokens=10)
+    output = llm.generate(prompt, sampling_params)
+
+    llm.sleep(level=1)
+    llm.wake_up()
+
+    output2 = llm.generate(prompt, sampling_params)
+    assert output[0].outputs[0].text == output2[0].outputs[0].text
+
+
 @requires_fp8
 def test_deep_sleep_fp8_kvcache():
     model = "Qwen/Qwen2-0.5B"

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -20,6 +20,7 @@ instead of embedding feature-specific logic directly.
 import functools
 import gc
 import time
+from contextlib import AbstractContextManager, nullcontext
 from copy import deepcopy
 from typing import Any, NamedTuple
 
@@ -314,6 +315,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     def get_kv_cache_spec(self):
         return get_kv_cache_spec(self.vllm_config)
 
+    def _kv_cache_memory_pool_context(self) -> AbstractContextManager:
+        """Return a context manager that tags GPU allocations as 'kv_cache'
+        when sleep mode is enabled, or a no-op context otherwise."""
+        if self.model_config.enable_sleep_mode:
+            from vllm.device_allocator.cumem import CuMemAllocator
+
+            allocator = CuMemAllocator.get_instance()
+            return allocator.use_memory_pool(tag="kv_cache")
+        return nullcontext()
+
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         kv_cache_config = deepcopy(kv_cache_config)
         self.kv_cache_config = kv_cache_config
@@ -356,13 +367,17 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             )
 
         self.kv_caches: list[torch.Tensor] = []
-        kv_caches_dict = init_kv_cache(
-            self.kv_caches,
-            self.compilation_config.static_forward_context,
-            self.kv_cache_config,
-            self.attn_backends,
-            self.device,
-        )
+        # Wrap only the actual KV cache tensor allocation with the
+        # kv_cache mempool tag, so that metadata setup above doesn't
+        # inherit the tag (which would cause issues with sleep/wake).
+        with self._kv_cache_memory_pool_context():
+            kv_caches_dict = init_kv_cache(
+                self.kv_caches,
+                self.compilation_config.static_forward_context,
+                self.kv_cache_config,
+                self.attn_backends,
+                self.device,
+            )
         self.kv_connector = get_kv_connector(self.vllm_config, kv_caches_dict)
 
     @torch.inference_mode()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -8,7 +8,7 @@ import threading
 import time
 from collections import defaultdict
 from collections.abc import Iterable, Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager, nullcontext
 from copy import copy, deepcopy
 from dataclasses import dataclass, replace
 from functools import reduce
@@ -6401,6 +6401,16 @@ class GPUModelRunner(
                         stride=(hidden_size, 2 * hidden_size, *kv_cache.stride()[2:]),
                     )
 
+    def _kv_cache_memory_pool_context(self) -> AbstractContextManager:
+        """Return a context manager that tags GPU allocations as 'kv_cache'
+        when sleep mode is enabled, or a no-op context otherwise."""
+        if self.model_config.enable_sleep_mode:
+            from vllm.device_allocator.cumem import CuMemAllocator
+
+            allocator = CuMemAllocator.get_instance()
+            return allocator.use_memory_pool(tag="kv_cache")
+        return nullcontext()
+
     def initialize_kv_cache_tensors(
         self, kv_cache_config: KVCacheConfig, kernel_block_sizes: list[int]
     ) -> dict[str, torch.Tensor]:
@@ -6512,9 +6522,15 @@ class GPUModelRunner(
 
         # Reinitialize need to after initialize_attn_backend
         self.may_reinitialize_input_batch(kv_cache_config, kernel_block_sizes)
-        kv_caches = self.initialize_kv_cache_tensors(
-            kv_cache_config, kernel_block_sizes
-        )
+
+        # Wrap only the actual KV cache tensor allocation with the
+        # kv_cache mempool tag, so that metadata builders and other
+        # initialization above don't inherit the tag (which would
+        # cause issues with sleep/wake).
+        with self._kv_cache_memory_pool_context():
+            kv_caches = self.initialize_kv_cache_tensors(
+                kv_cache_config, kernel_block_sizes
+            )
 
         if (
             self.speculative_config

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -543,14 +543,7 @@ class Worker(WorkerBase):
         # related to kv cache connector (e.g. kv cache sharing layers).
         ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
 
-        if self.vllm_config.model_config.enable_sleep_mode:
-            from vllm.device_allocator.cumem import CuMemAllocator
-
-            allocator = CuMemAllocator.get_instance()
-            with allocator.use_memory_pool(tag="kv_cache"):
-                self.model_runner.initialize_kv_cache(kv_cache_config)
-        else:
-            self.model_runner.initialize_kv_cache(kv_cache_config)
+        self.model_runner.initialize_kv_cache(kv_cache_config)
 
         if self.model_config.enable_return_routed_experts:
             self.model_runner.init_routed_experts_capturer()


### PR DESCRIPTION
## Summary

Fixes a latent architectural risk related to #31016 (FlashInfer + sleep mode crash).

The original bug was already fixed by #23174, but the `"kv_cache"` mempool context in `gpu_worker.py` still wrapped the **entire** `initialize_kv_cache()` call — including attention backend initialization, metadata builder creation, and input batch setup. Any future GPU tensor allocated in those setup steps would silently inherit the `"kv_cache"` tag and break on sleep/wake.

This PR narrows the scope so only the actual KV cache tensor allocation is wrapped:

- **`gpu_worker.py`**: Remove the sleep-mode conditional wrapping around `initialize_kv_cache()`, call it unconditionally
- **`gpu_model_runner.py` (v1)**: Wrap only `initialize_kv_cache_tensors()` with the `kv_cache` mempool context
- **`gpu/model_runner.py` (v2)**: Wrap only `init_kv_cache()` with the `kv_cache` mempool context
- **`test_cumem.py`**: Add regression test exercising FlashInfer + sleep/wake cycle

## Test plan

- [x] `ruff check` and `ruff format` pass on all changed files
- [x] All pre-commit hooks pass
- [ ] `pytest tests/basic_correctness/test_cumem.py::test_flashinfer_sleep_wake` passes on a GPU with FlashInfer installed
- [ ] `pytest tests/basic_correctness/test_cumem.py::test_end_to_end` still passes (existing sleep mode tests unaffected)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)