### PR TITLE
[Bugfix] Fix DeepSeek V3.2 tool parser

### DIFF
--- a/vllm/tokenizers/deepseek_v32_encoding.py
+++ b/vllm/tokenizers/deepseek_v32_encoding.py
@@ -268,6 +268,9 @@ def render_message(
 
         summary_content = content or ""
 
+        # Trailing "\n\n" is the separator before the tool call block, not actual content
+        summary_content = summary_content.removesuffix("\n\n")
+
         if thinking_mode == "thinking" and index > last_user_idx:
             if not (reasoning or tool_calls):
                 raise ValueError(

--- a/vllm/tool_parsers/deepseekv32_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv32_tool_parser.py
@@ -223,6 +223,10 @@ class DeepSeekV32ToolParser(ToolParser):
         if value.lower() == "null":
             return None
 
+        # Handle cases like ["string", "null"] or similar
+        if isinstance(param_type, list):
+            param_type = next((t for t in param_type if t != "null"), "string")
+
         param_type = param_type.lower()
         if param_type in ["string", "str", "text"]:
             return value
@@ -329,11 +333,12 @@ class DeepSeekV32ToolParser(ToolParser):
                     # We just ended a tool call, skip whitespace
                     return None
                 # Normal content, no tool call
+                content = delta_text
                 if delta_text.endswith("<"):
-                    return DeltaMessage(content=delta_text[:-1])
+                    content = content[:-1]
                 if previous_text and previous_text.endswith("<"):
-                    return DeltaMessage(content="<" + delta_text)
-                return DeltaMessage(content=delta_text)
+                    content = "<" + content
+                return DeltaMessage(content=content)
 
         # Check if we're between tool calls (waiting for next one)
         invoke_starts_count = current_text.count(self.invoke_start_prefix)

--- a/vllm/tool_parsers/deepseekv32_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv32_tool_parser.py
@@ -218,7 +218,7 @@ class DeepSeekV32ToolParser(ToolParser):
         end = input_str.find('"', start)
         return input_str[start:end] if start > 0 and end > start else input_str
 
-    def _convert_param_value(self, value: str, param_type: str) -> Any:
+    def _convert_param_value(self, value: str, param_type: str | list[str]) -> Any:
         """Convert parameter value to the correct type."""
         if value.lower() == "null":
             return None


### PR DESCRIPTION
## Purpose

Fix bugs in the DeepSeek V3.2 tool parser and encoding:

1. **`DeepSeekV32ToolParser._convert_param_value`**: Crash when a JSON Schema parameter type is specified as a list (e.g. `["string", "null"]` for nullable fields). The method assumed `param_type` is always a string and called `.lower()` on it directly. Now, if `param_type` is a list, the first non-`"null"` type is selected before further processing.

2. **`DeepSeekV32ToolParser.extract_tool_calls_streaming`**: Minor bug in the `"<"` lookahead logic for streaming content. When both `previous_text` ends with `"<"` (withheld in the previous delta) and `delta_text` also ends with `"<"` (should be withheld again), the original code would drop the previously withheld `"<"` entirely. The fix correctly flushes the old withheld `"<"` while still withholding the new trailing one.

3. **`render_message` in `deepseek_v32_encoding.py`**: When an assistant message has tool calls, the model emits a trailing `"\n\n"` in the content before the tool call block. This separator was being double-counted during re-encoding, since the template already adds `"\n\n"` before the tool call block. The fix strips that suffix from the content before rendering.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>