### PR TITLE
[Doc] Fix GPU Worker count in Process Count Summary

### DIFF
--- a/docs/design/arch_overview.md
+++ b/docs/design/arch_overview.md
@@ -122,7 +122,7 @@ For a deployment with `N` GPUs, `TP` tensor parallel size, `DP` data parallel si
 |---|---|---|
 | API Server | `A` (default `DP`) | Handles HTTP requests and input processing |
 | Engine Core | `DP` (default 1) | Scheduler and KV cache management |
-| GPU Worker | `N` (= `DP x TP`) | One per GPU, executes model forward passes |
+| GPU Worker | `N` (= `PP x TP`) | One per GPU, executes model forward passes |
 | DP Coordinator | 1 if `DP > 1`, else 0 | Load balancing across DP ranks |
 | **Total** | **`A + DP + N` (+ 1 if DP > 1)** | |
 

--- a/docs/design/arch_overview.md
+++ b/docs/design/arch_overview.md
@@ -122,7 +122,7 @@ For a deployment with `N` GPUs, `TP` tensor parallel size, `DP` data parallel si
 |---|---|---|
 | API Server | `A` (default `DP`) | Handles HTTP requests and input processing |
 | Engine Core | `DP` (default 1) | Scheduler and KV cache management |
-| GPU Worker | `N` (= `PP x TP`) | One per GPU, executes model forward passes |
+| GPU Worker | `N` (= `DP x PP x TP`) | One per GPU, executes model forward passes |
 | DP Coordinator | 1 if `DP > 1`, else 0 | Load balancing across DP ranks |
 | **Total** | **`A + DP + N` (+ 1 if DP > 1)** | |
 


### PR DESCRIPTION
## Purpose
Fix the GPU worker count in the Process Count Summary.

According to the vLLM architecture documentation:
https://docs.vllm.ai/en/latest/design/arch_overview/#gpu-worker-processes

> There is 1 worker process per GPU. The total number of GPU worker processes equals tensor_parallel_size x pipeline_parallel_size per engine core.

This update corrects the documented GPU worker count.

## Test Plan
No code changes were made.
## Test Result
No code changes were made.