### PR TITLE
[Misc] Fix SyntaxWarning - invalid escape sequence '\e'

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -343,7 +343,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
         "in output tokens. If such repetition is detected, generation will "
         "be ended early. LLMs can sometimes generate repetitive, unhelpful "
         "token patterns, stopping only when they hit the maximum output length "
-        "(e.g. 'abcdabcdabcd...' or '\emoji \emoji \emoji ...'). This feature "
+        "(e.g. 'abcdabcdabcd...' or '\\emoji \\emoji \\emoji ...'). This feature "
         "can detect such behavior and terminate early, saving time and tokens.",
     )
 

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -173,7 +173,7 @@ class CompletionRequest(OpenAIBaseModel):
         "in output tokens. If such repetition is detected, generation will "
         "be ended early. LLMs can sometimes generate repetitive, unhelpful "
         "token patterns, stopping only when they hit the maximum output length "
-        "(e.g. 'abcdabcdabcd...' or '\emoji \emoji \emoji ...'). This feature "
+        "(e.g. 'abcdabcdabcd...' or '\\emoji \\emoji \\emoji ...'). This feature "
         "can detect such behavior and terminate early, saving time and tokens.",
     )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

After #35451, vllm online serving warns the following python syntax warning at the very beginning:

```txt
/root/.local/lib/python3.12/site-packages/vllm/entrypoints/openai/chat_completion/protocol.py:346: SyntaxWarning: invalid escape sequence '\e'
  "(e.g. 'abcdabcdabcd...' or '\emoji \emoji \emoji ...'). This feature "
/root/.local/lib/python3.12/site-packages/vllm/entrypoints/openai/completion/protocol.py:176: SyntaxWarning: invalid escape sequence '\e'
  "(e.g. 'abcdabcdabcd...' or '\emoji \emoji \emoji ...'). This feature "
(APIServer pid=1) INFO 03-05 00:45:18 [utils.py:302]
(APIServer pid=1) INFO 03-05 00:45:18 [utils.py:302]        █     █     █▄   ▄█
...
```

This trivial PR fixes this syntax warning with proper escape.

## Test Plan

Launch vllm online server and see the logs upfront the vllm logo.

```shell
vllm serve Qwen/Qwen2.5-1.5B-Instruct
```

## Test Result

No syntax warning appears.

```txt
(APIServer pid=1) INFO 03-05 01:14:43 [utils.py:302]
...
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
</details>

