### PR TITLE
[Bugfix] Fix zombie EngineCore processes after parent exit

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1065,6 +1065,38 @@ class EngineCoreProc(EngineCore):
         # Ensure we can serialize transformer config after spawning
         maybe_register_config_serialize_by_value()
 
+        # Extract death pipe if provided (for parent death detection).
+        from multiprocessing.connection import Connection
+
+        death_pipe: Connection | None = kwargs.pop("death_pipe", None)
+
+        # Start death monitoring thread if death_pipe is provided.
+        # When the parent process exits, the pipe writer end closes,
+        # causing recv() to raise EOFError. We then send SIGTERM to
+        # ourselves to trigger graceful shutdown via the signal handler.
+        if death_pipe is not None:
+
+            def monitor_parent_death():
+                try:
+                    # This will block until parent process exits
+                    # (pipe writer end closes)
+                    death_pipe.recv()
+                except EOFError:
+                    # Parent process has exited
+                    logger.info("Parent process exited, terminating EngineCore")
+                    os.kill(os.getpid(), signal.SIGTERM)
+                except Exception:
+                    logger.warning("EngineCore death monitoring error", exc_info=True)
+                finally:
+                    death_pipe.close()
+
+            death_monitor = threading.Thread(
+                target=monitor_parent_death,
+                daemon=True,
+                name="EngineCoreDeathMonitor",
+            )
+            death_monitor.start()
+
         engine_core: EngineCoreProc | None = None
         signal_callback: SignalCallback | None = None
         try:
@@ -1287,8 +1319,9 @@ class EngineCoreProc(EngineCore):
                 return
             output = UtilityOutput(call_id)
             # Lazily look-up utility method so that failure will be handled/returned.
-            get_result = lambda: (method := getattr(self, method_name)) and method(
-                *self._convert_msgspec_args(method, args)
+            get_result = lambda: (
+                (method := getattr(self, method_name))
+                and method(*self._convert_msgspec_args(method, args))
             )
             enqueue_output = lambda out: self.output_queue.put_nowait(
                 (client_idx, EngineCoreOutputs(utility_output=out))

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -110,10 +110,17 @@ class CoreEngineProcManager:
             common_kwargs["client_handshake_address"] = client_handshake_address
 
         self.processes: list[BaseProcess] = []
+        # Keep death pipe writers alive in parent - when parent exits,
+        # the pipes close and child processes detect the parent death.
+        self.death_writers: list[connection.Connection] = []
         local_dp_ranks = []
         for index in range(local_engine_count):
             local_index = local_start_index + index
             global_index = start_index + index
+
+            # Create death pipe to detect parent process exit.
+            # The reader end goes to the child, writer stays in the parent.
+            death_reader, death_writer = context.Pipe(duplex=False)
 
             # Start EngineCore in background process.
             local_dp_ranks.append(local_index)
@@ -125,11 +132,15 @@ class CoreEngineProcManager:
                     | {
                         "dp_rank": global_index,
                         "local_dp_rank": local_index,
+                        "death_pipe": death_reader,
                     },
                 )
             )
+            self.death_writers.append(death_writer)
 
-        self._finalizer = weakref.finalize(self, shutdown, self.processes)
+        self._finalizer = weakref.finalize(
+            self, shutdown, self.processes, self.death_writers
+        )
 
         data_parallel = vllm_config.parallel_config.data_parallel_size > 1
         try:
@@ -157,7 +168,7 @@ class CoreEngineProcManager:
     def shutdown(self, timeout: float | None = None) -> None:
         """Shutdown engine core processes with configurable timeout."""
         if self._finalizer.detach() is not None:
-            shutdown(self.processes, timeout=timeout)
+            shutdown(self.processes, self.death_writers, timeout=timeout)
 
     def join_first(self):
         """Wait for any process to exit."""

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -294,13 +294,25 @@ def wait_for_completion_or_failure(
 
 # Note(rob): shutdown function cannot be a bound method,
 # else the gc cannot collect the object.
-def shutdown(procs: list[BaseProcess], timeout: float | None = None) -> None:
+def shutdown(
+    procs: list[BaseProcess],
+    death_writers: list[connection.Connection] | None = None,
+    timeout: float | None = None,
+) -> None:
     """Shutdown processes with timeout.
 
     Args:
         procs: List of processes to shutdown
+        death_writers: Death pipe writers to close (signals child processes)
         timeout: Maximum time in seconds to wait for graceful shutdown
     """
+    # Close death pipe writers first to signal child processes
+    # to exit before sending SIGTERM. This allows for graceful shutdown.
+    if death_writers:
+        for writer in death_writers:
+            with contextlib.suppress(OSError):
+                writer.close()
+
     if timeout is None:
         timeout = 0.0
 


### PR DESCRIPTION
## Summary

Closes #25850

Add a "death pipe" so EngineCore child processes detect parent exit via EOF
and shut down, instead of lingering as zombies.