### PR TITLE
Fix phi4-mm and remove cuda binding

### DIFF
--- a/vllm/model_executor/models/phi4mm_audio.py
+++ b/vllm/model_executor/models/phi4mm_audio.py
@@ -585,10 +585,10 @@ class TransformerEncoderBase(abc.ABC, nn.Module):
         enc_streaming_mask = self._streaming_mask(
             seq_len, batch_size, self.chunk_size, self.left_chunk
         )
-
-        if xs_pad.is_cuda:
-            enc_streaming_mask = enc_streaming_mask.cuda()
-            xs_pad = xs_pad.cuda()
+        device = xs_pad.device
+        if device.type != "cpu":
+            enc_streaming_mask = enc_streaming_mask.to(device)
+            xs_pad = xs_pad.to(device)
 
         input_tensor = xs_pad
         input_tensor, masks = self._forward_embeddings_core(input_tensor, masks)
@@ -605,8 +605,8 @@ class TransformerEncoderBase(abc.ABC, nn.Module):
             enc_streaming_mask_nc = self._streaming_mask(
                 seq_len, batch_size, chunk_size_nc, left_chunk_nc
             )
-            if xs_pad.is_cuda:
-                enc_streaming_mask_nc = enc_streaming_mask_nc.cuda()
+            if device.type != "cpu":
+                enc_streaming_mask_nc = enc_streaming_mask_nc.to(device)
             if masks is not None:
                 hs_mask_nc = masks & enc_streaming_mask_nc
             else:

--- a/vllm/model_executor/models/phi4mm_audio.py
+++ b/vllm/model_executor/models/phi4mm_audio.py
@@ -586,9 +586,8 @@ class TransformerEncoderBase(abc.ABC, nn.Module):
             seq_len, batch_size, self.chunk_size, self.left_chunk
         )
         device = xs_pad.device
-        if device.type != "cpu":
-            enc_streaming_mask = enc_streaming_mask.to(device)
-            xs_pad = xs_pad.to(device)
+        enc_streaming_mask = enc_streaming_mask.to(device)
+        xs_pad = xs_pad.to(device)
 
         input_tensor = xs_pad
         input_tensor, masks = self._forward_embeddings_core(input_tensor, masks)

--- a/vllm/model_executor/models/phi4mm_utils.py
+++ b/vllm/model_executor/models/phi4mm_utils.py
@@ -1309,16 +1309,15 @@ class NemoConvSubsampling(torch.nn.Module):
             raise ValueError(f"Not valid sub-sampling: {subsampling}!")
 
         if subsampling in ["dw_striding", "striding"]:
-            in_length = torch.tensor(feat_in, dtype=torch.float)
-            out_length = calc_length(
-                lengths=in_length,
+            out_length = calc_length_int(
+                lengths=feat_in,
                 all_paddings=self._left_padding + self._right_padding,
                 kernel_size=self._kernel_size,
                 stride=self._stride,
                 ceil_mode=self._ceil_mode,
                 repeat_num=self._sampling_num,
             )
-            self.out = torch.nn.Linear(conv_channels * int(out_length), feat_out)
+            self.out = torch.nn.Linear(conv_channels * out_length, feat_out)
             self.conv2d_subsampling = True
         elif subsampling in ["striding_conv1d", "dw_striding_conv1d"]:
             self.out = None
@@ -1559,6 +1558,29 @@ def calc_length(
         lengths = torch.div(lengths.to(dtype=torch.float) + add_pad, stride) + one
         lengths = torch.ceil(lengths) if ceil_mode else torch.floor(lengths)
     return lengths.to(dtype=torch.int)
+
+
+def calc_length_int(
+    lengths: int,
+    all_paddings: int,
+    kernel_size: int,
+    stride: int,
+    ceil_mode: bool,
+    repeat_num: int = 1,
+) -> int:
+    """Integer-only variant of calc_length for meta-safe shape computation.
+
+    Computes the output length of a 1D convolution / pooling stack using
+    the same formula as calc_length, but operates purely on Python numbers
+    so it can be safely used during meta tensor initialization.
+    """
+    add_pad: float = all_paddings - kernel_size
+    one: float = 1.0
+    length_f: float = float(lengths)
+    for _ in range(repeat_num):
+        length_f = (length_f + add_pad) / stride + one
+        length_f = math.ceil(length_f) if ceil_mode else math.floor(length_f)
+    return int(length_f)
 
 
 ####  multihead attention starts here

--- a/vllm/model_executor/models/phi4mm_utils.py
+++ b/vllm/model_executor/models/phi4mm_utils.py
@@ -1542,24 +1542,6 @@ class NemoConvSubsampling(torch.nn.Module):
         self.subsampling_conv_chunking_factor = subsampling_conv_chunking_factor
 
 
-def calc_length(
-    lengths: Tensor,
-    all_paddings: int,
-    kernel_size: int,
-    stride: int,
-    ceil_mode: bool,
-    repeat_num: int = 1,
-) -> Tensor:
-    """Calculates the output length of a Tensor passed through a convolution or
-    max pooling layer"""
-    add_pad: float = all_paddings - kernel_size
-    one: float = 1.0
-    for i in range(repeat_num):
-        lengths = torch.div(lengths.to(dtype=torch.float) + add_pad, stride) + one
-        lengths = torch.ceil(lengths) if ceil_mode else torch.floor(lengths)
-    return lengths.to(dtype=torch.int)
-
-
 def calc_length_int(
     lengths: int,
     all_paddings: int,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
This PR removes cuda binding for phi4-mm model and also fix error about operation on meta tensors.
```
(EngineCore_DP0 pid=35974)   File "/workspace/vllm-minicpm/vllm/model_executor/models/phi4mm_audio.py", line 378, in __init__
(EngineCore_DP0 pid=35974)     self.embed = NemoConvSubsampling(
(EngineCore_DP0 pid=35974)                  ^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=35974)   File "/workspace/vllm-minicpm/vllm/model_executor/models/phi4mm_utils.py", line 1321, in __init__
(EngineCore_DP0 pid=35974)     self.out = torch.nn.Linear(conv_channels * int(out_length), feat_out)
(EngineCore_DP0 pid=35974)                                                ^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=35974)   File "/opt/venv/lib/python3.12/site-packages/torch/utils/_device.py", line 109, in __torch_function__
(EngineCore_DP0 pid=35974)     return func(*args, **kwargs)
(EngineCore_DP0 pid=35974)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=35974)   File "/opt/venv/lib/python3.12/site-packages/torch/utils/_device.py", line 109, in __torch_function__
(EngineCore_DP0 pid=35974)     return func(*args, **kwargs)
(EngineCore_DP0 pid=35974)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=35974)   File "/opt/venv/lib/python3.12/site-packages/torch/_meta_registrations.py", line 7779, in meta_local_scalar_dense
(EngineCore_DP0 pid=35974)     raise RuntimeError("Tensor.item() cannot be called on meta tensors")
(EngineCore_DP0 pid=35974) RuntimeError: Tensor.item() cannot be called on meta tensors
```
## Test Plan

```
python examples/offline_inference/vision_language.py -m phi4_mm
```

## Test Result
```
Processed prompts: 100%|██████████████████| 4/4 [00:24<00:00,  6.04s/it, est. speed input: 509.40 toks/s, output: 9.10 toks/s]
--------------------------------------------------
The image shows a tall tower with a spherical structure at the top, which appears to be the Tokyo Skytree. The tower is partially obscured by pink cherry blossom branches in the foreground. The sky is clear and blue, and the cherry blossoms are in full bloom, creating a beautiful contrast with the tower.
--------------------------------------------------
The image shows a tall tower with a spherical structure at the top, surrounded by cherry blossoms. The sky is clear and blue, and the cherry blossoms are in full bloom, creating a beautiful contrast with the tower.
--------------------------------------------------
The image shows a cherry blossom tree in the foreground with pink flowers. In the background, there is a tall tower with a spherical structure at the top, which appears to be the Tokyo Skytree. The sky is clear and blue, and the overall scene is vibrant and colorful.
--------------------------------------------------
The image shows a view of a tall tower with a spherical structure at the top, partially obscured by pink cherry blossom branches in the foreground. The sky is clear and blue, and the cherry blossoms are in full bloom, creating a beautiful contrast with the tower.
--------------------------------------------------
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

