### PR TITLE
[compile] Reduce log spam from compile.

### DIFF
--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -577,7 +577,6 @@ def _support_torch_compile(
             self.aot_compiled_fn and self._aot_compilation_path and self._aot_cache_dir
         )
 
-        logger.info("saving AOT compiled function to %s", self._aot_compilation_path)
         try:
             os.makedirs(self._aot_cache_dir, exist_ok=True)
             # File saving should be atomic, so we will save to a temporary location
@@ -585,7 +584,11 @@ def _support_torch_compile(
             tmp_file = f"{self._aot_compilation_path}.{os.getpid()}.tmp"
             self.aot_compiled_fn.save_compiled_function(tmp_file)
             os.replace(tmp_file, self._aot_compilation_path)
-            logger.info("saved AOT compiled function to %s", self._aot_compilation_path)
+            logger.info_once(
+                "saved AOT compiled function to %s",
+                self._aot_compilation_path,
+                scope="local",
+            )
         except Exception as e:
             logger.warning(
                 "unable to save AOT compiled function to %s: %s",


### PR DESCRIPTION
Summary:

Today we have many redundant log lines pointing to similar artifacts like
```
(EngineCore_DP0 pid=3763151) (Worker pid=3763542) (Worker_TP0 pid=3763542) INFO 03-04 12:10:02 [decorators.py:580] saving AOT compiled function to /home/zhxchen17/.cache/vllm/torch_compile_cache/torch_aot_compile/b2b985921d7c0517fda37290a608da6814119df0529a818ad95b93e670bbfaf2/rank_0_0/model
(EngineCore_DP0 pid=3763151) (Worker pid=3763554) (Worker_TP1 pid=3763554) INFO 03-04 12:10:02 [decorators.py:580] saving AOT compiled function to /home/zhxchen17/.cache/vllm/torch_compile_cache/torch_aot_compile/b2b985921d7c0517fda37290a608da6814119df0529a818ad95b93e670bbfaf2/rank_1_0/model
(EngineCore_DP0 pid=3763151) (Worker pid=3763566) (Worker_TP2 pid=3763566) INFO 03-04 12:10:02 [decorators.py:580] saving AOT compiled function to /home/zhxchen17/.cache/vllm/torch_compile_cache/torch_aot_compile/b2b985921d7c0517fda37290a608da6814119df0529a818ad95b93e670bbfaf2/rank_2_0/model
(EngineCore_DP0 pid=3763151) (Worker pid=3763578) (Worker_TP3 pid=3763578) INFO 03-04 12:10:02 [decorators.py:580] saving AOT compiled function to /home/zhxchen17/.cache/vllm/torch_compile_cache/torch_aot_compile/b2b985921d7c0517fda37290a608da6814119df0529a818ad95b93e670bbfaf2/rank_3_0/model
(EngineCore_DP0 pid=3763151) (Worker pid=3763542) (Worker_TP0 pid=3763542) INFO 03-04 12:10:06 [decorators.py:588] saved AOT compiled function to /home/zhxchen17/.cache/vllm/torch_compile_cache/torch_aot_compile/b2b985921d7c0517fda37290a608da6814119df0529a818ad95b93e670bbfaf2/rank_0_0/model
(EngineCore_DP0 pid=3763151) (Worker pid=3763554) (Worker_TP1 pid=3763554) INFO 03-04 12:10:07 [decorators.py:588] saved AOT compiled function to /home/zhxchen17/.cache/vllm/torch_compile_cache/torch_aot_compile/b2b985921d7c0517fda37290a608da6814119df0529a818ad95b93e670bbfaf2/rank_1_0/model
(EngineCore_DP0 pid=3763151) (Worker pid=3763578) (Worker_TP3 pid=3763578) INFO 03-04 12:10:07 [decorators.py:588] saved AOT compiled function to /home/zhxchen17/.cache/vllm/torch_compile_cache/torch_aot_compile/b2b985921d7c0517fda37290a608da6814119df0529a818ad95b93e670bbfaf2/rank_3_0/model
(EngineCore_DP0 pid=3763151) (Worker pid=3763566) (Worker_TP2 pid=3763566) INFO 03-04 12:10:07 [decorators.py:588] saved AOT compiled function to /home/zhxchen17/.cache/vllm/torch_compile_cache/torch_aot_compile/b2b985921d7c0517fda37290a608da6814119df0529a818ad95b93e670bbfaf2/rank_2_0/model
```

After the change, the log will be less spammy and reduced to:
```
(EngineCore_DP0 pid=3763151) (Worker pid=3763542) (Worker_TP0 pid=3763542) INFO 03-04 12:10:02 [decorators.py:580] saved AOT compiled function to /home/zhxchen17/.cache/vllm/torch_compile_cache/torch_aot_compile/b2b985921d7c0517fda37290a608da6814119df0529a818ad95b93e670bbfaf2/rank_0_0/model
```

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

Signed-off-by: zhxchen17 <zhxchen17@fb.com>


## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

