### PR TITLE
[Bugfix] Qwen3.5-397B-A17B model loading with transformer=5.2

### DIFF
--- a/vllm/transformers_utils/configs/qwen3_5_moe.py
+++ b/vllm/transformers_utils/configs/qwen3_5_moe.py
@@ -75,10 +75,10 @@ class Qwen3_5MoeTextConfig(PretrainedConfig):
         eos_token_id=None,
         **kwargs,
     ):
-        kwargs["ignore_keys_at_rope_validation"] = [
+        kwargs["ignore_keys_at_rope_validation"] = {
             "mrope_section",
             "mrope_interleaved",
-        ]
+        }
         self.vocab_size = vocab_size
         self.max_position_embeddings = max_position_embeddings
         self.hidden_size = hidden_size


### PR DESCRIPTION
transformer 5.2 requrires `ignore_keys_at_rope_validation` param to passed in as a set [link](https://github.com/huggingface/transformers/blob/5c1c72be5f864d10d0efe8ece0768d9ed6ee4fdd/src/transformers/modeling_rope_utils.py#L632C1-L633C1):
```python
    def convert_rope_params_to_dict(self, ignore_keys_at_rope_validation: set | None = None, **kwargs):
```


## Purpose

the following docker image all failed to load 'Qwen3.5-397B-A17B' model
- vllm/vllm-openai:qwen3_5
- vllm/vllm-openai:nightly

the error is 
```
(APIServer pid=1) ValueError: The checkpoint you are trying to load has model type `qwen3_5_moe` but Transformers does not recognize this architecture. This could be because of an issue with the checkpoint, or because your version of Transformers is out of date.
(APIServer pid=1)
(APIServer pid=1) You can update Transformers with the command `pip install --upgrade transformers`. If this does not work, and the checkpoint is very new, then there may not be a release version that supports this model yet. In this case, you can get the most up-to-date
code by installing Transformers from source with the command `pip install git+https://github.com/huggingface/transformers.git`
```

however after unpgrade transformer 5.2, the error becomes
```
(APIServer pid=1543)   File "/usr/local/lib/python3.12/dist-packages/transformers/modeling_rope_utils.py", line 651, in convert_rope_params_to_dict
(APIServer pid=1543)     ignore_keys_at_rope_validation = ignore_keys_at_rope_validation | {"partial_rotary_factor"}
(APIServer pid=1543)                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
(APIServer pid=1543) TypeError: unsupported operand type(s) for |: 'list' and 'set'
```
this commit tries to sovle the problem, by create ignore_keys_at_rope_validation  as set.


## Test Plan
test if vllm can load Qwen3.5-397B-A17B

## Test Result
yes, it does

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

