### PR TITLE
qwen3coder tool parser fix anyOf double encoded parameters

### DIFF
--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -157,6 +157,12 @@ class Qwen3CoderToolParser(ToolParser):
             and "type" in param_config[param_name]
         ):
             param_type = str(param_config[param_name]["type"]).strip().lower()
+        elif (
+            isinstance(param_config[param_name], dict)
+            and "anyOf" in param_config[param_name]
+        ):
+            # anyOf has no top-level "type"; treat as object to trigger json.loads.
+            param_type = "object"
         else:
             param_type = "string"
         if param_type in ["string", "str", "text", "varchar", "char", "enum"]:


### PR DESCRIPTION
## Problem                               


When a tool parameter uses anyOf instead of an explicit type, _convert_param_value falls back to param_type = "string" because anyOf schemas have no top-level "type" key. This causes the extracted parameter value (e.g. {"city": "Paris"}) to be returned as a raw string, which json.dumps then double-encodes into "{\"city\": \"Paris\"}". The caller receives a string where an object is expected.

## Fix 

Add an elif branch that detects anyOf and sets param_type = "object", routing the value through the existing json.loads path.

## Repro 

```
  tools = [{"type": "function", "function": {
      "name": "get_weather",
      "parameters": {"type": "object", "required": ["location"], "properties": {
          "location": {"anyOf": [
              {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
              {"type": "object", "properties": {"lat": {"type": "number"}, "lon": {"type": "number"}}, "required": ["lat", "lon"]}
          ]}
      }}
  }}]
  # prompt: "What's the weather in Paris?"

  Before: {"location": "{\"city\": \"Paris\"}"} - string, should be object.
  After: {"location": {"city": "Paris"}} - correct.
```
## Test Plan and Result

Tested patch locally, works as described above
