### PR TITLE
[Bugfix] Fix MXFP4A16 degenerate output via compressed-tensors bump

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -37,7 +37,7 @@ pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=77.0.3,<81.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
-compressed-tensors == 0.13.0 # required for compressed-tensors
+compressed-tensors == 0.14.0 # required for compressed-tensors
 depyf==0.20.0 # required for profiling and debugging with compilation config
 cloudpickle # allows pickling lambda functions in model_executor/models/registry.py
 watchfiles # required for http server to monitor the updates of TLS files


### PR DESCRIPTION
## Summary
- compressed-tensors 0.13.0 has a double -2 exponent offset bug in MXFP4 scale encoding: compress_scale() re-applies the offset already present from generate_mxfp4_scales(), making dequantized weights 4x too small (PPL 22,953 vs 8.74)
- Bump to 0.14.0 which fixes this (upstream PRs vllm-project/compressed-tensors#538, #541)

Fixes #35562