### PR TITLE
[Bugfix] Fix async OffloadingConnector silently losing decode-phase blocks

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -418,14 +418,20 @@ class OffloadingConnectorScheduler:
             new_tokens = scheduler_output.num_scheduled_tokens[req_id]
             total_tokens = req.num_computed_tokens + new_tokens
             num_blocks = total_tokens // self.offloaded_block_size
+
+            # Clamp to blocks that have confirmed hashes. In async
+            # scheduling or speculative decoding, num_scheduled_tokens
+            # may include unverified tokens, inflating num_blocks beyond
+            # the hashes available. block_hashes is the ground truth
+            # since it is only updated after tokens are confirmed.
+            max_hashable_blocks = len(req.block_hashes) // self.block_size_factor
+            num_blocks = min(num_blocks, max_hashable_blocks)
+
             start_block_idx = self._next_stored_block_idx.get(req_id, 0)
             num_new_blocks = num_blocks - start_block_idx
 
             if num_new_blocks <= 0:
                 continue
-
-            # NOTE: In async scheduling, placeholders may temporarily make
-            # len(req.block_hashes) < num_blocks * self.block_size_factor.
 
             new_block_hashes = self._get_block_hashes(
                 req, start_idx=start_block_idx, end_idx=num_blocks


### PR DESCRIPTION
## Summary

With async scheduling (default), `OffloadingConnector` fails to store any decode-phase blocks to CPU. Only prompt blocks are stored, making CPU offloading ineffective for generated text.

**Root cause**: `_get_reqs_to_store()` computes `num_blocks` from `num_scheduled_tokens`, which includes unverified tokens. But `req.block_hashes` only updates after tokens are confirmed (in `update_from_output()`). This causes `_next_stored_block_idx` to advance past blocks whose hashes aren't available yet, permanently skipping them.

**Fix**: Clamp `num_blocks` to `len(req.block_hashes) // block_size_factor`. Missed blocks are naturally picked up next step.



@NickLucche @orozery 


> The same root cause also affects speculative decoding (`num_scheduled_tokens` includes spec tokens). The fix potentially also handles that. 

### Speculative decoding (sync offloading scheduling + EAGLE3, no fix)

The same bug also triggers with speculative decoding even when async scheduling is disabled, because `num_scheduled_tokens` includes speculative tokens (`new_tokens=6` instead of `1` with `num_speculative_tokens=5`).

Config: `Qwen/Qwen3-8B` + `AngelSlim/Qwen3-8B_eagle3`, `async_scheduling=False`, `num_speculative_tokens=5`

```
--- Step 1: cold generate (500 tokens) ---
  prompt_len:        202
  num_cached_tokens: 0  (from RequestOutput)
  expected_cached:   0
  difference:        0

--- Step 2: same prompt, GPU prefix cache ---
  prompt_len:        202
  num_cached_tokens: 192  (from RequestOutput)
  expected_cached:   192
  difference:        0

--- Step 3: reset_prefix_cache() called ---

--- Step 4: same prompt, CPU prefix cache ---
  prompt_len:        202
  num_cached_tokens: 192  (from RequestOutput)
  expected_cached:   192
  difference:        0

--- Step 5: reset_prefix_cache() called ---

--- Step 6: prompt+output as new prompt, CPU prefix cache ---
  prompt_len:        702
  num_cached_tokens: 192  (from RequestOutput)
  expected_cached:   688
  difference:        496    ← ALL decode blocks lost (same as async case)
```

## Test Plan

Generate 500 tokens with Qwen3-8B + OffloadingConnector, then verify CPU cache hits:

| Step | Action | Expected behavior |
|------|--------|-------------------|
| 1 | Cold generate 500 tokens | `num_cached_tokens = 0`, decode blocks stored to CPU |
| 2 | Same prompt, 1 token | `num_cached_tokens = 192` (GPU prefix cache hit) |
| 3 | `reset_prefix_cache()` | GPU cache cleared, CPU cache preserved |
| 4 | Same prompt, 1 token | `num_cached_tokens = 192` (CPU prefix cache hit) |
| 5 | `reset_prefix_cache()` | GPU cache cleared again |
| 6 | prompt+output as new prompt, 1 token | `num_cached_tokens = 688` (CPU hit for **all** blocks) |


<details>
<summary>Reproduction scripts</summary>

### test_offload_async.py (async scheduling)

```python
"""
Test: OffloadingConnector with async scheduling, no spec decode.
"""
import time

from vllm import LLM, SamplingParams, TokensPrompt
from vllm.config import KVTransferConfig

BLOCK_SIZE = 16

llm = LLM(
    model="Qwen/Qwen3-8B",
    gpu_memory_utilization=0.8,
    kv_transfer_config=KVTransferConfig(
        kv_connector="OffloadingConnector",
        kv_role="kv_both",
        kv_connector_extra_config={"cpu_bytes_to_use": 4 << 30},
    ),
)

sampling_1tok = SamplingParams(max_tokens=1, temperature=0.0)
sampling_gen = SamplingParams(max_tokens=500, temperature=0.0)

prompt = "Explain the theory of relativity in great detail. " * 20


def report(step, description, output, expected_cached=None):
    prompt_len = len(output[0].prompt_token_ids)
    cached = output[0].num_cached_tokens
    print(f"\n--- Step {step}: {description} ---")
    print(f"  prompt_len:        {prompt_len}")
    print(f"  num_cached_tokens: {cached}  (from RequestOutput)")
    if expected_cached is not None:
        diff = expected_cached - cached
        print(f"  expected_cached:   {expected_cached}")
        print(f"  difference:        {diff}")


# Step 1: Cold generate
out1 = llm.generate([prompt], sampling_gen, use_tqdm=False)
prompt_len = len(out1[0].prompt_token_ids)
gen_tokens = list(out1[0].outputs[0].token_ids)
report(1, "cold generate (500 tokens)", out1, expected_cached=0)

# Step 2: Same prompt — GPU prefix cache hit
out2 = llm.generate([prompt], sampling_1tok, use_tqdm=False)
expected_gpu = (prompt_len // BLOCK_SIZE) * BLOCK_SIZE
report(2, "same prompt, GPU prefix cache", out2, expected_cached=expected_gpu)

# Step 3: Reset GPU prefix cache
llm.reset_prefix_cache()
time.sleep(1.0)
print("\n--- Step 3: reset_prefix_cache() called ---")

# Step 4: Same prompt — CPU prefix cache hit
out4 = llm.generate([prompt], sampling_1tok, use_tqdm=False)
report(4, "same prompt, CPU prefix cache", out4, expected_cached=expected_gpu)

# Step 5: Reset GPU prefix cache
llm.reset_prefix_cache()
time.sleep(1.0)
print("\n--- Step 5: reset_prefix_cache() called ---")

# Step 6: prompt+output as new prompt — CPU prefix cache hit for all blocks
combined_ids = list(out1[0].prompt_token_ids) + gen_tokens
combined_len = len(combined_ids)
expected_all = (combined_len // BLOCK_SIZE) * BLOCK_SIZE
out6 = llm.generate([TokensPrompt(prompt_token_ids=combined_ids)],
                     sampling_1tok, use_tqdm=False)
report(6, "prompt+output as new prompt, CPU prefix cache", out6,
       expected_cached=expected_all)
```

### test_offload_sync.py (sync scheduling baseline)

Same as above but with `async_scheduling=False`:

```python
llm = LLM(
    model="Qwen/Qwen3-8B",
    gpu_memory_utilization=0.8,
    async_scheduling=False,
    kv_transfer_config=KVTransferConfig(
        kv_connector="OffloadingConnector",
        kv_role="kv_both",
        kv_connector_extra_config={"cpu_bytes_to_use": 4 << 30},
    ),
)
```

</details>


## Test Results 

Test generates 500 tokens with Qwen3-8B, resets GPU prefix cache, then feeds prompt+generated output back as a new prompt to measure CPU cache hits via `RequestOutput.num_cached_tokens`. Step 6 is the critical check — it verifies decode-phase blocks were stored to CPU.

### Before fix (async scheduling enabled)

```
--- Step 1: cold generate (500 tokens) ---
  prompt_len:        202
  num_cached_tokens: 0  (from RequestOutput)
  expected_cached:   0
  difference:        0

--- Step 2: same prompt, GPU prefix cache ---
  prompt_len:        202
  num_cached_tokens: 192  (from RequestOutput)
  expected_cached:   192
  difference:        0

--- Step 3: reset_prefix_cache() called ---

--- Step 4: same prompt, CPU prefix cache ---
  prompt_len:        202
  num_cached_tokens: 192  (from RequestOutput)
  expected_cached:   192
  difference:        0

--- Step 5: reset_prefix_cache() called ---

--- Step 6: prompt+output as new prompt, CPU prefix cache ---
  prompt_len:        702
  num_cached_tokens: 192  (from RequestOutput)
  expected_cached:   688
  difference:        496    ← ALL decode blocks lost
```

### After fix (async scheduling enabled, default)

```
--- Step 1: cold generate (500 tokens) ---
  prompt_len:        202
  num_cached_tokens: 0  (from RequestOutput)
  expected_cached:   0
  difference:        0

--- Step 2: same prompt, GPU prefix cache ---
  prompt_len:        202
  num_cached_tokens: 192  (from RequestOutput)
  expected_cached:   192
  difference:        0

--- Step 3: reset_prefix_cache() called ---

--- Step 4: same prompt, CPU prefix cache ---
  prompt_len:        202
  num_cached_tokens: 192  (from RequestOutput)
  expected_cached:   192
  difference:        0

--- Step 5: reset_prefix_cache() called ---

--- Step 6: prompt+output as new prompt, CPU prefix cache ---
  prompt_len:        702
  num_cached_tokens: 688  (from RequestOutput)
  expected_cached:   688
  difference:        0      ← all blocks correctly stored and retrieved
```

### Baseline: sync scheduling (no fix needed, confirms root cause)

```
--- Step 1: cold generate (500 tokens) ---
  prompt_len:        202
  num_cached_tokens: 0  (from RequestOutput)
  expected_cached:   0
  difference:        0

--- Step 2: same prompt, GPU prefix cache ---
  prompt_len:        202
  num_cached_tokens: 192  (from RequestOutput)
  expected_cached:   192
  difference:        0

--- Step 3: reset_prefix_cache() called ---

--- Step 4: same prompt, CPU prefix cache ---
  prompt_len:        202
  num_cached_tokens: 192  (from RequestOutput)
  expected_cached:   192
  difference:        0

--- Step 5: reset_prefix_cache() called ---

--- Step 6: prompt+output as new prompt, CPU prefix cache ---
  prompt_len:        702
  num_cached_tokens: 688  (from RequestOutput)
  expected_cached:   688
  difference:        0
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

