### PR TITLE
[ROCM][MORI] Add MoRI & Aiter installation script 

### DIFF
--- a/tools/ep_kernels/rocm/README.md
+++ b/tools/ep_kernels/rocm/README.md
@@ -4,7 +4,7 @@ This directory contains installation scripts to install all2all EP kernels used 
 installs,
  - MoRI
 
-Note: As a side-effect it also installs Aiter, so MoRI could be used with AiterExperts
+Note: As a side-effect it also installs Aiter, so MoRI could be used with AiterExperts.
 
 ## Usage
 
@@ -13,10 +13,10 @@ Note: As a side-effect it also installs Aiter, so MoRI could be used with AiterE
  bash install_python_libraries.sh
 ```
 
-### Install kernels for a specific GPU_ARCHS
+### Install kernels for specific GPU_ARCHS
 ```bash
- GPU_ARCHS="gfx942" bash install_python_libraries.sh
+ GPU_ARCHS="gfx942;gfx950" bash install_python_libraries.sh
 ```
 
-The scripts has hard-coded repository and hash values picked from Dockerfile.rocm_base. The script avoids installation
-if it finds an existing installation of the package. To force a reinstall, use `--force-install`
+The script has hard-coded repository and hash values picked from Dockerfile.rocm_base. The script avoids installation
+if it finds an existing installation of the package. To force a reinstall, use `--force-install`.

--- a/tools/ep_kernels/rocm/README.md
+++ b/tools/ep_kernels/rocm/README.md
@@ -1,0 +1,22 @@
+# RoCM Expert Parallel(EP) Kernel installation
+
+This directory contains installation scripts to install all2all EP kernels used on RoCM. At the time of writing it
+installs,
+ - MoRI
+
+Note: As a side-effect it also installs Aiter, so MoRI could be used with AiterExperts
+
+## Usage
+
+### Install kernels with automatic GPU_ARCHS detection.
+```bash
+ bash install_python_libraries.sh
+```
+
+### Install kernels for a specific GPU_ARCHS
+```bash
+ GPU_ARCHS="gfx942" bash install_python_libraries.sh
+```
+
+The scripts has hard-coded repository and hash values picked from Dockerfile.rocm_base. The script avoids installation
+if it finds an existing installation of the package. To force a reinstall, use `--force-install`

--- a/tools/ep_kernels/rocm/README.md
+++ b/tools/ep_kernels/rocm/README.md
@@ -1,21 +1,24 @@
 # RoCM Expert Parallel(EP) Kernel installation
 
 This directory contains installation scripts to install all2all EP kernels used on RoCM. At the time of writing it
-installs,
- - MoRI
+installs:
+
+- MoRI
 
 Note: As a side-effect it also installs Aiter, so MoRI could be used with AiterExperts.
 
 ## Usage
 
-### Install kernels with automatic GPU_ARCHS detection.
+### Install kernels with automatic GPU_ARCHS detection
+
 ```bash
- bash install_python_libraries.sh
+bash install_python_libraries.sh
 ```
 
 ### Install kernels for specific GPU_ARCHS
+
 ```bash
- GPU_ARCHS="gfx942;gfx950" bash install_python_libraries.sh
+GPU_ARCHS="gfx942;gfx950" bash install_python_libraries.sh
 ```
 
 The script has hard-coded repository and hash values picked from Dockerfile.rocm_base. The script avoids installation

--- a/tools/ep_kernels/rocm/install_python_libraries.sh
+++ b/tools/ep_kernels/rocm/install_python_libraries.sh
@@ -3,7 +3,6 @@ set -ex
 
 # usage: ./install_python_libraries.sh [options]
 #   --workspace <dir>    workspace directory (default: ./ep_kernels_workspace).
-#   --mode <mode>        "install" (default) or "wheel".
 #   --mori-ref <commit>  MoRI commit hash.
 #   --aiter-ref <commit> Aiter commit hash.
 #   --force-install      Avoids installs when an installation exists already.
@@ -38,7 +37,6 @@ AITER_REPO="https://github.com/ROCm/aiter.git"
 AITER_GPU_ARCHS=${AITER_GPU_ARCHS:-"$(resolve_gpu_archs)"}
 
 WORKSPACE=${WORKSPACE:-$(pwd)/ep_kernels_workspace}
-MODE=${MODE:-install}
 FORCE_INSTALL=False
 
 # Parse arguments
@@ -50,14 +48,6 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             WORKSPACE="$2"
-            shift 2
-            ;;
-        --mode)
-            if [[ -z "$2" || "$2" =~ ^- ]]; then
-                echo "Error: --mode requires an argument." >&2
-                exit 1
-            fi
-            MODE="$2"
             shift 2
             ;;
         --mori-ref)
@@ -154,18 +144,16 @@ do_build() {
     ORANGE='\033[38;5;208m'
     NC='\033[0m'
 
-    if [ "$MODE" = "install" ]; then
-        # Check if the package is already installed
-        if python3 -c "import $package_name" > /dev/null 2>&1; then 
-            echo -e "${ORANGE} Package $name is already installed. Skipping installation. Use --force-install to install again.${NC}"
-        else
-            echo "Installing $name into environment"
-            eval "$cmake_args $extra_env" uv pip install --no-build-isolation -vvv .
+    # Check if the package is already installed
+    if [ "$FORCE_INSTALL" != "True" ]; then
+        if uv pip show $package_name > /dev/null 2>&1; then 
+            echo -e "${ORANGE} Package $package_name is already installed. Skipping installation. Use --force-install to install again.${NC}"
+            return 0
         fi
-    else
-        echo "Building $name wheel into $WHEEL_DIR"
-        eval "$cmake_args $extra_env" uv build --wheel --no-build-isolation -vvv --out-dir "$WHEEL_DIR" .
     fi
+
+    echo "Installing $package_name into environment"
+    eval "$cmake_args $extra_env" uv pip install --no-build-isolation -vvv .
 }
 
 do_build_mori() {
@@ -181,7 +169,7 @@ do_build_mori() {
 
     # Patch MoRI to let it find uv's python
     sed -i 's/find_package(PythonLibs REQUIRED)/find_package(Python3 COMPONENTS Interpreter Development REQUIRED)/g' src/pybind/CMakeLists.txt
-    sed -i 's/\${PYTHON_INCLUDE_DIRS}/${Pthon3_INCLUDE_DIRS}/g' src/pybind/CMakeLists.txt
+    sed -i 's/\${PYTHON_INCLUDE_DIRS}/${Python3_INCLUDE_DIRS}/g' src/pybind/CMakeLists.txt
     # Set cmake python executable to uv so it finds the right includes / libraries.
     cmake_args="CMAKE_ARGS=\"-DPython3_EXECUTABLE=$(uv python find)\""
 
@@ -210,7 +198,7 @@ do_build_aiter() {
     cmake_args="CMAKE_ARGS=\"-DPython3_EXECUTABLE=$(uv python find)\""
 
     export HIP_CLANG_PATH=./sccache-wrappers
-    do_build "mori" "$cmake_args $extra_env"
+    do_build "amd-aiter" "$cmake_args $extra_env"
     unset HIP_CLANG_PATH
 
     popd

--- a/tools/ep_kernels/rocm/install_python_libraries.sh
+++ b/tools/ep_kernels/rocm/install_python_libraries.sh
@@ -5,9 +5,10 @@ set -ex
 #   --workspace <dir>    workspace directory (default: ./ep_kernels_workspace)
 #   --mode <mode>        "install" (default) or "wheel"
 #   --mori-ref <commit> MoRI commit hash
+#   --aiter-ref <commit> Aiter commit hash
 
-function resolve_mori_gpu_archs() {
-    arch=${MORI_GPU_ARCHS:-""}
+function resolve_gpu_archs() {
+    arch=""
 
     # attempt to get arch from rocm-info
     if [ -z "$arch" ] && command -v rocminfo >/dev/null 2>&1; then
@@ -28,7 +29,11 @@ function resolve_mori_gpu_archs() {
 
 MORI_COMMIT_HASH="2d02c6a9"
 MORI_REPO="https://github.com/ROCm/mori.git"
-MORI_GPU_ARCHS=$(resolve_mori_gpu_archs)
+MORI_GPU_ARCHS=${MORI_GPU_ARCHS:-"$(resolve_gpu_archs)"}
+
+AITER_COMMIT_HASH="v0.1.10.post2"
+AITER_REPO="https://github.com/ROCm/aiter.git"
+AITER_GPU_ARCHS=${AITER_GPU_ARCHS:-"$(resolve_gpu_archs)"}
 
 WORKSPACE=${WORKSPACE:-$(pwd)/ep_kernels_workspace}
 MODE=${MODE:-install}
@@ -58,6 +63,14 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             MORI_COMMIT_HASH="$2"
+            shift 2
+            ;;
+        --aiter-ref)
+            if [[ -z "$2" || "$2" =~ ^- ]]; then
+                echo "Error: --aiter-ref requires an argument." >&2
+                exit 1
+            fi
+            AITER_COMMIT_HASH="$2"
             shift 2
             ;;
         *)
@@ -127,7 +140,7 @@ clone_repo() {
     fi
 }
 
-do_build() {
+do_build_mori() {
     local repo=$1
     local name=$2
     local key=$3
@@ -138,7 +151,12 @@ do_build() {
     clone_repo "$repo" "$name" "$key" "$commit"
     cd "$name"
 
-    cmake_args="CMAKE_ARGS=\"-DPython3_EXECUTABLE=$(uv python find) -DPYTHON_EXECUTABLE=$(uv python find)\""
+    # Patch MoRI to let it find uv's python
+    sed -i 's/find_package(PythonLibs REQUIRED)/find_package(Python3 COMPONENTS Interpreter Development REQUIRED)/g' src/pybind/CMakeLists.txt
+    sed -i 's/\${PYTHON_INCLUDE_DIRS}/${Pthon3_INCLUDE_DIRS}/g' src/pybind/CMakeLists.txt
+
+    # Set cmake python executable to uv so it finds the right includes / libraries.
+    cmake_args="CMAKE_ARGS=\"-DPython3_EXECUTABLE=$(uv python find)\""
 
     if [ "$MODE" = "install" ]; then
         echo "Installing $name into environment"
@@ -150,14 +168,54 @@ do_build() {
     popd
 }
 
+do_build_aiter() {
+
+    local repo=$1
+    local name=$2
+    local key=$3
+    local commit=$4
+    local extra_env=$5
+
+    pushd "$WORKSPACE"
+    clone_repo "$repo" "$name" "$key" "$commit"
+    cd "$name"
+
+    # aiter requirements
+    uv pip install -r requirements.txt 
+    uv pip install pyyaml
+    export HIP_CLANG_PATH=./sccache-wrappers
+    
+    # Set cmake python executable to uv so it finds the right includes / libraries.
+    cmake_args="CMAKE_ARGS=\"-DPython3_EXECUTABLE=$(uv python find)\""
+
+    if [ "$MODE" = "install" ]; then
+        echo "Installing $name into environment"
+        eval "$cmake_args $extra_env" uv pip install --no-build-isolation -vvv .
+    else
+        echo "Building $name wheel into $WHEEL_DIR"
+        eval "$cmake_args $extra_env" uv build --wheel --no-build-isolation -vvv --out-dir "$WHEEL_DIR" .
+    fi
+
+    unset HIP_CLANG_PATH
+    popd
+}
+
+# build Aiter
+do_build_aiter \
+    "$AITER_REPO" \
+    "aiter" \
+    "setup.py" \
+    "$AITER_COMMIT_HASH" \
+    "GPU_ARCHS=${AITER_GPU_ARCHS}"
+
 # build MoRI
-do_build \
+do_build_mori \
     "$MORI_REPO" \
     "mori" \
     "setup.py" \
     "$MORI_COMMIT_HASH" \
     "MORI_GPU_ARCHS=${MORI_GPU_ARCHS}"
-    
+
 if [ "$MODE" = "wheel" ]; then
     echo "All wheels written to $WHEEL_DIR"
     ls -l "$WHEEL_DIR"

--- a/tools/ep_kernels/rocm/install_python_libraries.sh
+++ b/tools/ep_kernels/rocm/install_python_libraries.sh
@@ -80,11 +80,6 @@ done
 
 mkdir -p "$WORKSPACE"
 
-WHEEL_DIR="$WORKSPACE/dist"
-mkdir -p "$WHEEL_DIR"
-
-pushd "$WORKSPACE"
-
 is_git_dirty() {
     local dir=$1
     pushd "$dir" > /dev/null
@@ -219,8 +214,3 @@ do_build_mori \
     "setup.py" \
     "$MORI_COMMIT_HASH" \
     "MORI_GPU_ARCHS=${MORI_GPU_ARCHS}"
-
-if [ "$MODE" = "wheel" ]; then
-    echo "All wheels written to $WHEEL_DIR"
-    ls -l "$WHEEL_DIR"
-fi

--- a/tools/ep_kernels/rocm/install_python_libraries.sh
+++ b/tools/ep_kernels/rocm/install_python_libraries.sh
@@ -27,6 +27,7 @@ function resolve_gpu_archs() {
     echo "${arch}"
 }
 
+# Repo and Hash picked from Dockerfile.rocm_base
 MORI_COMMIT_HASH="2d02c6a9"
 MORI_REPO="https://github.com/ROCm/mori.git"
 MORI_GPU_ARCHS=${MORI_GPU_ARCHS:-"$(resolve_gpu_archs)"}

--- a/tools/ep_kernels/rocm/install_python_libraries.sh
+++ b/tools/ep_kernels/rocm/install_python_libraries.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -ex
+
+# usage: ./install_python_libraries.sh [options]
+#   --workspace <dir>    workspace directory (default: ./ep_kernels_workspace)
+#   --mode <mode>        "install" (default) or "wheel"
+#   --mori-ref <commit> MoRI commit hash
+
+function resolve_mori_gpu_archs() {
+    arch=${MORI_GPU_ARCHS:-""}
+
+    # attempt to get arch from rocm-info
+    if [ -z "$arch" ] && command -v rocminfo >/dev/null 2>&1; then
+        # rocminfo Name lines could like, 
+        #   Name:                    gfx942                             
+        #   Name:                    amdgcn-amd-amdhsa--gfx942:sramecc+:xnack-
+        # it is important to add a space before gfx so we pick the first
+        arch=$(rocminfo | awk '/Name:/ && / gfx/ {print $2}' | sort -u | paste -sd ';' -)
+    fi
+
+    # set defaults if everything else fails
+    if [ -z "$arch" ]; then
+        arch="gfx942;gfx950"
+    fi
+
+    echo "${arch}"
+}
+
+MORI_COMMIT_HASH="2d02c6a9"
+MORI_REPO="https://github.com/ROCm/mori.git"
+MORI_GPU_ARCHS=$(resolve_mori_gpu_archs)
+
+WORKSPACE=${WORKSPACE:-$(pwd)/ep_kernels_workspace}
+MODE=${MODE:-install}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --workspace)
+            if [[ -z "$2" || "$2" =~ ^- ]]; then
+                echo "Error: --workspace requires an argument." >&2
+                exit 1
+            fi
+            WORKSPACE="$2"
+            shift 2
+            ;;
+        --mode)
+            if [[ -z "$2" || "$2" =~ ^- ]]; then
+                echo "Error: --mode requires an argument." >&2
+                exit 1
+            fi
+            MODE="$2"
+            shift 2
+            ;;
+        --mori-ref)
+            if [[ -z "$2" || "$2" =~ ^- ]]; then
+                echo "Error: --mori-ref requires an argument." >&2
+                exit 1
+            fi
+            MORI_COMMIT_HASH="$2"
+            shift 2
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            exit 1
+            ;;
+    esac
+done
+
+
+mkdir -p "$WORKSPACE"
+
+WHEEL_DIR="$WORKSPACE/dist"
+mkdir -p "$WHEEL_DIR"
+
+pushd "$WORKSPACE"
+
+is_git_dirty() {
+    local dir=$1
+    pushd "$dir" > /dev/null
+    if [ -d ".git" ] && [ -n "$(git status --porcelain 3>/dev/null)" ]; then
+        popd > /dev/null
+        return 0
+    else
+        popd > /dev/null
+        return 1
+    fi
+}
+
+init_submodules() {
+    # Check for submodules and update if they exist
+    if [ -f ".gitmodules" ]; then
+        echo "Submodules detected, initializing and updating..."
+        git submodule update --init --recursive
+    fi
+}
+
+clone_repo() {
+    local repo_url=$1
+    local dir_name=$2
+    local key_file=$3
+    local commit_hash=$4
+    if [ -d "$dir_name" ]; then
+        if is_git_dirty "$dir_name"; then
+            echo "$dir_name directory is dirty, skipping clone"
+        elif [ ! -d "$dir_name/.git" ] || [ ! -f "$dir_name/$key_file" ]; then
+            echo "$dir_name directory exists but clone appears incomplete, cleaning up and re-cloning"
+            rm -rf "$dir_name"
+            git clone "$repo_url"
+            if [ -n "$commit_hash" ]; then
+                cd "$dir_name"
+                git checkout "$commit_hash"
+                init_submodules
+                cd ..
+            fi
+        else
+            echo "$dir_name directory exists and appears complete"
+        fi
+    else
+        git clone "$repo_url"
+        if [ -n "$commit_hash" ]; then
+            cd "$dir_name"
+            git checkout "$commit_hash"
+            init_submodules
+            cd ..
+        fi
+    fi
+}
+
+do_build() {
+    local repo=$1
+    local name=$2
+    local key=$3
+    local commit=$4
+    local extra_env=$5
+
+    pushd "$WORKSPACE"
+    clone_repo "$repo" "$name" "$key" "$commit"
+    cd "$name"
+
+    cmake_args="CMAKE_ARGS=\"-DPython3_EXECUTABLE=$(uv python find) -DPYTHON_EXECUTABLE=$(uv python find)\""
+
+    if [ "$MODE" = "install" ]; then
+        echo "Installing $name into environment"
+        eval "$cmake_args $extra_env" uv pip install --no-build-isolation -vvv .
+    else
+        echo "Building $name wheel into $WHEEL_DIR"
+        eval "$cmake_args $extra_env" uv build --wheel --no-build-isolation -vvv --out-dir "$WHEEL_DIR" .
+    fi
+    popd
+}
+
+# build MoRI
+do_build \
+    "$MORI_REPO" \
+    "mori" \
+    "setup.py" \
+    "$MORI_COMMIT_HASH" \
+    "MORI_GPU_ARCHS=${MORI_GPU_ARCHS}"
+    
+if [ "$MODE" = "wheel" ]; then
+    echo "All wheels written to $WHEEL_DIR"
+    ls -l "$WHEEL_DIR"
+fi

--- a/tools/ep_kernels/rocm/install_python_libraries.sh
+++ b/tools/ep_kernels/rocm/install_python_libraries.sh
@@ -2,10 +2,11 @@
 set -ex
 
 # usage: ./install_python_libraries.sh [options]
-#   --workspace <dir>    workspace directory (default: ./ep_kernels_workspace)
-#   --mode <mode>        "install" (default) or "wheel"
-#   --mori-ref <commit> MoRI commit hash
-#   --aiter-ref <commit> Aiter commit hash
+#   --workspace <dir>    workspace directory (default: ./ep_kernels_workspace).
+#   --mode <mode>        "install" (default) or "wheel".
+#   --mori-ref <commit>  MoRI commit hash.
+#   --aiter-ref <commit> Aiter commit hash.
+#   --force-install      Avoids installs when an installation exists already.
 
 function resolve_gpu_archs() {
     arch=""
@@ -38,6 +39,7 @@ AITER_GPU_ARCHS=${AITER_GPU_ARCHS:-"$(resolve_gpu_archs)"}
 
 WORKSPACE=${WORKSPACE:-$(pwd)/ep_kernels_workspace}
 MODE=${MODE:-install}
+FORCE_INSTALL=False
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -73,6 +75,10 @@ while [[ $# -gt 0 ]]; do
             fi
             AITER_COMMIT_HASH="$2"
             shift 2
+            ;;
+        --force-install)
+            FORCE_INSTALL=True
+            shift 1
             ;;
         *)
             echo "Error: Unknown argument '$1'" >&2
@@ -141,6 +147,27 @@ clone_repo() {
     fi
 }
 
+do_build() {
+    local package_name=$1
+    local extra_env=$2
+
+    ORANGE='\033[38;5;208m'
+    NC='\033[0m'
+
+    if [ "$MODE" = "install" ]; then
+        # Check if the package is already installed
+        if python3 -c "import $package_name" > /dev/null 2>&1; then 
+            echo -e "${ORANGE} Package $name is already installed. Skipping installation. Use --force-install to install again.${NC}"
+        else
+            echo "Installing $name into environment"
+            eval "$cmake_args $extra_env" uv pip install --no-build-isolation -vvv .
+        fi
+    else
+        echo "Building $name wheel into $WHEEL_DIR"
+        eval "$cmake_args $extra_env" uv build --wheel --no-build-isolation -vvv --out-dir "$WHEEL_DIR" .
+    fi
+}
+
 do_build_mori() {
     local repo=$1
     local name=$2
@@ -155,17 +182,11 @@ do_build_mori() {
     # Patch MoRI to let it find uv's python
     sed -i 's/find_package(PythonLibs REQUIRED)/find_package(Python3 COMPONENTS Interpreter Development REQUIRED)/g' src/pybind/CMakeLists.txt
     sed -i 's/\${PYTHON_INCLUDE_DIRS}/${Pthon3_INCLUDE_DIRS}/g' src/pybind/CMakeLists.txt
-
     # Set cmake python executable to uv so it finds the right includes / libraries.
     cmake_args="CMAKE_ARGS=\"-DPython3_EXECUTABLE=$(uv python find)\""
 
-    if [ "$MODE" = "install" ]; then
-        echo "Installing $name into environment"
-        eval "$cmake_args $extra_env" uv pip install --no-build-isolation -vvv .
-    else
-        echo "Building $name wheel into $WHEEL_DIR"
-        eval "$cmake_args $extra_env" uv build --wheel --no-build-isolation -vvv --out-dir "$WHEEL_DIR" .
-    fi
+    do_build "mori" "$cmake_args $extra_env"
+
     popd
 }
 
@@ -184,20 +205,14 @@ do_build_aiter() {
     # aiter requirements
     uv pip install -r requirements.txt 
     uv pip install pyyaml
-    export HIP_CLANG_PATH=./sccache-wrappers
     
     # Set cmake python executable to uv so it finds the right includes / libraries.
     cmake_args="CMAKE_ARGS=\"-DPython3_EXECUTABLE=$(uv python find)\""
 
-    if [ "$MODE" = "install" ]; then
-        echo "Installing $name into environment"
-        eval "$cmake_args $extra_env" uv pip install --no-build-isolation -vvv .
-    else
-        echo "Building $name wheel into $WHEEL_DIR"
-        eval "$cmake_args $extra_env" uv build --wheel --no-build-isolation -vvv --out-dir "$WHEEL_DIR" .
-    fi
-
+    export HIP_CLANG_PATH=./sccache-wrappers
+    do_build "mori" "$cmake_args $extra_env"
     unset HIP_CLANG_PATH
+
     popd
 }
 

--- a/tools/ep_kernels/rocm/install_python_libraries.sh
+++ b/tools/ep_kernels/rocm/install_python_libraries.sh
@@ -30,11 +30,11 @@ function resolve_gpu_archs() {
 # Repo and Hash picked from Dockerfile.rocm_base
 MORI_COMMIT_HASH="2d02c6a9"
 MORI_REPO="https://github.com/ROCm/mori.git"
-MORI_GPU_ARCHS=${MORI_GPU_ARCHS:-"$(resolve_gpu_archs)"}
+MORI_GPU_ARCHS=${GPU_ARCHS:-"$(resolve_gpu_archs)"}
 
 AITER_COMMIT_HASH="v0.1.10.post2"
 AITER_REPO="https://github.com/ROCm/aiter.git"
-AITER_GPU_ARCHS=${AITER_GPU_ARCHS:-"$(resolve_gpu_archs)"}
+AITER_GPU_ARCHS=${GPU_ARCHS:-"$(resolve_gpu_archs)"}
 
 WORKSPACE=${WORKSPACE:-$(pwd)/ep_kernels_workspace}
 FORCE_INSTALL=False
@@ -148,7 +148,7 @@ do_build() {
     fi
 
     echo "Installing $package_name into environment"
-    eval "$cmake_args $extra_env" uv pip install --no-build-isolation -vvv .
+    eval "$extra_env" uv pip install --no-build-isolation -vvv .
 }
 
 do_build_mori() {
@@ -192,9 +192,7 @@ do_build_aiter() {
     # Set cmake python executable to uv so it finds the right includes / libraries.
     cmake_args="CMAKE_ARGS=\"-DPython3_EXECUTABLE=$(uv python find)\""
 
-    export HIP_CLANG_PATH=./sccache-wrappers
     do_build "amd-aiter" "$cmake_args $extra_env"
-    unset HIP_CLANG_PATH
 
     popd
 }
@@ -205,7 +203,7 @@ do_build_aiter \
     "aiter" \
     "setup.py" \
     "$AITER_COMMIT_HASH" \
-    "GPU_ARCHS=${AITER_GPU_ARCHS}"
+    "GPU_ARCHS=\"${AITER_GPU_ARCHS}\""
 
 # build MoRI
 do_build_mori \
@@ -213,4 +211,4 @@ do_build_mori \
     "mori" \
     "setup.py" \
     "$MORI_COMMIT_HASH" \
-    "MORI_GPU_ARCHS=${MORI_GPU_ARCHS}"
+    "MORI_GPU_ARCHS=\"${MORI_GPU_ARCHS}\""

--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -295,7 +295,7 @@ def rocm_aiter_fused_experts(
 class AiterExperts(mk.FusedMoEExpertsModular):
     @property
     def expects_unquantized_inputs(self) -> bool:
-        return True
+        return False
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:

--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -295,7 +295,7 @@ def rocm_aiter_fused_experts(
 class AiterExperts(mk.FusedMoEExpertsModular):
     @property
     def expects_unquantized_inputs(self) -> bool:
-        return False
+        return True
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:


### PR DESCRIPTION
## Purpose
Add `tools/ep_kernels/rocm/install_python_libraries.sh` similar to `tools/ep_kernels/install_python_libraries.sh` for CUDA.

This helps in local development.

## Test Plan
Tested on a machine with rocm-7.1.1 + `MI300X`.

Requires https://github.com/vllm-project/vllm/pull/36034 for testing
and Install MoRI and Aiter using `cd tools/ep_kernels/rocm/ && ./install_python_libraries.sh`

serve command : `VLLM_ROCM_USE_AITER=1 VLLM_ROCM_USE_AITER_MOE=1  canhazgpu run -g2 -- vllm serve Qwen/Qwen3-30B-A3B-FP8 -dp 2 --enable-expert-parallel --port 9010  --all2all-backend mori`

lm-eval command : `lm_eval --model local-completions --tasks gsm8k --model_args model=Qwen/Qwen3-30B-A3B-FP8,base_url=http://localhost:9010/v1/completions,num_concurrent=30,max_retries=3 --limit 100`

## Test Result

eval : 
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.77|±  |0.0423|
|     |       |strict-match    |     5|exact_match|↑  | 0.93|±  |0.0256|
```