### PR TITLE
[Bugfix] Fix tokenize endpoint malformed token_strs

### DIFF
--- a/tests/entrypoints/openai/test_tokenization.py
+++ b/tests/entrypoints/openai/test_tokenization.py
@@ -220,13 +220,13 @@ async def test_tokenize_with_return_token_strs(
     response.raise_for_status()
 
     tokens = tokenizer.encode(prompt, add_special_tokens=True)
-    tokens_str = tokenizer.convert_ids_to_tokens(tokens)
+    expected_token_strs = [tokenizer.decode(token_id) for token_id in tokens]
 
     result = response.json()
     assert result["tokens"] == tokens
     assert result["count"] == len(tokens)
     assert result["max_model_len"] == 8192
-    assert result["token_strs"] == tokens_str
+    assert result["token_strs"] == expected_token_strs
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/serve/tokenize/serving.py
+++ b/vllm/entrypoints/serve/tokenize/serving.py
@@ -104,7 +104,7 @@ class OpenAIServingTokenization(OpenAIServing):
         token_strs = None
         if request.return_token_strs:
             tokenizer = self.renderer.get_tokenizer()
-            token_strs = tokenizer.convert_ids_to_tokens(input_ids)
+            token_strs = [tokenizer.decode(token_id) for token_id in input_ids]
 
         return TokenizeResponse(
             tokens=input_ids,


### PR DESCRIPTION
## Summary

Closes #27825

Use `tokenizer.decode()` instead of `convert_ids_to_tokens()` for `token_strs`
so non-Latin characters render correctly instead of raw byte tokens.