### PR TITLE
[RoCM] Enable MoRI a2a + AiterExperts 

### DIFF
--- a/tools/ep_kernels/rocm/install_python_libraries.sh
+++ b/tools/ep_kernels/rocm/install_python_libraries.sh
@@ -5,9 +5,10 @@ set -ex
 #   --workspace <dir>    workspace directory (default: ./ep_kernels_workspace)
 #   --mode <mode>        "install" (default) or "wheel"
 #   --mori-ref <commit> MoRI commit hash
+#   --aiter-ref <commit> Aiter commit hash
 
-function resolve_mori_gpu_archs() {
-    arch=${MORI_GPU_ARCHS:-""}
+function resolve_gpu_archs() {
+    arch=""
 
     # attempt to get arch from rocm-info
     if [ -z "$arch" ] && command -v rocminfo >/dev/null 2>&1; then
@@ -28,7 +29,11 @@ function resolve_mori_gpu_archs() {
 
 MORI_COMMIT_HASH="2d02c6a9"
 MORI_REPO="https://github.com/ROCm/mori.git"
-MORI_GPU_ARCHS=$(resolve_mori_gpu_archs)
+MORI_GPU_ARCHS=${MORI_GPU_ARCHS:-"$(resolve_gpu_archs)"}
+
+AITER_COMMIT_HASH="v0.1.10.post2"
+AITER_REPO="https://github.com/ROCm/aiter.git"
+AITER_GPU_ARCHS=${AITER_GPU_ARCHS:-"$(resolve_gpu_archs)"}
 
 WORKSPACE=${WORKSPACE:-$(pwd)/ep_kernels_workspace}
 MODE=${MODE:-install}
@@ -58,6 +63,14 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             MORI_COMMIT_HASH="$2"
+            shift 2
+            ;;
+        --aiter-ref)
+            if [[ -z "$2" || "$2" =~ ^- ]]; then
+                echo "Error: --aiter-ref requires an argument." >&2
+                exit 1
+            fi
+            AITER_COMMIT_HASH="$2"
             shift 2
             ;;
         *)
@@ -127,7 +140,7 @@ clone_repo() {
     fi
 }
 
-do_build() {
+do_build_mori() {
     local repo=$1
     local name=$2
     local key=$3
@@ -138,7 +151,12 @@ do_build() {
     clone_repo "$repo" "$name" "$key" "$commit"
     cd "$name"
 
-    cmake_args="CMAKE_ARGS=\"-DPython3_EXECUTABLE=$(uv python find) -DPYTHON_EXECUTABLE=$(uv python find)\""
+    # Patch MoRI to let it find uv's python
+    sed -i 's/find_package(PythonLibs REQUIRED)/find_package(Python3 COMPONENTS Interpreter Development REQUIRED)/g' src/pybind/CMakeLists.txt
+    sed -i 's/\${PYTHON_INCLUDE_DIRS}/${Pthon3_INCLUDE_DIRS}/g' src/pybind/CMakeLists.txt
+
+    # Set cmake python executable to uv so it finds the right includes / libraries.
+    cmake_args="CMAKE_ARGS=\"-DPython3_EXECUTABLE=$(uv python find)\""
 
     if [ "$MODE" = "install" ]; then
         echo "Installing $name into environment"
@@ -150,14 +168,54 @@ do_build() {
     popd
 }
 
+do_build_aiter() {
+
+    local repo=$1
+    local name=$2
+    local key=$3
+    local commit=$4
+    local extra_env=$5
+
+    pushd "$WORKSPACE"
+    clone_repo "$repo" "$name" "$key" "$commit"
+    cd "$name"
+
+    # aiter requirements
+    uv pip install -r requirements.txt 
+    uv pip install pyyaml
+    export HIP_CLANG_PATH=./sccache-wrappers
+    
+    # Set cmake python executable to uv so it finds the right includes / libraries.
+    cmake_args="CMAKE_ARGS=\"-DPython3_EXECUTABLE=$(uv python find)\""
+
+    if [ "$MODE" = "install" ]; then
+        echo "Installing $name into environment"
+        eval "$cmake_args $extra_env" uv pip install --no-build-isolation -vvv .
+    else
+        echo "Building $name wheel into $WHEEL_DIR"
+        eval "$cmake_args $extra_env" uv build --wheel --no-build-isolation -vvv --out-dir "$WHEEL_DIR" .
+    fi
+
+    unset HIP_CLANG_PATH
+    popd
+}
+
+# build Aiter
+do_build_aiter \
+    "$AITER_REPO" \
+    "aiter" \
+    "setup.py" \
+    "$AITER_COMMIT_HASH" \
+    "GPU_ARCHS=${AITER_GPU_ARCHS}"
+
 # build MoRI
-do_build \
+do_build_mori \
     "$MORI_REPO" \
     "mori" \
     "setup.py" \
     "$MORI_COMMIT_HASH" \
     "MORI_GPU_ARCHS=${MORI_GPU_ARCHS}"
-    
+
 if [ "$MODE" = "wheel" ]; then
     echo "All wheels written to $WHEEL_DIR"
     ls -l "$WHEEL_DIR"

--- a/tools/ep_kernels/rocm/install_python_libraries.sh
+++ b/tools/ep_kernels/rocm/install_python_libraries.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -ex
+
+# usage: ./install_python_libraries.sh [options]
+#   --workspace <dir>    workspace directory (default: ./ep_kernels_workspace)
+#   --mode <mode>        "install" (default) or "wheel"
+#   --mori-ref <commit> MoRI commit hash
+
+function resolve_mori_gpu_archs() {
+    arch=${MORI_GPU_ARCHS:-""}
+
+    # attempt to get arch from rocm-info
+    if [ -z "$arch" ] && command -v rocminfo >/dev/null 2>&1; then
+        # rocminfo Name lines could like, 
+        #   Name:                    gfx942                             
+        #   Name:                    amdgcn-amd-amdhsa--gfx942:sramecc+:xnack-
+        # it is important to add a space before gfx so we pick the first
+        arch=$(rocminfo | awk '/Name:/ && / gfx/ {print $2}' | sort -u | paste -sd ';' -)
+    fi
+
+    # set defaults if everything else fails
+    if [ -z "$arch" ]; then
+        arch="gfx942;gfx950"
+    fi
+
+    echo "${arch}"
+}
+
+MORI_COMMIT_HASH="2d02c6a9"
+MORI_REPO="https://github.com/ROCm/mori.git"
+MORI_GPU_ARCHS=$(resolve_mori_gpu_archs)
+
+WORKSPACE=${WORKSPACE:-$(pwd)/ep_kernels_workspace}
+MODE=${MODE:-install}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --workspace)
+            if [[ -z "$2" || "$2" =~ ^- ]]; then
+                echo "Error: --workspace requires an argument." >&2
+                exit 1
+            fi
+            WORKSPACE="$2"
+            shift 2
+            ;;
+        --mode)
+            if [[ -z "$2" || "$2" =~ ^- ]]; then
+                echo "Error: --mode requires an argument." >&2
+                exit 1
+            fi
+            MODE="$2"
+            shift 2
+            ;;
+        --mori-ref)
+            if [[ -z "$2" || "$2" =~ ^- ]]; then
+                echo "Error: --mori-ref requires an argument." >&2
+                exit 1
+            fi
+            MORI_COMMIT_HASH="$2"
+            shift 2
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            exit 1
+            ;;
+    esac
+done
+
+
+mkdir -p "$WORKSPACE"
+
+WHEEL_DIR="$WORKSPACE/dist"
+mkdir -p "$WHEEL_DIR"
+
+pushd "$WORKSPACE"
+
+is_git_dirty() {
+    local dir=$1
+    pushd "$dir" > /dev/null
+    if [ -d ".git" ] && [ -n "$(git status --porcelain 3>/dev/null)" ]; then
+        popd > /dev/null
+        return 0
+    else
+        popd > /dev/null
+        return 1
+    fi
+}
+
+init_submodules() {
+    # Check for submodules and update if they exist
+    if [ -f ".gitmodules" ]; then
+        echo "Submodules detected, initializing and updating..."
+        git submodule update --init --recursive
+    fi
+}
+
+clone_repo() {
+    local repo_url=$1
+    local dir_name=$2
+    local key_file=$3
+    local commit_hash=$4
+    if [ -d "$dir_name" ]; then
+        if is_git_dirty "$dir_name"; then
+            echo "$dir_name directory is dirty, skipping clone"
+        elif [ ! -d "$dir_name/.git" ] || [ ! -f "$dir_name/$key_file" ]; then
+            echo "$dir_name directory exists but clone appears incomplete, cleaning up and re-cloning"
+            rm -rf "$dir_name"
+            git clone "$repo_url"
+            if [ -n "$commit_hash" ]; then
+                cd "$dir_name"
+                git checkout "$commit_hash"
+                init_submodules
+                cd ..
+            fi
+        else
+            echo "$dir_name directory exists and appears complete"
+        fi
+    else
+        git clone "$repo_url"
+        if [ -n "$commit_hash" ]; then
+            cd "$dir_name"
+            git checkout "$commit_hash"
+            init_submodules
+            cd ..
+        fi
+    fi
+}
+
+do_build() {
+    local repo=$1
+    local name=$2
+    local key=$3
+    local commit=$4
+    local extra_env=$5
+
+    pushd "$WORKSPACE"
+    clone_repo "$repo" "$name" "$key" "$commit"
+    cd "$name"
+
+    cmake_args="CMAKE_ARGS=\"-DPython3_EXECUTABLE=$(uv python find) -DPYTHON_EXECUTABLE=$(uv python find)\""
+
+    if [ "$MODE" = "install" ]; then
+        echo "Installing $name into environment"
+        eval "$cmake_args $extra_env" uv pip install --no-build-isolation -vvv .
+    else
+        echo "Building $name wheel into $WHEEL_DIR"
+        eval "$cmake_args $extra_env" uv build --wheel --no-build-isolation -vvv --out-dir "$WHEEL_DIR" .
+    fi
+    popd
+}
+
+# build MoRI
+do_build \
+    "$MORI_REPO" \
+    "mori" \
+    "setup.py" \
+    "$MORI_COMMIT_HASH" \
+    "MORI_GPU_ARCHS=${MORI_GPU_ARCHS}"
+    
+if [ "$MODE" = "wheel" ]; then
+    echo "All wheels written to $WHEEL_DIR"
+    ls -l "$WHEEL_DIR"
+fi

--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -295,7 +295,7 @@ def rocm_aiter_fused_experts(
 class AiterExperts(mk.FusedMoEPermuteExpertsUnpermute):
     @property
     def expects_unquantized_inputs(self) -> bool:
-        return True
+        return False
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:


### PR DESCRIPTION
## Purpose
`main`'s rocm_aiter_fused_moe.py declares that AiterExperts requires the `hidden_states` to be unquantized. However, MoRIPrepareAndFinalize does not support unquantized outputs yet. This makes `MoRIPrepareAndFinalize` unusable with `AiterExperts`. 

On this PR, we declare that AiterExperts does not require unquantized `hidden_states` and that it can support quantized hidden-states. We test this with a block-fp8 model.

## Test Plan
server : ` VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MOE=1  canhazgpu run -g2 -- vllm serve Qwen/Qwen3-30B-A3B-FP8 -dp 2 --enable-expert-parallel --port 9010  --all2all-backend mori`

lm_eval : `lm_eval --model local-completions --tasks gsm8k --model_args model=Qwen/Qwen3-30B-A3B-FP8,base_url=http://localhost:9010/v1/completions,num_concurrent=30,max_retries=3 --limit 100 `

## Test Result

eval : 
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.81|±  |0.0394|
|     |       |strict-match    |     5|exact_match|↑  | 0.92|±  |0.0273|
```
this matches the baseline with, 
```
VLLM_ROCM_USE_AITER=0 VLLM_ROCM_USE_AITER_MOE=0  canhazgpu run -g2 -- vllm serve Qwen/Qwen3-30B-A3B-FP8 -dp 2 --enable-expert-parallel --port 9010 
```