### PR TITLE
[Bugfix] Fix RunAI streamer crash with S3-hosted model paths

### DIFF
--- a/vllm/transformers_utils/repo_utils.py
+++ b/vllm/transformers_utils/repo_utils.py
@@ -220,33 +220,45 @@ def get_model_path(model: str | Path, revision: str | None = None):
     return snapshot_download(repo_id=model, **common_kwargs)
 
 
+def _try_download_from_hf_hub(
+    model: str | Path, file_name: str, revision: str | None
+) -> Path | None:
+    """Try to download a file from HuggingFace Hub.
+
+    Returns the local path on success, None on failure.
+    Skips download if model is a local directory.
+    """
+    if Path(model).is_dir():
+        return None
+    try:
+        return Path(hf_hub_download(model, file_name, revision=revision))
+    except huggingface_hub.errors.OfflineModeIsEnabled:
+        return None
+    except (
+        RepositoryNotFoundError,
+        RevisionNotFoundError,
+        EntryNotFoundError,
+        LocalEntryNotFoundError,
+    ) as e:
+        logger.debug("File or repository not found in hf_hub_download:", exc_info=e)
+        return None
+    except HfHubHTTPError as e:
+        logger.warning(
+            "Cannot connect to Hugging Face Hub. Skipping file download for '%s':",
+            file_name,
+            exc_info=e,
+        )
+        return None
+
+
 def get_hf_file_bytes(
     file_name: str, model: str | Path, revision: str | None = "main"
 ) -> bytes | None:
     """Get file contents from HuggingFace repository as bytes."""
     file_path = try_get_local_file(model=model, file_name=file_name, revision=revision)
 
-    if file_path is None and not Path(model).is_dir():
-        try:
-            hf_hub_file = hf_hub_download(model, file_name, revision=revision)
-        except huggingface_hub.errors.OfflineModeIsEnabled:
-            return None
-        except (
-            RepositoryNotFoundError,
-            RevisionNotFoundError,
-            EntryNotFoundError,
-            LocalEntryNotFoundError,
-        ) as e:
-            logger.debug("File or repository not found in hf_hub_download:", exc_info=e)
-            return None
-        except HfHubHTTPError as e:
-            logger.warning(
-                "Cannot connect to Hugging Face Hub. Skipping file download for '%s':",
-                file_name,
-                exc_info=e,
-            )
-            return None
-        file_path = Path(hf_hub_file)
+    if file_path is None:
+        file_path = _try_download_from_hf_hub(model, file_name, revision)
 
     if file_path is not None and file_path.is_file():
         with open(file_path, "rb") as file:
@@ -292,27 +304,8 @@ def get_hf_file_to_dict(
 
     file_path = try_get_local_file(model=model, file_name=file_name, revision=revision)
 
-    if file_path is None and not Path(model).is_dir():
-        try:
-            hf_hub_file = hf_hub_download(model, file_name, revision=revision)
-        except huggingface_hub.errors.OfflineModeIsEnabled:
-            return None
-        except (
-            RepositoryNotFoundError,
-            RevisionNotFoundError,
-            EntryNotFoundError,
-            LocalEntryNotFoundError,
-        ) as e:
-            logger.debug("File or repository not found in hf_hub_download:", exc_info=e)
-            return None
-        except HfHubHTTPError as e:
-            logger.warning(
-                "Cannot connect to Hugging Face Hub. Skipping file download for '%s':",
-                file_name,
-                exc_info=e,
-            )
-            return None
-        file_path = Path(hf_hub_file)
+    if file_path is None:
+        file_path = _try_download_from_hf_hub(model, file_name, revision)
 
     if file_path is not None and file_path.is_file():
         with open(file_path) as file:

--- a/vllm/transformers_utils/repo_utils.py
+++ b/vllm/transformers_utils/repo_utils.py
@@ -226,8 +226,26 @@ def get_hf_file_bytes(
     """Get file contents from HuggingFace repository as bytes."""
     file_path = try_get_local_file(model=model, file_name=file_name, revision=revision)
 
-    if file_path is None:
-        hf_hub_file = hf_hub_download(model, file_name, revision=revision)
+    if file_path is None and not Path(model).is_dir():
+        try:
+            hf_hub_file = hf_hub_download(model, file_name, revision=revision)
+        except huggingface_hub.errors.OfflineModeIsEnabled:
+            return None
+        except (
+            RepositoryNotFoundError,
+            RevisionNotFoundError,
+            EntryNotFoundError,
+            LocalEntryNotFoundError,
+        ) as e:
+            logger.debug("File or repository not found in hf_hub_download:", exc_info=e)
+            return None
+        except HfHubHTTPError as e:
+            logger.warning(
+                "Cannot connect to Hugging Face Hub. Skipping file download for '%s':",
+                file_name,
+                exc_info=e,
+            )
+            return None
         file_path = Path(hf_hub_file)
 
     if file_path is not None and file_path.is_file():
@@ -274,7 +292,7 @@ def get_hf_file_to_dict(
 
     file_path = try_get_local_file(model=model, file_name=file_name, revision=revision)
 
-    if file_path is None:
+    if file_path is None and not Path(model).is_dir():
         try:
             hf_hub_file = hf_hub_download(model, file_name, revision=revision)
         except huggingface_hub.errors.OfflineModeIsEnabled:


### PR DESCRIPTION
## Summary
- When using --load-format runai_streamer with S3 models, the local cache path was passed to hf_hub_download() which validates it as a HuggingFace repo_id, causing a ValidationError
- Guard download calls with Path(model).is_dir() to skip HF download for local directories where the file simply doesn't exist

Fixes #35717