### PR TITLE
[Bugfix] Make `kaldi_native_fbank` optional

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -57,4 +57,3 @@ opentelemetry-sdk >= 1.27.0
 opentelemetry-api >= 1.27.0
 opentelemetry-exporter-otlp >= 1.27.0
 opentelemetry-semantic-conventions-ai >= 0.4.1
-kaldi-native-fbank >= 1.18.7

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -67,6 +67,7 @@ segmentation-models-pytorch > 0.4.0 # Required for Prithvi tests
 gpt-oss >= 0.0.7; python_version > '3.11'
 
 perceptron # required for isaac test
+kaldi-native-fbank >= 1.18.7 # required for fireredasr2 test
 
 # Newer versions of datasets require torchcoded, that makes the tests fail in CI because of a missing library.
 # Older versions are in conflict with teerratorch requirements.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -417,6 +417,8 @@ jsonschema-specifications==2024.10.1
     # via jsonschema
 junit-xml==1.9
     # via schemathesis
+kaldi-native-fbank==1.22.3
+    # via -r requirements/test.in
 kaleido==0.2.1
     # via genai-perf
 kiwisolver==1.4.7

--- a/vllm/transformers_utils/processors/fireredasr2_processor.py
+++ b/vllm/transformers_utils/processors/fireredasr2_processor.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import TYPE_CHECKING
 
-import kaldi_native_fbank as knf
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -16,6 +16,13 @@ from transformers.processing_utils import ProcessorMixin
 from transformers.utils import TensorType
 
 from vllm.logger import init_logger
+from vllm.utils.import_utils import LazyLoader
+
+if TYPE_CHECKING:
+    import kaldi_native_fbank as knf
+else:
+    knf = LazyLoader("kaldi_native_fbank")
+
 
 logger = init_logger(__name__)
 

--- a/vllm/transformers_utils/processors/fireredasr2_processor.py
+++ b/vllm/transformers_utils/processors/fireredasr2_processor.py
@@ -21,7 +21,7 @@ from vllm.utils.import_utils import LazyLoader
 if TYPE_CHECKING:
     import kaldi_native_fbank as knf
 else:
-    knf = LazyLoader("kaldi_native_fbank")
+    knf = LazyLoader("knf", globals(), "kaldi_native_fbank")
 
 
 logger = init_logger(__name__)


### PR DESCRIPTION

## Purpose

Don't force people to install `kaldi_native_fbank` if they don't actually use FireRedASR2. This is a problem because any use of `vllm.transformers_utils.processors` triggers this import.

I think a more proper way to solve this would be to make all imports in `vllm.transformers_utils.processors` lazy, just like for the configs. But I'm not sure whether we need to execute `AutoProcessor.register` for the submodules at import time. Happy to update the PR if that isn't a problem.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

