### PR TITLE
[feat] Kimi K2/DeepSeek Support eagle3

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -774,6 +774,7 @@ class SpeculativeConfig:
             "hunyuan_v1_dense",
             "afmoe",
             "nemotron_h",
+            "kimi_k2",
         ]
         if (
             self.method in ("eagle3", "extract_hidden_states")

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1172,7 +1172,6 @@ class DeepseekV2Model(nn.Module):
         else:
             self.norm = PPMissingLayer()
 
-        # Eagle3 support: track which layers should output auxiliary hidden states
         self.aux_hidden_state_layers = tuple[int, ...]()
 
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
@@ -1214,14 +1213,11 @@ class DeepseekV2Model(nn.Module):
         else:
             llama_4_scaling = None
 
-        # Eagle3 support: collect auxiliary hidden states from specified layers
         aux_hidden_states = []
         for idx, layer in enumerate(self.layers[self.start_layer : self.end_layer]):
-            # Calculate global layer index for pipeline parallelism
             global_layer_idx = self.start_layer + idx
-            # Save hidden states before layer processing if this layer is marked
             if global_layer_idx in self.aux_hidden_state_layers:
-                # Store pre-normalization state (hidden_states + residual)
+                # Pre-normalization state
                 aux_hidden_states.append(hidden_states + residual)
 
             hidden_states, residual = layer(
@@ -1235,7 +1231,6 @@ class DeepseekV2Model(nn.Module):
 
         hidden_states, _ = self.norm(hidden_states, residual)
 
-        # Eagle3 support: return auxiliary hidden states if collected
         if len(aux_hidden_states) > 0:
             return hidden_states, aux_hidden_states
 
@@ -1372,43 +1367,18 @@ class DeepseekV2ForCausalLM(
         return self.model.embed_input_ids(input_ids)
 
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
-        """Set which layers should output auxiliary hidden states for Eagle3.
-
-        Args:
-            layers: Tuple of layer indices that should output auxiliary hidden states.
-        """
+        """Set which layers should output auxiliary hidden states."""
         self.model.aux_hidden_state_layers = layers
 
     def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
-        """Get default auxiliary layer indices for DeepseekV2.
-
-        Returns default layer selection based on model size. These defaults
-        can be overridden by speculative config if the draft model specifies
-        eagle_aux_hidden_state_layer_ids in its config.
-
-        Returns:
-            Tuple of layer indices (typically: early, middle, late layers)
-        """
-        # Use total number of layers from config, not len(layers) which
-        # only reflects the current pipeline parallel rank
+        """Return default auxiliary layer indices: early, middle, and late layers."""
+        # Use config.num_hidden_layers for correct count across pipeline stages
         num_layers = self.model.config.num_hidden_layers
 
-        # Handle small models gracefully
         if num_layers < 4:
-            # For very small models, return middle layer only (or empty if no layers)
             return (num_layers // 2,) if num_layers > 0 else ()
 
-        # Select 3 representative layers: early, middle, and late
-        # Use set to avoid duplicates in edge cases, then sort
-        return tuple(
-            sorted(
-                {
-                    2,  # Early layer (captures low-level features)
-                    num_layers // 2,  # Middle layer (captures mid-level semantics)
-                    num_layers - 3,  # Late layer (captures high-level semantics)
-                }
-            )
-        )
+        return tuple(sorted({2, num_layers // 2, num_layers - 3}))
 
     def forward(
         self,

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -26,7 +26,6 @@
 
 import typing
 from collections.abc import Callable, Iterable
-from itertools import islice
 
 import torch
 from torch import nn
@@ -1217,11 +1216,11 @@ class DeepseekV2Model(nn.Module):
 
         # Eagle3 support: collect auxiliary hidden states from specified layers
         aux_hidden_states = []
-        for idx, layer in enumerate(
-            islice(self.layers, self.start_layer, self.end_layer)
-        ):
+        for idx, layer in enumerate(self.layers[self.start_layer : self.end_layer]):
+            # Calculate global layer index for pipeline parallelism
+            global_layer_idx = self.start_layer + idx
             # Save hidden states before layer processing if this layer is marked
-            if idx in self.aux_hidden_state_layers:
+            if global_layer_idx in self.aux_hidden_state_layers:
                 # Store pre-normalization state (hidden_states + residual)
                 aux_hidden_states.append(hidden_states + residual)
 
@@ -1285,7 +1284,12 @@ class DeepseekV2MixtureOfExperts(MixtureOfExperts):
 
 
 class DeepseekV2ForCausalLM(
-    nn.Module, SupportsPP, DeepseekV2MixtureOfExperts, SupportsLoRA, SupportsEagle, SupportsEagle3
+    nn.Module,
+    SupportsPP,
+    DeepseekV2MixtureOfExperts,
+    SupportsLoRA,
+    SupportsEagle,
+    SupportsEagle3,
 ):
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
@@ -1385,12 +1389,25 @@ class DeepseekV2ForCausalLM(
         Returns:
             Tuple of layer indices (typically: early, middle, late layers)
         """
-        num_layers = len(self.model.layers)
+        # Use total number of layers from config, not len(layers) which
+        # only reflects the current pipeline parallel rank
+        num_layers = self.model.config.num_hidden_layers
+
+        # Handle small models gracefully
+        if num_layers < 4:
+            # For very small models, return middle layer only (or empty if no layers)
+            return (num_layers // 2,) if num_layers > 0 else ()
+
         # Select 3 representative layers: early, middle, and late
-        return (
-            2,                  # Early layer (captures low-level features)
-            num_layers // 2,    # Middle layer (captures mid-level semantics)
-            num_layers - 3      # Late layer (captures high-level semantics)
+        # Use set to avoid duplicates in edge cases, then sort
+        return tuple(
+            sorted(
+                {
+                    2,  # Early layer (captures low-level features)
+                    num_layers // 2,  # Middle layer (captures mid-level semantics)
+                    num_layers - 3,  # Late layer (captures high-level semantics)
+                }
+            )
         )
 
     def forward(

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -82,7 +82,13 @@ from vllm.v1.attention.backends.mla.indexer import (
 )
 from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 
-from .interfaces import MixtureOfExperts, SupportsEagle, SupportsLoRA, SupportsPP
+from .interfaces import (
+    MixtureOfExperts,
+    SupportsEagle,
+    SupportsEagle3,
+    SupportsLoRA,
+    SupportsPP,
+)
 from .utils import (
     PPMissingLayer,
     is_pp_missing_parameter,
@@ -1166,6 +1172,10 @@ class DeepseekV2Model(nn.Module):
             self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         else:
             self.norm = PPMissingLayer()
+
+        # Eagle3 support: track which layers should output auxiliary hidden states
+        self.aux_hidden_state_layers = tuple[int, ...]()
+
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
             ["hidden_states", "residual"], config.hidden_size
         )
@@ -1179,7 +1189,7 @@ class DeepseekV2Model(nn.Module):
         positions: torch.Tensor,
         intermediate_tensors: IntermediateTensors | None,
         inputs_embeds: torch.Tensor | None = None,
-    ) -> torch.Tensor | IntermediateTensors:
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
@@ -1205,7 +1215,16 @@ class DeepseekV2Model(nn.Module):
         else:
             llama_4_scaling = None
 
-        for layer in islice(self.layers, self.start_layer, self.end_layer):
+        # Eagle3 support: collect auxiliary hidden states from specified layers
+        aux_hidden_states = []
+        for idx, layer in enumerate(
+            islice(self.layers, self.start_layer, self.end_layer)
+        ):
+            # Save hidden states before layer processing if this layer is marked
+            if idx in self.aux_hidden_state_layers:
+                # Store pre-normalization state (hidden_states + residual)
+                aux_hidden_states.append(hidden_states + residual)
+
             hidden_states, residual = layer(
                 positions, hidden_states, residual, llama_4_scaling
             )
@@ -1216,6 +1235,11 @@ class DeepseekV2Model(nn.Module):
             )
 
         hidden_states, _ = self.norm(hidden_states, residual)
+
+        # Eagle3 support: return auxiliary hidden states if collected
+        if len(aux_hidden_states) > 0:
+            return hidden_states, aux_hidden_states
+
         return hidden_states
 
 
@@ -1261,7 +1285,7 @@ class DeepseekV2MixtureOfExperts(MixtureOfExperts):
 
 
 class DeepseekV2ForCausalLM(
-    nn.Module, SupportsPP, DeepseekV2MixtureOfExperts, SupportsLoRA, SupportsEagle
+    nn.Module, SupportsPP, DeepseekV2MixtureOfExperts, SupportsLoRA, SupportsEagle, SupportsEagle3
 ):
     packed_modules_mapping = {
         "gate_up_proj": ["gate_proj", "up_proj"],
@@ -1342,6 +1366,32 @@ class DeepseekV2ForCausalLM(
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        """Set which layers should output auxiliary hidden states for Eagle3.
+
+        Args:
+            layers: Tuple of layer indices that should output auxiliary hidden states.
+        """
+        self.model.aux_hidden_state_layers = layers
+
+    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        """Get default auxiliary layer indices for DeepseekV2.
+
+        Returns default layer selection based on model size. These defaults
+        can be overridden by speculative config if the draft model specifies
+        eagle_aux_hidden_state_layer_ids in its config.
+
+        Returns:
+            Tuple of layer indices (typically: early, middle, late layers)
+        """
+        num_layers = len(self.model.layers)
+        # Select 3 representative layers: early, middle, and late
+        return (
+            2,                  # Early layer (captures low-level features)
+            num_layers // 2,    # Middle layer (captures mid-level semantics)
+            num_layers - 3      # Late layer (captures high-level semantics)
+        )
 
     def forward(
         self,

--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -458,23 +458,11 @@ class KimiK25ForConditionalGeneration(
         return vision_embeddings
 
     def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
-        """Set which layers should output auxiliary hidden states for Eagle3.
-
-        Delegates to the underlying language model (DeepseekV2ForCausalLM).
-
-        Args:
-            layers: Tuple of layer indices that should output auxiliary hidden states.
-        """
+        """Set which layers should output auxiliary hidden states."""
         self.language_model.set_aux_hidden_state_layers(layers)
 
     def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
-        """Get default auxiliary layer indices for Kimi K2.5.
-
-        Delegates to the underlying language model (DeepseekV2ForCausalLM).
-
-        Returns:
-            Tuple of layer indices (typically: early, middle, late layers)
-        """
+        """Return default auxiliary layer indices."""
         return self.language_model.get_eagle3_aux_hidden_state_layers()
 
     def forward(

--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -28,6 +28,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
     CompressedTensorsConfig,
 )
 from vllm.model_executor.models.interfaces import (
+    SupportsEagle3,
     SupportsMultiModal,
     SupportsPP,
     SupportsQuant,
@@ -310,7 +311,7 @@ class KimiK25MultiModalProcessor(BaseMultiModalProcessor[KimiK25ProcessingInfo])
     dummy_inputs=KimiK25DummyInputsBuilder,
 )
 class KimiK25ForConditionalGeneration(
-    nn.Module, SupportsMultiModal, SupportsPP, SupportsQuant
+    nn.Module, SupportsMultiModal, SupportsPP, SupportsQuant, SupportsEagle3
 ):
     """Kimi-K2.5 model for conditional generation.
 
@@ -455,6 +456,26 @@ class KimiK25ForConditionalGeneration(
         # Run multimodal inputs through encoder and projector
         vision_embeddings = self._process_media_input(media_input)
         return vision_embeddings
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        """Set which layers should output auxiliary hidden states for Eagle3.
+
+        Delegates to the underlying language model (DeepseekV2ForCausalLM).
+
+        Args:
+            layers: Tuple of layer indices that should output auxiliary hidden states.
+        """
+        self.language_model.set_aux_hidden_state_layers(layers)
+
+    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        """Get default auxiliary layer indices for Kimi K2.5.
+
+        Delegates to the underlying language model (DeepseekV2ForCausalLM).
+
+        Returns:
+            Tuple of layer indices (typically: early, middle, late layers)
+        """
+        return self.language_model.get_eagle3_aux_hidden_state_layers()
 
     def forward(
         self,

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1301,6 +1301,10 @@ class SpecDecodeBaseProposer:
                 self.model.config.image_token_index = (
                     target_model.config.vision_config.image_token_id
                 )
+            elif self.get_model_name(target_model) == "KimiK25ForConditionalGeneration":
+                self.model.config.image_token_index = getattr(
+                    target_model.config, "media_placeholder_token_id", None
+                )
             else:
                 self.model.config.image_token_index = (
                     target_model.config.image_token_index


### PR DESCRIPTION
Hi from [novita.ai](https://novita.ai/) team 👋
<!-- markdownlint-disable -->

## Purpose

improve throughput
## Test Plan

## Test Result

I just used the [draft model](https://huggingface.co/AQ-MedAI/Kimi-K25-eagle3)

serve args:
```
vllm serve /to/path/Kimi-K2.5/ \
  --speculative_config '{"model": "/models/Kimi-K25-eagle3", "num_speculative_tokens": 4, "method": "eagle3", "draft_tensor_parallel_size": 8}' \
  --port 3333 \
  --tensor-parallel-size 8 \
  --trust-remote-code \
  --tool-call-parser kimi_k2 \
  --reasoning-parser kimi_k2 \
  --enable-auto-tool-choice \
  --served-model-name moonshotai/kimi-k2.5 
```

test with gsm8k
```
python tests/evals/gsm8k/gsm8k_eval.py \
```

From metrics, the acceptance rate is 51.78%.
```
curl http://127.0.0.1:3333/metrics | grep spec_decode
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 58595  100 58595    0     0  5684k      0 --:--:# HELP vllm:spec_decode_num_drafts_total Number of spec decoding drafts.
-# TYPE vllm:spec_decode_num_drafts_total counter
-vllm:spec_decode_num_drafts_total{engine="0",model_name="moonshotai/kimi-k2.5"} 42668.0
 # HELP vllm:spec_decode_num_drafts_created Number of spec decoding drafts.
-# TYPE vllm:spec_decode_num_drafts_created gauge
-vllm:spec_decode_num_drafts_created{engine="0",model_name="moonshotai/kimi-k2.5"} 1.7730446216168053e+09
:# HELP vllm:spec_decode_num_draft_tokens_total Number of draft tokens.
-# TYPE vllm:spec_decode_num_draft_tokens_total counter
-vllm:spec_decode_num_draft_tokens_total{engine="0",model_name="moonshotai/kimi-k2.5"} 170672.0
:# HELP vllm:spec_decode_num_draft_tokens_created Number of draft tokens.
-# TYPE vllm:spec_decode_num_draft_tokens_created gauge
-vllm:spec_decode_num_draft_tokens_created{engine="0",model_name="moonshotai/kimi-k2.5"} 1.7730446216168284e+09
 # HELP vllm:spec_decode_num_accepted_tokens_total Number of accepted tokens.
-# TYPE vllm:spec_decode_num_accepted_tokens_total counter
-vllm:spec_decode_num_accepted_tokens_total{engine="0",model_name="moonshotai/kimi-k2.5"} 88381.0
:# HELP vllm:spec_decode_num_accepted_tokens_created Number of accepted tokens.
-# TYPE vllm:spec_decode_num_accepted_tokens_created gauge
-vllm:spec_decode_num_accepted_tokens_created{engine="0",model_name="moonshotai/kimi-k2.5"} 1.7730446216168435e+09
:# HELP vllm:spec_decode_num_accepted_tokens_per_pos_total Accepted tokens per draft position.
-# TYPE vllm:spec_decode_num_accepted_tokens_per_pos_total counter
-vllm:spec_decode_num_accepted_tokens_per_pos_total{engine="0",model_name="moonshotai/kimi-k2.5",position="0"} 32894.0
 vllm:spec_decode_num_accepted_tokens_per_pos_total{engine="0",model_name="moonshotai/kimi-k2.5",position="1"} 24858.0
6vllm:spec_decode_num_accepted_tokens_per_pos_total{engine="0",model_name="moonshotai/kimi-k2.5",position="2"} 17916.0
3vllm:spec_decode_num_accepted_tokens_per_pos_total{engine="0",model_name="moonshotai/kimi-k2.5",position="3"} 12713.0
57# HELP vllm:spec_decode_num_accepted_tokens_per_pos_created Accepted tokens per draft position.
k# TYPE vllm:spec_decode_num_accepted_tokens_per_pos_created gauge
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

