### PR TITLE
[Core] Add KV transfer support to sparse attention indexer

### DIFF
--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -5,6 +5,11 @@
 import torch
 
 from vllm._aiter_ops import rocm_aiter_ops
+from vllm.distributed.kv_transfer import (
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+    is_v1_kv_transfer_group,
+)
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
@@ -241,6 +246,12 @@ def sparse_attn_indexer(
             topk_indices_buffer[:num_decode_tokens, : topk_indices.shape[-1]] = (
                 topk_indices
             )
+
+    # KV transfer: save indexer KV cache layer after forward
+    if has_kv_transfer_group() and is_v1_kv_transfer_group():
+        connector = get_kv_transfer_group()
+        if connector.has_connector_metadata():
+            connector.save_kv_layer(k_cache_prefix, kv_cache, attn_metadata)
 
     return topk_indices_buffer
 


### PR DESCRIPTION
## Summary

Add KV cache save operation to `sparse_attn_indexer` for external KV cache connectors (e.g., distributed prefix caching).

**Problem**: Previously, only the main MLA attention layers had KV transfer support via the `@maybe_transfer_kv_layer` decorator. The sparse attention indexer layers were missing this, causing:
- Mismatch between registered layers (158) and actual save operations (79)
- KV connector pending counters never reaching zero
- External prefix cache hits always failing

**Solution**: Add KV transfer save call to `sparse_attn_indexer` function, matching the behavior of main MLA attention layers.

## Changes

- Add KV transfer imports to `sparse_attn_indexer.py`
- Add `save_kv_layer` call after indexer forward completes

## Test Results

Tested with GLM5 + MTP + external KV connector:

| Metric | Before | After |
|--------|--------|-------|
| External prefix cache hit rate | 0% | 45.6% |
| Second request cache hits | 0 blocks | 4 blocks (256 tokens) |
| async_save_completed | Never | Normal |

## Test plan

- [x] GLM5 + MTP + external KV connector: cache hits work
- [ ] Non-MLA models: behavior unchanged (no regression)
- [ ] Models without KV connector: no impact (guards check for connector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)