### PR TITLE
fix online fp8 for MiniCPM models

### DIFF
--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -1051,8 +1051,16 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
                 quant_config=quant_config,
                 prefix=maybe_prefix(prefix, "resampler"),
             )
+            self._resampler_moved = False
 
         self.make_empty_intermediate_tensors = self.llm.make_empty_intermediate_tensors
+
+    def _ensure_resampler_device(self) -> None:
+        if self._resampler_moved:
+            return
+        # Only move device, DO NOT touch dtype (fp8 quant needs its own dtype)
+        self.resampler.to(current_platform.device_type)
+        self._resampler_moved = True
 
     def _parse_and_validate_vision_input(
         self,
@@ -1172,7 +1180,9 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights)
+        loaded = loader.load_weights(weights)
+        self._ensure_resampler_device()
+        return loaded
 
     def get_mm_mapping(self) -> MultiModelKeys:
         """
@@ -1277,9 +1287,7 @@ class MiniCPMV2_0(MiniCPMVBaseModel):
                 prefix=prefix,
             )
 
-        return resampler.to(
-            device=current_platform.device_type, dtype=torch.get_default_dtype()
-        )
+        return resampler.to(dtype=torch.get_default_dtype())
 
     def get_vision_hidden_states(self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
@@ -1360,9 +1368,7 @@ class MiniCPMV2_5(MiniCPMVBaseModel, SupportsLoRA):
                 prefix=prefix,
             )
 
-        return resampler.to(
-            device=current_platform.device_type, dtype=torch.get_default_dtype()
-        )
+        return resampler.to(dtype=torch.get_default_dtype())
 
     def get_vision_hidden_states(self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
@@ -1392,7 +1398,6 @@ class MiniCPMV2_5(MiniCPMVBaseModel, SupportsLoRA):
             patch_attention_mask=patch_attn_mask.unsqueeze(1),
             tgt_sizes=None,
         )
-
         return self.resampler(vision_embedding, tgt_sizes)
 
 
@@ -1454,9 +1459,7 @@ class MiniCPMV2_6(MiniCPMVBaseModel, SupportsLoRA):
                 prefix=prefix,
             )
 
-        return resampler.to(
-            device=current_platform.device_type, dtype=torch.get_default_dtype()
-        )
+        return resampler.to(dtype=torch.get_default_dtype())
 
     def get_vision_hidden_states(self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
@@ -1486,12 +1489,13 @@ class MiniCPMV2_6(MiniCPMVBaseModel, SupportsLoRA):
             patch_attention_mask=patch_attn_mask.unsqueeze(1),
             tgt_sizes=tgt_sizes,
         )
-
         return self.resampler(vision_embedding, tgt_sizes)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_prefixes=["apm.", "audio", "tts"])
-        return loader.load_weights(weights)
+        loaded = loader.load_weights(weights)
+        self._ensure_resampler_device()
+        return loaded
 
 
 class MiniCPMV4_0(MiniCPMVBaseModel, SupportsLoRA):
@@ -1551,10 +1555,7 @@ class MiniCPMV4_0(MiniCPMVBaseModel, SupportsLoRA):
                 quant_config=quant_config,
                 prefix=prefix,
             )
-
-        return resampler.to(
-            device=current_platform.device_type, dtype=torch.get_default_dtype()
-        )
+        return resampler.to(dtype=torch.get_default_dtype())
 
     def get_vision_hidden_states(self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
@@ -1589,7 +1590,9 @@ class MiniCPMV4_0(MiniCPMVBaseModel, SupportsLoRA):
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_prefixes=["apm.", "audio", "tts"])
-        return loader.load_weights(weights)
+        loaded = loader.load_weights(weights)
+        self._ensure_resampler_device()
+        return loaded
 
 
 class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA):
@@ -1650,9 +1653,7 @@ class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA):
                 prefix=prefix,
             )
 
-        return resampler.to(
-            device=current_platform.device_type, dtype=torch.get_default_dtype()
-        )
+        return resampler.to(dtype=torch.get_default_dtype())
 
     def get_vision_hidden_states(self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
@@ -1686,12 +1687,13 @@ class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA):
             patch_attention_mask=patch_attn_mask.unsqueeze(1),
             tgt_sizes=tgt_sizes,
         )
-
         return self.resampler(vision_embedding, tgt_sizes, all_temporal_ids)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_prefixes=["apm.", "audio", "tts"])
-        return loader.load_weights(weights)
+        loaded = loader.load_weights(weights)
+        self._ensure_resampler_device()
+        return loaded
 
 
 _SUPPORT_VERSION = {

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -1398,6 +1398,7 @@ class MiniCPMV2_5(MiniCPMVBaseModel, SupportsLoRA):
             patch_attention_mask=patch_attn_mask.unsqueeze(1),
             tgt_sizes=None,
         )
+
         return self.resampler(vision_embedding, tgt_sizes)
 
 
@@ -1489,6 +1490,7 @@ class MiniCPMV2_6(MiniCPMVBaseModel, SupportsLoRA):
             patch_attention_mask=patch_attn_mask.unsqueeze(1),
             tgt_sizes=tgt_sizes,
         )
+
         return self.resampler(vision_embedding, tgt_sizes)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
@@ -1687,6 +1689,7 @@ class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA):
             patch_attention_mask=patch_attn_mask.unsqueeze(1),
             tgt_sizes=tgt_sizes,
         )
+
         return self.resampler(vision_embedding, tgt_sizes, all_temporal_ids)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:


### PR DESCRIPTION
## Purpose

With fp8 online quantization memory [fix](https://github.com/vllm-project/vllm/pull/31914) introducing `meta` device, `minicpmv` will break with error:
```
(EngineCore_DP0 pid=33065)   File "/workspace/vllm-minicpm/vllm/model_executor/models/minicpmv.py", line 1552, in init_resampler
(EngineCore_DP0 pid=33065)     return resampler.to(
(EngineCore_DP0 pid=33065)            ^^^^^^^^^^^^^
(EngineCore_DP0 pid=33065)   File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1381, in to
(EngineCore_DP0 pid=33065)     return self._apply(convert)
(EngineCore_DP0 pid=33065)            ^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=33065)   File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 933, in _apply
(EngineCore_DP0 pid=33065)     module._apply(fn)
(EngineCore_DP0 pid=33065)   File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 964, in _apply
(EngineCore_DP0 pid=33065)     param_applied = fn(param)
(EngineCore_DP0 pid=33065)                     ^^^^^^^^^
(EngineCore_DP0 pid=33065)   File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1374, in convert
(EngineCore_DP0 pid=33065)     raise NotImplementedError(
(EngineCore_DP0 pid=33065) NotImplementedError: Cannot copy out of meta tensor; no data! Please use torch.nn.Module.to_empty() instead of torch.nn.Module.to() when moving module from meta to a different device.

```

## Test Plan
```
VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/offline_inference/basic/generate.py --model openbmb/MiniCPM-V-4 --enforce-eager --max-model-len=4096 --trust_remote_code --quantization=fp8
```
## Test Result
```
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Nautli Navarrete!\nI am a Peruvian woman,'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' an elected representative of the American people, not a god or messiah, as'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' and has been since the time of Augustus Caesar. It is located in'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: " here: Tesla's Autopilot - the first Level 4 driver"
--------------------------------------------------
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

