### PR TITLE
[Core] Add sharding metadata to model parameters

### DIFF
--- a/tests/model_executor/test_sharding_metadata.py
+++ b/tests/model_executor/test_sharding_metadata.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for sharding metadata on model parameters."""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.sharding import (
+    Sharding,
+    ShardingType,
+    _attach_sharding,
+)
+
+
+# ── TestShardingDataclass ────────────────────────────────────────────────
+class TestShardingDataclass:
+    def test_creation(self):
+        s = Sharding(
+            shape=(1024, 768),
+            nd_num_shards=(2, 1),
+            sharding_type=ShardingType.COLUMN_WISE,
+        )
+        assert s.shape == (1024, 768)
+        assert s.nd_num_shards == (2, 1)
+        assert s.sharding_type == ShardingType.COLUMN_WISE
+
+    def test_frozen(self):
+        s = Sharding(
+            shape=(1024, 768),
+            nd_num_shards=(1, 1),
+            sharding_type=ShardingType.REPLICATED,
+        )
+        with pytest.raises(AttributeError):
+            s.shape = (512, 768)  # type: ignore[misc]
+
+    def test_validation_mismatched_lengths(self):
+        with pytest.raises(ValueError, match="same length"):
+            Sharding(
+                shape=(1024, 768),
+                nd_num_shards=(2,),
+                sharding_type=ShardingType.COLUMN_WISE,
+            )
+
+    def test_validation_shard_lt_one(self):
+        with pytest.raises(ValueError, match="must be >= 1"):
+            Sharding(
+                shape=(1024, 768),
+                nd_num_shards=(0, 1),
+                sharding_type=ShardingType.COLUMN_WISE,
+            )
+
+
+# ── TestAttachSharding ───────────────────────────────────────────────────
+class TestAttachSharding:
+    def test_attach_to_parameter(self):
+        param = torch.nn.Parameter(torch.empty(4, 4))
+        sharding = Sharding(
+            shape=(8, 4),
+            nd_num_shards=(2, 1),
+            sharding_type=ShardingType.COLUMN_WISE,
+        )
+        _attach_sharding(param, sharding)
+        assert hasattr(param, "sharding")
+        assert param.sharding is sharding
+
+
+# ── Helper to mock TP ────────────────────────────────────────────────────
+def _mock_tp(tp_rank: int = 0, tp_size: int = 2):
+    """Return a context manager that patches TP rank/size for linear layers."""
+    return (
+        patch(
+            "vllm.model_executor.layers.linear.get_tensor_model_parallel_rank",
+            return_value=tp_rank,
+        ),
+        patch(
+            "vllm.model_executor.layers.linear.get_tensor_model_parallel_world_size",
+            return_value=tp_size,
+        ),
+        patch(
+            "vllm.model_executor.layers.linear.divide",
+            side_effect=lambda a, b: a // b,
+        ),
+    )
+
+
+# ── TestLinearSharding ───────────────────────────────────────────────────
+class TestLinearSharding:
+    def test_replicated_linear(self):
+        from vllm.model_executor.layers.linear import ReplicatedLinear
+
+        layer = ReplicatedLinear(768, 1024, bias=False)
+        assert hasattr(layer.weight, "sharding")
+        s = layer.weight.sharding
+        assert s.sharding_type == ShardingType.REPLICATED
+        assert s.shape == (1024, 768)
+        assert s.nd_num_shards == (1, 1)
+
+    def test_replicated_linear_with_bias(self):
+        from vllm.model_executor.layers.linear import ReplicatedLinear
+
+        layer = ReplicatedLinear(768, 1024, bias=True)
+        assert layer.bias.sharding.sharding_type == ShardingType.REPLICATED
+        assert layer.bias.sharding.shape == (1024,)
+        assert layer.bias.sharding.nd_num_shards == (1,)
+
+    def test_column_parallel_linear(self):
+        from vllm.model_executor.layers.linear import ColumnParallelLinear
+
+        tp_size = 2
+        rank_patch, size_patch, div_patch = _mock_tp(0, tp_size)
+        with rank_patch, size_patch, div_patch:
+            layer = ColumnParallelLinear(768, 1024, bias=False)
+        s = layer.weight.sharding
+        assert s.sharding_type == ShardingType.COLUMN_WISE
+        assert s.shape == (1024, 768)
+        assert s.nd_num_shards == (tp_size, 1)
+
+    def test_column_parallel_linear_bias(self):
+        from vllm.model_executor.layers.linear import ColumnParallelLinear
+
+        tp_size = 2
+        rank_patch, size_patch, div_patch = _mock_tp(0, tp_size)
+        with rank_patch, size_patch, div_patch:
+            layer = ColumnParallelLinear(768, 1024, bias=True)
+        bs = layer.bias.sharding
+        assert bs.sharding_type == ShardingType.COLUMN_WISE
+        assert bs.shape == (1024,)
+        assert bs.nd_num_shards == (tp_size,)
+
+    def test_row_parallel_linear(self):
+        from vllm.model_executor.layers.linear import RowParallelLinear
+
+        tp_size = 4
+        rank_patch, size_patch, div_patch = _mock_tp(0, tp_size)
+        with rank_patch, size_patch, div_patch:
+            layer = RowParallelLinear(1024, 768, bias=False)
+        s = layer.weight.sharding
+        assert s.sharding_type == ShardingType.ROW_WISE
+        assert s.shape == (768, 1024)
+        assert s.nd_num_shards == (1, tp_size)
+
+    def test_row_parallel_linear_bias_is_replicated(self):
+        from vllm.model_executor.layers.linear import RowParallelLinear
+
+        tp_size = 2
+        rank_patch, size_patch, div_patch = _mock_tp(0, tp_size)
+        with rank_patch, size_patch, div_patch:
+            layer = RowParallelLinear(1024, 768, bias=True)
+        bs = layer.bias.sharding
+        assert bs.sharding_type == ShardingType.REPLICATED
+        assert bs.shape == (768,)
+        assert bs.nd_num_shards == (1,)
+
+    def test_qkv_parallel_linear(self):
+        from vllm.model_executor.layers.linear import QKVParallelLinear
+
+        tp_size = 2
+        rank_patch, size_patch, div_patch = _mock_tp(0, tp_size)
+        with rank_patch, size_patch, div_patch:
+            layer = QKVParallelLinear(
+                hidden_size=768,
+                head_size=64,
+                total_num_heads=12,
+                total_num_kv_heads=4,
+                bias=False,
+            )
+        s = layer.weight.sharding
+        assert s.sharding_type == ShardingType.QKV_PARALLEL
+        # qk_ratio = 12 // 4 = 3, shape = (3+2, 4, 64, 768)
+        assert s.shape == (5, 4, 64, 768)
+        assert s.nd_num_shards == (1, tp_size, 1, 1)
+
+
+# ── TestReplaceParameterPreservation ─────────────────────────────────────
+class TestReplaceParameterPreservation:
+    def test_utils_replace_parameter_preserves_sharding(self):
+        from vllm.model_executor.utils import replace_parameter
+
+        layer = torch.nn.Linear(4, 8, bias=False)
+        sharding = Sharding(
+            shape=(8, 4),
+            nd_num_shards=(2, 1),
+            sharding_type=ShardingType.COLUMN_WISE,
+        )
+        _attach_sharding(layer.weight, sharding)
+
+        new_data = torch.randn(8, 4)
+        replace_parameter(layer, "weight", new_data)
+
+        assert hasattr(layer.weight, "sharding")
+        assert layer.weight.sharding == sharding
+
+    def test_quant_replace_parameter_preserves_sharding(self):
+        from vllm.model_executor.layers.quantization.utils.layer_utils import (
+            replace_parameter,
+        )
+
+        layer = torch.nn.Module()
+        old = torch.nn.Parameter(torch.randn(4, 4))
+        sharding = Sharding(
+            shape=(8, 4),
+            nd_num_shards=(2, 1),
+            sharding_type=ShardingType.COLUMN_WISE,
+        )
+        _attach_sharding(old, sharding)
+        layer.register_parameter("w", old)
+
+        # Force the fallback path (different dtype)
+        new = torch.nn.Parameter(torch.randn(4, 4, dtype=torch.float16))
+        replace_parameter(layer, "w", new)
+
+        assert hasattr(layer.w, "sharding")
+        assert layer.w.sharding == sharding

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -643,6 +643,48 @@ class FusedMoE(CustomOp):
         )
 
         self.runner = self._init_runner()
+        self._attach_moe_sharding_metadata(intermediate_size, unpadded_hidden_size)
+
+    def _attach_moe_sharding_metadata(
+        self, intermediate_size: int, hidden_size: int
+    ) -> None:
+        from vllm.model_executor.layers.sharding import (
+            Sharding,
+            ShardingType,
+            _attach_sharding,
+        )
+
+        ep_size = self.ep_size if self.use_ep else 1
+
+        w13 = getattr(self, "w13_weight", None)
+        if w13 is not None:
+            _attach_sharding(
+                w13,
+                Sharding(
+                    shape=(
+                        self.global_num_experts,
+                        2 * intermediate_size,
+                        hidden_size,
+                    ),
+                    nd_num_shards=(ep_size, self.tp_size, 1),
+                    sharding_type=ShardingType.EXPERT_PARALLEL,
+                ),
+            )
+
+        w2 = getattr(self, "w2_weight", None)
+        if w2 is not None:
+            _attach_sharding(
+                w2,
+                Sharding(
+                    shape=(
+                        self.global_num_experts,
+                        hidden_size,
+                        intermediate_size,
+                    ),
+                    nd_num_shards=(ep_size, 1, self.tp_size),
+                    sharding_type=ShardingType.EXPERT_PARALLEL,
+                ),
+            )
 
     def _init_runner(self):
         # Storing the runner in the FusedMoE is an intermediate state, eventually

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -25,6 +25,11 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
 )
+from vllm.model_executor.layers.sharding import (
+    Sharding,
+    ShardingType,
+    _attach_sharding,
+)
 from vllm.model_executor.layers.utils import (
     dispatch_unquantized_gemm,
 )
@@ -352,6 +357,28 @@ class ReplicatedLinear(LinearBase):
         else:
             self.register_parameter("bias", None)
 
+        self._attach_sharding_metadata()
+
+    def _attach_sharding_metadata(self) -> None:
+        sharding = Sharding(
+            shape=(self.output_size, self.input_size),
+            nd_num_shards=(1, 1),
+            sharding_type=ShardingType.REPLICATED,
+        )
+        weight = getattr(self, "weight", None)
+        if weight is not None:
+            _attach_sharding(weight, sharding)
+        bias = getattr(self, "bias", None)
+        if bias is not None:
+            _attach_sharding(
+                bias,
+                Sharding(
+                    shape=(self.output_size,),
+                    nd_num_shards=(1,),
+                    sharding_type=ShardingType.REPLICATED,
+                ),
+            )
+
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
         # If the weight on disk does not have a shape, give it one
         # (such scales for AutoFp8).
@@ -492,6 +519,27 @@ class ColumnParallelLinear(LinearBase):
         else:
             self.register_parameter("bias", None)
         self.update_param_tp_status()
+        self._attach_sharding_metadata()
+
+    def _attach_sharding_metadata(self) -> None:
+        sharding = Sharding(
+            shape=(self.output_size, self.input_size),
+            nd_num_shards=(self.tp_size, 1),
+            sharding_type=ShardingType.COLUMN_WISE,
+        )
+        weight = getattr(self, "weight", None)
+        if weight is not None:
+            _attach_sharding(weight, sharding)
+        bias = getattr(self, "bias", None)
+        if bias is not None:
+            _attach_sharding(
+                bias,
+                Sharding(
+                    shape=(self.output_size,),
+                    nd_num_shards=(self.tp_size,),
+                    sharding_type=ShardingType.COLUMN_WISE,
+                ),
+            )
 
     def _maybe_allow_fp8_block_shape_mismatch(self) -> None:
         quant_config = getattr(self, "quant_config", None)
@@ -1018,6 +1066,32 @@ class QKVParallelLinear(ColumnParallelLinear):
             disable_tp=disable_tp,
         )
 
+    def _attach_sharding_metadata(self) -> None:
+        qk_ratio = self.total_num_heads // self.total_num_kv_heads
+        sharding = Sharding(
+            shape=(
+                qk_ratio + 2,
+                self.total_num_kv_heads,
+                self.head_size,
+                self.hidden_size,
+            ),
+            nd_num_shards=(1, self.tp_size, 1, 1),
+            sharding_type=ShardingType.QKV_PARALLEL,
+        )
+        weight = getattr(self, "weight", None)
+        if weight is not None:
+            _attach_sharding(weight, sharding)
+        bias = getattr(self, "bias", None)
+        if bias is not None:
+            _attach_sharding(
+                bias,
+                Sharding(
+                    shape=(qk_ratio + 2, self.total_num_kv_heads, self.head_size),
+                    nd_num_shards=(1, self.tp_size, 1),
+                    sharding_type=ShardingType.QKV_PARALLEL,
+                ),
+            )
+
     def validate_shard_id(self, loaded_shard_id: str | None):
         if loaded_shard_id is None:
             return
@@ -1435,6 +1509,28 @@ class RowParallelLinear(LinearBase):
         else:
             self.register_parameter("bias", None)
         self.update_param_tp_status()
+        self._attach_sharding_metadata()
+
+    def _attach_sharding_metadata(self) -> None:
+        sharding = Sharding(
+            shape=(self.output_size, self.input_size),
+            nd_num_shards=(1, self.tp_size),
+            sharding_type=ShardingType.ROW_WISE,
+        )
+        weight = getattr(self, "weight", None)
+        if weight is not None:
+            _attach_sharding(weight, sharding)
+        # Bias in RowParallel is replicated (not sharded)
+        bias = getattr(self, "bias", None)
+        if bias is not None:
+            _attach_sharding(
+                bias,
+                Sharding(
+                    shape=(self.output_size,),
+                    nd_num_shards=(1,),
+                    sharding_type=ShardingType.REPLICATED,
+                ),
+            )
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
         input_dim = getattr(param, "input_dim", None)

--- a/vllm/model_executor/layers/quantization/utils/layer_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/layer_utils.py
@@ -38,4 +38,9 @@ def replace_parameter(
         # parameters for `torch.compile` compatibility
         if not isinstance(new, torch.nn.Parameter):
             new = torch.nn.Parameter(new, requires_grad=False)
-        mod.register_parameter(name, torch.nn.Parameter(new, requires_grad=False))
+        final = torch.nn.Parameter(new, requires_grad=False)
+        if hasattr(old, "sharding"):
+            from vllm.model_executor.utils import set_weight_attrs
+
+            set_weight_attrs(final, {"sharding": old.sharding})
+        mod.register_parameter(name, final)

--- a/vllm/model_executor/layers/sharding.py
+++ b/vllm/model_executor/layers/sharding.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Sharding metadata for model parameters.
+
+RL frameworks (OpenRLHF, VeRL, TRL, etc.) need to understand how vLLM
+shards model weights across GPUs.  This module exposes that information
+as a lightweight ``Sharding`` dataclass attached to each weight
+parameter at construction time.
+"""
+
+import dataclasses
+import enum
+
+from vllm.model_executor.utils import set_weight_attrs
+
+
+class ShardingType(enum.Enum):
+    """How a weight tensor is distributed across the tensor-parallel group."""
+
+    REPLICATED = "replicated"
+    COLUMN_WISE = "column_wise"
+    ROW_WISE = "row_wise"
+    VOCAB_PARALLEL = "vocab_parallel"
+    EXPERT_PARALLEL = "expert_parallel"
+    QKV_PARALLEL = "qkv_parallel"
+
+
+@dataclasses.dataclass(frozen=True)
+class Sharding:
+    """Describes the global (unsharded) shape of a parameter and how it is
+    partitioned.
+
+    Attributes:
+        shape: Global (unsharded) shape of the weight.
+        nd_num_shards: Number of shards along each dimension.  Must have the
+            same length as *shape*.
+        sharding_type: High-level category of the sharding strategy.
+    """
+
+    shape: tuple[int, ...]
+    nd_num_shards: tuple[int, ...]
+    sharding_type: ShardingType
+
+    def __post_init__(self):
+        if len(self.shape) != len(self.nd_num_shards):
+            raise ValueError(
+                f"shape ({len(self.shape)}D) and nd_num_shards "
+                f"({len(self.nd_num_shards)}D) must have the same length"
+            )
+        for i, s in enumerate(self.nd_num_shards):
+            if s < 1:
+                raise ValueError(f"nd_num_shards[{i}] must be >= 1, got {s}")
+
+
+def _attach_sharding(param, sharding: Sharding) -> None:
+    """Attach a ``Sharding`` descriptor to *param* via ``set_weight_attrs``."""
+    set_weight_attrs(param, {"sharding": sharding})

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -311,6 +311,26 @@ class VocabParallelEmbedding(CustomOp):
             weight_loader=self.weight_loader,
         )
 
+        self._attach_sharding_metadata()
+
+    def _attach_sharding_metadata(self) -> None:
+        from vllm.model_executor.layers.sharding import (
+            Sharding,
+            ShardingType,
+            _attach_sharding,
+        )
+
+        weight = getattr(self, "weight", None)
+        if weight is not None:
+            _attach_sharding(
+                weight,
+                Sharding(
+                    shape=(self.num_embeddings_padded, self.embedding_dim),
+                    nd_num_shards=(self.tp_size, 1),
+                    sharding_type=ShardingType.VOCAB_PARALLEL,
+                ),
+            )
+
     @classmethod
     def _get_indices(
         cls,

--- a/vllm/model_executor/utils.py
+++ b/vllm/model_executor/utils.py
@@ -73,6 +73,8 @@ def replace_parameter(
     if old_param is not None and hasattr(old_param, "weight_loader"):
         weight_loader = old_param.weight_loader
         set_weight_attrs(new_param, {"weight_loader": weight_loader})
+    if old_param is not None and hasattr(old_param, "sharding"):
+        set_weight_attrs(new_param, {"sharding": old_param.sharding})
 
     setattr(layer, param_name, new_param)
 


### PR DESCRIPTION
## Purpose

Attach a frozen `Sharding` dataclass to every sharded parameter so that
external frameworks (OpenRLHF, VeRL, TRL) can introspect how weights are
distributed across GPUs without reverse-engineering each layer's init logic.

Covers: `ReplicatedLinear`, `ColumnParallelLinear`, `RowParallelLinear`,
`QKVParallelLinear`, `VocabParallelEmbedding`, and `FusedMoE`.

Both `replace_parameter()` call sites (model_executor/utils.py and
quantization/utils/layer_utils.py) now preserve sharding metadata when
parameters are replaced.

## Test Plan

```bash
pytest tests/model_executor/test_sharding_metadata.py -v
```

## Test Result

- 7 unit tests pass (dataclass validation, attachment, parameter replacement)
- 7 integration tests require full vLLM installation (Linear layer sharding)

```
PASSED  TestShardingDataclass::test_creation
PASSED  TestShardingDataclass::test_frozen
PASSED  TestShardingDataclass::test_validation_mismatched_lengths
PASSED  TestShardingDataclass::test_validation_shard_lt_one
PASSED  TestAttachSharding::test_attach_to_parameter
PASSED  TestReplaceParameterPreservation::test_utils_replace_parameter_preserves_sharding
PASSED  TestReplaceParameterPreservation::test_quant_replace_parameter_preserves_sharding
```

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
