### PR TITLE
Perf: Enable double-buffered chunked EP communication in DeepEP

### DIFF
--- a/tests/kernels/moe/test_deepep_chunking.py
+++ b/tests/kernels/moe/test_deepep_chunking.py
@@ -1,0 +1,108 @@
+
+import pytest
+import sys
+from unittest.mock import MagicMock
+import torch
+
+# Mock deep_ep module before importing vllm modules that depend on it
+mock_deep_ep = MagicMock()
+sys.modules["deep_ep"] = mock_deep_ep
+
+# Mock Buffer class
+class MockBuffer:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.dispatch_count = 0
+        self.combine_count = 0
+
+    def low_latency_dispatch(self, *args, **kwargs):
+        self.dispatch_count += 1
+        # Return dummy values: expert_x, expert_num_tokens, handle, _, hook
+        return (
+            torch.randn(1, 1, 1), 
+            torch.ones(1), 
+            f"handle_{id(self)}_{self.dispatch_count}", 
+            None, 
+            lambda: None
+        )
+
+    def low_latency_combine(self, *args, **kwargs):
+        self.combine_count += 1
+        return None, None, lambda: None
+
+    @staticmethod
+    def get_low_latency_rdma_size_hint(*args, **kwargs):
+        return 1024
+
+mock_deep_ep.Buffer = MockBuffer
+
+# Now import the class under test
+from vllm.model_executor.layers.fused_moe.deepep_ll_prepare_finalize import DeepEPLLPrepareAndFinalize
+from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
+
+def test_deepep_double_buffering():
+    # Setup
+    buffer1 = MockBuffer(name="buf1")
+    buffer2 = MockBuffer(name="buf2")
+    buffers = [buffer1, buffer2]
+    
+    prepare_finalize = DeepEPLLPrepareAndFinalize(
+        buffer=buffers,
+        max_tokens_per_rank=1024,
+        num_dispatchers=2,
+    )
+    
+    # Mock inputs
+    a1 = torch.randn(10, 128)
+    topk_ids = torch.randint(0, 8, (10, 1))
+    topk_weights = torch.ones(10, 1)
+    quant_config = MagicMock(spec=FusedMoEQuantConfig)
+    quant_config.quant_dtype = torch.float16
+    quant_config.a1_scale = None
+    quant_config.a1_gscale = None
+    quant_config.a2_scale = None
+    
+    # Mock ubatch_id context
+    with pytest.mock.patch("vllm.model_executor.layers.fused_moe.deepep_ll_prepare_finalize.dbo_current_ubatch_id", return_value=0):
+        # 1. First Prepare -> Should use Buffer 1 (index 0)
+        hook1, recv1 = prepare_finalize.prepare_async(
+            a1, topk_weights, topk_ids, 8, None, False, quant_config
+        )
+        assert buffer1.dispatch_count == 1
+        assert buffer2.dispatch_count == 0
+        
+        # 2. Second Prepare -> Should use Buffer 2 (index 1)
+        hook2, recv2 = prepare_finalize.prepare_async(
+            a1, topk_weights, topk_ids, 8, None, False, quant_config
+        )
+        assert buffer1.dispatch_count == 1
+        assert buffer2.dispatch_count == 1
+        
+        # 3. First Finalize -> Should use Buffer 1 handle (FIFO)
+        # We need mock outputs for finalize
+        out = torch.empty_like(a1)
+        fused_out = torch.empty_like(a1)
+        weight_reduce = MagicMock()
+        
+        prepare_finalize.finalize_async(
+            out, fused_out, topk_weights, topk_ids, False, weight_reduce
+        )
+        assert buffer1.combine_count == 1
+        assert buffer2.combine_count == 0
+        
+        # 4. Third Prepare -> Should use Buffer 1 (index 0) again
+        hook3, recv3 = prepare_finalize.prepare_async(
+            a1, topk_weights, topk_ids, 8, None, False, quant_config
+        )
+        assert buffer1.dispatch_count == 2
+        assert buffer2.dispatch_count == 1
+        
+        # 5. Second Finalize -> Should use Buffer 2 handle
+        prepare_finalize.finalize_async(
+            out, fused_out, topk_weights, topk_ids, False, weight_reduce
+        )
+        assert buffer1.combine_count == 1
+        assert buffer2.combine_count == 1
+
+if __name__ == "__main__":
+    test_deepep_double_buffering()

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -361,6 +361,7 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
         num_ep_ranks: int,
         num_global_experts: int,
         num_local_experts: int,
+        buffer_index: int = 0,
     ) -> dict[Any, Any]:
         """
         max_num_tokens_per_dp_rank : the maximum number of tokens a DP rank
@@ -369,6 +370,7 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
         num_ep_ranks: the number of EP group ranks.
         num_global_experts: Number of experts in the model.
         num_local_experts: Number of experts in an EP rank.
+        buffer_index: Index of the buffer (for double buffering).
         """
         import deep_ep  # type: ignore[import-not-found]
 
@@ -392,6 +394,7 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
             allow_nvlink_for_low_latency_mode=True,
             allow_mnnvl=envs.VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL,
             explicitly_destroy=True,
+            buffer_index=buffer_index,
         )
 
     def get_handle(self, kwargs):
@@ -403,8 +406,14 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
 
         buffer_kwargs = self._make_all2all_kwargs(**kwargs)
         logger.debug("DeepEP all2all args %s", buffer_kwargs)
+
+        def create_buffer(**kwargs):
+            # Remove buffer_index as it is not an argument for deep_ep.Buffer
+            kwargs.pop("buffer_index", None)
+            return deep_ep.Buffer(**kwargs)
+
         handle: deep_ep.Buffer = self.handle_cache.get_or_create(
-            buffer_kwargs, deep_ep.Buffer
+            buffer_kwargs, create_buffer
         )
         return handle
 

--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -146,7 +146,20 @@ def maybe_make_prepare_finalize(
             num_global_experts=moe.num_experts,
             num_local_experts=moe.num_experts // all2all_manager.world_size,
         )
-        handle = all2all_manager.get_handle(all_to_all_args)
+
+        # Handle double buffering if chunking is enabled
+        use_chunking = (
+             hasattr(envs, "VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING")
+             and envs.VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING
+        )
+        
+        handles = []
+        num_buffers = 2 if use_chunking else 1
+        
+        for i in range(num_buffers):
+             args = all_to_all_args.copy()
+             args['buffer_index'] = i
+             handles.append(all2all_manager.get_handle(args))
 
         # Note: We may want to use FP8 dispatch just to reduce
         # data movement.
@@ -156,7 +169,7 @@ def maybe_make_prepare_finalize(
         )
 
         prepare_finalize = DeepEPLLPrepareAndFinalize(
-            handle,
+            handles if num_buffers > 1 else handles[0],
             max_tokens_per_rank=moe.max_num_tokens,
             num_dispatchers=all2all_manager.world_size,
             use_fp8_dispatch=use_fp8_dispatch,

--- a/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
+++ b/vllm/model_executor/layers/fused_moe/deepep_ll_prepare_finalize.py
@@ -82,9 +82,14 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             f"maximum supported hidden size {_supported_hs[-1]}"
         )
 
+from collections import deque
+from itertools import cycle
+
+# ...
+
     def __init__(
         self,
-        buffer: deep_ep.Buffer,
+        buffer: deep_ep.Buffer | list[deep_ep.Buffer],
         max_tokens_per_rank: int,
         num_dispatchers: int,
         use_fp8_dispatch: bool = False,
@@ -94,13 +99,17 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
     ):
         super().__init__()
 
-        self.buffer = buffer
+        self.buffers = buffer if isinstance(buffer, list) else [buffer]
+        self.num_buffers = len(self.buffers)
+        self.buffer_cycler = cycle(range(self.num_buffers))
         self.max_tokens_per_rank = max_tokens_per_rank
         self.use_fp8_dispatch = use_fp8_dispatch
         # The dispatch function returns a handle that the combine function
         # requires. We store the handle here so it is available to the
         # combine function.
-        self.handles: list[tuple | None] = [None, None]
+        # We use a deque per ubatch_id to support pipelined chunks.
+        # handles[ubatch_id] -> deque[(handle, buffer_idx)]
+        self.handles: dict[int, deque] = {}
         self.num_dispatchers_ = num_dispatchers
 
         topk_indices_dtype = self.topk_indices_dtype()
@@ -295,7 +304,16 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
         # Dispatch
         dispatch_topk_ids = self._map_global_to_physical_ids(topk_ids)
-        expert_x, expert_num_tokens, handle, _, hook = self.buffer.low_latency_dispatch(
+        
+        a2a_idx = dbo_current_ubatch_id()
+        if a2a_idx not in self.handles:
+             self.handles[a2a_idx] = deque()
+             
+        # Cycle buffer
+        buffer_idx = next(self.buffer_cycler)
+        current_buffer = self.buffers[buffer_idx]
+        
+        expert_x, expert_num_tokens, handle, _, hook = current_buffer.low_latency_dispatch(
             a1,
             dispatch_topk_ids,
             self.max_tokens_per_rank,
@@ -312,7 +330,7 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
             async_finish=False,
             return_recv_hook=True,
         )
-        self.handles[a2a_idx] = handle
+        self.handles[a2a_idx].append((handle, buffer_idx))
 
         return (
             hook,
@@ -385,8 +403,15 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
         a2a_idx = dbo_current_ubatch_id()
         do_recv_hook = dbo_enabled() or do_async
-        handle = self.handles[a2a_idx]
-        assert handle is not None
+        
+        handle = None
+        current_buffer = None
+        
+        if a2a_idx in self.handles and self.handles[a2a_idx]:
+             handle, buffer_idx = self.handles[a2a_idx].popleft()
+             current_buffer = self.buffers[buffer_idx]
+        
+        assert handle is not None and current_buffer is not None, f"Handle not found for a2a_idx {a2a_idx}"
 
         combine_topk_weights = topk_weights
         if apply_router_weight_on_input:
@@ -396,7 +421,7 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         combine_topk_ids = self._map_global_to_physical_ids(topk_ids)
         # TODO (varun) : Enable zero copy mode
         dbo_maybe_run_recv_hook()
-        _, _, recv_hook = self.buffer.low_latency_combine(
+        _, _, recv_hook = current_buffer.low_latency_combine(
             fused_expert_output,
             combine_topk_ids,
             combine_topk_weights,


### PR DESCRIPTION
This change enables pipelined execution for Expert Parallelism when using DeepEP backend.
1. Modified All2AllManager to support double buffering by index.
2. Updated DeepEPLLPrepareAndFinalize to cycle between two buffers for dispatch/combine.
3. Updated all2all_utils to request two buffers if chunking is enabled.
4. Added unit test for double buffering logic.

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

