### PR TITLE
Fix random dataset parameter defaults silently overriding user input

### DIFF
--- a/vllm/benchmarks/datasets/__init__.py
+++ b/vllm/benchmarks/datasets/__init__.py
@@ -40,6 +40,7 @@ from vllm.benchmarks.datasets.datasets import (
     process_audio,
     process_image,
     process_video,
+    resolve_random_dataset_args,
     zeta_prompt,
 )
 from vllm.benchmarks.datasets.utils import RangeRatio
@@ -67,6 +68,7 @@ __all__ = [
     "RandomDataset",
     "RandomDatasetForReranking",
     "RandomMultiModalDataset",
+    "resolve_random_dataset_args",
     "SampleRequest",
     "ShareGPTDataset",
     "SonnetDataset",

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -2083,8 +2083,16 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
                 tokenizer=tokenizer,
                 num_requests=args.num_prompts,
                 prefix_len=args.random_prefix_len,
-                input_len=args.random_input_len,
-                output_len=args.random_output_len,
+                input_len=(
+                    args.random_input_len
+                    if args.random_input_len is not None
+                    else RandomDataset.DEFAULT_INPUT_LEN
+                ),
+                output_len=(
+                    args.random_output_len
+                    if args.random_output_len is not None
+                    else RandomDataset.DEFAULT_OUTPUT_LEN
+                ),
                 range_ratio=args.random_range_ratio,
                 request_id_prefix=args.request_id_prefix,
                 batchsize=args.random_batch_size,
@@ -2099,8 +2107,16 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
                 num_requests=args.num_prompts,
                 prefix_len=args.random_prefix_len,
                 range_ratio=args.random_range_ratio,
-                input_len=args.random_input_len,
-                output_len=args.random_output_len,
+                input_len=(
+                    args.random_input_len
+                    if args.random_input_len is not None
+                    else RandomDataset.DEFAULT_INPUT_LEN
+                ),
+                output_len=(
+                    args.random_output_len
+                    if args.random_output_len is not None
+                    else RandomDataset.DEFAULT_OUTPUT_LEN
+                ),
                 base_items_per_request=args.random_mm_base_items_per_request,
                 limit_mm_per_prompt=args.random_mm_limit_mm_per_prompt,
                 num_mm_items_range_ratio=args.random_mm_num_mm_items_range_ratio,
@@ -2116,7 +2132,11 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
             ).sample(
                 tokenizer=tokenizer,
                 num_requests=args.num_prompts,
-                input_len=args.random_input_len,
+                input_len=(
+                    args.random_input_len
+                    if args.random_input_len is not None
+                    else RandomDataset.DEFAULT_INPUT_LEN
+                ),
                 range_ratio=args.random_range_ratio,
                 request_id_prefix=args.request_id_prefix,
                 batchsize=args.random_batch_size,

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -1822,6 +1822,58 @@ def _parse_range_ratio(value: str) -> RangeRatio:
         return json.loads(value)
 
 
+def resolve_random_dataset_args(
+    args: argparse.Namespace, dataset_name: str
+) -> tuple[int, int, int]:
+    """Resolve input/output/prefix lengths for random datasets.
+
+    Implements complete fallback chain:
+    - prefix_len: random_prefix_len → prefix_len → 0
+    - input_len: random_input_len → input_len → DEFAULT_INPUT_LEN (1024)
+    - output_len: random_output_len → output_len → DEFAULT_OUTPUT_LEN (128)
+
+    Args:
+        args: Command line arguments.
+        dataset_name: Name of the dataset (e.g., 'random', 'random-mm').
+
+    Returns:
+        Tuple of (prefix_len, input_len, output_len) - all non-None integers.
+    """
+    # Prefix length resolution
+    random_prefix_len = getattr(args, "random_prefix_len", None)
+    prefix_len = (
+        random_prefix_len
+        if random_prefix_len is not None
+        else (getattr(args, "prefix_len", None) or 0)
+    )
+
+    # Input length resolution
+    random_input_len = getattr(args, "random_input_len", None)
+    input_len = (
+        random_input_len
+        if random_input_len is not None
+        else (
+            getattr(args, "input_len", None)
+            if getattr(args, "input_len", None) is not None
+            else RandomDataset.DEFAULT_INPUT_LEN
+        )
+    )
+
+    # Output length resolution
+    random_output_len = getattr(args, "random_output_len", None)
+    output_len = (
+        random_output_len
+        if random_output_len is not None
+        else (
+            getattr(args, "output_len", None)
+            if getattr(args, "output_len", None) is not None
+            else RandomDataset.DEFAULT_OUTPUT_LEN
+        )
+    )
+
+    return prefix_len, input_len, output_len
+
+
 def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
     if not hasattr(args, "request_id_prefix"):
         args.request_id_prefix = ""
@@ -2039,6 +2091,11 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
         )
 
     else:
+        # Resolve random dataset parameters once for all random dataset types
+        random_prefix_len, random_input_len, random_output_len = (
+            resolve_random_dataset_args(args, args.dataset_name)
+        )
+
         # For datasets that follow a similar structure, use a mapping.
         dataset_mapping = {
             "spec_bench": lambda: SpecBench(
@@ -2082,17 +2139,9 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
             ).sample(
                 tokenizer=tokenizer,
                 num_requests=args.num_prompts,
-                prefix_len=args.random_prefix_len,
-                input_len=(
-                    args.random_input_len
-                    if args.random_input_len is not None
-                    else RandomDataset.DEFAULT_INPUT_LEN
-                ),
-                output_len=(
-                    args.random_output_len
-                    if args.random_output_len is not None
-                    else RandomDataset.DEFAULT_OUTPUT_LEN
-                ),
+                prefix_len=random_prefix_len,
+                input_len=random_input_len,
+                output_len=random_output_len,
                 range_ratio=args.random_range_ratio,
                 request_id_prefix=args.request_id_prefix,
                 batchsize=args.random_batch_size,
@@ -2105,18 +2154,10 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
             ).sample(
                 tokenizer=tokenizer,
                 num_requests=args.num_prompts,
-                prefix_len=args.random_prefix_len,
+                prefix_len=random_prefix_len,
                 range_ratio=args.random_range_ratio,
-                input_len=(
-                    args.random_input_len
-                    if args.random_input_len is not None
-                    else RandomDataset.DEFAULT_INPUT_LEN
-                ),
-                output_len=(
-                    args.random_output_len
-                    if args.random_output_len is not None
-                    else RandomDataset.DEFAULT_OUTPUT_LEN
-                ),
+                input_len=random_input_len,
+                output_len=random_output_len,
                 base_items_per_request=args.random_mm_base_items_per_request,
                 limit_mm_per_prompt=args.random_mm_limit_mm_per_prompt,
                 num_mm_items_range_ratio=args.random_mm_num_mm_items_range_ratio,
@@ -2132,11 +2173,7 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
             ).sample(
                 tokenizer=tokenizer,
                 num_requests=args.num_prompts,
-                input_len=(
-                    args.random_input_len
-                    if args.random_input_len is not None
-                    else RandomDataset.DEFAULT_INPUT_LEN
-                ),
+                input_len=random_input_len,
                 range_ratio=args.random_range_ratio,
                 request_id_prefix=args.request_id_prefix,
                 batchsize=args.random_batch_size,

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -1661,13 +1661,13 @@ def add_random_dataset_base_args(
     parser_or_group.add_argument(
         "--random-input-len",
         type=int,
-        default=1024,
+        default=None,
         help="Number of input tokens per request, used only for random sampling.",
     )
     parser_or_group.add_argument(
         "--random-output-len",
         type=int,
-        default=128,
+        default=None,
         help="Number of output tokens per request, used only for random sampling.",
     )
     parser_or_group.add_argument(

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -625,26 +625,18 @@ def validate_args(args):
         random_output_len = getattr(args, "random_output_len", None)
         random_prefix_len = getattr(args, "random_prefix_len", None)
 
-        if (
-            args.input_len is not None
-            and random_input_len is not None
-            and args.input_len != random_input_len
-        ):
+        if args.input_len is not None and random_input_len is not None:
             warnings.warn(
-                f"Both --input-len={args.input_len} and "
-                f"--random-input-len={random_input_len} are specified. "
-                f"Using --random-input-len={random_input_len}.",
+                "Both --input-len and --random-input-len are specified. "
+                "The random version (--random-input-len) will be preferred "
+                "in this run.",
                 stacklevel=2,
             )
-        if (
-            args.output_len is not None
-            and random_output_len is not None
-            and args.output_len != random_output_len
-        ):
+        if args.output_len is not None and random_output_len is not None:
             warnings.warn(
-                f"Both --output-len={args.output_len} and "
-                f"--random-output-len={random_output_len} are specified. "
-                f"Using --random-output-len={random_output_len}.",
+                "Both --output-len and --random-output-len are specified. "
+                "The random version (--random-output-len) will be preferred "
+                "in this run.",
                 stacklevel=2,
             )
         if args.prefix_len is not None and random_prefix_len is not None:

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -577,12 +577,9 @@ def validate_args(args):
     ):
         print("When dataset path is not set, it will default to random dataset")
         args.dataset_name = "random"
-        random_input_len = getattr(args, "random_input_len", None)
-        if args.input_len is None and random_input_len is None:
-            raise ValueError(
-                "Either --input-len or --random-input-len must be provided "
-                "for a random dataset"
-            )
+        # Note: If --input-len and --random-input-len are both None,
+        # datasets.py will fall back to RandomDataset.DEFAULT_INPUT_LEN (1024)
+        # and DEFAULT_OUTPUT_LEN (128)
 
     # === Dataset Name Specific Checks ===
     # --hf-subset and --hf-split: only used

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -338,10 +338,14 @@ def save_to_pytorch_benchmark_format(
         write_to_json(pt_file, pt_records)
 
 
-def validate_random_dataset_args(
+def get_random_dataset_args(
     args: argparse.Namespace, dataset_name: str
 ) -> tuple[int | None, int | None]:
-    """Validate and return input/output lengths for random datasets.
+    """Get input/output lengths for random datasets.
+
+    Prefers random-specific parameters over generic ones. If neither is
+    specified, datasets.py will fall back to RandomDataset.DEFAULT_INPUT_LEN
+    and DEFAULT_OUTPUT_LEN (1024/128).
 
     Args:
         args: Command line arguments.
@@ -349,25 +353,9 @@ def validate_random_dataset_args(
 
     Returns:
         Tuple of (random_input_len, random_output_len).
-
-    Raises:
-        ValueError: If neither random-specific nor generic length parameters
-                    are specified.
     """
     random_input_len = getattr(args, "random_input_len", None)
     random_output_len = getattr(args, "random_output_len", None)
-
-    # Validate that user provided length values
-    if random_input_len is None and args.input_len is None:
-        raise ValueError(
-            f"When using --dataset-name={dataset_name}, you must specify "
-            "either --random-input-len or --input-len"
-        )
-    if random_output_len is None and args.output_len is None:
-        raise ValueError(
-            f"When using --dataset-name={dataset_name}, you must specify "
-            "either --random-output-len or --output-len"
-        )
 
     return random_input_len, random_output_len
 
@@ -396,10 +384,8 @@ def get_requests(args, tokenizer):
         sample_kwargs["prefix_len"] = (
             random_prefix_len if random_prefix_len is not None else args.prefix_len
         )
-        # Validate and get random dataset parameters
-        random_input_len, random_output_len = validate_random_dataset_args(
-            args, "random"
-        )
+        # Get random dataset parameters (prefer random-specific over generic)
+        random_input_len, random_output_len = get_random_dataset_args(args, "random")
 
         sample_kwargs["input_len"] = (
             random_input_len if random_input_len is not None else args.input_len
@@ -485,10 +471,8 @@ def get_requests(args, tokenizer):
         sample_kwargs["output_len"] = args.prefix_repetition_output_len
     elif args.dataset_name == "random-mm":
         dataset_cls = RandomMultiModalDataset
-        # Validate and get random dataset parameters
-        random_input_len, random_output_len = validate_random_dataset_args(
-            args, "random-mm"
-        )
+        # Get random dataset parameters (prefer random-specific over generic)
+        random_input_len, random_output_len = get_random_dataset_args(args, "random-mm")
 
         sample_kwargs["input_len"] = (
             random_input_len
@@ -519,8 +503,8 @@ def get_requests(args, tokenizer):
         sample_kwargs["range_ratio"] = args.random_range_ratio
     elif args.dataset_name == "random-rerank":
         dataset_cls = RandomDatasetForReranking
-        # Validate and get random dataset parameters
-        random_input_len, random_output_len = validate_random_dataset_args(
+        # Get random dataset parameters (prefer random-specific over generic)
+        random_input_len, random_output_len = get_random_dataset_args(
             args, "random-rerank"
         )
 

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -338,6 +338,40 @@ def save_to_pytorch_benchmark_format(
         write_to_json(pt_file, pt_records)
 
 
+def validate_random_dataset_args(
+    args: argparse.Namespace, dataset_name: str
+) -> tuple[int | None, int | None]:
+    """Validate and return input/output lengths for random datasets.
+
+    Args:
+        args: Command line arguments.
+        dataset_name: Name of the dataset (e.g., 'random', 'random-mm').
+
+    Returns:
+        Tuple of (random_input_len, random_output_len).
+
+    Raises:
+        ValueError: If neither random-specific nor generic length parameters
+                    are specified.
+    """
+    random_input_len = getattr(args, "random_input_len", None)
+    random_output_len = getattr(args, "random_output_len", None)
+
+    # Validate that user provided length values
+    if random_input_len is None and args.input_len is None:
+        raise ValueError(
+            f"When using --dataset-name={dataset_name}, you must specify "
+            "either --random-input-len or --input-len"
+        )
+    if random_output_len is None and args.output_len is None:
+        raise ValueError(
+            f"When using --dataset-name={dataset_name}, you must specify "
+            "either --random-output-len or --output-len"
+        )
+
+    return random_input_len, random_output_len
+
+
 def get_requests(args, tokenizer):
     # Common parameters for all dataset types.
     common_kwargs = {
@@ -362,11 +396,14 @@ def get_requests(args, tokenizer):
         sample_kwargs["prefix_len"] = (
             random_prefix_len if random_prefix_len is not None else args.prefix_len
         )
-        random_input_len = getattr(args, "random_input_len", None)
+        # Validate and get random dataset parameters
+        random_input_len, random_output_len = validate_random_dataset_args(
+            args, "random"
+        )
+
         sample_kwargs["input_len"] = (
             random_input_len if random_input_len is not None else args.input_len
         )
-        random_output_len = getattr(args, "random_output_len", None)
         sample_kwargs["output_len"] = (
             random_output_len if random_output_len is not None else args.output_len
         )
@@ -448,14 +485,16 @@ def get_requests(args, tokenizer):
         sample_kwargs["output_len"] = args.prefix_repetition_output_len
     elif args.dataset_name == "random-mm":
         dataset_cls = RandomMultiModalDataset
-        # prefer random_* arguments, fall back to regular arguments
-        random_input_len = getattr(args, "random_input_len", None)
+        # Validate and get random dataset parameters
+        random_input_len, random_output_len = validate_random_dataset_args(
+            args, "random-mm"
+        )
+
         sample_kwargs["input_len"] = (
             random_input_len
             if random_input_len is not None
             else getattr(args, "input_len", None)
         )
-        random_output_len = getattr(args, "random_output_len", None)
         sample_kwargs["output_len"] = (
             random_output_len
             if random_output_len is not None
@@ -480,14 +519,16 @@ def get_requests(args, tokenizer):
         sample_kwargs["range_ratio"] = args.random_range_ratio
     elif args.dataset_name == "random-rerank":
         dataset_cls = RandomDatasetForReranking
-        # prefer random_* arguments, fall back to regular arguments
-        random_input_len = getattr(args, "random_input_len", None)
+        # Validate and get random dataset parameters
+        random_input_len, random_output_len = validate_random_dataset_args(
+            args, "random-rerank"
+        )
+
         sample_kwargs["input_len"] = (
             random_input_len
             if random_input_len is not None
             else getattr(args, "input_len", None)
         )
-        random_output_len = getattr(args, "random_output_len", None)
         sample_kwargs["output_len"] = (
             random_output_len
             if random_output_len is not None
@@ -650,18 +691,26 @@ def validate_args(args):
         random_output_len = getattr(args, "random_output_len", None)
         random_prefix_len = getattr(args, "random_prefix_len", None)
 
-        if args.input_len is not None and random_input_len is not None:
+        if (
+            args.input_len is not None
+            and random_input_len is not None
+            and args.input_len != random_input_len
+        ):
             warnings.warn(
-                "Both --input-len and --random-input-len are specified. "
-                "The random version (--random-input-len) will be preferred "
-                "in this run.",
+                f"Both --input-len={args.input_len} and "
+                f"--random-input-len={random_input_len} are specified. "
+                f"Using --random-input-len={random_input_len}.",
                 stacklevel=2,
             )
-        if args.output_len is not None and random_output_len is not None:
+        if (
+            args.output_len is not None
+            and random_output_len is not None
+            and args.output_len != random_output_len
+        ):
             warnings.warn(
-                "Both --output-len and --random-output-len are specified. "
-                "The random version (--random-output-len) will be preferred "
-                "in this run.",
+                f"Both --output-len={args.output_len} and "
+                f"--random-output-len={random_output_len} are specified. "
+                f"Using --random-output-len={random_output_len}.",
                 stacklevel=2,
             )
         if args.prefix_len is not None and random_prefix_len is not None:

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -32,6 +32,7 @@ from vllm.benchmarks.datasets import (
     VisionArenaDataset,
     add_random_dataset_base_args,
     add_random_multimodal_dataset_args,
+    resolve_random_dataset_args,
 )
 from vllm.benchmarks.lib.utils import convert_to_pytorch_benchmark_format, write_to_json
 from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
@@ -338,28 +339,6 @@ def save_to_pytorch_benchmark_format(
         write_to_json(pt_file, pt_records)
 
 
-def get_random_dataset_args(
-    args: argparse.Namespace, dataset_name: str
-) -> tuple[int | None, int | None]:
-    """Get input/output lengths for random datasets.
-
-    Prefers random-specific parameters over generic ones. If neither is
-    specified, datasets.py will fall back to RandomDataset.DEFAULT_INPUT_LEN
-    and DEFAULT_OUTPUT_LEN (1024/128).
-
-    Args:
-        args: Command line arguments.
-        dataset_name: Name of the dataset (e.g., 'random', 'random-mm').
-
-    Returns:
-        Tuple of (random_input_len, random_output_len).
-    """
-    random_input_len = getattr(args, "random_input_len", None)
-    random_output_len = getattr(args, "random_output_len", None)
-
-    return random_input_len, random_output_len
-
-
 def get_requests(args, tokenizer):
     # Common parameters for all dataset types.
     common_kwargs = {
@@ -379,20 +358,12 @@ def get_requests(args, tokenizer):
         and args.dataset_name not in {"prefix_repetition", "random-mm", "random-rerank"}
     ):
         sample_kwargs["range_ratio"] = args.random_range_ratio
-        # prefer random_* arguments, fall back to regular arguments
-        random_prefix_len = getattr(args, "random_prefix_len", None)
-        sample_kwargs["prefix_len"] = (
-            random_prefix_len if random_prefix_len is not None else args.prefix_len
-        )
-        # Get random dataset parameters (prefer random-specific over generic)
-        random_input_len, random_output_len = get_random_dataset_args(args, "random")
 
-        sample_kwargs["input_len"] = (
-            random_input_len if random_input_len is not None else args.input_len
-        )
-        sample_kwargs["output_len"] = (
-            random_output_len if random_output_len is not None else args.output_len
-        )
+        # Get fully resolved random dataset parameters
+        prefix_len, input_len, output_len = resolve_random_dataset_args(args, "random")
+        sample_kwargs["prefix_len"] = prefix_len
+        sample_kwargs["input_len"] = input_len
+        sample_kwargs["output_len"] = output_len
         dataset_cls = RandomDataset
     elif args.dataset_name == "sharegpt":
         dataset_cls = ShareGPTDataset
@@ -471,19 +442,14 @@ def get_requests(args, tokenizer):
         sample_kwargs["output_len"] = args.prefix_repetition_output_len
     elif args.dataset_name == "random-mm":
         dataset_cls = RandomMultiModalDataset
-        # Get random dataset parameters (prefer random-specific over generic)
-        random_input_len, random_output_len = get_random_dataset_args(args, "random-mm")
 
-        sample_kwargs["input_len"] = (
-            random_input_len
-            if random_input_len is not None
-            else getattr(args, "input_len", None)
+        # Get fully resolved random dataset parameters
+        prefix_len, input_len, output_len = resolve_random_dataset_args(
+            args, "random-mm"
         )
-        sample_kwargs["output_len"] = (
-            random_output_len
-            if random_output_len is not None
-            else getattr(args, "output_len", None)
-        )
+        sample_kwargs["prefix_len"] = prefix_len
+        sample_kwargs["input_len"] = input_len
+        sample_kwargs["output_len"] = output_len
         sample_kwargs["base_items_per_request"] = getattr(
             args, "random_mm_base_items_per_request", None
         )
@@ -495,29 +461,16 @@ def get_requests(args, tokenizer):
         )
         sample_kwargs["bucket_config"] = getattr(args, "random_mm_bucket_config", None)
         sample_kwargs["enable_multimodal_chat"] = True
-        random_prefix_len = getattr(args, "random_prefix_len", None)
-        prefix_len = getattr(args, "prefix_len", None)
-        sample_kwargs["prefix_len"] = (
-            random_prefix_len if random_prefix_len is not None else prefix_len
-        )
         sample_kwargs["range_ratio"] = args.random_range_ratio
     elif args.dataset_name == "random-rerank":
         dataset_cls = RandomDatasetForReranking
-        # Get random dataset parameters (prefer random-specific over generic)
-        random_input_len, random_output_len = get_random_dataset_args(
+
+        # Get fully resolved random dataset parameters
+        _prefix_len, input_len, output_len = resolve_random_dataset_args(
             args, "random-rerank"
         )
-
-        sample_kwargs["input_len"] = (
-            random_input_len
-            if random_input_len is not None
-            else getattr(args, "input_len", None)
-        )
-        sample_kwargs["output_len"] = (
-            random_output_len
-            if random_output_len is not None
-            else getattr(args, "output_len", None)
-        )
+        sample_kwargs["input_len"] = input_len
+        sample_kwargs["output_len"] = output_len
         sample_kwargs["batchsize"] = getattr(args, "random_batch_size", 1)
         sample_kwargs["is_reranker"] = not getattr(args, "no_reranker", False)
         sample_kwargs["range_ratio"] = args.random_range_ratio


### PR DESCRIPTION
## Problem

The `--random-input-len` and `--random-output-len` parameters have argparse default values (1024 and 128) that silently override user-specified `--input-len` and `--output-len` values when using `--dataset-name random`.

This causes silent data corruption in benchmarks where users specify different token lengths but all benchmarks run with the same workload.

### Example
```bash
# User specifies 256 tokens
vllm bench throughput --dataset-name random --input-len 256 --output-len 256

# But vLLM actually uses 1024 input and 128 output (from defaults)
# User has no idea their parameters were ignored
```

This affects ANY token size (128, 256, 512, 2048, etc.), not just specific values.

## Root Cause

The fallback logic checks `if random_input_len is not None`, but since argparse sets defaults, `random_input_len` is never None (it's always 1024), so the fallback to `args.input_len` never happens.

## Solution

1. **Remove argparse defaults** - Set `default=None` for both parameters

## Testing

  ***Before (Broken): ***                                                                                                                                                                                                         
```bash
  # User specifies 256, but silently gets 1024/128 from argparse defaults
  vllm bench throughput --dataset-name random --input-len 256 --output-len 256                                                                                                                                                
 ```                                                                                                                                                                                                                         
  ***After (Fixed):***
```bash                                                                                                                                                                                                              
  # Option A: User specifies values → uses them                                                                                                                                                                          
  vllm bench throughput --dataset-name random --input-len 256 --output-len 256

  # Option B: User omits values → gets defaults (1024/128) from RandomDataset
  vllm bench throughput --dataset-name random
```

  