### PR TITLE
fix: force prefill path for MTP drafting on SM121 (GB10 Spark)

### DIFF
--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1193,22 +1193,17 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # drafting with fp8 KV cache + head_dim=256. Force the prefill path by
         # temporarily setting decode_threshold=0 so that 1-token steps are
         # classified as prefills (computationally identical to decode).
+        original_threshold = self.reorder_batch_threshold
         if not self.use_trtllm_decode_attention:
-            orig = self.reorder_batch_threshold
             self.reorder_batch_threshold = 0
-            try:
-                return self.build(
-                    common_prefix_len=0,
-                    common_attn_metadata=common_attn_metadata,
-                    fast_build=True,
-                )
-            finally:
-                self.reorder_batch_threshold = orig
-        return self.build(
-            common_prefix_len=0,
-            common_attn_metadata=common_attn_metadata,
-            fast_build=True,
-        )
+        try:
+            return self.build(
+                common_prefix_len=0,
+                common_attn_metadata=common_attn_metadata,
+                fast_build=True,
+            )
+        finally:
+            self.reorder_batch_threshold = original_threshold
 
     def use_cascade_attention(self, *args, **kwargs) -> bool:
         if self.kv_cache_spec.dtype != self.vllm_config.model_config.dtype:

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1183,6 +1183,33 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                 attn_metadata.decode = FIDecode(wrapper=decode_wrapper)
         return attn_metadata
 
+    def build_for_drafting(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int,
+    ) -> FlashInferMetadata:
+        # On platforms where TRTLLM decode attention is unavailable (e.g.
+        # SM121/GB10 Spark), the flashinfer native decode path fails for MTP
+        # drafting with fp8 KV cache + head_dim=256. Force the prefill path by
+        # temporarily setting decode_threshold=0 so that 1-token steps are
+        # classified as prefills (computationally identical to decode).
+        if not self.use_trtllm_decode_attention:
+            orig = self.reorder_batch_threshold
+            self.reorder_batch_threshold = 0
+            try:
+                return self.build(
+                    common_prefix_len=0,
+                    common_attn_metadata=common_attn_metadata,
+                    fast_build=True,
+                )
+            finally:
+                self.reorder_batch_threshold = orig
+        return self.build(
+            common_prefix_len=0,
+            common_attn_metadata=common_attn_metadata,
+            fast_build=True,
+        )
+
     def use_cascade_attention(self, *args, **kwargs) -> bool:
         if self.kv_cache_spec.dtype != self.vllm_config.model_config.dtype:
             # TODO: The cascade wrapper currently does not support setting


### PR DESCRIPTION
## Summary

On SM121 (DGX GB10 Spark, CC 12.1), `supports_trtllm_attention` returns `False` for the SM12x family. This leaves `use_trtllm_decode_attention=False` and `reorder_batch_threshold=1` in `FlashInferMetadataBuilder`, so the MTP drafter's 1-token second pass gets classified as a decode and routed to `BatchDecodeWithPagedKVCacheWrapper`.

This causes an **illegal memory access** crash when using:
- bf16 query dtype
- fp8 KV cache
- `head_dim=256` (e.g. DeepSeek-R1 with MTP enabled)

## Fix

Override `build_for_drafting` in `FlashInferMetadataBuilder` to temporarily set `reorder_batch_threshold=0` when `use_trtllm_decode_attention` is `False`. This forces all MTP drafting steps through `BatchPrefillWithPagedKVCacheWrapper`, which handles this configuration correctly.

A 1-token "prefill" is computationally identical to a decode, so there is no performance regression.

## Root cause details

- `FlashInferMetadataBuilder.__init__` sets `reorder_batch_threshold = 1` when TRTLLM decode is unavailable (line ~821)
- The MTP drafter calls `build_for_drafting` with a single-token step, which hits the decode path
- `BatchDecodeWithPagedKVCacheWrapper` does not support bf16 Q + fp8 KV + head_dim=256 on SM121, crashing with illegal memory access

## Test

Verified on NVIDIA GB10 Spark (SM121, CUDA 13.0) with DeepSeek-R1-0528-NVFP4 + MTP enabled. Model now runs correctly end-to-end.

## FYI

- Only affects SM12x-family GPUs where `supports_trtllm_attention` returns `False`
- No behavioral change on SM89/SM90/SM100 (TRTLLM path is used, existing `build_for_drafting` falls through unchanged)