### PR TITLE
[RoCM] Enable MoRI a2a + AiterExperts

### DIFF
--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -295,7 +295,7 @@ def rocm_aiter_fused_experts(
 class AiterExperts(mk.FusedMoEPermuteExpertsUnpermute):
     @property
     def expects_unquantized_inputs(self) -> bool:
-        return True
+        return False
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:


### PR DESCRIPTION
## Purpose
`main`'s rocm_aiter_fused_moe.py declares that AiterExperts requires the `hidden_states` to be unquantized. However, MoRIPrepareAndFinalize does not support unquantized outputs yet. This makes `MoRIPrepareAndFinalize` unusable with `AiterExperts`. 

On this PR, we declare that AiterExperts does not require unquantized `hidden_states` and that it can support quantized hidden-states. We test this with a block-fp8 model.

## Test Plan
server : ` VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MOE=1  canhazgpu run -g2 -- vllm serve Qwen/Qwen3-30B-A3B-FP8 -dp 2 --enable-expert-parallel --port 9010  --all2all-backend mori`

lm_eval : `lm_eval --model local-completions --tasks gsm8k --model_args model=Qwen/Qwen3-30B-A3B-FP8,base_url=http://localhost:9010/v1/completions,num_concurrent=30,max_retries=3 --limit 100 `

## Test Result

eval : 
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.81|±  |0.0394|
|     |       |strict-match    |     5|exact_match|↑  | 0.92|±  |0.0273|
```
this matches the baseline with, 
```
VLLM_ROCM_USE_AITER=0 VLLM_ROCM_USE_AITER_MOE=0  canhazgpu run -g2 -- vllm serve Qwen/Qwen3-30B-A3B-FP8 -dp 2 --enable-expert-parallel --port 9010 
```