### PR TITLE
[Frontend] Add SubscribeKvEvents KV event streaming bridge

### DIFF
--- a/docs/serving/grpc_server.md
+++ b/docs/serving/grpc_server.md
@@ -1,0 +1,46 @@
+# gRPC Server
+
+vLLM includes a standalone gRPC server entrypoint:
+
+```bash
+python -m vllm.entrypoints.grpc_server --model <model>
+```
+
+This server exposes the `VllmEngine` protobuf service defined in
+`vllm/grpc/vllm_engine.proto`.
+
+## KV Event Streaming
+
+The gRPC server supports server-streaming KV cache events via:
+
+- `SubscribeKvEvents(SubscribeKvEventsRequest) returns (stream KvEventBatch)`
+
+KV event streaming is disabled by default for backward compatibility.  
+When disabled, `SubscribeKvEvents` returns `UNIMPLEMENTED`.
+
+To enable KV event streaming, set `--kv-events-config` with ZMQ publishing:
+
+```bash
+python -m vllm.entrypoints.grpc_server \
+  --model <model> \
+  --kv-events-config '{"enable_kv_cache_events": true, "publisher": "zmq", "endpoint": "tcp://*:5557", "replay_endpoint": "tcp://*:5558", "topic": "kv-events"}'
+```
+
+### Resume and Replay Semantics
+
+- `start_sequence_number=0` starts from live stream state.
+- `start_sequence_number>0` requests replay from that sequence number before
+  live streaming, if `replay_endpoint` is configured.
+- Replay completion is indicated by the publisher sentinel `(-1, empty payload)`.
+
+### Data Parallel Endpoints
+
+For data parallel configurations, the gRPC bridge follows the same endpoint
+port offset logic as the internal ZMQ publisher. It also normalizes bind-style
+`tcp://*:<port>` endpoints to connectable loopback addresses.
+
+## Notes
+
+- This is a dedicated gRPC entrypoint and is separate from the OpenAI-compatible
+  HTTP server (`vllm serve`).
+- Keep generated protobuf stubs in sync when changing `vllm/grpc/vllm_engine.proto`.

--- a/tests/entrypoints/test_grpc_kv_events.py
+++ b/tests/entrypoints/test_grpc_kv_events.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import msgspec
+import pytest
+import zmq
+
+from vllm.config.kv_events import KVEventsConfig
+from vllm.distributed.kv_events import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+)
+from vllm.distributed.kv_events import (
+    KVEventBatch as InternalKVEventBatch,
+)
+from vllm.entrypoints.grpc_kv_events import GrpcKVEventBridge
+
+
+class _FakeServicerContext:
+    def __init__(self) -> None:
+        self._done = False
+
+    def done(self) -> bool:
+        return self._done
+
+    def cancelled(self) -> bool:
+        return False
+
+
+class _FakeSocket:
+    def __init__(self, frames):
+        self.frames = list(frames)
+        self.closed = False
+        self.connected = None
+        self.subscribed_topic = None
+        self.sent = []
+
+    def connect(self, endpoint):
+        self.connected = endpoint
+
+    def setsockopt_string(self, opt, value):
+        assert opt == zmq.SUBSCRIBE
+        self.subscribed_topic = value
+
+    def send(self, payload):
+        self.sent.append(payload)
+
+    def poll(self, _timeout):
+        return 1 if self.frames else 0
+
+    def recv_multipart(self):
+        return self.frames.pop(0)
+
+    def close(self, linger=0):
+        self.closed = True
+
+
+class _FakeZmqContext:
+    def __init__(self, sub_socket: _FakeSocket, replay_socket: _FakeSocket):
+        self.sub_socket = sub_socket
+        self.replay_socket = replay_socket
+
+    def socket(self, kind):
+        if kind == zmq.SUB:
+            return self.sub_socket
+        if kind == zmq.REQ:
+            return self.replay_socket
+        raise AssertionError(f"Unexpected socket kind: {kind}")
+
+
+def _encode_batch(batch: InternalKVEventBatch) -> bytes:
+    return msgspec.msgpack.Encoder().encode(batch)
+
+
+def test_bridge_enablement_backwards_compatibility():
+    assert not GrpcKVEventBridge(None).enabled
+
+    # Explicitly "null" keeps legacy no-streaming behavior even when
+    # kv-cache events are enabled internally.
+    disabled = KVEventsConfig(enable_kv_cache_events=True, publisher="null")
+    assert not GrpcKVEventBridge(disabled).enabled
+
+    enabled = KVEventsConfig(
+        enable_kv_cache_events=True,
+        publisher="zmq",
+        endpoint="tcp://*:5557",
+        replay_endpoint="tcp://*:5558",
+        topic="kv-events",
+    )
+    assert GrpcKVEventBridge(enabled).enabled
+
+
+def test_bridge_offsets_and_normalizes_tcp_wildcard_endpoints():
+    cfg = KVEventsConfig(
+        enable_kv_cache_events=True,
+        publisher="zmq",
+        endpoint="tcp://*:5557",
+        replay_endpoint="tcp://*:5558",
+        topic="kv-events",
+    )
+    bridge = GrpcKVEventBridge(cfg, data_parallel_rank=2)
+
+    assert bridge.enabled
+    assert bridge._config is not None
+    assert bridge._config.endpoint == "tcp://127.0.0.1:5559"
+    assert bridge._config.replay_endpoint == "tcp://127.0.0.1:5560"
+
+
+def test_convert_batch_handles_int_and_bytes_hashes_backwards_compatibility():
+    batch = InternalKVEventBatch(
+        ts=123.0,
+        data_parallel_rank=None,
+        events=[
+            BlockStored(
+                block_hashes=[(1 << 63) + 5, 42],
+                parent_block_hash=(1 << 63) + 3,
+                token_ids=[10, 11, 12, 13],
+                block_size=2,
+                lora_id=7,
+                medium="GPU",
+                lora_name="adapter-a",
+            ),
+            BlockStored(
+                block_hashes=[(b"\xff" * 32)],
+                parent_block_hash=None,
+                token_ids=[99],
+                block_size=1,
+                lora_id=None,
+                medium="GPU",
+                lora_name=None,
+            ),
+            BlockRemoved(block_hashes=[(b"\xff" * 32), 9], medium="GPU"),
+            AllBlocksCleared(),
+        ],
+    )
+
+    out = GrpcKVEventBridge._convert_batch(77, batch)
+
+    assert out.sequence_number == 77
+    assert len(out.events) == 4
+
+    stored0 = out.events[0]
+    assert stored0.HasField("stored")
+    assert stored0.stored.parent_block_hash == -(1 << 63) + 3
+    assert [b.block_hash for b in stored0.stored.blocks] == [-(1 << 63) + 5, 42]
+    assert [list(b.token_ids) for b in stored0.stored.blocks] == [[10, 11], [12, 13]]
+    assert [b.lora_id for b in stored0.stored.blocks] == [7, 7]
+
+    stored1 = out.events[1]
+    assert stored1.HasField("stored")
+    assert stored1.stored.blocks[0].block_hash == -1
+
+    removed = out.events[2]
+    assert removed.HasField("removed")
+    assert list(removed.removed.block_hashes) == [-1, 9]
+
+    cleared = out.events[3]
+    assert cleared.HasField("cleared")
+
+    # dp_rank is optional and should stay unset when absent in source.
+    assert not out.HasField("dp_rank")
+
+    # Event IDs stay in uint64 range even for large sequence numbers.
+    big_seq_out = GrpcKVEventBridge._convert_batch((1 << 40) + 9, batch)
+    assert big_seq_out.events[0].event_id == (9 << 32)
+
+
+@pytest.mark.asyncio
+async def test_stream_replay_then_live_with_sequence_filtering(monkeypatch):
+    replay_seq_old = (2).to_bytes(8, byteorder="big", signed=False)
+    replay_seq_keep = (3).to_bytes(8, byteorder="big", signed=False)
+    replay_end = (-1).to_bytes(8, byteorder="big", signed=True)
+
+    replay_payload_old = _encode_batch(
+        InternalKVEventBatch(
+            ts=1.0,
+            data_parallel_rank=None,
+            events=[AllBlocksCleared()],
+        )
+    )
+    replay_payload_keep = _encode_batch(
+        InternalKVEventBatch(
+            ts=2.0,
+            data_parallel_rank=1,
+            events=[AllBlocksCleared()],
+        )
+    )
+    live_payload_dup = _encode_batch(
+        InternalKVEventBatch(
+            ts=3.0,
+            data_parallel_rank=2,
+            events=[AllBlocksCleared()],
+        )
+    )
+    live_payload_keep = _encode_batch(
+        InternalKVEventBatch(
+            ts=4.0,
+            data_parallel_rank=3,
+            events=[AllBlocksCleared()],
+        )
+    )
+
+    replay_socket = _FakeSocket(
+        frames=[
+            (replay_seq_old, replay_payload_old),
+            (replay_seq_keep, replay_payload_keep),
+            (replay_end, b""),
+        ]
+    )
+    sub_socket = _FakeSocket(
+        frames=[
+            (b"kv-events", replay_seq_keep, live_payload_dup),
+            (
+                b"kv-events",
+                (4).to_bytes(8, byteorder="big", signed=False),
+                live_payload_keep,
+            ),
+        ]
+    )
+    fake_ctx = _FakeZmqContext(sub_socket=sub_socket, replay_socket=replay_socket)
+
+    async def _inline_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "vllm.entrypoints.grpc_kv_events.asyncio.to_thread", _inline_to_thread
+    )
+    monkeypatch.setattr(
+        "vllm.entrypoints.grpc_kv_events.zmq.Context.instance", lambda: fake_ctx
+    )
+
+    cfg = KVEventsConfig(
+        enable_kv_cache_events=True,
+        publisher="zmq",
+        endpoint="tcp://localhost:5557",
+        replay_endpoint="tcp://localhost:5558",
+        topic="kv-events",
+    )
+    bridge = GrpcKVEventBridge(cfg)
+
+    context = _FakeServicerContext()
+    got = []
+    async for item in bridge.stream(start_sequence_number=3, context=context):
+        got.append(item)
+        if len(got) == 2:
+            break
+
+    assert replay_socket.sent == [(3).to_bytes(8, byteorder="big", signed=False)]
+    assert [b.sequence_number for b in got] == [3, 4]
+    assert [b.dp_rank for b in got] == [1, 3]
+    assert sub_socket.subscribed_topic == "kv-events"
+    assert replay_socket.closed
+    assert sub_socket.closed
+
+
+@pytest.mark.asyncio
+async def test_stream_replay_handles_high_bit_sequence_numbers(monkeypatch):
+    start_seq = (1 << 63) + 9
+    replay_seq_keep = start_seq.to_bytes(8, byteorder="big", signed=False)
+    replay_end = (-1).to_bytes(8, byteorder="big", signed=True)
+
+    replay_payload = _encode_batch(
+        InternalKVEventBatch(
+            ts=10.0,
+            data_parallel_rank=0,
+            events=[AllBlocksCleared()],
+        )
+    )
+    live_payload = _encode_batch(
+        InternalKVEventBatch(
+            ts=11.0,
+            data_parallel_rank=0,
+            events=[AllBlocksCleared()],
+        )
+    )
+
+    replay_socket = _FakeSocket(
+        frames=[
+            (replay_seq_keep, replay_payload),
+            (replay_end, b""),
+        ]
+    )
+    sub_socket = _FakeSocket(
+        frames=[
+            (
+                b"kv-events",
+                (start_seq + 1).to_bytes(8, byteorder="big", signed=False),
+                live_payload,
+            ),
+        ]
+    )
+    fake_ctx = _FakeZmqContext(sub_socket=sub_socket, replay_socket=replay_socket)
+
+    async def _inline_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "vllm.entrypoints.grpc_kv_events.asyncio.to_thread", _inline_to_thread
+    )
+    monkeypatch.setattr(
+        "vllm.entrypoints.grpc_kv_events.zmq.Context.instance", lambda: fake_ctx
+    )
+
+    cfg = KVEventsConfig(
+        enable_kv_cache_events=True,
+        publisher="zmq",
+        endpoint="tcp://localhost:5557",
+        replay_endpoint="tcp://localhost:5558",
+        topic="kv-events",
+    )
+    bridge = GrpcKVEventBridge(cfg)
+
+    context = _FakeServicerContext()
+    got = []
+    async for item in bridge.stream(start_sequence_number=start_seq, context=context):
+        got.append(item)
+        if len(got) == 2:
+            break
+
+    assert [b.sequence_number for b in got] == [start_seq, start_seq + 1]

--- a/tests/entrypoints/test_grpc_server.py
+++ b/tests/entrypoints/test_grpc_server.py
@@ -426,3 +426,14 @@ async def test_abort_request(grpc_client):
     assert was_aborted and received_chunks < 500, (
         "Request should have been aborted before generating all 500 tokens"
     )
+
+
+@pytest.mark.asyncio
+async def test_subscribe_kv_events_disabled_by_default(grpc_client):
+    """Backwards compatibility: KV event stream stays disabled unless configured."""
+    request = vllm_engine_pb2.SubscribeKvEventsRequest(start_sequence_number=0)
+
+    with pytest.raises(grpc.RpcError) as exc_info:
+        _ = [r async for r in grpc_client.SubscribeKvEvents(request)]
+
+    assert exc_info.value.code() == grpc.StatusCode.UNIMPLEMENTED

--- a/vllm/entrypoints/grpc_kv_events.py
+++ b/vllm/entrypoints/grpc_kv_events.py
@@ -1,0 +1,305 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KV event bridge for gRPC SubscribeKvEvents.
+
+Bridges vLLM's internal ZMQ KV event publisher to gRPC server-streaming.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+
+import grpc
+import msgspec
+import zmq
+
+from vllm.config.kv_events import KVEventsConfig
+from vllm.distributed.kv_events import (
+    AllBlocksCleared,
+    BlockRemoved,
+    BlockStored,
+    ZmqEventPublisher,
+)
+from vllm.distributed.kv_events import (
+    KVEventBatch as InternalKVEventBatch,
+)
+from vllm.grpc import vllm_engine_pb2
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_SEQ_BYTES = 8
+_POLL_TIMEOUT_MS = 200
+_MASK_64 = (1 << 64) - 1
+_INT64_SIGN_BIT = 1 << 63
+_INT64_MOD = 1 << 64
+_EVENT_ID_SEQ_MASK = (1 << 32) - 1
+
+
+@dataclass(frozen=True)
+class KVEventStreamConfig:
+    endpoint: str
+    replay_endpoint: str | None
+    topic: str
+
+
+class GrpcKVEventBridge:
+    """Expose vLLM KV events as gRPC KvEventBatch messages."""
+
+    _decoder = msgspec.msgpack.Decoder(type=InternalKVEventBatch)
+
+    def __init__(
+        self,
+        config: KVEventsConfig | None,
+        data_parallel_rank: int = 0,
+    ):
+        if (
+            config is None
+            or not config.enable_kv_cache_events
+            or config.publisher != "zmq"
+        ):
+            self._config = None
+            return
+
+        endpoint = ZmqEventPublisher.offset_endpoint_port(
+            config.endpoint, data_parallel_rank
+        )
+        replay_endpoint = ZmqEventPublisher.offset_endpoint_port(
+            config.replay_endpoint, data_parallel_rank
+        )
+
+        normalized_endpoint = self._normalize_endpoint_for_connect(endpoint)
+        if normalized_endpoint is None:
+            self._config = None
+            return
+
+        self._config = KVEventStreamConfig(
+            endpoint=normalized_endpoint,
+            replay_endpoint=self._normalize_endpoint_for_connect(replay_endpoint),
+            topic=config.topic,
+        )
+
+    @property
+    def enabled(self) -> bool:
+        return self._config is not None
+
+    async def stream(
+        self,
+        start_sequence_number: int,
+        context: grpc.aio.ServicerContext,
+    ) -> AsyncGenerator[vllm_engine_pb2.KvEventBatch, None]:
+        """Yield KV batches from replay (optional) and then live stream."""
+        if self._config is None:
+            return
+
+        sub_socket: zmq.Socket | None = None
+        replay_socket: zmq.Socket | None = None
+
+        try:
+            zmq_ctx = zmq.Context.instance()
+            sub_socket = zmq_ctx.socket(zmq.SUB)
+            sub_socket.connect(self._config.endpoint)
+            sub_socket.setsockopt_string(zmq.SUBSCRIBE, self._config.topic)
+
+            last_seq = -1
+
+            # Replay first, if requested and endpoint is configured.
+            if start_sequence_number > 0 and self._config.replay_endpoint:
+                replay_socket = zmq_ctx.socket(zmq.REQ)
+                replay_socket.connect(self._config.replay_endpoint)
+
+                replay_req = int(start_sequence_number).to_bytes(
+                    _SEQ_BYTES, byteorder="big", signed=False
+                )
+                await asyncio.to_thread(replay_socket.send, replay_req)
+
+                while True:
+                    if self._context_cancelled(context):
+                        return
+
+                    if not await asyncio.to_thread(
+                        replay_socket.poll, _POLL_TIMEOUT_MS
+                    ):
+                        continue
+
+                    frames = await asyncio.to_thread(replay_socket.recv_multipart)
+                    if len(frames) != 2:
+                        logger.warning(
+                            "Invalid replay frame length: %s (expected 2)", len(frames)
+                        )
+                        continue
+
+                    seq_bytes, payload = frames
+                    if len(seq_bytes) != _SEQ_BYTES:
+                        logger.warning(
+                            "Invalid replay sequence length: %s (expected %s)",
+                            len(seq_bytes),
+                            _SEQ_BYTES,
+                        )
+                        continue
+
+                    if seq_bytes == ZmqEventPublisher.END_SEQ and not payload:
+                        break
+                    replay_seq = int.from_bytes(
+                        seq_bytes, byteorder="big", signed=False
+                    )
+
+                    if replay_seq < start_sequence_number:
+                        continue
+                    if replay_seq <= last_seq:
+                        continue
+
+                    batch = self._decode_and_convert_batch(replay_seq, payload)
+                    if batch is None:
+                        continue
+                    last_seq = replay_seq
+                    yield batch
+
+            # Live stream.
+            while True:
+                if self._context_cancelled(context):
+                    return
+
+                if not await asyncio.to_thread(sub_socket.poll, _POLL_TIMEOUT_MS):
+                    continue
+
+                frames = await asyncio.to_thread(sub_socket.recv_multipart)
+                if len(frames) != 3:
+                    logger.warning(
+                        "Invalid SUB frame length: %s (expected 3)", len(frames)
+                    )
+                    continue
+
+                _, seq_bytes, payload = frames
+                if len(seq_bytes) != _SEQ_BYTES:
+                    logger.warning(
+                        "Invalid SUB sequence length: %s (expected %s)",
+                        len(seq_bytes),
+                        _SEQ_BYTES,
+                    )
+                    continue
+
+                seq = int.from_bytes(seq_bytes, byteorder="big", signed=False)
+                if seq < start_sequence_number:
+                    continue
+                if seq <= last_seq:
+                    continue
+
+                batch = self._decode_and_convert_batch(seq, payload)
+                if batch is None:
+                    continue
+                last_seq = seq
+                yield batch
+        finally:
+            if replay_socket is not None:
+                replay_socket.close(linger=0)
+            if sub_socket is not None:
+                sub_socket.close(linger=0)
+
+    @classmethod
+    def _decode_and_convert_batch(
+        cls, sequence_number: int, payload: bytes
+    ) -> vllm_engine_pb2.KvEventBatch | None:
+        try:
+            batch = cls._decoder.decode(payload)
+        except Exception as exc:
+            logger.warning(
+                "Failed to decode KV event batch seq=%s: %s", sequence_number, exc
+            )
+            return None
+        return cls._convert_batch(sequence_number, batch)
+
+    @classmethod
+    def _convert_batch(
+        cls, sequence_number: int, batch: InternalKVEventBatch
+    ) -> vllm_engine_pb2.KvEventBatch:
+        out_events: list[vllm_engine_pb2.KvCacheEvent] = []
+
+        for idx, event in enumerate(batch.events):
+            # Keep event_id within uint64 bounds even for very long-lived streams.
+            event_id = ((sequence_number & _EVENT_ID_SEQ_MASK) << 32) | idx
+            if isinstance(event, BlockStored):
+                out_events.append(cls._convert_block_stored(event, event_id))
+            elif isinstance(event, BlockRemoved):
+                out_events.append(cls._convert_block_removed(event, event_id))
+            elif isinstance(event, AllBlocksCleared):
+                out_events.append(
+                    vllm_engine_pb2.KvCacheEvent(
+                        event_id=event_id, cleared=vllm_engine_pb2.KvCacheCleared()
+                    )
+                )
+
+        out_batch = vllm_engine_pb2.KvEventBatch(
+            sequence_number=sequence_number,
+            timestamp=batch.ts,
+            events=out_events,
+        )
+        if batch.data_parallel_rank is not None:
+            out_batch.dp_rank = batch.data_parallel_rank
+        return out_batch
+
+    @classmethod
+    def _convert_block_stored(
+        cls, event: BlockStored, event_id: int
+    ) -> vllm_engine_pb2.KvCacheEvent:
+        tokens = list(event.token_ids)
+        block_size = max(int(event.block_size), 1)
+
+        blocks: list[vllm_engine_pb2.KvBlock] = []
+        for block_idx, block_hash in enumerate(event.block_hashes):
+            start = block_idx * block_size
+            end = min(start + block_size, len(tokens))
+            block = vllm_engine_pb2.KvBlock(
+                block_hash=cls._to_signed_int64(block_hash),
+                token_ids=tokens[start:end],
+                block_size=event.block_size,
+            )
+            if event.lora_id is not None:
+                block.lora_id = event.lora_id
+            blocks.append(block)
+
+        stored = vllm_engine_pb2.KvBlocksStored(blocks=blocks)
+        if event.parent_block_hash is not None:
+            stored.parent_block_hash = cls._to_signed_int64(event.parent_block_hash)
+        return vllm_engine_pb2.KvCacheEvent(event_id=event_id, stored=stored)
+
+    @classmethod
+    def _convert_block_removed(
+        cls, event: BlockRemoved, event_id: int
+    ) -> vllm_engine_pb2.KvCacheEvent:
+        removed = vllm_engine_pb2.KvBlocksRemoved(
+            block_hashes=[cls._to_signed_int64(h) for h in event.block_hashes]
+        )
+        return vllm_engine_pb2.KvCacheEvent(event_id=event_id, removed=removed)
+
+    @staticmethod
+    def _to_signed_int64(value: int | bytes) -> int:
+        if isinstance(value, bytes):
+            unsigned = int.from_bytes(value, byteorder="big", signed=False) & _MASK_64
+        else:
+            unsigned = int(value) & _MASK_64
+
+        if unsigned >= _INT64_SIGN_BIT:
+            return unsigned - _INT64_MOD
+        return unsigned
+
+    @staticmethod
+    def _context_cancelled(context: grpc.aio.ServicerContext) -> bool:
+        # `done()` and `cancelled()` are available in grpc aio ServicerContext.
+        # Guard with getattr for compatibility in unit tests/mocks.
+        done = getattr(context, "done", None)
+        if callable(done) and done():
+            return True
+        cancelled = getattr(context, "cancelled", None)
+        return bool(callable(cancelled) and cancelled())
+
+    @staticmethod
+    def _normalize_endpoint_for_connect(endpoint: str | None) -> str | None:
+        """Normalize bind-style wildcard endpoints into connectable addresses."""
+        if endpoint is None:
+            return None
+        if endpoint.startswith("tcp://*"):
+            return endpoint.replace("*", "127.0.0.1", 1)
+        return endpoint

--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -30,6 +30,7 @@ from grpc_reflection.v1alpha import reflection
 
 from vllm import SamplingParams, TextPrompt, TokensPrompt
 from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.entrypoints.grpc_kv_events import GrpcKVEventBridge
 from vllm.entrypoints.utils import log_version_and_model
 from vllm.grpc import vllm_engine_pb2, vllm_engine_pb2_grpc
 from vllm.logger import init_logger
@@ -47,13 +48,14 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
     """
     gRPC servicer implementing the VllmEngine service.
 
-    Handles 6 RPCs:
+    Handles 7 RPCs:
     - Generate: Streaming text generation
     - Embed: Embeddings (TODO)
     - HealthCheck: Health probe
     - Abort: Cancel requests out-of-band
     - GetModelInfo: Model metadata
     - GetServerInfo: Server state
+    - SubscribeKvEvents: KV cache event stream
     """
 
     def __init__(self, async_llm: AsyncLLM, start_time: float):
@@ -66,6 +68,11 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
         """
         self.async_llm = async_llm
         self.start_time = start_time
+        dp_rank = async_llm.vllm_config.parallel_config.data_parallel_index
+        self.kv_event_bridge = GrpcKVEventBridge(
+            async_llm.vllm_config.kv_events_config,
+            data_parallel_rank=dp_rank,
+        )
         logger.info("VllmEngineServicer initialized")
 
     async def Generate(
@@ -241,6 +248,36 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             uptime_seconds=time.time() - self.start_time,
             server_type="vllm-grpc",
         )
+
+    async def SubscribeKvEvents(
+        self,
+        request: vllm_engine_pb2.SubscribeKvEventsRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> AsyncGenerator[vllm_engine_pb2.KvEventBatch, None]:
+        """Handle KV cache event subscriptions."""
+        if not self.kv_event_bridge.enabled:
+            await context.abort(
+                grpc.StatusCode.UNIMPLEMENTED,
+                "KV event streaming disabled. Enable --kv-events-config with "
+                "enable_kv_cache_events=true and publisher=zmq.",
+            )
+            return
+
+        logger.info(
+            "SubscribeKvEvents connected: start_sequence_number=%s",
+            request.start_sequence_number,
+        )
+        try:
+            async for batch in self.kv_event_bridge.stream(
+                request.start_sequence_number, context
+            ):
+                yield batch
+        except asyncio.CancelledError:
+            logger.debug("SubscribeKvEvents cancelled by client")
+            raise
+        except Exception as e:
+            logger.exception("Error in SubscribeKvEvents")
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
 
     # ========== Helper methods ==========
 

--- a/vllm/grpc/vllm_engine.proto
+++ b/vllm/grpc/vllm_engine.proto
@@ -23,6 +23,10 @@ service VllmEngine {
 
   // Get server information
   rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
+
+  // Subscribe to KV cache events (server-streaming)
+  rpc SubscribeKvEvents(SubscribeKvEventsRequest)
+      returns (stream KvEventBatch);
 }
 
 // =====================
@@ -193,3 +197,48 @@ message GetServerInfoResponse {
   double uptime_seconds = 4;
   string server_type = 5;  // "vllm-grpc"
 }
+
+// =====================
+// KV Cache Events
+// =====================
+
+message SubscribeKvEventsRequest {
+  // Resume from this sequence number (0 = start from current state).
+  uint64 start_sequence_number = 1;
+}
+
+message KvEventBatch {
+  uint64 sequence_number = 1;
+  double timestamp = 2;
+  repeated KvCacheEvent events = 3;
+  optional int32 dp_rank = 4;
+}
+
+message KvCacheEvent {
+  uint64 event_id = 1;
+  oneof data {
+    KvBlocksStored stored = 2;
+    KvBlocksRemoved removed = 3;
+    KvCacheCleared cleared = 4;
+  }
+}
+
+message KvBlocksStored {
+  repeated KvBlock blocks = 1;
+  optional int64 parent_block_hash = 2;
+}
+
+message KvBlock {
+  int64 block_hash = 1;
+  repeated uint32 token_ids = 2;
+  int32 block_size = 3;
+  optional int64 lora_id = 4;
+  optional int32 cache_level = 5;
+}
+
+message KvBlocksRemoved {
+  repeated int64 block_hashes = 1;
+  optional int32 cache_level = 2;
+}
+
+message KvCacheCleared {}


### PR DESCRIPTION
  ## Purpose

  Add KV-cache event streaming to the standalone gRPC server via a new
  `SubscribeKvEvents` RPC.

  This PR:
  - Adds `SubscribeKvEvents(SubscribeKvEventsRequest) returns (stream
  KvEventBatch)` to `VllmEngine` in `vllm_engine.proto`.
  - Implements `SubscribeKvEvents` in the gRPC servicer.
  - Introduces `GrpcKVEventBridge` to bridge internal ZMQ KV events to gRPC
  stream responses.
  - Preserves backward compatibility by keeping KV event streaming disabled by
  default.
  - Returns `UNIMPLEMENTED` when KV event streaming is not enabled.
  - Documents gRPC KV event streaming usage/config in `docs/serving/
  grpc_server.md`.

  ## Test Plan

  - Run pre-commit hooks on commit.
  - Validate new/updated tests:
    - `pytest -q tests/entrypoints/test_grpc_kv_events.py`
    - `pytest -q tests/entrypoints/test_grpc_server.py -k
  subscribe_kv_events_disabled_by_default`

  ## Test Result

  - Pre-commit checks passed on this commit (including `ruff`, `typos`, and
  `mypy-local`).
  - Added test coverage for:
    - Disabled-by-default behavior (`UNIMPLEMENTED`) in gRPC server test.
    - KV event bridge behavior (enablement, endpoint normalization, replay/live
  sequencing, conversion edge cases).

  ## Documentation

  - Added `docs/serving/grpc_server.md` with:
    - RPC overview
    - Enablement config (`--kv-events-config`)
    - Replay/resume semantics
    - Data-parallel endpoint notes

  ---

  - [x] Purpose of PR is clearly described.
  - [x] Test plan is included.
  - [x] Test results are included.
  - [x] Documentation updated for user-facing behavior.
  - [ ] Release notes update (if required for this user-facing API addition).