### PR TITLE
Fix CUDA graph decode capture crash in AITER FlashAttention

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_fa.py
+++ b/vllm/v1/attention/backends/rocm_aiter_fa.py
@@ -1152,11 +1152,10 @@ class AiterFlashAttentionImpl(AttentionImpl):
                 decode_max_query_len = attn_metadata.decode_metadata.max_query_len
 
                 # Use unified_attention for speculative decoding (multi-token)
-                # or when sliding window is enabled
-                if self.sliding_window[0] != -1 or decode_max_query_len > 1:
+                if decode_max_query_len > 1:
                     assert not rocm_aiter_ops.is_shuffle_kv_cache_enabled(), (
-                        "Shuffle KV cache layout is not supported with sliding "
-                        "window or speculative decoding (multi-token decode)."
+                        "Shuffle KV cache layout is not supported with "
+                        "speculative decoding (multi-token decode)."
                     )
                     from aiter.ops.triton.unified_attention import (
                         unified_attention,


### PR DESCRIPTION
Summary:
Upstream vLLM commit vllm-project/vllm#32877 added speculative decoding
support to the ROCm AITER FA backend by routing `decode_max_query_len > 1`
through `unified_attention` (a Triton kernel). However, it also added
`self.sliding_window[0] != -1` to the same condition, which causes the
`unified_attention` path to be taken during CUDA graph decode FULL capture
even for non-speculative workloads.

`unified_attention` is not CUDA-graph-capture-safe because it performs
dynamic memory allocations (`torch.empty`) and runtime kernel selection
inside the wrapper. This causes `Memory access fault by GPU node-X on
address (nil)` at 91% (10/11) of decode FULL graph capture.

The fix removes the sliding window condition from the `unified_attention`
gate, keeping it only for actual speculative decoding (`decode_max_query_len
> 1`). Sliding window attention continues to work correctly through the
existing `paged_attention_v1` path, which has native sliding window support.

Test Plan:
Verified on (8x MI300X) with an internal model:

Before fix :
- `Memory access fault by GPU node-8 on address (nil)` during
  "Capturing CUDA graphs (decode, FULL): 91% (10/11)"

After fix:
- Decode FULL capture completes 100% (11/11 graphs)
- `onStartServing done` reached
- Server runs healthy on all 8 GPUs (87% VRAM)

Differential Revision: D95245071


