### PR TITLE
fix qwen3 streaming reasoning parser when thinking is disabled

### DIFF
--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -140,8 +140,8 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         if not delta_text:
             # Nothing left after stripping start token.
             return None
-        elif self.end_token_id in previous_token_ids:
-            # End token already passed: everything is content now.
+        elif self.end_token_id in previous_token_ids or not self.thinking_enabled:
+            # End token already passed or thinking disabled: everything is content now.
             return DeltaMessage(content=delta_text)
         else:
             # No end token yet: still in reasoning phase.


### PR DESCRIPTION
fix qwen3 streaming reasoning parser when thinking is disabled

test request:
{
            "model": "Qwen3.5-35B-A3B",
            "messages": [
                {
                    "role": "user",
                    "content": "0.11和0.9哪个大？"
                }
            ],
            "stream": true,
            "chat_template_kwargs": {"enable_thinking": false}
}