### PR TITLE
[Bugfix] Fix message queue initialization order for cross-node DP

### DIFF
--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -608,7 +608,6 @@ class WorkerProc:
         )
 
         # Load model
-        self._init_message_queues(input_shm_handle, vllm_config)
         is_eep_new_worker = envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH
         if not is_eep_new_worker:
             self.worker.init_device()
@@ -617,6 +616,11 @@ class WorkerProc:
                 enable_ep=vllm_config.parallel_config.enable_expert_parallel
             )
             self.worker.load_model()
+
+        # Initialize message queues after parallel groups are initialized.
+        # This is required for cross-node DP (nnodes_within_dp > 1) which
+        # needs get_inner_dp_world_group() to be available.
+        self._init_message_queues(input_shm_handle, vllm_config)
 
         # Enable environment variable cache (e.g. assume no more
         # environment variable overrides after this point)


### PR DESCRIPTION
## Summary

Fixes a bug where `_init_message_queues()` was called before `worker.init_device()`, causing failures when `nnodes_within_dp > 1`.

## Problem

When `nnodes_within_dp > 1` (cross-node DP group), the message queue initialization requires `get_inner_dp_world_group()` which is only available after parallel groups are initialized during `init_device()`. The incorrect order caused:

```
AssertionError: inner dp world group is not initialized
```

## Root Cause

**Dependency chain:**
```
_init_message_queues() (Branch B)
    └── requires get_inner_dp_world_group()
            └── requires _INNER_DP_WORLD variable
                    └── initialized in initialize_model_parallel()
                            └── called in worker.init_device()
```

## Fix

Move `_init_message_queues()` call to after `worker.init_device()` and `worker.load_model()`.

## Affected Configurations

This bug affects ANY configuration where `nnodes_within_dp > 1`, including:
- Uniform cross-node DP (e.g., PP=4, TP=2, DP=1 across 2 nodes)
- Non-uniform topology scenarios

## Test Plan

- E2E-20: Uniform cross-node PP=4, TP=2, DP=1 (nnodes_within_dp=2) - **PASSES** with fix
- Verified same test **FAILS** on main branch commit `a60985b07`